### PR TITLE
Enforce stackability and disable the checkbox on item editor for currencies

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -383,6 +383,7 @@ namespace Intersect.Editor.Forms.Editors
             grpEquipment.Visible = false;
             grpEvent.Visible = false;
             grpBags.Visible = false;
+            chkStackable.Visible = true;
 
             if ((int) mEditorItem.ItemType != cmbType.SelectedIndex)
             {
@@ -439,6 +440,12 @@ namespace Intersect.Editor.Forms.Editors
                 mEditorItem.SlotCount = Math.Max(1, mEditorItem.SlotCount);
                 grpBags.Visible = true;
                 nudBag.Value = mEditorItem.SlotCount;
+            }
+            else if (cmbType.SelectedIndex == (int)ItemTypes.Currency)
+            {
+                // Whether this item type is stackable is not up for debate.
+                chkStackable.Checked = true;
+                chkStackable.Visible = false;
             }
 
             mEditorItem.ItemType = (ItemTypes) cmbType.SelectedIndex;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -383,7 +383,7 @@ namespace Intersect.Editor.Forms.Editors
             grpEquipment.Visible = false;
             grpEvent.Visible = false;
             grpBags.Visible = false;
-            chkStackable.Visible = true;
+            chkStackable.Enabled = true;
 
             if ((int) mEditorItem.ItemType != cmbType.SelectedIndex)
             {
@@ -445,7 +445,7 @@ namespace Intersect.Editor.Forms.Editors
             {
                 // Whether this item type is stackable is not up for debate.
                 chkStackable.Checked = true;
-                chkStackable.Visible = false;
+                chkStackable.Enabled = false;
             }
 
             mEditorItem.ItemType = (ItemTypes) cmbType.SelectedIndex;


### PR DESCRIPTION
Resolves #206 

Enforce Stackability on Currency type items in the editor, and disable the option to remove this.