### PR TITLE
Add options to draw Player and NPC levels by their names

### DIFF
--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -29,6 +29,11 @@
         /// </summary>
         public bool ResetVitalsAndStatusses = false;
 
+        /// <summary>
+        /// Configures whether or not the level of an Npc is shown next to their name.
+        /// </summary>
+        public bool ShowLevelByName = false;
+
     }
 
 }

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -54,6 +54,11 @@
         /// </summary>
         public bool AllowCombatMovement = true;
 
+        /// <summary>
+        /// Configures whether or not the level of a player is shown next to their name.
+        /// </summary>
+        public bool ShowLevelByName = false;
+
     }
 
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -12,6 +12,7 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.General;
 using Intersect.Client.Items;
+using Intersect.Client.Localization;
 using Intersect.Client.Maps;
 using Intersect.Client.Spells;
 using Intersect.Enums;
@@ -1354,7 +1355,13 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            var textSize = Graphics.Renderer.MeasureText(Name, Graphics.EntityNameFont, 1);
+            var name = Name;
+            if ((this is Player && Options.Player.ShowLevelByName) || Options.Npc.ShowLevelByName)
+            {
+                name = Strings.GameWindow.EntityNameAndLevel.ToString(Name, Level);
+            }
+
+            var textSize = Graphics.Renderer.MeasureText(name, Graphics.EntityNameFont, 1);
 
             var x = (int) Math.Ceiling(GetCenterPos().X);
             var y = GetLabelLocation(LabelType.Name);
@@ -1368,7 +1375,7 @@ namespace Intersect.Client.Entities
             }
 
             Graphics.Renderer.DrawString(
-                Name, Graphics.EntityNameFont, (int) (x - (int) Math.Ceiling(textSize.X / 2f)), (int) y, 1,
+                name, Graphics.EntityNameFont, (int) (x - (int) Math.Ceiling(textSize.X / 2f)), (int) y, 1,
                 Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
             );
         }

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1539,6 +1539,12 @@ namespace Intersect.Client.Localization
 
         }
 
+        public struct GameWindow
+        {
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString EntityNameAndLevel = @"{00} [Lv. {01}]";
+        }
+
     }
 
 }


### PR DESCRIPTION
resolves #382 

Adds to simple options to the server config and a localization option to the client strings to render names next to Player and Npc names. Can be configured to do either or.

![Image](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/00ba224b45ba53716781d111c14df075.png)