### PR TITLE
Added loot ownership

### DIFF
--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -14,6 +14,8 @@ namespace Intersect.Config
 
         public int ItemDespawnTime = 15000;
 
+        public int ItemOwnershipTime = 5000;
+
         public int ItemSpawnTime = 15000;
 
         public int TileHeight = 32;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -119,6 +119,8 @@ namespace Intersect
 
         public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
 
+        public static int ItemOwnershipTime => Instance.MapOpts.ItemOwnershipTime;
+
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
         public static int MapWidth => Instance?.MapOpts?.Width ?? 32;

--- a/Intersect.Client/Items/MapItem.cs
+++ b/Intersect.Client/Items/MapItem.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+
 
 namespace Intersect.Client.Items
 {

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1510,7 +1510,7 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1);
+            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1, Id);
 
             slot.Quantity = Math.Max(0, slot.Quantity - amount);
 

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -215,6 +215,11 @@ namespace Intersect.Server.Maps
 
         public void SpawnItem(int x, int y, Item item, int amount)
         {
+            this.SpawnItem(x, y, item, amount, Guid.Empty);
+        }
+
+        public void SpawnItem(int x, int y, Item item, int amount, Guid owner)
+        {
             if (item == null)
             {
                 Log.Warn($"Tried to spawn {amount} of a null item at ({x}, {y}) in map {Id}.");
@@ -234,7 +239,9 @@ namespace Intersect.Server.Maps
             {
                 X = x,
                 Y = y,
-                DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime
+                DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime,
+                Owner = owner,
+                OwnershipTime = Globals.Timing.TimeMs + Options.ItemOwnershipTime
             };
 
             if (itemBase.ItemType == ItemTypes.Equipment)

--- a/Intersect.Server/Maps/MapItemInstance.cs
+++ b/Intersect.Server/Maps/MapItemInstance.cs
@@ -17,6 +17,10 @@ namespace Intersect.Server.Maps
 
         [JsonIgnore] public long DespawnTime;
 
+        [JsonIgnore] public Guid Owner;
+
+        [JsonIgnore] public long OwnershipTime;
+
         public int X = 0;
 
         public int Y = 0;


### PR DESCRIPTION
* Map items can be spawned with an owner, and only be picked up by the owner and their party. Anyone can still see it, however.
* The time that loot is exclusive to the owner and their party is configurable through the server's config.json under Map Options.
* NPC Drops are owned by the player (and their party) that dealt the most damage to them. (Unless killed by an NPC or something else, then there is no owner)
* Player drops on death are owned by whoever dealt the killing blow and their party.
* Items dropped from your inventory to the map are owned by you and your party until the timer expires.

* Made the packet handler for PickupItempacket slightly less a hassle to read by shortening some checks.