### PR TITLE
 Unselect a target without using the mouse

### DIFF
--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -56,7 +56,14 @@ namespace Intersect.Client.Core
                     return;
                 }
 
-                Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+                if (Globals.Me?.TargetBox != null)
+                {
+                    Globals.Me?.TryTarget(true);
+                }
+                else
+                {
+                    Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+                }
             }
 
             if (Interface.Interface.HasInputFocus())
@@ -286,7 +293,7 @@ namespace Intersect.Client.Core
                 return;
             }
 
-            if (Globals.Me.TryTarget())
+            if (Globals.Me.TryTarget(false))
             {
                 return;
             }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1096,7 +1096,7 @@ namespace Intersect.Client.Entities
             return false;
         }
 
-        public bool TryTarget()
+        public bool TryTarget(bool removeTarget)
         {
             //Check for taunt status if so don't allow to change target
             for (var i = 0; i < Status.Count; i++)
@@ -1137,7 +1137,8 @@ namespace Intersect.Client.Entities
                                 if (en.Value.CurrentMap == mapId &&
                                     en.Value.X == x &&
                                     en.Value.Y == y &&
-                                    (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                                    (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)) ||
+                                    removeTarget)
                                 {
                                     if (en.Value.GetType() != typeof(Projectile) &&
                                         en.Value.GetType() != typeof(Resource))
@@ -1165,7 +1166,7 @@ namespace Intersect.Client.Entities
                                             }
                                         }
 
-                                        if (TargetType == 0 && TargetIndex == en.Value.Id)
+                                        if (TargetType == 0 && TargetIndex == en.Value.Id || removeTarget)
                                         {
                                             ClearTarget();
 


### PR DESCRIPTION
Sometimes you want to unselect a target without using the mouse. With this patch, you can click on Esc to do so.