### PR TITLE
Revert "Add option for map animations to be considered blocks"

### DIFF
--- a/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
@@ -181,13 +181,10 @@ namespace Intersect.GameObjects.Maps
 
         public Guid AnimationId { get; set; }
 
-        public bool IsBlock { get; set; }
-
         public override MapAttribute Clone()
         {
             var att = (MapAnimationAttribute) base.Clone();
             att.AnimationId = AnimationId;
-            att.IsBlock = IsBlock;
 
             return att;
         }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1669,8 +1669,7 @@ namespace Intersect.Client.Entities
                 {
                     if (gameMap.Attributes[tmpX, tmpY] != null)
                     {
-                        if (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Blocked || 
-                            (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Animation && ((MapAnimationAttribute)gameMap.Attributes[tmpX, tmpY]).IsBlock))
+                        if (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Blocked)
                         {
                             return -2;
                         }

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
@@ -120,7 +120,6 @@ namespace Intersect.Editor.Forms.DockingElements
             this.lightEditor = new Intersect.Editor.Forms.Controls.LightEditorCtrl();
             this.pnlAttributes = new System.Windows.Forms.Panel();
             this.pnlNpcs = new System.Windows.Forms.Panel();
-            this.chkAnimationBlock = new DarkUI.Controls.DarkCheckBox();
             this.grpResource.SuspendLayout();
             this.grpZResource.SuspendLayout();
             this.grpItem.SuspendLayout();
@@ -876,13 +875,12 @@ namespace Intersect.Editor.Forms.DockingElements
             // 
             this.grpAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpAnimation.Controls.Add(this.chkAnimationBlock);
             this.grpAnimation.Controls.Add(this.cmbAnimationAttribute);
             this.grpAnimation.Controls.Add(this.lblAnimation);
             this.grpAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpAnimation.Location = new System.Drawing.Point(6, 179);
             this.grpAnimation.Name = "grpAnimation";
-            this.grpAnimation.Size = new System.Drawing.Size(256, 96);
+            this.grpAnimation.Size = new System.Drawing.Size(256, 69);
             this.grpAnimation.TabIndex = 33;
             this.grpAnimation.TabStop = false;
             this.grpAnimation.Text = "Animaton";
@@ -1306,15 +1304,6 @@ namespace Intersect.Editor.Forms.DockingElements
             this.pnlNpcs.Size = new System.Drawing.Size(276, 422);
             this.pnlNpcs.TabIndex = 1;
             // 
-            // chkAnimationBlock
-            // 
-            this.chkAnimationBlock.AutoSize = true;
-            this.chkAnimationBlock.Location = new System.Drawing.Point(16, 66);
-            this.chkAnimationBlock.Name = "chkAnimationBlock";
-            this.chkAnimationBlock.Size = new System.Drawing.Size(73, 17);
-            this.chkAnimationBlock.TabIndex = 27;
-            this.chkAnimationBlock.Text = "Block Tile";
-            // 
             // FrmMapLayers
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1474,6 +1463,5 @@ namespace Intersect.Editor.Forms.DockingElements
         private DarkNumericUpDown nudWarpX;
         private DarkNumericUpDown nudItemQuantity;
         private DarkNumericUpDown nudSoundDistance;
-        private DarkCheckBox chkAnimationBlock;
     }
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -621,7 +621,6 @@ namespace Intersect.Editor.Forms.DockingElements
                 case MapAttributes.Animation:
                     var animationAttribute = attribute as MapAnimationAttribute;
                     animationAttribute.AnimationId = AnimationBase.IdFromList(cmbAnimationAttribute.SelectedIndex);
-                    animationAttribute.IsBlock = chkAnimationBlock.Checked;
                     break;
 
                 case MapAttributes.Slide:
@@ -897,7 +896,6 @@ namespace Intersect.Editor.Forms.DockingElements
             //Map Animation Groupbox
             grpAnimation.Text = Strings.Attributes.mapanimation;
             lblAnimation.Text = Strings.Attributes.mapanimation;
-            chkAnimationBlock.Text = Strings.Attributes.mapanimationblock;
 
             //Slide Groupbox
             grpSlide.Text = Strings.Attributes.slide;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -630,8 +630,6 @@ namespace Intersect.Editor.Localization
 
             public static LocalizedString mapanimation = @"Animation";
 
-            public static LocalizedString mapanimationblock = @"Block Tile";
-
             public static LocalizedString mapsound = @"Map Sound";
 
             public static LocalizedString npcavoid = @"NPC Avoid";

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -328,7 +328,7 @@ namespace Intersect.Server.Entities
                 var tileAttribute = MapInstance.Get(tile.GetMapId()).Attributes[tile.GetX(), tile.GetY()];
                 if (tileAttribute != null)
                 {
-                    if (tileAttribute.Type == MapAttributes.Blocked || (tileAttribute.Type == MapAttributes.Animation && ((MapAnimationAttribute)tileAttribute).IsBlock))
+                    if (tileAttribute.Type == MapAttributes.Blocked)
                     {
                         return -2;
                     }

--- a/Intersect.Server/Entities/Projectile.cs
+++ b/Intersect.Server/Entities/Projectile.cs
@@ -383,7 +383,7 @@ namespace Intersect.Server.Entities
                 }
 
                 if (attribute != null &&
-                    (attribute.Type == MapAttributes.Blocked || attribute.Type == MapAttributes.Animation && ((MapAnimationAttribute)attribute).IsBlock) &&
+                    attribute.Type == MapAttributes.Blocked &&
                     !spawn.ProjectileBase.IgnoreMapBlocks)
                 {
                     killSpawn = true;

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -163,8 +163,7 @@ namespace Intersect.Server.Maps
                     if (Attributes[x, y] != null)
                     {
                         if (Attributes[x, y].Type == MapAttributes.Blocked ||
-                            Attributes[x, y].Type == MapAttributes.GrappleStone ||
-                            Attributes[x,y].Type == MapAttributes.Animation && ((MapAnimationAttribute)Attributes[x,y]).IsBlock) 
+                            Attributes[x, y].Type == MapAttributes.GrappleStone)
                         {
                             blocks.Add(new BytePoint(x, y));
                             npcBlocks.Add(new BytePoint(x, y));
@@ -1108,8 +1107,7 @@ namespace Intersect.Server.Maps
         public bool TileBlocked(int x, int y)
         {
             //Check if tile is a blocked attribute
-            if (Attributes[x, y] != null && (Attributes[x, y].Type == MapAttributes.Blocked ||
-                Attributes[x,y].Type == MapAttributes.Animation && ((MapAnimationAttribute)Attributes[x,y]).IsBlock))
+            if (Attributes[x, y] != null && Attributes[x, y].Type == MapAttributes.Blocked)
             {
                 return true;
             }


### PR DESCRIPTION
Reverts AscensionGameDev/Intersect-Engine#369

We need to revert this modification because it will break games until we do a db migration and save our map attributes using ceras with version tolerance enabled.