### PR TITLE
Player & Npc Tags Implementation

### DIFF
--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -1,39 +1,151 @@
 ﻿namespace Intersect.Config
 {
 
-    /// <summary>
-    /// Contains configurable options pertaining to the way Npcs are handled by the engine.
-    /// </summary>
-    public class NpcOptions
-    {
+	/// <summary>
+	/// Contains configurable options pertaining to the way Npcs are handled by the engine.
+	/// </summary>
+	public class NpcOptions
+	{
+		/// <summary>
+		/// Configures whether or not Npcs are allowed to reset after moving out of a specified radius when starting to fight another entity.
+		/// </summary>
+		public bool AllowResetRadius
+		{
+			get;
+			set;
+		} = false;
 
-        /// <summary>
-        /// Configures whether or not Npcs are allowed to reset after moving out of a specified radius when starting to fight another entity.
-        /// </summary>
-        public bool AllowResetRadius = false;
+		/// <summary>
+		/// Configures the radius in which an NPC is allowed to move after starting to fight another entity.
+		/// </summary>
+		public int ResetRadius
+		{
+			get;
+			set;
+		} = 8;
 
-        /// <summary>
-        /// Configures the radius in which an NPC is allowed to move after starting to fight another entity.
-        /// </summary>
-        public int ResetRadius = 8;
+		/// <summary>
+		/// Configures whether or not the NPC is allowed to gain a new reset center point while it is still busy moving to its original reset point.
+		/// NOTE: Can be used to allow the NPCs to be dragged far far away, as it constantly resets the center of its radius!!!
+		/// </summary>
+		public bool AllowNewResetLocationBeforeFinish
+		{
+			get;
+			set;
+		} = false;
 
-        /// <summary>
-        /// Configures whether or not the NPC is allowed to gain a new reset center point while it is still busy moving to its original reset point.
-        /// NOTE: Can be used to allow the NPCs to be dragged far far away, as it constantly resets the center of its radius!!!
-        /// </summary>
+		/// <summary>
+		/// Configures whether or not the NPC should completely restore its vitals and statusses once it resets.
+		/// </summary>
+		public bool ResetVitalsAndStatusses
+		{
+			get;
+			set;
+		} = false;
 
-        public bool AllowNewResetLocationBeforeFinish = false;
+		/// <summary>
+		/// Configures whether or not the level of an Npc is shown next to their name.
+		/// </summary>
+		public bool ShowLevelByName
+		{
+			get;
+			set;
+		} = false;
 
-        /// <summary>
-        /// Configures whether or not the NPC should completely restore its vitals and statusses once it resets.
-        /// </summary>
-        public bool ResetVitalsAndStatusses = false;
+		/// <summary>
+		/// Configures whether or not to display Npc's Tags.
+		/// NOTE: Npc Tag Sprites are always loaded from the "tags" resource folder.
+		/// *Recommended sizes: 32x16, 64x32, 128x64 and so on [2:1 px]
+		/// </summary>
+		public bool ShowTags
+		{
+			get;
+			set;
+		} = false;
 
-        /// <summary>
-        /// Configures whether or not the level of an Npc is shown next to their name.
-        /// </summary>
-        public bool ShowLevelByName = false;
+		/// <summary>
+		/// Configures whether or not to ONLY allow Custom Tags for Npcs.
+		/// NOTE: default tags won't be rendered on NPCs anymore.
+		/// </summary>
+		public bool ShowCustomTagsOnly
+		{
+			get;
+			set;
+		} = false;
 
-    }
+		/// <summary>
+		/// Configures the position of the Tags. Only works if ShowTags = true.
+		/// 0: Positions the tag 2 pixels above the name label.
+		/// 1: Positions the tag 2 pixels under the name label.
+		/// 2: Positions the tag as prefix (2 pixels left from the name label).
+		/// 3: Positions the tag as suffix (2 pixels right from the name label).
+		/// </summary>
+		public Enums.NpcTagPos TagPosition
+		{
+			get;
+			set;
+		} = Enums.NpcTagPos.Above;
 
+		/// <summary>
+		/// Configures the default tag sprite for Aggressive Npcs.
+		/// </summary>
+		public string AggressiveTagIcon
+		{
+			get;
+			set;
+		} = "Aggressive.png";
+
+		/// <summary>
+		/// Configures the default tag sprite for AttackWhenAttacked Npcs.
+		/// </summary>
+		public string AttackWhenAttackedTagIcon
+		{
+			get;
+			set;
+		} = "AttackWhenAttacked.png";
+
+		/// <summary>
+		/// Configures the default tag sprite for AttackOnSight Npcs.
+		/// </summary>
+		public string AttackOnSightTagIcon
+		{
+			get;
+			set;
+		} = "AttackOnSight.png";
+
+		/// <summary>
+		/// Configures the default tag sprite for Guard Npcs.
+		/// </summary>
+		public string GuardTagIcon
+		{
+			get;
+			set;
+		} = "Guard.png";
+
+		/// <summary>
+		/// Configures default tag sprite for Neutral Npcs.
+		/// </summary>
+		public string NeutralTagIcon
+		{
+			get;
+			set;
+		} = "Neutral.png";
+
+		/// <summary>
+		/// Configures which Npcs should have a custom Tag. Only works if ShowTags = true.
+		/// In order to set a custom tag for a specific Npc, lets say, one named "Doe",
+		/// add it's name to this string list, then create a custom tag named "Npc_Doe.png"
+		/// and place it inside the "tags" resource folder.
+		/// </summary>
+		public string[] CustomTagIcons
+		{
+			get;
+			set;
+		} = {
+			"Doe",
+			"Monster",
+			"Boss"
+		};
+
+	}
 }

--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Intersect.Config
+﻿using Intersect.Enums;
+
+namespace Intersect.Config
 {
 
 	/// <summary>
@@ -75,16 +77,12 @@
 
 		/// <summary>
 		/// Configures the position of the Tags. Only works if ShowTags = true.
-		/// 0: Positions the tag 2 pixels above the name label.
-		/// 1: Positions the tag 2 pixels under the name label.
-		/// 2: Positions the tag as prefix (2 pixels left from the name label).
-		/// 3: Positions the tag as suffix (2 pixels right from the name label).
 		/// </summary>
-		public Enums.NpcTagPos TagPosition
+		public TagPosition TagPosition
 		{
 			get;
 			set;
-		} = Enums.NpcTagPos.Above;
+		} = TagPosition.Above;
 
 		/// <summary>
 		/// Configures the default tag sprite for Aggressive Npcs.

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -1,9 +1,9 @@
-﻿namespace Intersect.Config
-{
+﻿using Intersect.Enums;
 
+namespace Intersect.Config
+{
 	public class PlayerOptions
 	{
-
 		/// <summary>
 		/// A percentage between 0 and 100 which determines the chance in which they will lose any given item in their inventory when killed.
 		/// </summary>
@@ -116,16 +116,12 @@
 
 		/// <summary>
 		/// Configures the position of the Tags. Only works if ShowTags = true.
-		/// 0: Positions the tag 2 pixels above the name label.
-		/// 1: Positions the tag 2 pixels under the name label.
-		/// 2: Positions the tag as prefix (2 pixels left from the name label).
-		/// 3: Positions the tag as suffix (2 pixels right from the name label).
 		/// </summary>
-		public Enums.PlayerTagPos TagPosition
+		public TagPosition TagPosition
 		{
 			get;
 			set;
-		} = Enums.PlayerTagPos.Above;
+		} = TagPosition.Above;
 
 		/// <summary>
 		/// Configures which Players should have a custom Tag. Only works if ShowTags = true.
@@ -144,5 +140,4 @@
 		};
 
 	}
-
 }

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -1,64 +1,148 @@
 ﻿namespace Intersect.Config
 {
 
-    public class PlayerOptions
-    {
+	public class PlayerOptions
+	{
 
-        /// <summary>
-        /// A percentage between 0 and 100 which determines the chance in which they will lose any given item in their inventory when killed.
-        /// </summary>
-        public int ItemDropChance = 0;
+		/// <summary>
+		/// A percentage between 0 and 100 which determines the chance in which they will lose any given item in their inventory when killed.
+		/// </summary>
+		public int ItemDropChance
+		{
+			get;
+			set;
+		} = 0;
 
-        /// <summary>
-        /// Number of bank slots a player has.
-        /// </summary>
-        public int MaxBank = 100;
+		/// <summary>
+		/// Number of bank slots a player has.
+		/// </summary>
+		public int MaxBank
+		{
+			get;
+			set;
+		} = 100;
 
-        /// <summary>
-        /// Number of characters an account may create.
-        /// </summary>
-        public int MaxCharacters = 1;
+		/// <summary>
+		/// Number of characters an account may create.
+		/// </summary>
+		public int MaxCharacters
+		{
+			get;
+			set;
+		} = 1;
 
-        /// <summary>
-        /// Number of inventory slots a player has.
-        /// </summary>
-        public int MaxInventory = 35;
+		/// <summary>
+		/// Number of inventory slots a player has.
+		/// </summary>
+		public int MaxInventory
+		{
+			get;
+			set;
+		} = 35;
 
-        /// <summary>
-        /// Max level a player can achieve.
-        /// </summary>
-        public int MaxLevel = 100;
+		/// <summary>
+		/// Max level a player can achieve.
+		/// </summary>
+		public int MaxLevel
+		{
+			get;
+			set;
+		} = 100;
 
-        /// <summary>
-        /// Number of spell slots a player has.
-        /// </summary>
-        public int MaxSpells = 35;
+		/// <summary>
+		/// Number of spell slots a player has.
+		/// </summary>
+		public int MaxSpells
+		{
+			get;
+			set;
+		} = 35;
 
-        /// <summary>
-        /// The highest value a single stat can be for a player.
-        /// </summary>
-        public int MaxStat = 255;
+		/// <summary>
+		/// The highest value a single stat can be for a player.
+		/// </summary>
+		public int MaxStat
+		{
+			get;
+			set;
+		} = 255;
 
-        /// <summary>
-        /// How long a player must wait before sending a trade/party/friend request after the first as been denied.
-        /// </summary>
-        public int RequestTimeout = 300000;
+		/// <summary>
+		/// How long a player must wait before sending a trade/party/friend request after the first as been denied.
+		/// </summary>
+		public int RequestTimeout
+		{
+			get;
+			set;
+		} = 300000;
 
-        /// <summary>
-        /// Distance (in tiles) between players in which a trade offer can be sent and accepted.
-        /// </summary>
-        public int TradeRange = 6;
+		/// <summary>
+		/// Distance (in tiles) between players in which a trade offer can be sent and accepted.
+		/// </summary>
+		public int TradeRange
+		{
+			get;
+			set;
+		} = 6;
 
-        /// <summary>
-        /// Unlinks the timers for combat and movement to facilitate complex combat (e.g. kiting)
-        /// </summary>
-        public bool AllowCombatMovement = true;
+		/// <summary>
+		/// Unlinks the timers for combat and movement to facilitate complex combat (e.g. kiting)
+		/// </summary>
+		public bool AllowCombatMovement
+		{
+			get;
+			set;
+		} = true;
 
-        /// <summary>
-        /// Configures whether or not the level of a player is shown next to their name.
-        /// </summary>
-        public bool ShowLevelByName = false;
+		/// <summary>
+		/// Configures whether or not the level of a player is shown next to their name.
+		/// </summary>
+		public bool ShowLevelByName
+		{
+			get;
+			set;
+		} = false;
 
-    }
+		/// <summary>
+		/// Configures whether or not to display Player's Tags.
+		/// NOTE: Npc Tag Sprites are always loaded from the "tags" resource folder.
+		/// *Recommended sizes: 32x16, 64x32, 128x64 and so on [2:1 px]
+		/// </summary>
+		public bool ShowTags
+		{
+			get;
+			set;
+		} = false;
+
+		/// <summary>
+		/// Configures the position of the Tags. Only works if ShowTags = true.
+		/// 0: Positions the tag 2 pixels above the name label.
+		/// 1: Positions the tag 2 pixels under the name label.
+		/// 2: Positions the tag as prefix (2 pixels left from the name label).
+		/// 3: Positions the tag as suffix (2 pixels right from the name label).
+		/// </summary>
+		public Enums.PlayerTagPos TagPosition
+		{
+			get;
+			set;
+		} = Enums.PlayerTagPos.Above;
+
+		/// <summary>
+		/// Configures which Players should have a custom Tag. Only works if ShowTags = true.
+		/// In order to set a custom tag for a specific Player, lets say, one named "Rick",
+		/// add it's name to this string list, then create a custom tag named "Player_Rick.png"
+		/// and place it inside the "tags" resource folder.
+		/// </summary>
+		public string[] CustomTagIcons
+		{
+			get;
+			set;
+		} = {
+			"Aru",
+			"Bobby",
+			"Rick"
+		};
+
+	}
 
 }

--- a/Intersect (Core)/Enums/TagsPosition.cs
+++ b/Intersect (Core)/Enums/TagsPosition.cs
@@ -1,0 +1,25 @@
+namespace Intersect.Enums
+{
+	/// <summary>
+	/// Enum used for switching Npc Tags Position.
+	/// </summary>
+	public enum NpcTagPos
+	{
+		Above,
+		Under,
+		Prefix,
+		Suffix
+	}
+
+	/// <summary>
+	/// Enum used for switching Player Tags Position.
+	/// </summary>
+	public enum PlayerTagPos
+	{
+		Above,
+		Under,
+		Prefix,
+		Suffix
+	}
+
+}

--- a/Intersect (Core)/Enums/TagsPosition.cs
+++ b/Intersect (Core)/Enums/TagsPosition.cs
@@ -1,25 +1,19 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace Intersect.Enums
 {
-	/// <summary>
-	/// Enum used for switching Npc Tags Position.
-	/// </summary>
-	public enum NpcTagPos
+	/// <summary> Enum used for switching Tags Position. </summary>
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum TagPosition
 	{
+		/// <summary> Positions the tag above the name label. </summary>
 		Above,
+		/// <summary> Positions the tag under the name label. </summary>
 		Under,
+		/// <summary> Positions the tag as prefix (left) of the name label. </summary>
 		Prefix,
+		/// <summary> Positions the tag as suffix (right) of the name label. </summary>
 		Suffix
 	}
-
-	/// <summary>
-	/// Enum used for switching Player Tags Position.
-	/// </summary>
-	public enum PlayerTagPos
-	{
-		Above,
-		Under,
-		Prefix,
-		Suffix
-	}
-
 }

--- a/Intersect.Client.Framework/File Management/GameContentManager.cs
+++ b/Intersect.Client.Framework/File Management/GameContentManager.cs
@@ -44,6 +44,8 @@ namespace Intersect.Client.Framework.File_Management
 
             Misc,
 
+            Tag
+
         }
 
         public enum UI
@@ -74,6 +76,8 @@ namespace Intersect.Client.Framework.File_Management
         protected Dictionary<string, IAsset> mItemDict = new Dictionary<string, IAsset>();
 
         protected Dictionary<string, IAsset> mMiscDict = new Dictionary<string, IAsset>();
+
+        protected Dictionary<string, IAsset> mTagDict = new Dictionary<string, IAsset>();
 
         protected Dictionary<string, GameAudioSource> mMusicDict = new Dictionary<string, GameAudioSource>();
 
@@ -123,6 +127,7 @@ namespace Intersect.Client.Framework.File_Management
             LoadResources();
             LoadPaperdolls();
             LoadMisc();
+            LoadTags();
             LoadGui();
             LoadFonts();
             LoadShaders();
@@ -153,6 +158,8 @@ namespace Intersect.Client.Framework.File_Management
         public abstract void LoadGui();
 
         public abstract void LoadMisc();
+
+        public abstract void LoadTags();
 
         public abstract void LoadFonts();
 
@@ -219,6 +226,9 @@ namespace Intersect.Client.Framework.File_Management
 
                 case TextureType.Misc:
                     return mMiscDict.Keys.ToArray();
+
+                case TextureType.Tag:
+                    return mTagDict.Keys.ToArray();
             }
 
             return null;
@@ -292,6 +302,11 @@ namespace Intersect.Client.Framework.File_Management
 
                 case TextureType.Misc:
                     textureDict = mMiscDict;
+
+                    break;
+
+                case TextureType.Tag:
+                    textureDict = mTagDict;
 
                     break;
 

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -364,8 +364,7 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
-                            entity.DrawTag(Options.Player.TagPosition); // Player Tags
-                            entity.DrawTag(Options.Npc.TagPosition); // Npc Tags
+                            entity.DrawTag(Options.Npc.TagPosition, Options.Player.TagPosition);
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }
@@ -384,8 +383,7 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
-                            entity.DrawTag(Options.Player.TagPosition); // Player Tags
-                            entity.DrawTag(Options.Npc.TagPosition); // Npc Tags
+                            entity.DrawTag(Options.Npc.TagPosition, Options.Player.TagPosition);
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -364,7 +364,7 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
-                            entity.DrawTag(Options.Npc.TagPosition, Options.Player.TagPosition);
+                            entity.DrawTag();
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }
@@ -383,7 +383,7 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
-                            entity.DrawTag(Options.Npc.TagPosition, Options.Player.TagPosition);
+                            entity.DrawTag();
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -364,6 +364,8 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
+                            entity.DrawTag(Options.Player.TagPosition); // Player Tags
+                            entity.DrawTag(Options.Npc.TagPosition); // Npc Tags
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }
@@ -382,6 +384,8 @@ namespace Intersect.Client.Core
                         entity.DrawName(null);
                         if (entity.GetType() != typeof(Event))
                         {
+                            entity.DrawTag(Options.Player.TagPosition); // Player Tags
+                            entity.DrawTag(Options.Npc.TagPosition); // Npc Tags
                             entity.DrawHpBar();
                             entity.DrawCastingBar();
                         }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1387,143 +1387,101 @@ namespace Intersect.Client.Entities
         }
 
         // Tags
-        public virtual void DrawTag(NpcTagPos npcTagPos, PlayerTagPos playerTagPos)
+        public virtual void DrawTag()
         {
             // Variables
-            string tagFileName = "";
+            string tagFileName = string.Empty;
             string entityName = this.Name;
             bool customNpcTag = Options.Npc.CustomTagIcons.Contains(entityName);
-            bool customPlayerTag = Options.Player.CustomTagIcons.Contains(entityName);
             bool customNpcTagOnly = Options.Npc.ShowCustomTagsOnly;
             var nameSize = Graphics.Renderer.MeasureText(entityName, Graphics.EntityNameFont, 1);
             var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
             var nameVertPos = GetLabelLocation(LabelType.Name);
-            float x;
-            float y;
-            // Feature check
-            if (!Options.Npc.ShowTags || !Options.Player.ShowTags)
+            var tagPos = Options.Npc.TagPosition;
+            float x, y;
+            // Feature and Entity check
+            if (!Options.Npc.ShowTags || this is Player)
             {
                 return;
             }
-            // Npc Tags
-            if (Options.Npc.ShowTags && !(this is Player))
+            // Custom Npc Tag
+            if (customNpcTag)
             {
-                // Custom Npc Tag
-                if (customNpcTag)
+                tagFileName = $@"Npc_{entityName}.png";
+            }
+            // Default Npc Tags.
+            else if (!customNpcTagOnly)
+            {
+                switch (Type)
                 {
-                    tagFileName = $@"Npc_{entityName}.png";
-                }
-                // Default Npc Tags.
-                if (!customNpcTag && !customNpcTagOnly)
-                {
-                    switch (Type)
-                    {
-                        case -1:
-                            // Default Tag when entity has aggression towards a target.
-                            tagFileName = Options.Npc.AggressiveTagIcon;
+                    case -1:
+                        // Default Tag when entity has aggression towards a target.
+                        tagFileName = Options.Npc.AggressiveTagIcon;
 
-                            break;
-                        case 0:
-                            // Default Tag when entity Attacks when attacked.
-                            tagFileName = Options.Npc.AttackWhenAttackedTagIcon;
+                        break;
+                    case 0:
+                        // Default Tag when entity Attacks when attacked.
+                        tagFileName = Options.Npc.AttackWhenAttackedTagIcon;
 
-                            break;
-                        case 1:
-                            // Default Tag when entity Attacks on sight.
-                            tagFileName = Options.Npc.AttackOnSightTagIcon;
+                        break;
+                    case 1:
+                        // Default Tag when entity Attacks on sight.
+                        tagFileName = Options.Npc.AttackOnSightTagIcon;
 
-                            break;
-                        case 3:
-                            // Default Tag when entity is Guard.
-                            tagFileName = Options.Npc.GuardTagIcon;
+                        break;
+                    case 3:
+                        // Default Tag when entity is Guard.
+                        tagFileName = Options.Npc.GuardTagIcon;
 
-                            break;
-                        case 2:
-                        default:
-                            // Default Tag when entity is Neutral.
-                            tagFileName = Options.Npc.NeutralTagIcon;
-
-                            break;
-                    }
-                }
-                // Now that we have the name of the sprite file, we load it as a texture.
-                GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
-                // Before we draw the sprite, lets have it's position set.
-                switch (npcTagPos)
-                {
-                    case NpcTagPos.Above:
+                        break;
+                    case 2:
                     default:
-                        // Position the tag 2 pixels above the name label.
-                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                        y = nameVertPos - tagTexture.GetHeight() - 2;
+                        // Default Tag when entity is Neutral.
+                        tagFileName = Options.Npc.NeutralTagIcon;
 
                         break;
-                    case NpcTagPos.Under:
-                        // Position the tag 2 pixels under the name label.
-                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                        y = nameVertPos + nameSize.Y + 2;
-
-                        break;
-                    case NpcTagPos.Prefix:
-                        // Position the tag as prefix (2 pixels left from the name label).
-                        x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
-                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
-
-                        break;
-                    case NpcTagPos.Suffix:
-                        // Position the tag as suffix (2 pixels right from the name label).
-                        x = nameCentHorPos + (nameSize.X / 2) + 6;
-                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
-
-                        break;
-                }
-                // And finally, we draw the tag.
-                if (tagTexture != null)
-                {
-                    Graphics.DrawGameTexture(tagTexture, x, y);
                 }
             }
-            // Player Tags
-            if (Options.Player.ShowTags && this is Player && customPlayerTag)
+            // Now that we have the name of the sprite file, we load it as a texture.
+            var tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
+            // If the texture is null, we do nothing.
+            if (tagTexture == null)
             {
-                // Custom Player Tag.
-                tagFileName = $@"Player_{entityName}.png";
-                // Now that we have the name of the sprite file, we load it as a texture.
-                GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
-                // Before we draw the sprite, lets have it's position set.
-                switch (playerTagPos)
-                {
-                    case PlayerTagPos.Above:
-                    default:
-                        // Position the tag 2 pixels above the name label.
-                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                        y = nameVertPos - tagTexture.GetHeight() - 2;
+                return;
+            }
+            // Before we draw the sprite, lets have it's position set.
+            switch (tagPos)
+            {
+                case TagPosition.Above:
+                default:
+                    // Position the tag 2 pixels above the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos - tagTexture.GetHeight() - 2;
 
-                        break;
-                    case PlayerTagPos.Under:
-                        // Position the tag 2 pixels under the name label.
-                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                        y = nameVertPos + nameSize.Y + 2;
+                    break;
+                case TagPosition.Under:
+                    // Position the tag 2 pixels under the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos + nameSize.Y + 2;
 
-                        break;
-                    case PlayerTagPos.Prefix:
-                        // Position the tag as prefix (2 pixels left from the name label).
-                        x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
-                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+                    break;
+                case TagPosition.Prefix:
+                    // Position the tag as prefix (2 pixels left from the name label).
+                    x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
 
-                        break;
-                    case PlayerTagPos.Suffix:
-                        // Position the tag as suffix (2 pixels right from the name label).
-                        x = nameCentHorPos + (nameSize.X / 2) + 6;
-                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+                    break;
+                case TagPosition.Suffix:
+                    // Position the tag as suffix (2 pixels right from the name label).
+                    x = nameCentHorPos + (nameSize.X / 2) + 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
 
-                        break;
-                }
-                // And finally, we draw the tag.
-                if (tagTexture != null)
-                {
-                    Graphics.DrawGameTexture(tagTexture, x, y);
-                }
+                    break;
+            }
+            // And finally, we draw the tag.
+            if (tagTexture != null)
+            {
+                Graphics.DrawGameTexture(tagTexture, x, y);
             }
         }
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1386,6 +1386,160 @@ namespace Intersect.Client.Entities
             );
         }
 
+        // Player Tags
+        public virtual void DrawTag(PlayerTagPos playerTagPos)
+        {
+            // Variables
+            string tagFileName = "";
+            string entityName = this.Name;
+            bool customPlayerTag = Options.Player.CustomTagIcons.Contains(entityName);
+            var nameSize = Graphics.Renderer.MeasureText(entityName, Graphics.EntityNameFont, 1);
+            var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
+            var nameVertPos = GetLabelLocation(LabelType.Name);
+            float x;
+            float y;
+            // Feature check and Entity type check.
+            if (!Options.Player.ShowTags || !(this is Player))
+            {
+                return;
+            }
+            // Custom Player Tag.
+            if (Options.Player.ShowTags && this is Player && customPlayerTag)
+            {
+                tagFileName = $@"Player_{entityName}.png";
+            }
+            // Now that we have the name of the sprite file, we load it as a texture.
+            GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
+            // Before we draw the sprite, lets have it's position set.
+            switch (playerTagPos)
+            {
+                case PlayerTagPos.Above:
+                default:
+                    // Position the tag 2 pixels above the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos - tagTexture.GetHeight() - 2;
+
+                    break;
+                case PlayerTagPos.Under:
+                    // Position the tag 2 pixels under the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos + nameSize.Y + 2;
+
+                    break;
+                case PlayerTagPos.Prefix:
+                    // Position the tag as prefix (2 pixels left from the name label).
+                    x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                    break;
+                case PlayerTagPos.Suffix:
+                    // Position the tag as suffix (2 pixels right from the name label).
+                    x = nameCentHorPos + (nameSize.X / 2) + 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                    break;
+            }
+            // And finally, we draw the tag.
+            if (tagTexture != null)
+            {
+                Graphics.DrawGameTexture(tagTexture, x, y);
+            }
+        }
+
+        // Npc Tags
+        public virtual void DrawTag(NpcTagPos npcTagPos)
+        {
+            // Variables
+            string tagFileName = "";
+            string entityName = this.Name;
+            bool customNpcTag = Options.Npc.CustomTagIcons.Contains(entityName);
+            bool customNpcTagOnly = Options.Npc.ShowCustomTagsOnly;
+            var nameSize = Graphics.Renderer.MeasureText(entityName, Graphics.EntityNameFont, 1);
+            var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
+            var nameVertPos = GetLabelLocation(LabelType.Name);
+            float x;
+            float y;
+            // Feature check and Entity type check.
+            if (!Options.Npc.ShowTags || this is Player)
+            {
+                return;
+            }
+            // Custom Npc Tag
+            if (Options.Npc.ShowTags && !(this is Player) && customNpcTag)
+            {
+                tagFileName = $@"Npc_{entityName}.png";
+            }
+            // Default Npc Tags.
+            if (Options.Npc.ShowTags && !(this is Player) && !customNpcTag && !customNpcTagOnly)
+            {
+                switch (Type)
+                {
+                    case -1:
+                        // Default Tag when entity has aggression towards a target.
+                        tagFileName = Options.Npc.AggressiveTagIcon;
+
+                        break;
+                    case 0:
+                        // Default Tag when entity Attacks when attacked.
+                        tagFileName = Options.Npc.AttackWhenAttackedTagIcon;
+
+                        break;
+                    case 1:
+                        // Default Tag when entity Attacks on sight.
+                        tagFileName = Options.Npc.AttackOnSightTagIcon;
+
+                        break;
+                    case 3:
+                        // Default Tag when entity is Guard.
+                        tagFileName = Options.Npc.GuardTagIcon;
+
+                        break;
+                    case 2:
+                    default:
+                        // Default Tag when entity is Neutral.
+                        tagFileName = Options.Npc.NeutralTagIcon;
+
+                        break;
+                }
+            }
+            // Now that we have the name of the sprite file, we load it as a texture.
+            GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
+            // Before we draw the sprite, lets have it's position set.
+            switch (npcTagPos)
+            {
+                case NpcTagPos.Above:
+                default:
+                    // Position the tag 2 pixels above the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos - tagTexture.GetHeight() - 2;
+
+                    break;
+                case NpcTagPos.Under:
+                    // Position the tag 2 pixels under the name label.
+                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                    y = nameVertPos + nameSize.Y + 2;
+
+                    break;
+                case NpcTagPos.Prefix:
+                    // Position the tag as prefix (2 pixels left from the name label).
+                    x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                    break;
+                case NpcTagPos.Suffix:
+                    // Position the tag as suffix (2 pixels right from the name label).
+                    x = nameCentHorPos + (nameSize.X / 2) + 6;
+                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                    break;
+            }
+            // And finally, we draw the tag.
+            if (tagTexture != null)
+            {
+                Graphics.DrawGameTexture(tagTexture, x, y);
+            }
+        }
+
         public float GetLabelLocation(LabelType type)
         {
             var y = GetTopPos() - 4;

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1479,10 +1479,7 @@ namespace Intersect.Client.Entities
                     break;
             }
             // And finally, we draw the tag.
-            if (tagTexture != null)
-            {
-                Graphics.DrawGameTexture(tagTexture, x, y);
-            }
+            Graphics.DrawGameTexture(tagTexture, x, y);
         }
 
         public float GetLabelLocation(LabelType type)

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1386,157 +1386,144 @@ namespace Intersect.Client.Entities
             );
         }
 
-        // Player Tags
-        public virtual void DrawTag(PlayerTagPos playerTagPos)
-        {
-            // Variables
-            string tagFileName = "";
-            string entityName = this.Name;
-            bool customPlayerTag = Options.Player.CustomTagIcons.Contains(entityName);
-            var nameSize = Graphics.Renderer.MeasureText(entityName, Graphics.EntityNameFont, 1);
-            var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
-            var nameVertPos = GetLabelLocation(LabelType.Name);
-            float x;
-            float y;
-            // Feature check and Entity type check.
-            if (!Options.Player.ShowTags || !(this is Player))
-            {
-                return;
-            }
-            // Custom Player Tag.
-            if (Options.Player.ShowTags && this is Player && customPlayerTag)
-            {
-                tagFileName = $@"Player_{entityName}.png";
-            }
-            // Now that we have the name of the sprite file, we load it as a texture.
-            GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
-            // Before we draw the sprite, lets have it's position set.
-            switch (playerTagPos)
-            {
-                case PlayerTagPos.Above:
-                default:
-                    // Position the tag 2 pixels above the name label.
-                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                    y = nameVertPos - tagTexture.GetHeight() - 2;
-
-                    break;
-                case PlayerTagPos.Under:
-                    // Position the tag 2 pixels under the name label.
-                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                    y = nameVertPos + nameSize.Y + 2;
-
-                    break;
-                case PlayerTagPos.Prefix:
-                    // Position the tag as prefix (2 pixels left from the name label).
-                    x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
-                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
-
-                    break;
-                case PlayerTagPos.Suffix:
-                    // Position the tag as suffix (2 pixels right from the name label).
-                    x = nameCentHorPos + (nameSize.X / 2) + 6;
-                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
-
-                    break;
-            }
-            // And finally, we draw the tag.
-            if (tagTexture != null)
-            {
-                Graphics.DrawGameTexture(tagTexture, x, y);
-            }
-        }
-
-        // Npc Tags
-        public virtual void DrawTag(NpcTagPos npcTagPos)
+        // Tags
+        public virtual void DrawTag(NpcTagPos npcTagPos, PlayerTagPos playerTagPos)
         {
             // Variables
             string tagFileName = "";
             string entityName = this.Name;
             bool customNpcTag = Options.Npc.CustomTagIcons.Contains(entityName);
+            bool customPlayerTag = Options.Player.CustomTagIcons.Contains(entityName);
             bool customNpcTagOnly = Options.Npc.ShowCustomTagsOnly;
             var nameSize = Graphics.Renderer.MeasureText(entityName, Graphics.EntityNameFont, 1);
             var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
             var nameVertPos = GetLabelLocation(LabelType.Name);
             float x;
             float y;
-            // Feature check and Entity type check.
-            if (!Options.Npc.ShowTags || this is Player)
+            // Feature check
+            if (!Options.Npc.ShowTags || !Options.Player.ShowTags)
             {
                 return;
             }
-            // Custom Npc Tag
-            if (Options.Npc.ShowTags && !(this is Player) && customNpcTag)
+            // Npc Tags
+            if (Options.Npc.ShowTags && !(this is Player))
             {
-                tagFileName = $@"Npc_{entityName}.png";
-            }
-            // Default Npc Tags.
-            if (Options.Npc.ShowTags && !(this is Player) && !customNpcTag && !customNpcTagOnly)
-            {
-                switch (Type)
+                // Custom Npc Tag
+                if (customNpcTag)
                 {
-                    case -1:
-                        // Default Tag when entity has aggression towards a target.
-                        tagFileName = Options.Npc.AggressiveTagIcon;
+                    tagFileName = $@"Npc_{entityName}.png";
+                }
+                // Default Npc Tags.
+                if (!customNpcTag && !customNpcTagOnly)
+                {
+                    switch (Type)
+                    {
+                        case -1:
+                            // Default Tag when entity has aggression towards a target.
+                            tagFileName = Options.Npc.AggressiveTagIcon;
 
-                        break;
-                    case 0:
-                        // Default Tag when entity Attacks when attacked.
-                        tagFileName = Options.Npc.AttackWhenAttackedTagIcon;
+                            break;
+                        case 0:
+                            // Default Tag when entity Attacks when attacked.
+                            tagFileName = Options.Npc.AttackWhenAttackedTagIcon;
 
-                        break;
-                    case 1:
-                        // Default Tag when entity Attacks on sight.
-                        tagFileName = Options.Npc.AttackOnSightTagIcon;
+                            break;
+                        case 1:
+                            // Default Tag when entity Attacks on sight.
+                            tagFileName = Options.Npc.AttackOnSightTagIcon;
 
-                        break;
-                    case 3:
-                        // Default Tag when entity is Guard.
-                        tagFileName = Options.Npc.GuardTagIcon;
+                            break;
+                        case 3:
+                            // Default Tag when entity is Guard.
+                            tagFileName = Options.Npc.GuardTagIcon;
 
-                        break;
-                    case 2:
+                            break;
+                        case 2:
+                        default:
+                            // Default Tag when entity is Neutral.
+                            tagFileName = Options.Npc.NeutralTagIcon;
+
+                            break;
+                    }
+                }
+                // Now that we have the name of the sprite file, we load it as a texture.
+                GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
+                // Before we draw the sprite, lets have it's position set.
+                switch (npcTagPos)
+                {
+                    case NpcTagPos.Above:
                     default:
-                        // Default Tag when entity is Neutral.
-                        tagFileName = Options.Npc.NeutralTagIcon;
+                        // Position the tag 2 pixels above the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos - tagTexture.GetHeight() - 2;
+
+                        break;
+                    case NpcTagPos.Under:
+                        // Position the tag 2 pixels under the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos + nameSize.Y + 2;
+
+                        break;
+                    case NpcTagPos.Prefix:
+                        // Position the tag as prefix (2 pixels left from the name label).
+                        x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                        break;
+                    case NpcTagPos.Suffix:
+                        // Position the tag as suffix (2 pixels right from the name label).
+                        x = nameCentHorPos + (nameSize.X / 2) + 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
 
                         break;
                 }
+                // And finally, we draw the tag.
+                if (tagTexture != null)
+                {
+                    Graphics.DrawGameTexture(tagTexture, x, y);
+                }
             }
-            // Now that we have the name of the sprite file, we load it as a texture.
-            GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
-            // Before we draw the sprite, lets have it's position set.
-            switch (npcTagPos)
+            // Player Tags
+            if (Options.Player.ShowTags && this is Player && customPlayerTag)
             {
-                case NpcTagPos.Above:
-                default:
-                    // Position the tag 2 pixels above the name label.
-                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                    y = nameVertPos - tagTexture.GetHeight() - 2;
+                // Custom Player Tag.
+                tagFileName = $@"Player_{entityName}.png";
+                // Now that we have the name of the sprite file, we load it as a texture.
+                GameTexture tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, tagFileName);
+                // Before we draw the sprite, lets have it's position set.
+                switch (playerTagPos)
+                {
+                    case PlayerTagPos.Above:
+                    default:
+                        // Position the tag 2 pixels above the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos - tagTexture.GetHeight() - 2;
 
-                    break;
-                case NpcTagPos.Under:
-                    // Position the tag 2 pixels under the name label.
-                    x = nameCentHorPos - (tagTexture.GetWidth() / 2);
-                    y = nameVertPos + nameSize.Y + 2;
+                        break;
+                    case PlayerTagPos.Under:
+                        // Position the tag 2 pixels under the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos + nameSize.Y + 2;
 
-                    break;
-                case NpcTagPos.Prefix:
-                    // Position the tag as prefix (2 pixels left from the name label).
-                    x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
-                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+                        break;
+                    case PlayerTagPos.Prefix:
+                        // Position the tag as prefix (2 pixels left from the name label).
+                        x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
 
-                    break;
-                case NpcTagPos.Suffix:
-                    // Position the tag as suffix (2 pixels right from the name label).
-                    x = nameCentHorPos + (nameSize.X / 2) + 6;
-                    y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+                        break;
+                    case PlayerTagPos.Suffix:
+                        // Position the tag as suffix (2 pixels right from the name label).
+                        x = nameCentHorPos + (nameSize.X / 2) + 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
 
-                    break;
-            }
-            // And finally, we draw the tag.
-            if (tagTexture != null)
-            {
-                Graphics.DrawGameTexture(tagTexture, x, y);
+                        break;
+                }
+                // And finally, we draw the tag.
+                if (tagTexture != null)
+                {
+                    Graphics.DrawGameTexture(tagTexture, x, y);
+                }
             }
         }
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2068,10 +2068,7 @@ namespace Intersect.Client.Entities
                         break;
                 }
                 // And finally, we draw the tag.
-                if (tagTexture != null)
-                {
-                    Graphics.DrawGameTexture(tagTexture, x, y);
-                }
+                Graphics.DrawGameTexture(tagTexture, x, y);
             }
         }
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2069,6 +2069,7 @@ namespace Intersect.Client.Entities
                 }
                 // And finally, we draw the tag.
                 Graphics.DrawGameTexture(tagTexture, x, y);
+            }
         }
 
         public void DrawTargets()

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2069,7 +2069,6 @@ namespace Intersect.Client.Entities
                 }
                 // And finally, we draw the tag.
                 Graphics.DrawGameTexture(tagTexture, x, y);
-            }
         }
 
         public void DrawTargets()

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -6,6 +6,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Entities.Projectiles;
+using Intersect.Client.Framework.File_Management;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game;
 using Intersect.Client.Interface.Game.EntityPanel;
@@ -20,7 +21,6 @@ using Intersect.Network.Packets.Server;
 using Newtonsoft.Json;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Utilities;
-using Intersect.Client.Items;
 
 namespace Intersect.Client.Entities
 {
@@ -2010,6 +2010,69 @@ namespace Intersect.Client.Entities
             base.DrawName(textColor, borderColor, backgroundColor);
             DrawLabels(HeaderLabel.Text, 0, HeaderLabel.Color, textColor, borderColor, backgroundColor);
             DrawLabels(FooterLabel.Text, 1, FooterLabel.Color, textColor, borderColor, backgroundColor);
+        }
+
+        // Tags
+        public override void DrawTag()
+        {
+            // Variables
+            string playerName = this.Name;
+            bool customPlayerTag = Options.Player.CustomTagIcons.Contains(playerName);
+            var nameSize = Graphics.Renderer.MeasureText(playerName, Graphics.EntityNameFont, 1);
+            var nameCentHorPos = (int)Math.Ceiling(GetCenterPos().X);
+            var nameVertPos = GetLabelLocation(LabelType.Name);
+            var tagPos = Options.Player.TagPosition;
+            float x, y;
+            // Feature Check
+            if (!Options.Player.ShowTags || !customPlayerTag)
+            {
+                return;
+            }
+            // Player Tags
+            else if (customPlayerTag)
+            {
+                // Lets load the player's custom tag texture right away.
+                var tagTexture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Tag, $@"Player_{playerName}.png");
+                // If the texture is null, we do nothing.
+                if (tagTexture == null)
+                {
+                    return;
+                }
+                // Before we draw the sprite, lets have it's position set.
+                switch (tagPos)
+                {
+                    case TagPosition.Above:
+                    default:
+                        // Position the tag 2 pixels above the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos - tagTexture.GetHeight() - 2;
+
+                        break;
+                    case TagPosition.Under:
+                        // Position the tag 2 pixels under the name label.
+                        x = nameCentHorPos - (tagTexture.GetWidth() / 2);
+                        y = nameVertPos + nameSize.Y + 2;
+
+                        break;
+                    case TagPosition.Prefix:
+                        // Position the tag as prefix (2 pixels left from the name label).
+                        x = nameCentHorPos - (nameSize.X / 2) - tagTexture.GetWidth() - 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                        break;
+                    case TagPosition.Suffix:
+                        // Position the tag as suffix (2 pixels right from the name label).
+                        x = nameCentHorPos + (nameSize.X / 2) + 6;
+                        y = nameVertPos + (nameSize.Y / 2) - (tagTexture.GetHeight() / 2);
+
+                        break;
+                }
+                // And finally, we draw the tag.
+                if (tagTexture != null)
+                {
+                    Graphics.DrawGameTexture(tagTexture, x, y);
+                }
+            }
         }
 
         public void DrawTargets()

--- a/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
@@ -204,6 +204,11 @@ namespace Intersect.Client.MonoGame.File_Management
             LoadTextureGroup("misc", mMiscDict);
         }
 
+        public override void LoadTags()
+        {
+            LoadTextureGroup("tags", mTagDict);
+        }
+
         public override void LoadFonts()
         {
             mFontDict.Clear();


### PR DESCRIPTION
Resolves #394 

This PR implements _Default and Custom Tags_ for **Npcs** **+** _Custom Tags_ for **Players**  !

> `Re-opened this PR because the initial code/idea changed a lot and it may be easier to review it on a single commit.`
> PS : _To whoever decides to review this (lodicolo was first reviewing) - i would like to ask if the development has a discord group or something similar that allows us to speak in real time in order to avoid unnnecesary PRs and commits. Thanks <3_

Devs are opted out of this feature by default (bool = **false** for **ShowTags** in server/resources/config.json), they may toggle it on if they want to test their own tags with Npcs and Players.

Few Examples of this Feature Implementation:

> ![CtsmNpc Players](https://user-images.githubusercontent.com/17498701/108653228-c54e3080-747a-11eb-881d-9f8fba96784e.png)
> _Custom Npc Tags (Doe Npc wearing its own tag) + Custom Player Tags (Rick wearing the Admin tag)_
> 
> ![2021-02-21 10_57_06-Intersect Client](https://user-images.githubusercontent.com/17498701/108653271-e151d200-747a-11eb-898a-4d02b9a48288.png)
> _Custom Npc Tags (Doe) + Custom Player Tags (Rick) + Default Npc Tags 
>(SomeNpc is an Entity Type 0 - AttackWhenAttacked)_
> 
> ![DWN3](https://user-images.githubusercontent.com/17498701/108653309-f3cc0b80-747a-11eb-8abd-f6de248974a6.png)
> _Above, Under, Prefix or Suffix, it doesn't matter, devs can choose where to position the tags._
> 
> ![big](https://user-images.githubusercontent.com/17498701/108653311-f464a200-747a-11eb-8b8a-d1b685b9d1dc.png)
> _Recommended sizes: 32x16, 64x32, 128x64 and so on. [2:1 px] - Even bigger tags will adjust properly to the desired position!_

### PR SUMMARY
- [x] [Tags] Created a texture dictionary for tags only, which load the sprites from the resource folder **"tags"**.
- [x] [Tags] Suggested size for Tag sprites is 32x16 px (.png). Devs can make bigger tags if they wish of course, the positioning of the tags its partially based on the size of the sprites now.
- [x] [Tags] TagPosition.cs with Enum TagPosition with types converted to strings for proper JSON config files set up - used for positioning the tags.

- [x] [Npcs] Created generic "DrawTag" public virtual void in Entity.cs + the proper checks so it doesn't render tags on Players.
- [x] [Npcs] Npcs may have _default tags_ and _custom tags._
- [x] [Npcs] Ability to toggle this function on and off, configurable through the npc options (_server/resources/config.json_).
- [x] [Npcs] Ability to set the default tags sprite file names, configurable through the npc options (_server/resources/config.json_).
- [x] [Npcs] Ability to set the position of the tags, configurable through the npc options (_server/resources/config.json_).
- [x] [Npcs] Ability to add custom tags for specific Npcs, configurable through the npc options (_server/resources/config.json_).
- [x] [Npcs] Ability to ONLY allow custom tags for Npcs, configurable through the npc options (_server/resources/config.json_).

- [x] [Players] Created it's own "DrawTag" public override void in Player.cs.
- [x] [Players] Players may have _custom tags only._
- [x] [Players] Ability to toggle this function on and off, configurable through the player options (_server/resources/config.json_).
- [x] [Players] Ability to set the position of the tags, configurable through the player options (_server/resources/config.json_).
- [x] [Players] Ability to add custom tags for specific Players, configurable through the player options (_server/resources/config.json_).

- [x] [Code Clean Up] - Thanks @lodicolo for guiding me!