### PR TITLE
Setting focus to appropriate window elements, allow for return submits

### DIFF
--- a/Intersect.Client/Interface/Game/InputBox.cs
+++ b/Intersect.Client/Interface/Game/InputBox.cs
@@ -89,6 +89,7 @@ namespace Intersect.Client.Interface.Game
 
             mNumericTextboxBg = new ImagePanel(mMyWindow, "Textbox");
             mNumericTextbox = new TextBoxNumeric(mNumericTextboxBg, "TextboxText");
+            mNumericTextbox.SubmitPressed += TextBox_SubmitPressed;
             if (inputtype == InputType.NumericInput)
             {
                 mNumericTextbox.Focus();
@@ -96,6 +97,7 @@ namespace Intersect.Client.Interface.Game
 
             mTextboxBg = new ImagePanel(mMyWindow, "Textbox");
             mTextbox = new TextBox(mTextboxBg, "TextboxText");
+            mTextbox.SubmitPressed += TextBox_SubmitPressed;
             if (inputtype == InputType.TextInput)
             {
                 mTextbox.Focus();
@@ -124,6 +126,11 @@ namespace Intersect.Client.Interface.Game
             mOkayButton.Clicked += okayBtn_Clicked;
 
             mPromptLabel = new Label(mMyWindow, "PromptLabel");
+        }
+
+        private void TextBox_SubmitPressed(Base sender, EventArgs arguments)
+        {
+            SubmitInput();
         }
 
         private void _myWindow_BeforeDraw(Base sender, EventArgs arguments)
@@ -216,6 +223,11 @@ namespace Intersect.Client.Interface.Game
         }
 
         void okayBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            SubmitInput();
+        }
+
+        private void SubmitInput()
         {
             if (mNumericTextbox != null)
             {

--- a/Intersect.Client/Interface/Menu/LoginWindow.cs
+++ b/Intersect.Client/Interface/Menu/LoginWindow.cs
@@ -111,7 +111,6 @@ namespace Intersect.Client.Interface.Menu
 
             mLoginWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
 
-            //Hide Forgot Password Button if not supported by server
         }
 
         public bool IsHidden => mLoginWindow.IsHidden;
@@ -152,6 +151,16 @@ namespace Intersect.Client.Interface.Menu
             if (!mForgotPassswordButton.IsHidden)
             {
                 mForgotPassswordButton.IsHidden = !Options.Instance.SmtpValid;
+            }
+
+            // Set focus to the appropriate elements.
+            if (!string.IsNullOrWhiteSpace(mUsernameTextbox.Text))
+            {
+                mPasswordTextbox.Focus();
+            }
+            else
+            {
+                mUsernameTextbox.Focus();
             }
         }
 

--- a/Intersect.Client/Interface/Menu/RegisterWindow.cs
+++ b/Intersect.Client/Interface/Menu/RegisterWindow.cs
@@ -141,6 +141,7 @@ namespace Intersect.Client.Interface.Menu
         public void Show()
         {
             mRegistrationPanel.Show();
+            mUsernameTextbox.Focus();
         }
 
         public void Hide()


### PR DESCRIPTION
resolves #357 

Haven't figured out a way to do the same for Event dialogs with a single choice, either Gwen doesn't let me submit buttons with return or it's not retaining focus.

Still, this sets the focus on a few forms properly so we can submit with enter and tab through things.