### PR TITLE
fix 232: common autoscaling grid rendering

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
+using Intersect.Editor.Forms.Helpers;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
@@ -180,42 +181,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void UpdateSpawnPreview()
         {
-            var destBitmap = new Bitmap(pnlSpawnLoc.Width, pnlSpawnLoc.Height);
-            var renderFont = new Font(new FontFamily("Arial"), 14);
-            var cellWidth = pnlSpawnLoc.Width / 5;
-            var cellHeight = pnlSpawnLoc.Height / 5;
-
-            var g = Graphics.FromImage(destBitmap);
-            g.Clear(System.Drawing.Color.White);
-            g.FillRectangle(
-                Brushes.Red,
-                new Rectangle(
-                    (pnlSpawnLoc.Width - cellWidth) / 2, (pnlSpawnLoc.Height - cellHeight) / 2, cellWidth, cellHeight
-                )
-            );
-
-            for (var i = 1; i < 5; ++i)
-            {
-                g.DrawLine(Pens.Black, 0, cellHeight * i, pnlSpawnLoc.Width, cellHeight * i);
-                g.DrawLine(Pens.Black, cellWidth * i, 0, cellWidth * i, pnlSpawnLoc.Height);
-            }
-
-            //            g.FillRectangle(Brushes.Red, new Rectangle((mSpawnX + 2) * 32, (mSpawnY + 2) * 32, 32, 32));
-            //            for (int x = 0; x < 5; x++)
-            //            {
-            //                g.DrawLine(Pens.Black, x * 32, 0, x * 32, 32 * 5);
-            //                g.DrawLine(Pens.Black, 0, x * 32, 32 * 5, x * 32);
-            //            }
-            //            g.DrawLine(Pens.Black, 0, 32 * 5 - 1, 32 * 5, 32 * 5 - 1);
-            //            g.DrawLine(Pens.Black, 32 * 5 - 1, 0, 32 * 5 - 1, 32 * 5 - 1);
-
-            g.DrawString(
-                "E", renderFont, Brushes.Black, pnlSpawnLoc.Width / 2 - g.MeasureString("E", renderFont).Width / 2,
-                pnlSpawnLoc.Height / 2 - g.MeasureString("S", renderFont).Height / 2
-            );
-
-            g.Dispose();
-            pnlSpawnLoc.BackgroundImage = destBitmap;
+            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridTile(2, 2, null, "E"), new GridTile(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
         }
 
         private void btnSave_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
@@ -181,7 +181,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void UpdateSpawnPreview()
         {
-            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridTile(2, 2, null, "E"), new GridTile(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
+            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridCell(2, 2, null, "E"), new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
         }
 
         private void btnSave_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
@@ -162,7 +162,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void UpdateSpawnPreview()
         {
-            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridTile(2, 2, null, "E"), new GridTile(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
+            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridCell(2, 2, null, "E"), new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
         }
 
         private void btnSave_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
+using Intersect.Editor.Forms.Helpers;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
@@ -161,26 +162,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void UpdateSpawnPreview()
         {
-            var destBitmap = new Bitmap(pnlSpawnLoc.Width, pnlSpawnLoc.Height);
-            var renderFont = new Font(new FontFamily("Arial"), 14);
-            var g = Graphics.FromImage(destBitmap);
-            g.Clear(System.Drawing.Color.White);
-            g.FillRectangle(Brushes.Red, new Rectangle((mSpawnX + 2) * 32, (mSpawnY + 2) * 32, 32, 32));
-            for (var x = 0; x < 5; x++)
-            {
-                g.DrawLine(Pens.Black, x * 32, 0, x * 32, 32 * 5);
-                g.DrawLine(Pens.Black, 0, x * 32, 32 * 5, x * 32);
-            }
-
-            g.DrawLine(Pens.Black, 0, 32 * 5 - 1, 32 * 5, 32 * 5 - 1);
-            g.DrawLine(Pens.Black, 32 * 5 - 1, 0, 32 * 5 - 1, 32 * 5 - 1);
-            g.DrawString(
-                "E", renderFont, Brushes.Black, pnlSpawnLoc.Width / 2 - g.MeasureString("E", renderFont).Width / 2,
-                pnlSpawnLoc.Height / 2 - g.MeasureString("S", renderFont).Height / 2
-            );
-
-            g.Dispose();
-            pnlSpawnLoc.BackgroundImage = destBitmap;
+            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(pnlSpawnLoc.Width, pnlSpawnLoc.Height, 5, 5, new GridTile(2, 2, null, "E"), new GridTile(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red));
         }
 
         private void btnSave_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Editor.Forms.Helpers
 {
@@ -52,7 +49,7 @@ namespace Intersect.Editor.Forms.Helpers
 
         public GridTile WithLabel(string label)
         {
-            if (string.Equals(Label, label, StringComparison.Ordinal))
+            if (String.Equals(Label, label, StringComparison.Ordinal))
             {
                 return this;
             }
@@ -69,6 +66,9 @@ namespace Intersect.Editor.Forms.Helpers
 
             return new GridTile(X, Y, Color, Label, labelColor);
         }
+
+        public static int CalculatePrecedenceKey(GridTile gridTile) =>
+            (String.IsNullOrEmpty(gridTile.Label) ? 0 : 2) + (gridTile.Color == null ? 0 : 1);
     }
 
     public static class GridHelper
@@ -80,9 +80,6 @@ namespace Intersect.Editor.Forms.Helpers
         public static Color ColorSelection { get; set; } = Color.Red;
 
         public static Font DefaultFont { get; set; } = new Font(new FontFamily("Arial"), 14);
-
-        private static int OrderKeyForGridTile(GridTile gridTile) =>
-            (string.IsNullOrEmpty(gridTile.Label) ? 0 : 2) + (gridTile.Color == null ? 0 : 1);
 
         public static Bitmap DrawGrid(
             int bitmapWidth,
@@ -129,7 +126,7 @@ namespace Intersect.Editor.Forms.Helpers
             {
                 graphics.Clear(ColorBackground);
 
-                foreach (var gridTile in gridTiles.OrderBy(OrderKeyForGridTile))
+                foreach (var gridTile in gridTiles.OrderBy(GridTile.CalculatePrecedenceKey))
                 {
                     var x = gridTile.X * cellWidth;
                     var y = gridTile.Y * cellHeight;

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Editor.Forms.Helpers
+{
+    using Color = System.Drawing.Color;
+
+    public struct GridTile
+    {
+        public int X { get; private set; }
+
+        public int Y { get; private set; }
+
+        public Color? Color { get; private set; }
+
+        public string Label { get; private set; }
+
+        public Color? LabelColor { get; private set; }
+
+        public GridTile(int x, int y, Color? color = default, string label = null, Color? labelColor = default)
+        {
+            X = x;
+            Y = y;
+            Color = color;
+            Label = label;
+            LabelColor = labelColor;
+        }
+
+        public GridTile At(int x, int y)
+        {
+            if (X == x && Y == y)
+            {
+                return this;
+            }
+
+            return new GridTile(x, y, Color, Label);
+        }
+
+        public GridTile WithColor(Color color)
+        {
+            if (Color == color)
+            {
+                return this;
+            }
+
+            return new GridTile(X, Y, color, Label);
+        }
+
+        public GridTile WithLabel(string label)
+        {
+            if (string.Equals(Label, label, StringComparison.Ordinal))
+            {
+                return this;
+            }
+
+            return new GridTile(X, Y, Color, label);
+        }
+
+        public GridTile WithLabelColor(Color labelColor)
+        {
+            if (LabelColor == labelColor)
+            {
+                return this;
+            }
+
+            return new GridTile(X, Y, Color, Label, labelColor);
+        }
+    }
+
+    public static class GridHelper
+    {
+        public static Color ColorBackground { get; set; } = Color.White;
+
+        public static Color ColorForeground { get; set; } = Color.Black;
+
+        public static Color ColorSelection { get; set; } = Color.Red;
+
+        public static Font DefaultFont { get; set; } = new Font(new FontFamily("Arial"), 14);
+
+        private static int OrderKeyForGridTile(GridTile gridTile) =>
+            (string.IsNullOrEmpty(gridTile.Label) ? 0 : 2) + (gridTile.Color == null ? 0 : 1);
+
+        public static Bitmap DrawGrid(
+            int bitmapWidth,
+            int bitmapHeight,
+            int gridColumns,
+            int gridRows,
+            params GridTile[] gridTiles
+        ) =>
+            DrawGrid(bitmapWidth, bitmapHeight, gridColumns, gridRows, DefaultFont, gridTiles);
+
+        public static Bitmap DrawGrid(
+            int bitmapWidth,
+            int bitmapHeight,
+            int gridColumns,
+            int gridRows,
+            Font font,
+            params GridTile[] gridTiles
+        ) =>
+            DrawGrid(new Bitmap(bitmapWidth, bitmapHeight), gridColumns, gridRows, font, gridTiles);
+
+        public static Bitmap DrawGrid(Bitmap bitmap, int gridColumns, int gridRows, params GridTile[] gridTiles) =>
+            DrawGrid(bitmap, gridColumns, gridRows, DefaultFont, gridTiles);
+
+        public static Bitmap DrawGrid(
+            Bitmap bitmap,
+            int gridColumns,
+            int gridRows,
+            Font font,
+            params GridTile[] gridTiles
+        )
+        {
+            if (bitmap == null)
+            {
+                throw new ArgumentNullException(nameof(bitmap));
+            }
+
+            var gridWidth = bitmap.Width;
+            var cellWidth = gridWidth / gridColumns;
+
+            var gridHeight = bitmap.Height;
+            var cellHeight = gridHeight / gridRows;
+
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.Clear(ColorBackground);
+
+                foreach (var gridTile in gridTiles.OrderBy(OrderKeyForGridTile))
+                {
+                    var x = gridTile.X * cellWidth;
+                    var y = gridTile.Y * cellHeight;
+
+                    if (gridTile.Color != null && gridTile.Color != Color.Transparent && gridTile.Color.Value.A != 0)
+                    {
+                        graphics.FillRectangle(
+                            new SolidBrush(ColorSelection), new Rectangle(x, y, cellWidth, cellHeight)
+                        );
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(gridTile.Label))
+                    {
+                        var measurement = graphics.MeasureString(gridTile.Label, font);
+                        graphics.DrawString(
+                            gridTile.Label, font, new SolidBrush(gridTile.LabelColor ?? ColorForeground),
+                            x + (cellWidth - measurement.Width) / 2, y + (cellHeight - measurement.Height) / 2
+                        );
+                    }
+                }
+
+                for (var lineIndex = 1; lineIndex < Math.Max(gridColumns, gridRows); ++lineIndex)
+                {
+                    if (lineIndex < gridColumns)
+                    {
+                        graphics.DrawLine(Pens.Black, cellWidth * lineIndex, 0, cellWidth * lineIndex, gridHeight);
+                    }
+
+                    if (lineIndex < gridRows)
+                    {
+                        graphics.DrawLine(Pens.Black, 0, cellHeight * lineIndex, gridWidth, cellHeight * lineIndex);
+                    }
+                }
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -6,7 +6,7 @@ namespace Intersect.Editor.Forms.Helpers
 {
     using Color = System.Drawing.Color;
 
-    public struct GridTile
+    public struct GridCell
     {
         public int X { get; private set; }
 
@@ -18,7 +18,7 @@ namespace Intersect.Editor.Forms.Helpers
 
         public Color? LabelColor { get; private set; }
 
-        public GridTile(int x, int y, Color? color = default, string label = null, Color? labelColor = default)
+        public GridCell(int x, int y, Color? color = default, string label = null, Color? labelColor = default)
         {
             X = x;
             Y = y;
@@ -27,88 +27,139 @@ namespace Intersect.Editor.Forms.Helpers
             LabelColor = labelColor;
         }
 
-        public GridTile At(int x, int y)
+        public GridCell At(int x, int y)
         {
             if (X == x && Y == y)
             {
                 return this;
             }
 
-            return new GridTile(x, y, Color, Label);
+            return new GridCell(x, y, Color, Label);
         }
 
-        public GridTile WithColor(Color color)
+        public GridCell WithColor(Color color)
         {
             if (Color == color)
             {
                 return this;
             }
 
-            return new GridTile(X, Y, color, Label);
+            return new GridCell(X, Y, color, Label);
         }
 
-        public GridTile WithLabel(string label)
+        public GridCell WithLabel(string label)
         {
             if (String.Equals(Label, label, StringComparison.Ordinal))
             {
                 return this;
             }
 
-            return new GridTile(X, Y, Color, label);
+            return new GridCell(X, Y, Color, label);
         }
 
-        public GridTile WithLabelColor(Color labelColor)
+        public GridCell WithLabelColor(Color labelColor)
         {
             if (LabelColor == labelColor)
             {
                 return this;
             }
 
-            return new GridTile(X, Y, Color, Label, labelColor);
+            return new GridCell(X, Y, Color, Label, labelColor);
         }
 
-        public static int CalculatePrecedenceKey(GridTile gridTile) =>
-            (String.IsNullOrEmpty(gridTile.Label) ? 0 : 2) + (gridTile.Color == null ? 0 : 1);
+        public static int CalculatePrecedenceKey(GridCell gridCell) =>
+            (String.IsNullOrEmpty(gridCell.Label) ? 0 : 2) + (gridCell.Color == null ? 0 : 1);
     }
 
+    /// <summary>
+    /// Helper class for drawing grids on <see cref="Bitmap"/>s.
+    /// </summary>
     public static class GridHelper
     {
+        /// <summary>
+        /// Mutable background color for all grids, default <see cref="Color.White"/>.
+        /// </summary>
         public static Color ColorBackground { get; set; } = Color.White;
 
+        /// <summary>
+        /// Mutable foreground color for all grids (only affects the grid lines, not text color), default <see cref="Color.Black"/>.
+        /// </summary>
         public static Color ColorForeground { get; set; } = Color.Black;
 
+        /// <summary>
+        /// Mutable selection tile color for all grids, default <see cref="Color.Red"/>.
+        /// </summary>
         public static Color ColorSelection { get; set; } = Color.Red;
 
+        /// <summary>
+        /// Mutable fallback font for text rendering on grids, default Arial 14pt.
+        /// </summary>
         public static Font DefaultFont { get; set; } = new Font(new FontFamily("Arial"), 14);
 
+        /// <summary>
+        /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
+        /// </summary>
+        /// <param name="bitmapWidth">width of the bitmap in pixels</param>
+        /// <param name="bitmapHeight">height of the bitmap in pixels</param>
+        /// <param name="gridColumns">number of columns the grid should have</param>
+        /// <param name="gridRows">number of rows the grid should have</param>
+        /// <param name="gridCells">the optional cell contents</param>
+        /// <returns>a bitmap with the configured grid drawn on it</returns>
         public static Bitmap DrawGrid(
             int bitmapWidth,
             int bitmapHeight,
             int gridColumns,
             int gridRows,
-            params GridTile[] gridTiles
+            params GridCell[] gridCells
         ) =>
-            DrawGrid(bitmapWidth, bitmapHeight, gridColumns, gridRows, DefaultFont, gridTiles);
+            DrawGrid(bitmapWidth, bitmapHeight, gridColumns, gridRows, DefaultFont, gridCells);
 
+        /// <summary>
+        /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
+        /// </summary>
+        /// <param name="bitmapWidth">width of the bitmap in pixels</param>
+        /// <param name="bitmapHeight">height of the bitmap in pixels</param>
+        /// <param name="gridColumns">number of columns the grid should have</param>
+        /// <param name="gridRows">number of rows the grid should have</param>
+        /// <param name="font">the font to use for text rendering</param>
+        /// <param name="gridCells">the optional cell contents</param>
+        /// <returns>a bitmap with the configured grid drawn on it</returns>
         public static Bitmap DrawGrid(
             int bitmapWidth,
             int bitmapHeight,
             int gridColumns,
             int gridRows,
             Font font,
-            params GridTile[] gridTiles
+            params GridCell[] gridCells
         ) =>
-            DrawGrid(new Bitmap(bitmapWidth, bitmapHeight), gridColumns, gridRows, font, gridTiles);
+            DrawGrid(new Bitmap(bitmapWidth, bitmapHeight), gridColumns, gridRows, font, gridCells);
 
-        public static Bitmap DrawGrid(Bitmap bitmap, int gridColumns, int gridRows, params GridTile[] gridTiles) =>
-            DrawGrid(bitmap, gridColumns, gridRows, DefaultFont, gridTiles);
+        /// <summary>
+        /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
+        /// </summary>
+        /// <param name="bitmap">the bitmap to render the grid on</param>
+        /// <param name="gridColumns">number of columns the grid should have</param>
+        /// <param name="gridRows">number of rows the grid should have</param>
+        /// <param name="gridCells">the optional cell contents</param>
+        /// <returns>a bitmap with the configured grid drawn on it</returns>
+        public static Bitmap DrawGrid(Bitmap bitmap, int gridColumns, int gridRows, params GridCell[] gridCells) =>
+            DrawGrid(bitmap, gridColumns, gridRows, DefaultFont, gridCells);
 
+        /// <summary>
+        /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
+        /// </summary>
+        /// <param name="bitmap">the bitmap to render the grid on</param>
+        /// <param name="gridColumns">number of columns the grid should have</param>
+        /// <param name="gridRows">number of rows the grid should have</param>
+        /// <param name="font">the font to use for text rendering</param>
+        /// <param name="gridCells">the optional cell contents</param>
+        /// <returns>a bitmap with the configured grid drawn on it</returns>
         public static Bitmap DrawGrid(
             Bitmap bitmap,
             int gridColumns,
             int gridRows,
             Font font,
-            params GridTile[] gridTiles
+            params GridCell[] gridCells
         )
         {
             if (bitmap == null)
@@ -126,7 +177,7 @@ namespace Intersect.Editor.Forms.Helpers
             {
                 graphics.Clear(ColorBackground);
 
-                foreach (var gridTile in gridTiles.OrderBy(GridTile.CalculatePrecedenceKey))
+                foreach (var gridTile in gridCells.OrderBy(GridCell.CalculatePrecedenceKey))
                 {
                     var x = gridTile.X * cellWidth;
                     var y = gridTile.Y * cellHeight;

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -177,28 +177,33 @@ namespace Intersect.Editor.Forms.Helpers
             {
                 graphics.Clear(ColorBackground);
 
-                foreach (var gridTile in gridCells.OrderBy(GridCell.CalculatePrecedenceKey))
+                // Draw the cell contents in order of precedence (color-only first, then text, so that text doesn't get rendered under background colors)
+                foreach (var gridCell in gridCells.OrderBy(GridCell.CalculatePrecedenceKey))
                 {
-                    var x = gridTile.X * cellWidth;
-                    var y = gridTile.Y * cellHeight;
+                    var x = gridCell.X * cellWidth;
+                    var y = gridCell.Y * cellHeight;
 
-                    if (gridTile.Color != null && gridTile.Color != Color.Transparent && gridTile.Color.Value.A != 0)
+                    // Draw the background color (if any for this cell)
+                    if (gridCell.Color != null && gridCell.Color != Color.Transparent && gridCell.Color.Value.A != 0)
                     {
                         graphics.FillRectangle(
                             new SolidBrush(ColorSelection), new Rectangle(x, y, cellWidth, cellHeight)
                         );
                     }
 
-                    if (!string.IsNullOrWhiteSpace(gridTile.Label))
+                    // Draw the text (if any for this cell)
+                    if (!string.IsNullOrWhiteSpace(gridCell.Label))
                     {
-                        var measurement = graphics.MeasureString(gridTile.Label, font);
+                        var measurement = graphics.MeasureString(gridCell.Label, font);
                         graphics.DrawString(
-                            gridTile.Label, font, new SolidBrush(gridTile.LabelColor ?? ColorForeground),
+                            gridCell.Label, font, new SolidBrush(gridCell.LabelColor ?? ColorForeground),
                             x + (cellWidth - measurement.Width) / 2, y + (cellHeight - measurement.Height) / 2
                         );
                     }
                 }
 
+                // Draw separator lines (1 less than the number of columns/rows
+                // Columns and rows are combined into a single for-loop to reduce the number of iterations
                 for (var lineIndex = 1; lineIndex < Math.Max(gridColumns, gridRows); ++lineIndex)
                 {
                     if (lineIndex < gridColumns)

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Forms\frmUpdate.Designer.cs">
       <DependentUpon>frmUpdate.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\Helpers\GridHelper.cs" />
     <Compile Include="Maps\MapGridItem.cs" />
     <Compile Include="Maps\MapSaveState.cs" />
     <Compile Include="Forms\Controls\SearchableDarkTreeView.cs">


### PR DESCRIPTION
Resolves #232 

Introduces `Intersect.Editor.Forms.Helpers.GridHelper`:
- Draws grids of a specified column/row count
- Grid tiles can be specified, with labels rendering over top of simple background color tiles
  - Selection tile (`red`) is rendered at `<spawn X>,<spawn Y>`
  - `E` tile is rendered second at `2,2`
- Cell sizes scale according to destination bitmap size to account for environmental skew and scaling
  - This is to accommodate an older bug that has been seen but unable to diagnose where the panel would be skewed (and not evenly) on some systems but is totally normal on others

Updates the following selection panels to use `GridHelper` for rendering:
- `EventCommand_PlayAnimation` (the part that addresses #287)
- `EventCommand_SpawnNpc`