### PR TITLE
Removing unnecessary usage of string.ToCharArray() in ClientMain

### DIFF
--- a/Intersect.Client/ClientMain.cs
+++ b/Intersect.Client/ClientMain.cs
@@ -190,8 +190,7 @@ namespace Intersect.Client
                 Debug.Assert(resourceStream != null, "resourceStream != null");
                 var resources = new ResourceSet(resourceStream);
 
-                // TODO: JC, is there a reason you are doing ".".ToCharArray()? -- Because it works? :P
-                path = "resources/" + folder + "/" + filename.Split(".".ToCharArray())[0]?.Split("-".ToCharArray())[0];
+                path = Path.Combine("resources", folder, filename.Split(new char[] { '.' })[0]?.Split(new char[] { '-' })[0]);
                 path = path.ToLower();
 
                 var enumerator = resources.GetEnumerator();


### PR DESCRIPTION
Clone of #32 that doesn't muck with commit authorship