### PR TITLE
Implement #63: Server status details

### DIFF
--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -296,6 +296,8 @@
     <Compile Include="Models\INamedObject.cs" />
     <Compile Include="Network\Ceras.cs" />
     <Compile Include="Network\ConnectionPacket.cs" />
+    <Compile Include="Network\Events\ConnectionEventArgs.cs" />
+    <Compile Include="Network\NetworkStatus.cs" />
     <Compile Include="Network\PacketDispatcher.cs" />
     <Compile Include="Network\Packets\Client\AbandonQuestPacket.cs" />
     <Compile Include="Network\Packets\Client\ActivateEventPacket.cs" />

--- a/Intersect (Core)/Network/Events/ConnectionEventArgs.cs
+++ b/Intersect (Core)/Network/Events/ConnectionEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Intersect.Network.Events
+{
+    public class ConnectionEventArgs : EventArgs
+    {
+        public NetworkStatus NetworkStatus { get; set; }
+
+        public IConnection Connection { get; set; }
+    }
+}

--- a/Intersect (Core)/Network/INetworkLayerInterface.cs
+++ b/Intersect (Core)/Network/INetworkLayerInterface.cs
@@ -2,15 +2,18 @@
 using System.Collections.Generic;
 
 using Intersect.Memory;
+using Intersect.Network.Events;
+
+using JetBrains.Annotations;
 
 namespace Intersect.Network
 {
 
-    public delegate void HandlePacketAvailable(INetworkLayerInterface sender);
+    public delegate void HandlePacketAvailable([NotNull] INetworkLayerInterface sender);
 
-    public delegate void HandleConnectionEvent(INetworkLayerInterface sender, IConnection connection);
+    public delegate void HandleConnectionEvent([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs);
 
-    public delegate bool HandleConnectionRequest(INetworkLayerInterface sender, IConnection connection);
+    public delegate bool HandleConnectionRequest([NotNull] INetworkLayerInterface sender, IConnection connection);
 
     public interface INetworkLayerInterface : IDisposable
     {

--- a/Intersect (Core)/Network/NetworkStatus.cs
+++ b/Intersect (Core)/Network/NetworkStatus.cs
@@ -1,0 +1,23 @@
+﻿namespace Intersect.Network
+{
+    public enum NetworkStatus
+    {
+
+        Unknown = 0,
+
+        Connecting,
+
+        Online,
+
+        Offline,
+
+        Failed,
+
+        VersionMismatch,
+
+        ServerFull,
+
+        HandshakeFailure
+
+    }
+}

--- a/Intersect.Client.Framework/Network/GameSocket.cs
+++ b/Intersect.Client.Framework/Network/GameSocket.cs
@@ -1,4 +1,7 @@
 ﻿using Intersect.Network;
+using Intersect.Network.Events;
+
+using JetBrains.Annotations;
 
 namespace Intersect.Client.Framework.Network
 {
@@ -33,29 +36,29 @@ namespace Intersect.Client.Framework.Network
             DataReceived?.Invoke(packet);
         }
 
-        protected void OnConnected()
+        protected void OnConnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Connected?.Invoke();
+            Connected?.Invoke(sender, connectionEventArgs);
         }
 
-        protected void OnConnectionFailed(bool denied)
+        protected void OnConnectionFailed([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs, bool denied)
         {
-            ConnectionFailed?.Invoke(denied);
+            ConnectionFailed?.Invoke(sender, connectionEventArgs, denied);
         }
 
-        protected void OnDisconnected()
+        protected void OnDisconnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Disconnected?.Invoke();
+            Disconnected?.Invoke(sender, connectionEventArgs);
         }
 
     }
 
     public delegate void DataReceivedHandler(IPacket packet);
 
-    public delegate void ConnectedHandler();
+    public delegate void ConnectedHandler([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs);
 
-    public delegate void ConnectionFailedHandler(bool denied);
+    public delegate void ConnectionFailedHandler([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs, bool denied);
 
-    public delegate void DisconnectedHandler();
+    public delegate void DisconnectedHandler([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs);
 
 }

--- a/Intersect.Client/Interface/Menu/MainMenu.cs
+++ b/Intersect.Client/Interface/Menu/MainMenu.cs
@@ -9,6 +9,8 @@ using Intersect.Client.General;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
+using Intersect.Network;
+using Intersect.Network.Events;
 
 using JetBrains.Annotations;
 
@@ -326,7 +328,7 @@ namespace Intersect.Client.Interface.Menu
         {
             mLoginButton.IsDisabled = ActiveNetworkStatus != NetworkStatus.Online;
             mRegisterButton.IsDisabled = ActiveNetworkStatus != NetworkStatus.Online ||
-                                         Options.Loaded && Options.BlockClientRegistrations == true;
+                                         Options.Loaded && Options.BlockClientRegistrations;
         }
 
         public static void OnNetworkConnecting()
@@ -334,21 +336,9 @@ namespace Intersect.Client.Interface.Menu
             ActiveNetworkStatus = NetworkStatus.Connecting;
         }
 
-        public static void OnNetworkConnected()
+        public static void SetNetworkStatus(NetworkStatus networkStatus)
         {
-            ActiveNetworkStatus = NetworkStatus.Online;
-            NetworkStatusChanged?.Invoke();
-        }
-
-        public static void OnNetworkDisconnected()
-        {
-            ActiveNetworkStatus = NetworkStatus.Offline;
-            NetworkStatusChanged?.Invoke();
-        }
-
-        public static void OnNetworkFailed(bool denied)
-        {
-            ActiveNetworkStatus = denied ? NetworkStatus.Failed : NetworkStatus.Connecting;
+            ActiveNetworkStatus = networkStatus;
             NetworkStatusChanged?.Invoke();
         }
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1335,11 +1335,11 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString Unknown = @"Unknown";
 
-            public static LocalizedString VersionMismatch = @"Version mismatch";
+            public static LocalizedString VersionMismatch = @"Bad Version";
 
-            public static LocalizedString ServerFull = @"Server Full";
+            public static LocalizedString ServerFull = @"Full";
 
-            public static LocalizedString HandshakeFailure = @"Handshake Failure";
+            public static LocalizedString HandshakeFailure = @"Handshake Error";
 
         }
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1335,6 +1335,12 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString Unknown = @"Unknown";
 
+            public static LocalizedString VersionMismatch = @"Version mismatch";
+
+            public static LocalizedString ServerFull = @"Server Full";
+
+            public static LocalizedString HandshakeFailure = @"Handshake Failure";
+
         }
 
         public struct Shop

--- a/Intersect.Client/MonoGame/IntersectGame.cs
+++ b/Intersect.Client/MonoGame/IntersectGame.cs
@@ -95,9 +95,9 @@ namespace Intersect.Client.MonoGame
 
             // TODO: Remove old netcode
             Networking.Network.Socket = new MonoSocket();
-            Networking.Network.Socket.Connected += MainMenu.OnNetworkConnected;
-            Networking.Network.Socket.ConnectionFailed += MainMenu.OnNetworkFailed;
-            Networking.Network.Socket.Disconnected += MainMenu.OnNetworkDisconnected;
+            Networking.Network.Socket.Connected += (sender, connectionEventArgs) => MainMenu.SetNetworkStatus(connectionEventArgs.NetworkStatus);
+            Networking.Network.Socket.ConnectionFailed += (sender, connectionEventArgs, denied) => MainMenu.SetNetworkStatus(connectionEventArgs.NetworkStatus);
+            Networking.Network.Socket.Disconnected += (sender, connectionEventArgs) => MainMenu.SetNetworkStatus(connectionEventArgs.NetworkStatus);
 
             Main.Start();
             base.Initialize();

--- a/Intersect.Client/MonoGame/Network/MonoSocket.cs
+++ b/Intersect.Client/MonoGame/Network/MonoSocket.cs
@@ -48,9 +48,9 @@ namespace Intersect.Client.MonoGame.Network
             }
 
             ClientLidgrenNetwork.Handler = AddPacketToQueue;
-            ClientLidgrenNetwork.OnConnected += delegate { OnConnected(); };
-            ClientLidgrenNetwork.OnDisconnected += delegate { OnDisconnected(); };
-            ClientLidgrenNetwork.OnConnectionDenied += delegate { OnConnectionFailed(true); };
+            ClientLidgrenNetwork.OnConnected += OnConnected;
+            ClientLidgrenNetwork.OnDisconnected += OnDisconnected;
+            ClientLidgrenNetwork.OnConnectionDenied += (sender, connectionEventArgs) => OnConnectionFailed(sender, connectionEventArgs, true);
 
             if (!ClientLidgrenNetwork.Connect())
             {

--- a/Intersect.Client/Networking/Network.cs
+++ b/Intersect.Client/Networking/Network.cs
@@ -6,6 +6,9 @@ using Intersect.Client.Interface.Menu;
 using Intersect.Configuration;
 using Intersect.Logging;
 using Intersect.Network;
+using Intersect.Network.Events;
+
+using JetBrains.Annotations;
 
 namespace Intersect.Client.Networking
 {
@@ -50,7 +53,7 @@ namespace Intersect.Client.Networking
             Socket?.Connect(ClientConfiguration.Instance.Host, ClientConfiguration.Instance.Port);
         }
 
-        private static void MySocket_OnConnectionFailed(bool denied)
+        private static void MySocket_OnConnectionFailed([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs, bool denied)
         {
             sConnected = false;
             if (!denied)
@@ -64,7 +67,7 @@ namespace Intersect.Client.Networking
             PacketHandler.HandlePacket(packet);
         }
 
-        private static void MySocket_OnDisconnected()
+        private static void MySocket_OnDisconnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
             //Not sure how to handle this yet!
             sConnected = false;
@@ -81,7 +84,7 @@ namespace Intersect.Client.Networking
             }
         }
 
-        private static void MySocket_OnConnected()
+        private static void MySocket_OnConnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
             //Not sure how to handle this yet!
             sConnected = true;

--- a/Intersect.Client/Networking/NetworkStatus.cs
+++ b/Intersect.Client/Networking/NetworkStatus.cs
@@ -1,24 +1,10 @@
 ﻿using System;
 
 using Intersect.Client.Localization;
+using Intersect.Network;
 
 namespace Intersect.Client.Networking
 {
-
-    public enum NetworkStatus
-    {
-
-        Unknown = 0,
-
-        Connecting,
-
-        Online,
-
-        Offline,
-
-        Failed
-
-    }
 
     public static class NetworkStatusExtensions
     {
@@ -41,6 +27,15 @@ namespace Intersect.Client.Networking
 
                 case NetworkStatus.Failed:
                     return Strings.Server.Failed;
+
+                case NetworkStatus.VersionMismatch:
+                    return Strings.Server.VersionMismatch;
+
+                case NetworkStatus.ServerFull:
+                    return Strings.Server.ServerFull;
+
+                case NetworkStatus.HandshakeFailure:
+                    return Strings.Server.HandshakeFailure;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(networkStatus), networkStatus, null);

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -9,6 +9,9 @@ using Intersect.Logging;
 using Intersect.Network;
 using Intersect.Network.Crypto;
 using Intersect.Network.Crypto.Formats;
+using Intersect.Network.Events;
+
+using JetBrains.Annotations;
 
 namespace Intersect.Editor.Networking
 {
@@ -80,7 +83,7 @@ namespace Intersect.Editor.Networking
             }
         }
 
-        public static void HandleDc(INetworkLayerInterface netInterface, IConnection netConnection)
+        public static void HandleDc([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
             DestroyNetwork();
             if (Globals.MainForm != null && Globals.MainForm.Visible)

--- a/Intersect.Network/ClientNetwork.cs
+++ b/Intersect.Network/ClientNetwork.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 
 using Intersect.Logging;
+using Intersect.Network.Events;
 
 using JetBrains.Annotations;
 
@@ -94,30 +95,30 @@ namespace Intersect.Network
             return Send(packet);
         }
 
-        protected virtual void HandleInterfaceOnConnected(INetworkLayerInterface sender, IConnection connection)
+        protected virtual void HandleInterfaceOnConnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Log.Info($"Connected [{connection?.Guid}].");
+            Log.Info($"Connected [{connectionEventArgs.Connection?.Guid}].");
             IsConnected = true;
-            OnConnected?.Invoke(sender, connection);
+            OnConnected?.Invoke(sender, connectionEventArgs);
         }
 
-        protected virtual void HandleInterfaceOnConnectonApproved(INetworkLayerInterface sender, IConnection connection)
+        protected virtual void HandleInterfaceOnConnectonApproved([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Log.Info($"Connection approved [{connection?.Guid}].");
-            OnConnectionApproved?.Invoke(sender, connection);
+            Log.Info($"Connection approved [{connectionEventArgs.Connection?.Guid}].");
+            OnConnectionApproved?.Invoke(sender, connectionEventArgs);
         }
 
-        protected virtual void HandleInterfaceOnConnectonDenied(INetworkLayerInterface sender, IConnection connection)
+        protected virtual void HandleInterfaceOnConnectonDenied([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Log.Info($"Connection denied [{connection?.Guid}].");
-            OnConnectionDenied?.Invoke(sender, connection);
+            Log.Info($"Connection denied [{connectionEventArgs.Connection?.Guid}].");
+            OnConnectionDenied?.Invoke(sender, connectionEventArgs);
         }
 
-        protected virtual void HandleInterfaceOnDisconnected(INetworkLayerInterface sender, IConnection connection)
+        protected virtual void HandleInterfaceOnDisconnected([NotNull] INetworkLayerInterface sender, [NotNull] ConnectionEventArgs connectionEventArgs)
         {
-            Log.Info($"Disconnected [{connection?.Guid ?? Guid.Empty}].");
+            Log.Info($"Disconnected [{connectionEventArgs.Connection?.Guid ?? Guid.Empty}].");
             IsConnected = false;
-            OnDisconnected?.Invoke(sender, connection);
+            OnDisconnected?.Invoke(sender, connectionEventArgs);
         }
 
         public void Close()

--- a/Intersect.Network/LidgrenInterface.cs
+++ b/Intersect.Network/LidgrenInterface.cs
@@ -7,6 +7,7 @@ using System.Threading;
 
 using Intersect.Logging;
 using Intersect.Memory;
+using Intersect.Network.Events;
 using Intersect.Network.Packets;
 using Intersect.Utilities;
 
@@ -21,12 +22,6 @@ namespace Intersect.Network
     {
 
         public delegate void HandleUnconnectedMessage(NetPeer peer, NetIncomingMessage message);
-
-        private const string RejectBadHail = "bad_hail";
-
-        private const string RejectBadVersion = "bad_version";
-
-        private const string RejectServerError = "server_error";
 
         private static readonly IConnection[] EmptyConnections = { };
 
@@ -494,6 +489,7 @@ namespace Intersect.Network
                             Log.Diagnostic($"{message.MessageType}: {message} [{connection?.Status}]");
 
                             break;
+
                         case NetConnectionStatus.Disconnecting:
                             Log.Debug($"{message.MessageType}: {message} [{connection?.Status}]");
 
@@ -515,7 +511,14 @@ namespace Intersect.Network
                                 }
 
                                 FireHandler(
-                                    OnConnectionApproved, nameof(OnConnectionApproved), this, intersectConnection
+                                    OnConnectionApproved,
+                                    nameof(OnConnectionApproved),
+                                    this,
+                                    new ConnectionEventArgs
+                                    {
+                                        NetworkStatus = NetworkStatus.Connecting,
+                                        Connection = intersectConnection
+                                    }
                                 );
 
                                 Debug.Assert(connection != null, "connection != null");
@@ -523,14 +526,13 @@ namespace Intersect.Network
 
                                 if (!intersectConnection.HandleApproval(approval))
                                 {
-                                    mNetwork?.Disconnect("bad_handshake_secret");
-                                    connection.Disconnect("bad_handshake_secret");
+                                    mNetwork.Disconnect(NetworkStatus.HandshakeFailure.ToString());
+                                    connection.Disconnect(NetworkStatus.HandshakeFailure.ToString());
 
                                     break;
                                 }
 
-                                var clientNetwork = mNetwork as ClientNetwork;
-                                if (clientNetwork == null)
+                                if (!(mNetwork is ClientNetwork clientNetwork))
                                 {
                                     throw new InvalidOperationException();
                                 }
@@ -559,7 +561,16 @@ namespace Intersect.Network
                                 intersectConnection?.HandleConnected();
                             }
 
-                            FireHandler(OnConnected, nameof(OnConnected), this, intersectConnection);
+                            FireHandler(
+                                OnConnected,
+                                nameof(OnConnected),
+                                this,
+                                new ConnectionEventArgs
+                                {
+                                    NetworkStatus = NetworkStatus.Online,
+                                    Connection = intersectConnection
+                                }
+                            );
                         }
 
                             break;
@@ -571,29 +582,45 @@ namespace Intersect.Network
                             var result = (NetConnectionStatus) message.ReadByte();
                             var reason = message.ReadString();
 
+                            NetworkStatus networkStatus;
+                            try
+                            {
+                                networkStatus = (NetworkStatus) Enum.Parse(typeof(NetworkStatus), reason, true);
+                            }
+                            catch (Exception exception)
+                            {
+                                Log.Diagnostic(exception);
+                                networkStatus = NetworkStatus.Unknown;
+                            }
+
                             HandleConnectionEvent disconnectHandler;
                             string disconnectHandlerName;
-                            switch (reason)
+                            switch (networkStatus)
                             {
-                                case RejectBadHail:
-                                case RejectBadVersion:
-                                case RejectServerError:
+                                case NetworkStatus.Unknown:
+                                case NetworkStatus.HandshakeFailure:
+                                case NetworkStatus.ServerFull:
+                                case NetworkStatus.VersionMismatch:
+                                case NetworkStatus.Failed:
                                     disconnectHandler = OnConnectionDenied;
                                     disconnectHandlerName = nameof(OnConnectionDenied);
+                                    break;
 
+                                case NetworkStatus.Connecting:
+                                case NetworkStatus.Online:
+                                case NetworkStatus.Offline:
+                                    disconnectHandler = OnDisconnected;
+                                    disconnectHandlerName = nameof(OnDisconnected);
                                     break;
 
                                 default:
-                                    disconnectHandler = OnDisconnected;
-                                    disconnectHandlerName = nameof(OnDisconnected);
-
-                                    break;
+                                    throw new ArgumentOutOfRangeException();
                             }
 
                             if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
                             {
                                 Log.Debug($"Unknown client disconnected ({lidgrenIdHex}).");
-                                FireHandler(disconnectHandler, disconnectHandlerName, this, null);
+                                FireHandler(disconnectHandler, disconnectHandlerName, this, new ConnectionEventArgs { NetworkStatus = networkStatus });
 
                                 break;
                             }
@@ -602,7 +629,8 @@ namespace Intersect.Network
                             if (client != null)
                             {
                                 client.HandleDisconnected();
-                                FireHandler(disconnectHandler, disconnectHandlerName, this, client);
+
+                                FireHandler(disconnectHandler, disconnectHandlerName, this, new ConnectionEventArgs { Connection = client, NetworkStatus = NetworkStatus.Offline });
                                 mNetwork.RemoveConnection(client);
                             }
 
@@ -625,59 +653,66 @@ namespace Intersect.Network
 
                 case NetIncomingMessageType.ConnectionApproval:
                 {
-                    var hail = (HailPacket) mCeras.Deserialize(message.Data);
-
-                    Debug.Assert(SharedConstants.VersionData != null, "SharedConstants.VERSION_DATA != null");
-                    Debug.Assert(hail.VersionData != null, "hail.VersionData != null");
-                    if (!SharedConstants.VersionData.SequenceEqual(hail.VersionData))
+                    try
                     {
-                        Log.Error($"Bad version detected, denying connection [{lidgrenIdHex}].");
-                        connection?.Deny(RejectBadVersion);
+                        var hail = (HailPacket) mCeras.Deserialize(message.Data);
 
-                        break;
+                        Debug.Assert(SharedConstants.VersionData != null, "SharedConstants.VERSION_DATA != null");
+                        Debug.Assert(hail.VersionData != null, "hail.VersionData != null");
+                        if (!SharedConstants.VersionData.SequenceEqual(hail.VersionData))
+                        {
+                            Log.Error($"Bad version detected, denying connection [{lidgrenIdHex}].");
+                            connection?.Deny(NetworkStatus.VersionMismatch.ToString());
+
+                            break;
+                        }
+
+                        if (OnConnectionApproved == null)
+                        {
+                            Log.Error($"No handlers for OnConnectionApproved, denying connection [{lidgrenIdHex}].");
+                            connection?.Deny(NetworkStatus.Failed.ToString());
+
+                            break;
+                        }
+
+                        /* Approving connection from here-on. */
+                        var aesKey = new byte[32];
+                        mRng?.GetNonZeroBytes(aesKey);
+                        var client = new LidgrenConnection(mNetwork, connection, aesKey, hail.RsaParameters);
+
+                        if (!OnConnectionRequested(this, client))
+                        {
+                            Log.Warn($"Connection blocked due to ban or ip filter!");
+                            connection?.Deny(NetworkStatus.Failed.ToString());
+
+                            break;
+                        }
+
+                        Debug.Assert(mNetwork != null, "mNetwork != null");
+                        if (!mNetwork.AddConnection(client))
+                        {
+                            Log.Error($"Failed to add the connection.");
+                            connection?.Deny(NetworkStatus.Failed.ToString());
+
+                            break;
+                        }
+
+                        Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
+                        Debug.Assert(connection != null, "connection != null");
+                        mGuidLookup.Add(connection.RemoteUniqueIdentifier, client.Guid);
+
+                        Debug.Assert(mPeer != null, "mPeer != null");
+                        var approval = new ApprovalPacket(client.Rsa, hail.HandshakeSecret, aesKey, client.Guid);
+                        var approvalMessage = mPeer.CreateMessage();
+                        approvalMessage.Data = approval.Data;
+                        approvalMessage.LengthBytes = approvalMessage.Data.Length;
+                        connection.Approve(approvalMessage);
+                        OnConnectionApproved(this, new ConnectionEventArgs { Connection = client, NetworkStatus = NetworkStatus.Online });
                     }
-
-                    if (OnConnectionApproved == null)
+                    catch
                     {
-                        Log.Error($"No handlers for OnConnectionApproved, denying connection [{lidgrenIdHex}].");
-                        connection?.Deny(RejectServerError);
-
-                        break;
+                        connection?.Deny(NetworkStatus.Failed.ToString());
                     }
-
-                    /* Approving connection from here-on. */
-                    var aesKey = new byte[32];
-                    mRng?.GetNonZeroBytes(aesKey);
-                    var client = new LidgrenConnection(mNetwork, connection, aesKey, hail.RsaParameters);
-
-                    if (!OnConnectionRequested(this, client))
-                    {
-                        Log.Warn($"Connection blocked due to ban or ip filter!");
-                        connection?.Deny(RejectServerError);
-
-                        break;
-                    }
-
-                    Debug.Assert(mNetwork != null, "mNetwork != null");
-                    if (!mNetwork.AddConnection(client))
-                    {
-                        Log.Error($"Failed to add the connection.");
-                        connection?.Deny(RejectServerError);
-
-                        break;
-                    }
-
-                    Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
-                    Debug.Assert(connection != null, "connection != null");
-                    mGuidLookup.Add(connection.RemoteUniqueIdentifier, client.Guid);
-
-                    Debug.Assert(mPeer != null, "mPeer != null");
-                    var approval = new ApprovalPacket(client.Rsa, hail.HandshakeSecret, aesKey, client.Guid);
-                    var approvalMessage = mPeer.CreateMessage();
-                    approvalMessage.Data = approval.Data;
-                    approvalMessage.LengthBytes = approvalMessage.Data.Length;
-                    connection.Approve(approvalMessage);
-                    OnConnectionApproved(this, client);
 
                     break;
                 }
@@ -726,11 +761,11 @@ namespace Intersect.Network
         private bool FireHandler(
             HandleConnectionEvent handler,
             string name,
-            INetworkLayerInterface sender,
-            IConnection connection
+            [NotNull] INetworkLayerInterface sender,
+            [NotNull] ConnectionEventArgs connectionEventArgs
         )
         {
-            handler?.Invoke(sender, connection);
+            handler?.Invoke(sender, connectionEventArgs);
 
             if (handler == null)
             {

--- a/Intersect.Network/LidgrenInterface.cs
+++ b/Intersect.Network/LidgrenInterface.cs
@@ -585,7 +585,16 @@ namespace Intersect.Network
                             NetworkStatus networkStatus;
                             try
                             {
-                                networkStatus = (NetworkStatus) Enum.Parse(typeof(NetworkStatus), reason, true);
+                                switch (reason)
+                                {
+                                    //Lidgren won't accept a connection with a bad version and sends this message back so we need to manually handle it
+                                    case "Wrong application identifier!":
+                                        networkStatus = NetworkStatus.VersionMismatch;
+                                        break;
+                                    default:
+                                        networkStatus = (NetworkStatus)Enum.Parse(typeof(NetworkStatus), reason, true);
+                                        break;
+                                }
                             }
                             catch (Exception exception)
                             {


### PR DESCRIPTION
Implements more detailed server status details for the main menu in the client for #63.

Introduces server full string and network status enum, but it is *not* currently used.

"Server full" will be implemented separately in the future to fulfill #77.