### PR TITLE
Fix projectile packets being sent too much

### DIFF
--- a/Intersect (Core)/Network/Packets/Server/ProjectileDeadPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ProjectileDeadPacket.cs
@@ -1,5 +1,6 @@
 ﻿using MessagePack;
 using System;
+using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {
@@ -11,17 +12,16 @@ namespace Intersect.Network.Packets.Server
         {
         }
 
-        public ProjectileDeadPacket(Guid projectileId, int spawnId)
+        public ProjectileDeadPacket(Guid[] projectileDeaths, KeyValuePair<Guid, int>[] spawnIndices)
         {
-            ProjectileId = projectileId;
-            SpawnId = spawnId;
+            ProjectileDeaths = projectileDeaths;
+            SpawnDeaths = spawnIndices;
         }
 
         [Key(0)]
-        public Guid ProjectileId { get; set; }
-
+        public Guid[] ProjectileDeaths { get; set; }
         [Key(1)]
-        public int SpawnId { get; set; }
+        public KeyValuePair<Guid, int>[] SpawnDeaths { get; set; }
 
     }
 

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -1289,10 +1289,26 @@ namespace Intersect.Client.Networking
         //ProjectileDeadPacket
         public void HandlePacket(IPacketSender packetSender, ProjectileDeadPacket packet)
         {
-            var entityId = packet.ProjectileId;
-            if (Globals.Entities.ContainsKey(entityId) && Globals.Entities[entityId].GetType() == typeof(Projectile))
+            if (packet.ProjectileDeaths != null)
             {
-                ((Projectile) Globals.Entities[entityId]).SpawnDead(packet.SpawnId);
+                foreach (var projDeath in packet.ProjectileDeaths)
+                {
+                    if (Globals.Entities.ContainsKey(projDeath) && Globals.Entities[projDeath].GetType() == typeof(Projectile))
+                    {
+                        Globals.Entities[projDeath]?.Dispose();
+                        Globals.EntitiesToDispose?.Add(projDeath);
+                    }
+                }
+            }
+            if (packet.SpawnDeaths != null)
+            {
+                foreach (var spawnDeath in packet.SpawnDeaths)
+                {
+                    if (Globals.Entities.ContainsKey(spawnDeath.Key) && Globals.Entities[spawnDeath.Key].GetType() == typeof(Projectile))
+                    {
+                        ((Projectile)Globals.Entities[spawnDeath.Key]).SpawnDead(spawnDeath.Value);
+                    }
+                }
             }
         }
 

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -935,7 +935,7 @@ namespace Intersect.Server.Entities
 
                                         if (spawn.IsAtLocation(MapId, X, Y, Z) && spawn.HitEntity(this))
                                         {
-                                            projectile.KillSpawn(spawn);
+                                            spawn.Dead = true;
                                         }
                                     }
                                 }

--- a/Intersect.Server/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server/Entities/ProjectileSpawn.cs
@@ -31,6 +31,8 @@ namespace Intersect.Server.Entities
 
         public byte Z;
 
+        public bool Dead;
+
         private List<Guid> mEntitiesCollided = new List<Guid>();
 
         public ProjectileSpawn(
@@ -167,11 +169,6 @@ namespace Intersect.Server.Entities
             }
 
             return false;
-        }
-
-        public void Dispose(int spawnIndex)
-        {
-            PacketSender.SendRemoveProjectileSpawn(MapId, Parent.Id, spawnIndex);
         }
 
     }

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -766,9 +766,9 @@ namespace Intersect.Server.Networking
         }
 
         //ProjectileDeadPacket
-        public static void SendRemoveProjectileSpawn(Guid mapId, Guid baseEntityId, int spawnIndex)
+        public static void SendRemoveProjectileSpawns(Guid mapId, Guid[] projDeaths, KeyValuePair<Guid, int>[] spawnDeaths)
         {
-            SendDataToProximity(mapId, new ProjectileDeadPacket(baseEntityId, spawnIndex));
+            SendDataToProximity(mapId, new ProjectileDeadPacket(projDeaths, spawnDeaths));
         }
 
         //EntityMovePacket


### PR DESCRIPTION
Batch projectile and projectile spawn deaths into a singular packet when updating maps