### PR TITLE
Option for map animation attributes to also be blocked tiles

### DIFF
--- a/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
@@ -184,10 +184,13 @@ namespace Intersect.GameObjects.Maps
 
         public Guid AnimationId { get; set; }
 
+        public bool IsBlock { get; set; }
+
         public override MapAttribute Clone()
         {
             var att = (MapAnimationAttribute) base.Clone();
             att.AnimationId = AnimationId;
+            att.IsBlock = IsBlock;
 
             return att;
         }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1927,7 +1927,8 @@ namespace Intersect.Client.Entities
                 {
                     if (gameMap.Attributes[tmpX, tmpY] != null)
                     {
-                        if (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Blocked)
+                        if (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Blocked || 
+                            (gameMap.Attributes[tmpX, tmpY].Type == MapAttributes.Animation && ((MapAnimationAttribute)gameMap.Attributes[tmpX, tmpY]).IsBlock))
                         {
                             return -2;
                         }

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
@@ -124,6 +124,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.lightEditor = new Intersect.Editor.Forms.Controls.LightEditorCtrl();
             this.pnlAttributes = new System.Windows.Forms.Panel();
             this.pnlNpcs = new System.Windows.Forms.Panel();
+            this.chkAnimationBlock = new DarkUI.Controls.DarkCheckBox();
             this.grpResource.SuspendLayout();
             this.grpZResource.SuspendLayout();
             this.grpItem.SuspendLayout();
@@ -913,12 +914,13 @@ namespace Intersect.Editor.Forms.DockingElements
             // 
             this.grpAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpAnimation.Controls.Add(this.chkAnimationBlock);
             this.grpAnimation.Controls.Add(this.cmbAnimationAttribute);
             this.grpAnimation.Controls.Add(this.lblAnimation);
             this.grpAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpAnimation.Location = new System.Drawing.Point(6, 179);
             this.grpAnimation.Name = "grpAnimation";
-            this.grpAnimation.Size = new System.Drawing.Size(256, 69);
+            this.grpAnimation.Size = new System.Drawing.Size(256, 96);
             this.grpAnimation.TabIndex = 33;
             this.grpAnimation.TabStop = false;
             this.grpAnimation.Text = "Animaton";
@@ -1373,6 +1375,15 @@ namespace Intersect.Editor.Forms.DockingElements
             this.pnlNpcs.Name = "pnlNpcs";
             this.pnlNpcs.Size = new System.Drawing.Size(276, 422);
             this.pnlNpcs.TabIndex = 1;
+            // 
+            // chkAnimationBlock
+            // 
+            this.chkAnimationBlock.AutoSize = true;
+            this.chkAnimationBlock.Location = new System.Drawing.Point(16, 66);
+            this.chkAnimationBlock.Name = "chkAnimationBlock";
+            this.chkAnimationBlock.Size = new System.Drawing.Size(73, 17);
+            this.chkAnimationBlock.TabIndex = 27;
+            this.chkAnimationBlock.Text = "Block Tile";
             // 
             // FrmMapLayers
             // 

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -706,6 +706,7 @@ namespace Intersect.Editor.Forms.DockingElements
                 case MapAttributes.Animation:
                     var animationAttribute = attribute as MapAnimationAttribute;
                     animationAttribute.AnimationId = AnimationBase.IdFromList(cmbAnimationAttribute.SelectedIndex);
+                    animationAttribute.IsBlock = chkAnimationBlock.Checked;
                     break;
 
                 case MapAttributes.Slide:
@@ -981,6 +982,7 @@ namespace Intersect.Editor.Forms.DockingElements
             //Map Animation Groupbox
             grpAnimation.Text = Strings.Attributes.mapanimation;
             lblAnimation.Text = Strings.Attributes.mapanimation;
+            chkAnimationBlock.Text = Strings.Attributes.mapanimationblock;
 
             //Slide Groupbox
             grpSlide.Text = Strings.Attributes.slide;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -664,6 +664,8 @@ namespace Intersect.Editor.Localization
 
             public static LocalizedString mapanimation = @"Animation";
 
+            public static LocalizedString mapanimationblock = @"Block Tile";
+
             public static LocalizedString mapsound = @"Map Sound";
 
             public static LocalizedString npcavoid = @"NPC Avoid";

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -426,7 +426,7 @@ namespace Intersect.Server.Entities
                 var tileAttribute = mapInstance.Attributes[tileX, tileY];
                 if (tileAttribute != null)
                 {
-                    if (tileAttribute.Type == MapAttributes.Blocked)
+                    if (tileAttribute.Type == MapAttributes.Blocked || (tileAttribute.Type == MapAttributes.Animation && ((MapAnimationAttribute)tileAttribute).IsBlock))
                     {
                         return -2;
                     }

--- a/Intersect.Server/Entities/Projectile.cs
+++ b/Intersect.Server/Entities/Projectile.cs
@@ -380,7 +380,7 @@ namespace Intersect.Server.Entities
                 }
 
                 if (attribute != null &&
-                    attribute.Type == MapAttributes.Blocked &&
+                    (attribute.Type == MapAttributes.Blocked || attribute.Type == MapAttributes.Animation && ((MapAnimationAttribute)attribute).IsBlock) &&
                     !spawn.ProjectileBase.IgnoreMapBlocks)
                 {
                     killSpawn = true;

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -218,7 +218,8 @@ namespace Intersect.Server.Maps
                     if (Attributes[x, y] != null)
                     {
                         if (Attributes[x, y].Type == MapAttributes.Blocked ||
-                            Attributes[x, y].Type == MapAttributes.GrappleStone)
+                            Attributes[x, y].Type == MapAttributes.GrappleStone ||
+                            Attributes[x,y].Type == MapAttributes.Animation && ((MapAnimationAttribute)Attributes[x,y]).IsBlock) 
                         {
                             blocks.Add(new BytePoint(x, y));
                             npcBlocks.Add(new BytePoint(x, y));
@@ -1233,7 +1234,8 @@ namespace Intersect.Server.Maps
             }
 
             //Check if tile is a blocked attribute
-            if (Attributes[x, y] != null && (Attributes[x, y].Type == MapAttributes.Blocked))
+            if (Attributes[x, y] != null && (Attributes[x, y].Type == MapAttributes.Blocked ||
+                Attributes[x,y].Type == MapAttributes.Animation && ((MapAnimationAttribute)Attributes[x,y]).IsBlock))
             {
                 return true;
             }


### PR DESCRIPTION
Reintroducing this PR for map animation blocks.

This was all merged before in #369 for issue #368 but that PR broke the engine due to no sort of fault tolerance with how we were serializing map tiles/attributes.

Now that #379 as been merged this is safe to reintroduce.