### PR TITLE
Fix prerelease Asset Pack tileset loading

### DIFF
--- a/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
@@ -33,11 +33,18 @@ namespace Intersect.Client.MonoGame.File_Management
         public override void LoadTilesets(string[] tilesetnames)
         {
             mTilesetDict.Clear();
-            var tilesetFiles = Directory.GetFiles(Path.Combine("resources", "tilesets")).Select(f => Path.GetFileName(f));
+
+            var dir = Path.Combine("resources", "tilesets");
+            if (!Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            var tilesetFiles = Directory.GetFiles(dir).Select(f => Path.GetFileName(f));
             foreach (var t in tilesetnames)
             {
-                var realFilename = tilesetFiles.FirstOrDefault(file => t.Equals(file, StringComparison.InvariantCultureIgnoreCase));
-                if (t != "" &&
+                var realFilename = tilesetFiles.FirstOrDefault(file => t.Equals(file, StringComparison.InvariantCultureIgnoreCase)) ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(t) &&
                     (!string.IsNullOrWhiteSpace(realFilename) ||
                      GameTexturePacks.GetFrame(Path.Combine("resources", "tilesets", t.ToLower())) != null) &&
                     !mTilesetDict.ContainsKey(t.ToLower()))


### PR DESCRIPTION
resolves #386 

Recent quick and dirty fix in #371 broke tileset loading for asset packs.
- The directory was always assumed to exist, even when it does not (which is not the case for other assets)
- When using asset packs, the realFileName was null, crashing Path.Combine()