### PR TITLE
Return the max party size to 4

### DIFF
--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3517,7 +3517,7 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (Party.Count < 10)
+            if (Party.Count < 4)
             {
                 target.LeaveParty();
                 Party.Add(target);


### PR DESCRIPTION
Resolves #220 

For the master branch, only return the maximum size back to 4.
Development gets the fancy stuff. ;)