### PR TITLE
Adds Npc Tags

### DIFF
--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -33,7 +33,17 @@
         /// Configures whether or not the level of an Npc is shown next to their name.
         /// </summary>
         public bool ShowLevelByName = false;
-
+        
+        /// <summary>
+        /// Configures whether or not the type of Npc is displayed adove to their name as a sprite tag.
+        /// This requires 5 sprites in the entitytag resources folder:
+        /// "Aggressive.png"
+        /// "AttackWhenAttacked.png"
+        /// "AttackOnSight.png"
+        /// "Guard.png"
+        /// "Neutral.png"
+        /// </summary>
+        public bool ShowTagByType = false;
     }
 
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1384,6 +1384,41 @@ namespace Intersect.Client.Entities
                 name, Graphics.EntityNameFont, (int) (x - (int) Math.Ceiling(textSize.X / 2f)), (int) y, 1,
                 Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
             );
+            // NpcTags
+            if (!(this is Player) && Options.Npc.ShowTagByType)
+            {
+                string NpcTagFile;
+                switch (Type)
+                {
+                    case -1: //When entity has a target (showing aggression)
+                        NpcTagFile = "NpcTag_Aggressive.png";
+
+                        break;
+                    case 0: //Attack when attacked
+                        NpcTagFile = "NpcTag_AttackWhenAttacked.png";
+
+                        break;
+                    case 1: //Attack on sight
+                        NpcTagFile = "NpcTag_AttackOnSight.png";
+
+                        break;
+                    case 3: //Guard
+                        NpcTagFile = "NpcTag_Guard.png";
+
+                        break;
+                    case 2: //Neutral
+                    default:
+                        NpcTagFile = "NpcTag_Neutral.png";
+
+                        break;
+                }
+                var NpcTagTex = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Misc, NpcTagFile);
+                if (NpcTagTex != null)
+                {
+                    Graphics.DrawGameTexture(
+                        NpcTagTex, new FloatRect(0, 0, NpcTagTex.GetWidth(), NpcTagTex.GetHeight()), new FloatRect((x - NpcTagTex.GetWidth() / 2), (y - 20), NpcTagTex.GetWidth(), NpcTagTex.GetHeight()), Color.White);
+                }
+            }
         }
 
         public float GetLabelLocation(LabelType type)


### PR DESCRIPTION
Similar to text colours changing by NPC's behaviour, but now with tags!
a small approach to solve #394

the idea originally started with this:
![OG](https://user-images.githubusercontent.com/17498701/108024115-d4dffc00-6fd8-11eb-8b95-b1622f3def48.png)

but then, i couldn't find the proper way to ...
`GetTexture > GameContentManager.TextureType.NpcTag, (**FileNameString.png** from the NPCs database)`

Then, i decided to take a shorter path, its not as flexible like the first idea, where u could set static labels to specific NPCs, but this is neat as well! (Tags are dynamic, they change depending on the NPCs behaviour, just the the changing colour text, but now with tags!)

![shortpath](https://user-images.githubusercontent.com/17498701/108024788-18873580-6fda-11eb-86e3-6f09c30907f7.png)


You may use these tags that i drew in Aseprite while testing this:

![NpcTag_AttackOnSight](https://user-images.githubusercontent.com/17498701/108024083-c396ef80-6fd8-11eb-826c-23add79b17ee.png)      ![NpcTag_AttackWhenAttacked](https://user-images.githubusercontent.com/17498701/108024084-c42f8600-6fd8-11eb-9395-623f8736538a.png)      ![NpcTag_Guard](https://user-images.githubusercontent.com/17498701/108024086-c4c81c80-6fd8-11eb-8974-04379aa7e585.png)      ![NpcTag_Neutral](https://user-images.githubusercontent.com/17498701/108024088-c4c81c80-6fd8-11eb-8536-36e626ace42d.png)      ![NpcTag_Aggressive](https://user-images.githubusercontent.com/17498701/108024089-c560b300-6fd8-11eb-9757-3fe75874fed5.png)
