### PR TITLE
Fix 94: Add non-response reason and treat unknown as disconnect

### DIFF
--- a/Intersect.Network/LidgrenInterface.cs
+++ b/Intersect.Network/LidgrenInterface.cs
@@ -591,11 +591,17 @@ namespace Intersect.Network
                                     case "Wrong application identifier!":
                                         networkStatus = NetworkStatus.VersionMismatch;
                                         break;
+
                                     case "Connection timed out":
                                         networkStatus = NetworkStatus.Quitting;
                                         break;
+
+                                    case "Failed to establish connection - no response from remote host":
+                                        networkStatus = NetworkStatus.Offline;
+                                        break;
+
                                     default:
-                                        networkStatus = (NetworkStatus)Enum.Parse(typeof(NetworkStatus), reason, true);
+                                        networkStatus = (NetworkStatus)Enum.Parse(typeof(NetworkStatus), reason ?? "<null>", true);
                                         break;
                                 }
                             }
@@ -609,7 +615,6 @@ namespace Intersect.Network
                             string disconnectHandlerName;
                             switch (networkStatus)
                             {
-                                case NetworkStatus.Unknown:
                                 case NetworkStatus.HandshakeFailure:
                                 case NetworkStatus.ServerFull:
                                 case NetworkStatus.VersionMismatch:
@@ -622,6 +627,7 @@ namespace Intersect.Network
                                 case NetworkStatus.Online:
                                 case NetworkStatus.Offline:
                                 case NetworkStatus.Quitting:
+                                case NetworkStatus.Unknown:
                                     disconnectHandler = OnDisconnected;
                                     disconnectHandlerName = nameof(OnDisconnected);
                                     break;


### PR DESCRIPTION
Resolves #94 

**Issue**:
When the server is offline for a sufficient duration it is given a disconnect reason of `Failed to establish connection - no response from remote host`, which didn't have a mapping.

That moved it to a status of `Unknown` which was being treated as a denial of connection.

After connection denial, the client makes no further attempts to connect to the server.

**Resolution**:
Add additional mapping to offline.

Treat unknown as disconnect instead of denial.