### PR TITLE
Sprite Options (Frames/Timing/Etc)

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -56,7 +56,7 @@ namespace Intersect
 
         [JsonProperty("Loot")] public LootOptions LootOpts = new LootOptions();
 
-        [JsonProperty("Sprites")] public SpriteOptions SpriteOpts = new SpriteOptions();
+        public SpriteOptions Sprites = new SpriteOptions();
 
         [JsonProperty("Npc")] public NpcOptions NpcOpts = new NpcOptions();
 

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -56,6 +56,8 @@ namespace Intersect
 
         [JsonProperty("Loot")] public LootOptions LootOpts = new LootOptions();
 
+        [JsonProperty("Sprites")] public SpriteOptions SpriteOpts = new SpriteOptions();
+
         [JsonProperty("Npc")] public NpcOptions NpcOpts = new NpcOptions();
 
         public SmtpSettings SmtpSettings = new SmtpSettings();

--- a/Intersect (Core)/Config/SpriteOptions.cs
+++ b/Intersect (Core)/Config/SpriteOptions.cs
@@ -1,9 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Config
 { 

--- a/Intersect (Core)/Config/SpriteOptions.cs
+++ b/Intersect (Core)/Config/SpriteOptions.cs
@@ -1,0 +1,75 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Config
+{ 
+    /// <summary>
+    /// Contains configurable options pertaining to the way sprites are rendered within the engine
+    /// </summary>
+    public class SpriteOptions
+    {
+        /// <summary>
+        /// Defines the number of frames there will be in idling sprite sheets
+        /// </summary>
+        public int IdleFrames = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in normal (walking) sprite sheets
+        /// </summary>
+        public int NormalFrames = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in casting sprite sheets
+        /// </summary>
+        public int CastFrames = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in attacking sprite sheets
+        /// </summary>
+        public int AttackFrames = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in shooting sprite sheets
+        /// </summary>
+        public int ShootFrames = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in weapon attacking sprite sheets
+        /// </summary>
+        public int WeaponFrames = 4;
+
+        /// <summary>
+        /// The frame on the normal sprite sheet to show when attacking when there is no designated sheet for attack.
+        /// </summary>
+        public int NormalSheetAttackFrame = 3;
+
+        /// <summary>
+        /// The frame on the normal sprite sheet to show when dashing or sliding.
+        /// </summary>
+        public int NormalSheetDashFrame = 1;
+
+        /// <summary>
+        /// Defines how long (in ms) between walking frames
+        /// </summary>
+        public int MovingFrameDuration = 200;
+
+        /// <summary>
+        /// Defines how long (in ms) between idling frames
+        /// </summary>
+        public int IdleFrameDuration = 200;
+
+        /// <summary>
+        /// Defines how long (in ms) a player must idle before the idling sprite starts to render
+        /// </summary>
+        public int TimeBeforeIdle = 4000;
+
+        /// <summary>
+        /// Defines the number of rows in sprite sheets which will correlate to the number of directions in the game (Intersect is programmed by default with only 4 directions)
+        /// </summary>
+        [JsonIgnore] public int Directions => 4;
+    }
+}

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -199,6 +199,7 @@
     <Compile Include="Config\PacketOptions.cs" />
     <Compile Include="Config\PartyOptions.cs" />
     <Compile Include="Config\SecurityOptions.cs" />
+    <Compile Include="Config\SpriteOptions.cs" />
     <Compile Include="Core\ApplicationContext.cs" />
     <Compile Include="Core\ExperimentalFeatures\CommonExperiments.Core.cs" />
     <Compile Include="Core\ExperimentalFeatures\CommonExperiments.Static.cs" />

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -254,20 +254,20 @@ namespace Intersect.Client.Entities
                 switch (SpriteAnimation)
                 {
                     case SpriteAnimations.Normal:
-                        return Options.Instance.SpriteOpts.NormalFrames;
+                        return Options.Instance.Sprites.NormalFrames;
                     case SpriteAnimations.Idle:
-                        return Options.Instance.SpriteOpts.IdleFrames;
+                        return Options.Instance.Sprites.IdleFrames;
                     case SpriteAnimations.Attack:
-                        return Options.Instance.SpriteOpts.AttackFrames;
+                        return Options.Instance.Sprites.AttackFrames;
                     case SpriteAnimations.Shoot:
-                        return Options.Instance.SpriteOpts.ShootFrames;
+                        return Options.Instance.Sprites.ShootFrames;
                     case SpriteAnimations.Cast:
-                        return Options.Instance.SpriteOpts.CastFrames;
+                        return Options.Instance.Sprites.CastFrames;
                     case SpriteAnimations.Weapon:
-                        return Options.Instance.SpriteOpts.WeaponFrames;
+                        return Options.Instance.Sprites.WeaponFrames;
                 }
 
-                return Options.Instance.SpriteOpts.NormalFrames;
+                return Options.Instance.Sprites.NormalFrames;
 
             }
         }
@@ -500,7 +500,7 @@ namespace Intersect.Client.Entities
             elapsedtime = ecTime;
             if (Dashing != null)
             {
-                WalkFrame = Options.Instance.SpriteOpts.NormalSheetDashFrame; //Fix the frame whilst dashing
+                WalkFrame = Options.Instance.Sprites.NormalSheetDashFrame; //Fix the frame whilst dashing
             }
             else if (mWalkTimer < Globals.System.GetTimeMs())
             {
@@ -534,7 +534,7 @@ namespace Intersect.Client.Entities
                         }
                     }
 
-                    mWalkTimer = Globals.System.GetTimeMs() + Options.Instance.SpriteOpts.MovingFrameDuration;
+                    mWalkTimer = Globals.System.GetTimeMs() + Options.Instance.Sprites.MovingFrameDuration;
                 }
             }
 
@@ -890,10 +890,10 @@ namespace Intersect.Client.Entities
 
             if (texture != null)
             {
-                if (texture.GetHeight() / Options.Instance.SpriteOpts.Directions > Options.TileHeight)
+                if (texture.GetHeight() / Options.Instance.Sprites.Directions > Options.TileHeight)
                 {
                     destRectangle.X = map.GetX() + X * Options.TileWidth + OffsetX + Options.TileWidth / 2;
-                    destRectangle.Y = GetCenterPos().Y - texture.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2);
+                    destRectangle.Y = GetCenterPos().Y - texture.GetHeight() / (Options.Instance.Sprites.Directions * 2);
                 }
                 else
                 {
@@ -932,8 +932,8 @@ namespace Intersect.Client.Entities
                 if (Options.AnimatedSprites.Contains(sprite.ToLower()))
                 {
                     srcRectangle = new FloatRect(
-                        AnimationFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                        (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                        AnimationFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.Sprites.Directions,
+                        (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.Sprites.Directions
                     );
                 }
                 else
@@ -944,24 +944,24 @@ namespace Intersect.Client.Entities
                         if (AttackTimer - CalculateAttackTime() / 2 > Globals.System.GetTimeMs() || Blocking)
                         {
                             srcRectangle = new FloatRect(
-                                Options.Instance.SpriteOpts.NormalSheetAttackFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                Options.Instance.Sprites.NormalSheetAttackFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.Sprites.Directions,
+                                (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.Sprites.Directions
                             );
                         }
                         else
                         {
                             //Restore Original Attacking/Blocking Code
                             srcRectangle = new FloatRect(
-                                WalkFrame * (int) texture.GetWidth() / SpriteFrames, d * (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int) texture.GetWidth() / SpriteFrames, (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                WalkFrame * (int) texture.GetWidth() / SpriteFrames, d * (int) texture.GetHeight() / Options.Instance.Sprites.Directions,
+                                (int) texture.GetWidth() / SpriteFrames, (int) texture.GetHeight() / Options.Instance.Sprites.Directions
                             );
                         }
                     }
                     else
                     {
                         srcRectangle = new FloatRect(
-                            SpriteFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                            (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            SpriteFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.Sprites.Directions,
+                            (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.Sprites.Directions
                         );
                     }
                 }
@@ -1061,15 +1061,15 @@ namespace Intersect.Client.Entities
             if (paperdollTex == null)
             {
                 paperdollTex = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Paperdoll, filename);
-                spriteFrames = Options.Instance.SpriteOpts.NormalFrames;
+                spriteFrames = Options.Instance.Sprites.NormalFrames;
             }
 
             if (paperdollTex != null)
             {
-                if (paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions > Options.TileHeight)
+                if (paperdollTex.GetHeight() / Options.Instance.Sprites.Directions > Options.TileHeight)
                 {
                     destRectangle.X = map.GetX() + X * Options.TileWidth + OffsetX;
-                    destRectangle.Y = GetCenterPos().Y - paperdollTex.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2);
+                    destRectangle.Y = GetCenterPos().Y - paperdollTex.GetHeight() / (Options.Instance.Sprites.Directions * 2);
                 }
                 else
                 {
@@ -1109,23 +1109,23 @@ namespace Intersect.Client.Entities
                     if (AttackTimer - CalculateAttackTime() / 2 > Globals.System.GetTimeMs() || Blocking)
                     {
                         srcRectangle = new FloatRect(
-                            3 * (int)paperdollTex.GetWidth() / spriteFrames, d * (int)paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                            (int)paperdollTex.GetWidth() / spriteFrames, (int)paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            3 * (int)paperdollTex.GetWidth() / spriteFrames, d * (int)paperdollTex.GetHeight() / Options.Instance.Sprites.Directions,
+                            (int)paperdollTex.GetWidth() / spriteFrames, (int)paperdollTex.GetHeight() / Options.Instance.Sprites.Directions
                         );
                     }
                     else
                     {
                         srcRectangle = new FloatRect(
-                            WalkFrame * (int) paperdollTex.GetWidth() / spriteFrames, d * (int) paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                            (int) paperdollTex.GetWidth() / spriteFrames, (int) paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            WalkFrame * (int) paperdollTex.GetWidth() / spriteFrames, d * (int) paperdollTex.GetHeight() / Options.Instance.Sprites.Directions,
+                            (int) paperdollTex.GetWidth() / spriteFrames, (int) paperdollTex.GetHeight() / Options.Instance.Sprites.Directions
                         );
                     }
                 }
                 else
                 {
                     srcRectangle = new FloatRect(
-                        SpriteFrame * (int)paperdollTex.GetWidth() / spriteFrames, d * (int)paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                        (int)paperdollTex.GetWidth() / spriteFrames, (int)paperdollTex.GetHeight() / Options.Instance.SpriteOpts.Directions
+                        SpriteFrame * (int)paperdollTex.GetWidth() / spriteFrames, d * (int)paperdollTex.GetHeight() / Options.Instance.Sprites.Directions,
+                        (int)paperdollTex.GetWidth() / spriteFrames, (int)paperdollTex.GetHeight() / Options.Instance.Sprites.Directions
                     );
                 }
 
@@ -1147,7 +1147,7 @@ namespace Intersect.Client.Entities
             if (Texture != null)
             {
                 pos.Y += Options.TileHeight / 2;
-                pos.Y -= Texture.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2);
+                pos.Y -= Texture.GetHeight() / (Options.Instance.Sprites.Directions * 2);
             }
 
             mCenterPos = pos;
@@ -1175,14 +1175,14 @@ namespace Intersect.Client.Entities
             var y = (int) Math.Ceiling(GetCenterPos().Y);
             if (overrideHeight != 0)
             {
-                y = y - (int) (overrideHeight / (Options.Instance.SpriteOpts.Directions * 2));
+                y = y - (int) (overrideHeight / (Options.Instance.Sprites.Directions * 2));
                 y -= 12;
             }
             else
             {
                 if (Texture != null)
                 {
-                    y = y - (int) (Texture.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2));
+                    y = y - (int) (Texture.GetHeight() / (Options.Instance.Sprites.Directions * 2));
                     y -= 12;
                 }
             }
@@ -1482,7 +1482,7 @@ namespace Intersect.Client.Entities
             var entityTex = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, MySprite);
             if (entityTex != null)
             {
-                y = y - (int) (entityTex.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2));
+                y = y - (int) (entityTex.GetHeight() / (Options.Instance.Sprites.Directions * 2));
                 y -= 8;
             }
 
@@ -1546,7 +1546,7 @@ namespace Intersect.Client.Entities
                 var entityTex = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, MySprite);
                 if (entityTex != null)
                 {
-                    y = y + (int) (entityTex.GetHeight() / (Options.Instance.SpriteOpts.Directions * 2));
+                    y = y + (int) (entityTex.GetHeight() / (Options.Instance.Sprites.Directions * 2));
                     y += 3;
                 }
 
@@ -1670,7 +1670,7 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            SpriteAnimation = AnimatedTextures[SpriteAnimations.Idle] != null && LastActionTime + Options.Instance.SpriteOpts.TimeBeforeIdle < Globals.System.GetTimeMs() ? SpriteAnimations.Idle : SpriteAnimations.Normal;
+            SpriteAnimation = AnimatedTextures[SpriteAnimations.Idle] != null && LastActionTime + Options.Instance.Sprites.TimeBeforeIdle < Globals.System.GetTimeMs() ? SpriteAnimations.Idle : SpriteAnimations.Normal;
             if (IsMoving)
             {
                 SpriteAnimation = SpriteAnimations.Normal;
@@ -1751,7 +1751,7 @@ namespace Intersect.Client.Entities
             }
             else if (SpriteAnimation == SpriteAnimations.Idle)
             {
-                if (SpriteFrameTimer + Options.Instance.SpriteOpts.IdleFrameDuration < Globals.System.GetTimeMs())
+                if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration < Globals.System.GetTimeMs())
                 {
                     SpriteFrame++;
                     if (SpriteFrame >= SpriteFrames)

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -247,6 +247,31 @@ namespace Intersect.Client.Entities
             }
         }
 
+        public virtual int SpriteFrames
+        {
+            get
+            {
+                switch (SpriteAnimation)
+                {
+                    case SpriteAnimations.Normal:
+                        return Options.Instance.SpriteOpts.NormalFrames;
+                    case SpriteAnimations.Idle:
+                        return Options.Instance.SpriteOpts.IdleFrames;
+                    case SpriteAnimations.Attack:
+                        return Options.Instance.SpriteOpts.AttackFrames;
+                    case SpriteAnimations.Shoot:
+                        return Options.Instance.SpriteOpts.ShootFrames;
+                    case SpriteAnimations.Cast:
+                        return Options.Instance.SpriteOpts.CastFrames;
+                    case SpriteAnimations.Weapon:
+                        return Options.Instance.SpriteOpts.WeaponFrames;
+                }
+
+                return Options.Instance.SpriteOpts.NormalFrames;
+
+            }
+        }
+
         public MapInstance MapInstance => MapInstance.Get(CurrentMap);
 
         public virtual Guid CurrentMap { get; set; }
@@ -492,16 +517,16 @@ namespace Intersect.Client.Entities
                     if (IsMoving)
                     {
                         WalkFrame++;
-                        if (WalkFrame >= GetSpriteFrames())
+                        if (WalkFrame >= SpriteFrames)
                         {
                             WalkFrame = 0;
                         }
                     }
                     else
                     {
-                        if (WalkFrame > 0 && WalkFrame / GetSpriteFrames() < 0.7f)
+                        if (WalkFrame > 0 && WalkFrame / SpriteFrames < 0.7f)
                         {
-                            WalkFrame = (int)GetSpriteFrames() / 2;
+                            WalkFrame = (int)SpriteFrames / 2;
                         }
                         else
                         {
@@ -656,7 +681,7 @@ namespace Intersect.Client.Entities
             {
                 AnimationTimer = Globals.System.GetTimeMs() + 200;
                 AnimationFrame++;
-                if (AnimationFrame >= GetSpriteFrames())
+                if (AnimationFrame >= SpriteFrames)
                 {
                     AnimationFrame = 0;
                 }
@@ -876,7 +901,7 @@ namespace Intersect.Client.Entities
                     destRectangle.Y = map.GetY() + Y * Options.TileHeight + OffsetY;
                 }
 
-                destRectangle.X -= texture.GetWidth() / (GetSpriteFrames() * 2);
+                destRectangle.X -= texture.GetWidth() / (SpriteFrames * 2);
                 switch (Dir)
                 {
                     case 0:
@@ -907,8 +932,8 @@ namespace Intersect.Client.Entities
                 if (Options.AnimatedSprites.Contains(sprite.ToLower()))
                 {
                     srcRectangle = new FloatRect(
-                        AnimationFrame * (int)texture.GetWidth() / GetSpriteFrames(), d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                        (int)texture.GetWidth() / GetSpriteFrames(), (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                        AnimationFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                        (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                     );
                 }
                 else
@@ -919,24 +944,24 @@ namespace Intersect.Client.Entities
                         if (AttackTimer - CalculateAttackTime() / 2 > Globals.System.GetTimeMs() || Blocking)
                         {
                             srcRectangle = new FloatRect(
-                                Options.Instance.SpriteOpts.NormalSheetAttackFrame * (int)texture.GetWidth() / GetSpriteFrames(), d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int)texture.GetWidth() / GetSpriteFrames(), (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                Options.Instance.SpriteOpts.NormalSheetAttackFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                                (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
                         }
                         else
                         {
                             //Restore Original Attacking/Blocking Code
                             srcRectangle = new FloatRect(
-                                WalkFrame * (int) texture.GetWidth() / GetSpriteFrames(), d * (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int) texture.GetWidth() / GetSpriteFrames(), (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                WalkFrame * (int) texture.GetWidth() / SpriteFrames, d * (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                                (int) texture.GetWidth() / SpriteFrames, (int) texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
                         }
                     }
                     else
                     {
                         srcRectangle = new FloatRect(
-                            SpriteFrame * (int)texture.GetWidth() / GetSpriteFrames(), d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                            (int)texture.GetWidth() / GetSpriteFrames(), (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            SpriteFrame * (int)texture.GetWidth() / SpriteFrames, d * (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                            (int)texture.GetWidth() / SpriteFrames, (int)texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                         );
                     }
                 }
@@ -1031,7 +1056,7 @@ namespace Intersect.Client.Entities
                 GameContentManager.TextureType.Paperdoll, $"{filenameNoExt}_{SpriteAnimation.ToString()}.png"
             );
 
-            var spriteFrames = GetSpriteFrames();
+            var spriteFrames = SpriteFrames;
 
             if (paperdollTex == null)
             {
@@ -1635,27 +1660,6 @@ namespace Intersect.Client.Entities
             Status = Status.OrderByDescending(x => x.RemainingMs()).ToList();
         }
 
-        private float GetSpriteFrames()
-        {
-            switch (SpriteAnimation)
-            {
-                case SpriteAnimations.Normal:
-                    return Options.Instance.SpriteOpts.NormalFrames;
-                case SpriteAnimations.Idle:
-                    return Options.Instance.SpriteOpts.IdleFrames;
-                case SpriteAnimations.Attack:
-                    return Options.Instance.SpriteOpts.AttackFrames;
-                case SpriteAnimations.Shoot:
-                    return Options.Instance.SpriteOpts.ShootFrames;
-                case SpriteAnimations.Cast:
-                    return Options.Instance.SpriteOpts.CastFrames;
-                case SpriteAnimations.Weapon:
-                    return Options.Instance.SpriteOpts.WeaponFrames;
-            }
-
-            return Options.Instance.SpriteOpts.NormalFrames;
-        }
-
         public void UpdateSpriteAnimation()
         {
             var oldAnim = SpriteAnimation;
@@ -1680,7 +1684,7 @@ namespace Intersect.Client.Entities
                 if (AnimatedTextures[SpriteAnimations.Attack] != null)
                 {
                     SpriteAnimation = SpriteAnimations.Attack;
-                    SpriteFrame = (int)Math.Floor((timeIn / (CalculateAttackTime() / GetSpriteFrames())));
+                    SpriteFrame = (int)Math.Floor((timeIn / (CalculateAttackTime() / (float)SpriteFrames)));
                 }
 
                 if (Options.WeaponIndex > -1 && Options.WeaponIndex < Equipment.Length)
@@ -1725,7 +1729,7 @@ namespace Intersect.Client.Entities
                 {
                     var duration = spell.CastDuration;
                     var timeIn = duration - (CastTime - Globals.System.GetTimeMs());
-                    SpriteFrame = (int)Math.Floor((timeIn / (duration / GetSpriteFrames())));
+                    SpriteFrame = (int)Math.Floor((timeIn / (duration / (float)SpriteFrames)));
 
                     if (AnimatedTextures[SpriteAnimations.Cast] != null)
                     {
@@ -1750,7 +1754,7 @@ namespace Intersect.Client.Entities
                 if (SpriteFrameTimer + Options.Instance.SpriteOpts.IdleFrameDuration < Globals.System.GetTimeMs())
                 {
                     SpriteFrame++;
-                    if (SpriteFrame >= GetSpriteFrames())
+                    if (SpriteFrame >= SpriteFrames)
                     {
                         SpriteFrame = 0;
                     }

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -107,8 +107,8 @@ namespace Intersect.Client.Entities.Events
                     if (entityTex != null)
                     {
                         srcTexture = entityTex;
-                        height = srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions;
-                        width = srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames;
+                        height = srcTexture.GetHeight() / Options.Instance.Sprites.Directions;
+                        width = srcTexture.GetWidth() / Options.Instance.Sprites.NormalFrames;
                         d = Graphic.Y;
                         if (!DirectionFix)
                         {
@@ -142,15 +142,15 @@ namespace Intersect.Client.Entities.Events
                         if (Options.AnimatedSprites.Contains(Graphic.Filename.ToLower()))
                         {
                             srcRectangle = new FloatRect(
-                                AnimationFrame * (int) entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, d * (int) entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int) entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, (int) entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                AnimationFrame * (int) entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, d * (int) entityTex.GetHeight() / Options.Instance.Sprites.Directions,
+                                (int) entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, (int) entityTex.GetHeight() / Options.Instance.Sprites.Directions
                             );
                         }
                         else
                         {
                             srcRectangle = new FloatRect(
-                                frame * (int) srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, d * (int) srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions,
-                                (int) srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, (int) srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                frame * (int) srcTexture.GetWidth() / Options.Instance.Sprites.NormalFrames, d * (int) srcTexture.GetHeight() / Options.Instance.Sprites.Directions,
+                                (int) srcTexture.GetWidth() / Options.Instance.Sprites.NormalFrames, (int) srcTexture.GetHeight() / Options.Instance.Sprites.Directions
                             );
                         }
                     }
@@ -382,7 +382,7 @@ namespace Intersect.Client.Entities.Events
                     if (entityTex != null)
                     {
                         pos.Y += Options.TileHeight / 2;
-                        pos.Y -= entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions / 2;
+                        pos.Y -= entityTex.GetHeight() / Options.Instance.Sprites.Directions / 2;
                     }
 
                     break;

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -88,6 +88,7 @@ namespace Intersect.Client.Entities.Events
             {
                 return;
             }
+            
 
             var map = MapInstance.Get(CurrentMap);
             var srcRectangle = new FloatRect();
@@ -106,8 +107,8 @@ namespace Intersect.Client.Entities.Events
                     if (entityTex != null)
                     {
                         srcTexture = entityTex;
-                        height = srcTexture.GetHeight() / 4;
-                        width = srcTexture.GetWidth() / 4;
+                        height = srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions;
+                        width = srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames;
                         d = Graphic.Y;
                         if (!DirectionFix)
                         {
@@ -141,15 +142,15 @@ namespace Intersect.Client.Entities.Events
                         if (Options.AnimatedSprites.Contains(Graphic.Filename.ToLower()))
                         {
                             srcRectangle = new FloatRect(
-                                AnimationFrame * (int) entityTex.GetWidth() / 4, d * (int) entityTex.GetHeight() / 4,
-                                (int) entityTex.GetWidth() / 4, (int) entityTex.GetHeight() / 4
+                                AnimationFrame * (int) entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, d * (int) entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                                (int) entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, (int) entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
                         }
                         else
                         {
                             srcRectangle = new FloatRect(
-                                frame * (int) srcTexture.GetWidth() / 4, d * (int) srcTexture.GetHeight() / 4,
-                                (int) srcTexture.GetWidth() / 4, (int) srcTexture.GetHeight() / 4
+                                frame * (int) srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, d * (int) srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions,
+                                (int) srcTexture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, (int) srcTexture.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
                         }
                     }
@@ -381,7 +382,7 @@ namespace Intersect.Client.Entities.Events
                     if (entityTex != null)
                     {
                         pos.Y += Options.TileHeight / 2;
-                        pos.Y -= entityTex.GetHeight() / 4 / 2;
+                        pos.Y -= entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions / 2;
                     }
 
                     break;

--- a/Intersect.Client/Interface/Game/AdminWindow.cs
+++ b/Intersect.Client/Interface/Game/AdminWindow.cs
@@ -272,8 +272,8 @@ namespace Intersect.Client.Interface.Game
 
             if (SpritePanel.Texture != null)
             {
-                SpritePanel.SetUv(0, 0, .25f, .25f);
-                SpritePanel.SetSize(SpritePanel.Texture.GetWidth() / 4, SpritePanel.Texture.GetHeight() / 4);
+                SpritePanel.SetTextureRect(0, 0, SpritePanel.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions);
+                SpritePanel.SetSize(SpritePanel.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions);
                 Align.AlignTop(SpritePanel);
                 Align.CenterHorizontally(SpritePanel);
             }

--- a/Intersect.Client/Interface/Game/AdminWindow.cs
+++ b/Intersect.Client/Interface/Game/AdminWindow.cs
@@ -272,8 +272,8 @@ namespace Intersect.Client.Interface.Game
 
             if (SpritePanel.Texture != null)
             {
-                SpritePanel.SetTextureRect(0, 0, SpritePanel.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions);
-                SpritePanel.SetSize(SpritePanel.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions);
+                SpritePanel.SetTextureRect(0, 0, SpritePanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.Sprites.Directions);
+                SpritePanel.SetSize(SpritePanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, SpritePanel.Texture.GetHeight() / Options.Instance.Sprites.Directions);
                 Align.AlignTop(SpritePanel);
                 Align.CenterHorizontally(SpritePanel);
             }

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -226,7 +226,7 @@ namespace Intersect.Client.Interface.Game.Character
                     {
                         PaperdollPanels[z].Show();
                         PaperdollPanels[z].Texture = entityTex;
-                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / 4, entityTex.GetHeight() / 4);
+                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions);
                         PaperdollPanels[z].SizeToContents();
                         Align.Center(PaperdollPanels[z]);
                     }
@@ -248,14 +248,14 @@ namespace Intersect.Client.Interface.Game.Character
                         {
                             PaperdollPanels[z]
                                 .SetTextureRect(
-                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / 4,
-                                    PaperdollPanels[z].Texture.GetHeight() / 4
+                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                 );
 
                             PaperdollPanels[z]
                                 .SetSize(
-                                    PaperdollPanels[z].Texture.GetWidth() / 4,
-                                    PaperdollPanels[z].Texture.GetHeight() / 4
+                                    PaperdollPanels[z].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                 );
 
                             PaperdollPanels[z]

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -226,7 +226,7 @@ namespace Intersect.Client.Interface.Game.Character
                     {
                         PaperdollPanels[z].Show();
                         PaperdollPanels[z].Texture = entityTex;
-                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions);
+                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
                         PaperdollPanels[z].SizeToContents();
                         Align.Center(PaperdollPanels[z]);
                     }
@@ -248,14 +248,14 @@ namespace Intersect.Client.Interface.Game.Character
                         {
                             PaperdollPanels[z]
                                 .SetTextureRect(
-                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                 );
 
                             PaperdollPanels[z]
                                 .SetSize(
-                                    PaperdollPanels[z].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                    PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                 );
 
                             PaperdollPanels[z]

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -719,7 +719,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 if (entityTex != EntityFace.Texture)
                 {
                     EntityFace.Texture = entityTex;
-                    EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / 4, entityTex.GetHeight() / 4);
+                    EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions);
                     EntityFace.SizeToContents();
                     Align.Center(EntityFace);
                     mCurrentSprite = MyEntity.MySprite;
@@ -791,14 +791,14 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                         {
                             PaperdollPanels[n]
                                 .SetTextureRect(
-                                    0, 0, PaperdollPanels[n].Texture.GetWidth() / 4,
-                                    PaperdollPanels[n].Texture.GetHeight() / 4
+                                    0, 0, PaperdollPanels[n].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                 );
 
                             PaperdollPanels[n]
                                 .SetSize(
-                                    PaperdollPanels[n].Texture.GetWidth() / 4,
-                                    PaperdollPanels[n].Texture.GetHeight() / 4
+                                    PaperdollPanels[n].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                 );
 
                             PaperdollPanels[n]

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -719,7 +719,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 if (entityTex != EntityFace.Texture)
                 {
                     EntityFace.Texture = entityTex;
-                    EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, entityTex.GetHeight() / Options.Instance.SpriteOpts.Directions);
+                    EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
                     EntityFace.SizeToContents();
                     Align.Center(EntityFace);
                     mCurrentSprite = MyEntity.MySprite;
@@ -791,14 +791,14 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                         {
                             PaperdollPanels[n]
                                 .SetTextureRect(
-                                    0, 0, PaperdollPanels[n].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                    0, 0, PaperdollPanels[n].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                 );
 
                             PaperdollPanels[n]
                                 .SetSize(
-                                    PaperdollPanels[n].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                    PaperdollPanels[n].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    PaperdollPanels[n].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                 );
 
                             PaperdollPanels[n]

--- a/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
@@ -277,12 +277,12 @@ namespace Intersect.Client.Interface.Menu
                         else
                         {
                             mCharacterPortrait.SetTextureRect(
-                                0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
                             );
 
                             mCharacterPortrait.SetSize(
-                                mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
                             );
 
                             mCharacterPortrait.SetPosition(

--- a/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
@@ -277,12 +277,12 @@ namespace Intersect.Client.Interface.Menu
                         else
                         {
                             mCharacterPortrait.SetTextureRect(
-                                0, 0, mCharacterPortrait.Texture.GetWidth() / 4,
-                                mCharacterPortrait.Texture.GetHeight() / 4
+                                0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
 
                             mCharacterPortrait.SetSize(
-                                mCharacterPortrait.Texture.GetWidth() / 4, mCharacterPortrait.Texture.GetHeight() / 4
+                                mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                             );
 
                             mCharacterPortrait.SetPosition(

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -228,11 +228,11 @@ namespace Intersect.Client.Interface.Menu
                     else
                     {
                         mCharacterPortrait.SetTextureRect(
-                            0, 0, mCharacterPortrait.Texture.GetWidth() / 4, mCharacterPortrait.Texture.GetHeight() / 4
+                            0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                         );
 
                         mCharacterPortrait.SetSize(
-                            mCharacterPortrait.Texture.GetWidth() / 4, mCharacterPortrait.Texture.GetHeight() / 4
+                            mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                         );
 
                         mCharacterPortrait.SetPosition(
@@ -253,14 +253,14 @@ namespace Intersect.Client.Interface.Menu
                                     mPaperdollPortraits[i].Show();
                                     mPaperdollPortraits[i]
                                         .SetTextureRect(
-                                            0, 0, mPaperdollPortraits[i].Texture.GetWidth() / 4,
-                                            mPaperdollPortraits[i].Texture.GetHeight() / 4
+                                            0, 0, mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                         );
 
                                     mPaperdollPortraits[i]
                                         .SetSize(
-                                            mPaperdollPortraits[i].Texture.GetWidth() / 4,
-                                            mPaperdollPortraits[i].Texture.GetHeight() / 4
+                                            mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
+                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
                                         );
 
                                     mPaperdollPortraits[i]

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -228,11 +228,11 @@ namespace Intersect.Client.Interface.Menu
                     else
                     {
                         mCharacterPortrait.SetTextureRect(
-                            0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
                         );
 
                         mCharacterPortrait.SetSize(
-                            mCharacterPortrait.Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                            mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
                         );
 
                         mCharacterPortrait.SetPosition(
@@ -253,14 +253,14 @@ namespace Intersect.Client.Interface.Menu
                                     mPaperdollPortraits[i].Show();
                                     mPaperdollPortraits[i]
                                         .SetTextureRect(
-                                            0, 0, mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                            0, 0, mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                         );
 
                                     mPaperdollPortraits[i]
                                         .SetSize(
-                                            mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.SpriteOpts.NormalFrames,
-                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.SpriteOpts.Directions
+                                            mPaperdollPortraits[i].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                            mPaperdollPortraits[i].Texture.GetHeight() / Options.Instance.Sprites.Directions
                                         );
 
                                     mPaperdollPortraits[i]

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
@@ -59,9 +59,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 g.DrawImage(
                     sourceBitmap,
                     new Rectangle(
-                        pnlPreview.Width / 2 - sourceBitmap.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), pnlPreview.Height / 2 - sourceBitmap.Height / (Options.Instance.SpriteOpts.Directions * 2),
-                        sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
-                    ), new Rectangle(0, 0, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
+                        pnlPreview.Width / 2 - sourceBitmap.Width / (Options.Instance.Sprites.NormalFrames * 2), pnlPreview.Height / 2 - sourceBitmap.Height / (Options.Instance.Sprites.Directions * 2),
+                        sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
+                    ), new Rectangle(0, 0, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
                 );
             }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
@@ -59,9 +59,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 g.DrawImage(
                     sourceBitmap,
                     new Rectangle(
-                        pnlPreview.Width / 2 - sourceBitmap.Width / 8, pnlPreview.Height / 2 - sourceBitmap.Height / 8,
-                        sourceBitmap.Width / 4, sourceBitmap.Height / 4
-                    ), new Rectangle(0, 0, sourceBitmap.Width / 4, sourceBitmap.Height / 4), GraphicsUnit.Pixel
+                        pnlPreview.Width / 2 - sourceBitmap.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), pnlPreview.Height / 2 - sourceBitmap.Height / (Options.Instance.SpriteOpts.Directions * 2),
+                        sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
+                    ), new Rectangle(0, 0, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
                 );
             }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -179,8 +179,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             if (cmbGraphicType.SelectedIndex == 1) //Sprite
             {
                 sourceBitmap = new Bitmap("resources/entities/" + cmbGraphic.Text);
-                mSpriteWidth = sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames;
-                mSpriteHeight = sourceBitmap.Height / Options.Instance.SpriteOpts.Directions;
+                mSpriteWidth = sourceBitmap.Width / Options.Instance.Sprites.NormalFrames;
+                mSpriteHeight = sourceBitmap.Height / Options.Instance.Sprites.Directions;
             }
             else if (cmbGraphicType.SelectedIndex == 2) //Tileset
             {
@@ -201,8 +201,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     graphics.DrawRectangle(
                         new Pen(System.Drawing.Color.White, 2f),
                         new Rectangle(
-                            mTmpGraphic.X * sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, mTmpGraphic.Y * sourceBitmap.Height / Options.Instance.SpriteOpts.Directions,
-                            sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
+                            mTmpGraphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, mTmpGraphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions,
+                            sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
                         )
                     );
                 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -179,8 +179,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             if (cmbGraphicType.SelectedIndex == 1) //Sprite
             {
                 sourceBitmap = new Bitmap("resources/entities/" + cmbGraphic.Text);
-                mSpriteWidth = sourceBitmap.Width / 4;
-                mSpriteHeight = sourceBitmap.Height / 4;
+                mSpriteWidth = sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames;
+                mSpriteHeight = sourceBitmap.Height / Options.Instance.SpriteOpts.Directions;
             }
             else if (cmbGraphicType.SelectedIndex == 2) //Tileset
             {
@@ -201,8 +201,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     graphics.DrawRectangle(
                         new Pen(System.Drawing.Color.White, 2f),
                         new Rectangle(
-                            mTmpGraphic.X * sourceBitmap.Width / 4, mTmpGraphic.Y * sourceBitmap.Height / 4,
-                            sourceBitmap.Width / 4, sourceBitmap.Height / 4
+                            mTmpGraphic.X * sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, mTmpGraphic.Y * sourceBitmap.Height / Options.Instance.SpriteOpts.Directions,
+                            sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames, sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
                         )
                     );
                 }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -206,14 +206,14 @@ namespace Intersect.Editor.Forms.Editors.Events
                     graphics.DrawImage(
                         sourceBitmap,
                         new Rectangle(
-                            pnlPreview.Width / 2 - sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames / 2,
-                            pnlPreview.Height / 2 - sourceBitmap.Height / Options.Instance.SpriteOpts .Directions / 2, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
-                            sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
+                            pnlPreview.Width / 2 - sourceBitmap.Width / Options.Instance.Sprites.NormalFrames / 2,
+                            pnlPreview.Height / 2 - sourceBitmap.Height / Options.Instance.Sprites .Directions / 2, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                            sourceBitmap.Height / Options.Instance.Sprites.Directions
                         ),
                         new Rectangle(
-                            CurrentPage.Graphic.X * sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
-                            CurrentPage.Graphic.Y * sourceBitmap.Height / Options.Instance.SpriteOpts.Directions, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
-                            sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
+                            CurrentPage.Graphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                            CurrentPage.Graphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                            sourceBitmap.Height / Options.Instance.Sprites.Directions
                         ), GraphicsUnit.Pixel
                     );
                 }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -206,14 +206,14 @@ namespace Intersect.Editor.Forms.Editors.Events
                     graphics.DrawImage(
                         sourceBitmap,
                         new Rectangle(
-                            pnlPreview.Width / 2 - sourceBitmap.Width / 4 / 2,
-                            pnlPreview.Height / 2 - sourceBitmap.Height / 4 / 2, sourceBitmap.Width / 4,
-                            sourceBitmap.Height / 4
+                            pnlPreview.Width / 2 - sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames / 2,
+                            pnlPreview.Height / 2 - sourceBitmap.Height / Options.Instance.SpriteOpts .Directions / 2, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
+                            sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
                         ),
                         new Rectangle(
-                            CurrentPage.Graphic.X * sourceBitmap.Width / 4,
-                            CurrentPage.Graphic.Y * sourceBitmap.Height / 4, sourceBitmap.Width / 4,
-                            sourceBitmap.Height / 4
+                            CurrentPage.Graphic.X * sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
+                            CurrentPage.Graphic.Y * sourceBitmap.Height / Options.Instance.SpriteOpts.Directions, sourceBitmap.Width / Options.Instance.SpriteOpts.NormalFrames,
+                            sourceBitmap.Height / Options.Instance.SpriteOpts.Directions
                         ), GraphicsUnit.Pixel
                     );
                 }

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -719,8 +719,8 @@ namespace Intersect.Editor.Forms.Editors
                 {
                     var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
                     gfx.DrawImage(
-                        img, new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions),
-                        new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
+                        img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
+                        new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
                     );
 
                     img.Dispose();

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -719,8 +719,8 @@ namespace Intersect.Editor.Forms.Editors
                 {
                     var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
                     gfx.DrawImage(
-                        img, new Rectangle(0, 0, img.Width / 4, img.Height / 4),
-                        new Rectangle(0, 0, img.Width / 4, img.Height / 4), GraphicsUnit.Pixel
+                        img, new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions),
+                        new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
                     );
 
                     img.Dispose();

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -369,8 +369,8 @@ namespace Intersect.Editor.Forms.Editors
             {
                 var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
                 gfx.DrawImage(
-                    img, new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions),
-                    new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
+                    img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
+                    new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
                 );
 
                 img.Dispose();

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -369,8 +369,8 @@ namespace Intersect.Editor.Forms.Editors
             {
                 var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
                 gfx.DrawImage(
-                    img, new Rectangle(0, 0, img.Width / 4, img.Height / 4),
-                    new Rectangle(0, 0, img.Width / 4, img.Height / 4), GraphicsUnit.Pixel
+                    img, new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions),
+                    new Rectangle(0, 0, img.Width / Options.Instance.SpriteOpts.NormalFrames, img.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
                 );
 
                 img.Dispose();

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -517,9 +517,9 @@ namespace Intersect.Editor.Forms.Editors
                     g.DrawImage(
                         src,
                         new Rectangle(
-                            picSprite.Width / 2 - src.Width / 8, picSprite.Height / 2 - src.Height / 8, src.Width / 4,
-                            src.Height / 4
-                        ), new Rectangle(0, 0, src.Width / 4, src.Height / 4), GraphicsUnit.Pixel
+                            picSprite.Width / 2 - src.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.SpriteOpts.Directions * 2), src.Width / Options.Instance.SpriteOpts.NormalFrames,
+                            src.Height / Options.Instance.SpriteOpts.Directions
+                        ), new Rectangle(0, 0, src.Width / Options.Instance.SpriteOpts.NormalFrames, src.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
                     );
 
                     g.Dispose();
@@ -575,9 +575,9 @@ namespace Intersect.Editor.Forms.Editors
                 g.DrawImage(
                     src,
                     new Rectangle(
-                        picSprite.Width / 2 - src.Width / 8, picSprite.Height / 2 - src.Height / 8, src.Width / 4,
-                        src.Height / 4
-                    ), new Rectangle(0, 0, src.Width / 4, src.Height / 4), GraphicsUnit.Pixel
+                        picSprite.Width / 2 - src.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.SpriteOpts.Directions * 2), src.Width / Options.Instance.SpriteOpts.NormalFrames,
+                        src.Height / Options.Instance.SpriteOpts.Directions
+                    ), new Rectangle(0, 0, src.Width / Options.Instance.SpriteOpts.NormalFrames, src.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
                 );
 
                 g.Dispose();

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -517,9 +517,9 @@ namespace Intersect.Editor.Forms.Editors
                     g.DrawImage(
                         src,
                         new Rectangle(
-                            picSprite.Width / 2 - src.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.SpriteOpts.Directions * 2), src.Width / Options.Instance.SpriteOpts.NormalFrames,
-                            src.Height / Options.Instance.SpriteOpts.Directions
-                        ), new Rectangle(0, 0, src.Width / Options.Instance.SpriteOpts.NormalFrames, src.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
+                            picSprite.Width / 2 - src.Width / (Options.Instance.Sprites.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.Sprites.Directions * 2), src.Width / Options.Instance.Sprites.NormalFrames,
+                            src.Height / Options.Instance.Sprites.Directions
+                        ), new Rectangle(0, 0, src.Width / Options.Instance.Sprites.NormalFrames, src.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
                     );
 
                     g.Dispose();
@@ -575,9 +575,9 @@ namespace Intersect.Editor.Forms.Editors
                 g.DrawImage(
                     src,
                     new Rectangle(
-                        picSprite.Width / 2 - src.Width / (Options.Instance.SpriteOpts.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.SpriteOpts.Directions * 2), src.Width / Options.Instance.SpriteOpts.NormalFrames,
-                        src.Height / Options.Instance.SpriteOpts.Directions
-                    ), new Rectangle(0, 0, src.Width / Options.Instance.SpriteOpts.NormalFrames, src.Height / Options.Instance.SpriteOpts.Directions), GraphicsUnit.Pixel
+                        picSprite.Width / 2 - src.Width / (Options.Instance.Sprites.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.Sprites.Directions * 2), src.Width / Options.Instance.Sprites.NormalFrames,
+                        src.Height / Options.Instance.Sprites.Directions
+                    ), new Rectangle(0, 0, src.Width / Options.Instance.Sprites.NormalFrames, src.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
                 );
 
                 g.Dispose();


### PR DESCRIPTION
Pulls out options for # of sprite frames, time before idling, and more into the server config instead of being hard coded into the client/editor.

Changes a lot of "/4" and "/8" into meaningful and readable values.

Resolves #316 