### PR TITLE
Resolves 517 by making spell cast canceling via movement optional

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -18,6 +18,13 @@
         public int RegenTime = 3000; //3 seconds
 
         public bool EnableCombatChatMessages = false; // Enables or disables combat chat messages.
+
+        //Spells
+
+        /// <summary>
+        /// If enabled this allows spell casts to stop/be canceled if the player tries to move around (WASD)
+        /// </summary>
+        public bool MovementCancelsCast = false;
         
         // Cooldowns
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1610,9 +1610,12 @@ namespace Intersect.Client.Entities
             if (MoveDir > -1 && Globals.EventDialogs.Count == 0)
             {
                 //Try to move if able and not casting spells.
-                if (!IsMoving && MoveTimer < Timing.Global.Ticks / TimeSpan.TicksPerMillisecond)
+                if (!IsMoving && MoveTimer < Timing.Global.Ticks / TimeSpan.TicksPerMillisecond && (Options.Combat.MovementCancelsCast || CastTime < Globals.System.GetTimeMs())) 
                 {
-                    CastTime = 0;
+                    if (Options.Combat.MovementCancelsCast)
+                    {
+                        CastTime = 0;
+                    }
 
                     switch (MoveDir)
                     {

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -560,7 +560,7 @@ namespace Intersect.Client.Networking
                 return;
             }
 
-            if (en is Player)
+            if (en is Player && Options.Combat.MovementCancelsCast)
             {
                 en.CastTime = 0;
             }

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -804,14 +804,14 @@ namespace Intersect.Server.Entities
 
         public virtual void Move(int moveDir, Player forPlayer, bool doNotUpdate = false, bool correction = false)
         {
-            if (Globals.Timing.Milliseconds < MoveTimer)
+            if (Globals.Timing.Milliseconds < MoveTimer || (!Options.Combat.MovementCancelsCast && CastTime > 0))
             {
                 return;
             }
 
             lock (EntityLock)
             {
-                if (this is Player && CastTime > 0)
+                if (this is Player && CastTime > 0 && Options.Combat.MovementCancelsCast)
                 {
                     CastTime = 0;
                     CastTarget = null;


### PR DESCRIPTION
Enhancement was unintentionally pulled in while merging changes made to Leafling, allowing it as an option (disabled by default) seems to be the best move forward.

Resolves #517 