### PR TITLE
Thank you Jon Skeet

### DIFF
--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -331,8 +331,13 @@
     <Compile Include="Network\ConnectionPacket.cs" />
     <Compile Include="Network\ConnectionStatistics.cs" />
     <Compile Include="Network\Events\ConnectionEventArgs.cs" />
+    <Compile Include="Network\IPacketHandler.cs" />
+    <Compile Include="Network\IPacketSender.cs" />
     <Compile Include="Network\NetworkStatus.cs" />
     <Compile Include="Network\PacketDispatcher.cs" />
+    <Compile Include="Network\PacketHandlerAttribute.cs" />
+    <Compile Include="Network\PacketHandlerRegistry.cs" />
+    <Compile Include="Network\PacketHandlerRegistry.DisposableHandler.cs" />
     <Compile Include="Network\Packets\AbstractTimedPacket.cs" />
     <Compile Include="Network\Packets\Client\AbandonQuestPacket.cs" />
     <Compile Include="Network\Packets\Client\ActivateEventPacket.cs" />
@@ -620,7 +625,7 @@
     <Compile Include="Network\AbstractConnection.cs" />
     <Compile Include="Network\AbstractNetwork.cs" />
     <Compile Include="Network\DnsUtils.cs" />
-    <Compile Include="Network\HandlePacket.cs" />
+    <Compile Include="Network\Delegates.cs" />
     <Compile Include="Network\IClient.cs" />
     <Compile Include="Network\IConnection.cs" />
     <Compile Include="Network\INetwork.cs" />

--- a/Intersect (Core)/Network/Delegates.cs
+++ b/Intersect (Core)/Network/Delegates.cs
@@ -1,0 +1,14 @@
+﻿namespace Intersect.Network
+{
+    public delegate bool HandlePacket<TPacketSender, TPacket>(TPacketSender packetSender, TPacket packet)
+        where TPacketSender : IPacketSender where TPacket : IPacket;
+
+    public delegate void HandlePacketVoid<TPacketSender, TPacket>(TPacketSender packetSender, TPacket packet)
+        where TPacketSender : IPacketSender where TPacket : IPacket;
+
+    public delegate bool HandlePacketGeneric(IPacketSender packetSender, IPacket packet);
+
+    public delegate bool HandlePacket(IConnection connection, IPacket packet);
+
+    public delegate bool ShouldProcessPacket(IConnection connection, long pSize);
+}

--- a/Intersect (Core)/Network/HandlePacket.cs
+++ b/Intersect (Core)/Network/HandlePacket.cs
@@ -1,8 +1,0 @@
-﻿namespace Intersect.Network
-{
-
-    public delegate bool HandlePacket(IConnection connection, IPacket packet);
-
-    public delegate bool ShouldProcessPacket(IConnection connection, long pSize);
-
-}

--- a/Intersect (Core)/Network/IPacketHandler.cs
+++ b/Intersect (Core)/Network/IPacketHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace Intersect.Network
+{
+    public interface IPacketHandler
+    {
+        bool Handle(IPacketSender packetSender, IPacket packet);
+    }
+
+    public interface IPacketHandler<TPacket> : IPacketHandler where TPacket : IPacket
+    {
+        bool Handle(IPacketSender packetSender, TPacket packet);
+    }
+}

--- a/Intersect (Core)/Network/IPacketSender.cs
+++ b/Intersect (Core)/Network/IPacketSender.cs
@@ -1,0 +1,7 @@
+﻿namespace Intersect.Network
+{
+    public interface IPacketSender
+    {
+        bool Send(IPacket packet);
+    }
+}

--- a/Intersect (Core)/Network/PacketHandlerAttribute.cs
+++ b/Intersect (Core)/Network/PacketHandlerAttribute.cs
@@ -1,0 +1,203 @@
+﻿using Intersect.Reflection;
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Intersect.Network
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate | AttributeTargets.Struct,
+        AllowMultiple = false
+    )]
+    public class PacketHandlerAttribute : Attribute
+    {
+        internal static Type TypeIPacketHandlerInterface_1 = typeof(IPacketHandler<>);
+
+        internal static Type TypeIPacket = typeof(IPacket);
+
+        internal static Type TypeIPacketSender = typeof(IPacketSender);
+
+        public Type PacketType { get; }
+
+        public PacketHandlerAttribute(Type packetType)
+        {
+            if (packetType == default)
+            {
+                throw new ArgumentNullException(nameof(packetType));
+            }
+
+            if (!typeof(IPacket).IsAssignableFrom(packetType))
+            {
+                throw new ArgumentException(
+                    $"{packetType.FullName} does not implement {typeof(IPacket).FullName}.", nameof(packetType)
+                );
+            }
+
+            PacketType = packetType;
+        }
+
+        public static Type GetPacketType(MethodInfo methodInfo)
+        {
+            if (default == methodInfo)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            var parameterTypes = methodInfo.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+            if (parameterTypes.Length != 2)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(methodInfo), $"Invalid packet handler '{methodInfo.GetFullSignature()}'."
+                );
+            }
+
+            var packetSenderType = parameterTypes[0];
+            if (!TypeIPacketSender.IsAssignableFrom(packetSenderType))
+            {
+                throw new ArgumentException(
+                    $"Invalid sender parameter type ({packetSenderType.FullName}) in handler '{methodInfo.GetFullSignature()}'.",
+                    nameof(methodInfo)
+                );
+            }
+
+            var packetTypeFromMethod = parameterTypes[1];
+            if (packetTypeFromMethod.IsInterface ||
+                packetTypeFromMethod.IsAbstract ||
+                packetTypeFromMethod.IsGenericType ||
+                !TypeIPacket.IsAssignableFrom(packetTypeFromMethod))
+            {
+                throw new ArgumentException(
+                    $"Invalid packet parameter type ({packetTypeFromMethod.FullName}) in handler '{methodInfo.GetFullSignature()}'.",
+                    nameof(methodInfo)
+                );
+            }
+
+            var packetHandlerAttribute =
+                GetCustomAttribute(methodInfo, typeof(PacketHandlerAttribute)) as PacketHandlerAttribute;
+
+            var packetTypeFromAttribute = packetHandlerAttribute?.PacketType;
+            var expectedPacketType = packetTypeFromAttribute ?? packetTypeFromMethod;
+
+            if (packetTypeFromMethod != expectedPacketType)
+            {
+                throw new ArgumentException(
+                    $"{methodInfo.Name} is a packet handler for {packetTypeFromMethod.FullName} but is marked with an attribute for {packetTypeFromAttribute.FullName}.",
+                    nameof(methodInfo)
+                );
+            }
+
+            return expectedPacketType;
+        }
+
+        public static Type GetHandlerInterface(Type implementationType)
+        {
+            if (implementationType == null)
+            {
+                throw new ArgumentNullException(nameof(implementationType));
+            }
+
+            return implementationType.GetInterfaces()
+                .FirstOrDefault(
+                    interfaceType => interfaceType.IsGenericType &&
+                                     interfaceType.GetGenericTypeDefinition() == TypeIPacketHandlerInterface_1
+                );
+        }
+
+        public static Type GetPacketType(Type packetHandlerType)
+        {
+            if (packetHandlerType == default)
+            {
+                throw new ArgumentNullException(nameof(packetHandlerType));
+            }
+
+            var interfaceType = GetHandlerInterface(packetHandlerType);
+            if (interfaceType == null)
+            {
+                throw new ArgumentException(
+                    $"{packetHandlerType.FullName} does not implement {TypeIPacketHandlerInterface_1.FullName}.",
+                    nameof(packetHandlerType)
+                );
+            }
+
+            var packetTypeFromType = interfaceType.GenericTypeArguments.FirstOrDefault();
+            if (packetTypeFromType.IsInterface ||
+                packetTypeFromType.IsAbstract ||
+                packetTypeFromType.IsGenericType ||
+                !TypeIPacket.IsAssignableFrom(packetTypeFromType))
+            {
+                throw new ArgumentException(
+                    $"Invalid packet generic type ({packetTypeFromType.FullName}) in handler declaration '{packetHandlerType.FullName}'.",
+                    nameof(packetHandlerType)
+                );
+            }
+
+            var packetHandlerAttribute =
+                GetCustomAttribute(packetHandlerType, typeof(PacketHandlerAttribute)) as PacketHandlerAttribute;
+
+            var packetTypeFromAttribute = packetHandlerAttribute?.PacketType;
+            var expectedPacketType = packetTypeFromAttribute ?? packetTypeFromType;
+
+            if (packetTypeFromType != expectedPacketType)
+            {
+                throw new ArgumentException(
+                    $"{packetHandlerType.FullName} is a packet handler for {packetTypeFromType.FullName} but is marked with an attribute for {packetTypeFromAttribute.FullName}.",
+                    nameof(packetHandlerType)
+                );
+            }
+
+            return expectedPacketType;
+        }
+
+        public static bool IsValidHandler(MethodInfo methodInfo)
+        {
+            if (methodInfo == default)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            try
+            {
+                return GetPacketType(methodInfo) != default;
+            }
+            catch (ArgumentNullException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return false;
+            }
+        }
+
+        public static bool IsValidHandler(Type type)
+        {
+            if (type == default)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (type.IsInterface || type.IsAbstract || type.IsGenericType)
+            {
+                return false;
+            }
+
+            try
+            {
+                return GetPacketType(type) != default;
+            }
+            catch (ArgumentNullException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Intersect (Core)/Network/PacketHandlerRegistry.DisposableHandler.cs
+++ b/Intersect (Core)/Network/PacketHandlerRegistry.DisposableHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Intersect.Network
+{
+    public partial class PacketHandlerRegistry
+    {
+        #region DisposableHandler
+
+        private struct DisposableHandler : IDisposable
+        {
+            public Type PacketType { get; }
+
+            public IDisposable Reference { get; }
+
+            public DisposableHandler(Type packetType, IDisposable reference)
+            {
+                PacketType = packetType ?? throw new ArgumentNullException(nameof(packetType));
+                Reference = reference ?? throw new ArgumentNullException(nameof(reference));
+            }
+
+            public void Dispose()
+            {
+                Reference.Dispose();
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Intersect (Core)/Network/PacketHandlerRegistry.cs
+++ b/Intersect (Core)/Network/PacketHandlerRegistry.cs
@@ -1,0 +1,362 @@
+﻿using Intersect.Logging;
+using Intersect.Reflection;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Intersect.Network
+{
+    public partial class PacketHandlerRegistry : IDisposable
+    {
+        private static Type HandlePacketDelegateType { get; } = typeof(HandlePacket<,>);
+
+        private static Type HandlePacketVoidDelegateType { get; } = typeof(HandlePacketVoid<,>);
+
+        private MethodInfo CreateWeaklyTypedDelegateForMethodInfoInfo { get; }
+
+        private MethodInfo CreateHandlerDelegateForTypeInfo { get; }
+
+        private Dictionary<Type, HandlePacketGeneric> Handlers { get; }
+
+        private Stack<DisposableHandler> DisposableHandlers { get; }
+
+        public Logger Logger { get; }
+
+        public PacketHandlerRegistry(Logger logger)
+        {
+            if (default == logger)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            Logger = logger;
+
+            CreateWeaklyTypedDelegateForMethodInfoInfo = GetType()
+                .GetMethod(
+                    nameof(CreateWeaklyTypedDelegateForMethodInfo), BindingFlags.Instance | BindingFlags.NonPublic
+                );
+
+            if (default == CreateWeaklyTypedDelegateForMethodInfoInfo)
+            {
+                throw new NullReferenceException(
+                    $"Failed to reflect {nameof(CreateWeaklyTypedDelegateForMethodInfo)}."
+                );
+            }
+
+            CreateHandlerDelegateForTypeInfo = GetType()
+                .GetMethod(nameof(CreateHandlerDelegateForType), BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (default == CreateHandlerDelegateForTypeInfo)
+            {
+                throw new NullReferenceException($"Failed to reflect {nameof(CreateHandlerDelegateForType)}.");
+            }
+
+            Handlers = new Dictionary<Type, HandlePacketGeneric>();
+            DisposableHandlers = new Stack<DisposableHandler>();
+        }
+
+        public int Count => Handlers.Count;
+
+        public bool IsEmpty => Count < 1;
+
+        protected virtual HandlePacketGeneric CreateWeaklyTypedDelegateForMethodInfo<TPacketSender, TPacket>(
+            MethodInfo methodInfo,
+            object target = null
+        ) where TPacketSender : IPacketSender where TPacket : IPacket
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            if (typeof(bool) == methodInfo.ReturnType)
+            {
+                var stronglyTyped =
+                    Delegate.CreateDelegate(typeof(HandlePacket<TPacketSender, TPacket>), target, methodInfo) as
+                        HandlePacket<TPacketSender, TPacket>;
+
+                return (IPacketSender packetSender, IPacket packet) => stronglyTyped(
+                    (TPacketSender) packetSender, (TPacket) packet
+                );
+            }
+
+            if (typeof(void) == methodInfo.ReturnType)
+            {
+                var stronglyTyped = Delegate.CreateDelegate(
+                    typeof(HandlePacketVoid<TPacketSender, TPacket>), target, methodInfo
+                ) as HandlePacketVoid<TPacketSender, TPacket>;
+
+                return (IPacketSender packetSender, IPacket packet) =>
+                {
+                    stronglyTyped((TPacketSender) packetSender, (TPacket) packet);
+
+                    return true;
+                };
+            }
+
+            throw new ArgumentException($"Unsupported packet handler return type '{methodInfo.ReturnType.FullName}'.");
+        }
+
+        protected virtual HandlePacketGeneric CreateHandlerDelegateForInstance<TPacket>(
+            IPacketHandler packetHandlerGeneric
+        ) where TPacket : IPacket
+        {
+            var stronglyTypedPacketHandler = packetHandlerGeneric as IPacketHandler<TPacket>;
+
+            return (IPacketSender packetSender, IPacket packet) =>
+                stronglyTypedPacketHandler.Handle(packetSender, (TPacket) packet);
+        }
+
+        protected virtual HandlePacketGeneric CreateHandlerDelegateForType<TPacket>(Type handlerType)
+            where TPacket : IPacket
+        {
+            var packetHandler = Activator.CreateInstance(handlerType) as IPacketHandler;
+
+            if (packetHandler is IDisposable disposable)
+            {
+                DisposableHandlers.Push(new DisposableHandler(typeof(TPacket), disposable));
+            }
+
+            return CreateHandlerDelegateForInstance<TPacket>(packetHandler);
+        }
+
+        protected virtual HandlePacketGeneric CreateInstance(
+            Type packetSenderType,
+            Type packetType,
+            MethodInfo methodInfo,
+            object target = null
+        )
+        {
+            var typedDelegateFactory =
+                CreateWeaklyTypedDelegateForMethodInfoInfo.MakeGenericMethod(packetSenderType, packetType);
+
+            var weakDelegate =
+                typedDelegateFactory.Invoke(this, new object[] {methodInfo, target}) as HandlePacketGeneric;
+
+            return weakDelegate;
+        }
+
+        protected virtual HandlePacketGeneric CreateInstance(Type packetType, Type type)
+        {
+            var typedDelegateFactory = CreateHandlerDelegateForTypeInfo.MakeGenericMethod(packetType);
+            var weakDelegate = typedDelegateFactory.Invoke(this, new object[] {type}) as HandlePacketGeneric;
+
+            return weakDelegate;
+        }
+
+        public bool HasHandler<TPacket>() where TPacket : IPacket => HasHandler(typeof(TPacket));
+
+        public bool HasHandler(Type packetType) => Handlers.ContainsKey(packetType);
+
+        public bool TryGetHandler(IPacket packet, out HandlePacketGeneric handlerInstance) =>
+            Handlers.TryGetValue(packet?.GetType(), out handlerInstance);
+
+        protected static Type GetPacketSenderType(MethodInfo methodInfo)
+        {
+            if (default == methodInfo)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            var parameterTypes = methodInfo.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+            if (parameterTypes.Length != 2)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(methodInfo), $"Invalid packet handler '{methodInfo.GetFullSignature()}'."
+                );
+            }
+
+            var packetSenderType = parameterTypes[0];
+            if (!PacketHandlerAttribute.TypeIPacketSender.IsAssignableFrom(packetSenderType))
+            {
+                throw new ArgumentException(
+                    $"Invalid sender parameter type ({packetSenderType.FullName}) in handler '{methodInfo.GetFullSignature()}'.",
+                    nameof(methodInfo)
+                );
+            }
+
+            return packetSenderType;
+        }
+
+        protected virtual bool TryRegister(IEnumerable<MethodInfo> methodInfos, object target = null)
+        {
+            if (default == methodInfos)
+            {
+                throw new ArgumentNullException(nameof(methodInfos));
+            }
+
+            foreach (var methodInfo in methodInfos)
+            {
+                try
+                {
+                    var packetType = PacketHandlerAttribute.GetPacketType(methodInfo);
+                    if (HasHandler(packetType))
+                    {
+                        Logger.Error($"There is already a packet handler for {packetType.FullName}.");
+
+                        return false;
+                    }
+
+                    var instance = CreateInstance(GetPacketSenderType(methodInfo), packetType, methodInfo, target);
+                    Handlers.Add(packetType, instance);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                    Logger.Error(exception);
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        protected virtual bool TryRegister(IEnumerable<Type> types)
+        {
+            if (default == types)
+            {
+                throw new ArgumentNullException(nameof(types));
+            }
+
+            foreach (var type in types)
+            {
+                var packetType = PacketHandlerAttribute.GetPacketType(type);
+                if (HasHandler(packetType))
+                {
+                    Logger.Error($"There is already a packet handler for {packetType.FullName}.");
+
+                    return false;
+                }
+
+                var instance = CreateInstance(packetType, type);
+                Handlers.Add(packetType, instance);
+            }
+
+            return true;
+        }
+
+        // TODO: Expose this
+        bool TryRegisterAvailableHandlers(Assembly assembly, bool requireAttribute = true) =>
+            TryRegisterAvailableMethodHandlers(assembly, requireAttribute) &&
+            TryRegisterAvailableTypeHandlers(assembly, requireAttribute);
+
+        // TODO: Expose this
+        bool TryRegisterAvailableMethodHandlers(Assembly assembly, bool requireAttribute = true) =>
+            TryRegister(DiscoverMethods(assembly, requireAttribute));
+
+        public bool TryRegisterAvailableMethodHandlers(Type type, object target = null, bool requireAttribute = true) =>
+            TryRegister(
+                DiscoverMethods(type, target == null ? BindingFlags.Static : BindingFlags.Instance, requireAttribute),
+                target
+            );
+
+        // TODO: Expose this
+        bool TryRegisterAvailableTypeHandlers(Assembly assembly, bool requireAttribute = true) =>
+            TryRegister(DiscoverTypes(assembly, requireAttribute));
+
+        /// <summary>
+        /// Discovers all <see langword="static"/> methods in a given assembly that are valid packet handlers, by default requiring a <see cref="PacketHandlerAttribute"/>.
+        /// 
+        /// Note: Changing <paramref name="requireAttribute"/> to <see langword="false"/> is very computationally expensive.
+        /// </summary>
+        /// <param name="assembly">the <see cref="Assembly"/> to scan</param>
+        /// <param name="requireAttribute">if <see cref="PacketHandlerAttribute"/> needs to be specified (default <see langword="true"/>, <see langword="false"/> is slow)</param>
+        /// <returns>an <see cref="IEnumerable{T}"/> of valid <see cref="MethodInfo"/>s</returns>
+        public static IEnumerable<MethodInfo> DiscoverMethods(Assembly assembly, bool requireAttribute = true)
+        {
+            if (default == assembly)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            var assemblyTypes = assembly.GetTypes();
+            var methodInfos = assemblyTypes.SelectMany(
+                assemblyType => DiscoverMethods(assemblyType, BindingFlags.Static, requireAttribute)
+            );
+
+            return methodInfos;
+        }
+
+        /// <summary>
+        /// Discovers all <see langword="static"/> methods in a given type that are valid packet handlers, by default requiring a <see cref="PacketHandlerAttribute"/>.
+        /// 
+        /// Note: Changing <paramref name="requireAttribute"/> to <see langword="false"/> is very computationally expensive.
+        /// </summary>
+        /// <param name="type">the <see cref="Type"/> to scan</param>
+        /// <param name="extraBindingFlags">extra <see cref="BindingFlags"/> (besides <see cref="BindingFlags.Public"/>) to filter the methods by</param>
+        /// <param name="requireAttribute">if <see cref="PacketHandlerAttribute"/> needs to be specified (default <see langword="true"/>, <see langword="false"/> is slow)</param>
+        /// <returns>an <see cref="IEnumerable{T}"/> of valid <see cref="MethodInfo"/>s</returns>
+        public static IEnumerable<MethodInfo> DiscoverMethods(
+            Type type,
+            BindingFlags extraBindingFlags,
+            bool requireAttribute = true
+        )
+        {
+            if (default == type)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            var methodInfos = type.GetMethods(BindingFlags.Public | extraBindingFlags)
+                .Where(
+                    methodInfo =>
+                        (!requireAttribute || Attribute.IsDefined(methodInfo, typeof(PacketHandlerAttribute))) &&
+                        PacketHandlerAttribute.IsValidHandler(methodInfo)
+                );
+
+            return methodInfos;
+        }
+
+        /// <summary>
+        /// Discovers all <see cref="Type"/>s in a given assembly that are valid packet handlers, by default requiring a <see cref="PacketHandlerAttribute"/>.
+        ///
+        /// Note: Changing <paramref name="requireAttribute"/> to <see langword="false"/> is very computationally expensive.
+        /// </summary>
+        /// <param name="assembly">the <see cref="Assembly"/> to scan</param>
+        /// <param name="requireAttribute">if <see cref="PacketHandlerAttribute"/> needs to be specified (default <see langword="true"/>, <see langword="false"/> is slow)</param>
+        /// <returns>an <see cref="IEnumerable{T}"/> of valid <see cref="Type"/>s</returns>
+        public static IEnumerable<Type> DiscoverTypes(Assembly assembly, bool requireAttribute = true)
+        {
+            if (default == assembly)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            var assemblyTypes = assembly.GetTypes();
+            var packetHandlerTypes = assemblyTypes.Where(
+                type => (!requireAttribute || Attribute.IsDefined(type, typeof(PacketHandlerAttribute))) &&
+                        PacketHandlerAttribute.IsValidHandler(type)
+            );
+
+            return packetHandlerTypes;
+        }
+
+        #region IDisposable
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                while (DisposableHandlers.Count > 0)
+                {
+                    var disposableHandler = DisposableHandlers.Pop();
+                    Handlers.Remove(disposableHandler.PacketType);
+                    disposableHandler.Dispose();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/Intersect (Core)/Reflection/MemberInfoExtensions.cs
+++ b/Intersect (Core)/Reflection/MemberInfoExtensions.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 using JetBrains.Annotations;
 
 namespace Intersect.Reflection
 {
-
     public static class MemberInfoExtensions
     {
-
         public static string GetFullName([NotNull] this MemberInfo memberInfo)
         {
             if (memberInfo is Type type)
@@ -21,6 +21,20 @@ namespace Intersect.Reflection
             return declaringType == null ? memberInfo.Name : $@"{declaringType.FullName}.{memberInfo.Name}";
         }
 
-    }
+        public static string GetSignature(this MethodInfo methodInfo, bool fullyQualified = false)
+        {
+            Debug.Assert(methodInfo != null);
 
+            var returnTypeName = fullyQualified ? methodInfo.ReturnType.FullName : methodInfo.ReturnType.Name;
+            var declaringTypeName = fullyQualified ? methodInfo.DeclaringType.FullName : methodInfo.DeclaringType.Name;
+            var parameterTypes = methodInfo.GetParameters().Select(parameter => parameter.ParameterType);
+            var parameterTypeNames = parameterTypes.Select(
+                parameterType => fullyQualified ? parameterType.FullName : parameterType.Name
+            );
+
+            return $"{returnTypeName} {declaringTypeName}.{methodInfo.Name}({string.Join(", ", parameterTypeNames)})";
+        }
+
+        public static string GetFullSignature(this MethodInfo methodInfo) => GetSignature(methodInfo, true);
+    }
 }

--- a/Intersect.Client/Networking/Network.cs
+++ b/Intersect.Client/Networking/Network.cs
@@ -20,7 +20,9 @@ namespace Intersect.Client.Networking
 
         private static bool sConnected;
 
-        public static GameSocket Socket;
+        public static GameSocket Socket { get; set; }
+
+        public static PacketHandler PacketHandler { get; }
 
         private static int sPing;
 
@@ -30,6 +32,11 @@ namespace Intersect.Client.Networking
         {
             get => Socket?.Ping ?? sPing;
             set => sPing = value;
+        }
+
+        static Network()
+        {
+            PacketHandler = new PacketHandler(Log.Default);
         }
 
         public static void InitNetwork()

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -26,30 +26,76 @@ using Intersect.Utilities;
 namespace Intersect.Client.Networking
 {
 
-    public static class PacketHandler
+    public class PacketHandler
     {
+        private sealed class VirtualPacketSender : IPacketSender
+        {
+            #region Implementation of IPacketSender
 
-        public static long Ping = 0;
+            /// <inheritdoc />
+            public bool Send(IPacket packet)
+            {
+                if (packet is CerasPacket cerasPacket)
+                {
+                    Network.SendPacket(cerasPacket);
+                    return true;
+                }
 
-        public static long PingTime;
+                return false;
+            }
 
-        public static bool HandlePacket(IPacket packet)
+            #endregion
+        }
+
+        public long Ping { get; set; } = 0;
+
+        public long PingTime { get; set; }
+
+        public Logger Logger { get; }
+
+        public PacketHandlerRegistry Registry { get; }
+
+        public IPacketSender VirtualSender { get; }
+
+        public PacketHandler(Logger logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            Registry = new PacketHandlerRegistry(logger);
+            if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
+            {
+                throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
+            }
+
+            VirtualSender = new VirtualPacketSender();
+        }
+
+        public bool HandlePacket(IPacket packet)
         {
             if (packet is AbstractTimedPacket timedPacket)
             {
                 Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
             }
 
-            if (packet is CerasPacket)
+            if (!(packet is CerasPacket))
             {
-                HandlePacket((dynamic)packet);
+                return false;
             }
+
+            if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+            {
+                Logger.Error($"No registered handler for {packet.GetType().FullName}!");
+
+                return false;
+            }
+
+            handler(VirtualSender, packet);
 
             return true;
         }
 
         //PingPacket
-        private static void HandlePacket(PingPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PingPacket packet)
         {
             if (packet.RequestingReply)
             {
@@ -63,7 +109,7 @@ namespace Intersect.Client.Networking
         }
 
         //ConfigPacket
-        private static void HandlePacket(ConfigPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ConfigPacket packet)
         {
             Options.LoadFromServer(packet.Config);
             Globals.Bank = new Item[Options.MaxBankSlots];
@@ -71,23 +117,23 @@ namespace Intersect.Client.Networking
         }
 
         //JoinGamePacket
-        private static void HandlePacket(JoinGamePacket packet)
+        public void HandlePacket(IPacketSender packetSender, JoinGamePacket packet)
         {
             Main.JoinGame();
             Globals.JoiningGame = true;
         }
 
         //MapAreaPacket
-        private static void HandlePacket(MapAreaPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapAreaPacket packet)
         {
             foreach (var map in packet.Maps)
             {
-                HandleMap(map);
+                HandleMap(packetSender, map);
             }
         }
 
         //MapPacket
-        private static void HandleMap(MapPacket packet)
+        private void HandleMap(IPacketSender packetSender, MapPacket packet)
         {
             var mapId = packet.MapId;
             var map = MapInstance.Get(mapId);
@@ -124,12 +170,12 @@ namespace Intersect.Client.Networking
                 //Process Entities and Items if provided in this packet
                 if (packet.MapEntities != null)
                 {
-                    HandlePacket((dynamic) packet.MapEntities);
+                    HandlePacket(packet.MapEntities);
                 }
 
                 if (packet.MapItems != null)
                 {
-                    HandlePacket((dynamic) packet.MapItems);
+                    HandlePacket(packet.MapItems);
                 }
 
                 if (Globals.PendingEvents.ContainsKey(mapId))
@@ -150,14 +196,14 @@ namespace Intersect.Client.Networking
         }
 
         //MapPacket
-        private static void HandlePacket(MapPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapPacket packet)
         {
-            HandleMap(packet);
+            HandleMap(packetSender, packet);
             Globals.Me.FetchNewMaps();
         }
 
         //PlayerEntityPacket
-        private static void HandlePacket(PlayerEntityPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PlayerEntityPacket packet)
         {
             var en = Globals.GetEntity(packet.EntityId, EntityTypes.Player);
             if (en != null)
@@ -179,7 +225,7 @@ namespace Intersect.Client.Networking
         }
 
         //NpcEntityPacket
-        private static void HandlePacket(NpcEntityPacket packet)
+        public void HandlePacket(IPacketSender packetSender, NpcEntityPacket packet)
         {
             var en = Globals.GetEntity(packet.EntityId, EntityTypes.GlobalEntity);
             if (en != null)
@@ -195,7 +241,7 @@ namespace Intersect.Client.Networking
         }
 
         //ResourceEntityPacket
-        private static void HandlePacket(ResourceEntityPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
         {
             var en = Globals.GetEntity(packet.EntityId, EntityTypes.Resource);
             if (en != null)
@@ -209,7 +255,7 @@ namespace Intersect.Client.Networking
         }
 
         //ProjectileEntityPacket
-        private static void HandlePacket(ProjectileEntityPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ProjectileEntityPacket packet)
         {
             var en = Globals.GetEntity(packet.EntityId, EntityTypes.Projectile);
             if (en != null)
@@ -223,7 +269,7 @@ namespace Intersect.Client.Networking
         }
 
         //EventEntityPacket
-        private static void HandlePacket(EventEntityPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EventEntityPacket packet)
         {
             var map = MapInstance.Get(packet.MapId);
             if (map != null)
@@ -253,12 +299,12 @@ namespace Intersect.Client.Networking
         }
 
         //MapEntitiesPacket
-        private static void HandlePacket(MapEntitiesPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapEntitiesPacket packet)
         {
             var mapEntities = new Dictionary<Guid, List<Guid>>();
             foreach (var pkt in packet.MapEntities)
             {
-                HandlePacket((dynamic) pkt);
+                HandlePacket(pkt);
 
                 if (!mapEntities.ContainsKey(pkt.MapId))
                 {
@@ -285,7 +331,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityPositionPacket
-        private static void HandlePacket(EntityPositionPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityPositionPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -345,7 +391,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityLeftPacket
-        private static void HandlePacket(EntityLeftPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityLeftPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -376,7 +422,7 @@ namespace Intersect.Client.Networking
         }
 
         //ChatMsgPacket
-        private static void HandlePacket(ChatMsgPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ChatMsgPacket packet)
         {
             ChatboxMsg.AddMessage(
                 new ChatboxMsg(
@@ -387,13 +433,13 @@ namespace Intersect.Client.Networking
         }
 
         //AnnouncementPacket
-        private static void HandlePacket(AnnouncementPacket packet)
+        public void HandlePacket(IPacketSender packetSender, AnnouncementPacket packet)
         {
             Interface.Interface.GameUi.AnnouncementWindow.ShowAnnouncement(packet.Message, packet.Duration);   
         }
 
         //ActionMsgPacket
-        private static void HandlePacket(ActionMsgPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ActionMsgPacket packet)
         {
             var map = MapInstance.Get(packet.MapId);
             if (map != null)
@@ -408,11 +454,11 @@ namespace Intersect.Client.Networking
         }
 
         //GameDataPacket
-        private static void HandlePacket(GameDataPacket packet)
+        public void HandlePacket(IPacketSender packetSender, GameDataPacket packet)
         {
             foreach (var pkt in packet.GameObjects)
             {
-                HandlePacket((dynamic) pkt);
+                HandlePacket(pkt);
             }
 
             CustomColors.Load(packet.ColorsJson);
@@ -420,7 +466,7 @@ namespace Intersect.Client.Networking
         }
 
         //MapListPacket
-        private static void HandlePacket(MapListPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapListPacket packet)
         {
             MapList.List.JsonData = packet.MapListData;
             MapList.List.PostLoad(MapBase.Lookup, false, true);
@@ -429,7 +475,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityMovePacket
-        private static void HandlePacket(EntityMovePacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityMovePacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -528,7 +574,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityVitalsPacket
-        private static void HandlePacket(EntityVitalsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityVitalsPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -608,7 +654,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityStatsPacket
-        private static void HandlePacket(EntityStatsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityStatsPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -648,7 +694,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityDirectionPacket
-        private static void HandlePacket(EntityDirectionPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityDirectionPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -688,7 +734,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityAttackPacket
-        private static void HandlePacket(EntityAttackPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityAttackPacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -734,7 +780,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityDiePacket
-        private static void HandlePacket(EntityDiePacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityDiePacket packet)
         {
             var id = packet.Id;
             var type = packet.Type;
@@ -775,7 +821,7 @@ namespace Intersect.Client.Networking
         }
 
         //EventDialogPacket
-        private static void HandlePacket(EventDialogPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EventDialogPacket packet)
         {
             var ed = new Dialog();
             ed.Prompt = packet.Prompt;
@@ -793,7 +839,7 @@ namespace Intersect.Client.Networking
         }
 
         //InputVariablePacket
-        private static void HandlePacket(InputVariablePacket packet)
+        public void HandlePacket(IPacketSender packetSender, InputVariablePacket packet)
         {
             var type = InputBox.InputType.NumericInput;
             switch (packet.Type)
@@ -820,7 +866,7 @@ namespace Intersect.Client.Networking
         }
 
         //ErrorMessagePacket
-        private static void HandlePacket(ErrorMessagePacket packet)
+        public void HandlePacket(IPacketSender packetSender, ErrorMessagePacket packet)
         {
             Fade.FadeIn();
             Globals.WaitingOnServer = false;
@@ -829,7 +875,7 @@ namespace Intersect.Client.Networking
         }
 
         //MapItemsPacket
-        private static void HandlePacket(MapItemsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapItemsPacket packet)
         {
             var map = MapInstance.Get(packet.MapId);
             if (map == null)
@@ -849,7 +895,7 @@ namespace Intersect.Client.Networking
         }
 
         //MapItemUpdatePacket
-        private static void HandlePacket(MapItemUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapItemUpdatePacket packet)
         {
             var map = MapInstance.Get(packet.MapId);
             if (map == null)
@@ -899,16 +945,16 @@ namespace Intersect.Client.Networking
         }
 
         //InventoryPacket
-        private static void HandlePacket(InventoryPacket packet)
+        public void HandlePacket(IPacketSender packetSender, InventoryPacket packet)
         {
             foreach (var inv in packet.Slots)
             {
-                HandlePacket((dynamic) inv);
+                HandlePacket(inv);
             }
         }
 
         //InventoryUpdatePacket
-        private static void HandlePacket(InventoryUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, InventoryUpdatePacket packet)
         {
             if (Globals.Me != null)
             {
@@ -921,16 +967,16 @@ namespace Intersect.Client.Networking
         }
 
         //SpellsPacket
-        private static void HandlePacket(SpellsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, SpellsPacket packet)
         {
             foreach (var spl in packet.Slots)
             {
-                HandlePacket((dynamic) spl);
+                HandlePacket(spl);
             }
         }
 
         //SpellUpdatePacket
-        private static void HandlePacket(SpellUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, SpellUpdatePacket packet)
         {
             if (Globals.Me != null)
             {
@@ -939,7 +985,7 @@ namespace Intersect.Client.Networking
         }
 
         //EquipmentPacket
-        private static void HandlePacket(EquipmentPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EquipmentPacket packet)
         {
             var entityId = packet.EntityId;
             if (Globals.Entities.ContainsKey(entityId))
@@ -960,7 +1006,7 @@ namespace Intersect.Client.Networking
         }
 
         //StatPointsPacket
-        private static void HandlePacket(StatPointsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, StatPointsPacket packet)
         {
             if (Globals.Me != null)
             {
@@ -969,7 +1015,7 @@ namespace Intersect.Client.Networking
         }
 
         //HotbarPacket
-        private static void HandlePacket(HotbarPacket packet)
+        public void HandlePacket(IPacketSender packetSender, HotbarPacket packet)
         {
             for (var i = 0; i < Options.MaxHotbar; i++)
             {
@@ -993,20 +1039,20 @@ namespace Intersect.Client.Networking
         }
 
         //CharacterCreationPacket
-        private static void HandlePacket(CharacterCreationPacket packet)
+        public void HandlePacket(IPacketSender packetSender, CharacterCreationPacket packet)
         {
             Globals.WaitingOnServer = false;
             Interface.Interface.MenuUi.MainMenu.NotifyOpenCharacterCreation();
         }
 
         //AdminPanelPacket
-        private static void HandlePacket(AdminPanelPacket packet)
+        public void HandlePacket(IPacketSender packetSender, AdminPanelPacket packet)
         {
             Interface.Interface.GameUi.NotifyOpenAdminWindow();
         }
 
         //SpellCastPacket
-        private static void HandlePacket(SpellCastPacket packet)
+        public void HandlePacket(IPacketSender packetSender, SpellCastPacket packet)
         {
             var entityId = packet.EntityId;
             var spellId = packet.SpellId;
@@ -1018,7 +1064,7 @@ namespace Intersect.Client.Networking
         }
 
         //SpellCooldownPacket
-        private static void HandlePacket(SpellCooldownPacket packet)
+        public void HandlePacket(IPacketSender packetSender, SpellCooldownPacket packet)
         {
             foreach (var cd in packet.SpellCds)
             {
@@ -1035,7 +1081,7 @@ namespace Intersect.Client.Networking
         }
 
         //ItemCooldownPacket
-        private static void HandlePacket(ItemCooldownPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ItemCooldownPacket packet)
         {
             foreach (var cd in packet.ItemCds)
             {
@@ -1052,7 +1098,7 @@ namespace Intersect.Client.Networking
         }
 
         //ExperiencePacket
-        private static void HandlePacket(ExperiencePacket packet)
+        public void HandlePacket(IPacketSender packetSender, ExperiencePacket packet)
         {
             if (Globals.Me != null)
             {
@@ -1062,7 +1108,7 @@ namespace Intersect.Client.Networking
         }
 
         //ProjectileDeadPacket
-        private static void HandlePacket(ProjectileDeadPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ProjectileDeadPacket packet)
         {
             var entityId = packet.ProjectileId;
             if (Globals.Entities.ContainsKey(entityId) && Globals.Entities[entityId].GetType() == typeof(Projectile))
@@ -1072,7 +1118,7 @@ namespace Intersect.Client.Networking
         }
 
         //PlayAnimationPacket
-        private static void HandlePacket(PlayAnimationPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PlayAnimationPacket packet)
         {
             var mapId = packet.MapId;
             var animId = packet.AnimationId;
@@ -1140,7 +1186,7 @@ namespace Intersect.Client.Networking
         }
 
         //HoldPlayerPacket
-        private static void HandlePacket(HoldPlayerPacket packet)
+        public void HandlePacket(IPacketSender packetSender, HoldPlayerPacket packet)
         {
             var eventId = packet.EventId;
             var mapId = packet.MapId;
@@ -1161,31 +1207,31 @@ namespace Intersect.Client.Networking
         }
 
         //PlayMusicPacket
-        private static void HandlePacket(PlayMusicPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PlayMusicPacket packet)
         {
             Audio.PlayMusic(packet.BGM, 1f, 1f, true);
         }
 
         //StopMusicPacket
-        private static void HandlePacket(StopMusicPacket packet)
+        public void HandlePacket(IPacketSender packetSender, StopMusicPacket packet)
         {
             Audio.StopMusic(3f);
         }
 
         //PlaySoundPacket
-        private static void HandlePacket(PlaySoundPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PlaySoundPacket packet)
         {
             Audio.AddGameSound(packet.Sound, false);
         }
 
         //StopSoundsPacket
-        private static void HandlePacket(StopSoundsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, StopSoundsPacket packet)
         {
             Audio.StopAllSounds();
         }
 
         //ShowPicturePacket
-        private static void HandlePacket(ShowPicturePacket packet)
+        public void HandlePacket(IPacketSender packetSender, ShowPicturePacket packet)
         {
             Globals.Picture = packet.Picture;
             Globals.PictureSize = packet.Size;
@@ -1193,13 +1239,13 @@ namespace Intersect.Client.Networking
         }
 
         //HidePicturePacket
-        private static void HandlePacket(HidePicturePacket packet)
+        public void HandlePacket(IPacketSender packetSender, HidePicturePacket packet)
         {
             Globals.Picture = null;
         }
 
         //ShopPacket
-        private static void HandlePacket(ShopPacket packet)
+        public void HandlePacket(IPacketSender packetSender, ShopPacket packet)
         {
             if (Interface.Interface.GameUi == null)
             {
@@ -1225,7 +1271,7 @@ namespace Intersect.Client.Networking
         }
 
         //CraftingTablePacket
-        private static void HandlePacket(CraftingTablePacket packet)
+        public void HandlePacket(IPacketSender packetSender, CraftingTablePacket packet)
         {
             if (!packet.Close)
             {
@@ -1240,7 +1286,7 @@ namespace Intersect.Client.Networking
         }
 
         //BankPacket
-        private static void HandlePacket(BankPacket packet)
+        public void HandlePacket(IPacketSender packetSender, BankPacket packet)
         {
             if (!packet.Close)
             {
@@ -1253,7 +1299,7 @@ namespace Intersect.Client.Networking
         }
 
         //BankUpdatePacket
-        private static void HandlePacket(BankUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, BankUpdatePacket packet)
         {
             var slot = packet.Slot;
             if (packet.ItemId != Guid.Empty)
@@ -1268,7 +1314,7 @@ namespace Intersect.Client.Networking
         }
 
         //GameObjectPacket
-        private static void HandlePacket(GameObjectPacket packet)
+        public void HandlePacket(IPacketSender packetSender, GameObjectPacket packet)
         {
             var type = packet.Type;
             var id = packet.Id;
@@ -1316,7 +1362,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityDashPacket
-        private static void HandlePacket(EntityDashPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityDashPacket packet)
         {
             if (Globals.Entities.ContainsKey(packet.EntityId))
             {
@@ -1331,7 +1377,7 @@ namespace Intersect.Client.Networking
         }
 
         //MapGridPacket
-        private static void HandlePacket(MapGridPacket packet)
+        public void HandlePacket(IPacketSender packetSender, MapGridPacket packet)
         {
             Globals.MapGridWidth = packet.Grid.GetLength(0);
             Globals.MapGridHeight = packet.Grid.GetLength(1);
@@ -1376,7 +1422,7 @@ namespace Intersect.Client.Networking
         }
 
         //TimePacket
-        private static void HandlePacket(TimePacket packet)
+        public void HandlePacket(IPacketSender packetSender, TimePacket packet)
         {
             Time.LoadTime(
                 packet.Time, Color.FromArgb(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Rate
@@ -1384,7 +1430,7 @@ namespace Intersect.Client.Networking
         }
 
         //PartyPacket
-        private static void HandlePacket(PartyPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PartyPacket packet)
         {
             if (Globals.Me == null || Globals.Me.Party == null)
             {
@@ -1400,7 +1446,7 @@ namespace Intersect.Client.Networking
         }
 
         //PartyUpdatePacket
-        private static void HandlePacket(PartyUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, PartyUpdatePacket packet)
         {
             var index = packet.MemberIndex;
             if (index < Globals.Me.Party.Count)
@@ -1411,7 +1457,7 @@ namespace Intersect.Client.Networking
         }
 
         //PartyInvitePacket
-        private static void HandlePacket(PartyInvitePacket packet)
+        public void HandlePacket(IPacketSender packetSender, PartyInvitePacket packet)
         {
             var iBox = new InputBox(
                 Strings.Parties.partyinvite, Strings.Parties.inviteprompt.ToString(packet.LeaderName), true,
@@ -1420,7 +1466,7 @@ namespace Intersect.Client.Networking
         }
 
         //ChatBubblePacket
-        private static void HandlePacket(ChatBubblePacket packet)
+        public void HandlePacket(IPacketSender packetSender, ChatBubblePacket packet)
         {
             var id = packet.EntityId;
             var type = packet.Type;
@@ -1460,7 +1506,7 @@ namespace Intersect.Client.Networking
         }
 
         //QuestOfferPacket
-        private static void HandlePacket(QuestOfferPacket packet)
+        public void HandlePacket(IPacketSender packetSender, QuestOfferPacket packet)
         {
             if (!Globals.QuestOffers.Contains(packet.QuestId))
             {
@@ -1469,7 +1515,7 @@ namespace Intersect.Client.Networking
         }
 
         //QuestProgressPacket
-        private static void HandlePacket(QuestProgressPacket packet)
+        public void HandlePacket(IPacketSender packetSender, QuestProgressPacket packet)
         {
             if (Globals.Me != null)
             {
@@ -1503,7 +1549,7 @@ namespace Intersect.Client.Networking
         }
 
         //TradePacket
-        private static void HandlePacket(TradePacket packet)
+        public void HandlePacket(IPacketSender packetSender, TradePacket packet)
         {
             if (!string.IsNullOrEmpty(packet.TradePartner))
             {
@@ -1527,7 +1573,7 @@ namespace Intersect.Client.Networking
         }
 
         //TradeUpdatePacket
-        private static void HandlePacket(TradeUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, TradeUpdatePacket packet)
         {
             var side = 0;
 
@@ -1549,7 +1595,7 @@ namespace Intersect.Client.Networking
         }
 
         //TradeRequestPacket
-        private static void HandlePacket(TradeRequestPacket packet)
+        public void HandlePacket(IPacketSender packetSender, TradeRequestPacket packet)
         {
             var iBox = new InputBox(
                 Strings.Trading.traderequest, Strings.Trading.requestprompt.ToString(packet.PartnerName), true,
@@ -1559,7 +1605,7 @@ namespace Intersect.Client.Networking
         }
 
         //NpcAggressionPacket
-        private static void HandlePacket(NpcAggressionPacket packet)
+        public void HandlePacket(IPacketSender packetSender, NpcAggressionPacket packet)
         {
             if (Globals.Entities.ContainsKey(packet.EntityId))
             {
@@ -1568,7 +1614,7 @@ namespace Intersect.Client.Networking
         }
 
         //PlayerDeathPacket
-        private static void HandlePacket(PlayerDeathPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PlayerDeathPacket packet)
         {
             if (Globals.Entities.ContainsKey(packet.PlayerId))
             {
@@ -1580,7 +1626,7 @@ namespace Intersect.Client.Networking
         }
 
         //EntityZDimensionPacket
-        private static void HandlePacket(EntityZDimensionPacket packet)
+        public void HandlePacket(IPacketSender packetSender, EntityZDimensionPacket packet)
         {
             if (Globals.Entities.ContainsKey(packet.EntityId))
             {
@@ -1589,7 +1635,7 @@ namespace Intersect.Client.Networking
         }
 
         //BagPacket
-        private static void HandlePacket(BagPacket packet)
+        public void HandlePacket(IPacketSender packetSender, BagPacket packet)
         {
             if (!packet.Close)
             {
@@ -1603,7 +1649,7 @@ namespace Intersect.Client.Networking
         }
 
         //BagUpdatePacket
-        private static void HandlePacket(BagUpdatePacket packet)
+        public void HandlePacket(IPacketSender packetSender, BagUpdatePacket packet)
         {
             if (packet.ItemId == Guid.Empty)
             {
@@ -1617,13 +1663,13 @@ namespace Intersect.Client.Networking
         }
 
         //MoveRoutePacket
-        private static void HandlePacket(MoveRoutePacket packet)
+        public void HandlePacket(IPacketSender packetSender, MoveRoutePacket packet)
         {
             Globals.MoveRouteActive = packet.Active;
         }
 
         //FriendsPacket
-        private static void HandlePacket(FriendsPacket packet)
+        public void HandlePacket(IPacketSender packetSender, FriendsPacket packet)
         {
             Globals.Me.Friends.Clear();
 
@@ -1654,7 +1700,7 @@ namespace Intersect.Client.Networking
         }
 
         //FriendRequestPacket
-        private static void HandlePacket(FriendRequestPacket packet)
+        public void HandlePacket(IPacketSender packetSender, FriendRequestPacket packet)
         {
             var iBox = new InputBox(
                 Strings.Friends.request, Strings.Friends.requestprompt.ToString(packet.FriendName), true,
@@ -1664,7 +1710,7 @@ namespace Intersect.Client.Networking
         }
 
         //CharactersPacket
-        private static void HandlePacket(CharactersPacket packet)
+        public void HandlePacket(IPacketSender packetSender, CharactersPacket packet)
         {
             var characters = new List<Character>();
 
@@ -1685,7 +1731,7 @@ namespace Intersect.Client.Networking
         }
 
         //PasswordResetResultPacket
-        private static void HandlePacket(PasswordResetResultPacket packet)
+        public void HandlePacket(IPacketSender packetSender, PasswordResetResultPacket packet)
         {
             if (packet.Succeeded)
             {
@@ -1708,7 +1754,7 @@ namespace Intersect.Client.Networking
         }
 
         //TargetOverridePacket
-        private static void HandlePacket(TargetOverridePacket packet)
+        public void HandlePacket(IPacketSender packetSender, TargetOverridePacket packet)
         {
             if (Globals.Entities.ContainsKey(packet.TargetId))
             {
@@ -1717,7 +1763,7 @@ namespace Intersect.Client.Networking
         }
 
         //EnteringGamePacket
-        private static void HandlePacket(EnteringGamePacket packet)
+        public void HandlePacket(IPacketSender packetSender, EnteringGamePacket packet)
         {
             //Fade out, we're finally loading the game world!
             Fade.FadeOut();

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -25,7 +25,14 @@ namespace Intersect.Editor.Networking
 
         public static ClientNetwork EditorLidgrenNetwork;
 
+        public static PacketHandler PacketHandler { get; }
+
         public static bool Connected => EditorLidgrenNetwork?.IsConnected ?? false;
+
+        static Network()
+        {
+            PacketHandler = new PacketHandler(Log.Default);
+        }
 
         public static void InitNetwork()
         {

--- a/Intersect.Server/Core/ServerContext.cs
+++ b/Intersect.Server/Core/ServerContext.cs
@@ -194,7 +194,7 @@ namespace Intersect.Server.Core
 
             #region Configure Packet Handlers
 
-            var packetHandler = new PacketHandler();
+            var packetHandler = new PacketHandler(Logger);
             network.Handler = packetHandler.HandlePacket;
             network.PreProcessHandler = packetHandler.PreProcessPacket;
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -203,7 +203,7 @@ namespace Intersect.Server.Entities
 
         public void SendPacket(CerasPacket packet)
         {
-            Client?.SendPacket(packet);
+            Client?.Send(packet);
         }
 
         public override void Dispose()

--- a/Intersect.Server/Networking/Client.cs
+++ b/Intersect.Server/Networking/Client.cs
@@ -13,7 +13,7 @@ using Intersect.Server.General;
 namespace Intersect.Server.Networking
 {
 
-    public class Client
+    public class Client : IPacketSender
     {
 
         public Guid EditorMap = Guid.Empty;
@@ -124,14 +124,6 @@ namespace Intersect.Server.Networking
 
             Entity.LastOnline = DateTime.Now;
             Entity.Client = this;
-        }
-
-        public void SendPacket(CerasPacket packet)
-        {
-            if (mConnection != null)
-            {
-                mConnection.Send(packet);
-            }
         }
 
         public void Pinged()
@@ -251,6 +243,12 @@ namespace Intersect.Server.Networking
             }
         }
 
+        #region Implementation of IPacketSender
+
+        /// <inheritdoc />
+        public bool Send(IPacket packet) => mConnection?.Send(packet) ?? false;
+
+        #endregion
     }
 
 }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-
 using Intersect.Enums;
 using Intersect.ErrorHandling;
 using Intersect.GameObjects;
@@ -32,10 +26,31 @@ using Intersect.Utilities;
 
 using JetBrains.Annotations;
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
 namespace Intersect.Server.Networking
 {
     public class PacketHandler
     {
+        public Logger Logger { get; }
+
+        public PacketHandlerRegistry Registry { get; }
+
+        public PacketHandler(Logger logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            Registry = new PacketHandlerRegistry(logger);
+
+            if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
+            {
+                throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
+            }
+        }
+
         public bool PreProcessPacket(IConnection connection, long pSize)
         {
             var client = Client.FindBeta4Client(connection);
@@ -244,8 +259,11 @@ namespace Intersect.Server.Networking
                 var configurableNaturalUpperMargin = Options.Instance.SecurityOpts.PacketOpts.NaturalUpperMargin;
                 var configurableAllowedSpikePackets = Options.Instance.SecurityOpts.PacketOpts.AllowedSpikePackets;
                 var configurableBaseDesyncForgiveness = Options.Instance.SecurityOpts.PacketOpts.BaseDesyncForegiveness;
-                var configurablePingDesyncForgivenessFactor = Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessFactor;
-                var configurablePacketDesyncForgivenessInternal = Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessInterval;
+                var configurablePingDesyncForgivenessFactor =
+                    Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessFactor;
+
+                var configurablePacketDesyncForgivenessInternal =
+                    Options.Instance.SecurityOpts.PacketOpts.DesyncForgivenessInterval;
 
                 var errorMargin = Math.Max(ping, configurableMininumPing) * configurableErrorMarginFactor;
                 var errorRangeMinimum = ping - errorMargin;
@@ -266,17 +284,19 @@ namespace Intersect.Server.Networking
                 var naturalWithPing = configurableNaturalLowerMargin < deltaWithPing &&
                                       deltaWithPing < configurableNaturalUpperMargin;
 
-
                 var adjustedDesync = Math.Abs(deltaAdjusted);
-                var timeDesync = adjustedDesync > configurableBaseDesyncForgiveness + errorRangeMaximum * configurablePingDesyncForgivenessFactor;
+                var timeDesync = adjustedDesync >
+                                 configurableBaseDesyncForgiveness +
+                                 errorRangeMaximum * configurablePingDesyncForgivenessFactor;
 
                 if (timeDesync && Globals.Timing.MillisecondsUTC > client.LastPacketDesyncForgiven)
                 {
-                    client.LastPacketDesyncForgiven = Globals.Timing.MillisecondsUTC + configurablePacketDesyncForgivenessInternal;
+                    client.LastPacketDesyncForgiven =
+                        Globals.Timing.MillisecondsUTC + configurablePacketDesyncForgivenessInternal;
+
                     PacketSender.SendPing(client, false);
                     timeDesync = false;
                 }
-
 
                 if (Debugger.IsAttached)
                 {
@@ -334,9 +354,13 @@ namespace Intersect.Server.Networking
                 {
                     client.TimedBufferPacketsRemaining = configurableAllowedSpikePackets;
                 }
-                else if (natural && naturalWithPing || naturalWithPing && naturalWithError || naturalWithError && natural)
+                else if (natural && naturalWithPing ||
+                         naturalWithPing && naturalWithError ||
+                         naturalWithError && natural)
                 {
-                    client.TimedBufferPacketsRemaining += (int)Math.Ceiling((configurableAllowedSpikePackets - client.TimedBufferPacketsRemaining) / 2.0);
+                    client.TimedBufferPacketsRemaining += (int) Math.Ceiling(
+                        (configurableAllowedSpikePackets - client.TimedBufferPacketsRemaining) / 2.0
+                    );
                 }
                 else
                 {
@@ -347,7 +371,14 @@ namespace Intersect.Server.Networking
 
             try
             {
-                HandlePacket(client, client.Entity, (dynamic) packet);
+                if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+                {
+                    Logger.Error($"No registered handler for {packet.GetType().FullName}!");
+
+                    return false;
+                }
+
+                handler(client, packet);
             }
             catch (Exception exception)
             {
@@ -385,12 +416,13 @@ namespace Intersect.Server.Networking
             {
                 case MovePacket _:
                     PacketSender.SendEntityPositionTo(client, client.Entity);
+
                     break;
             }
         }
 
         //PingPacket
-        public void HandlePacket(Client client, Player player, PingPacket packet)
+        public void HandlePacket(Client client, PingPacket packet)
         {
             client.Pinged();
             if (!packet.Responding)
@@ -400,7 +432,7 @@ namespace Intersect.Server.Networking
         }
 
         //LoginPacket
-        public void HandlePacket(Client client, Player player, LoginPacket packet)
+        public void HandlePacket(Client client, LoginPacket packet)
         {
             if (client.AccountAttempts > 3 && client.TimeoutMs > Globals.Timing.Milliseconds)
             {
@@ -411,7 +443,6 @@ namespace Intersect.Server.Networking
             }
 
             client.ResetTimeout();
-
 
             // Are we at capacity yet, or can this user still log in?
             if (Globals.OnlineList.Count >= Options.MaxLoggedinUsers)
@@ -540,7 +571,7 @@ namespace Intersect.Server.Networking
         }
 
         //LogoutPacket
-        public void HandlePacket(Client client, Player player, LogoutPacket packet)
+        public void HandlePacket(Client client, LogoutPacket packet)
         {
             if (client != null)
             {
@@ -570,8 +601,9 @@ namespace Intersect.Server.Networking
         }
 
         //NeedMapPacket
-        public void HandlePacket(Client client, Player player, NeedMapPacket packet)
+        public void HandlePacket(Client client, NeedMapPacket packet)
         {
+            var player = client?.Entity;
             var map = MapInstance.Get(packet.MapId);
             if (map != null)
             {
@@ -584,8 +616,9 @@ namespace Intersect.Server.Networking
         }
 
         //MovePacket
-        public void HandlePacket(Client client, Player player, MovePacket packet)
+        public void HandlePacket(Client client, MovePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -612,7 +645,8 @@ namespace Intersect.Server.Networking
             }
 
             var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
-            if (player.ClientMoveTimer <= clientTime && (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
+            if (player.ClientMoveTimer <= clientTime &&
+                (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
             {
                 var canMove = player.CanMove(packet.Dir);
                 if ((canMove == -1 || canMove == -4) && client.Entity.MoveRoute == null)
@@ -623,8 +657,8 @@ namespace Intersect.Server.Networking
                     var currentMs = Globals.Timing.Milliseconds;
                     if (player.MoveTimer > currentMs)
                     {
-                        player.MoveTimer = currentMs + latencyAdjustmentMs + (long)(player.GetMovementTime() * .75f);
-                        player.ClientMoveTimer = clientTime + (long)player.GetMovementTime();
+                        player.MoveTimer = currentMs + latencyAdjustmentMs + (long) (player.GetMovementTime() * .75f);
+                        player.ClientMoveTimer = clientTime + (long) player.GetMovementTime();
                     }
                 }
                 else
@@ -637,6 +671,7 @@ namespace Intersect.Server.Networking
             else
             {
                 PacketSender.SendEntityPositionTo(client, client.Entity);
+
                 return;
             }
 
@@ -647,8 +682,10 @@ namespace Intersect.Server.Networking
         }
 
         //ChatMsgPacket
-        public void HandlePacket(Client client, Player player, ChatMsgPacket packet)
+        public void HandlePacket(Client client, ChatMsgPacket packet)
         {
+            var player = client?.Entity;
+
             if (player == null)
             {
                 return;
@@ -911,8 +948,9 @@ namespace Intersect.Server.Networking
         }
 
         //BlockPacket
-        public void HandlePacket(Client client, Player player, BlockPacket packet)
+        public void HandlePacket(Client client, BlockPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -941,8 +979,9 @@ namespace Intersect.Server.Networking
         }
 
         //BumpPacket
-        public void HandlePacket(Client client, Player player, BumpPacket packet)
+        public void HandlePacket(Client client, BumpPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -952,8 +991,9 @@ namespace Intersect.Server.Networking
         }
 
         //AttackPacket
-        public void HandlePacket(Client client, Player player, AttackPacket packet)
+        public void HandlePacket(Client client, AttackPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -963,7 +1003,8 @@ namespace Intersect.Server.Networking
             var target = packet.Target;
 
             var clientTime = packet.Adjusted / TimeSpan.TicksPerMillisecond;
-            if (player.ClientAttackTimer > clientTime || (!Options.Instance.PlayerOpts.AllowCombatMovement && player.ClientMoveTimer > clientTime))
+            if (player.ClientAttackTimer > clientTime ||
+                (!Options.Instance.PlayerOpts.AllowCombatMovement && player.ClientMoveTimer > clientTime))
             {
                 return;
             }
@@ -1035,7 +1076,7 @@ namespace Intersect.Server.Networking
 
             PacketSender.SendEntityAttack(player, player.CalculateAttackTime());
 
-            player.ClientAttackTimer = clientTime + (long)player.CalculateAttackTime();
+            player.ClientAttackTimer = clientTime + (long) player.CalculateAttackTime();
 
             //Fire projectile instead if weapon has it
             if (Options.WeaponIndex > -1)
@@ -1111,7 +1152,9 @@ namespace Intersect.Server.Networking
                                 (byte) player.Y, (byte) player.Z, (byte) player.Dir, null
                             );
 
-                        player.AttackTimer = Globals.Timing.Milliseconds + latencyAdjustmentMs + player.CalculateAttackTime();
+                        player.AttackTimer = Globals.Timing.Milliseconds +
+                                             latencyAdjustmentMs +
+                                             player.CalculateAttackTime();
 
                         return;
                     }
@@ -1124,7 +1167,6 @@ namespace Intersect.Server.Networking
                             return;
                         }
 #endif
-
                 }
                 else
                 {
@@ -1177,8 +1219,9 @@ namespace Intersect.Server.Networking
         }
 
         //DirectionPacket
-        public void HandlePacket(Client client, Player player, DirectionPacket packet)
+        public void HandlePacket(Client client, DirectionPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1188,13 +1231,14 @@ namespace Intersect.Server.Networking
         }
 
         //EnterGamePacket
-        public void HandlePacket(Client client, Player player, EnterGamePacket packet)
+        public void HandlePacket(Client client, EnterGamePacket packet)
         {
         }
 
         //ActivateEventPacket
-        public void HandlePacket(Client client, Player player, ActivateEventPacket packet)
+        public void HandlePacket(Client client, ActivateEventPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1204,8 +1248,9 @@ namespace Intersect.Server.Networking
         }
 
         //EventResponsePacket
-        public void HandlePacket(Client client, Player player, EventResponsePacket packet)
+        public void HandlePacket(Client client, EventResponsePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1215,7 +1260,7 @@ namespace Intersect.Server.Networking
         }
 
         //EventInputVariablePacket
-        public void HandlePacket(Client client, Player player, EventInputVariablePacket packet)
+        public void HandlePacket(Client client, EventInputVariablePacket packet)
         {
             ((Player) client.Entity).RespondToEventInput(
                 packet.EventId, packet.Value, packet.StringValue, packet.Canceled
@@ -1223,7 +1268,7 @@ namespace Intersect.Server.Networking
         }
 
         //CreateAccountPacket
-        public void HandlePacket(Client client, Player player, CreateAccountPacket packet)
+        public void HandlePacket(Client client, CreateAccountPacket packet)
         {
             if (client.TimeoutMs > Globals.Timing.Milliseconds)
             {
@@ -1320,7 +1365,7 @@ namespace Intersect.Server.Networking
         }
 
         //CreateCharacterPacket
-        public void HandlePacket(Client client, Player player, CreateCharacterPacket packet)
+        public void HandlePacket(Client client, CreateCharacterPacket packet)
         {
             if (client.User == null)
             {
@@ -1346,6 +1391,7 @@ namespace Intersect.Server.Networking
             if (DbInterface.CharacterNameInUse(packet.Name))
             {
                 PacketSender.SendError(client, Strings.Account.characterexists);
+
                 return;
             }
 
@@ -1422,8 +1468,9 @@ namespace Intersect.Server.Networking
         }
 
         //PickupItemPacket
-        public void HandlePacket(Client client, Player player, PickupItemPacket packet)
+        public void HandlePacket(Client client, PickupItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1449,6 +1496,7 @@ namespace Intersect.Server.Networking
             }
 
             var giveItems = new List<MapItem>();
+
             // Are we trying to pick up everything on this location or one specific item?
             if (packet.UniqueId == Guid.Empty)
             {
@@ -1463,7 +1511,7 @@ namespace Intersect.Server.Networking
 
             // Go through each item we're trying to give our player and see if we can do so.
             var toRemove = new List<Guid>();
-            foreach(var mapItem in giveItems)
+            foreach (var mapItem in giveItems)
             {
                 if (mapItem == null)
                 {
@@ -1471,6 +1519,7 @@ namespace Intersect.Server.Networking
                 }
 
                 var canTake = false;
+
                 // Can we actually take this item?
                 if (mapItem.Owner == Guid.Empty || Globals.Timing.Milliseconds > mapItem.OwnershipTime)
                 {
@@ -1505,17 +1554,17 @@ namespace Intersect.Server.Networking
                 }
             }
 
-
             // Remove all items that were picked up.
-            foreach(var id in toRemove)
+            foreach (var id in toRemove)
             {
                 map.RemoveItem(id);
             }
         }
 
         //SwapInvItemsPacket
-        public void HandlePacket(Client client, Player player, SwapInvItemsPacket packet)
+        public void HandlePacket(Client client, SwapInvItemsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1525,8 +1574,9 @@ namespace Intersect.Server.Networking
         }
 
         //DropItemPacket
-        public void HandlePacket(Client client, Player player, DropItemPacket packet)
+        public void HandlePacket(Client client, DropItemPacket packet)
         {
+            var player = client?.Entity;
             if (packet == null)
             {
                 return;
@@ -1536,8 +1586,9 @@ namespace Intersect.Server.Networking
         }
 
         //UseItemPacket
-        public void HandlePacket(Client client, Player player, UseItemPacket packet)
+        public void HandlePacket(Client client, UseItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1564,8 +1615,9 @@ namespace Intersect.Server.Networking
         }
 
         //SwapSpellsPacket
-        public void HandlePacket(Client client, Player player, SwapSpellsPacket packet)
+        public void HandlePacket(Client client, SwapSpellsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1575,8 +1627,9 @@ namespace Intersect.Server.Networking
         }
 
         //ForgetSpellPacket
-        public void HandlePacket(Client client, Player player, ForgetSpellPacket packet)
+        public void HandlePacket(Client client, ForgetSpellPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1586,8 +1639,9 @@ namespace Intersect.Server.Networking
         }
 
         //UseSpellPacket
-        public void HandlePacket(Client client, Player player, UseSpellPacket packet)
+        public void HandlePacket(Client client, UseSpellPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1619,8 +1673,9 @@ namespace Intersect.Server.Networking
         }
 
         //UnequipItemPacket
-        public void HandlePacket(Client client, Player player, UnequipItemPacket packet)
+        public void HandlePacket(Client client, UnequipItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1630,8 +1685,9 @@ namespace Intersect.Server.Networking
         }
 
         //UpgradeStatPacket
-        public void HandlePacket(Client client, Player player, UpgradeStatPacket packet)
+        public void HandlePacket(Client client, UpgradeStatPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1641,8 +1697,9 @@ namespace Intersect.Server.Networking
         }
 
         //HotbarUpdatePacket
-        public void HandlePacket(Client client, Player player, HotbarUpdatePacket packet)
+        public void HandlePacket(Client client, HotbarUpdatePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1652,8 +1709,9 @@ namespace Intersect.Server.Networking
         }
 
         //HotbarSwapPacket
-        public void HandlePacket(Client client, Player player, HotbarSwapPacket packet)
+        public void HandlePacket(Client client, HotbarSwapPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1663,7 +1721,7 @@ namespace Intersect.Server.Networking
         }
 
         //OpenAdminWindowPacket
-        public void HandlePacket(Client client, Player player, OpenAdminWindowPacket packet)
+        public void HandlePacket(Client client, OpenAdminWindowPacket packet)
         {
             if (client.Power.IsModerator)
             {
@@ -1673,8 +1731,9 @@ namespace Intersect.Server.Networking
         }
 
         //AdminActionPacket
-        public void HandlePacket(Client client, Player player, AdminActionPacket packet)
+        public void HandlePacket(Client client, AdminActionPacket packet)
         {
+            var player = client?.Entity;
             if (!client.Power.Editor && !client.Power.IsModerator)
             {
                 return;
@@ -1684,8 +1743,9 @@ namespace Intersect.Server.Networking
         }
 
         //BuyItemPacket
-        public void HandlePacket(Client client, Player player, BuyItemPacket packet)
+        public void HandlePacket(Client client, BuyItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1695,8 +1755,9 @@ namespace Intersect.Server.Networking
         }
 
         //SellItemPacket
-        public void HandlePacket(Client client, Player player, SellItemPacket packet)
+        public void HandlePacket(Client client, SellItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1706,8 +1767,9 @@ namespace Intersect.Server.Networking
         }
 
         //CloseShopPacket
-        public void HandlePacket(Client client, Player player, CloseShopPacket packet)
+        public void HandlePacket(Client client, CloseShopPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1717,8 +1779,9 @@ namespace Intersect.Server.Networking
         }
 
         //CloseCraftingPacket
-        public void HandlePacket(Client client, Player player, CloseCraftingPacket packet)
+        public void HandlePacket(Client client, CloseCraftingPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1728,8 +1791,9 @@ namespace Intersect.Server.Networking
         }
 
         //CraftItemPacket
-        public void HandlePacket(Client client, Player player, CraftItemPacket packet)
+        public void HandlePacket(Client client, CraftItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1740,8 +1804,9 @@ namespace Intersect.Server.Networking
         }
 
         //CloseBankPacket
-        public void HandlePacket(Client client, Player player, CloseBankPacket packet)
+        public void HandlePacket(Client client, CloseBankPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1751,8 +1816,9 @@ namespace Intersect.Server.Networking
         }
 
         //DepositItemPacket
-        public void HandlePacket(Client client, Player player, DepositItemPacket packet)
+        public void HandlePacket(Client client, DepositItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1762,8 +1828,9 @@ namespace Intersect.Server.Networking
         }
 
         //WithdrawItemPacket
-        public void HandlePacket(Client client, Player player, WithdrawItemPacket packet)
+        public void HandlePacket(Client client, WithdrawItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1773,8 +1840,9 @@ namespace Intersect.Server.Networking
         }
 
         //MoveBankItemPacket
-        public void HandlePacket(Client client, Player player, SwapBankItemsPacket packet)
+        public void HandlePacket(Client client, SwapBankItemsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1784,8 +1852,9 @@ namespace Intersect.Server.Networking
         }
 
         //PartyInvitePacket
-        public void HandlePacket(Client client, Player player, PartyInvitePacket packet)
+        public void HandlePacket(Client client, PartyInvitePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1804,8 +1873,9 @@ namespace Intersect.Server.Networking
         }
 
         //PartyInviteResponsePacket
-        public void HandlePacket(Client client, Player player, PartyInviteResponsePacket packet)
+        public void HandlePacket(Client client, PartyInviteResponsePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1846,8 +1916,9 @@ namespace Intersect.Server.Networking
         }
 
         //PartyKickPacket
-        public void HandlePacket(Client client, Player player, PartyKickPacket packet)
+        public void HandlePacket(Client client, PartyKickPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1857,8 +1928,9 @@ namespace Intersect.Server.Networking
         }
 
         //PartyLeavePacket
-        public void HandlePacket(Client client, Player player, PartyLeavePacket packet)
+        public void HandlePacket(Client client, PartyLeavePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1868,8 +1940,9 @@ namespace Intersect.Server.Networking
         }
 
         //QuestResponsePacket
-        public void HandlePacket(Client client, Player player, QuestResponsePacket packet)
+        public void HandlePacket(Client client, QuestResponsePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1886,8 +1959,9 @@ namespace Intersect.Server.Networking
         }
 
         //AbandonQuestPacket
-        public void HandlePacket(Client client, Player player, AbandonQuestPacket packet)
+        public void HandlePacket(Client client, AbandonQuestPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1897,8 +1971,9 @@ namespace Intersect.Server.Networking
         }
 
         //TradeRequestPacket
-        public void HandlePacket(Client client, Player player, TradeRequestPacket packet)
+        public void HandlePacket(Client client, TradeRequestPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1921,8 +1996,9 @@ namespace Intersect.Server.Networking
         }
 
         //TradeRequestResponsePacket
-        public void HandlePacket(Client client, Player player, TradeRequestResponsePacket packet)
+        public void HandlePacket(Client client, TradeRequestResponsePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -1983,8 +2059,9 @@ namespace Intersect.Server.Networking
         }
 
         //OfferTradeItemPacket
-        public void HandlePacket(Client client, Player player, [NotNull] OfferTradeItemPacket packet)
+        public void HandlePacket(Client client, [NotNull] OfferTradeItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null || player.Trading.Counterparty == null)
             {
                 return;
@@ -1994,8 +2071,9 @@ namespace Intersect.Server.Networking
         }
 
         //RevokeTradeItemPacket
-        public void HandlePacket(Client client, Player player, [NotNull] RevokeTradeItemPacket packet)
+        public void HandlePacket(Client client, [NotNull] RevokeTradeItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null || player.Trading.Counterparty == null)
             {
                 return;
@@ -2015,8 +2093,9 @@ namespace Intersect.Server.Networking
         }
 
         //AcceptTradePacket
-        public void HandlePacket(Client client, Player player, AcceptTradePacket packet)
+        public void HandlePacket(Client client, AcceptTradePacket packet)
         {
+            var player = client?.Entity;
             if (player == null || player.Trading.Counterparty == null)
             {
                 return;
@@ -2047,8 +2126,9 @@ namespace Intersect.Server.Networking
         }
 
         //DeclineTradePacket
-        public void HandlePacket(Client client, Player player, DeclineTradePacket packet)
+        public void HandlePacket(Client client, DeclineTradePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2058,8 +2138,9 @@ namespace Intersect.Server.Networking
         }
 
         //CloseBagPacket
-        public void HandlePacket(Client client, Player player, CloseBagPacket packet)
+        public void HandlePacket(Client client, CloseBagPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2069,8 +2150,9 @@ namespace Intersect.Server.Networking
         }
 
         //StoreBagItemPacket
-        public void HandlePacket(Client client, Player player, StoreBagItemPacket packet)
+        public void HandlePacket(Client client, StoreBagItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2080,8 +2162,9 @@ namespace Intersect.Server.Networking
         }
 
         //RetrieveBagItemPacket
-        public void HandlePacket(Client client, Player player, RetrieveBagItemPacket packet)
+        public void HandlePacket(Client client, RetrieveBagItemPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2091,8 +2174,9 @@ namespace Intersect.Server.Networking
         }
 
         //SwapBagItemPacket
-        public void HandlePacket(Client client, Player player, SwapBagItemsPacket packet)
+        public void HandlePacket(Client client, SwapBagItemsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2102,8 +2186,9 @@ namespace Intersect.Server.Networking
         }
 
         //RequestFriendsPacket
-        public void HandlePacket(Client client, Player player, RequestFriendsPacket packet)
+        public void HandlePacket(Client client, RequestFriendsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2113,8 +2198,9 @@ namespace Intersect.Server.Networking
         }
 
         //UpdateFriendsPacket
-        public void HandlePacket(Client client, Player player, UpdateFriendsPacket packet)
+        public void HandlePacket(Client client, UpdateFriendsPacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2174,8 +2260,9 @@ namespace Intersect.Server.Networking
         }
 
         //FriendRequestResponsePacket
-        public void HandlePacket(Client client, Player player, FriendRequestResponsePacket packet)
+        public void HandlePacket(Client client, FriendRequestResponsePacket packet)
         {
+            var player = client?.Entity;
             if (player == null)
             {
                 return;
@@ -2235,7 +2322,7 @@ namespace Intersect.Server.Networking
         }
 
         //SelectCharacterPacket
-        public void HandlePacket(Client client, Player player, SelectCharacterPacket packet)
+        public void HandlePacket(Client client, SelectCharacterPacket packet)
         {
             if (client.User == null)
                 return;
@@ -2275,7 +2362,7 @@ namespace Intersect.Server.Networking
         }
 
         //DeleteCharacterPacket
-        public void HandlePacket(Client client, Player player, DeleteCharacterPacket packet)
+        public void HandlePacket(Client client, DeleteCharacterPacket packet)
         {
             if (client.User == null)
                 return;
@@ -2287,7 +2374,6 @@ namespace Intersect.Server.Networking
                 {
                     if (chr.Id == packet.CharacterId)
                     {
-
                         using (var logging = DbInterface.LoggingContext)
                         {
                             logging.UserActivityHistory.Add(
@@ -2313,7 +2399,7 @@ namespace Intersect.Server.Networking
         }
 
         //NewCharacterPacket
-        public void HandlePacket(Client client, Player player, NewCharacterPacket packet)
+        public void HandlePacket(Client client, NewCharacterPacket packet)
         {
             if (client?.Characters?.Count < Options.MaxCharacters)
             {
@@ -2327,7 +2413,7 @@ namespace Intersect.Server.Networking
         }
 
         //RequestPasswordResetPacket
-        public void HandlePacket(Client client, Player player, RequestPasswordResetPacket packet)
+        public void HandlePacket(Client client, RequestPasswordResetPacket packet)
         {
             if (client.TimeoutMs > Globals.Timing.Milliseconds)
             {
@@ -2365,7 +2451,7 @@ namespace Intersect.Server.Networking
         }
 
         //ResetPasswordPacket
-        public void HandlePacket(Client client, Player player, ResetPasswordPacket packet)
+        public void HandlePacket(Client client, ResetPasswordPacket packet)
         {
             //Find account with that name or email
             var success = false;
@@ -2397,12 +2483,12 @@ namespace Intersect.Server.Networking
         #region "Editor Packets"
 
         //PingPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.PingPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.PingPacket packet)
         {
         }
 
         //LoginPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.LoginPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.LoginPacket packet)
         {
             if (client.AccountAttempts > 3 && client.TimeoutMs > Globals.Timing.Milliseconds)
             {
@@ -2472,7 +2558,7 @@ namespace Intersect.Server.Networking
         }
 
         //MapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.MapUpdatePacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.MapUpdatePacket packet)
         {
             if (!client.IsEditor)
             {
@@ -2553,7 +2639,7 @@ namespace Intersect.Server.Networking
         }
 
         //CreateMapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.CreateMapPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.CreateMapPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -2738,7 +2824,7 @@ namespace Intersect.Server.Networking
         }
 
         //MapListUpdatePacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.MapListUpdatePacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.MapListUpdatePacket packet)
         {
             if (!client.IsEditor)
             {
@@ -2846,7 +2932,7 @@ namespace Intersect.Server.Networking
         }
 
         //UnlinkMapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.UnlinkMapPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.UnlinkMapPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -2910,7 +2996,7 @@ namespace Intersect.Server.Networking
         }
 
         //LinkMapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.LinkMapPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.LinkMapPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3038,7 +3124,7 @@ namespace Intersect.Server.Networking
         }
 
         //CreateGameObjectPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.CreateGameObjectPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.CreateGameObjectPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3058,7 +3144,7 @@ namespace Intersect.Server.Networking
         }
 
         //RequestOpenEditorPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.RequestOpenEditorPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.RequestOpenEditorPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3071,7 +3157,7 @@ namespace Intersect.Server.Networking
         }
 
         //DeleteGameObjectPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.DeleteGameObjectPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.DeleteGameObjectPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3199,7 +3285,7 @@ namespace Intersect.Server.Networking
         }
 
         //SaveGameObjectPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.SaveGameObjectPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.SaveGameObjectPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3354,7 +3440,7 @@ namespace Intersect.Server.Networking
         }
 
         //SaveTimeDataPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.SaveTimeDataPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.SaveTimeDataPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3368,7 +3454,7 @@ namespace Intersect.Server.Networking
         }
 
         //AddTilesetsPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.AddTilesetsPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.AddTilesetsPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3399,7 +3485,7 @@ namespace Intersect.Server.Networking
         }
 
         //RequestGridPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.RequestGridPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.RequestGridPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3416,7 +3502,7 @@ namespace Intersect.Server.Networking
         }
 
         //OpenMapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.EnterMapPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.EnterMapPacket packet)
         {
             if (!client.IsEditor)
             {
@@ -3427,7 +3513,7 @@ namespace Intersect.Server.Networking
         }
 
         //NeedMapPacket
-        public void HandlePacket(Client client, Player player, Network.Packets.Editor.NeedMapPacket packet)
+        public void HandlePacket(Client client, Network.Packets.Editor.NeedMapPacket packet)
         {
             if (!client.IsEditor)
             {

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -40,14 +40,14 @@ namespace Intersect.Server.Networking
         {
             if (client != null)
             {
-                client.SendPacket(new PingPacket(request));
+                client.Send(new PingPacket(request));
             }
         }
 
         //ConfigPacket
         public static void SendServerConfig(Client client)
         {
-            client.SendPacket(new ConfigPacket(Options.OptionsData));
+            client.Send(new ConfigPacket(Options.OptionsData));
         }
 
         //EnteringGamePacket
@@ -81,7 +81,7 @@ namespace Intersect.Server.Networking
             }
 
             client.TimedBufferPacketsRemaining = 5;
-            client.SendPacket(new JoinGamePacket());
+            client.Send(new JoinGamePacket());
             PacketSender.SendGameData(client);
 
             if (!client.IsEditor)
@@ -260,12 +260,12 @@ namespace Intersect.Server.Networking
                 }
                 else
                 {
-                    client.SendPacket(GenerateMapPacket(client, mapId));
+                    client.Send(GenerateMapPacket(client, mapId));
                 }
             }
             else
             {
-                client.SendPacket(GenerateMapPacket(client, mapId));
+                client.Send(GenerateMapPacket(client, mapId));
                 var entity = client.Entity;
                 if (entity != null)
                 {
@@ -463,7 +463,7 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            client.SendPacket(
+            client.Send(
                 new EntityPositionPacket(
                     en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, en.Passable,
                     en.HideName
@@ -565,7 +565,7 @@ namespace Intersect.Server.Networking
             {
                 var sw = new Stopwatch();
                 sw.Start();
-                client.SendPacket(CachedGameDataPacket);
+                client.Send(CachedGameDataPacket);
                 SendGameObject(client, ClassBase.Get(client.Entity.ClassId));
                 Log.Debug("Took " + sw.ElapsedMilliseconds + "ms to send game data to client!");
 
@@ -595,7 +595,7 @@ namespace Intersect.Server.Networking
             }
 
             //Let the client/editor know they have everything now
-            client.SendPacket(new GameDataPacket(gameObjects.ToArray(), CustomColors.Json()));
+            client.Send(new GameDataPacket(gameObjects.ToArray(), CustomColors.Json()));
         }
 
         //GameDataPacket
@@ -753,7 +753,7 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            client.SendPacket(GenerateEntityVitalsPacket(en));
+            client.Send(GenerateEntityVitalsPacket(en));
         }
 
         //EntityStatsPacket
@@ -771,7 +771,7 @@ namespace Intersect.Server.Networking
         //EntityStatsPacket
         public static void SendEntityStatsTo(Client client, Entity en)
         {
-            client.SendPacket(GenerateEntityStatsPacket(en));
+            client.Send(GenerateEntityStatsPacket(en));
         }
 
         //EntityDirectionPacket
@@ -835,7 +835,7 @@ namespace Intersect.Server.Networking
         //MapListPacket
         public static void SendMapList(Client client)
         {
-            client.SendPacket(new MapListPacket(MapList.List.JsonData));
+            client.Send(new MapListPacket(MapList.List.JsonData));
         }
 
         //MapListPacket
@@ -847,7 +847,7 @@ namespace Intersect.Server.Networking
         //ErrorPacket
         public static void SendError(Client client, string error, string header = "")
         {
-            client.SendPacket(new ErrorMessagePacket(header, error));
+            client.Send(new ErrorMessagePacket(header, error));
         }
 
         //MapItemsPacket
@@ -1030,7 +1030,7 @@ namespace Intersect.Server.Networking
         //CreateCharacterPacket
         public static void SendCreateCharacter(Client client)
         {
-            client.SendPacket(new CharacterCreationPacket());
+            client.Send(new CharacterCreationPacket());
         }
 
         //CharactersPacket
@@ -1094,7 +1094,7 @@ namespace Intersect.Server.Networking
                 }
             }
 
-            client.SendPacket(
+            client.Send(
                 new CharactersPacket(characters.ToArray(), client.Characters.Count < Options.MaxCharacters)
             );
         }
@@ -1102,7 +1102,7 @@ namespace Intersect.Server.Networking
         //AdminPanelPacket
         public static void SendOpenAdminWindow(Client client)
         {
-            client.SendPacket(new AdminPanelPacket());
+            client.Send(new AdminPanelPacket());
         }
 
         //MapGridPacket
@@ -1158,11 +1158,11 @@ namespace Intersect.Server.Networking
 
             if (client.IsEditor)
             {
-                client.SendPacket(new MapGridPacket(null, grid.GetEditorData(), clearKnownMaps));
+                client.Send(new MapGridPacket(null, grid.GetEditorData(), clearKnownMaps));
             }
             else
             {
-                client.SendPacket(new MapGridPacket(grid.GetClientData(), null, clearKnownMaps));
+                client.Send(new MapGridPacket(grid.GetClientData(), null, clearKnownMaps));
                 if (clearKnownMaps)
                 {
                     SendAreaPacket(client.Entity);
@@ -1508,7 +1508,7 @@ namespace Intersect.Server.Networking
 
             if (packetList == null)
             {
-                client.SendPacket(
+                client.Send(
                     new GameObjectPacket(obj.Id, obj.Type, deleted ? null : obj.JsonData, deleted, another)
                 );
             }
@@ -1550,7 +1550,7 @@ namespace Intersect.Server.Networking
         //OpenEditorPacket
         public static void SendOpenEditor(Client client, GameObjectType type)
         {
-            client.SendPacket(new OpenEditorPacket(type));
+            client.Send(new OpenEditorPacket(type));
         }
 
         //EntityDashPacket
@@ -1578,13 +1578,13 @@ namespace Intersect.Server.Networking
         //EnterMapPacket
         public static void SendEnterMap(Client client, Guid mapId)
         {
-            client.SendPacket(new EnterMapPacket(mapId));
+            client.Send(new EnterMapPacket(mapId));
         }
 
         //TimeDataPacket
         public static void SendTimeBaseTo(Client client)
         {
-            client.SendPacket(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
+            client.Send(new TimeDataPacket(TimeBase.GetTimeBase().GetInstanceJson()));
         }
 
         //TimeDataPacket
@@ -1607,7 +1607,7 @@ namespace Intersect.Server.Networking
         //TimePacket
         public static void SendTimeTo(Client client)
         {
-            client?.SendPacket(
+            client?.Send(
                 new TimePacket(
                     Time.GetTime(), TimeBase.GetTimeBase().SyncTime ? 1 : TimeBase.GetTimeBase().Rate,
                     Time.GetTimeColor()
@@ -1839,7 +1839,7 @@ namespace Intersect.Server.Networking
         //PasswordResetResultPacket
         public static void SendPasswordResetResult(Client client, bool result)
         {
-            client.SendPacket(new PasswordResetResultPacket(result));
+            client.Send(new PasswordResetResultPacket(result));
         }
 
         //TargetOverridePacket
@@ -1889,7 +1889,7 @@ namespace Intersect.Server.Networking
                 {
                     if (client.IsEditor)
                     {
-                        client.SendPacket(packet);
+                        client.Send(packet);
                     }
                 }
             }
@@ -1903,7 +1903,7 @@ namespace Intersect.Server.Networking
                 {
                     if (client?.Entity != null)
                     {
-                        client.SendPacket(packet);
+                        client.Send(packet);
                     }
                 }
             }
@@ -1917,7 +1917,7 @@ namespace Intersect.Server.Networking
                 {
                     if ((client?.IsEditor ?? false) || client?.Entity != null)
                     {
-                        client.SendPacket(packet);
+                        client.Send(packet);
                     }
                 }
             }

--- a/Intersect.Tests/Intersect.Tests.csproj
+++ b/Intersect.Tests/Intersect.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Extensions\RandomExtensionsTests.cs" />
     <Compile Include="IO\Files\FileSystemHelperTests.cs" />
     <Compile Include="Factories\FactoryRegistryTests.cs" />
+    <Compile Include="Network\PacketHandlerAttributeTests.cs" />
     <Compile Include="Plugins\Loaders\ManifestLoaderTest.cs" />
     <Compile Include="Plugins\Manifests\JsonManifestTests.cs" />
     <Compile Include="Plugins\Manifests\Types\AuthorTests.cs" />

--- a/Intersect.Tests/Network/PacketHandlerAttributeTests.cs
+++ b/Intersect.Tests/Network/PacketHandlerAttributeTests.cs
@@ -1,0 +1,384 @@
+﻿using Intersect.Collections;
+
+using NUnit.Framework;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Intersect.Network
+{
+    [TestFixture]
+    public class PacketHandlerAttributeTests
+    {
+        [Test]
+        public void TestGetPacketType_MethodInfo_null() =>
+            Assert.Throws<ArgumentNullException>(() => PacketHandlerAttribute.GetPacketType(default(MethodInfo)));
+
+        [Test]
+        public void TestGetPacketType_MethodInfo_InvalidParameterCount() => Assert.Throws<ArgumentOutOfRangeException>(
+            () => PacketHandlerAttribute.GetPacketType(
+                typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleInvalidParameterCount))
+            )
+        );
+
+        [Test]
+        public void TestGetPacketType_MethodInfo_InvalidSenderParameterType() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleInvalidSenderParameterType)
+                )
+            )
+        );
+
+        [Test]
+        public void TestGetPacketType_MethodInfo_InvalidPacketParameterType() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleInvalidPacketParameterType)
+                )
+            )
+        );
+
+        [Test]
+        public void TestGetPacketType_MethodInfo_MismatchedAttribute() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleWithMismatchedAttribute)
+                )
+            )
+        );
+
+        [Test]
+        public void TestGetPacketType_MethodInfo()
+        {
+            Assert.AreEqual(
+                typeof(TestPacket),
+                PacketHandlerAttribute.GetPacketType(
+                    typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleNoAttribute))
+                )
+            );
+
+            Assert.AreEqual(
+                typeof(TestPacket),
+                PacketHandlerAttribute.GetPacketType(
+                    typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleWithAttribute))
+                )
+            );
+
+            Assert.AreEqual(
+                typeof(TestPacket2),
+                PacketHandlerAttribute.GetPacketType(
+                    typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleWithAttribute2))
+                )
+            );
+        }
+
+        [Test]
+        public void TestGetPacketType_Type_null() =>
+            Assert.Throws<ArgumentNullException>(() => PacketHandlerAttribute.GetPacketType(default(Type)));
+
+        [Test]
+        public void TestGetPacketType_Type_NotPacketHandlerImplementation() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(typeof(TestClassNotPacketHandler))
+        );
+
+        [Test]
+        public void TestGetPacketType_Type_InvalidPacketType() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(typeof(TestClassPacketHandlerInvalidPacketType))
+        );
+
+        [Test]
+        public void TestGetPacketType_Type_MismatchedAttribute() => Assert.Throws<ArgumentException>(
+            () => PacketHandlerAttribute.GetPacketType(typeof(TestClassPacketHandlerWithMismatchedAttribute))
+        );
+
+        [Test]
+        public void TestGetPacketType_Type()
+        {
+            Assert.AreEqual(
+                typeof(TestPacket), PacketHandlerAttribute.GetPacketType(typeof(TestClassPacketHandlerNoAttribute))
+            );
+
+            Assert.AreEqual(
+                typeof(TestPacket), PacketHandlerAttribute.GetPacketType(typeof(TestClassPacketHandlerWithAttribute))
+            );
+
+            Assert.AreEqual(
+                typeof(TestPacket2), PacketHandlerAttribute.GetPacketType(typeof(TestClassPacketHandlerWithAttribute2))
+            );
+        }
+
+        [Test]
+        public void TestGetHandlerInterface_Type_null() =>
+            Assert.Throws<ArgumentNullException>(() => PacketHandlerAttribute.GetHandlerInterface(null));
+
+        [Test]
+        public void TestGetHandlerInterface_Type_NotHandler() =>
+            Assert.IsNull(PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassNotPacketHandler)));
+
+        [Test]
+        public void TestGetHandlerInterface_Type()
+        {
+            Assert.AreEqual(
+                typeof(IPacketHandler<TestPacket>),
+                PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassPacketHandlerNoAttribute))
+            );
+
+            Assert.AreEqual(
+                typeof(IPacketHandler<TestPacket>),
+                PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassPacketHandlerWithAttribute))
+            );
+
+            Assert.AreEqual(
+                typeof(IPacketHandler<TestPacket2>),
+                PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassPacketHandlerWithAttribute2))
+            );
+
+            Assert.AreEqual(
+                typeof(IPacketHandler<TestPacket>),
+                PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassPacketHandlerWithMismatchedAttribute))
+            );
+
+            // This specific handler is disallowed in the registry and filtered out elsewhere,
+            // but PacketHandlerAttribute.GetHandlerInterface() allowing it is acceptable.
+            Assert.AreEqual(
+                typeof(IPacketHandler<IPacket>),
+                PacketHandlerAttribute.GetHandlerInterface(typeof(TestClassPacketHandlerInvalidPacketType))
+            );
+        }
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_null() =>
+            Assert.Throws<ArgumentNullException>(() => PacketHandlerAttribute.GetPacketType(default(MethodInfo)));
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_NoAttribute() => Assert.IsTrue(
+            PacketHandlerAttribute.IsValidHandler(
+                typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleNoAttribute))
+            )
+        );
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_MismatchedAttribute() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleWithMismatchedAttribute)
+                )
+            )
+        );
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_InvalidParameterCount() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(
+                typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleInvalidParameterCount))
+            )
+        );
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_InvalidSenderParameterType() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleInvalidSenderParameterType)
+                )
+            )
+        );
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo_InvalidPacketParameterType() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(
+                typeof(TestPacketHandlerMethods).GetMethod(
+                    nameof(TestPacketHandlerMethods.HandleInvalidPacketParameterType)
+                )
+            )
+        );
+
+        [Test]
+        public void TestIsValidHandler_MethodInfo()
+        {
+            Assert.IsTrue(
+                PacketHandlerAttribute.IsValidHandler(
+                    typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleWithAttribute))
+                )
+            );
+
+            Assert.IsTrue(
+                PacketHandlerAttribute.IsValidHandler(
+                    typeof(TestPacketHandlerMethods).GetMethod(nameof(TestPacketHandlerMethods.HandleWithAttribute2))
+                )
+            );
+        }
+
+        [Test]
+        public void TestIsValidHandler_Type_null() =>
+            Assert.Throws<ArgumentNullException>(() => PacketHandlerAttribute.GetPacketType(default(Type)));
+
+        [Test]
+        public void TestIsValidHandler_Type_NoAttribute() => Assert.IsTrue(
+            PacketHandlerAttribute.IsValidHandler(typeof(TestClassPacketHandlerNoAttribute))
+        );
+
+        [Test]
+        public void TestIsValidHandler_Type_MismatchedAttribute() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(typeof(TestClassPacketHandlerWithMismatchedAttribute))
+        );
+
+        [Test]
+        public void TestIsValidHandler_Type_InvalidPacketType() => Assert.IsFalse(
+            PacketHandlerAttribute.IsValidHandler(typeof(TestClassPacketHandlerInvalidPacketType))
+        );
+
+        [Test]
+        public void TestIsValidHandler_Type()
+        {
+            Assert.IsTrue(PacketHandlerAttribute.IsValidHandler(typeof(TestClassPacketHandlerWithAttribute)));
+
+            Assert.IsTrue(PacketHandlerAttribute.IsValidHandler(typeof(TestClassPacketHandlerWithAttribute2)));
+        }
+    }
+
+    internal static class TestPacketHandlerMethods
+    {
+        public static bool HandleInvalidParameterCount(IPacketSender packetSender) =>
+            throw new NotImplementedException();
+
+        public static bool HandleInvalidSenderParameterType(object sender, TestPacket packet) =>
+            throw new NotImplementedException();
+
+        public static bool HandleInvalidPacketParameterType(IPacketSender packetSender, IPacket packet) =>
+            throw new NotImplementedException();
+
+        public static bool HandleNoAttribute(IPacketSender packetSender, TestPacket packet) =>
+            throw new NotImplementedException();
+
+        [PacketHandler(typeof(TestPacket))]
+        public static bool HandleWithAttribute(IPacketSender packetSender, TestPacket packet) =>
+            throw new NotImplementedException();
+
+        [PacketHandler(typeof(TestPacket2))]
+        public static bool HandleWithAttribute2(IPacketSender packetSender, TestPacket2 packet) =>
+            throw new NotImplementedException();
+
+        [PacketHandler(typeof(TestPacket2))]
+        public static bool HandleWithMismatchedAttribute(IPacketSender packetSender, TestPacket packet) =>
+            throw new NotImplementedException();
+    }
+
+    internal sealed class TestClassPacketHandlerNoAttribute : IPacketHandler<TestPacket>
+    {
+        #region Implementation of IPacketHandler
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, TestPacket packet) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    [PacketHandler(typeof(TestPacket))]
+    internal sealed class TestClassPacketHandlerWithAttribute : IPacketHandler<TestPacket>
+    {
+        #region Implementation of IPacketHandler
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, TestPacket packet) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    [PacketHandler(typeof(TestPacket2))]
+    internal sealed class TestClassPacketHandlerWithAttribute2 : IPacketHandler<TestPacket2>
+    {
+        #region Implementation of IPacketHandler
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, TestPacket2 packet) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    [PacketHandler(typeof(TestPacket2))]
+    internal sealed class TestClassPacketHandlerWithMismatchedAttribute : IPacketHandler<TestPacket>
+    {
+        #region Implementation of IPacketHandler
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, TestPacket packet) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    internal sealed class TestClassNotPacketHandler
+    {
+    }
+
+    internal sealed class TestClassPacketHandlerInvalidPacketType : IPacketHandler<IPacket>
+    {
+        #region Implementation of IPacketHandler
+
+        /// <inheritdoc />
+        public bool Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        bool IPacketHandler.Handle(IPacketSender packetSender, IPacket packet) => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    internal sealed class TestPacket : IPacket
+    {
+        #region Implementation of IDisposable
+
+        /// <inheritdoc />
+        public void Dispose() => throw new NotImplementedException();
+
+        #endregion
+
+        #region Implementation of IPacket
+
+        /// <inheritdoc />
+        public byte[] Data { get; }
+
+        /// <inheritdoc />
+        public bool IsValid { get; }
+
+        /// <inheritdoc />
+        public Dictionary<string, SanitizedValue<object>> Sanitize() => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    internal sealed class TestPacket2 : IPacket
+    {
+        #region Implementation of IDisposable
+
+        /// <inheritdoc />
+        public void Dispose() => throw new NotImplementedException();
+
+        #endregion
+
+        #region Implementation of IPacket
+
+        /// <inheritdoc />
+        public byte[] Data { get; }
+
+        /// <inheritdoc />
+        public bool IsValid { get; }
+
+        /// <inheritdoc />
+        public Dictionary<string, SanitizedValue<object>> Sanitize() => throw new NotImplementedException();
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Resolves #446 

Adapted [Jon Skeet's blog post](https://blogs.msmvps.com/jonskeet/2008/08/09/making-reflection-fly-and-exploring-delegates/) to fit our use case.

Added (non-public) endpoints in the registry to enable blindly registering _static only_ delegates across an entire assembly and registering interface-based packet handlers for future implementations.
- The static only delegates option may be outright removed, it's not a very good paradigm and if we remove delegates entirely we can remove most if not all of the horrible wrapper system.

This updates the client, server and editor.

Client and editor got an extra parameter in packet handlers, server lost one.

All dynamic nested packet handling is now non-dynamic (it never needed to be dynamic...), the only dynamic is for admin actions on the server (infrequent) that isn't dynamic on a packet itself anymore. That can be handled separately/later.