### PR TITLE
fix 268: check if ban expired

### DIFF
--- a/Intersect.Server/Database/PlayerData/Mute.cs
+++ b/Intersect.Server/Database/PlayerData/Mute.cs
@@ -70,6 +70,11 @@ namespace Intersect.Server.Database.PlayerData
 
         public string Muter { get; private set; }
 
+        [NotMapped]
+        public bool IsExpired => Expired(this);
+
+        public static bool Expired(Mute mute) => mute.EndTime <= DateTime.UtcNow;
+
         public static bool Add([NotNull] Mute mute, [CanBeNull] PlayerContext playerContext = null)
         {
             lock (DbInterface.GetPlayerContextLock())
@@ -99,10 +104,8 @@ namespace Intersect.Server.Database.PlayerData
             [NotNull] string muter,
             string ip,
             [CanBeNull] PlayerContext playerContext = null
-        )
-        {
-            return Add(new Mute(userId, ip, reason, duration, muter), playerContext);
-        }
+        ) =>
+            Add(new Mute(userId, ip, reason, duration, muter), playerContext);
 
         public static bool Add(
             [NotNull] User user,
@@ -125,12 +128,10 @@ namespace Intersect.Server.Database.PlayerData
             [NotNull] string muter,
             string ip,
             [CanBeNull] PlayerContext playerContext = null
-        )
-        {
-            return client.User != null && Add(client.User, duration, reason, muter, ip, playerContext);
-        }
+        ) =>
+            client.User != null && Add(client.User, duration, reason, muter, ip, playerContext);
 
-        public static bool Remove(Guid userId, [CanBeNull] PlayerContext playerContext = null)
+        public static bool Remove(Mute mute)
         {
             lock (DbInterface.GetPlayerContextLock())
             {
@@ -140,22 +141,67 @@ namespace Intersect.Server.Database.PlayerData
                     return false;
                 }
 
-                var mute = context.Mutes.FirstOrDefault(p => p.UserId == userId);
-                if (mute == null)
-                {
-                    return true;
-                }
-
                 context.Mutes.Remove(mute);
+
                 DbInterface.SavePlayerDatabaseAsync();
 
                 return true;
             }
         }
 
-        public static bool Remove([NotNull] User user, [CanBeNull] PlayerContext playerContext = null)
+        public static bool Remove(string ip, bool expired = true)
         {
-            if (!Remove(user.Id, playerContext))
+            lock (DbInterface.GetPlayerContextLock())
+            {
+                var context = DbInterface.GetPlayerContext();
+                if (context == null)
+                {
+                    return false;
+                }
+
+                var mutes = context.Mutes.Where(e => e.Ip == ip && (!expired || Expired(e))).ToList();
+
+                if ((mutes?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+
+                context.Mutes.RemoveRange(mutes);
+
+                DbInterface.SavePlayerDatabaseAsync();
+
+                return true;
+            }
+        }
+
+        public static bool Remove(Guid userId, bool expired = true)
+        {
+            lock (DbInterface.GetPlayerContextLock())
+            {
+                var context = DbInterface.GetPlayerContext();
+                if (context == null)
+                {
+                    return false;
+                }
+
+                var mutes = context.Mutes.Where(e => e.UserId == userId && (!expired || Expired(e))).ToList();
+
+                if ((mutes?.Count ?? 0) == 0)
+                {
+                    return true;
+                }
+
+                context.Mutes.RemoveRange(mutes);
+
+                DbInterface.SavePlayerDatabaseAsync();
+
+                return true;
+            }
+        }
+
+        public static bool Remove([NotNull] User user)
+        {
+            if (!Remove(user.UserMute))
             {
                 return false;
             }
@@ -165,10 +211,7 @@ namespace Intersect.Server.Database.PlayerData
             return true;
         }
 
-        public static bool Remove([NotNull] Client client, [CanBeNull] PlayerContext playerContext = null)
-        {
-            return client.User != null && Remove(client.User, playerContext);
-        }
+        public static bool Remove([NotNull] Client client, [CanBeNull] PlayerContext playerContext = null) => client.User != null && Remove(client.User);
 
         public static string FindMuteReason(
             Guid userId,
@@ -186,7 +229,14 @@ namespace Intersect.Server.Database.PlayerData
 
                 var mute = Find(userId) ?? Find(ip);
 
-                return mute == null
+                var expired = mute?.IsExpired ?? true;
+
+                if (expired && mute != null)
+                {
+                    Remove(mute);
+                }
+
+                return expired
                     ? null
                     : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
             }
@@ -198,22 +248,37 @@ namespace Intersect.Server.Database.PlayerData
             [CanBeNull] PlayerContext playerContext = null
         )
         {
-            if (user.Mute == null)
+            lock (DbInterface.GetPlayerContextLock())
             {
-                user.IpMute = Find(ip);
+                var context = DbInterface.GetPlayerContext();
+                if (context == null)
+                {
+                    return null;
+                }
+
+                if (user.Mute == null)
+                {
+                    user.IpMute = Find(ip);
+                }
+
+                var mute = user.Mute;
+
+                var expired = mute?.IsExpired ?? true;
+
+                if (expired && mute != null)
+                {
+                    Remove(mute);
+                    user.IpMute = null;
+                    user.UserMute = null;
+                }
+
+                return expired
+                    ? null
+                    : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
             }
-
-            var mute = user.Mute;
-
-            return mute == null
-                ? null
-                : Strings.Account.mutestatus.ToString(mute.StartTime, mute.Muter, mute.EndTime, mute.Reason);
         }
 
-        public static Mute Find([NotNull] User user)
-        {
-            return Find(user.Id);
-        }
+        public static Mute Find([NotNull] User user) => Find(user.Id);
 
         public static Mute Find(Guid userId)
         {
@@ -236,20 +301,11 @@ namespace Intersect.Server.Database.PlayerData
             }
         }
 
-        public static IEnumerable<Mute> FindAll([NotNull] User user)
-        {
-            return ByUser(DbInterface.GetPlayerContext(), user.Id);
-        }
+        public static IEnumerable<Mute> FindAll([NotNull] User user) => ByUser(DbInterface.GetPlayerContext(), user.Id);
 
-        public static IEnumerable<Mute> FindAll(Guid userId)
-        {
-            return ByUser(DbInterface.GetPlayerContext(), userId);
-        }
+        public static IEnumerable<Mute> FindAll(Guid userId) => ByUser(DbInterface.GetPlayerContext(), userId);
 
-        public static IEnumerable<Mute> FindAll(string ip)
-        {
-            return ByIp(DbInterface.GetPlayerContext(), ip);
-        }
+        public static IEnumerable<Mute> FindAll(string ip) => ByIp(DbInterface.GetPlayerContext(), ip);
 
         #region Compiled Queries
 


### PR DESCRIPTION
Resolves #268 

Realized mutes will have the same issue, and fixed those as well
After a ban/mute is selected by user or IP, it is checked to see if it
is expired. If it has been expired, null is returned and it is removed.