### PR TITLE
Open InventoryWindow when Bank,Shop,Trade or CraftingTable Open

### DIFF
--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -360,6 +360,7 @@ namespace Intersect.Client.Interface.Game
             if (mShouldOpenShop)
             {
                 OpenShop();
+                GameMenu.OpenInventory();
             }
 
             if (mShopWindow != null && (!mShopWindow.IsVisible() || mShouldCloseShop))
@@ -374,6 +375,7 @@ namespace Intersect.Client.Interface.Game
             if (mShouldOpenBank)
             {
                 OpenBank();
+                GameMenu.OpenInventory();
             }
 
             if (mBankWindow != null)
@@ -416,6 +418,7 @@ namespace Intersect.Client.Interface.Game
             if (mShouldOpenCraftingTable)
             {
                 OpenCraftingTable();
+                GameMenu.OpenInventory();
             }
 
             if (mCraftingWindow != null)
@@ -437,6 +440,7 @@ namespace Intersect.Client.Interface.Game
             if (mShouldOpenTrading)
             {
                 OpenTrading();
+                GameMenu.OpenInventory();
             }
 
             if (mTradingWindow != null)

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -200,6 +200,10 @@ namespace Intersect.Client.Interface.Game
                 mInventoryWindow.Show();
             }
         }
+        public void OpenInventory()
+        {
+            mInventoryWindow.Show();
+        }
 
         public void TogglePartyWindow()
         {


### PR DESCRIPTION
Resolves #214 

Good when opening Trade, Bank, Shop, Crafting ... the inventory is not open in my opinion it should be opened so that the player knows what is giving, receiving and others 
