### PR TITLE
Upgrading monogame to dev

### DIFF
--- a/Intersect.Client/Intersect.Client.csproj
+++ b/Intersect.Client/Intersect.Client.csproj
@@ -198,8 +198,8 @@
       <HintPath>..\packages\AscensionGameDev.Lidgren.Network.1.7.2\lib\net46\Lidgren.Network.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MonoGame.Framework, Version=3.7.1.189, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\lib\net45\MonoGame.Framework.dll</HintPath>
+    <Reference Include="MonoGame.Framework, Version=3.8.0.1217, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\lib\net452\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -215,39 +215,39 @@
     <EmbeddedResource Include="Icon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\lib\net45\MonoGame.Framework.dll">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\lib\net452\MonoGame.Framework.dll">
       <Link>Resources\MonoGame.Framework.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x86\SDL2.dll">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\win-x86\native\SDL2.dll">
       <Link>Resources\x86\SDL2.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x64\SDL2.dll">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\win-x64\native\SDL2.dll">
       <Link>Resources\x64\SDL2.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x86\soft_oal.dll">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\win-x86\native\soft_oal.dll">
       <Link>Resources\x86\soft_oal.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x64\soft_oal.dll">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\win-x64\native\soft_oal.dll">
       <Link>Resources\x64\soft_oal.dll</Link>
     </EmbeddedResource>
     <None Include="app.config" />
     <None Include="packages.config" />
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x86\libSDL2-2.0.so.0">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\linux-x64\native\libSDL2-2.0.so.0">
       <Link>Resources\x86\libSDL2</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x64\libSDL2-2.0.so.0">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\linux-x64\native\libSDL2-2.0.so.0">
       <Link>Resources\x64\libSDL2</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x86\libopenal.so.1">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\linux-x64\native\libopenal.so.1">
       <Link>Resources\x86\libopenal</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\x64\libopenal.so.1">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\linux-x64\native\libopenal.so.1">
       <Link>Resources\x64\libopenal</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\libSDL2-2.0.0.dylib">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\osx\native\libSDL2-2.0.0.dylib">
       <Link>Resources\libSDL2-2.0.0.dylib</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\native\libopenal.1.dylib">
+    <EmbeddedResource Include="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\runtimes\osx\native\libopenal.1.dylib">
       <Link>Resources\libopenal.1.dylib</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
@@ -297,14 +297,14 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\MonoGame.Framework.DesktopGL.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\MonoGame.Framework.DesktopGL.targets'))" />
     <Error Condition="!Exists('..\packages\MonoGame.Content.Builder.3.7.0.9\build\MonoGame.Content.Builder.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MonoGame.Content.Builder.3.7.0.9\build\MonoGame.Content.Builder.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Fody.4.2.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.4.2.1\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\build\MonoGame.Framework.DesktopGL.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\build\MonoGame.Framework.DesktopGL.targets'))" />
   </Target>
-  <Import Project="..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\MonoGame.Framework.DesktopGL.targets" Condition="Exists('..\packages\MonoGame.Framework.DesktopGL.3.7.1.189\build\MonoGame.Framework.DesktopGL.targets')" />
   <Import Project="..\packages\MonoGame.Content.Builder.3.7.0.9\build\MonoGame.Content.Builder.targets" Condition="Exists('..\packages\MonoGame.Content.Builder.3.7.0.9\build\MonoGame.Content.Builder.targets')" />
   <Import Project="..\packages\Fody.4.2.1\build\Fody.targets" Condition="Exists('..\packages\Fody.4.2.1\build\Fody.targets')" />
+  <Import Project="..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\build\MonoGame.Framework.DesktopGL.targets" Condition="Exists('..\packages\MonoGame.Framework.DesktopGL.3.8.0.1217-develop\build\MonoGame.Framework.DesktopGL.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Intersect.Client/MonoGame/Audio/MonoMusicSource.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoMusicSource.cs
@@ -3,13 +3,9 @@
 using Intersect.Client.Framework.Audio;
 using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Localization;
-using Intersect.Client.Utilities;
 using Intersect.Logging;
 
-using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Media;
-
-using NVorbis;
 
 namespace Intersect.Client.MonoGame.Audio
 {
@@ -18,10 +14,6 @@ namespace Intersect.Client.MonoGame.Audio
     {
 
         private readonly string mPath;
-
-        private VorbisReader mReader;
-
-        private DynamicSoundEffectInstance mInstance;
 
         public MonoMusicSource(string path)
         {
@@ -33,28 +25,13 @@ namespace Intersect.Client.MonoGame.Audio
             return new MonoMusicInstance(this);
         }
 
-        public DynamicSoundEffectInstance LoadSong()
+        public Song LoadSong()
         {
             if (!string.IsNullOrWhiteSpace(mPath))
             {
                 try
                 {
-                    if (mReader == null)
-                    {
-                        mReader = new VorbisReader(mPath);
-                    }
-
-                    if (mInstance != null)
-                    {
-                        mInstance.Dispose();
-                        mInstance = null;
-                    }
-
-                    mInstance = new DynamicSoundEffectInstance(mReader.SampleRate, mReader.Channels == 1 ? AudioChannels.Mono : AudioChannels.Stereo);
-                    mInstance.BufferNeeded += BufferNeeded;
-
-
-                    return mInstance;
+                    return Song.FromUri(mPath, new Uri(mPath, UriKind.Relative));
                 }
                 catch (Exception exception)
                 {
@@ -68,47 +45,6 @@ namespace Intersect.Client.MonoGame.Audio
             }
 
             return null;
-        }
-
-        public void Close()
-        {
-            if (mReader != null)
-            {
-                mReader.Dispose();
-                mReader = null;
-            }
-        }
-
-        private void BufferNeeded(object sender, EventArgs args)
-            => FillBuffers();
-
-        private void FillBuffers(int buffers = 3, int samples = 44100)
-        {
-            float[] sampleBuffer = null;
-
-            while (mInstance.PendingBufferCount < buffers && mReader != null)
-            {
-                if (sampleBuffer == null)
-                    sampleBuffer = new float[samples];
-
-                var read = mReader.ReadSamples(sampleBuffer, 0, sampleBuffer.Length);
-                if (read == 0)
-                {
-                    mReader.DecodedPosition = 0;
-                    continue;
-                }
-
-                var dataBuffer = new byte[read << 1];
-                for (var sampleIndex = 0; sampleIndex < read; ++sampleIndex)
-                {
-                    var sample = (short)MathHelper.Clamp(sampleBuffer[sampleIndex] * 32767f, short.MinValue, short.MaxValue);
-                    var sampleData = BitConverter.GetBytes(sample);
-                    for (var sampleByteIndex = 0; sampleByteIndex < sampleData.Length; ++sampleByteIndex)
-                        dataBuffer[(sampleIndex << 1) + sampleByteIndex] = sampleData[sampleByteIndex];
-                }
-
-                mInstance.SubmitBuffer(dataBuffer, 0, read << 1);
-            }
         }
 
     }

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -97,6 +97,7 @@ namespace Intersect.Client.MonoGame.Graphics
             mGame = monoGame;
             mGraphics = graphics;
             mContentManager = contentManager;
+            mGraphics.PreferHalfPixelOffset = true;
 
             mNormalState = new BlendState()
             {

--- a/Intersect.Client/Networking/NetworkStatus.cs
+++ b/Intersect.Client/Networking/NetworkStatus.cs
@@ -37,6 +37,9 @@ namespace Intersect.Client.Networking
                 case NetworkStatus.HandshakeFailure:
                     return Strings.Server.HandshakeFailure;
 
+                case NetworkStatus.Quitting:
+                    return "";
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(networkStatus), networkStatus, null);
             }

--- a/Intersect.Client/app.config
+++ b/Intersect.Client/app.config
@@ -7,8 +7,7 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions"
-                          publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -20,13 +19,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -34,8 +31,7 @@
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -55,13 +51,11 @@
         <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a"
-                          culture="neutral" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -77,8 +71,7 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"
-                          culture="neutral" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>

--- a/Intersect.Client/packages.config
+++ b/Intersect.Client/packages.config
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="AscensionGameDev.Lidgren.Network" version="1.7.2" targetFramework="net461" />
   <package id="Costura.Fody" version="3.3.3" targetFramework="net461" developmentDependency="true" />
   <package id="Fody" version="4.2.1" targetFramework="net461" developmentDependency="true" />
   <package id="JetBrains.Annotations" version="2018.3.0" targetFramework="net461" />
   <package id="MonoGame.Content.Builder" version="3.7.0.9" targetFramework="net461" />
-  <package id="MonoGame.Framework.DesktopGL" version="3.7.1.189" targetFramework="net461" />
+  <package id="MonoGame.Framework.DesktopGL" version="3.8.0.1217-develop" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/Intersect.Tests.Client/app.config
+++ b/Intersect.Tests.Client/app.config
@@ -4,8 +4,7 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -17,8 +16,7 @@
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -30,8 +28,7 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a"
-                          culture="neutral" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -39,18 +36,15 @@
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions"
-                          publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60"
-                          culture="neutral" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
@@ -70,8 +64,7 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"
-                          culture="neutral" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
       <dependentAssembly>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,5 +4,6 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="nuget2" value="https://www.nuget.org/api/v2" />
     <add key="Nancy MyGet" value="https://www.myget.org/F/nancyfx/api/v3/index.json" />
+	<add key="MonoGame Dev" value="http://teamcity.monogame.net/guestAuth/app/nuget/v1/FeedService.svc/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Upgrades the version of MonoGame we use to a recent develop build with our OpenGL audio fixes included.

Nothing really important to note here other than it also requires an updated radial gradient shader.

People will need to download and replace their Client/resources/shaders/radialgradient.xnb with the one inside [this zip archive](https://github.com/AscensionGameDev/Intersect-Engine/files/4464398/radialgradient.zip).

This also reverts our DynamicSoundEffectInstance changes and goes back to using Songs/MediaPlayer for ogg playback since it handles streaming really well.

This will resolve #116 and resolve #102.

@panda please feel free to add your review but please don't merge yet. Thanks!


