### PR TITLE
Added more npc reset options

### DIFF
--- a/Intersect (Core)/Config/NpcOptions.cs
+++ b/Intersect (Core)/Config/NpcOptions.cs
@@ -25,9 +25,19 @@
         public bool AllowNewResetLocationBeforeFinish = false;
 
         /// <summary>
-        /// Configures whether or not the NPC should completely restore its vitals and statusses once it resets.
+        /// Configures whether or not the NPC should completely restore its vitals and statusses once it starts resetting.
         /// </summary>
         public bool ResetVitalsAndStatusses = false;
+
+        /// <summary>
+        /// Configures whether or not the NPCs health should continue to reset to full and clear statuses while working its way to the reset location
+        /// </summary>
+        public bool ContinuouslyResetVitalsAndStatuses = false;
+
+        /// <summary>
+        /// If true, a NPC can be attacked while they are resetting. Their new attacker will become a target if they are within the reset radius
+        /// </summary>
+        public bool AllowEngagingWhileResetting = false;
 
         /// <summary>
         /// Configures whether or not the level of an Npc is shown next to their name.

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1796,7 +1796,7 @@ namespace Intersect.Server.Entities
 
                         enemyNpc.LootMap.TryAdd(Id, true);
                         enemyNpc.LootMapCache = enemyNpc.LootMap.Keys.ToArray();
-                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds);
+                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
                     }
 
                     enemy.NotifySwarm(this);
@@ -1832,7 +1832,7 @@ namespace Intersect.Server.Entities
                     //No Matter what, if we attack the entitiy, make them chase us
                     if (enemy is Npc enemyNpc)
                     {
-                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds);
+                        enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
                     }
 
                     enemy.NotifySwarm(this);

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -189,7 +189,16 @@ namespace Intersect.Server.Entities
             if (AggroCenterMap != null && pathTarget != null &&
                 pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
             {
-                return;
+                if (en == null)
+                {
+                                    return;
+
+                }
+                else
+                {
+                    return;
+
+                }
             }
 
             //Why are we doing all of this logic if we are assigning a target that we already have?
@@ -748,7 +757,7 @@ namespace Intersect.Server.Entities
                                 mResetting = false;
                             }
 
-                            ResetNpc();
+                            ResetNpc(Options.Instance.NpcOpts.ContinuouslyResetVitalsAndStatuses);
                             tempTarget = Target;
 
                             if (distance != mResetDistance)
@@ -1247,7 +1256,7 @@ namespace Intersect.Server.Entities
             return false;
         }
 
-        public void TryFindNewTarget(long timeMs, Guid avoidId = new Guid(), bool ignoreTimer = false)
+        public void TryFindNewTarget(long timeMs, Guid avoidId = new Guid(), bool ignoreTimer = false, Entity attackedBy = null)
         {
             if (!ignoreTimer && FindTargetWaitTime > timeMs)
             {
@@ -1259,7 +1268,18 @@ namespace Intersect.Server.Entities
             if (AggroCenterMap != null && pathTarget != null &&
                 pathTarget.TargetMapId == AggroCenterMap.Id && pathTarget.TargetX == AggroCenterX && pathTarget.TargetY == AggroCenterY)
             {
-                return;
+                if (!Options.Instance.NpcOpts.AllowEngagingWhileResetting || attackedBy == null || attackedBy.GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Instance.NpcOpts.ResetRadius, Base.ResetRadius))
+                {
+                    return;
+                }
+                else
+                {
+                    //We're resetting and just got attacked, and we allow reengagement.. let's stop resetting and fight!
+                    mPathFinder?.SetTarget(null);
+                    mResetting = false;
+                    AssignTarget(attackedBy);
+                    return;
+                }
             }
 
             var maps = MapInstance.Get(MapId).GetSurroundingMaps(true);


### PR DESCRIPTION
Should resolve #643 

ContinuouslyResetVitalsAndStatuses (true/false) will determine whether the npc restores hp/resets statuses while they work their way back to their reset point.

AllowEngagingWhileResetting (true/false) will determine if a npc that is resetting can be engaged again if their new attacker is within the reset radius.