### PR TITLE
Fixed bgm looping by disposing of Song objects so OpenAL buffers actu…

### DIFF
--- a/Intersect.Client/Classes/MonoGame/Audio/MonoMusicInstance.cs
+++ b/Intersect.Client/Classes/MonoGame/Audio/MonoMusicInstance.cs
@@ -17,12 +17,13 @@ namespace Intersect.Client.MonoGame.Audio
         // ReSharper disable once SuggestBaseTypeForParameter
         public MonoMusicInstance([NotNull] MonoMusicSource source) : base(source)
         {
-            mSong = source.Song;
+            mSong = source.LoadSong();
         }
 
         public override void Play()
         {
-            MediaPlayer.Play(mSong);
+            if (mSong != null)
+                MediaPlayer.Play(mSong);
         }
 
         public override void Pause()
@@ -88,6 +89,7 @@ namespace Intersect.Client.MonoGame.Audio
             try
             {
                 MediaPlayer.Stop();
+                mSong.Dispose();
             }
             catch
             {

--- a/Intersect.Client/Classes/MonoGame/Audio/MonoMusicSource.cs
+++ b/Intersect.Client/Classes/MonoGame/Audio/MonoMusicSource.cs
@@ -10,7 +10,6 @@ namespace Intersect.Client.MonoGame.Audio
     public class MonoMusicSource : GameAudioSource
     {
         private readonly string mPath;
-        private Song mSong;
 
         public MonoMusicSource(string path)
         {
@@ -19,35 +18,21 @@ namespace Intersect.Client.MonoGame.Audio
 
         public override GameAudioInstance CreateInstance() => new MonoMusicInstance(this);
 
-        private void Load()
+        public Song LoadSong()
         {
-            if (string.IsNullOrWhiteSpace(mPath))
+            if (!string.IsNullOrWhiteSpace(mPath))
             {
-                return;
-            }
-
-            try
-            {
-                mSong = Song.FromUri(mPath, new Uri(mPath, UriKind.Relative));
-            }
-            catch (Exception exception)
-            {
-                Log.Error($"Error loading '{mPath}'.", exception);
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Errors.LoadFile.ToString(Strings.Words.lcase_sound), new Color(0xBF, 0x0, 0x0)));
-            }
-        }
-
-        public Song Song
-        {
-            get
-            {
-                if (mSong == null)
+                try
                 {
-                    Load();
+                    return Song.FromUri(mPath, new Uri(mPath, UriKind.Relative));
                 }
-
-                return mSong;
+                catch (Exception exception)
+                {
+                    Log.Error($"Error loading '{mPath}'.", exception);
+                    ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Errors.LoadFile.ToString(Strings.Words.lcase_sound), new Color(0xBF, 0x0, 0x0)));
+                }
             }
+            return null;
         }
 
     }


### PR DESCRIPTION
…ally get disposed of.

MediaPlayer.Stop() doesn't clear the OpenAl resources for a song that's been playing. The song itself must actually be disposed of. Restructured so song objects are temporary and I think this fixes the BGM looping problem that people have been having.