### PR TITLE
Properly load list data within locking region

### DIFF
--- a/Intersect.Server/Database/PlayerData/Api/RefreshToken.cs
+++ b/Intersect.Server/Database/PlayerData/Api/RefreshToken.cs
@@ -86,16 +86,12 @@ namespace Intersect.Server.Database.PlayerData.Api
             return true;
         }
 
+        [CanBeNull]
         public static RefreshToken Find(Guid id)
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
-                return DbInterface.GetPlayerContext()?.RefreshTokens.Find(id);
+                return DbInterface.GetPlayerContext()?.RefreshTokens?.Find(id);
             }
         }
 
@@ -108,23 +104,16 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var playerContext = DbInterface.GetPlayerContext();
-                var refreshToken = playerContext?.RefreshTokens?.Where(queryToken => queryToken.TicketId == ticketId)
-                    .FirstOrDefault();
+                var refreshToken =
+                    playerContext?.RefreshTokens.FirstOrDefault(queryToken => queryToken.TicketId == ticketId);
 
                 if (refreshToken == null || DateTime.UtcNow < refreshToken.Expires)
                 {
                     return refreshToken;
                 }
-                else
-                {
-                    Remove(refreshToken, true);
-                }
+
+                Remove(refreshToken, true);
             }
 
             return null;
@@ -139,13 +128,8 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var tokenQuery = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.Where(queryToken => queryToken.ClientId == clientId);
+                    ?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId);
 
                 return tokenQuery.AsEnumerable()?.ToList();
             }
@@ -160,13 +144,8 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var tokenQuery = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.Where(queryToken => queryToken.UserId == userId);
+                    ?.RefreshTokens.Where(queryToken => queryToken.UserId == userId);
 
                 return tokenQuery.AsEnumerable()?.ToList();
             }
@@ -181,13 +160,8 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var token = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.First(queryToken => queryToken.UserId == userId);
+                    ?.RefreshTokens.First(queryToken => queryToken.UserId == userId);
 
                 return token;
             }
@@ -202,23 +176,13 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             var token = Find(id);
 
-            if (token == null)
-            {
-                return false;
-            }
-
-            return Remove(token, commit);
+            return token != null && Remove(token, commit);
         }
 
         public static bool Remove([NotNull] RefreshToken token, bool commit = false)
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return false;
-                }
-
                 DbInterface.GetPlayerContext()?.RefreshTokens.Remove(token);
 
                 return true;
@@ -229,11 +193,6 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return false;
-                }
-
                 DbInterface.GetPlayerContext()?.RefreshTokens.RemoveRange(tokens);
 
                 return true;

--- a/Intersect.Server/Database/PlayerData/User.cs
+++ b/Intersect.Server/Database/PlayerData/User.cs
@@ -247,7 +247,7 @@ namespace Intersect.Server.Database.PlayerData
                     var context = DbInterface.GetPlayerContext();
                     try
                     {
-                        return QueryUsers(context, page * count, count) ?? throw new InvalidOperationException();
+                        return QueryUsers(context, page * count, count)?.ToList() ?? throw new InvalidOperationException();
                     }
                     catch (Exception exception)
                     {
@@ -259,7 +259,7 @@ namespace Intersect.Server.Database.PlayerData
             }
             else
             {
-                return QueryUsers(playerContext, page, count) ?? throw new InvalidOperationException();
+                return QueryUsers(playerContext, page, count)?.ToList() ?? throw new InvalidOperationException();
             }
         }
 

--- a/Intersect.Server/Entities/Player.Database.cs
+++ b/Intersect.Server/Entities/Player.Database.cs
@@ -154,7 +154,7 @@ namespace Intersect.Server.Entities
         }
 
         [NotNull]
-        public static IEnumerable<Player> List(int page, int count, [CanBeNull] PlayerContext playerContext = null)
+        public static IList<Player> List(int page, int count, [CanBeNull] PlayerContext playerContext = null)
         {
             if (playerContext == null)
             {
@@ -162,12 +162,12 @@ namespace Intersect.Server.Entities
                 {
                     var context = DbInterface.GetPlayerContext();
 
-                    return QueryPlayers(context, page * count, count) ?? throw new InvalidOperationException();
+                    return QueryPlayers(context, page * count, count)?.ToList() ?? throw new InvalidOperationException();
                 }
             }
             else
             {
-                return QueryPlayers(playerContext, page * count, count) ?? throw new InvalidOperationException();
+                return QueryPlayers(playerContext, page * count, count)?.ToList() ?? throw new InvalidOperationException();
             }
         }
 
@@ -192,7 +192,7 @@ namespace Intersect.Server.Entities
                     ? QueryPlayersWithRankAscending(context, page * count, count)
                     : QueryPlayersWithRank(context, page * count, count);
 
-                return results ?? throw new InvalidOperationException();
+                return results?.ToList() ?? throw new InvalidOperationException();
             }
         }
 


### PR DESCRIPTION
This addresses #54 

The general gist is compiled queries do not actually load data, they return an `IQueryable<T>` which has a reference to the context in order to load the data. This happens with transformations like `ToList()`.

With this change, `ToList()` is now called within the confines of the locking region, rather than outside of it. Since all of our reads are bounded by locking regions, this ensures that the list reads do not collide with any other database accesses.