### PR TITLE
Configurable reset radius and behaviour for NPCs after going into combat.

### DIFF
--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -1,0 +1,34 @@
+﻿namespace Intersect.Config
+{
+
+    /// <summary>
+    /// Contains configurable options pertaining to the way Npcs are handled by the engine.
+    /// </summary>
+    public class NpcOptions
+    {
+
+        /// <summary>
+        /// Configures whether or not Npcs are allowed to reset after moving out of a specified radius when starting to fight another entity.
+        /// </summary>
+        public bool AllowResetRadius = false;
+
+        /// <summary>
+        /// Configures the radius in which an NPC is allowed to move after starting to fight another entity.
+        /// </summary>
+        public int ResetRadius = 8;
+
+        /// <summary>
+        /// Configures whether or not the NPC is allowed to gain a new reset center point while it is still busy moving to its original reset point.
+        /// NOTE: Can be used to allow the NPCs to be dragged far far away, as it constantly resets the center of its radius!!!
+        /// </summary>
+
+        public bool AllowNewResetLocationBeforeFinish = false;
+
+        /// <summary>
+        /// Configures whether or not the NPC should completely restore its vitals and statusses once it resets.
+        /// </summary>
+        public bool ResetVitalsAndStatusses = false;
+
+    }
+
+}

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -56,6 +56,8 @@ namespace Intersect
 
         [JsonProperty("Loot")] public LootOptions LootOpts = new LootOptions();
 
+        [JsonProperty("Npc")] public NpcOptions NpcOpts = new NpcOptions();
+
         public SmtpSettings SmtpSettings = new SmtpSettings();
 
         [NotNull]
@@ -128,6 +130,8 @@ namespace Intersect
         public static int MinChatInterval => Instance.ChatOpts.MinIntervalBetweenChats;
 
         public static LootOptions Loot => Instance.LootOpts;
+
+        public static NpcOptions Npc => Instance.NpcOpts;
 
         public static PartyOptions Party => Instance.PartyOpts;
 

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -195,6 +195,7 @@
     <Compile Include="Configuration\ConfigurationHelper.cs" />
     <Compile Include="Config\ChatOptions.cs" />
     <Compile Include="Config\LootOptions.cs" />
+    <Compile Include="Config\NpcOptions.cs" />
     <Compile Include="Config\PacketOptions.cs" />
     <Compile Include="Config\PartyOptions.cs" />
     <Compile Include="Config\SecurityOptions.cs" />


### PR DESCRIPTION
Adds features requested in #302 
Request discussed in shoutbox pertained a reset radius, not a new behaviour type though..

Adds the ability to configure several new global options for NPC behaviour through the server configuration:

* AllowResetRadius - Configures whether or not Npcs are allowed to reset after moving out of a specified radius when starting to fight another entity.
* ResetRadius - Configures the radius in which an NPC is allowed to move after starting to fight another entity.
* AllowNewResetLocationBeforeFinish - Configures whether or not the NPC is allowed to gain a new reset center point while it is still busy moving to its original reset point. NOTE: Can be used to allow the NPCs to be dragged far far away, as it constantly resets the center of its radius!!!
* ResetVitalsAndStatusses - Configures whether or not the NPC should completely restore its vitals and statusses once it resets.

After being forcibly reset, the NPC will attempt to move back to its original location.

Had to adjust some of the nonsensical horrors that was the pathfinding system being COMPLETELY reliant on having a target before allowing it to work. Hasn't broken in my testing yet.




