### PR TITLE
Assigning loot ownership + small fixes

### DIFF
--- a/Intersect (Core)/Config/LootOptions.cs
+++ b/Intersect (Core)/Config/LootOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Intersect.Config
+{
+    public class LootOptions
+    {
+
+        // Defines how long (in ms) an item drop will be ''owned'' by a player and their party.
+        public int ItemOwnershipTime = 5000;
+
+        // Defines whether players can see items they do not ''own'' on the map.
+        public bool ShowUnownedItems = false;
+    }
+}

--- a/Intersect (Core)/Config/LootOptions.cs
+++ b/Intersect (Core)/Config/LootOptions.cs
@@ -7,6 +7,11 @@
     {
 
         /// <summary>
+        /// Defines how long (in ms) loot will be available for picking up on the map.
+        /// </summary>
+        public int ItemDespawnTime = 15000;
+
+        /// <summary>
         /// Defines how long (in ms) an item drop will be ''owned'' by a player and their party.
         /// </summary>
         public int ItemOwnershipTime = 5000;

--- a/Intersect (Core)/Config/LootOptions.cs
+++ b/Intersect (Core)/Config/LootOptions.cs
@@ -1,12 +1,19 @@
 ﻿namespace Intersect.Config
 {
+    /// <summary>
+    /// Contains configurable options pertaining to the way loot (item) drops are handled by the engine.
+    /// </summary>
     public class LootOptions
     {
 
-        // Defines how long (in ms) an item drop will be ''owned'' by a player and their party.
+        /// <summary>
+        /// Defines how long (in ms) an item drop will be ''owned'' by a player and their party.
+        /// </summary>
         public int ItemOwnershipTime = 5000;
 
-        // Defines whether players can see items they do not ''own'' on the map.
+        /// <summary>
+        /// Defines whether players can see items they do not ''own'' on the map.
+        /// </summary>
         public bool ShowUnownedItems = false;
     }
 }

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -14,6 +14,8 @@ namespace Intersect.Config
 
         public int ItemDespawnTime = 15000;
 
+        public int ItemOwnershipTime = 5000;
+
         public int ItemSpawnTime = 15000;
 
         public int TileHeight = 32;

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -14,10 +14,6 @@ namespace Intersect.Config
 
         public int ItemDespawnTime = 15000;
 
-        public int ItemOwnershipTime = 5000;
-
-        public bool ShowUnownedItems = false;
-
         public int ItemSpawnTime = 15000;
 
         public int TileHeight = 32;

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -12,8 +12,10 @@ namespace Intersect.Config
 
         public int Height = 26;
 
+        // TODO: (panda) Move this to the LootOptions class, this is unrelated to map attribute items. (https://github.com/AscensionGameDev/Intersect-Engine/pull/181#issuecomment-619745057)
         public int ItemDespawnTime = 15000;
 
+        // TODO: (panda) Rename to something like MapItemRespawnItem for clarity, would need an alias to the original however. (https://github.com/AscensionGameDev/Intersect-Engine/pull/181#issuecomment-619745057)
         public int ItemSpawnTime = 15000;
 
         public int TileHeight = 32;

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -16,6 +16,8 @@ namespace Intersect.Config
 
         public int ItemOwnershipTime = 5000;
 
+        public bool ShowUnownedItems = false;
+
         public int ItemSpawnTime = 15000;
 
         public int TileHeight = 32;

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -12,11 +12,7 @@ namespace Intersect.Config
 
         public int Height = 26;
 
-        // TODO: (panda) Move this to the LootOptions class, this is unrelated to map attribute items. (https://github.com/AscensionGameDev/Intersect-Engine/pull/181#issuecomment-619745057)
-        public int ItemDespawnTime = 15000;
-
-        // TODO: (panda) Rename to something like MapItemRespawnItem for clarity, would need an alias to the original however. (https://github.com/AscensionGameDev/Intersect-Engine/pull/181#issuecomment-619745057)
-        public int ItemSpawnTime = 15000;
+        public int ItemAttributeRespawnTime = 15000;
 
         public int TileHeight = 32;
 

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -137,9 +137,7 @@ namespace Intersect
 
         public static int MinChatInterval => Instance.ChatOpts.MinIntervalBetweenChats;
 
-        public static bool ShowUnownedItems => Instance.LootOpts.ShowUnownedItems;
-
-        public static int ItemOwnershipTime => Instance.LootOpts.ItemOwnershipTime;
+        public static LootOptions Loot => Instance.LootOpts;
 
         public static bool UPnP => Instance._upnp;
 

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -119,6 +119,8 @@ namespace Intersect
 
         public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
 
+        public static int ItemOwnershipTime => Instance.MapOpts.ItemOwnershipTime;
+
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
         public static int MapWidth => Instance?.MapOpts?.Width ?? 32;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -119,6 +119,8 @@ namespace Intersect
 
         public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
 
+        public static bool ShowUnownedItems => Instance.MapOpts.ShowUnownedItems;
+
         public static int ItemOwnershipTime => Instance.MapOpts.ItemOwnershipTime;
 
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -117,10 +117,6 @@ namespace Intersect
 
         public static int GameBorderStyle => Instance.MapOpts.GameBorderStyle;
 
-        public static int ItemRepawnTime => Instance.MapOpts.ItemSpawnTime;
-
-        public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
-
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
         public static int MapWidth => Instance?.MapOpts?.Width ?? 32;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -54,6 +54,8 @@ namespace Intersect
 
         [JsonProperty("Security")] public SecurityOptions SecurityOpts = new SecurityOptions();
 
+        [JsonProperty("Loot")] public LootOptions LootOpts = new LootOptions();
+
         public SmtpSettings SmtpSettings = new SmtpSettings();
 
         [NotNull]
@@ -119,10 +121,6 @@ namespace Intersect
 
         public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
 
-        public static bool ShowUnownedItems => Instance.MapOpts.ShowUnownedItems;
-
-        public static int ItemOwnershipTime => Instance.MapOpts.ItemOwnershipTime;
-
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
         public static int MapWidth => Instance?.MapOpts?.Width ?? 32;
@@ -138,6 +136,10 @@ namespace Intersect
         public static int MaxChatLength => Instance.ChatOpts.MaxChatLength;
 
         public static int MinChatInterval => Instance.ChatOpts.MinIntervalBetweenChats;
+
+        public static bool ShowUnownedItems => Instance.LootOpts.ShowUnownedItems;
+
+        public static int ItemOwnershipTime => Instance.LootOpts.ItemOwnershipTime;
 
         public static bool UPnP => Instance._upnp;
 

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -191,6 +191,7 @@
     <Compile Include="Configuration\IConfiguration.cs" />
     <Compile Include="Configuration\ConfigurationHelper.cs" />
     <Compile Include="Config\ChatOptions.cs" />
+    <Compile Include="Config\LootOptions.cs" />
     <Compile Include="Config\PacketOptions.cs" />
     <Compile Include="Config\PartyOptions.cs" />
     <Compile Include="Config\SecurityOptions.cs" />

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -846,7 +846,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
                     {
                         return;
                     }
@@ -1217,7 +1217,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
                     {
                         return;
                     }
@@ -1309,7 +1309,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
                     {
                         return;
                     }
@@ -1430,7 +1430,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
                     {
                         return;
                     }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -846,7 +846,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1217,7 +1217,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1309,7 +1309,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1430,7 +1430,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me || this is Player player && !Globals.Me.IsInMyParty(player))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -115,7 +115,7 @@ namespace Intersect.Client.Entities
             return Party.Count > 0;
         }
 
-        public bool IsInMyParty(Player player) => Party.Any(member => member.Id == player.Id);
+        public bool IsInMyParty(Player player) => IsInMyParty(player.Id);
 
         public bool IsInMyParty(Guid id) => Party.Any(member => member.Id == id);
 
@@ -877,7 +877,7 @@ namespace Intersect.Client.Entities
                     if (en.Value.GetEntityType() == EntityTypes.GlobalEntity ||
                         en.Value.GetEntityType() == EntityTypes.Player)
                     {
-                        if (en.Value != Globals.Me || en.Value is Player player && Globals.Me.IsInMyParty(player))
+                        if (en.Value != Globals.Me && !(en.Value is Player player && Globals.Me.IsInMyParty(player)))
                         {
                             if (GetDistanceTo(en.Value) < GetDistanceTo(closestEntity))
                             {
@@ -1191,7 +1191,7 @@ namespace Intersect.Client.Entities
                                         en.Value.X == x &&
                                         en.Value.Y == y &&
                                         !((Event) en.Value).DisablePreview &&
-                                        !en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player))
+                                        (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                                     {
                                         if (TargetBox != null)
                                         {

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -130,6 +130,19 @@ namespace Intersect.Client.Entities
             return false;
         }
 
+        public bool IsInMyParty(Guid id)
+        {
+            foreach (var member in Party)
+            {
+                if (member.Id == Id)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public bool IsBusy()
         {
             return !(Globals.EventHolds.Count == 0 &&
@@ -1267,6 +1280,13 @@ namespace Intersect.Client.Entities
             {
                 if (item.Value.X == X && item.Value.Y == Y)
                 {
+                    // Are we allowed to see and pick this item up?
+                    if (!item.Value.VisibleToAll && !item.Value.Owner.Equals(Globals.Me.Id) && !Globals.Me.IsInMyParty(item.Value.Owner))
+                    {
+                        // This item does not apply to us!
+                        return false;
+                    }
+
                     PacketSender.SendPickupItem(item.Key);
 
                     return true;

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Intersect.Client.Core;
@@ -114,34 +115,9 @@ namespace Intersect.Client.Entities
             return Party.Count > 0;
         }
 
-        public bool IsInMyParty(Entity entity)
-        {
-            if (EntityTypes.Player == entity.GetEntityType())
-            {
-                foreach (var member in Party)
-                {
-                    if (member.Id == entity.Id)
-                    {
-                        return true;
-                    }
-                }
-            }
+        public bool IsInMyParty(Player player) => Party.Any(member => member.Id == player.Id);
 
-            return false;
-        }
-
-        public bool IsInMyParty(Guid id)
-        {
-            foreach (var member in Party)
-            {
-                if (member.Id == Id)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+        public bool IsInMyParty(Guid id) => Party.Any(member => member.Id == id);
 
         public bool IsBusy()
         {
@@ -901,7 +877,7 @@ namespace Intersect.Client.Entities
                     if (en.Value.GetEntityType() == EntityTypes.GlobalEntity ||
                         en.Value.GetEntityType() == EntityTypes.Player)
                     {
-                        if (en.Value != Globals.Me && !Globals.Me.IsInMyParty(en.Value))
+                        if (en.Value != Globals.Me || en.Value is Player player && Globals.Me.IsInMyParty(player))
                         {
                             if (GetDistanceTo(en.Value) < GetDistanceTo(closestEntity))
                             {
@@ -1150,7 +1126,7 @@ namespace Intersect.Client.Entities
                                 if (en.Value.CurrentMap == mapId &&
                                     en.Value.X == x &&
                                     en.Value.Y == y &&
-                                    (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                                    (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                                 {
                                     if (en.Value.GetType() != typeof(Projectile) &&
                                         en.Value.GetType() != typeof(Resource))
@@ -1215,7 +1191,7 @@ namespace Intersect.Client.Entities
                                         en.Value.X == x &&
                                         en.Value.Y == y &&
                                         !((Event) en.Value).DisablePreview &&
-                                        (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                                        !en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player))
                                     {
                                         if (TargetBox != null)
                                         {
@@ -1281,7 +1257,7 @@ namespace Intersect.Client.Entities
                 if (item.Value.X == X && item.Value.Y == Y)
                 {
                     // Are we allowed to see and pick this item up?
-                    if (!item.Value.VisibleToAll && !item.Value.Owner.Equals(Globals.Me.Id) && !Globals.Me.IsInMyParty(item.Value.Owner))
+                    if (!item.Value.VisibleToAll && item.Value.Owner != Globals.Me.Id && !Globals.Me.IsInMyParty(item.Value.Owner))
                     {
                         // This item does not apply to us!
                         return false;
@@ -1795,7 +1771,7 @@ namespace Intersect.Client.Entities
                     continue;
                 }
 
-                if (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value))
+                if (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player))
                 {
                     if (en.Value.GetType() != typeof(Projectile) && en.Value.GetType() != typeof(Resource))
                     {
@@ -1823,7 +1799,7 @@ namespace Intersect.Client.Entities
 
                     if (en.Value.CurrentMap == eventMap.Id &&
                         !((Event) en.Value).DisablePreview &&
-                        (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                        (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         if (TargetType == 1 && TargetIndex == en.Value.Id)
                         {

--- a/Intersect.Client/Items/MapItem.cs
+++ b/Intersect.Client/Items/MapItem.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+
 
 namespace Intersect.Client.Items
 {

--- a/Intersect.Client/Items/MapItem.cs
+++ b/Intersect.Client/Items/MapItem.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 
 namespace Intersect.Client.Items
@@ -10,6 +11,10 @@ namespace Intersect.Client.Items
         public int X;
 
         public int Y;
+
+        public Guid Owner;
+
+        public bool VisibleToAll;
 
         public MapItemInstance() : base()
         {

--- a/Intersect.Client/Items/MapItem.cs
+++ b/Intersect.Client/Items/MapItem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 
 namespace Intersect.Client.Items

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -651,6 +651,13 @@ namespace Intersect.Client.Maps
             //Draw Map Items
             foreach (var item in MapItems)
             {
+                // Are we allowed to see and pick this item up?
+                if (!item.Value.VisibleToAll && !item.Value.Owner.Equals(Globals.Me.Id) && !Globals.Me.IsInMyParty(item.Value.Owner))
+                {
+                    // This item does not apply to us!
+                    continue;
+                }
+
                 var itemBase = ItemBase.Get(item.Value.ItemId);
                 if (itemBase != null)
                 {

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -652,7 +652,7 @@ namespace Intersect.Client.Maps
             foreach (var item in MapItems)
             {
                 // Are we allowed to see and pick this item up?
-                if (!item.Value.VisibleToAll && !item.Value.Owner.Equals(Globals.Me.Id) && !Globals.Me.IsInMyParty(item.Value.Owner))
+                if (!item.Value.VisibleToAll && item.Value.Owner != Globals.Me.Id && !Globals.Me.IsInMyParty(item.Value.Owner))
                 {
                     // This item does not apply to us!
                     continue;

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1776,7 +1776,14 @@ namespace Intersect.Server.Entities
                         dmgMap.TryGetValue(this, out var damage);
                         dmgMap[this] = damage + baseDamage;
 
-                        enemyNpc.AssignTarget(enemyNpc.DamageMapHighest);
+                        if (enemyNpc.Base.FocusHighestDamageDealer)
+                        {
+                            enemyNpc.AssignTarget(enemyNpc.DamageMapHighest);
+                        }
+                        else
+                        {
+                            enemyNpc.AssignTarget(this);
+                        }
                     }
 
                     enemy.NotifySwarm(this);

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2421,10 +2421,10 @@ namespace Intersect.Server.Entities
 
                     // Decide if we want to have a loot ownership timer or not.
                     Guid lootOwner = Guid.Empty;
-                    if (this is Npc)
+                    if (this is Npc thisNpc)
                     {
                         // Check if we have someone that tagged this NPC.
-                        var taggedBy = ((Npc)this).DamageMapHighest;
+                        var taggedBy = thisNpc.DamageMapHighest;
                         if (taggedBy != null && taggedBy is Player)
                         {
                             // Spawn with ownership!
@@ -2434,7 +2434,7 @@ namespace Intersect.Server.Entities
                     else
                     {
                         // There's no tracking of who damaged what player as of now, so going by last hit.. Or set ownership to the player themselves.
-                        lootOwner = playerKiller != null ? playerKiller.Id : Id; 
+                        lootOwner = playerKiller?.Id ?? Id;
                     }
 
                     // Spawn the actual item!

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2451,6 +2451,7 @@ namespace Intersect.Server.Entities
                             if (pair.Value > damage)
                             {
                                 taggedBy = pair.Key;
+                                damage = pair.Value;
                             }
                         }
 

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2433,9 +2433,8 @@ namespace Intersect.Server.Entities
                     } 
                     else
                     {
-                        // This is not an NPC that died, moving on!
-                        // There's no tracking of who damaged what player as of now, so going by last hit!
-                        lootOwner = playerKiller != null ? playerKiller.Id : Guid.Empty; 
+                        // There's no tracking of who damaged what player as of now, so going by last hit.. Or set ownership to the player themselves.
+                        lootOwner = playerKiller != null ? playerKiller.Id : Id; 
                     }
 
                     // Spawn the actual item!

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -29,16 +29,19 @@ namespace Intersect.Server.Entities
         //Spell casting
         public long CastFreq;
 
-        //Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
+        /// <summary>
+        /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
+        /// </summary>
         public ConcurrentDictionary<Entity, long> DamageMap = new ConcurrentDictionary<Entity, long>();
 
-        // Returns the entity that ranks the highest on this NPC's damage map.
+        /// <summary>
+        /// Returns the entity that ranks the highest on this NPC's damage map.
+        /// </summary>
         public Entity DamageMapHighest { 
             get {
-                var damageMap = DamageMap;
                 long damage = 0;
                 Entity top = null;
-                foreach (var pair in damageMap)
+                foreach (var pair in DamageMap)
                 {
                     if (pair.Value > damage)
                     {

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -32,6 +32,24 @@ namespace Intersect.Server.Entities
         //Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
         public ConcurrentDictionary<Entity, long> DamageMap = new ConcurrentDictionary<Entity, long>();
 
+        // Returns the entity that ranks the highest on this NPC's damage map.
+        public Entity DamageMapHighest { 
+            get {
+                var damageMap = DamageMap;
+                long damage = 0;
+                Entity top = null;
+                foreach (var pair in damageMap)
+                {
+                    if (pair.Value > damage)
+                    {
+                        top = pair.Key;
+                        damage = pair.Value;
+                    }
+                }
+                return top;
+            } 
+        }
+
         public bool Despawnable;
 
         //Moving

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3427,7 +3427,7 @@ namespace Intersect.Server.Entities
 
                 if (!TryGiveItem(new Item(offer)))
                 {
-                    MapInstance.Get(MapId)?.SpawnItem(X, Y, offer, offer.Quantity);
+                    MapInstance.Get(MapId)?.SpawnItem(X, Y, offer, offer.Quantity, Id);
                     PacketSender.SendChatMsg(this, Strings.Trading.itemsdropped, CustomColors.Alerts.Error);
                 }
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1510,7 +1510,7 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1);
+            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1, Id);
 
             slot.Quantity = Math.Max(0, slot.Quantity - amount);
 

--- a/Intersect.Server/Entities/Resource.cs
+++ b/Intersect.Server/Entities/Resource.cs
@@ -161,7 +161,7 @@ namespace Intersect.Server.Entities
                     if (ItemBase.Get(item.ItemId) != null)
                     {
                         MapInstance.Get(selectedTile.GetMapId())
-                            .SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity);
+                            .SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity, killer.Id);
                     }
                 }
             }

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -776,6 +776,9 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString stunned = @"You cannot use this item whilst stunned.";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString notyours = @"This item does not belong to you!";
+
         }
 
         public sealed class MappingNamespace : LocaleNamespace

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -776,8 +776,13 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString stunned = @"You cannot use this item whilst stunned.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString notyours = @"This item does not belong to you!";
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString NotYours = @"This item does not belong to you!";
+
+            // TODO: Generalize this shit. It's everywhere!
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString InventoryNoSpace =
+                @"There is no space left in your inventory for that item!";
 
         }
 

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -215,6 +215,11 @@ namespace Intersect.Server.Maps
 
         public void SpawnItem(int x, int y, Item item, int amount)
         {
+            this.SpawnItem(x, y, item, amount, Guid.Empty);
+        }
+
+        public void SpawnItem(int x, int y, Item item, int amount, Guid owner)
+        {
             if (item == null)
             {
                 Log.Warn($"Tried to spawn {amount} of a null item at ({x}, {y}) in map {Id}.");
@@ -234,7 +239,9 @@ namespace Intersect.Server.Maps
             {
                 X = x,
                 Y = y,
-                DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime
+                DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime,
+                Owner = owner,
+                OwnershipTime = Globals.Timing.TimeMs + Options.ItemOwnershipTime
             };
 
             if (itemBase.ItemType == ItemTypes.Equipment)

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -820,7 +820,7 @@ namespace Intersect.Server.Maps
                         if (timeMs > LastUpdateTime + 30000)
                         {
                             //Regen Everything & Forget Targets
-                            if (en.Value is Resource || en is Npc)
+                            if (en.Value is Resource || en.Value is Npc)
                             {
                                 en.Value.RestoreVital(Vitals.Health);
                                 en.Value.RestoreVital(Vitals.Mana);

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -240,7 +240,7 @@ namespace Intersect.Server.Maps
             var mapItem = new MapItem(item.ItemId, item.Quantity, item.BagId, item.Bag) {
                 X = x,
                 Y = y,
-                DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime,
+                DespawnTime = Globals.Timing.TimeMs + Options.Loot.ItemDespawnTime,
                 Owner = owner,
                 OwnershipTime = Globals.Timing.TimeMs + Options.Loot.ItemOwnershipTime,
                 VisibleToAll = Options.Loot.ShowUnownedItems
@@ -320,7 +320,7 @@ namespace Intersect.Server.Maps
                             ItemRespawns[ItemRespawns.Count - 1].AttributeSpawnX = MapItems[index].AttributeSpawnX;
                             ItemRespawns[ItemRespawns.Count - 1].AttributeSpawnY = MapItems[index].AttributeSpawnY;
                             ItemRespawns[ItemRespawns.Count - 1].RespawnTime =
-                                Globals.Timing.TimeMs + Options.ItemRepawnTime;
+                                Globals.Timing.TimeMs + Options.Map.ItemAttributeRespawnTime;
                         }
                     }
 

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -785,17 +785,17 @@ namespace Intersect.Server.Maps
                     {
                         if (MapItems[i] != null)
                         {
-                            // Do we need to delete this item?
-                            if (MapItems[i].DespawnTime != -1 && MapItems[i].DespawnTime < timeMs)
-                            {
-                                RemoveItem(i);
-                            }
-                            
                             // Should this item be visible to everyone now?
                             if (!MapItems[i].VisibleToAll && MapItems[i].OwnershipTime < timeMs)
                             {
                                 MapItems[i].VisibleToAll = true;
                                 PacketSender.SendMapItemUpdate(Id, i);
+                            }
+
+                            // Do we need to delete this item?
+                            if (MapItems[i].DespawnTime != -1 && MapItems[i].DespawnTime < timeMs)
+                            {
+                                RemoveItem(i);
                             }
                         }
 

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -242,8 +242,8 @@ namespace Intersect.Server.Maps
                 Y = y,
                 DespawnTime = Globals.Timing.TimeMs + Options.ItemDespawnTime,
                 Owner = owner,
-                OwnershipTime = Globals.Timing.TimeMs + Options.ItemOwnershipTime,
-                VisibleToAll = Options.ShowUnownedItems
+                OwnershipTime = Globals.Timing.TimeMs + Options.Loot.ItemOwnershipTime,
+                VisibleToAll = Options.Loot.ShowUnownedItems
             };
 
             if (itemBase.ItemType == ItemTypes.Equipment)
@@ -783,17 +783,18 @@ namespace Intersect.Server.Maps
 
                     for (var i = 0; i < MapItems.Count; i++)
                     {
-                        if (MapItems[i] != null)
+                        var mapItem = MapItems[i];
+                        if (mapItem != null)
                         {
                             // Should this item be visible to everyone now?
-                            if (!MapItems[i].VisibleToAll && MapItems[i].OwnershipTime < timeMs)
+                            if (!mapItem.VisibleToAll && mapItem.OwnershipTime < timeMs)
                             {
-                                MapItems[i].VisibleToAll = true;
+                                mapItem.VisibleToAll = true;
                                 PacketSender.SendMapItemUpdate(Id, i);
                             }
 
                             // Do we need to delete this item?
-                            if (MapItems[i].DespawnTime != -1 && MapItems[i].DespawnTime < timeMs)
+                            if (mapItem.DespawnTime != -1 && mapItem.DespawnTime < timeMs)
                             {
                                 RemoveItem(i);
                             }
@@ -803,9 +804,10 @@ namespace Intersect.Server.Maps
 
                     for (var i = 0; i < ItemRespawns.Count; i++)
                     {
-                        if (ItemRespawns[i].RespawnTime < timeMs)
+                        var itemRespawn = ItemRespawns[i];
+                        if (itemRespawn.RespawnTime < timeMs)
                         {
-                            SpawnAttributeItem(ItemRespawns[i].AttributeSpawnX, ItemRespawns[i].AttributeSpawnY);
+                            SpawnAttributeItem(itemRespawn.AttributeSpawnX, itemRespawn.AttributeSpawnY);
                             ItemRespawns.RemoveAt(i);
                         }
                     }

--- a/Intersect.Server/Maps/MapItemInstance.cs
+++ b/Intersect.Server/Maps/MapItemInstance.cs
@@ -17,6 +17,10 @@ namespace Intersect.Server.Maps
 
         [JsonIgnore] public long DespawnTime;
 
+        [JsonIgnore] public Guid Owner;
+
+        [JsonIgnore] public long OwnershipTime;
+
         public int X = 0;
 
         public int Y = 0;

--- a/Intersect.Server/Maps/MapItemInstance.cs
+++ b/Intersect.Server/Maps/MapItemInstance.cs
@@ -17,9 +17,12 @@ namespace Intersect.Server.Maps
 
         [JsonIgnore] public long DespawnTime;
 
-        [JsonIgnore] public Guid Owner;
+        public Guid Owner;
 
         [JsonIgnore] public long OwnershipTime;
+
+        // We need this mostly for the client-side.. They can't keep track of our timer after all!
+        public bool VisibleToAll = true;
 
         public int X = 0;
 

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1167,7 +1167,7 @@ namespace Intersect.Server.Networking
                         // The ownership time has run out, or there's no owner!
                         canTake = true;
                     }
-                    else if (mapItem.Owner.Equals(player.Id) || player.Party.Any(p => p.Id.Equals(mapItem.Owner)))
+                    else if (mapItem.Owner == player.Id || player.Party.Any(p => p.Id == mapItem.Owner))
                     {
                         // The current player is the owner, or one of their party members is.
                         canTake = true;
@@ -1175,15 +1175,22 @@ namespace Intersect.Server.Networking
 
                     if (canTake)
                     {
+                        // Try to give the item to our player.
                         if (player.TryGiveItem(mapItem))
                         {
-                            //Remove Item From Map
+                            // Remove Item From Map
                             MapInstance.Get(player.MapId).RemoveItem(packet.MapItemIndex);
+                        } 
+                        else 
+                        {
+                            // We couldn't give the player their item, notify them.
+                            PacketSender.SendChatMsg(player, Strings.Items.InventoryNoSpace, Color.Red);
                         }
                     } 
                     else
                     {
-                        PacketSender.SendChatMsg(player, Strings.Items.notyours, Color.Red);
+                        // Item does not belong to them.
+                        PacketSender.SendChatMsg(player, Strings.Items.NotYours, Color.Red);
                     }
                     
                 }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1183,7 +1183,7 @@ namespace Intersect.Server.Networking
                     } 
                     else
                     {
-                        PacketSender.SendChatMsg(player, "This item does not belong to you!", Color.Red);
+                        PacketSender.SendChatMsg(player, Strings.Items.notyours, Color.Red);
                     }
                     
                 }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1184,13 +1184,13 @@ namespace Intersect.Server.Networking
                         else 
                         {
                             // We couldn't give the player their item, notify them.
-                            PacketSender.SendChatMsg(player, Strings.Items.InventoryNoSpace, Color.Red);
+                            PacketSender.SendChatMsg(player, Strings.Items.InventoryNoSpace, CustomColors.Alerts.Error);
                         }
                     } 
                     else
                     {
                         // Item does not belong to them.
-                        PacketSender.SendChatMsg(player, Strings.Items.NotYours, Color.Red);
+                        PacketSender.SendChatMsg(player, Strings.Items.NotYours, CustomColors.Alerts.Error);
                     }
                     
                 }


### PR DESCRIPTION
Resolves #182 
Resolves #184 

Adds the ability to tag MapItems with an owner, and only allow the owner (and their party) to pick the items up for a configurable amount of time.

NPC drops will attempt to use the player that did the most damage to it as the owner, unless killed by something other than a player.
Player drops will attempt to use player that did the killing blow as the owner for the items. Unless killed by something else.

Items dropped from the inventory voluntarily are also subject to ownership.

[Preview](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/6e3028d392bae32b70620ae58e7901fc.gif)

Some small fixes are mixed in to this as well as I run into them.
