### PR TITLE
Scrollback on event editor, event map previews

### DIFF
--- a/Intersect.Editor/Core/Database.cs
+++ b/Intersect.Editor/Core/Database.cs
@@ -41,6 +41,8 @@ namespace Intersect.Editor
 
         public static bool GridHideResources;
 
+        public static bool GridHideEvents;
+
         public static int GridLightColor = System.Drawing.Color.White.ToArgb();
 
         private static SqliteConnection sDbConnection;
@@ -82,6 +84,7 @@ namespace Intersect.Editor
             GridHideOverlay = GetOptionBool("HideOverlay");
             GridLightColor = GetOptionInt("LightColor");
             GridHideResources = GetOptionBool("HideResources");
+            GridHideEvents = GetOptionBool("HideEvents");
         }
 
         private static void CreateDatabase()
@@ -118,6 +121,7 @@ namespace Intersect.Editor
             SaveOption("HideFog", GridHideFog.ToString());
             SaveOption("HideOverlay", GridHideOverlay.ToString());
             SaveOption("HideResources", GridHideResources.ToString());
+            SaveOption("HideEvents", GridHideEvents.ToString());
             SaveOption("LightColor", GridLightColor.ToString());
         }
 

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1593,7 +1593,7 @@ namespace Intersect.Editor.Core
 
                     if (height > Options.TileHeight)
                     {
-                        destinationY -= Options.TileHeight;
+                        destinationY -= (height - Options.TileHeight);
                     }
 
                     if (width > Options.TileWidth)

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Linq;
 using System.Windows.Forms;
 
 using Intersect.Editor.Content;
@@ -45,6 +47,9 @@ namespace Intersect.Editor.Core
 
         //Resources
         public static bool HideResources = false;
+
+        // Events
+        public static bool HideEvents = false;
 
         //Advanced Editing Features
         public static bool HideTilePreview = false;
@@ -277,6 +282,28 @@ namespace Intersect.Editor.Core
                                             map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
                                             false, null, true, true
                                         );
+                                    }
+                                }
+                            }
+                        }
+
+                        // Draw events
+                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                        {
+                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                            {
+                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                                {
+                                    var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                                    if (map != null)
+                                    {
+                                        lock (map.MapLock)
+                                        {
+                                            DrawMapEvents(
+                                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                                false, null
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1453,6 +1480,131 @@ namespace Intersect.Editor.Core
             }
         }
 
+        private static void DrawMapEvents(
+            MapInstance map,
+            int gridX,
+            int gridY,
+            bool screenShotting,
+            RenderTarget2D renderTarget
+        )
+        {
+            if (!screenShotting && HideEvents)
+            {
+                return;
+            }
+
+            if (screenShotting && Database.GridHideEvents)
+            {
+                return;
+            }
+
+            var tmpMap = Globals.CurrentMap;
+            if (tmpMap == null)
+            {
+                return;
+            }
+
+            int x1 = 0, y1 = 0, x2 = 0, y2 = 0, xoffset = 0, yoffset = 0;
+
+            x1 = 0;
+            x2 = Options.MapWidth;
+            y1 = 0;
+            y2 = Options.MapHeight;
+            xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
+            yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
+            if (gridX != 0 || gridY != 0)
+            {
+                tmpMap = map;
+            }
+
+            if (screenShotting)
+            {
+                xoffset -= CurrentView.Left;
+                yoffset -= CurrentView.Top;
+            }
+
+            if (gridX == 0 && gridY == 0)
+            {
+                if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
+                {
+                    tmpMap = TilePreviewStruct;
+                }
+            }
+
+            if (tmpMap == null)
+            {
+                return;
+            }
+
+            for (var y = y1; y < y2; y++)
+            {
+                for (var x = x1; x < x2; x++)
+                {
+                    var tmpEvent = tmpMap.FindEventAt(x, y);
+                    if (tmpEvent == null)
+                    {
+                        continue;
+                    }
+
+                    if (tmpEvent.Pages[0].Graphic == null)
+                    {
+                        continue;
+                    }
+
+                    var tmpGraphic = tmpEvent.Pages[0].Graphic;
+                    if (TextUtils.IsNone(tmpGraphic.Filename))
+                    {
+                        continue;
+                    }
+
+                    Texture2D eventTex = null;
+                    var destinationX = x * Options.TileWidth + xoffset;
+                    var destinationY = y * Options.TileHeight + yoffset;
+                    var sourceX = 0;
+                    var sourceY = 0;
+                    var width = 0;
+                    var height = 0;
+
+                    switch (tmpGraphic.Type)
+                    {
+                        case EventGraphicType.Sprite: //Sprite
+                            eventTex = GameContentManager.GetTexture(
+                                GameContentManager.TextureType.Entity, tmpGraphic.Filename
+                            );
+
+                            sourceX = (int)tmpGraphic.X * (eventTex.Width / Options.Instance.Sprites.NormalFrames);
+                            sourceY = (int)tmpGraphic.Y * (eventTex.Height / Options.Instance.Sprites.Directions);
+                            width = (eventTex.Width / Options.Instance.Sprites.NormalFrames);
+                            height = (eventTex.Height / Options.Instance.Sprites.Directions);
+
+                            break;
+                        case EventGraphicType.Tileset: //Tile
+                            eventTex = GameContentManager.GetTexture(
+                                GameContentManager.TextureType.Tileset, tmpGraphic.Filename
+                            );
+
+                            sourceX = (int)tmpGraphic.X * Options.TileWidth;
+                            sourceY = (int)tmpGraphic.Y * Options.TileHeight;
+                            width = (tmpGraphic.Width + 1) * Options.TileWidth;
+                            height = (tmpGraphic.Height + 1) * Options.TileHeight;
+
+                            break;
+                    }
+
+                    if (height > Options.TileHeight)
+                    {
+                        destinationY -= Options.TileHeight;
+                    }
+
+                    if (width > Options.TileWidth)
+                    {
+                        destinationX -= (width  - Options.TileWidth) / 2;
+                    }
+
+                    DrawTexture(eventTex, destinationX, destinationY, sourceX, sourceY, width, height, renderTarget);
+                }
+            }
+        }
         private static void DrawMapOverlay(RenderTarget2D target)
         {
             DrawTexture(
@@ -1534,6 +1686,28 @@ namespace Intersect.Editor.Core
                                     DrawMapAttributes(
                                         map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
                                         sScreenShotRenderTexture, true, true
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Draw events
+                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                {
+                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                    {
+                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                        {
+                            var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                            if (map != null)
+                            {
+                                lock (map.MapLock)
+                                {
+                                    DrawMapEvents(
+                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                        true, sScreenShotRenderTexture
                                     );
                                 }
                             }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -32,25 +32,25 @@ namespace Intersect.Editor.Forms.Editors.Events
         /// </summary>
         private void InitializeComponent()
         {
-      this.components = new System.ComponentModel.Container();
-      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmEvent));
-      System.Windows.Forms.TreeNode treeNode1 = new System.Windows.Forms.TreeNode("Show Text");
-      System.Windows.Forms.TreeNode treeNode2 = new System.Windows.Forms.TreeNode("Show Options");
-      System.Windows.Forms.TreeNode treeNode3 = new System.Windows.Forms.TreeNode("Input Variable");
-      System.Windows.Forms.TreeNode treeNode4 = new System.Windows.Forms.TreeNode("Add Chatbox Text");
-      System.Windows.Forms.TreeNode treeNode5 = new System.Windows.Forms.TreeNode("Dialogue", new System.Windows.Forms.TreeNode[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmEvent));
+            System.Windows.Forms.TreeNode treeNode1 = new System.Windows.Forms.TreeNode("Show Text");
+            System.Windows.Forms.TreeNode treeNode2 = new System.Windows.Forms.TreeNode("Show Options");
+            System.Windows.Forms.TreeNode treeNode3 = new System.Windows.Forms.TreeNode("Input Variable");
+            System.Windows.Forms.TreeNode treeNode4 = new System.Windows.Forms.TreeNode("Add Chatbox Text");
+            System.Windows.Forms.TreeNode treeNode5 = new System.Windows.Forms.TreeNode("Dialogue", new System.Windows.Forms.TreeNode[] {
             treeNode1,
             treeNode2,
             treeNode3,
             treeNode4});
-      System.Windows.Forms.TreeNode treeNode6 = new System.Windows.Forms.TreeNode("Set Variable");
-      System.Windows.Forms.TreeNode treeNode7 = new System.Windows.Forms.TreeNode("Set Self Switch");
-      System.Windows.Forms.TreeNode treeNode8 = new System.Windows.Forms.TreeNode("Conditional Branch");
-      System.Windows.Forms.TreeNode treeNode9 = new System.Windows.Forms.TreeNode("Exit Event Process");
-      System.Windows.Forms.TreeNode treeNode10 = new System.Windows.Forms.TreeNode("Label");
-      System.Windows.Forms.TreeNode treeNode11 = new System.Windows.Forms.TreeNode("Go To Label");
-      System.Windows.Forms.TreeNode treeNode12 = new System.Windows.Forms.TreeNode("Start Common Event");
-      System.Windows.Forms.TreeNode treeNode13 = new System.Windows.Forms.TreeNode("Logic Flow", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode6 = new System.Windows.Forms.TreeNode("Set Variable");
+            System.Windows.Forms.TreeNode treeNode7 = new System.Windows.Forms.TreeNode("Set Self Switch");
+            System.Windows.Forms.TreeNode treeNode8 = new System.Windows.Forms.TreeNode("Conditional Branch");
+            System.Windows.Forms.TreeNode treeNode9 = new System.Windows.Forms.TreeNode("Exit Event Process");
+            System.Windows.Forms.TreeNode treeNode10 = new System.Windows.Forms.TreeNode("Label");
+            System.Windows.Forms.TreeNode treeNode11 = new System.Windows.Forms.TreeNode("Go To Label");
+            System.Windows.Forms.TreeNode treeNode12 = new System.Windows.Forms.TreeNode("Start Common Event");
+            System.Windows.Forms.TreeNode treeNode13 = new System.Windows.Forms.TreeNode("Logic Flow", new System.Windows.Forms.TreeNode[] {
             treeNode6,
             treeNode7,
             treeNode8,
@@ -58,22 +58,22 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode10,
             treeNode11,
             treeNode12});
-      System.Windows.Forms.TreeNode treeNode14 = new System.Windows.Forms.TreeNode("Restore HP");
-      System.Windows.Forms.TreeNode treeNode15 = new System.Windows.Forms.TreeNode("Restore MP");
-      System.Windows.Forms.TreeNode treeNode16 = new System.Windows.Forms.TreeNode("Level Up");
-      System.Windows.Forms.TreeNode treeNode17 = new System.Windows.Forms.TreeNode("Give Experience");
-      System.Windows.Forms.TreeNode treeNode18 = new System.Windows.Forms.TreeNode("Change Level");
-      System.Windows.Forms.TreeNode treeNode19 = new System.Windows.Forms.TreeNode("Change Spells");
-      System.Windows.Forms.TreeNode treeNode20 = new System.Windows.Forms.TreeNode("Change Items");
-      System.Windows.Forms.TreeNode treeNode21 = new System.Windows.Forms.TreeNode("Change Sprite");
-      System.Windows.Forms.TreeNode treeNode22 = new System.Windows.Forms.TreeNode("Change Face");
-      System.Windows.Forms.TreeNode treeNode23 = new System.Windows.Forms.TreeNode("Change Gender");
-      System.Windows.Forms.TreeNode treeNode24 = new System.Windows.Forms.TreeNode("Set Access");
-      System.Windows.Forms.TreeNode treeNode25 = new System.Windows.Forms.TreeNode("Change Class");
-      System.Windows.Forms.TreeNode treeNode26 = new System.Windows.Forms.TreeNode("Equip Item");
-      System.Windows.Forms.TreeNode treeNode27 = new System.Windows.Forms.TreeNode("Change Name Color");
-      System.Windows.Forms.TreeNode treeNode28 = new System.Windows.Forms.TreeNode("Change Player Label");
-      System.Windows.Forms.TreeNode treeNode29 = new System.Windows.Forms.TreeNode("Player Control", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode14 = new System.Windows.Forms.TreeNode("Restore HP");
+            System.Windows.Forms.TreeNode treeNode15 = new System.Windows.Forms.TreeNode("Restore MP");
+            System.Windows.Forms.TreeNode treeNode16 = new System.Windows.Forms.TreeNode("Level Up");
+            System.Windows.Forms.TreeNode treeNode17 = new System.Windows.Forms.TreeNode("Give Experience");
+            System.Windows.Forms.TreeNode treeNode18 = new System.Windows.Forms.TreeNode("Change Level");
+            System.Windows.Forms.TreeNode treeNode19 = new System.Windows.Forms.TreeNode("Change Spells");
+            System.Windows.Forms.TreeNode treeNode20 = new System.Windows.Forms.TreeNode("Change Items");
+            System.Windows.Forms.TreeNode treeNode21 = new System.Windows.Forms.TreeNode("Change Sprite");
+            System.Windows.Forms.TreeNode treeNode22 = new System.Windows.Forms.TreeNode("Change Face");
+            System.Windows.Forms.TreeNode treeNode23 = new System.Windows.Forms.TreeNode("Change Gender");
+            System.Windows.Forms.TreeNode treeNode24 = new System.Windows.Forms.TreeNode("Set Access");
+            System.Windows.Forms.TreeNode treeNode25 = new System.Windows.Forms.TreeNode("Change Class");
+            System.Windows.Forms.TreeNode treeNode26 = new System.Windows.Forms.TreeNode("Equip Item");
+            System.Windows.Forms.TreeNode treeNode27 = new System.Windows.Forms.TreeNode("Change Name Color");
+            System.Windows.Forms.TreeNode treeNode28 = new System.Windows.Forms.TreeNode("Change Player Label");
+            System.Windows.Forms.TreeNode treeNode29 = new System.Windows.Forms.TreeNode("Player Control", new System.Windows.Forms.TreeNode[] {
             treeNode14,
             treeNode15,
             treeNode16,
@@ -89,16 +89,16 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode26,
             treeNode27,
             treeNode28});
-      System.Windows.Forms.TreeNode treeNode30 = new System.Windows.Forms.TreeNode("Warp Player");
-      System.Windows.Forms.TreeNode treeNode31 = new System.Windows.Forms.TreeNode("Set Move Route");
-      System.Windows.Forms.TreeNode treeNode32 = new System.Windows.Forms.TreeNode("Wait for Route Completion");
-      System.Windows.Forms.TreeNode treeNode33 = new System.Windows.Forms.TreeNode("Hold Player");
-      System.Windows.Forms.TreeNode treeNode34 = new System.Windows.Forms.TreeNode("Release Player");
-      System.Windows.Forms.TreeNode treeNode35 = new System.Windows.Forms.TreeNode("Spawn NPC");
-      System.Windows.Forms.TreeNode treeNode36 = new System.Windows.Forms.TreeNode("Despawn NPC");
-      System.Windows.Forms.TreeNode treeNode37 = new System.Windows.Forms.TreeNode("Hide Player");
-      System.Windows.Forms.TreeNode treeNode38 = new System.Windows.Forms.TreeNode("Show Player");
-      System.Windows.Forms.TreeNode treeNode39 = new System.Windows.Forms.TreeNode("Movement", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode30 = new System.Windows.Forms.TreeNode("Warp Player");
+            System.Windows.Forms.TreeNode treeNode31 = new System.Windows.Forms.TreeNode("Set Move Route");
+            System.Windows.Forms.TreeNode treeNode32 = new System.Windows.Forms.TreeNode("Wait for Route Completion");
+            System.Windows.Forms.TreeNode treeNode33 = new System.Windows.Forms.TreeNode("Hold Player");
+            System.Windows.Forms.TreeNode treeNode34 = new System.Windows.Forms.TreeNode("Release Player");
+            System.Windows.Forms.TreeNode treeNode35 = new System.Windows.Forms.TreeNode("Spawn NPC");
+            System.Windows.Forms.TreeNode treeNode36 = new System.Windows.Forms.TreeNode("Despawn NPC");
+            System.Windows.Forms.TreeNode treeNode37 = new System.Windows.Forms.TreeNode("Hide Player");
+            System.Windows.Forms.TreeNode treeNode38 = new System.Windows.Forms.TreeNode("Show Player");
+            System.Windows.Forms.TreeNode treeNode39 = new System.Windows.Forms.TreeNode("Movement", new System.Windows.Forms.TreeNode[] {
             treeNode30,
             treeNode31,
             treeNode32,
@@ -108,14 +108,14 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode36,
             treeNode37,
             treeNode38});
-      System.Windows.Forms.TreeNode treeNode40 = new System.Windows.Forms.TreeNode("Play Animation");
-      System.Windows.Forms.TreeNode treeNode41 = new System.Windows.Forms.TreeNode("Play BGM");
-      System.Windows.Forms.TreeNode treeNode42 = new System.Windows.Forms.TreeNode("Fadeout BGM");
-      System.Windows.Forms.TreeNode treeNode43 = new System.Windows.Forms.TreeNode("Play Sound");
-      System.Windows.Forms.TreeNode treeNode44 = new System.Windows.Forms.TreeNode("Stop Sounds");
-      System.Windows.Forms.TreeNode treeNode45 = new System.Windows.Forms.TreeNode("Show Picture");
-      System.Windows.Forms.TreeNode treeNode46 = new System.Windows.Forms.TreeNode("Hide Picture");
-      System.Windows.Forms.TreeNode treeNode47 = new System.Windows.Forms.TreeNode("Special Effects", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode40 = new System.Windows.Forms.TreeNode("Play Animation");
+            System.Windows.Forms.TreeNode treeNode41 = new System.Windows.Forms.TreeNode("Play BGM");
+            System.Windows.Forms.TreeNode treeNode42 = new System.Windows.Forms.TreeNode("Fadeout BGM");
+            System.Windows.Forms.TreeNode treeNode43 = new System.Windows.Forms.TreeNode("Play Sound");
+            System.Windows.Forms.TreeNode treeNode44 = new System.Windows.Forms.TreeNode("Stop Sounds");
+            System.Windows.Forms.TreeNode treeNode45 = new System.Windows.Forms.TreeNode("Show Picture");
+            System.Windows.Forms.TreeNode treeNode46 = new System.Windows.Forms.TreeNode("Hide Picture");
+            System.Windows.Forms.TreeNode treeNode47 = new System.Windows.Forms.TreeNode("Special Effects", new System.Windows.Forms.TreeNode[] {
             treeNode40,
             treeNode41,
             treeNode42,
@@ -123,845 +123,845 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode44,
             treeNode45,
             treeNode46});
-      System.Windows.Forms.TreeNode treeNode48 = new System.Windows.Forms.TreeNode("Start Quest");
-      System.Windows.Forms.TreeNode treeNode49 = new System.Windows.Forms.TreeNode("Complete Quest Task");
-      System.Windows.Forms.TreeNode treeNode50 = new System.Windows.Forms.TreeNode("End Quest");
-      System.Windows.Forms.TreeNode treeNode51 = new System.Windows.Forms.TreeNode("Quest Control", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode48 = new System.Windows.Forms.TreeNode("Start Quest");
+            System.Windows.Forms.TreeNode treeNode49 = new System.Windows.Forms.TreeNode("Complete Quest Task");
+            System.Windows.Forms.TreeNode treeNode50 = new System.Windows.Forms.TreeNode("End Quest");
+            System.Windows.Forms.TreeNode treeNode51 = new System.Windows.Forms.TreeNode("Quest Control", new System.Windows.Forms.TreeNode[] {
             treeNode48,
             treeNode49,
             treeNode50});
-      System.Windows.Forms.TreeNode treeNode52 = new System.Windows.Forms.TreeNode("Wait...");
-      System.Windows.Forms.TreeNode treeNode53 = new System.Windows.Forms.TreeNode("Etc", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode52 = new System.Windows.Forms.TreeNode("Wait...");
+            System.Windows.Forms.TreeNode treeNode53 = new System.Windows.Forms.TreeNode("Etc", new System.Windows.Forms.TreeNode[] {
             treeNode52});
-      System.Windows.Forms.TreeNode treeNode54 = new System.Windows.Forms.TreeNode("Open Bank");
-      System.Windows.Forms.TreeNode treeNode55 = new System.Windows.Forms.TreeNode("Open Shop");
-      System.Windows.Forms.TreeNode treeNode56 = new System.Windows.Forms.TreeNode("Open Crafting Station");
-      System.Windows.Forms.TreeNode treeNode57 = new System.Windows.Forms.TreeNode("Shop and Bank", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode54 = new System.Windows.Forms.TreeNode("Open Bank");
+            System.Windows.Forms.TreeNode treeNode55 = new System.Windows.Forms.TreeNode("Open Shop");
+            System.Windows.Forms.TreeNode treeNode56 = new System.Windows.Forms.TreeNode("Open Crafting Station");
+            System.Windows.Forms.TreeNode treeNode57 = new System.Windows.Forms.TreeNode("Shop and Bank", new System.Windows.Forms.TreeNode[] {
             treeNode54,
             treeNode55,
             treeNode56});
-      this.lblName = new System.Windows.Forms.Label();
-      this.txtEventname = new DarkUI.Controls.DarkTextBox();
-      this.grpEntityOptions = new DarkUI.Controls.DarkGroupBox();
-      this.grpExtra = new DarkUI.Controls.DarkGroupBox();
-      this.chkInteractionFreeze = new DarkUI.Controls.DarkCheckBox();
-      this.chkWalkingAnimation = new DarkUI.Controls.DarkCheckBox();
-      this.chkDirectionFix = new DarkUI.Controls.DarkCheckBox();
-      this.chkHideName = new DarkUI.Controls.DarkCheckBox();
-      this.chkWalkThrough = new DarkUI.Controls.DarkCheckBox();
-      this.grpInspector = new DarkUI.Controls.DarkGroupBox();
-      this.pnlFacePreview = new System.Windows.Forms.Panel();
-      this.lblInspectorDesc = new System.Windows.Forms.Label();
-      this.txtDesc = new DarkUI.Controls.DarkTextBox();
-      this.chkDisableInspector = new DarkUI.Controls.DarkCheckBox();
-      this.cmbPreviewFace = new DarkUI.Controls.DarkComboBox();
-      this.lblFace = new System.Windows.Forms.Label();
-      this.grpPreview = new DarkUI.Controls.DarkGroupBox();
-      this.lblAnimation = new System.Windows.Forms.Label();
-      this.cmbAnimation = new DarkUI.Controls.DarkComboBox();
-      this.pnlPreview = new System.Windows.Forms.Panel();
-      this.grpMovement = new DarkUI.Controls.DarkGroupBox();
-      this.lblLayer = new System.Windows.Forms.Label();
-      this.cmbLayering = new DarkUI.Controls.DarkComboBox();
-      this.cmbEventFreq = new DarkUI.Controls.DarkComboBox();
-      this.cmbEventSpeed = new DarkUI.Controls.DarkComboBox();
-      this.lblFreq = new System.Windows.Forms.Label();
-      this.lblSpeed = new System.Windows.Forms.Label();
-      this.btnSetRoute = new DarkUI.Controls.DarkButton();
-      this.lblType = new System.Windows.Forms.Label();
-      this.cmbMoveType = new DarkUI.Controls.DarkComboBox();
-      this.grpTriggers = new DarkUI.Controls.DarkGroupBox();
-      this.txtCommand = new DarkUI.Controls.DarkTextBox();
-      this.lblCommand = new System.Windows.Forms.Label();
-      this.lblTriggerVal = new System.Windows.Forms.Label();
-      this.cmbTriggerVal = new DarkUI.Controls.DarkComboBox();
-      this.cmbTrigger = new DarkUI.Controls.DarkComboBox();
-      this.grpEventConditions = new DarkUI.Controls.DarkGroupBox();
-      this.btnEditConditions = new DarkUI.Controls.DarkButton();
-      this.grpNewCommands = new DarkUI.Controls.DarkGroupBox();
-      this.lblCloseCommands = new System.Windows.Forms.Label();
-      this.lstCommands = new System.Windows.Forms.TreeView();
-      this.grpEventCommands = new DarkUI.Controls.DarkGroupBox();
-      this.lstEventCommands = new System.Windows.Forms.ListBox();
-      this.grpCreateCommands = new DarkUI.Controls.DarkGroupBox();
-      this.btnSave = new DarkUI.Controls.DarkButton();
-      this.btnCancel = new DarkUI.Controls.DarkButton();
-      this.commandMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-      this.btnInsert = new System.Windows.Forms.ToolStripMenuItem();
-      this.btnEdit = new System.Windows.Forms.ToolStripMenuItem();
-      this.btnCut = new System.Windows.Forms.ToolStripMenuItem();
-      this.btnCopy = new System.Windows.Forms.ToolStripMenuItem();
-      this.btnPaste = new System.Windows.Forms.ToolStripMenuItem();
-      this.btnDelete = new System.Windows.Forms.ToolStripMenuItem();
-      this.grpPageOptions = new DarkUI.Controls.DarkGroupBox();
-      this.btnClearPage = new DarkUI.Controls.DarkButton();
-      this.btnDeletePage = new DarkUI.Controls.DarkButton();
-      this.btnPastePage = new DarkUI.Controls.DarkButton();
-      this.btnCopyPage = new DarkUI.Controls.DarkButton();
-      this.btnNewPage = new DarkUI.Controls.DarkButton();
-      this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
-      this.chkIsGlobal = new DarkUI.Controls.DarkCheckBox();
-      this.pnlTabsContainer = new System.Windows.Forms.Panel();
-      this.pnlTabs = new System.Windows.Forms.Panel();
-      this.btnTabsRight = new DarkUI.Controls.DarkButton();
-      this.btnTabsLeft = new DarkUI.Controls.DarkButton();
-      this.panel1 = new System.Windows.Forms.Panel();
-      this.grpEntityOptions.SuspendLayout();
-      this.grpExtra.SuspendLayout();
-      this.grpInspector.SuspendLayout();
-      this.grpPreview.SuspendLayout();
-      this.grpMovement.SuspendLayout();
-      this.grpTriggers.SuspendLayout();
-      this.grpEventConditions.SuspendLayout();
-      this.grpNewCommands.SuspendLayout();
-      this.grpEventCommands.SuspendLayout();
-      this.commandMenu.SuspendLayout();
-      this.grpPageOptions.SuspendLayout();
-      this.grpGeneral.SuspendLayout();
-      this.pnlTabsContainer.SuspendLayout();
-      this.SuspendLayout();
-      // 
-      // lblName
-      // 
-      this.lblName.AutoSize = true;
-      this.lblName.Location = new System.Drawing.Point(6, 22);
-      this.lblName.Name = "lblName";
-      this.lblName.Size = new System.Drawing.Size(38, 13);
-      this.lblName.TabIndex = 1;
-      this.lblName.Text = "Name:";
-      // 
-      // txtEventname
-      // 
-      this.txtEventname.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.txtEventname.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.txtEventname.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-      this.txtEventname.Location = new System.Drawing.Point(48, 19);
-      this.txtEventname.Name = "txtEventname";
-      this.txtEventname.Size = new System.Drawing.Size(124, 20);
-      this.txtEventname.TabIndex = 2;
-      this.txtEventname.TextChanged += new System.EventHandler(this.txtEventname_TextChanged);
-      // 
-      // grpEntityOptions
-      // 
-      this.grpEntityOptions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpEntityOptions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpEntityOptions.Controls.Add(this.grpExtra);
-      this.grpEntityOptions.Controls.Add(this.grpInspector);
-      this.grpEntityOptions.Controls.Add(this.grpPreview);
-      this.grpEntityOptions.Controls.Add(this.grpMovement);
-      this.grpEntityOptions.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpEntityOptions.Location = new System.Drawing.Point(21, 150);
-      this.grpEntityOptions.Name = "grpEntityOptions";
-      this.grpEntityOptions.Size = new System.Drawing.Size(326, 423);
-      this.grpEntityOptions.TabIndex = 12;
-      this.grpEntityOptions.TabStop = false;
-      this.grpEntityOptions.Text = "Entity Options";
-      // 
-      // grpExtra
-      // 
-      this.grpExtra.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpExtra.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpExtra.Controls.Add(this.chkInteractionFreeze);
-      this.grpExtra.Controls.Add(this.chkWalkingAnimation);
-      this.grpExtra.Controls.Add(this.chkDirectionFix);
-      this.grpExtra.Controls.Add(this.chkHideName);
-      this.grpExtra.Controls.Add(this.chkWalkThrough);
-      this.grpExtra.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpExtra.Location = new System.Drawing.Point(6, 297);
-      this.grpExtra.Name = "grpExtra";
-      this.grpExtra.Size = new System.Drawing.Size(315, 64);
-      this.grpExtra.TabIndex = 9;
-      this.grpExtra.TabStop = false;
-      this.grpExtra.Text = "Extra";
-      // 
-      // chkInteractionFreeze
-      // 
-      this.chkInteractionFreeze.AutoSize = true;
-      this.chkInteractionFreeze.Location = new System.Drawing.Point(6, 41);
-      this.chkInteractionFreeze.Name = "chkInteractionFreeze";
-      this.chkInteractionFreeze.Size = new System.Drawing.Size(111, 17);
-      this.chkInteractionFreeze.TabIndex = 6;
-      this.chkInteractionFreeze.Text = "Interaction Freeze";
-      this.chkInteractionFreeze.CheckedChanged += new System.EventHandler(this.chkInteractionFreeze_CheckedChanged);
-      // 
-      // chkWalkingAnimation
-      // 
-      this.chkWalkingAnimation.AutoSize = true;
-      this.chkWalkingAnimation.Location = new System.Drawing.Point(214, 19);
-      this.chkWalkingAnimation.Name = "chkWalkingAnimation";
-      this.chkWalkingAnimation.Size = new System.Drawing.Size(91, 17);
-      this.chkWalkingAnimation.TabIndex = 5;
-      this.chkWalkingAnimation.Text = "Walking Anim";
-      this.chkWalkingAnimation.CheckedChanged += new System.EventHandler(this.chkWalkingAnimation_CheckedChanged);
-      // 
-      // chkDirectionFix
-      // 
-      this.chkDirectionFix.AutoSize = true;
-      this.chkDirectionFix.Location = new System.Drawing.Point(156, 19);
-      this.chkDirectionFix.Name = "chkDirectionFix";
-      this.chkDirectionFix.Size = new System.Drawing.Size(55, 17);
-      this.chkDirectionFix.TabIndex = 4;
-      this.chkDirectionFix.Text = "Dir Fix";
-      this.chkDirectionFix.CheckedChanged += new System.EventHandler(this.chkDirectionFix_CheckedChanged);
-      // 
-      // chkHideName
-      // 
-      this.chkHideName.AutoSize = true;
-      this.chkHideName.Location = new System.Drawing.Point(75, 19);
-      this.chkHideName.Name = "chkHideName";
-      this.chkHideName.Size = new System.Drawing.Size(79, 17);
-      this.chkHideName.TabIndex = 3;
-      this.chkHideName.Text = "Hide Name";
-      this.chkHideName.CheckedChanged += new System.EventHandler(this.chkHideName_CheckedChanged);
-      // 
-      // chkWalkThrough
-      // 
-      this.chkWalkThrough.AutoSize = true;
-      this.chkWalkThrough.Location = new System.Drawing.Point(6, 19);
-      this.chkWalkThrough.Name = "chkWalkThrough";
-      this.chkWalkThrough.Size = new System.Drawing.Size(69, 17);
-      this.chkWalkThrough.TabIndex = 2;
-      this.chkWalkThrough.Text = "Passable";
-      this.chkWalkThrough.CheckedChanged += new System.EventHandler(this.chkWalkThrough_CheckedChanged);
-      // 
-      // grpInspector
-      // 
-      this.grpInspector.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpInspector.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpInspector.Controls.Add(this.pnlFacePreview);
-      this.grpInspector.Controls.Add(this.lblInspectorDesc);
-      this.grpInspector.Controls.Add(this.txtDesc);
-      this.grpInspector.Controls.Add(this.chkDisableInspector);
-      this.grpInspector.Controls.Add(this.cmbPreviewFace);
-      this.grpInspector.Controls.Add(this.lblFace);
-      this.grpInspector.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpInspector.Location = new System.Drawing.Point(6, 179);
-      this.grpInspector.Name = "grpInspector";
-      this.grpInspector.Size = new System.Drawing.Size(316, 117);
-      this.grpInspector.TabIndex = 7;
-      this.grpInspector.TabStop = false;
-      this.grpInspector.Text = "Entity Inspector Options";
-      // 
-      // pnlFacePreview
-      // 
-      this.pnlFacePreview.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-      this.pnlFacePreview.Location = new System.Drawing.Point(9, 46);
-      this.pnlFacePreview.Name = "pnlFacePreview";
-      this.pnlFacePreview.Size = new System.Drawing.Size(64, 64);
-      this.pnlFacePreview.TabIndex = 12;
-      // 
-      // lblInspectorDesc
-      // 
-      this.lblInspectorDesc.Location = new System.Drawing.Point(79, 42);
-      this.lblInspectorDesc.Name = "lblInspectorDesc";
-      this.lblInspectorDesc.Size = new System.Drawing.Size(112, 19);
-      this.lblInspectorDesc.TabIndex = 11;
-      this.lblInspectorDesc.Text = "Inspector Description:";
-      // 
-      // txtDesc
-      // 
-      this.txtDesc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.txtDesc.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.txtDesc.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-      this.txtDesc.Location = new System.Drawing.Point(79, 61);
-      this.txtDesc.Multiline = true;
-      this.txtDesc.Name = "txtDesc";
-      this.txtDesc.Size = new System.Drawing.Size(231, 50);
-      this.txtDesc.TabIndex = 0;
-      this.txtDesc.TextChanged += new System.EventHandler(this.txtDesc_TextChanged);
-      // 
-      // chkDisableInspector
-      // 
-      this.chkDisableInspector.Location = new System.Drawing.Point(204, 15);
-      this.chkDisableInspector.Name = "chkDisableInspector";
-      this.chkDisableInspector.Size = new System.Drawing.Size(107, 21);
-      this.chkDisableInspector.TabIndex = 4;
-      this.chkDisableInspector.Text = "Disable Inspector";
-      this.chkDisableInspector.CheckedChanged += new System.EventHandler(this.chkDisablePreview_CheckedChanged);
-      // 
-      // cmbPreviewFace
-      // 
-      this.cmbPreviewFace.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbPreviewFace.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbPreviewFace.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbPreviewFace.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbPreviewFace.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbPreviewFace.ButtonIcon")));
-      this.cmbPreviewFace.DrawDropdownHoverOutline = false;
-      this.cmbPreviewFace.DrawFocusRectangle = false;
-      this.cmbPreviewFace.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbPreviewFace.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbPreviewFace.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbPreviewFace.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbPreviewFace.FormattingEnabled = true;
-      this.cmbPreviewFace.Location = new System.Drawing.Point(46, 15);
-      this.cmbPreviewFace.Name = "cmbPreviewFace";
-      this.cmbPreviewFace.Size = new System.Drawing.Size(114, 21);
-      this.cmbPreviewFace.TabIndex = 10;
-      this.cmbPreviewFace.Text = null;
-      this.cmbPreviewFace.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbPreviewFace.SelectedIndexChanged += new System.EventHandler(this.cmbPreviewFace_SelectedIndexChanged);
-      // 
-      // lblFace
-      // 
-      this.lblFace.AutoSize = true;
-      this.lblFace.Location = new System.Drawing.Point(6, 18);
-      this.lblFace.Name = "lblFace";
-      this.lblFace.Size = new System.Drawing.Size(34, 13);
-      this.lblFace.TabIndex = 9;
-      this.lblFace.Text = "Face:";
-      // 
-      // grpPreview
-      // 
-      this.grpPreview.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpPreview.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpPreview.Controls.Add(this.lblAnimation);
-      this.grpPreview.Controls.Add(this.cmbAnimation);
-      this.grpPreview.Controls.Add(this.pnlPreview);
-      this.grpPreview.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpPreview.Location = new System.Drawing.Point(6, 13);
-      this.grpPreview.Name = "grpPreview";
-      this.grpPreview.Size = new System.Drawing.Size(160, 163);
-      this.grpPreview.TabIndex = 10;
-      this.grpPreview.TabStop = false;
-      this.grpPreview.Text = "Preview";
-      // 
-      // lblAnimation
-      // 
-      this.lblAnimation.AutoSize = true;
-      this.lblAnimation.Location = new System.Drawing.Point(4, 116);
-      this.lblAnimation.Name = "lblAnimation";
-      this.lblAnimation.Size = new System.Drawing.Size(56, 13);
-      this.lblAnimation.TabIndex = 2;
-      this.lblAnimation.Text = "Animation:";
-      // 
-      // cmbAnimation
-      // 
-      this.cmbAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbAnimation.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbAnimation.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbAnimation.ButtonIcon")));
-      this.cmbAnimation.DrawDropdownHoverOutline = false;
-      this.cmbAnimation.DrawFocusRectangle = false;
-      this.cmbAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbAnimation.FormattingEnabled = true;
-      this.cmbAnimation.Location = new System.Drawing.Point(20, 132);
-      this.cmbAnimation.Name = "cmbAnimation";
-      this.cmbAnimation.Size = new System.Drawing.Size(125, 21);
-      this.cmbAnimation.TabIndex = 1;
-      this.cmbAnimation.Text = null;
-      this.cmbAnimation.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbAnimation.SelectedIndexChanged += new System.EventHandler(this.cmbAnimation_SelectedIndexChanged);
-      // 
-      // pnlPreview
-      // 
-      this.pnlPreview.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-      this.pnlPreview.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.pnlPreview.Location = new System.Drawing.Point(33, 14);
-      this.pnlPreview.Name = "pnlPreview";
-      this.pnlPreview.Size = new System.Drawing.Size(96, 96);
-      this.pnlPreview.TabIndex = 0;
-      this.pnlPreview.DoubleClick += new System.EventHandler(this.pnlPreview_DoubleClick);
-      // 
-      // grpMovement
-      // 
-      this.grpMovement.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpMovement.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpMovement.Controls.Add(this.lblLayer);
-      this.grpMovement.Controls.Add(this.cmbLayering);
-      this.grpMovement.Controls.Add(this.cmbEventFreq);
-      this.grpMovement.Controls.Add(this.cmbEventSpeed);
-      this.grpMovement.Controls.Add(this.lblFreq);
-      this.grpMovement.Controls.Add(this.lblSpeed);
-      this.grpMovement.Controls.Add(this.btnSetRoute);
-      this.grpMovement.Controls.Add(this.lblType);
-      this.grpMovement.Controls.Add(this.cmbMoveType);
-      this.grpMovement.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpMovement.Location = new System.Drawing.Point(169, 13);
-      this.grpMovement.Name = "grpMovement";
-      this.grpMovement.Size = new System.Drawing.Size(154, 163);
-      this.grpMovement.TabIndex = 8;
-      this.grpMovement.TabStop = false;
-      this.grpMovement.Text = "Movement";
-      // 
-      // lblLayer
-      // 
-      this.lblLayer.AutoSize = true;
-      this.lblLayer.Location = new System.Drawing.Point(6, 134);
-      this.lblLayer.Name = "lblLayer";
-      this.lblLayer.Size = new System.Drawing.Size(36, 13);
-      this.lblLayer.TabIndex = 7;
-      this.lblLayer.Text = "Layer:";
-      // 
-      // cmbLayering
-      // 
-      this.cmbLayering.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbLayering.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbLayering.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbLayering.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbLayering.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbLayering.ButtonIcon")));
-      this.cmbLayering.DrawDropdownHoverOutline = false;
-      this.cmbLayering.DrawFocusRectangle = false;
-      this.cmbLayering.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbLayering.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbLayering.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbLayering.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbLayering.FormattingEnabled = true;
-      this.cmbLayering.Items.AddRange(new object[] {
+            this.lblName = new System.Windows.Forms.Label();
+            this.txtEventname = new DarkUI.Controls.DarkTextBox();
+            this.grpEntityOptions = new DarkUI.Controls.DarkGroupBox();
+            this.grpExtra = new DarkUI.Controls.DarkGroupBox();
+            this.chkInteractionFreeze = new DarkUI.Controls.DarkCheckBox();
+            this.chkWalkingAnimation = new DarkUI.Controls.DarkCheckBox();
+            this.chkDirectionFix = new DarkUI.Controls.DarkCheckBox();
+            this.chkHideName = new DarkUI.Controls.DarkCheckBox();
+            this.chkWalkThrough = new DarkUI.Controls.DarkCheckBox();
+            this.grpInspector = new DarkUI.Controls.DarkGroupBox();
+            this.pnlFacePreview = new System.Windows.Forms.Panel();
+            this.lblInspectorDesc = new System.Windows.Forms.Label();
+            this.txtDesc = new DarkUI.Controls.DarkTextBox();
+            this.chkDisableInspector = new DarkUI.Controls.DarkCheckBox();
+            this.cmbPreviewFace = new DarkUI.Controls.DarkComboBox();
+            this.lblFace = new System.Windows.Forms.Label();
+            this.grpPreview = new DarkUI.Controls.DarkGroupBox();
+            this.lblAnimation = new System.Windows.Forms.Label();
+            this.cmbAnimation = new DarkUI.Controls.DarkComboBox();
+            this.pnlPreview = new System.Windows.Forms.Panel();
+            this.grpMovement = new DarkUI.Controls.DarkGroupBox();
+            this.lblLayer = new System.Windows.Forms.Label();
+            this.cmbLayering = new DarkUI.Controls.DarkComboBox();
+            this.cmbEventFreq = new DarkUI.Controls.DarkComboBox();
+            this.cmbEventSpeed = new DarkUI.Controls.DarkComboBox();
+            this.lblFreq = new System.Windows.Forms.Label();
+            this.lblSpeed = new System.Windows.Forms.Label();
+            this.btnSetRoute = new DarkUI.Controls.DarkButton();
+            this.lblType = new System.Windows.Forms.Label();
+            this.cmbMoveType = new DarkUI.Controls.DarkComboBox();
+            this.grpTriggers = new DarkUI.Controls.DarkGroupBox();
+            this.txtCommand = new DarkUI.Controls.DarkTextBox();
+            this.lblCommand = new System.Windows.Forms.Label();
+            this.lblTriggerVal = new System.Windows.Forms.Label();
+            this.cmbTriggerVal = new DarkUI.Controls.DarkComboBox();
+            this.cmbTrigger = new DarkUI.Controls.DarkComboBox();
+            this.grpEventConditions = new DarkUI.Controls.DarkGroupBox();
+            this.btnEditConditions = new DarkUI.Controls.DarkButton();
+            this.grpNewCommands = new DarkUI.Controls.DarkGroupBox();
+            this.lblCloseCommands = new System.Windows.Forms.Label();
+            this.lstCommands = new System.Windows.Forms.TreeView();
+            this.grpEventCommands = new DarkUI.Controls.DarkGroupBox();
+            this.lstEventCommands = new System.Windows.Forms.ListBox();
+            this.grpCreateCommands = new DarkUI.Controls.DarkGroupBox();
+            this.btnSave = new DarkUI.Controls.DarkButton();
+            this.btnCancel = new DarkUI.Controls.DarkButton();
+            this.commandMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.btnInsert = new System.Windows.Forms.ToolStripMenuItem();
+            this.btnEdit = new System.Windows.Forms.ToolStripMenuItem();
+            this.btnCut = new System.Windows.Forms.ToolStripMenuItem();
+            this.btnCopy = new System.Windows.Forms.ToolStripMenuItem();
+            this.btnPaste = new System.Windows.Forms.ToolStripMenuItem();
+            this.btnDelete = new System.Windows.Forms.ToolStripMenuItem();
+            this.grpPageOptions = new DarkUI.Controls.DarkGroupBox();
+            this.btnClearPage = new DarkUI.Controls.DarkButton();
+            this.btnDeletePage = new DarkUI.Controls.DarkButton();
+            this.btnPastePage = new DarkUI.Controls.DarkButton();
+            this.btnCopyPage = new DarkUI.Controls.DarkButton();
+            this.btnNewPage = new DarkUI.Controls.DarkButton();
+            this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
+            this.chkIsGlobal = new DarkUI.Controls.DarkCheckBox();
+            this.pnlTabsContainer = new System.Windows.Forms.Panel();
+            this.pnlTabs = new System.Windows.Forms.Panel();
+            this.btnTabsRight = new DarkUI.Controls.DarkButton();
+            this.btnTabsLeft = new DarkUI.Controls.DarkButton();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.grpEntityOptions.SuspendLayout();
+            this.grpExtra.SuspendLayout();
+            this.grpInspector.SuspendLayout();
+            this.grpPreview.SuspendLayout();
+            this.grpMovement.SuspendLayout();
+            this.grpTriggers.SuspendLayout();
+            this.grpEventConditions.SuspendLayout();
+            this.grpNewCommands.SuspendLayout();
+            this.grpEventCommands.SuspendLayout();
+            this.commandMenu.SuspendLayout();
+            this.grpPageOptions.SuspendLayout();
+            this.grpGeneral.SuspendLayout();
+            this.pnlTabsContainer.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lblName
+            // 
+            this.lblName.AutoSize = true;
+            this.lblName.Location = new System.Drawing.Point(6, 22);
+            this.lblName.Name = "lblName";
+            this.lblName.Size = new System.Drawing.Size(38, 13);
+            this.lblName.TabIndex = 1;
+            this.lblName.Text = "Name:";
+            // 
+            // txtEventname
+            // 
+            this.txtEventname.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.txtEventname.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtEventname.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.txtEventname.Location = new System.Drawing.Point(48, 19);
+            this.txtEventname.Name = "txtEventname";
+            this.txtEventname.Size = new System.Drawing.Size(124, 20);
+            this.txtEventname.TabIndex = 2;
+            this.txtEventname.TextChanged += new System.EventHandler(this.txtEventname_TextChanged);
+            // 
+            // grpEntityOptions
+            // 
+            this.grpEntityOptions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpEntityOptions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpEntityOptions.Controls.Add(this.grpExtra);
+            this.grpEntityOptions.Controls.Add(this.grpInspector);
+            this.grpEntityOptions.Controls.Add(this.grpPreview);
+            this.grpEntityOptions.Controls.Add(this.grpMovement);
+            this.grpEntityOptions.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpEntityOptions.Location = new System.Drawing.Point(21, 150);
+            this.grpEntityOptions.Name = "grpEntityOptions";
+            this.grpEntityOptions.Size = new System.Drawing.Size(326, 423);
+            this.grpEntityOptions.TabIndex = 12;
+            this.grpEntityOptions.TabStop = false;
+            this.grpEntityOptions.Text = "Entity Options";
+            // 
+            // grpExtra
+            // 
+            this.grpExtra.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpExtra.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpExtra.Controls.Add(this.chkInteractionFreeze);
+            this.grpExtra.Controls.Add(this.chkWalkingAnimation);
+            this.grpExtra.Controls.Add(this.chkDirectionFix);
+            this.grpExtra.Controls.Add(this.chkHideName);
+            this.grpExtra.Controls.Add(this.chkWalkThrough);
+            this.grpExtra.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpExtra.Location = new System.Drawing.Point(6, 297);
+            this.grpExtra.Name = "grpExtra";
+            this.grpExtra.Size = new System.Drawing.Size(315, 64);
+            this.grpExtra.TabIndex = 9;
+            this.grpExtra.TabStop = false;
+            this.grpExtra.Text = "Extra";
+            // 
+            // chkInteractionFreeze
+            // 
+            this.chkInteractionFreeze.AutoSize = true;
+            this.chkInteractionFreeze.Location = new System.Drawing.Point(6, 41);
+            this.chkInteractionFreeze.Name = "chkInteractionFreeze";
+            this.chkInteractionFreeze.Size = new System.Drawing.Size(111, 17);
+            this.chkInteractionFreeze.TabIndex = 6;
+            this.chkInteractionFreeze.Text = "Interaction Freeze";
+            this.chkInteractionFreeze.CheckedChanged += new System.EventHandler(this.chkInteractionFreeze_CheckedChanged);
+            // 
+            // chkWalkingAnimation
+            // 
+            this.chkWalkingAnimation.AutoSize = true;
+            this.chkWalkingAnimation.Location = new System.Drawing.Point(214, 19);
+            this.chkWalkingAnimation.Name = "chkWalkingAnimation";
+            this.chkWalkingAnimation.Size = new System.Drawing.Size(91, 17);
+            this.chkWalkingAnimation.TabIndex = 5;
+            this.chkWalkingAnimation.Text = "Walking Anim";
+            this.chkWalkingAnimation.CheckedChanged += new System.EventHandler(this.chkWalkingAnimation_CheckedChanged);
+            // 
+            // chkDirectionFix
+            // 
+            this.chkDirectionFix.AutoSize = true;
+            this.chkDirectionFix.Location = new System.Drawing.Point(156, 19);
+            this.chkDirectionFix.Name = "chkDirectionFix";
+            this.chkDirectionFix.Size = new System.Drawing.Size(55, 17);
+            this.chkDirectionFix.TabIndex = 4;
+            this.chkDirectionFix.Text = "Dir Fix";
+            this.chkDirectionFix.CheckedChanged += new System.EventHandler(this.chkDirectionFix_CheckedChanged);
+            // 
+            // chkHideName
+            // 
+            this.chkHideName.AutoSize = true;
+            this.chkHideName.Location = new System.Drawing.Point(75, 19);
+            this.chkHideName.Name = "chkHideName";
+            this.chkHideName.Size = new System.Drawing.Size(79, 17);
+            this.chkHideName.TabIndex = 3;
+            this.chkHideName.Text = "Hide Name";
+            this.chkHideName.CheckedChanged += new System.EventHandler(this.chkHideName_CheckedChanged);
+            // 
+            // chkWalkThrough
+            // 
+            this.chkWalkThrough.AutoSize = true;
+            this.chkWalkThrough.Location = new System.Drawing.Point(6, 19);
+            this.chkWalkThrough.Name = "chkWalkThrough";
+            this.chkWalkThrough.Size = new System.Drawing.Size(69, 17);
+            this.chkWalkThrough.TabIndex = 2;
+            this.chkWalkThrough.Text = "Passable";
+            this.chkWalkThrough.CheckedChanged += new System.EventHandler(this.chkWalkThrough_CheckedChanged);
+            // 
+            // grpInspector
+            // 
+            this.grpInspector.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpInspector.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpInspector.Controls.Add(this.pnlFacePreview);
+            this.grpInspector.Controls.Add(this.lblInspectorDesc);
+            this.grpInspector.Controls.Add(this.txtDesc);
+            this.grpInspector.Controls.Add(this.chkDisableInspector);
+            this.grpInspector.Controls.Add(this.cmbPreviewFace);
+            this.grpInspector.Controls.Add(this.lblFace);
+            this.grpInspector.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpInspector.Location = new System.Drawing.Point(6, 179);
+            this.grpInspector.Name = "grpInspector";
+            this.grpInspector.Size = new System.Drawing.Size(316, 117);
+            this.grpInspector.TabIndex = 7;
+            this.grpInspector.TabStop = false;
+            this.grpInspector.Text = "Entity Inspector Options";
+            // 
+            // pnlFacePreview
+            // 
+            this.pnlFacePreview.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.pnlFacePreview.Location = new System.Drawing.Point(9, 46);
+            this.pnlFacePreview.Name = "pnlFacePreview";
+            this.pnlFacePreview.Size = new System.Drawing.Size(64, 64);
+            this.pnlFacePreview.TabIndex = 12;
+            // 
+            // lblInspectorDesc
+            // 
+            this.lblInspectorDesc.Location = new System.Drawing.Point(79, 42);
+            this.lblInspectorDesc.Name = "lblInspectorDesc";
+            this.lblInspectorDesc.Size = new System.Drawing.Size(112, 19);
+            this.lblInspectorDesc.TabIndex = 11;
+            this.lblInspectorDesc.Text = "Inspector Description:";
+            // 
+            // txtDesc
+            // 
+            this.txtDesc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.txtDesc.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtDesc.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.txtDesc.Location = new System.Drawing.Point(79, 61);
+            this.txtDesc.Multiline = true;
+            this.txtDesc.Name = "txtDesc";
+            this.txtDesc.Size = new System.Drawing.Size(231, 50);
+            this.txtDesc.TabIndex = 0;
+            this.txtDesc.TextChanged += new System.EventHandler(this.txtDesc_TextChanged);
+            // 
+            // chkDisableInspector
+            // 
+            this.chkDisableInspector.Location = new System.Drawing.Point(204, 15);
+            this.chkDisableInspector.Name = "chkDisableInspector";
+            this.chkDisableInspector.Size = new System.Drawing.Size(107, 21);
+            this.chkDisableInspector.TabIndex = 4;
+            this.chkDisableInspector.Text = "Disable Inspector";
+            this.chkDisableInspector.CheckedChanged += new System.EventHandler(this.chkDisablePreview_CheckedChanged);
+            // 
+            // cmbPreviewFace
+            // 
+            this.cmbPreviewFace.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbPreviewFace.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbPreviewFace.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbPreviewFace.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbPreviewFace.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbPreviewFace.ButtonIcon")));
+            this.cmbPreviewFace.DrawDropdownHoverOutline = false;
+            this.cmbPreviewFace.DrawFocusRectangle = false;
+            this.cmbPreviewFace.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbPreviewFace.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbPreviewFace.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbPreviewFace.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbPreviewFace.FormattingEnabled = true;
+            this.cmbPreviewFace.Location = new System.Drawing.Point(46, 15);
+            this.cmbPreviewFace.Name = "cmbPreviewFace";
+            this.cmbPreviewFace.Size = new System.Drawing.Size(114, 21);
+            this.cmbPreviewFace.TabIndex = 10;
+            this.cmbPreviewFace.Text = null;
+            this.cmbPreviewFace.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbPreviewFace.SelectedIndexChanged += new System.EventHandler(this.cmbPreviewFace_SelectedIndexChanged);
+            // 
+            // lblFace
+            // 
+            this.lblFace.AutoSize = true;
+            this.lblFace.Location = new System.Drawing.Point(6, 18);
+            this.lblFace.Name = "lblFace";
+            this.lblFace.Size = new System.Drawing.Size(34, 13);
+            this.lblFace.TabIndex = 9;
+            this.lblFace.Text = "Face:";
+            // 
+            // grpPreview
+            // 
+            this.grpPreview.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpPreview.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpPreview.Controls.Add(this.lblAnimation);
+            this.grpPreview.Controls.Add(this.cmbAnimation);
+            this.grpPreview.Controls.Add(this.pnlPreview);
+            this.grpPreview.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpPreview.Location = new System.Drawing.Point(6, 13);
+            this.grpPreview.Name = "grpPreview";
+            this.grpPreview.Size = new System.Drawing.Size(160, 163);
+            this.grpPreview.TabIndex = 10;
+            this.grpPreview.TabStop = false;
+            this.grpPreview.Text = "Preview";
+            // 
+            // lblAnimation
+            // 
+            this.lblAnimation.AutoSize = true;
+            this.lblAnimation.Location = new System.Drawing.Point(4, 116);
+            this.lblAnimation.Name = "lblAnimation";
+            this.lblAnimation.Size = new System.Drawing.Size(56, 13);
+            this.lblAnimation.TabIndex = 2;
+            this.lblAnimation.Text = "Animation:";
+            // 
+            // cmbAnimation
+            // 
+            this.cmbAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbAnimation.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbAnimation.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbAnimation.ButtonIcon")));
+            this.cmbAnimation.DrawDropdownHoverOutline = false;
+            this.cmbAnimation.DrawFocusRectangle = false;
+            this.cmbAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbAnimation.FormattingEnabled = true;
+            this.cmbAnimation.Location = new System.Drawing.Point(20, 132);
+            this.cmbAnimation.Name = "cmbAnimation";
+            this.cmbAnimation.Size = new System.Drawing.Size(125, 21);
+            this.cmbAnimation.TabIndex = 1;
+            this.cmbAnimation.Text = null;
+            this.cmbAnimation.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbAnimation.SelectedIndexChanged += new System.EventHandler(this.cmbAnimation_SelectedIndexChanged);
+            // 
+            // pnlPreview
+            // 
+            this.pnlPreview.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.pnlPreview.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pnlPreview.Location = new System.Drawing.Point(33, 14);
+            this.pnlPreview.Name = "pnlPreview";
+            this.pnlPreview.Size = new System.Drawing.Size(96, 96);
+            this.pnlPreview.TabIndex = 0;
+            this.pnlPreview.DoubleClick += new System.EventHandler(this.pnlPreview_DoubleClick);
+            // 
+            // grpMovement
+            // 
+            this.grpMovement.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpMovement.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpMovement.Controls.Add(this.lblLayer);
+            this.grpMovement.Controls.Add(this.cmbLayering);
+            this.grpMovement.Controls.Add(this.cmbEventFreq);
+            this.grpMovement.Controls.Add(this.cmbEventSpeed);
+            this.grpMovement.Controls.Add(this.lblFreq);
+            this.grpMovement.Controls.Add(this.lblSpeed);
+            this.grpMovement.Controls.Add(this.btnSetRoute);
+            this.grpMovement.Controls.Add(this.lblType);
+            this.grpMovement.Controls.Add(this.cmbMoveType);
+            this.grpMovement.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpMovement.Location = new System.Drawing.Point(169, 13);
+            this.grpMovement.Name = "grpMovement";
+            this.grpMovement.Size = new System.Drawing.Size(154, 163);
+            this.grpMovement.TabIndex = 8;
+            this.grpMovement.TabStop = false;
+            this.grpMovement.Text = "Movement";
+            // 
+            // lblLayer
+            // 
+            this.lblLayer.AutoSize = true;
+            this.lblLayer.Location = new System.Drawing.Point(6, 134);
+            this.lblLayer.Name = "lblLayer";
+            this.lblLayer.Size = new System.Drawing.Size(36, 13);
+            this.lblLayer.TabIndex = 7;
+            this.lblLayer.Text = "Layer:";
+            // 
+            // cmbLayering
+            // 
+            this.cmbLayering.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbLayering.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbLayering.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbLayering.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbLayering.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbLayering.ButtonIcon")));
+            this.cmbLayering.DrawDropdownHoverOutline = false;
+            this.cmbLayering.DrawFocusRectangle = false;
+            this.cmbLayering.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbLayering.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbLayering.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbLayering.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbLayering.FormattingEnabled = true;
+            this.cmbLayering.Items.AddRange(new object[] {
             "Below Player",
             "Same as Player",
             "Above Player"});
-      this.cmbLayering.Location = new System.Drawing.Point(48, 131);
-      this.cmbLayering.Name = "cmbLayering";
-      this.cmbLayering.Size = new System.Drawing.Size(101, 21);
-      this.cmbLayering.TabIndex = 1;
-      this.cmbLayering.Text = "Below Player";
-      this.cmbLayering.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbLayering.SelectedIndexChanged += new System.EventHandler(this.cmbLayering_SelectedIndexChanged);
-      // 
-      // cmbEventFreq
-      // 
-      this.cmbEventFreq.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbEventFreq.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbEventFreq.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbEventFreq.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbEventFreq.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbEventFreq.ButtonIcon")));
-      this.cmbEventFreq.DrawDropdownHoverOutline = false;
-      this.cmbEventFreq.DrawFocusRectangle = false;
-      this.cmbEventFreq.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbEventFreq.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbEventFreq.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbEventFreq.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbEventFreq.FormattingEnabled = true;
-      this.cmbEventFreq.Items.AddRange(new object[] {
+            this.cmbLayering.Location = new System.Drawing.Point(48, 131);
+            this.cmbLayering.Name = "cmbLayering";
+            this.cmbLayering.Size = new System.Drawing.Size(101, 21);
+            this.cmbLayering.TabIndex = 1;
+            this.cmbLayering.Text = "Below Player";
+            this.cmbLayering.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbLayering.SelectedIndexChanged += new System.EventHandler(this.cmbLayering_SelectedIndexChanged);
+            // 
+            // cmbEventFreq
+            // 
+            this.cmbEventFreq.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbEventFreq.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbEventFreq.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbEventFreq.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbEventFreq.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbEventFreq.ButtonIcon")));
+            this.cmbEventFreq.DrawDropdownHoverOutline = false;
+            this.cmbEventFreq.DrawFocusRectangle = false;
+            this.cmbEventFreq.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbEventFreq.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbEventFreq.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbEventFreq.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbEventFreq.FormattingEnabled = true;
+            this.cmbEventFreq.Items.AddRange(new object[] {
             "Not Very Often",
             "Not Often",
             "Normal",
             "Often",
             "Very Often"});
-      this.cmbEventFreq.Location = new System.Drawing.Point(48, 104);
-      this.cmbEventFreq.Name = "cmbEventFreq";
-      this.cmbEventFreq.Size = new System.Drawing.Size(100, 21);
-      this.cmbEventFreq.TabIndex = 6;
-      this.cmbEventFreq.Text = "Not Very Often";
-      this.cmbEventFreq.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbEventFreq.SelectedIndexChanged += new System.EventHandler(this.cmbEventFreq_SelectedIndexChanged);
-      // 
-      // cmbEventSpeed
-      // 
-      this.cmbEventSpeed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbEventSpeed.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbEventSpeed.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbEventSpeed.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbEventSpeed.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbEventSpeed.ButtonIcon")));
-      this.cmbEventSpeed.DrawDropdownHoverOutline = false;
-      this.cmbEventSpeed.DrawFocusRectangle = false;
-      this.cmbEventSpeed.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbEventSpeed.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbEventSpeed.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbEventSpeed.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbEventSpeed.FormattingEnabled = true;
-      this.cmbEventSpeed.Items.AddRange(new object[] {
+            this.cmbEventFreq.Location = new System.Drawing.Point(48, 104);
+            this.cmbEventFreq.Name = "cmbEventFreq";
+            this.cmbEventFreq.Size = new System.Drawing.Size(100, 21);
+            this.cmbEventFreq.TabIndex = 6;
+            this.cmbEventFreq.Text = "Not Very Often";
+            this.cmbEventFreq.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbEventFreq.SelectedIndexChanged += new System.EventHandler(this.cmbEventFreq_SelectedIndexChanged);
+            // 
+            // cmbEventSpeed
+            // 
+            this.cmbEventSpeed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbEventSpeed.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbEventSpeed.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbEventSpeed.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbEventSpeed.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbEventSpeed.ButtonIcon")));
+            this.cmbEventSpeed.DrawDropdownHoverOutline = false;
+            this.cmbEventSpeed.DrawFocusRectangle = false;
+            this.cmbEventSpeed.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbEventSpeed.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbEventSpeed.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbEventSpeed.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbEventSpeed.FormattingEnabled = true;
+            this.cmbEventSpeed.Items.AddRange(new object[] {
             "Slowest",
             "Slower",
             "Normal",
             "Faster",
             "Fastest"});
-      this.cmbEventSpeed.Location = new System.Drawing.Point(48, 77);
-      this.cmbEventSpeed.Name = "cmbEventSpeed";
-      this.cmbEventSpeed.Size = new System.Drawing.Size(100, 21);
-      this.cmbEventSpeed.TabIndex = 5;
-      this.cmbEventSpeed.Text = "Slowest";
-      this.cmbEventSpeed.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbEventSpeed.SelectedIndexChanged += new System.EventHandler(this.cmbEventSpeed_SelectedIndexChanged);
-      // 
-      // lblFreq
-      // 
-      this.lblFreq.AutoSize = true;
-      this.lblFreq.Location = new System.Drawing.Point(6, 107);
-      this.lblFreq.Name = "lblFreq";
-      this.lblFreq.Size = new System.Drawing.Size(31, 13);
-      this.lblFreq.TabIndex = 4;
-      this.lblFreq.Text = "Freq:";
-      // 
-      // lblSpeed
-      // 
-      this.lblSpeed.AutoSize = true;
-      this.lblSpeed.Location = new System.Drawing.Point(6, 80);
-      this.lblSpeed.Name = "lblSpeed";
-      this.lblSpeed.Size = new System.Drawing.Size(41, 13);
-      this.lblSpeed.TabIndex = 3;
-      this.lblSpeed.Text = "Speed:";
-      // 
-      // btnSetRoute
-      // 
-      this.btnSetRoute.Enabled = false;
-      this.btnSetRoute.Location = new System.Drawing.Point(73, 43);
-      this.btnSetRoute.Name = "btnSetRoute";
-      this.btnSetRoute.Padding = new System.Windows.Forms.Padding(5);
-      this.btnSetRoute.Size = new System.Drawing.Size(75, 23);
-      this.btnSetRoute.TabIndex = 2;
-      this.btnSetRoute.Text = "Set Route....";
-      this.btnSetRoute.Click += new System.EventHandler(this.btnSetRoute_Click);
-      // 
-      // lblType
-      // 
-      this.lblType.AutoSize = true;
-      this.lblType.Location = new System.Drawing.Point(6, 22);
-      this.lblType.Name = "lblType";
-      this.lblType.Size = new System.Drawing.Size(34, 13);
-      this.lblType.TabIndex = 1;
-      this.lblType.Text = "Type:";
-      // 
-      // cmbMoveType
-      // 
-      this.cmbMoveType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbMoveType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbMoveType.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbMoveType.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbMoveType.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbMoveType.ButtonIcon")));
-      this.cmbMoveType.DrawDropdownHoverOutline = false;
-      this.cmbMoveType.DrawFocusRectangle = false;
-      this.cmbMoveType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbMoveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbMoveType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbMoveType.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbMoveType.FormattingEnabled = true;
-      this.cmbMoveType.Items.AddRange(new object[] {
+            this.cmbEventSpeed.Location = new System.Drawing.Point(48, 77);
+            this.cmbEventSpeed.Name = "cmbEventSpeed";
+            this.cmbEventSpeed.Size = new System.Drawing.Size(100, 21);
+            this.cmbEventSpeed.TabIndex = 5;
+            this.cmbEventSpeed.Text = "Slowest";
+            this.cmbEventSpeed.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbEventSpeed.SelectedIndexChanged += new System.EventHandler(this.cmbEventSpeed_SelectedIndexChanged);
+            // 
+            // lblFreq
+            // 
+            this.lblFreq.AutoSize = true;
+            this.lblFreq.Location = new System.Drawing.Point(6, 107);
+            this.lblFreq.Name = "lblFreq";
+            this.lblFreq.Size = new System.Drawing.Size(31, 13);
+            this.lblFreq.TabIndex = 4;
+            this.lblFreq.Text = "Freq:";
+            // 
+            // lblSpeed
+            // 
+            this.lblSpeed.AutoSize = true;
+            this.lblSpeed.Location = new System.Drawing.Point(6, 80);
+            this.lblSpeed.Name = "lblSpeed";
+            this.lblSpeed.Size = new System.Drawing.Size(41, 13);
+            this.lblSpeed.TabIndex = 3;
+            this.lblSpeed.Text = "Speed:";
+            // 
+            // btnSetRoute
+            // 
+            this.btnSetRoute.Enabled = false;
+            this.btnSetRoute.Location = new System.Drawing.Point(73, 43);
+            this.btnSetRoute.Name = "btnSetRoute";
+            this.btnSetRoute.Padding = new System.Windows.Forms.Padding(5);
+            this.btnSetRoute.Size = new System.Drawing.Size(75, 23);
+            this.btnSetRoute.TabIndex = 2;
+            this.btnSetRoute.Text = "Set Route....";
+            this.btnSetRoute.Click += new System.EventHandler(this.btnSetRoute_Click);
+            // 
+            // lblType
+            // 
+            this.lblType.AutoSize = true;
+            this.lblType.Location = new System.Drawing.Point(6, 22);
+            this.lblType.Name = "lblType";
+            this.lblType.Size = new System.Drawing.Size(34, 13);
+            this.lblType.TabIndex = 1;
+            this.lblType.Text = "Type:";
+            // 
+            // cmbMoveType
+            // 
+            this.cmbMoveType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbMoveType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbMoveType.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbMoveType.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbMoveType.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbMoveType.ButtonIcon")));
+            this.cmbMoveType.DrawDropdownHoverOutline = false;
+            this.cmbMoveType.DrawFocusRectangle = false;
+            this.cmbMoveType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbMoveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbMoveType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbMoveType.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbMoveType.FormattingEnabled = true;
+            this.cmbMoveType.Items.AddRange(new object[] {
             "None",
             "Random",
             "Move Route"});
-      this.cmbMoveType.Location = new System.Drawing.Point(48, 19);
-      this.cmbMoveType.Name = "cmbMoveType";
-      this.cmbMoveType.Size = new System.Drawing.Size(100, 21);
-      this.cmbMoveType.TabIndex = 0;
-      this.cmbMoveType.Text = "None";
-      this.cmbMoveType.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbMoveType.SelectedIndexChanged += new System.EventHandler(this.cmbMoveType_SelectedIndexChanged);
-      // 
-      // grpTriggers
-      // 
-      this.grpTriggers.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpTriggers.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpTriggers.Controls.Add(this.txtCommand);
-      this.grpTriggers.Controls.Add(this.lblCommand);
-      this.grpTriggers.Controls.Add(this.lblTriggerVal);
-      this.grpTriggers.Controls.Add(this.cmbTriggerVal);
-      this.grpTriggers.Controls.Add(this.cmbTrigger);
-      this.grpTriggers.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpTriggers.Location = new System.Drawing.Point(25, 517);
-      this.grpTriggers.Name = "grpTriggers";
-      this.grpTriggers.Size = new System.Drawing.Size(317, 44);
-      this.grpTriggers.TabIndex = 21;
-      this.grpTriggers.TabStop = false;
-      this.grpTriggers.Text = "Trigger";
-      // 
-      // txtCommand
-      // 
-      this.txtCommand.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.txtCommand.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.txtCommand.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-      this.txtCommand.Location = new System.Drawing.Point(181, 13);
-      this.txtCommand.Name = "txtCommand";
-      this.txtCommand.Size = new System.Drawing.Size(130, 20);
-      this.txtCommand.TabIndex = 12;
-      this.txtCommand.Visible = false;
-      this.txtCommand.TextChanged += new System.EventHandler(this.txtCommand_TextChanged);
-      // 
-      // lblCommand
-      // 
-      this.lblCommand.AutoSize = true;
-      this.lblCommand.Location = new System.Drawing.Point(113, 17);
-      this.lblCommand.Name = "lblCommand";
-      this.lblCommand.Size = new System.Drawing.Size(70, 13);
-      this.lblCommand.TabIndex = 11;
-      this.lblCommand.Text = "/Command: /";
-      this.lblCommand.Visible = false;
-      // 
-      // lblTriggerVal
-      // 
-      this.lblTriggerVal.AutoSize = true;
-      this.lblTriggerVal.Location = new System.Drawing.Point(113, 17);
-      this.lblTriggerVal.Name = "lblTriggerVal";
-      this.lblTriggerVal.Size = new System.Drawing.Size(53, 13);
-      this.lblTriggerVal.TabIndex = 10;
-      this.lblTriggerVal.Text = "Projectile:";
-      this.lblTriggerVal.Visible = false;
-      // 
-      // cmbTriggerVal
-      // 
-      this.cmbTriggerVal.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbTriggerVal.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbTriggerVal.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbTriggerVal.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbTriggerVal.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbTriggerVal.ButtonIcon")));
-      this.cmbTriggerVal.DrawDropdownHoverOutline = false;
-      this.cmbTriggerVal.DrawFocusRectangle = false;
-      this.cmbTriggerVal.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbTriggerVal.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbTriggerVal.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbTriggerVal.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbTriggerVal.FormattingEnabled = true;
-      this.cmbTriggerVal.Items.AddRange(new object[] {
+            this.cmbMoveType.Location = new System.Drawing.Point(48, 19);
+            this.cmbMoveType.Name = "cmbMoveType";
+            this.cmbMoveType.Size = new System.Drawing.Size(100, 21);
+            this.cmbMoveType.TabIndex = 0;
+            this.cmbMoveType.Text = "None";
+            this.cmbMoveType.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbMoveType.SelectedIndexChanged += new System.EventHandler(this.cmbMoveType_SelectedIndexChanged);
+            // 
+            // grpTriggers
+            // 
+            this.grpTriggers.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpTriggers.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpTriggers.Controls.Add(this.txtCommand);
+            this.grpTriggers.Controls.Add(this.lblCommand);
+            this.grpTriggers.Controls.Add(this.lblTriggerVal);
+            this.grpTriggers.Controls.Add(this.cmbTriggerVal);
+            this.grpTriggers.Controls.Add(this.cmbTrigger);
+            this.grpTriggers.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpTriggers.Location = new System.Drawing.Point(25, 517);
+            this.grpTriggers.Name = "grpTriggers";
+            this.grpTriggers.Size = new System.Drawing.Size(317, 44);
+            this.grpTriggers.TabIndex = 21;
+            this.grpTriggers.TabStop = false;
+            this.grpTriggers.Text = "Trigger";
+            // 
+            // txtCommand
+            // 
+            this.txtCommand.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.txtCommand.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCommand.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.txtCommand.Location = new System.Drawing.Point(181, 13);
+            this.txtCommand.Name = "txtCommand";
+            this.txtCommand.Size = new System.Drawing.Size(130, 20);
+            this.txtCommand.TabIndex = 12;
+            this.txtCommand.Visible = false;
+            this.txtCommand.TextChanged += new System.EventHandler(this.txtCommand_TextChanged);
+            // 
+            // lblCommand
+            // 
+            this.lblCommand.AutoSize = true;
+            this.lblCommand.Location = new System.Drawing.Point(113, 17);
+            this.lblCommand.Name = "lblCommand";
+            this.lblCommand.Size = new System.Drawing.Size(70, 13);
+            this.lblCommand.TabIndex = 11;
+            this.lblCommand.Text = "/Command: /";
+            this.lblCommand.Visible = false;
+            // 
+            // lblTriggerVal
+            // 
+            this.lblTriggerVal.AutoSize = true;
+            this.lblTriggerVal.Location = new System.Drawing.Point(113, 17);
+            this.lblTriggerVal.Name = "lblTriggerVal";
+            this.lblTriggerVal.Size = new System.Drawing.Size(53, 13);
+            this.lblTriggerVal.TabIndex = 10;
+            this.lblTriggerVal.Text = "Projectile:";
+            this.lblTriggerVal.Visible = false;
+            // 
+            // cmbTriggerVal
+            // 
+            this.cmbTriggerVal.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbTriggerVal.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbTriggerVal.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbTriggerVal.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbTriggerVal.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbTriggerVal.ButtonIcon")));
+            this.cmbTriggerVal.DrawDropdownHoverOutline = false;
+            this.cmbTriggerVal.DrawFocusRectangle = false;
+            this.cmbTriggerVal.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbTriggerVal.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTriggerVal.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbTriggerVal.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbTriggerVal.FormattingEnabled = true;
+            this.cmbTriggerVal.Items.AddRange(new object[] {
             "None"});
-      this.cmbTriggerVal.Location = new System.Drawing.Point(181, 13);
-      this.cmbTriggerVal.Name = "cmbTriggerVal";
-      this.cmbTriggerVal.Size = new System.Drawing.Size(130, 21);
-      this.cmbTriggerVal.TabIndex = 9;
-      this.cmbTriggerVal.Text = "None";
-      this.cmbTriggerVal.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbTriggerVal.Visible = false;
-      // 
-      // cmbTrigger
-      // 
-      this.cmbTrigger.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-      this.cmbTrigger.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.cmbTrigger.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-      this.cmbTrigger.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-      this.cmbTrigger.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbTrigger.ButtonIcon")));
-      this.cmbTrigger.DrawDropdownHoverOutline = false;
-      this.cmbTrigger.DrawFocusRectangle = false;
-      this.cmbTrigger.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-      this.cmbTrigger.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cmbTrigger.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-      this.cmbTrigger.ForeColor = System.Drawing.Color.Gainsboro;
-      this.cmbTrigger.FormattingEnabled = true;
-      this.cmbTrigger.Items.AddRange(new object[] {
+            this.cmbTriggerVal.Location = new System.Drawing.Point(181, 13);
+            this.cmbTriggerVal.Name = "cmbTriggerVal";
+            this.cmbTriggerVal.Size = new System.Drawing.Size(130, 21);
+            this.cmbTriggerVal.TabIndex = 9;
+            this.cmbTriggerVal.Text = "None";
+            this.cmbTriggerVal.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbTriggerVal.Visible = false;
+            // 
+            // cmbTrigger
+            // 
+            this.cmbTrigger.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbTrigger.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbTrigger.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbTrigger.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbTrigger.ButtonIcon = ((System.Drawing.Bitmap)(resources.GetObject("cmbTrigger.ButtonIcon")));
+            this.cmbTrigger.DrawDropdownHoverOutline = false;
+            this.cmbTrigger.DrawFocusRectangle = false;
+            this.cmbTrigger.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbTrigger.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTrigger.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbTrigger.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbTrigger.FormattingEnabled = true;
+            this.cmbTrigger.Items.AddRange(new object[] {
             "Action Button",
             "Player Touch",
             "Autorun",
             "Projectile Hit"});
-      this.cmbTrigger.Location = new System.Drawing.Point(6, 13);
-      this.cmbTrigger.Name = "cmbTrigger";
-      this.cmbTrigger.Size = new System.Drawing.Size(101, 21);
-      this.cmbTrigger.TabIndex = 2;
-      this.cmbTrigger.Text = "Action Button";
-      this.cmbTrigger.TextPadding = new System.Windows.Forms.Padding(2);
-      this.cmbTrigger.SelectedIndexChanged += new System.EventHandler(this.cmbTrigger_SelectedIndexChanged);
-      // 
-      // grpEventConditions
-      // 
-      this.grpEventConditions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpEventConditions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpEventConditions.Controls.Add(this.btnEditConditions);
-      this.grpEventConditions.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpEventConditions.Location = new System.Drawing.Point(21, 89);
-      this.grpEventConditions.Name = "grpEventConditions";
-      this.grpEventConditions.Size = new System.Drawing.Size(326, 55);
-      this.grpEventConditions.TabIndex = 5;
-      this.grpEventConditions.TabStop = false;
-      this.grpEventConditions.Text = "Conditions";
-      // 
-      // btnEditConditions
-      // 
-      this.btnEditConditions.Location = new System.Drawing.Point(7, 20);
-      this.btnEditConditions.Name = "btnEditConditions";
-      this.btnEditConditions.Padding = new System.Windows.Forms.Padding(5);
-      this.btnEditConditions.Size = new System.Drawing.Size(304, 23);
-      this.btnEditConditions.TabIndex = 0;
-      this.btnEditConditions.Text = "Spawn/Execution Conditions";
-      this.btnEditConditions.Click += new System.EventHandler(this.btnEditConditions_Click);
-      // 
-      // grpNewCommands
-      // 
-      this.grpNewCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpNewCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpNewCommands.Controls.Add(this.lblCloseCommands);
-      this.grpNewCommands.Controls.Add(this.lstCommands);
-      this.grpNewCommands.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpNewCommands.Location = new System.Drawing.Point(353, 89);
-      this.grpNewCommands.Name = "grpNewCommands";
-      this.grpNewCommands.Size = new System.Drawing.Size(457, 484);
-      this.grpNewCommands.TabIndex = 7;
-      this.grpNewCommands.TabStop = false;
-      this.grpNewCommands.Text = "Add Commands";
-      this.grpNewCommands.Visible = false;
-      // 
-      // lblCloseCommands
-      // 
-      this.lblCloseCommands.AutoSize = true;
-      this.lblCloseCommands.Location = new System.Drawing.Point(437, 14);
-      this.lblCloseCommands.Name = "lblCloseCommands";
-      this.lblCloseCommands.Size = new System.Drawing.Size(14, 13);
-      this.lblCloseCommands.TabIndex = 1;
-      this.lblCloseCommands.Text = "X";
-      this.lblCloseCommands.Click += new System.EventHandler(this.lblCloseCommands_Click);
-      // 
-      // lstCommands
-      // 
-      this.lstCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-      this.lstCommands.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.lstCommands.ForeColor = System.Drawing.Color.Gainsboro;
-      this.lstCommands.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(150)))), ((int)(((byte)(150)))), ((int)(((byte)(150)))));
-      this.lstCommands.Location = new System.Drawing.Point(6, 32);
-      this.lstCommands.Name = "lstCommands";
-      treeNode1.Name = "showtext";
-      treeNode1.Tag = "1";
-      treeNode1.Text = "Show Text";
-      treeNode2.Name = "showoptions";
-      treeNode2.Tag = "2";
-      treeNode2.Text = "Show Options";
-      treeNode3.Name = "inputvariable";
-      treeNode3.Tag = "49";
-      treeNode3.Text = "Input Variable";
-      treeNode4.Name = "addchatboxtext";
-      treeNode4.Tag = "3";
-      treeNode4.Text = "Add Chatbox Text";
-      treeNode5.Name = "dialogue";
-      treeNode5.Text = "Dialogue";
-      treeNode6.Name = "setvariable";
-      treeNode6.Tag = "5";
-      treeNode6.Text = "Set Variable";
-      treeNode7.Name = "setselfswitch";
-      treeNode7.Tag = "6";
-      treeNode7.Text = "Set Self Switch";
-      treeNode8.Name = "conditionalbranch";
-      treeNode8.Tag = "7";
-      treeNode8.Text = "Conditional Branch";
-      treeNode9.Name = "exiteventprocess";
-      treeNode9.Tag = "8";
-      treeNode9.Text = "Exit Event Process";
-      treeNode10.Name = "label";
-      treeNode10.Tag = "9";
-      treeNode10.Text = "Label";
-      treeNode11.Name = "gotolabel";
-      treeNode11.Tag = "10";
-      treeNode11.Text = "Go To Label";
-      treeNode12.Name = "startcommonevent";
-      treeNode12.Tag = "11";
-      treeNode12.Text = "Start Common Event";
-      treeNode13.Name = "logicflow";
-      treeNode13.Text = "Logic Flow";
-      treeNode14.Name = "restorehp";
-      treeNode14.Tag = "12";
-      treeNode14.Text = "Restore HP";
-      treeNode15.Name = "restoremp";
-      treeNode15.Tag = "13";
-      treeNode15.Text = "Restore MP";
-      treeNode16.Name = "levelup";
-      treeNode16.Tag = "14";
-      treeNode16.Text = "Level Up";
-      treeNode17.Name = "giveexperience";
-      treeNode17.Tag = "15";
-      treeNode17.Text = "Give Experience";
-      treeNode18.Name = "changelevel";
-      treeNode18.Tag = "16";
-      treeNode18.Text = "Change Level";
-      treeNode19.Name = "changespells";
-      treeNode19.Tag = "17";
-      treeNode19.Text = "Change Spells";
-      treeNode20.Name = "changeitems";
-      treeNode20.Tag = "18";
-      treeNode20.Text = "Change Items";
-      treeNode21.Name = "changesprite";
-      treeNode21.Tag = "19";
-      treeNode21.Text = "Change Sprite";
-      treeNode22.Name = "changeface";
-      treeNode22.Tag = "20";
-      treeNode22.Text = "Change Face";
-      treeNode23.Name = "changegender";
-      treeNode23.Tag = "21";
-      treeNode23.Text = "Change Gender";
-      treeNode24.Name = "setaccess";
-      treeNode24.Tag = "22";
-      treeNode24.Text = "Set Access";
-      treeNode25.Name = "changeclass";
-      treeNode25.Tag = "38";
-      treeNode25.Text = "Change Class";
-      treeNode26.Name = "equipitem";
-      treeNode26.Tag = "47";
-      treeNode26.Text = "Equip Item";
-      treeNode27.Name = "changenamecolor";
-      treeNode27.Tag = "48";
-      treeNode27.Text = "Change Name Color";
-      treeNode28.Name = "changeplayerlabel";
-      treeNode28.Tag = "50";
-      treeNode28.Text = "Change Player Label";
-      treeNode29.Name = "playercontrol";
-      treeNode29.Text = "Player Control";
-      treeNode30.Name = "warpplayer";
-      treeNode30.Tag = "23";
-      treeNode30.Text = "Warp Player";
-      treeNode31.Name = "setmoveroute";
-      treeNode31.Tag = "24";
-      treeNode31.Text = "Set Move Route";
-      treeNode32.Name = "waitmoveroute";
-      treeNode32.Tag = "25";
-      treeNode32.Text = "Wait for Route Completion";
-      treeNode33.Name = "holdplayer";
-      treeNode33.Tag = "26";
-      treeNode33.Text = "Hold Player";
-      treeNode34.Name = "releaseplayer";
-      treeNode34.Tag = "27";
-      treeNode34.Text = "Release Player";
-      treeNode35.Name = "spawnnpc";
-      treeNode35.Tag = "28";
-      treeNode35.Text = "Spawn NPC";
-      treeNode36.Name = "despawnnpcs";
-      treeNode36.Tag = "39";
-      treeNode36.Text = "Despawn NPC";
-      treeNode37.Name = "hideplayer";
-      treeNode37.Tag = "45";
-      treeNode37.Text = "Hide Player";
-      treeNode38.Name = "showplayer";
-      treeNode38.Tag = "46";
-      treeNode38.Text = "Show Player";
-      treeNode39.Name = "movement";
-      treeNode39.Text = "Movement";
-      treeNode40.Name = "playanimation";
-      treeNode40.Tag = "29";
-      treeNode40.Text = "Play Animation";
-      treeNode41.Name = "playbgm";
-      treeNode41.Tag = "30";
-      treeNode41.Text = "Play BGM";
-      treeNode42.Name = "fadeoutbgm";
-      treeNode42.Tag = "31";
-      treeNode42.Text = "Fadeout BGM";
-      treeNode43.Name = "playsound";
-      treeNode43.Tag = "32";
-      treeNode43.Text = "Play Sound";
-      treeNode44.Name = "stopsounds";
-      treeNode44.Tag = "33";
-      treeNode44.Text = "Stop Sounds";
-      treeNode45.Name = "showpicture";
-      treeNode45.Tag = "43";
-      treeNode45.Text = "Show Picture";
-      treeNode46.Name = "hidepicture";
-      treeNode46.Tag = "44";
-      treeNode46.Text = "Hide Picture";
-      treeNode47.Name = "specialeffects";
-      treeNode47.Text = "Special Effects";
-      treeNode48.Name = "startquest";
-      treeNode48.Tag = "40";
-      treeNode48.Text = "Start Quest";
-      treeNode49.Name = "completequesttask";
-      treeNode49.Tag = "41";
-      treeNode49.Text = "Complete Quest Task";
-      treeNode50.Name = "endquest";
-      treeNode50.Tag = "42";
-      treeNode50.Text = "End Quest";
-      treeNode51.Name = "questcontrol";
-      treeNode51.Text = "Quest Control";
-      treeNode52.Name = "wait";
-      treeNode52.Tag = "34";
-      treeNode52.Text = "Wait...";
-      treeNode53.Name = "etc";
-      treeNode53.Text = "Etc";
-      treeNode54.Name = "openbank";
-      treeNode54.Tag = "35";
-      treeNode54.Text = "Open Bank";
-      treeNode55.Name = "openshop";
-      treeNode55.Tag = "36";
-      treeNode55.Text = "Open Shop";
-      treeNode56.Name = "opencraftingstation";
-      treeNode56.Tag = "37";
-      treeNode56.Text = "Open Crafting Station";
-      treeNode57.Name = "shopandbank";
-      treeNode57.Text = "Shop and Bank";
-      this.lstCommands.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
+            this.cmbTrigger.Location = new System.Drawing.Point(6, 13);
+            this.cmbTrigger.Name = "cmbTrigger";
+            this.cmbTrigger.Size = new System.Drawing.Size(101, 21);
+            this.cmbTrigger.TabIndex = 2;
+            this.cmbTrigger.Text = "Action Button";
+            this.cmbTrigger.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbTrigger.SelectedIndexChanged += new System.EventHandler(this.cmbTrigger_SelectedIndexChanged);
+            // 
+            // grpEventConditions
+            // 
+            this.grpEventConditions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpEventConditions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpEventConditions.Controls.Add(this.btnEditConditions);
+            this.grpEventConditions.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpEventConditions.Location = new System.Drawing.Point(21, 89);
+            this.grpEventConditions.Name = "grpEventConditions";
+            this.grpEventConditions.Size = new System.Drawing.Size(326, 55);
+            this.grpEventConditions.TabIndex = 5;
+            this.grpEventConditions.TabStop = false;
+            this.grpEventConditions.Text = "Conditions";
+            // 
+            // btnEditConditions
+            // 
+            this.btnEditConditions.Location = new System.Drawing.Point(7, 20);
+            this.btnEditConditions.Name = "btnEditConditions";
+            this.btnEditConditions.Padding = new System.Windows.Forms.Padding(5);
+            this.btnEditConditions.Size = new System.Drawing.Size(304, 23);
+            this.btnEditConditions.TabIndex = 0;
+            this.btnEditConditions.Text = "Spawn/Execution Conditions";
+            this.btnEditConditions.Click += new System.EventHandler(this.btnEditConditions_Click);
+            // 
+            // grpNewCommands
+            // 
+            this.grpNewCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpNewCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpNewCommands.Controls.Add(this.lblCloseCommands);
+            this.grpNewCommands.Controls.Add(this.lstCommands);
+            this.grpNewCommands.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpNewCommands.Location = new System.Drawing.Point(353, 89);
+            this.grpNewCommands.Name = "grpNewCommands";
+            this.grpNewCommands.Size = new System.Drawing.Size(457, 484);
+            this.grpNewCommands.TabIndex = 7;
+            this.grpNewCommands.TabStop = false;
+            this.grpNewCommands.Text = "Add Commands";
+            this.grpNewCommands.Visible = false;
+            // 
+            // lblCloseCommands
+            // 
+            this.lblCloseCommands.AutoSize = true;
+            this.lblCloseCommands.Location = new System.Drawing.Point(437, 14);
+            this.lblCloseCommands.Name = "lblCloseCommands";
+            this.lblCloseCommands.Size = new System.Drawing.Size(14, 13);
+            this.lblCloseCommands.TabIndex = 1;
+            this.lblCloseCommands.Text = "X";
+            this.lblCloseCommands.Click += new System.EventHandler(this.lblCloseCommands_Click);
+            // 
+            // lstCommands
+            // 
+            this.lstCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.lstCommands.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.lstCommands.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lstCommands.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(150)))), ((int)(((byte)(150)))), ((int)(((byte)(150)))));
+            this.lstCommands.Location = new System.Drawing.Point(6, 32);
+            this.lstCommands.Name = "lstCommands";
+            treeNode1.Name = "showtext";
+            treeNode1.Tag = "1";
+            treeNode1.Text = "Show Text";
+            treeNode2.Name = "showoptions";
+            treeNode2.Tag = "2";
+            treeNode2.Text = "Show Options";
+            treeNode3.Name = "inputvariable";
+            treeNode3.Tag = "49";
+            treeNode3.Text = "Input Variable";
+            treeNode4.Name = "addchatboxtext";
+            treeNode4.Tag = "3";
+            treeNode4.Text = "Add Chatbox Text";
+            treeNode5.Name = "dialogue";
+            treeNode5.Text = "Dialogue";
+            treeNode6.Name = "setvariable";
+            treeNode6.Tag = "5";
+            treeNode6.Text = "Set Variable";
+            treeNode7.Name = "setselfswitch";
+            treeNode7.Tag = "6";
+            treeNode7.Text = "Set Self Switch";
+            treeNode8.Name = "conditionalbranch";
+            treeNode8.Tag = "7";
+            treeNode8.Text = "Conditional Branch";
+            treeNode9.Name = "exiteventprocess";
+            treeNode9.Tag = "8";
+            treeNode9.Text = "Exit Event Process";
+            treeNode10.Name = "label";
+            treeNode10.Tag = "9";
+            treeNode10.Text = "Label";
+            treeNode11.Name = "gotolabel";
+            treeNode11.Tag = "10";
+            treeNode11.Text = "Go To Label";
+            treeNode12.Name = "startcommonevent";
+            treeNode12.Tag = "11";
+            treeNode12.Text = "Start Common Event";
+            treeNode13.Name = "logicflow";
+            treeNode13.Text = "Logic Flow";
+            treeNode14.Name = "restorehp";
+            treeNode14.Tag = "12";
+            treeNode14.Text = "Restore HP";
+            treeNode15.Name = "restoremp";
+            treeNode15.Tag = "13";
+            treeNode15.Text = "Restore MP";
+            treeNode16.Name = "levelup";
+            treeNode16.Tag = "14";
+            treeNode16.Text = "Level Up";
+            treeNode17.Name = "giveexperience";
+            treeNode17.Tag = "15";
+            treeNode17.Text = "Give Experience";
+            treeNode18.Name = "changelevel";
+            treeNode18.Tag = "16";
+            treeNode18.Text = "Change Level";
+            treeNode19.Name = "changespells";
+            treeNode19.Tag = "17";
+            treeNode19.Text = "Change Spells";
+            treeNode20.Name = "changeitems";
+            treeNode20.Tag = "18";
+            treeNode20.Text = "Change Items";
+            treeNode21.Name = "changesprite";
+            treeNode21.Tag = "19";
+            treeNode21.Text = "Change Sprite";
+            treeNode22.Name = "changeface";
+            treeNode22.Tag = "20";
+            treeNode22.Text = "Change Face";
+            treeNode23.Name = "changegender";
+            treeNode23.Tag = "21";
+            treeNode23.Text = "Change Gender";
+            treeNode24.Name = "setaccess";
+            treeNode24.Tag = "22";
+            treeNode24.Text = "Set Access";
+            treeNode25.Name = "changeclass";
+            treeNode25.Tag = "38";
+            treeNode25.Text = "Change Class";
+            treeNode26.Name = "equipitem";
+            treeNode26.Tag = "47";
+            treeNode26.Text = "Equip Item";
+            treeNode27.Name = "changenamecolor";
+            treeNode27.Tag = "48";
+            treeNode27.Text = "Change Name Color";
+            treeNode28.Name = "changeplayerlabel";
+            treeNode28.Tag = "50";
+            treeNode28.Text = "Change Player Label";
+            treeNode29.Name = "playercontrol";
+            treeNode29.Text = "Player Control";
+            treeNode30.Name = "warpplayer";
+            treeNode30.Tag = "23";
+            treeNode30.Text = "Warp Player";
+            treeNode31.Name = "setmoveroute";
+            treeNode31.Tag = "24";
+            treeNode31.Text = "Set Move Route";
+            treeNode32.Name = "waitmoveroute";
+            treeNode32.Tag = "25";
+            treeNode32.Text = "Wait for Route Completion";
+            treeNode33.Name = "holdplayer";
+            treeNode33.Tag = "26";
+            treeNode33.Text = "Hold Player";
+            treeNode34.Name = "releaseplayer";
+            treeNode34.Tag = "27";
+            treeNode34.Text = "Release Player";
+            treeNode35.Name = "spawnnpc";
+            treeNode35.Tag = "28";
+            treeNode35.Text = "Spawn NPC";
+            treeNode36.Name = "despawnnpcs";
+            treeNode36.Tag = "39";
+            treeNode36.Text = "Despawn NPC";
+            treeNode37.Name = "hideplayer";
+            treeNode37.Tag = "45";
+            treeNode37.Text = "Hide Player";
+            treeNode38.Name = "showplayer";
+            treeNode38.Tag = "46";
+            treeNode38.Text = "Show Player";
+            treeNode39.Name = "movement";
+            treeNode39.Text = "Movement";
+            treeNode40.Name = "playanimation";
+            treeNode40.Tag = "29";
+            treeNode40.Text = "Play Animation";
+            treeNode41.Name = "playbgm";
+            treeNode41.Tag = "30";
+            treeNode41.Text = "Play BGM";
+            treeNode42.Name = "fadeoutbgm";
+            treeNode42.Tag = "31";
+            treeNode42.Text = "Fadeout BGM";
+            treeNode43.Name = "playsound";
+            treeNode43.Tag = "32";
+            treeNode43.Text = "Play Sound";
+            treeNode44.Name = "stopsounds";
+            treeNode44.Tag = "33";
+            treeNode44.Text = "Stop Sounds";
+            treeNode45.Name = "showpicture";
+            treeNode45.Tag = "43";
+            treeNode45.Text = "Show Picture";
+            treeNode46.Name = "hidepicture";
+            treeNode46.Tag = "44";
+            treeNode46.Text = "Hide Picture";
+            treeNode47.Name = "specialeffects";
+            treeNode47.Text = "Special Effects";
+            treeNode48.Name = "startquest";
+            treeNode48.Tag = "40";
+            treeNode48.Text = "Start Quest";
+            treeNode49.Name = "completequesttask";
+            treeNode49.Tag = "41";
+            treeNode49.Text = "Complete Quest Task";
+            treeNode50.Name = "endquest";
+            treeNode50.Tag = "42";
+            treeNode50.Text = "End Quest";
+            treeNode51.Name = "questcontrol";
+            treeNode51.Text = "Quest Control";
+            treeNode52.Name = "wait";
+            treeNode52.Tag = "34";
+            treeNode52.Text = "Wait...";
+            treeNode53.Name = "etc";
+            treeNode53.Text = "Etc";
+            treeNode54.Name = "openbank";
+            treeNode54.Tag = "35";
+            treeNode54.Text = "Open Bank";
+            treeNode55.Name = "openshop";
+            treeNode55.Tag = "36";
+            treeNode55.Text = "Open Shop";
+            treeNode56.Name = "opencraftingstation";
+            treeNode56.Tag = "37";
+            treeNode56.Text = "Open Crafting Station";
+            treeNode57.Name = "shopandbank";
+            treeNode57.Text = "Shop and Bank";
+            this.lstCommands.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode5,
             treeNode13,
             treeNode29,
@@ -970,329 +970,329 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode51,
             treeNode53,
             treeNode57});
-      this.lstCommands.Size = new System.Drawing.Size(445, 440);
-      this.lstCommands.TabIndex = 2;
-      this.lstCommands.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.lstCommands_NodeMouseDoubleClick);
-      // 
-      // grpEventCommands
-      // 
-      this.grpEventCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpEventCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpEventCommands.Controls.Add(this.lstEventCommands);
-      this.grpEventCommands.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpEventCommands.Location = new System.Drawing.Point(353, 89);
-      this.grpEventCommands.Name = "grpEventCommands";
-      this.grpEventCommands.Size = new System.Drawing.Size(457, 484);
-      this.grpEventCommands.TabIndex = 6;
-      this.grpEventCommands.TabStop = false;
-      this.grpEventCommands.Text = "Commands";
-      // 
-      // lstEventCommands
-      // 
-      this.lstEventCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-      this.lstEventCommands.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.lstEventCommands.ForeColor = System.Drawing.Color.Gainsboro;
-      this.lstEventCommands.FormattingEnabled = true;
-      this.lstEventCommands.HorizontalScrollbar = true;
-      this.lstEventCommands.Items.AddRange(new object[] {
+            this.lstCommands.Size = new System.Drawing.Size(445, 440);
+            this.lstCommands.TabIndex = 2;
+            this.lstCommands.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.lstCommands_NodeMouseDoubleClick);
+            // 
+            // grpEventCommands
+            // 
+            this.grpEventCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpEventCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpEventCommands.Controls.Add(this.lstEventCommands);
+            this.grpEventCommands.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpEventCommands.Location = new System.Drawing.Point(353, 89);
+            this.grpEventCommands.Name = "grpEventCommands";
+            this.grpEventCommands.Size = new System.Drawing.Size(457, 484);
+            this.grpEventCommands.TabIndex = 6;
+            this.grpEventCommands.TabStop = false;
+            this.grpEventCommands.Text = "Commands";
+            // 
+            // lstEventCommands
+            // 
+            this.lstEventCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.lstEventCommands.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.lstEventCommands.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lstEventCommands.FormattingEnabled = true;
+            this.lstEventCommands.HorizontalScrollbar = true;
+            this.lstEventCommands.Items.AddRange(new object[] {
             "@>"});
-      this.lstEventCommands.Location = new System.Drawing.Point(6, 19);
-      this.lstEventCommands.Name = "lstEventCommands";
-      this.lstEventCommands.Size = new System.Drawing.Size(445, 457);
-      this.lstEventCommands.TabIndex = 0;
-      this.lstEventCommands.SelectedIndexChanged += new System.EventHandler(this.lstEventCommands_SelectedIndexChanged);
-      this.lstEventCommands.DoubleClick += new System.EventHandler(this.lstEventCommands_DoubleClick);
-      this.lstEventCommands.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lstEventCommands_KeyDown);
-      this.lstEventCommands.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lstEventCommands_Click);
-      // 
-      // grpCreateCommands
-      // 
-      this.grpCreateCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpCreateCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpCreateCommands.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpCreateCommands.Location = new System.Drawing.Point(353, 89);
-      this.grpCreateCommands.Name = "grpCreateCommands";
-      this.grpCreateCommands.Size = new System.Drawing.Size(457, 484);
-      this.grpCreateCommands.TabIndex = 8;
-      this.grpCreateCommands.TabStop = false;
-      this.grpCreateCommands.Visible = false;
-      // 
-      // btnSave
-      // 
-      this.btnSave.Location = new System.Drawing.Point(628, 586);
-      this.btnSave.Name = "btnSave";
-      this.btnSave.Padding = new System.Windows.Forms.Padding(5);
-      this.btnSave.Size = new System.Drawing.Size(93, 30);
-      this.btnSave.TabIndex = 6;
-      this.btnSave.Text = "Save";
-      this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
-      // 
-      // btnCancel
-      // 
-      this.btnCancel.Location = new System.Drawing.Point(727, 586);
-      this.btnCancel.Name = "btnCancel";
-      this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
-      this.btnCancel.Size = new System.Drawing.Size(93, 30);
-      this.btnCancel.TabIndex = 7;
-      this.btnCancel.Text = "Cancel";
-      this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-      // 
-      // commandMenu
-      // 
-      this.commandMenu.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-      this.commandMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
-      this.commandMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lstEventCommands.Location = new System.Drawing.Point(6, 19);
+            this.lstEventCommands.Name = "lstEventCommands";
+            this.lstEventCommands.Size = new System.Drawing.Size(445, 457);
+            this.lstEventCommands.TabIndex = 0;
+            this.lstEventCommands.SelectedIndexChanged += new System.EventHandler(this.lstEventCommands_SelectedIndexChanged);
+            this.lstEventCommands.DoubleClick += new System.EventHandler(this.lstEventCommands_DoubleClick);
+            this.lstEventCommands.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lstEventCommands_KeyDown);
+            this.lstEventCommands.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lstEventCommands_Click);
+            // 
+            // grpCreateCommands
+            // 
+            this.grpCreateCommands.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpCreateCommands.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpCreateCommands.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpCreateCommands.Location = new System.Drawing.Point(353, 89);
+            this.grpCreateCommands.Name = "grpCreateCommands";
+            this.grpCreateCommands.Size = new System.Drawing.Size(457, 484);
+            this.grpCreateCommands.TabIndex = 8;
+            this.grpCreateCommands.TabStop = false;
+            this.grpCreateCommands.Visible = false;
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(628, 586);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Padding = new System.Windows.Forms.Padding(5);
+            this.btnSave.Size = new System.Drawing.Size(93, 30);
+            this.btnSave.TabIndex = 6;
+            this.btnSave.Text = "Save";
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(727, 586);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
+            this.btnCancel.Size = new System.Drawing.Size(93, 30);
+            this.btnCancel.TabIndex = 7;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // commandMenu
+            // 
+            this.commandMenu.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.commandMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.commandMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.btnInsert,
             this.btnEdit,
             this.btnCut,
             this.btnCopy,
             this.btnPaste,
             this.btnDelete});
-      this.commandMenu.Name = "commandMenu";
-      this.commandMenu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-      this.commandMenu.Size = new System.Drawing.Size(108, 136);
-      // 
-      // btnInsert
-      // 
-      this.btnInsert.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnInsert.Name = "btnInsert";
-      this.btnInsert.Size = new System.Drawing.Size(107, 22);
-      this.btnInsert.Text = "Insert";
-      this.btnInsert.Click += new System.EventHandler(this.btnInsert_Click);
-      // 
-      // btnEdit
-      // 
-      this.btnEdit.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnEdit.Name = "btnEdit";
-      this.btnEdit.Size = new System.Drawing.Size(107, 22);
-      this.btnEdit.Text = "Edit";
-      this.btnEdit.Click += new System.EventHandler(this.btnEdit_Click);
-      // 
-      // btnCut
-      // 
-      this.btnCut.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnCut.Name = "btnCut";
-      this.btnCut.Size = new System.Drawing.Size(107, 22);
-      this.btnCut.Text = "Cut";
-      this.btnCut.Click += new System.EventHandler(this.btnCut_Click);
-      // 
-      // btnCopy
-      // 
-      this.btnCopy.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnCopy.Name = "btnCopy";
-      this.btnCopy.Size = new System.Drawing.Size(107, 22);
-      this.btnCopy.Text = "Copy";
-      this.btnCopy.Click += new System.EventHandler(this.btnCopy_Click);
-      // 
-      // btnPaste
-      // 
-      this.btnPaste.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnPaste.Name = "btnPaste";
-      this.btnPaste.Size = new System.Drawing.Size(107, 22);
-      this.btnPaste.Text = "Paste";
-      this.btnPaste.Click += new System.EventHandler(this.btnPaste_Click);
-      // 
-      // btnDelete
-      // 
-      this.btnDelete.ForeColor = System.Drawing.Color.Gainsboro;
-      this.btnDelete.Name = "btnDelete";
-      this.btnDelete.Size = new System.Drawing.Size(107, 22);
-      this.btnDelete.Text = "Delete";
-      this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
-      // 
-      // grpPageOptions
-      // 
-      this.grpPageOptions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpPageOptions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpPageOptions.Controls.Add(this.btnClearPage);
-      this.grpPageOptions.Controls.Add(this.btnDeletePage);
-      this.grpPageOptions.Controls.Add(this.btnPastePage);
-      this.grpPageOptions.Controls.Add(this.btnCopyPage);
-      this.grpPageOptions.Controls.Add(this.btnNewPage);
-      this.grpPageOptions.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpPageOptions.Location = new System.Drawing.Point(313, 5);
-      this.grpPageOptions.Name = "grpPageOptions";
-      this.grpPageOptions.Size = new System.Drawing.Size(510, 50);
-      this.grpPageOptions.TabIndex = 13;
-      this.grpPageOptions.TabStop = false;
-      this.grpPageOptions.Text = "Page Options";
-      // 
-      // btnClearPage
-      // 
-      this.btnClearPage.Location = new System.Drawing.Point(402, 16);
-      this.btnClearPage.Name = "btnClearPage";
-      this.btnClearPage.Padding = new System.Windows.Forms.Padding(5);
-      this.btnClearPage.Size = new System.Drawing.Size(93, 30);
-      this.btnClearPage.TabIndex = 17;
-      this.btnClearPage.Text = "Clear Page";
-      this.btnClearPage.Click += new System.EventHandler(this.btnClearPage_Click);
-      // 
-      // btnDeletePage
-      // 
-      this.btnDeletePage.Enabled = false;
-      this.btnDeletePage.Location = new System.Drawing.Point(303, 16);
-      this.btnDeletePage.Name = "btnDeletePage";
-      this.btnDeletePage.Padding = new System.Windows.Forms.Padding(5);
-      this.btnDeletePage.Size = new System.Drawing.Size(93, 30);
-      this.btnDeletePage.TabIndex = 16;
-      this.btnDeletePage.Text = "Delete Page";
-      this.btnDeletePage.Click += new System.EventHandler(this.btnDeletePage_Click);
-      // 
-      // btnPastePage
-      // 
-      this.btnPastePage.Location = new System.Drawing.Point(204, 16);
-      this.btnPastePage.Name = "btnPastePage";
-      this.btnPastePage.Padding = new System.Windows.Forms.Padding(5);
-      this.btnPastePage.Size = new System.Drawing.Size(93, 30);
-      this.btnPastePage.TabIndex = 15;
-      this.btnPastePage.Text = "Paste Page";
-      this.btnPastePage.Click += new System.EventHandler(this.btnPastePage_Click);
-      // 
-      // btnCopyPage
-      // 
-      this.btnCopyPage.Location = new System.Drawing.Point(105, 16);
-      this.btnCopyPage.Name = "btnCopyPage";
-      this.btnCopyPage.Padding = new System.Windows.Forms.Padding(5);
-      this.btnCopyPage.Size = new System.Drawing.Size(93, 30);
-      this.btnCopyPage.TabIndex = 14;
-      this.btnCopyPage.Text = "Copy Page";
-      this.btnCopyPage.Click += new System.EventHandler(this.btnCopyPage_Click);
-      // 
-      // btnNewPage
-      // 
-      this.btnNewPage.Location = new System.Drawing.Point(6, 16);
-      this.btnNewPage.Name = "btnNewPage";
-      this.btnNewPage.Padding = new System.Windows.Forms.Padding(5);
-      this.btnNewPage.Size = new System.Drawing.Size(93, 30);
-      this.btnNewPage.TabIndex = 13;
-      this.btnNewPage.Text = "New Page";
-      this.btnNewPage.Click += new System.EventHandler(this.btnNewPage_Click);
-      // 
-      // grpGeneral
-      // 
-      this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-      this.grpGeneral.Controls.Add(this.chkIsGlobal);
-      this.grpGeneral.Controls.Add(this.lblName);
-      this.grpGeneral.Controls.Add(this.txtEventname);
-      this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
-      this.grpGeneral.Location = new System.Drawing.Point(12, 5);
-      this.grpGeneral.Name = "grpGeneral";
-      this.grpGeneral.Size = new System.Drawing.Size(295, 49);
-      this.grpGeneral.TabIndex = 18;
-      this.grpGeneral.TabStop = false;
-      this.grpGeneral.Text = "General";
-      // 
-      // chkIsGlobal
-      // 
-      this.chkIsGlobal.AutoSize = true;
-      this.chkIsGlobal.Location = new System.Drawing.Point(202, 22);
-      this.chkIsGlobal.Name = "chkIsGlobal";
-      this.chkIsGlobal.Size = new System.Drawing.Size(87, 17);
-      this.chkIsGlobal.TabIndex = 3;
-      this.chkIsGlobal.Text = "Global Event";
-      this.chkIsGlobal.CheckedChanged += new System.EventHandler(this.chkIsGlobal_CheckedChanged);
-      // 
-      // pnlTabsContainer
-      // 
-      this.pnlTabsContainer.Controls.Add(this.pnlTabs);
-      this.pnlTabsContainer.Location = new System.Drawing.Point(12, 61);
-      this.pnlTabsContainer.Name = "pnlTabsContainer";
-      this.pnlTabsContainer.Size = new System.Drawing.Size(811, 22);
-      this.pnlTabsContainer.TabIndex = 22;
-      // 
-      // pnlTabs
-      // 
-      this.pnlTabs.AutoSize = true;
-      this.pnlTabs.Location = new System.Drawing.Point(0, 0);
-      this.pnlTabs.Name = "pnlTabs";
-      this.pnlTabs.Size = new System.Drawing.Size(811, 22);
-      this.pnlTabs.TabIndex = 23;
-      // 
-      // btnTabsRight
-      // 
-      this.btnTabsRight.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-      this.btnTabsRight.Location = new System.Drawing.Point(773, 61);
-      this.btnTabsRight.Name = "btnTabsRight";
-      this.btnTabsRight.Padding = new System.Windows.Forms.Padding(5);
-      this.btnTabsRight.Size = new System.Drawing.Size(50, 23);
-      this.btnTabsRight.TabIndex = 1;
-      this.btnTabsRight.Text = ">";
-      this.btnTabsRight.Click += new System.EventHandler(this.btnTabsRight_Click);
-      // 
-      // btnTabsLeft
-      // 
-      this.btnTabsLeft.Location = new System.Drawing.Point(12, 61);
-      this.btnTabsLeft.Name = "btnTabsLeft";
-      this.btnTabsLeft.Padding = new System.Windows.Forms.Padding(5);
-      this.btnTabsLeft.Size = new System.Drawing.Size(50, 23);
-      this.btnTabsLeft.TabIndex = 0;
-      this.btnTabsLeft.Text = "<";
-      this.btnTabsLeft.Click += new System.EventHandler(this.btnTabsLeft_Click);
-      // 
-      // panel1
-      // 
-      this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-      this.panel1.Location = new System.Drawing.Point(12, 83);
-      this.panel1.Name = "panel1";
-      this.panel1.Size = new System.Drawing.Size(811, 498);
-      this.panel1.TabIndex = 23;
-      // 
-      // FrmEvent
-      // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-      this.AutoSize = true;
-      this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-      this.ClientSize = new System.Drawing.Size(835, 622);
-      this.Controls.Add(this.grpNewCommands);
-      this.Controls.Add(this.grpTriggers);
-      this.Controls.Add(this.btnTabsRight);
-      this.Controls.Add(this.btnTabsLeft);
-      this.Controls.Add(this.grpEntityOptions);
-      this.Controls.Add(this.grpEventConditions);
-      this.Controls.Add(this.grpPageOptions);
-      this.Controls.Add(this.grpGeneral);
-      this.Controls.Add(this.btnCancel);
-      this.Controls.Add(this.btnSave);
-      this.Controls.Add(this.pnlTabsContainer);
-      this.Controls.Add(this.grpEventCommands);
-      this.Controls.Add(this.grpCreateCommands);
-      this.Controls.Add(this.panel1);
-      this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-      this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-      this.KeyPreview = true;
-      this.MaximizeBox = false;
-      this.Name = "FrmEvent";
-      this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-      this.Text = "Event Editor";
-      this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmEvent_FormClosing);
-      this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FrmEvent_FormClosed);
-      this.Load += new System.EventHandler(this.frmEvent_Load);
-      this.VisibleChanged += new System.EventHandler(this.FrmEvent_VisibleChanged);
-      this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FrmEvent_KeyDown);
-      this.grpEntityOptions.ResumeLayout(false);
-      this.grpExtra.ResumeLayout(false);
-      this.grpExtra.PerformLayout();
-      this.grpInspector.ResumeLayout(false);
-      this.grpInspector.PerformLayout();
-      this.grpPreview.ResumeLayout(false);
-      this.grpPreview.PerformLayout();
-      this.grpMovement.ResumeLayout(false);
-      this.grpMovement.PerformLayout();
-      this.grpTriggers.ResumeLayout(false);
-      this.grpTriggers.PerformLayout();
-      this.grpEventConditions.ResumeLayout(false);
-      this.grpNewCommands.ResumeLayout(false);
-      this.grpNewCommands.PerformLayout();
-      this.grpEventCommands.ResumeLayout(false);
-      this.commandMenu.ResumeLayout(false);
-      this.grpPageOptions.ResumeLayout(false);
-      this.grpGeneral.ResumeLayout(false);
-      this.grpGeneral.PerformLayout();
-      this.pnlTabsContainer.ResumeLayout(false);
-      this.pnlTabsContainer.PerformLayout();
-      this.ResumeLayout(false);
+            this.commandMenu.Name = "commandMenu";
+            this.commandMenu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.commandMenu.Size = new System.Drawing.Size(108, 136);
+            // 
+            // btnInsert
+            // 
+            this.btnInsert.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnInsert.Name = "btnInsert";
+            this.btnInsert.Size = new System.Drawing.Size(107, 22);
+            this.btnInsert.Text = "Insert";
+            this.btnInsert.Click += new System.EventHandler(this.btnInsert_Click);
+            // 
+            // btnEdit
+            // 
+            this.btnEdit.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnEdit.Name = "btnEdit";
+            this.btnEdit.Size = new System.Drawing.Size(107, 22);
+            this.btnEdit.Text = "Edit";
+            this.btnEdit.Click += new System.EventHandler(this.btnEdit_Click);
+            // 
+            // btnCut
+            // 
+            this.btnCut.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnCut.Name = "btnCut";
+            this.btnCut.Size = new System.Drawing.Size(107, 22);
+            this.btnCut.Text = "Cut";
+            this.btnCut.Click += new System.EventHandler(this.btnCut_Click);
+            // 
+            // btnCopy
+            // 
+            this.btnCopy.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnCopy.Name = "btnCopy";
+            this.btnCopy.Size = new System.Drawing.Size(107, 22);
+            this.btnCopy.Text = "Copy";
+            this.btnCopy.Click += new System.EventHandler(this.btnCopy_Click);
+            // 
+            // btnPaste
+            // 
+            this.btnPaste.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnPaste.Name = "btnPaste";
+            this.btnPaste.Size = new System.Drawing.Size(107, 22);
+            this.btnPaste.Text = "Paste";
+            this.btnPaste.Click += new System.EventHandler(this.btnPaste_Click);
+            // 
+            // btnDelete
+            // 
+            this.btnDelete.ForeColor = System.Drawing.Color.Gainsboro;
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(107, 22);
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // 
+            // grpPageOptions
+            // 
+            this.grpPageOptions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpPageOptions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpPageOptions.Controls.Add(this.btnClearPage);
+            this.grpPageOptions.Controls.Add(this.btnDeletePage);
+            this.grpPageOptions.Controls.Add(this.btnPastePage);
+            this.grpPageOptions.Controls.Add(this.btnCopyPage);
+            this.grpPageOptions.Controls.Add(this.btnNewPage);
+            this.grpPageOptions.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpPageOptions.Location = new System.Drawing.Point(313, 5);
+            this.grpPageOptions.Name = "grpPageOptions";
+            this.grpPageOptions.Size = new System.Drawing.Size(510, 50);
+            this.grpPageOptions.TabIndex = 13;
+            this.grpPageOptions.TabStop = false;
+            this.grpPageOptions.Text = "Page Options";
+            // 
+            // btnClearPage
+            // 
+            this.btnClearPage.Location = new System.Drawing.Point(402, 16);
+            this.btnClearPage.Name = "btnClearPage";
+            this.btnClearPage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnClearPage.Size = new System.Drawing.Size(93, 30);
+            this.btnClearPage.TabIndex = 17;
+            this.btnClearPage.Text = "Clear Page";
+            this.btnClearPage.Click += new System.EventHandler(this.btnClearPage_Click);
+            // 
+            // btnDeletePage
+            // 
+            this.btnDeletePage.Enabled = false;
+            this.btnDeletePage.Location = new System.Drawing.Point(303, 16);
+            this.btnDeletePage.Name = "btnDeletePage";
+            this.btnDeletePage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnDeletePage.Size = new System.Drawing.Size(93, 30);
+            this.btnDeletePage.TabIndex = 16;
+            this.btnDeletePage.Text = "Delete Page";
+            this.btnDeletePage.Click += new System.EventHandler(this.btnDeletePage_Click);
+            // 
+            // btnPastePage
+            // 
+            this.btnPastePage.Location = new System.Drawing.Point(204, 16);
+            this.btnPastePage.Name = "btnPastePage";
+            this.btnPastePage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnPastePage.Size = new System.Drawing.Size(93, 30);
+            this.btnPastePage.TabIndex = 15;
+            this.btnPastePage.Text = "Paste Page";
+            this.btnPastePage.Click += new System.EventHandler(this.btnPastePage_Click);
+            // 
+            // btnCopyPage
+            // 
+            this.btnCopyPage.Location = new System.Drawing.Point(105, 16);
+            this.btnCopyPage.Name = "btnCopyPage";
+            this.btnCopyPage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnCopyPage.Size = new System.Drawing.Size(93, 30);
+            this.btnCopyPage.TabIndex = 14;
+            this.btnCopyPage.Text = "Copy Page";
+            this.btnCopyPage.Click += new System.EventHandler(this.btnCopyPage_Click);
+            // 
+            // btnNewPage
+            // 
+            this.btnNewPage.Location = new System.Drawing.Point(6, 16);
+            this.btnNewPage.Name = "btnNewPage";
+            this.btnNewPage.Padding = new System.Windows.Forms.Padding(5);
+            this.btnNewPage.Size = new System.Drawing.Size(93, 30);
+            this.btnNewPage.TabIndex = 13;
+            this.btnNewPage.Text = "New Page";
+            this.btnNewPage.Click += new System.EventHandler(this.btnNewPage_Click);
+            // 
+            // grpGeneral
+            // 
+            this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.chkIsGlobal);
+            this.grpGeneral.Controls.Add(this.lblName);
+            this.grpGeneral.Controls.Add(this.txtEventname);
+            this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpGeneral.Location = new System.Drawing.Point(12, 5);
+            this.grpGeneral.Name = "grpGeneral";
+            this.grpGeneral.Size = new System.Drawing.Size(295, 49);
+            this.grpGeneral.TabIndex = 18;
+            this.grpGeneral.TabStop = false;
+            this.grpGeneral.Text = "General";
+            // 
+            // chkIsGlobal
+            // 
+            this.chkIsGlobal.AutoSize = true;
+            this.chkIsGlobal.Location = new System.Drawing.Point(202, 22);
+            this.chkIsGlobal.Name = "chkIsGlobal";
+            this.chkIsGlobal.Size = new System.Drawing.Size(87, 17);
+            this.chkIsGlobal.TabIndex = 3;
+            this.chkIsGlobal.Text = "Global Event";
+            this.chkIsGlobal.CheckedChanged += new System.EventHandler(this.chkIsGlobal_CheckedChanged);
+            // 
+            // pnlTabsContainer
+            // 
+            this.pnlTabsContainer.Controls.Add(this.pnlTabs);
+            this.pnlTabsContainer.Location = new System.Drawing.Point(12, 61);
+            this.pnlTabsContainer.Name = "pnlTabsContainer";
+            this.pnlTabsContainer.Size = new System.Drawing.Size(811, 22);
+            this.pnlTabsContainer.TabIndex = 22;
+            // 
+            // pnlTabs
+            // 
+            this.pnlTabs.AutoSize = true;
+            this.pnlTabs.Location = new System.Drawing.Point(0, 0);
+            this.pnlTabs.Name = "pnlTabs";
+            this.pnlTabs.Size = new System.Drawing.Size(811, 22);
+            this.pnlTabs.TabIndex = 23;
+            // 
+            // btnTabsRight
+            // 
+            this.btnTabsRight.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnTabsRight.Location = new System.Drawing.Point(773, 61);
+            this.btnTabsRight.Name = "btnTabsRight";
+            this.btnTabsRight.Padding = new System.Windows.Forms.Padding(5);
+            this.btnTabsRight.Size = new System.Drawing.Size(50, 23);
+            this.btnTabsRight.TabIndex = 1;
+            this.btnTabsRight.Text = ">";
+            this.btnTabsRight.Click += new System.EventHandler(this.btnTabsRight_Click);
+            // 
+            // btnTabsLeft
+            // 
+            this.btnTabsLeft.Location = new System.Drawing.Point(12, 61);
+            this.btnTabsLeft.Name = "btnTabsLeft";
+            this.btnTabsLeft.Padding = new System.Windows.Forms.Padding(5);
+            this.btnTabsLeft.Size = new System.Drawing.Size(50, 23);
+            this.btnTabsLeft.TabIndex = 0;
+            this.btnTabsLeft.Text = "<";
+            this.btnTabsLeft.Click += new System.EventHandler(this.btnTabsLeft_Click);
+            // 
+            // panel1
+            // 
+            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panel1.Location = new System.Drawing.Point(12, 83);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(811, 498);
+            this.panel1.TabIndex = 23;
+            // 
+            // FrmEvent
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.ClientSize = new System.Drawing.Size(835, 622);
+            this.Controls.Add(this.grpNewCommands);
+            this.Controls.Add(this.grpTriggers);
+            this.Controls.Add(this.btnTabsRight);
+            this.Controls.Add(this.btnTabsLeft);
+            this.Controls.Add(this.grpEntityOptions);
+            this.Controls.Add(this.grpEventConditions);
+            this.Controls.Add(this.grpPageOptions);
+            this.Controls.Add(this.grpGeneral);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.pnlTabsContainer);
+            this.Controls.Add(this.grpEventCommands);
+            this.Controls.Add(this.grpCreateCommands);
+            this.Controls.Add(this.panel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
+            this.MaximizeBox = false;
+            this.Name = "FrmEvent";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Event Editor";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmEvent_FormClosing);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FrmEvent_FormClosed);
+            this.Load += new System.EventHandler(this.frmEvent_Load);
+            this.VisibleChanged += new System.EventHandler(this.FrmEvent_VisibleChanged);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FrmEvent_KeyDown);
+            this.grpEntityOptions.ResumeLayout(false);
+            this.grpExtra.ResumeLayout(false);
+            this.grpExtra.PerformLayout();
+            this.grpInspector.ResumeLayout(false);
+            this.grpInspector.PerformLayout();
+            this.grpPreview.ResumeLayout(false);
+            this.grpPreview.PerformLayout();
+            this.grpMovement.ResumeLayout(false);
+            this.grpMovement.PerformLayout();
+            this.grpTriggers.ResumeLayout(false);
+            this.grpTriggers.PerformLayout();
+            this.grpEventConditions.ResumeLayout(false);
+            this.grpNewCommands.ResumeLayout(false);
+            this.grpNewCommands.PerformLayout();
+            this.grpEventCommands.ResumeLayout(false);
+            this.commandMenu.ResumeLayout(false);
+            this.grpPageOptions.ResumeLayout(false);
+            this.grpGeneral.ResumeLayout(false);
+            this.grpGeneral.PerformLayout();
+            this.pnlTabsContainer.ResumeLayout(false);
+            this.pnlTabsContainer.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -60,6 +60,8 @@ namespace Intersect.Editor.Forms.Editors.Events
 
         public bool NewEvent;
 
+        public int mOldSelectedCommand;
+
         private void txtEventname_TextChanged(object sender, EventArgs e)
         {
             MyEvent.Name = txtEventname.Text;
@@ -69,6 +71,7 @@ namespace Intersect.Editor.Forms.Editors.Events
         private void lstEventCommands_SelectedIndexChanged(object sender, EventArgs e)
         {
             mCurrentCommand = lstEventCommands.SelectedIndex;
+            mOldSelectedCommand = lstEventCommands.SelectedIndex;
         }
 
         private void lstEventCommands_KeyDown(object sender, KeyEventArgs e)
@@ -97,6 +100,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             HandleRemoveCommand(mCommandProperties[mCurrentCommand].Cmd);
             mCommandProperties[mCurrentCommand].MyList.Remove(mCommandProperties[mCurrentCommand].Cmd);
             mCurrentCommand = -1;
+
+            mOldSelectedCommand = lstEventCommands.SelectedIndex;
             ListPageCommands();
         }
 
@@ -136,6 +141,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             btnCopy.Enabled = btnEdit.Enabled;
             btnCut.Enabled = btnEdit.Enabled;
             btnDelete.Enabled = true;
+
+            mOldSelectedCommand = lstEventCommands.SelectedIndex;
         }
 
         private void lstEventCommands_DoubleClick(object sender, EventArgs e)
@@ -162,6 +169,8 @@ namespace Intersect.Editor.Forms.Editors.Events
                 DisableButtons();
                 mIsInsert = true;
             }
+
+            mOldSelectedCommand = lstEventCommands.SelectedIndex;
         }
 
         /// <summary>
@@ -1077,6 +1086,16 @@ namespace Intersect.Editor.Forms.Editors.Events
             CommandPrinter.PrintCommandList(
                 CurrentPage, CurrentPage.CommandLists.Values.First(), " ", lstEventCommands, mCommandProperties, MyMap
             );
+
+            // Reset our view to roughly where the user left off.
+            if (mOldSelectedCommand > (lstEventCommands.Items.Count -1))
+            {
+                lstEventCommands.SelectedIndex = lstEventCommands.Items.Count - 1;
+            }
+            else
+            {
+                lstEventCommands.SelectedIndex = mOldSelectedCommand;
+            }
         }
 
         /// <summary>

--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -122,6 +122,7 @@ namespace Intersect.Editor.Forms
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.packClientTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.packageUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideEventsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.menuStrip.SuspendLayout();
@@ -626,45 +627,45 @@ namespace Intersect.Editor.Forms
             // undoToolStripMenuItem
             // 
             this.undoToolStripMenuItem.Enabled = false;
-            this.undoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.undoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.undoToolStripMenuItem.Text = "Undo";
             this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
             // 
             // redoToolStripMenuItem
             // 
             this.redoToolStripMenuItem.Enabled = false;
-            this.redoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.redoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
             this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
-            this.redoToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.redoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.redoToolStripMenuItem.Text = "Redo";
             this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
             // 
             // cutToolStripMenuItem
             // 
             this.cutToolStripMenuItem.Enabled = false;
-            this.cutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.cutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
             this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.cutToolStripMenuItem.Text = "Cut";
             this.cutToolStripMenuItem.Click += new System.EventHandler(this.cutToolStripMenuItem_Click);
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Enabled = false;
-            this.copyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.copyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.copyToolStripMenuItem.Text = "Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // pasteToolStripMenuItem
             // 
             this.pasteToolStripMenuItem.Enabled = false;
-            this.pasteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.pasteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.pasteToolStripMenuItem.Text = "Paste";
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
             // 
@@ -672,7 +673,7 @@ namespace Intersect.Editor.Forms
             // 
             this.fillToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.fillToolStripMenuItem.Name = "fillToolStripMenuItem";
-            this.fillToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.fillToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.fillToolStripMenuItem.Text = "Fill";
             this.fillToolStripMenuItem.Click += new System.EventHandler(this.fillToolStripMenuItem_Click);
             // 
@@ -680,7 +681,7 @@ namespace Intersect.Editor.Forms
             // 
             this.eraseLayerToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.eraseLayerToolStripMenuItem.Name = "eraseLayerToolStripMenuItem";
-            this.eraseLayerToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.eraseLayerToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.eraseLayerToolStripMenuItem.Text = "Erase Layer";
             this.eraseLayerToolStripMenuItem.Click += new System.EventHandler(this.eraseLayerToolStripMenuItem_Click);
             // 
@@ -691,7 +692,7 @@ namespace Intersect.Editor.Forms
             this.currentLayerOnlyToolStripMenuItem});
             this.selectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
-            this.selectToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+            this.selectToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.selectToolStripMenuItem.Text = "Select....";
             // 
             // allLayersToolStripMenuItem
@@ -718,6 +719,7 @@ namespace Intersect.Editor.Forms
             this.hideOverlayToolStripMenuItem,
             this.hideTilePreviewToolStripMenuItem,
             this.hideResourcesToolStripMenuItem,
+            this.hideEventsToolStripMenuItem,
             this.mapGridToolStripMenuItem});
             this.viewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
@@ -730,7 +732,7 @@ namespace Intersect.Editor.Forms
             this.hideDarknessToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideDarknessToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.hideDarknessToolStripMenuItem.Name = "hideDarknessToolStripMenuItem";
-            this.hideDarknessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.hideDarknessToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideDarknessToolStripMenuItem.Text = "Darkness";
             this.hideDarknessToolStripMenuItem.Click += new System.EventHandler(this.hideDarknessToolStripMenuItem_Click);
             // 
@@ -740,7 +742,7 @@ namespace Intersect.Editor.Forms
             this.hideFogToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideFogToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.hideFogToolStripMenuItem.Name = "hideFogToolStripMenuItem";
-            this.hideFogToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.hideFogToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideFogToolStripMenuItem.Text = "Fog";
             this.hideFogToolStripMenuItem.Click += new System.EventHandler(this.hideFogToolStripMenuItem_Click);
             // 
@@ -750,7 +752,7 @@ namespace Intersect.Editor.Forms
             this.hideOverlayToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideOverlayToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.hideOverlayToolStripMenuItem.Name = "hideOverlayToolStripMenuItem";
-            this.hideOverlayToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.hideOverlayToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideOverlayToolStripMenuItem.Text = "Overlay";
             this.hideOverlayToolStripMenuItem.Click += new System.EventHandler(this.hideOverlayToolStripMenuItem_Click);
             // 
@@ -760,7 +762,7 @@ namespace Intersect.Editor.Forms
             this.hideTilePreviewToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideTilePreviewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.hideTilePreviewToolStripMenuItem.Name = "hideTilePreviewToolStripMenuItem";
-            this.hideTilePreviewToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.hideTilePreviewToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideTilePreviewToolStripMenuItem.Text = "Tile Preview";
             this.hideTilePreviewToolStripMenuItem.Click += new System.EventHandler(this.hideTilePreviewToolStripMenuItem_Click);
             // 
@@ -770,7 +772,7 @@ namespace Intersect.Editor.Forms
             this.hideResourcesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideResourcesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.hideResourcesToolStripMenuItem.Name = "hideResourcesToolStripMenuItem";
-            this.hideResourcesToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.hideResourcesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideResourcesToolStripMenuItem.Text = "Resources";
             this.hideResourcesToolStripMenuItem.Click += new System.EventHandler(this.hideResourcesToolStripMenuItem_Click);
             // 
@@ -778,7 +780,7 @@ namespace Intersect.Editor.Forms
             // 
             this.mapGridToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.mapGridToolStripMenuItem.Name = "mapGridToolStripMenuItem";
-            this.mapGridToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.mapGridToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.mapGridToolStripMenuItem.Text = "Map Grid";
             this.mapGridToolStripMenuItem.Click += new System.EventHandler(this.mapGridToolStripMenuItem_Click);
             // 
@@ -983,7 +985,7 @@ namespace Intersect.Editor.Forms
             // 
             this.packClientTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.packClientTexturesToolStripMenuItem.Name = "packClientTexturesToolStripMenuItem";
-            this.packClientTexturesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.packClientTexturesToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.packClientTexturesToolStripMenuItem.Text = "Pack Client Textures";
             this.packClientTexturesToolStripMenuItem.Click += new System.EventHandler(this.packClientTexturesToolStripMenuItem_Click);
             // 
@@ -991,9 +993,19 @@ namespace Intersect.Editor.Forms
             // 
             this.packageUpdateToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.packageUpdateToolStripMenuItem.Name = "packageUpdateToolStripMenuItem";
-            this.packageUpdateToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.packageUpdateToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.packageUpdateToolStripMenuItem.Text = "Package Update";
             this.packageUpdateToolStripMenuItem.Click += new System.EventHandler(this.packageUpdateToolStripMenuItem_Click);
+            // 
+            // hideEventsToolStripMenuItem
+            // 
+            this.hideEventsToolStripMenuItem.Checked = true;
+            this.hideEventsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.hideEventsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.hideEventsToolStripMenuItem.Name = "hideEventsToolStripMenuItem";
+            this.hideEventsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.hideEventsToolStripMenuItem.Text = "Events";
+            this.hideEventsToolStripMenuItem.Click += new System.EventHandler(this.hideEventsToolStripMenuItem_Click);
             // 
             // FrmMain
             // 
@@ -1114,5 +1126,6 @@ namespace Intersect.Editor.Forms
 		private ToolStripMenuItem craftsEditorToolStripMenuItem;
         private ToolStripMenuItem packClientTexturesToolStripMenuItem;
         private ToolStripMenuItem packageUpdateToolStripMenuItem;
+        private ToolStripMenuItem hideEventsToolStripMenuItem;
     }
 }

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -164,6 +164,7 @@ namespace Intersect.Editor.Forms
             hideFogToolStripMenuItem.Text = Strings.MainForm.fog;
             hideOverlayToolStripMenuItem.Text = Strings.MainForm.overlay;
             hideResourcesToolStripMenuItem.Text = Strings.MainForm.resources;
+            hideEventsToolStripMenuItem.Text = Strings.MainForm.Events;
             hideTilePreviewToolStripMenuItem.Text = Strings.MainForm.tilepreview;
             mapGridToolStripMenuItem.Text = Strings.MainForm.grid;
 
@@ -1123,6 +1124,12 @@ namespace Intersect.Editor.Forms
             hideResourcesToolStripMenuItem.Checked = !Core.Graphics.HideResources;
         }
 
+        private void hideEventsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Core.Graphics.HideEvents = !Core.Graphics.HideEvents;
+            hideEventsToolStripMenuItem.Checked = !Core.Graphics.HideEvents;
+        }
+
         private void mapGridToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Core.Graphics.HideGrid = !Core.Graphics.HideGrid;
@@ -1940,6 +1947,7 @@ namespace Intersect.Editor.Forms
 
             return filesProcessed;
         }
+
     }
 
 }

--- a/Intersect.Editor/Forms/frmMain.resx
+++ b/Intersect.Editor/Forms/frmMain.resx
@@ -179,15 +179,15 @@
   <data name="toolStripBtnRedo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHASURBVDhPjVJNLwNhEF4qEiIkEhec8AOE+g/i6iMREgkO
-        4toSn3FwcJJeSBxU0fg4qfQgItrQQ1N1WVKk0Q0lot3URtrd9lAyZl5vaxvN8iSTfXfnmWdmnncFPQCg
-        Kp1OT2OEZFnOYnzg+RpjStO0BnyCqqoRPDfykh9kMpkWTIY3Tm+hfcIFZX12MPXawTzpgi3vHSSTycfX
-        xDtYHP7fItSZikdXz0HoXi8aAzYPRGMKO+dEeLkg4Ggz1JmSpT12WNi7BOnlDSIvCZjbCbJJKNdqOcgL
-        0jq8nAmE2qzfSSrG8TzUgUgU7gsJqge38sW/BOJxOUs7U+LhVQH0o4l2JJGxNV9BYS7+FKDvOZFi3hQI
-        IPGmA92mBF/hBI2t5DkmQjegjwIBfJl16ExcOw4RIYBXV8cpxqBuqVRK0o86vxukq7rHdZo5zRj0I2HH
-        qHXTnxcZXjmDlKrJuIaZ04yBxHocXbS5RbYKiXQuHkHiPanhNF2cZgxFUWrIxH1fGCr6HUyEfudb6fkT
-        pxzhNGOgJ+Uosu29eoLaIScTWT4UmbGYM3GaMZBYgiJLohSDaWeAGfrvW9EDRcaxc6z4bQjCFyc+2ILy
-        tHXhAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHASURBVDhPjVJNSwJhEN4ygiIKgi7VqfoBUfYfomsfEAVB
+        dYiuWmQfdOjQKbwUeMjMpI9ThoeISCkPYnax0EJSSkFcwxZRVw8W08zbq60kWw8M++7OM8/MPO8KSgBA
+        Uz6fN2AEkslkEeMDzw8YS7Isd+ATcrlcGM+dvOQHhUKhB5OhvatH6F+wQ92YGTSjZtAu2sHqeoJMJvOa
+        SKVBZ/H8FqHOVDy7cwPC8G7VmDA6ISpK7FwS4eWCgKMtU2dK1o6YYf34DiLxdwjHU7B66GOTUK5Xd1oW
+        pHV4ORMI9Om/k1SM4zmpA5EoHLcRaJ60lot/CYhiskg7U+IlIQH60UU7ksicyV1RWIo/Beh7SaSaNxUC
+        SAwOoNuU4CtcorGNPMdE6AaUUSGALysWhYmmiwARvHh1bZyiDuqWzWYjylHXjnx0Vc+4TjenqYN+JOwY
+        1e97yiLT29eQzclvuIaW09SBxHYc3W90+NkqJDK4cQ6pdEbGaYY4TR2SJLWQiSfuEDSMW5gI/c7BcOwT
+        p5zhNHWgJ/UocuC6j0HrlI2JbJ35mbGY03CaOpBYgyKb/ogIBpuXGfrvW1ECReaxs1j9NgThC/0O2HOk
+        ZCupAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="toolStripBtnPen.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3083,6 +3083,9 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString resources = @"Resources";
 
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Events = @"Events";
+
             public static LocalizedString revision = @"Revision: {00}";
 
             public static LocalizedString run = @"Run Client";


### PR DESCRIPTION
resolves #236
resolves #344 

This PR accomplishes two little things that might help out our more avid Event users:

- The event command list will attempt to remember where the user last added/removed a command and tries to select the item again to scroll back to it. (Especially helpful in LOOOOOOOOONG event command lists)
- The map editor has received an option to render Event previews in the map editor screen, rather than only the square E symbol on the event tab. The Event graphics are always rendered, unless the option under View is not ticked.

![image](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/731c4809d3976375665bd72367a6135c.png)
