### PR TITLE
Disables the Stackable checkbox on both Equipment and Bag item types as well

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -383,6 +383,7 @@ namespace Intersect.Editor.Forms.Editors
             grpEquipment.Visible = false;
             grpEvent.Visible = false;
             grpBags.Visible = false;
+            chkStackable.Visible = true;
 
             if ((int) mEditorItem.ItemType != cmbType.SelectedIndex)
             {
@@ -439,6 +440,12 @@ namespace Intersect.Editor.Forms.Editors
                 mEditorItem.SlotCount = Math.Max(1, mEditorItem.SlotCount);
                 grpBags.Visible = true;
                 nudBag.Value = mEditorItem.SlotCount;
+            }
+            else if (cmbType.SelectedIndex == (int)ItemTypes.Currency)
+            {
+                // Whether this item type is stackable is not up for debate.
+                chkStackable.Checked = true;
+                chkStackable.Visible = false;
             }
 
             mEditorItem.ItemType = (ItemTypes) cmbType.SelectedIndex;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -383,7 +383,7 @@ namespace Intersect.Editor.Forms.Editors
             grpEquipment.Visible = false;
             grpEvent.Visible = false;
             grpBags.Visible = false;
-            chkStackable.Visible = true;
+            chkStackable.Enabled = true;
 
             if ((int) mEditorItem.ItemType != cmbType.SelectedIndex)
             {
@@ -445,7 +445,7 @@ namespace Intersect.Editor.Forms.Editors
             {
                 // Whether this item type is stackable is not up for debate.
                 chkStackable.Checked = true;
-                chkStackable.Visible = false;
+                chkStackable.Enabled = false;
             }
 
             mEditorItem.ItemType = (ItemTypes) cmbType.SelectedIndex;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -433,6 +433,10 @@ namespace Intersect.Editor.Forms.Editors
 
                 cmbEquipmentSlot.SelectedIndex = mEditorItem.EquipmentSlot;
                 cmbEquipmentBonus.SelectedIndex = (int) mEditorItem.Effect.Type;
+
+                // Whether this item type is stackable is not up for debate.
+                chkStackable.Checked = false;
+                chkStackable.Enabled = false;
             }
             else if (cmbType.SelectedIndex == (int) ItemTypes.Bag)
             {
@@ -440,6 +444,10 @@ namespace Intersect.Editor.Forms.Editors
                 mEditorItem.SlotCount = Math.Max(1, mEditorItem.SlotCount);
                 grpBags.Visible = true;
                 nudBag.Value = mEditorItem.SlotCount;
+
+                // Whether this item type is stackable is not up for debate.
+                chkStackable.Checked = false;
+                chkStackable.Enabled = false;
             }
             else if (cmbType.SelectedIndex == (int)ItemTypes.Currency)
             {


### PR DESCRIPTION
Belonged in issue #206 as well, but was missed. Oopsie. 