### PR TITLE
Fix party max vitals being set to 0 resulting in a divide by 0 issue.

### DIFF
--- a/Intersect.Client/Interface/Game/PartyWindow.cs
+++ b/Intersect.Client/Interface/Game/PartyWindow.cs
@@ -210,17 +210,13 @@ namespace Intersect.Client.Interface.Game
 
                         if (mHpBar[i].Texture != null)
                         {
-                            var partyHpWidthRatio = 0f;
+                            var partyHpWidthRatio = 1f;
                             if (Globals.Me.Party[i].MaxVital[(int)Vitals.Health] > 0)
                             {
                                 var vitalHp = Globals.Me.Party[i].Vital[(int)Vitals.Health];
                                 var vitalMaxHp = Globals.Me.Party[i].MaxVital[(int)Vitals.Health];
                                 var ratioHp = (float)vitalHp / (float)vitalMaxHp;
                                 partyHpWidthRatio = Math.Min(1, Math.Max(0, ratioHp));
-                            }
-                            else
-                            {
-                                partyHpWidthRatio = 1f;
                             }
 
                             mHpBar[i]
@@ -242,7 +238,7 @@ namespace Intersect.Client.Interface.Game
 
                         if (mMpBar[i].Texture != null)
                         {
-                            var partyMpWidthRatio = 0f;
+                            var partyMpWidthRatio = 1f;
                             if (Globals.Me.Party[i].MaxVital[(int)Vitals.Mana] > 0)
                             {
                                 var vitalMp = Globals.Me.Party[i].Vital[(int)Vitals.Mana];
@@ -250,11 +246,7 @@ namespace Intersect.Client.Interface.Game
                                 var ratioMp = (float)vitalMp / (float)vitalMaxMp;
                                 partyMpWidthRatio = Math.Min(1, Math.Max(0, ratioMp));
                             }
-                            else
-                            {
-                                partyMpWidthRatio = 1f;
-                            }
-                            
+
                             mMpBar[i]
                                 .SetTextureRect(
                                     0, 0, Convert.ToInt32(mMpBar[i].Texture.GetWidth() * partyMpWidthRatio),

--- a/Intersect.Client/Interface/Game/PartyWindow.cs
+++ b/Intersect.Client/Interface/Game/PartyWindow.cs
@@ -210,19 +210,28 @@ namespace Intersect.Client.Interface.Game
 
                         if (mHpBar[i].Texture != null)
                         {
-                            var vitalHp = Globals.Me.Party[i].Vital[(int) Vitals.Health];
-                            var vitalMaxHp = Globals.Me.Party[i].MaxVital[(int) Vitals.Health];
-                            var ratioHp = (float) vitalHp / (float) vitalMaxHp;
-                            ratioHp = Math.Min(1, Math.Max(0, ratioHp));
+                            var partyHpWidthRatio = 0f;
+                            if (Globals.Me.Party[i].MaxVital[(int)Vitals.Health] > 0)
+                            {
+                                var vitalHp = Globals.Me.Party[i].Vital[(int)Vitals.Health];
+                                var vitalMaxHp = Globals.Me.Party[i].MaxVital[(int)Vitals.Health];
+                                var ratioHp = (float)vitalHp / (float)vitalMaxHp;
+                                partyHpWidthRatio = Math.Min(1, Math.Max(0, ratioHp));
+                            }
+                            else
+                            {
+                                partyHpWidthRatio = 1f;
+                            }
+
                             mHpBar[i]
                                 .SetTextureRect(
-                                    0, 0, Convert.ToInt32(mHpBar[i].Texture.GetWidth() * ratioHp),
+                                    0, 0, Convert.ToInt32(mHpBar[i].Texture.GetWidth() * partyHpWidthRatio),
                                     mHpBar[i].Texture.GetHeight()
                                 );
 
                             mHpBar[i]
                                 .SetSize(
-                                    Convert.ToInt32(ratioHp * mHpBarContainer[i].Width), mHpBarContainer[i].Height
+                                    Convert.ToInt32(partyHpWidthRatio * mHpBarContainer[i].Width), mHpBarContainer[i].Height
                                 );
                         }
 
@@ -233,19 +242,28 @@ namespace Intersect.Client.Interface.Game
 
                         if (mMpBar[i].Texture != null)
                         {
-                            var vitalMp = Globals.Me.Party[i].Vital[(int) Vitals.Mana];
-                            var vitalMaxMp = Globals.Me.Party[i].MaxVital[(int) Vitals.Mana];
-                            var ratioMp = (float) vitalMp / (float) vitalMaxMp;
-                            ratioMp = Math.Min(1, Math.Max(0, ratioMp));
+                            var partyMpWidthRatio = 0f;
+                            if (Globals.Me.Party[i].MaxVital[(int)Vitals.Mana] > 0)
+                            {
+                                var vitalMp = Globals.Me.Party[i].Vital[(int)Vitals.Mana];
+                                var vitalMaxMp = Globals.Me.Party[i].MaxVital[(int)Vitals.Mana];
+                                var ratioMp = (float)vitalMp / (float)vitalMaxMp;
+                                partyMpWidthRatio = Math.Min(1, Math.Max(0, ratioMp));
+                            }
+                            else
+                            {
+                                partyMpWidthRatio = 1f;
+                            }
+                            
                             mMpBar[i]
                                 .SetTextureRect(
-                                    0, 0, Convert.ToInt32(mMpBar[i].Texture.GetWidth() * ratioMp),
+                                    0, 0, Convert.ToInt32(mMpBar[i].Texture.GetWidth() * partyMpWidthRatio),
                                     mMpBar[i].Texture.GetHeight()
                                 );
 
                             mMpBar[i]
                                 .SetSize(
-                                    Convert.ToInt32(ratioMp * mMpBarContainer[i].Width), mMpBarContainer[i].Height
+                                    Convert.ToInt32(partyMpWidthRatio * mMpBarContainer[i].Width), mMpBarContainer[i].Height
                                 );
                         }
 


### PR DESCRIPTION
Resolves #199

This fix checks to see if the player's max vital for health or mana is over 0 before doing any math to see how to resize the bar, much like it works on the EntityBox. If max vital is not over 0, just set the bar to display as full like it does on the EntityBox.

