### PR TITLE
Fix cpu burning by sleeping instead of yielding on the main server loop

### DIFF
--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -157,7 +157,7 @@ namespace Intersect.Server.Core
                             Console.Title = $"Intersect Server - CPS: {Globals.Cps}, Players: {players}, Active Maps: {ActiveMaps.Count}, Logic Threads: {LogicPool.ActiveThreads} ({LogicPool.InUseThreads} In Use), Pool Queue: {LogicPool.CurrentWorkItemsCount}, Idle: {LogicPool.IsIdle}";
                         }
 
-                        Thread.Yield();
+                        Thread.Sleep(1);
                     }
                     LogicPool.Shutdown();
                 }


### PR DESCRIPTION
No need for the loop to iterate 1.8 million times a second for something that only divys out work to other threads.