### PR TITLE
When an event graphic is double clicked, it doesn't load the previous…

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -58,6 +58,8 @@ namespace Intersect.Client.Entities
 
         public int TargetType;
 
+        public long[] MoveDirectionTimers = new long[4];
+
         public Player(Guid id, PlayerEntityPacket packet) : base(id, packet)
         {
             for (var i = 0; i < Options.MaxHotbar; i++)
@@ -829,6 +831,40 @@ namespace Intersect.Client.Entities
                 if (movex > 0)
                 {
                     Globals.Me.MoveDir = 3;
+                }
+            }
+
+            //Loop through our direction timers and keep track of how long we've been requesting to move in each direction
+            //If we have only just tapped a button we will set Globals.Me.MoveDir to -1 in order to cancel the movement
+            for (var i = 0; i < 4; i++)
+            {
+                if (i == Globals.Me.MoveDir)
+                {
+                    //If we just started to change to a new direction then turn the player only (set the timer to now + 60ms)
+                    if (MoveDirectionTimers[i] == -1 && !Globals.Me.IsMoving && Dir != Globals.Me.MoveDir)
+                    {
+                        //Turn Only
+                        Dir = (byte)Globals.Me.MoveDir;
+                        PacketSender.SendDirection((byte)Globals.Me.MoveDir);
+                        MoveDirectionTimers[i] = Globals.System.GetTimeMs() + 60;
+                        Globals.Me.MoveDir = -1;
+                    }
+                    //If we're already facing the direction then just start moving (set the timer to now)
+                    else if (MoveDirectionTimers[i] == -1 && !Globals.Me.IsMoving && Dir == Globals.Me.MoveDir)
+                    {
+                        MoveDirectionTimers[i] = Globals.System.GetTimeMs();
+                    }
+                    //The timer is greater than the currect time, let's cancel the move.
+                    else if (MoveDirectionTimers[i] > Globals.System.GetTimeMs() && !Globals.Me.IsMoving)
+                    {
+                        //Don't trigger the actual move immediately, wait until button is held
+                        Globals.Me.MoveDir = -1;
+                    }
+                }
+                else
+                {
+                    //Reset the timer if the direction isn't being requested
+                    MoveDirectionTimers[i] = -1;
                 }
             }
         }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -41,11 +41,15 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         )
         {
             InitializeComponent();
+            InitLocalization();
             mEditingGraphic = editingGraphic;
             mEventEditor = eventEditor;
             mLoading = true;
+            cmbGraphicType.SelectedIndex = (int)mEditingGraphic.Type;
+
             UpdateGraphicList();
-            if (cmbGraphic.Items.IndexOf(mEditingGraphic.Filename) > -1)
+            int count = cmbGraphic.Items.Count;
+              if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
             {
                 cmbGraphic.SelectedIndex = cmbGraphic.Items.IndexOf(mEditingGraphic.Filename);
             }
@@ -53,8 +57,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             mRouteDesigner = moveRouteDesigner;
             mNewRouteAction = newMoveRouteAction;
             mLoading = false;
-            InitLocalization();
-            cmbGraphicType.SelectedIndex = (int) mEditingGraphic.Type;
+
             mTmpGraphic.CopyFrom(mEditingGraphic);
             UpdatePreview();
         }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -48,8 +48,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             cmbGraphicType.SelectedIndex = (int)mEditingGraphic.Type;
 
             UpdateGraphicList();
-            int count = cmbGraphic.Items.Count;
-              if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
+            if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
             {
                 cmbGraphic.SelectedIndex = cmbGraphic.Items.IndexOf(mEditingGraphic.Filename);
             }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.resx
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.resx
@@ -117,4 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cmbGraphic.ButtonIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAAkAAAAFCAYAAACXU8ZrAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAvSURBVBhXY4iJiflPCDP8//8f
+        r0KQPFgRLoUwObgiEMamAIRRFIEwuoL///8zAAC5cW+geGnZqAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="cmbGraphicType.ButtonIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAAkAAAAFCAYAAACXU8ZrAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAvSURBVBhXY4iJiflPCDP8//8f
+        r0KQPFgRLoUwObgiEMamAIRRFIEwuoL///8zAAC5cW+geGnZqAAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>


### PR DESCRIPTION
When an event graphic is double clicked, it doesn't load the previous image, it always reset to the first sprite