### PR TITLE
Reduce NPC Aggression Packet Spam

### DIFF
--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -1392,7 +1392,6 @@ namespace Intersect.Server.Entities
                 if (mTargetFailCounter > mTargetFailMax)
                 {
                     CheckForResetLocation(true);
-                    PacketSender.SendNpcAggressionToProximity(this);
                 }
             }
 


### PR DESCRIPTION
This line shouldn't exist. It spams clients with npc aggression updates even when the aggression isn't changing