### PR TITLE
Allow announcements to show a pop-up on the client-side.

### DIFF
--- a/Intersect (Core)/Config/ChatOptions.cs
+++ b/Intersect (Core)/Config/ChatOptions.cs
@@ -9,6 +9,16 @@
 
         public int MinIntervalBetweenChats = 400; //400 ms
 
+        /// <summary>
+        /// Is the client allowed to show in-game banners for announcements made?
+        /// </summary>
+        public bool ShowAnnouncementBanners = true;
+
+        /// <summary>
+        /// The time (in milliseconds) the announcement banners should display, if enabled.
+        /// </summary>
+        public int AnnouncementDisplayDuration = 15000;
+
     }
 
 }

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -153,6 +153,8 @@ namespace Intersect
 
         public static PartyOptions Party => Instance.PartyOpts;
 
+        public static ChatOptions Chat => Instance.ChatOpts;
+
         public static bool UPnP => Instance._upnp;
 
         public static bool OpenPortChecker => Instance._portChecker;

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -363,6 +363,7 @@
     <Compile Include="Network\Packets\Client\HotbarUpdatePacket.cs" />
     <Compile Include="Network\Packets\Client\LoginPacket.cs" />
     <Compile Include="Network\Packets\Client\LogoutPacket.cs" />
+    <Compile Include="Network\Packets\Server\AnnouncementPacket.cs" />
     <Compile Include="Network\Packets\SlotQuantityPacket.cs" />
     <Compile Include="Network\Packets\Client\SwapBankItemsPacket.cs" />
     <Compile Include="Network\Packets\Client\MovePacket.cs" />

--- a/Intersect (Core)/Network/Packets/Server/AnnouncementPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/AnnouncementPacket.cs
@@ -1,0 +1,31 @@
+﻿namespace Intersect.Network.Packets.Server
+{
+    /// <summary>
+    /// Defines the layout for an AnnouncementPacket.
+    /// </summary>
+    public class AnnouncementPacket : CerasPacket
+    {
+
+        /// <summary>
+        /// The announcement message to send.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// The time (in milliseconds) for the announcement to display.
+        /// </summary>
+        public long Duration { get; set; }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="AnnouncementPacket"/> class.
+        /// </summary>
+        /// <param name="message">The message to send to the client.</param>
+        /// <param name="duration">The duration for this message to appear for on the client.</param>
+        public AnnouncementPacket(string message, long duration)
+        {
+            Message = message;
+            Duration = duration;
+        }
+
+    }
+}

--- a/Intersect.Client/Interface/Game/AnnouncementWindow.cs
+++ b/Intersect.Client/Interface/Game/AnnouncementWindow.cs
@@ -1,0 +1,96 @@
+﻿using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen.Control;
+
+using Intersect.Utilities;
+
+namespace Intersect.Client.Interface.Game
+{
+    /// <summary>
+    /// The GUI class for the Announcement Window that can pop up on-screen during gameplay.
+    /// </summary>
+    public class AnnouncementWindow
+    {
+
+        //Controls
+        private Canvas mGameCanvas;
+
+        private ImagePanel mPicture;
+
+        private Label mLabel;
+
+        private string mLabelText;
+
+        private long mDisplayUntil = 0;
+
+        /// <summary>
+        /// Indicates whether the control is hidden.
+        /// </summary>
+        public bool IsHidden
+        {
+            get { return mPicture.IsHidden; }
+            set { mPicture.IsHidden = value; }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="AnnouncementWindow"/> class.
+        /// </summary>
+        /// <param name="gameCanvas">The <see cref="Canvas"/> to render this control on.</param>
+        public AnnouncementWindow(Canvas gameCanvas)
+        {
+           mGameCanvas = gameCanvas;
+           mPicture = new ImagePanel(gameCanvas, "AnnouncementWindow");
+           mLabel = new Label(mPicture, "AnnouncementLabel");
+        
+           mPicture.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        }
+
+        /// <summary>
+        /// Update this control..
+        /// </summary>
+        public void Update()
+        {
+            // Only update when we're visible to the user.
+            if (!mPicture.IsHidden)
+            {
+                mLabel.Text = mLabelText;
+
+                // Are we still supposed to be visible?
+                if (Timing.Global.Milliseconds > mDisplayUntil)
+                {
+                    Hide();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Display an announcement.
+        /// </summary>
+        /// <param name="announcementText">The text to display.</param>
+        /// <param name="displayTime">The time for which to display the announcement.</param>
+        public void ShowAnnouncement(string announcementText, long displayTime)
+        {
+            mLabelText = announcementText;
+            mDisplayUntil = Timing.Global.Milliseconds + displayTime;
+            Show();
+        }
+
+        /// <summary>
+        /// Hides the control.
+        /// </summary>
+        public void Hide()
+        {
+            mPicture.Hide();
+        }
+
+        /// <summary>
+        /// Shows the control.
+        /// </summary>
+        public void Show()
+        {
+            mPicture.Show();
+        }
+
+    }
+
+}

--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -84,6 +84,7 @@ namespace Intersect.Client.Interface.Game
         {
             GameCanvas = canvas;
             EscapeMenu = new EscapeMenu(GameCanvas) {IsHidden = true};
+            AnnouncementWindow = new AnnouncementWindow(GameCanvas) { IsHidden = true };
 
             InitGameGui();
         }
@@ -93,6 +94,9 @@ namespace Intersect.Client.Interface.Game
 
         [NotNull]
         public EscapeMenu EscapeMenu { get; }
+
+        [NotNull]
+        public AnnouncementWindow AnnouncementWindow { get; }
 
         public Menu GameMenu { get; private set; }
 
@@ -316,6 +320,7 @@ namespace Intersect.Client.Interface.Game
             EscapeMenu.Update();
             PlayerBox?.Update();
             mMapItemWindow.Update();
+            AnnouncementWindow?.Update();
 
             if (Globals.QuestOffers.Count > 0)
             {

--- a/Intersect.Client/Intersect.Client.csproj
+++ b/Intersect.Client/Intersect.Client.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Entities\Status.cs" />
     <Compile Include="General\Time.cs" />
     <Compile Include="General\Globals.cs" />
+    <Compile Include="Interface\Game\AnnouncementWindow.cs" />
     <Compile Include="Interface\Game\MapItem\MapItemIcon.cs" />
     <Compile Include="Interface\Game\MapItem\MapItemWindow.cs" />
     <Compile Include="Interface\MutableInterface.cs" />
@@ -326,13 +327,11 @@
     <!-- Based on https://github.com/dotnet/msbuild/issues/3064#issuecomment-418540984 -->
     <ItemGroup>
       <_ResourcesWithCultureFilename Include="@(EmbeddedResource)" Condition="$([System.String]::Copy('%(Filename)').Contains('.so'))" />
-      
       <_MixedResourceWithNoCulture Include="@(_ResourcesWithCultureFilename)">
         <WithCulture>false</WithCulture>
         <!-- Turns Resources\libopenal.so.1 to Intersect.Client.Resources.libopenal.so.1 -->
         <LogicalName>$(RootNamespace).$([System.String]::Copy('%(Link)').Replace('\', '/').Replace('/', '.'))</LogicalName>
       </_MixedResourceWithNoCulture>
-
       <EmbeddedResource Remove="@(_ResourcesWithCultureFilename)" />
     </ItemGroup>
   </Target>

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -386,6 +386,12 @@ namespace Intersect.Client.Networking
             );
         }
 
+        //AnnouncementPacket
+        private static void HandlePacket(AnnouncementPacket packet)
+        {
+            Interface.Interface.GameUi.AnnouncementWindow.ShowAnnouncement(packet.Message, packet.Duration);   
+        }
+
         //ActionMsgPacket
         private static void HandlePacket(ActionMsgPacket packet)
         {

--- a/Intersect.Server/Core/Commands/AnnouncementCommand.cs
+++ b/Intersect.Server/Core/Commands/AnnouncementCommand.cs
@@ -24,6 +24,11 @@ namespace Intersect.Server.Core.Commands
         protected override void HandleValue(ServerContext context, ParserResult result)
         {
             PacketSender.SendGlobalMsg(result.Find(Message));
+
+            if (Options.Chat.ShowAnnouncementBanners)
+            {
+                PacketSender.SendGameAnnouncement(result.Find(Message), Options.Chat.AnnouncementDisplayDuration);
+            }
         }
 
     }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -813,6 +813,13 @@ namespace Intersect.Server.Networking
                         Strings.Chat.announcement.ToString(player.Name, msg), CustomColors.Chat.AnnouncementChat,
                         player.Name
                     );
+
+                    // Show an announcement banner if configured to do so as well!
+                    if (Options.Chat.ShowAnnouncementBanners)
+                    {
+                        // TODO: Make the duration configurable through chat?
+                        PacketSender.SendGameAnnouncement(msg, Options.Chat.AnnouncementDisplayDuration);
+                    }
                 }
             }
             else if (cmd == Strings.Chat.pmcmd || cmd == Strings.Chat.messagecmd)

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -1559,6 +1559,16 @@ namespace Intersect.Server.Networking
             SendDataToProximity(en.MapId, new EntityDashPacket(en.Id, endMapId, endX, endY, dashTime, direction));
         }
 
+        /// <summary>
+        /// Send a game announcement to all players.
+        /// </summary>
+        /// <param name="message">The message to send as an announcement.</param>
+        /// <param name="duration">The duration (in milliseconds) for the message to display.</param>
+        public static void SendGameAnnouncement(string message, long duration)
+        {
+             SendDataToAllPlayers(new AnnouncementPacket(message, duration));
+        }
+
         //ActionMsgPacket
         public static void SendActionMsg(Entity en, string message, Color color)
         {


### PR DESCRIPTION
Ran into notifications disappearing into chat spam on a game, so decided to write up a quick little solution.. The option to display an announcement pop-up in game!

Can be disabled in the server config. 
Timing for it is configurable there as well.

Works with the in-game announcement command as well as the server console one.

![Image1](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/5b38c350c0ab534ac1a8c44bd2ce7423.png)

Additional resources: [Download](https://www.ascensiongamedev.com/resources/filehost/6824b9e000bf9d84a59db8a3089733b8.zip)