### PR TITLE
Clone dropchance when cloning items to fix all items always dropping

### DIFF
--- a/Intersect.Server/Database/Item.cs
+++ b/Intersect.Server/Database/Item.cs
@@ -57,6 +57,8 @@ namespace Intersect.Server.Database
             {
                 StatBuffs[i] = item.StatBuffs[i];
             }
+
+            DropChance = item.DropChance;
         }
         
         // TODO: THIS SHOULD NOT BE A NULLABLE. This needs to be fixed.


### PR DESCRIPTION
Resolves #523 