### PR TITLE
Custom Mouse Cursor

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -127,6 +127,11 @@ namespace Intersect.Configuration
 
         public string UpdateUrl { get; set; } = "";
 
+        /// <summary>
+        /// Sets a custom mouse cursor.
+        /// </summary>
+        public string MouseCursor { get; set; } = "";
+
         #endregion
 
         #region Serialization Hooks

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -8,6 +8,7 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.General;
 using Intersect.Client.Maps;
+using Intersect.Client.MonoGame.Input;
 using Intersect.Configuration;
 using Intersect.Enums;
 using Intersect.GameObjects;
@@ -488,6 +489,15 @@ namespace Intersect.Client.Core
                 new Color((int) Fade.GetFade(), 0, 0, 0), null, GameBlendModes.None
             );
 
+            // Draw our mousecursor at the very end, but not when taking screenshots.
+            if (!takingScreenshot && !string.IsNullOrWhiteSpace(ClientConfiguration.Instance.MouseCursor))
+            {
+                var renderLoc = ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
+                DrawGameTexture(
+                    Globals.ContentManager.GetTexture(GameContentManager.TextureType.Misc, ClientConfiguration.Instance.MouseCursor), renderLoc.X, renderLoc.Y
+               );
+            }
+            
             Renderer.End();
 
             if (takingScreenshot)
@@ -1118,6 +1128,15 @@ namespace Intersect.Client.Core
         }
 
         //Helper Functions
+        /// <summary>
+        /// Convert a position on the screen to a position on the actual map for rendering.
+        /// </summary>
+        /// <param name="windowPoint">The point to convert.</param>
+        /// <returns>The converted point.</returns>
+        public static Pointf ConvertToWorldPoint(Pointf windowPoint)
+        {
+            return new Pointf((int)Math.Floor(windowPoint.X + CurrentView.Left), (int)Math.Floor(windowPoint.Y + CurrentView.Top));
+        }
 
         //Rendering Functions
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1809,14 +1809,12 @@ namespace Intersect.Client.Entities
                 }
             }
 
-            var x = (int) Math.Floor(Globals.InputManager.GetMousePosition().X + Graphics.CurrentView.Left);
-            var y = (int) Math.Floor(Globals.InputManager.GetMousePosition().Y + Graphics.CurrentView.Top);
-
+            var mousePos = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
             foreach (MapInstance map in MapInstance.Lookup.Values)
             {
-                if (x >= map.GetX() && x <= map.GetX() + Options.MapWidth * Options.TileWidth)
+                if (mousePos.X >= map.GetX() && mousePos.X <= map.GetX() + Options.MapWidth * Options.TileWidth)
                 {
-                    if (y >= map.GetY() && y <= map.GetY() + Options.MapHeight * Options.TileHeight)
+                    if (mousePos.Y >= map.GetY() && mousePos.Y <= map.GetY() + Options.MapHeight * Options.TileHeight)
                     {
                         var mapId = map.Id;
 
@@ -1829,7 +1827,7 @@ namespace Intersect.Client.Entities
 
                             if (en.Value.CurrentMap == mapId &&
                                 !en.Value.IsStealthed() &&
-                                en.Value.WorldPos.Contains(x, y))
+                                en.Value.WorldPos.Contains(mousePos.X, mousePos.Y))
                             {
                                 if (en.Value.GetType() != typeof(Projectile) && en.Value.GetType() != typeof(Resource))
                                 {
@@ -1853,7 +1851,7 @@ namespace Intersect.Client.Entities
                                 if (en.Value.CurrentMap == mapId &&
                                     !((Event) en.Value).DisablePreview &&
                                     !en.Value.IsStealthed() &&
-                                    en.Value.WorldPos.Contains(x, y))
+                                    en.Value.WorldPos.Contains(mousePos.X, mousePos.Y))
                                 {
                                     if (TargetType != 1 || TargetIndex != en.Value.Id)
                                     {

--- a/Intersect.Client/MonoGame/IntersectGame.cs
+++ b/Intersect.Client/MonoGame/IntersectGame.cs
@@ -111,6 +111,12 @@ namespace Intersect.Client.MonoGame
             Window.Position = new Microsoft.Xna.Framework.Point(-20, -2000);
             Window.AllowAltF4 = false;
 
+            // If we're going to be rendering a custom mouse cursor, hide the default one!
+            if (!string.IsNullOrWhiteSpace(ClientConfiguration.Instance.MouseCursor))
+            {
+                IsMouseVisible = false;
+            }
+            
             if (!string.IsNullOrWhiteSpace(ClientConfiguration.Instance.UpdateUrl))
             {
                 mUpdater = new Updater.Updater(


### PR DESCRIPTION
Adds very basic support for a custom mouse cursor.
Can be set from the client configuration, since we want the cursor to work even if we don't have a connection to the server.
Hides the normal OS mouse.

Had to generalize a piece of code for re-using, because I didn't want to end up duplicating the code calculating the mouse's actual world position.