### PR TITLE
Reduce packet sizes 

### DIFF
--- a/Intersect (Core)/Core/ApplicationContext`2.cs
+++ b/Intersect (Core)/Core/ApplicationContext`2.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 
 using Intersect.Properties;
 using Intersect.Plugins.Interfaces;
+using Intersect.Network;
 
 namespace Intersect.Core
 {
@@ -211,6 +212,8 @@ namespace Intersect.Core
             try
             {
                 BootstrapServices();
+
+                PackedIntersectPacket.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
 
                 try
                 {

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -346,6 +346,7 @@
     <Compile Include="Network\IPacketHandler.cs" />
     <Compile Include="Network\IPacketSender.cs" />
     <Compile Include="Network\NetworkStatus.cs" />
+    <Compile Include="Network\PackedIntersectPacket.cs" />
     <Compile Include="Network\PacketDispatcher.cs" />
     <Compile Include="Network\PacketHandlerAttribute.cs" />
     <Compile Include="Network\PacketHandlerRegistry.cs" />

--- a/Intersect (Core)/Network/MessagePacker.cs
+++ b/Intersect (Core)/Network/MessagePacker.cs
@@ -30,7 +30,7 @@ namespace Intersect.Network
         {
             var packedPacket = new PackedIntersectPacket(pkt)
             {
-                PacketData = MessagePackSerializer.Serialize((object)pkt, mOptions)
+                Data = MessagePackSerializer.Serialize((object)pkt, mOptions)
             };
 
             return MessagePackSerializer.Serialize((object)packedPacket, mCompressedOptions);
@@ -41,7 +41,7 @@ namespace Intersect.Network
             try
             {
                 var packedPacket = MessagePackSerializer.Deserialize<PackedIntersectPacket>(data, mCompressedOptions);
-                var intersectPacket = MessagePackSerializer.Deserialize(packedPacket.PacketType, packedPacket.PacketData, mOptions);
+                var intersectPacket = MessagePackSerializer.Deserialize(packedPacket.PacketType, packedPacket.Data, mOptions);
                 return intersectPacket;
             }
             catch (Exception exception)

--- a/Intersect (Core)/Network/PackedIntersectPacket.cs
+++ b/Intersect (Core)/Network/PackedIntersectPacket.cs
@@ -1,0 +1,60 @@
+﻿using MessagePack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Network
+{
+    [MessagePackObject]
+    public class PackedIntersectPacket
+    {
+        private static readonly string[] BuiltInPacketNamespaces = new[]
+        {
+            "Intersect.Network.Packets",
+            "Intersect.Network.Packets.Client",
+            "Intersect.Network.Packets.Editor",
+            "Intersect.Network.Packets.Server",
+            "Intersect.Admin.Actions"
+        };
+
+        public static Dictionary<Type, Int32> KnownTypes { get; set; } = new Dictionary<Type, Int32>();
+
+        public static Dictionary<Int32, Type> KnownKeys { get; set; } = new Dictionary<Int32, Type>();
+
+        private static IEnumerable<Type> FindTypes(IEnumerable<string> nameSpaces) => nameSpaces.SelectMany(FindTypes);
+
+        private static IEnumerable<Type> FindTypes(string nameSpace) =>
+            typeof(Ceras).Assembly.GetTypes().Where(type => type.Namespace == nameSpace);
+
+        static PackedIntersectPacket()
+        {
+            var i = 0;
+            foreach (var type in FindTypes(BuiltInPacketNamespaces))
+            {
+                KnownKeys.Add(i, type);
+                KnownTypes.Add(type, i++);
+            }
+        }
+
+        [Key(0)]
+        public Int32 PacketKey { get; set; } = -1;
+
+        [Key(1)]
+        public byte[] PacketData { get; set; }
+
+        [IgnoreMember]
+        public Type PacketType => KnownKeys[PacketKey];
+
+        public PackedIntersectPacket()
+        {
+
+        }
+
+        public PackedIntersectPacket(IntersectPacket pkt)
+        {
+            PacketKey = KnownTypes[pkt.GetType()];
+        }
+    }
+}

--- a/Intersect (Core)/Network/PackedIntersectPacket.cs
+++ b/Intersect (Core)/Network/PackedIntersectPacket.cs
@@ -19,27 +19,31 @@ namespace Intersect.Network
             "Intersect.Admin.Actions"
         };
 
-        public static Dictionary<Type, Int32> KnownTypes { get; set; } = new Dictionary<Type, Int32>();
+        public static Dictionary<Type, short> KnownTypes { get; set; } = new Dictionary<Type, short>();
 
-        public static Dictionary<Int32, Type> KnownKeys { get; set; } = new Dictionary<Int32, Type>();
+        public static Dictionary<short, Type> KnownKeys { get; set; } = new Dictionary<short, Type>();
 
         private static IEnumerable<Type> FindTypes(IEnumerable<string> nameSpaces) => nameSpaces.SelectMany(FindTypes);
 
         private static IEnumerable<Type> FindTypes(string nameSpace) =>
             typeof(Ceras).Assembly.GetTypes().Where(type => type.Namespace == nameSpace);
 
-        static PackedIntersectPacket()
+        public static void AddKnownTypes(IReadOnlyList<Type> types)
         {
-            var i = 0;
-            foreach (var type in FindTypes(BuiltInPacketNamespaces))
-            {
+            short i = (short)KnownKeys.Count;
+            foreach (var type in types.Where(type => !KnownTypes.ContainsKey(type))) {
                 KnownKeys.Add(i, type);
                 KnownTypes.Add(type, i++);
             }
         }
 
+        static PackedIntersectPacket()
+        {
+            AddKnownTypes(FindTypes(BuiltInPacketNamespaces).ToList());
+        }
+
         [Key(0)]
-        public Int32 PacketKey { get; set; } = -1;
+        public short PacketKey { get; set; } = -1;
 
         [Key(1)]
         public byte[] PacketData { get; set; }

--- a/Intersect (Core)/Network/PackedIntersectPacket.cs
+++ b/Intersect (Core)/Network/PackedIntersectPacket.cs
@@ -30,10 +30,17 @@ namespace Intersect.Network
 
         public static void AddKnownTypes(IReadOnlyList<Type> types)
         {
-            short i = (short)KnownKeys.Count;
-            foreach (var type in types.Where(type => !KnownTypes.ContainsKey(type))) {
-                KnownKeys.Add(i, type);
-                KnownTypes.Add(type, i++);
+            var key = (short)KnownKeys.Count;
+            foreach (var type in types) {
+                if (KnownTypes.ContainsKey(type))
+                {
+                    continue;
+                }
+                
+                KnownKeys.Add(key, type);
+                KnownTypes.Add(type, key);
+
+                key++;
             }
         }
 
@@ -43,22 +50,27 @@ namespace Intersect.Network
         }
 
         [Key(0)]
-        public short PacketKey { get; set; } = -1;
+        public short Key { get; set; } = -1;
 
         [Key(1)]
-        public byte[] PacketData { get; set; }
+        public byte[] Data { get; set; }
 
         [IgnoreMember]
-        public Type PacketType => KnownKeys[PacketKey];
+        public Type PacketType => KnownKeys[Key];
 
         public PackedIntersectPacket()
         {
 
         }
 
-        public PackedIntersectPacket(IntersectPacket pkt)
+        public PackedIntersectPacket(IntersectPacket packet)
         {
-            PacketKey = KnownTypes[pkt.GetType()];
+            if (!KnownTypes.TryGetValue(packet.GetType(), out var key))
+            {
+                throw new ArgumentException($"Type not a known packet type: {packet.GetType().FullName}");
+            }
+
+            Key = key;
         }
     }
 }

--- a/Intersect (Core)/Network/PackedIntersectPacket.cs
+++ b/Intersect (Core)/Network/PackedIntersectPacket.cs
@@ -44,11 +44,6 @@ namespace Intersect.Network
             }
         }
 
-        static PackedIntersectPacket()
-        {
-            AddKnownTypes(FindTypes(BuiltInPacketNamespaces).ToList());
-        }
-
         [Key(0)]
         public short Key { get; set; } = -1;
 

--- a/Intersect.Client/Core/ClientContext.cs
+++ b/Intersect.Client/Core/ClientContext.cs
@@ -39,7 +39,6 @@ namespace Intersect.Client.Core
         /// <inheritdoc />
         protected override void InternalStart()
         {
-            PackedIntersectPacket.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
             Networking.Network.PacketHandler = new PacketHandler(this, NetworkHelper.HandlerRegistry);
             PlatformRunner = typeof(ClientContext).Assembly.CreateInstanceOf<IPlatformRunner>();
             PlatformRunner.Start(this, PostStartup);

--- a/Intersect.Client/Core/ClientContext.cs
+++ b/Intersect.Client/Core/ClientContext.cs
@@ -39,7 +39,7 @@ namespace Intersect.Client.Core
         /// <inheritdoc />
         protected override void InternalStart()
         {
-            Ceras.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
+            PackedIntersectPacket.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
             Networking.Network.PacketHandler = new PacketHandler(this, NetworkHelper.HandlerRegistry);
             PlatformRunner = typeof(ClientContext).Assembly.CreateInstanceOf<IPlatformRunner>();
             PlatformRunner.Start(this, PostStartup);

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -45,6 +45,7 @@ namespace Intersect.Editor.Networking
 
                 var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
                 var networkHelper = new NetworkHelper(packetTypeRegistry, packetHandlerRegistry);
+                PackedIntersectPacket.AddKnownTypes(networkHelper.AvailablePacketTypes);
                 var virtualEditorContext = new VirtualEditorContext(networkHelper, logger);
                 PacketHandler = new PacketHandler(virtualEditorContext, packetHandlerRegistry);
 

--- a/Intersect.Server/Core/ServerContext.cs
+++ b/Intersect.Server/Core/ServerContext.cs
@@ -71,7 +71,6 @@ namespace Intersect.Server.Core
         {
             try
             {
-                PackedIntersectPacket.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
                 InternalStartNetworking();
             }
             catch (Exception exception)

--- a/Intersect.Server/Core/ServerContext.cs
+++ b/Intersect.Server/Core/ServerContext.cs
@@ -71,7 +71,7 @@ namespace Intersect.Server.Core
         {
             try
             {
-                Ceras.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
+                PackedIntersectPacket.AddKnownTypes(NetworkHelper.AvailablePacketTypes);
                 InternalStartNetworking();
             }
             catch (Exception exception)


### PR DESCRIPTION
By wrapping packets into a class that saves them as an integer.

Intead of prefixing every packet with a full type name such as the one here:
"Intersect.Network.Packets.Client.AdminActionPacket, Intersect Core, Version=0.7.0.0, Culture=neutral, PublicKeyToken=null"

Fixes #492 