### PR TITLE
Batch movement, action message, and animation packets

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -68,6 +68,8 @@ namespace Intersect
 
         public MetricsOptions Metrics = new MetricsOptions();
 
+        public PacketOptions Packets = new PacketOptions();
+
         public SmtpSettings SmtpSettings = new SmtpSettings();
 
         public static Options Instance { get; private set; }

--- a/Intersect (Core)/Config/PacketOptions.cs
+++ b/Intersect (Core)/Config/PacketOptions.cs
@@ -1,122 +1,22 @@
-﻿using Newtonsoft.Json;
-
-namespace Intersect.Config
+﻿namespace Intersect.Config
 {
-
     public class PacketOptions
     {
-
-        #region "Packet Sanitization and Hacking Detection Options"
+        #region "Packet Batching"
+        /// <summary>
+        /// If this value is true, player movements will be sent in the batch with npc/event movement when maps update instead of in realtime which will reduce workload on the network pool at the expense of being slightly delayed
+        /// </summary>
+        public bool BatchPlayerMovementPackets { get; set; } = true;
 
         /// <summary>
-        /// Assumed minimum ping a client will have when communicating with the server.
+        /// If this value is true, action messages will be sent in a batch maps update instead of in realtime which will reduce workload on the network pool at the expense of being slightly delayed 
         /// </summary>
-        public int MinimumPing { get; set; } = 10;
+        public bool BatchActionMessagePackets { get; set; } = true;
 
         /// <summary>
-        /// This factor is multiplied by the client ping in order to determine the acceptable error margin in packet timing.
+        /// If this value is true, animation packetswill be sent in a batch maps update instead of in realtime which will reduce workload on the network pool at the expense of being slightly delayed 
         /// </summary>
-        public float ErrorMarginFactor { get; set; } = 0.25f;
-
-
-        /// <summary>
-        /// Lower bounds of adjusted packet times with pings taken into account for packets to be considered natural.
-        /// </summary>
-        public int NaturalLowerMargin { get; set; } = 0;
-
-        /// <summary>
-        /// Upper bounds of adjusted packet times with pings taken into account for packets to be considered natural.
-        /// </summary>
-        public int NaturalUpperMargin { get; set; } = 500;
-
-        /// <summary>
-        /// Number of consecutive unnatural packets that are accepted in short intervals before being dropped. 
-        /// </summary>
-        public int AllowedSpikePackets { get; set; } = 5;
-
-        /// <summary>
-        /// The base amount of time in ms that we will forgive the client for being desyned
-        /// </summary>
-        public int BaseDesyncForegiveness { get; set; } = 400;
-
-        /// <summary>
-        /// A factor in whch we will allow the client time to shift from the servers before dropping packets with configured error margins taken into account.
-        /// </summary>
-        public float DesyncForgivenessFactor { get; set; } = 2.0f;
-
-        /// <summary>
-        /// A value measured in milliseconds in which a packet that is out of sync will be forgiven (no matter how out of sync) and timing will sent to the client.
-        /// </summary>
-        public int DesyncForgivenessInterval { get; set; } = 5000;
-
-        #endregion
-
-
-        #region "Packet Flooding Threshholds"
-        /// <summary>
-        /// Packet flooding detection thresholds for the game editor. (No Restrictions.)
-        /// </summary>
-        [JsonProperty("EditorFloodThreshholds")]
-        public FloodThreshholds EditorThreshholds = FloodThreshholds.Editor();
-
-        /// <summary>
-        /// Packet flooding detection thresholds for general players. Pretty strict. 
-        /// Might need to be adjusted if there is a lot of high paceed actions/movement/combat in your game.
-        /// </summary>
-        [JsonProperty("PlayerFloodThreshholds")]
-        public FloodThreshholds PlayerThreshholds = new FloodThreshholds();
-
-        /// <summary>
-        /// Packet flooding detection thresholds for mods/admins. Hopefully you trust these guys.
-        /// Limits need to be higher than general players since they can warp quickly around the world with shift click.
-        /// </summary>
-        [JsonProperty("ModAdminFloodThreshholds")]
-        public FloodThreshholds ModAdminThreshholds = FloodThreshholds.Editor();
-
-        /// <summary>
-        /// Packet flooding detection threshholds for all users who are not yet logged in.
-        /// </summary>
-        [JsonProperty("FloodThreshholds")] public FloodThreshholds Threshholds = FloodThreshholds.NotLoggedIn();
+        public bool BatchAnimationPackets { get; set; } = true;
         #endregion
     }
-
-    public class FloodThreshholds
-    {
-        /// <summary>
-        /// The largest a single packet should be before it's considered flooding.
-        /// </summary>
-        public int MaxPacketSize { get; set; } = 10240;
-
-        /// <summary>
-        /// The maximum number of packets we should receive from a cient before we consider them to be flooding.
-        /// </summary>
-        public int MaxPacketPerSec { get; set; } = 50;
-
-        /// <summary>
-        /// The number of packets received per second on average that we will accept before kicking the client for flooding.
-        /// </summary>
-        public int KickAvgPacketPerSec { get; set; } = 30;
-
-        public static FloodThreshholds Editor()
-        {
-            return new FloodThreshholds()
-            {
-                MaxPacketSize = int.MaxValue,
-                MaxPacketPerSec = int.MaxValue,
-                KickAvgPacketPerSec = int.MaxValue
-            };
-        }
-
-        public static FloodThreshholds NotLoggedIn()
-        {
-            return new FloodThreshholds()
-            {
-                MaxPacketSize = 10240,
-                MaxPacketPerSec = 5,
-                KickAvgPacketPerSec = 3,
-            };
-        }
-
-    }
-
 }

--- a/Intersect (Core)/Config/PacketSecurityOptions.cs
+++ b/Intersect (Core)/Config/PacketSecurityOptions.cs
@@ -1,0 +1,122 @@
+﻿using Newtonsoft.Json;
+
+namespace Intersect.Config
+{
+
+    public class PacketSecurityOptions
+    {
+
+        #region "Packet Sanitization and Hacking Detection Options"
+
+        /// <summary>
+        /// Assumed minimum ping a client will have when communicating with the server.
+        /// </summary>
+        public int MinimumPing { get; set; } = 10;
+
+        /// <summary>
+        /// This factor is multiplied by the client ping in order to determine the acceptable error margin in packet timing.
+        /// </summary>
+        public float ErrorMarginFactor { get; set; } = 0.25f;
+
+
+        /// <summary>
+        /// Lower bounds of adjusted packet times with pings taken into account for packets to be considered natural.
+        /// </summary>
+        public int NaturalLowerMargin { get; set; } = 0;
+
+        /// <summary>
+        /// Upper bounds of adjusted packet times with pings taken into account for packets to be considered natural.
+        /// </summary>
+        public int NaturalUpperMargin { get; set; } = 500;
+
+        /// <summary>
+        /// Number of consecutive unnatural packets that are accepted in short intervals before being dropped. 
+        /// </summary>
+        public int AllowedSpikePackets { get; set; } = 5;
+
+        /// <summary>
+        /// The base amount of time in ms that we will forgive the client for being desyned
+        /// </summary>
+        public int BaseDesyncForegiveness { get; set; } = 400;
+
+        /// <summary>
+        /// A factor in whch we will allow the client time to shift from the servers before dropping packets with configured error margins taken into account.
+        /// </summary>
+        public float DesyncForgivenessFactor { get; set; } = 2.0f;
+
+        /// <summary>
+        /// A value measured in milliseconds in which a packet that is out of sync will be forgiven (no matter how out of sync) and timing will sent to the client.
+        /// </summary>
+        public int DesyncForgivenessInterval { get; set; } = 5000;
+
+        #endregion
+
+
+        #region "Packet Flooding Threshholds"
+        /// <summary>
+        /// Packet flooding detection thresholds for the game editor. (No Restrictions.)
+        /// </summary>
+        [JsonProperty("EditorFloodThreshholds")]
+        public FloodThreshholds EditorThreshholds = FloodThreshholds.Editor();
+
+        /// <summary>
+        /// Packet flooding detection thresholds for general players. Pretty strict. 
+        /// Might need to be adjusted if there is a lot of high paceed actions/movement/combat in your game.
+        /// </summary>
+        [JsonProperty("PlayerFloodThreshholds")]
+        public FloodThreshholds PlayerThreshholds = new FloodThreshholds();
+
+        /// <summary>
+        /// Packet flooding detection thresholds for mods/admins. Hopefully you trust these guys.
+        /// Limits need to be higher than general players since they can warp quickly around the world with shift click.
+        /// </summary>
+        [JsonProperty("ModAdminFloodThreshholds")]
+        public FloodThreshholds ModAdminThreshholds = FloodThreshholds.Editor();
+
+        /// <summary>
+        /// Packet flooding detection threshholds for all users who are not yet logged in.
+        /// </summary>
+        [JsonProperty("FloodThreshholds")] public FloodThreshholds Threshholds = FloodThreshholds.NotLoggedIn();
+        #endregion
+    }
+
+    public class FloodThreshholds
+    {
+        /// <summary>
+        /// The largest a single packet should be before it's considered flooding.
+        /// </summary>
+        public int MaxPacketSize { get; set; } = 10240;
+
+        /// <summary>
+        /// The maximum number of packets we should receive from a cient before we consider them to be flooding.
+        /// </summary>
+        public int MaxPacketPerSec { get; set; } = 50;
+
+        /// <summary>
+        /// The number of packets received per second on average that we will accept before kicking the client for flooding.
+        /// </summary>
+        public int KickAvgPacketPerSec { get; set; } = 30;
+
+        public static FloodThreshholds Editor()
+        {
+            return new FloodThreshholds()
+            {
+                MaxPacketSize = int.MaxValue,
+                MaxPacketPerSec = int.MaxValue,
+                KickAvgPacketPerSec = int.MaxValue
+            };
+        }
+
+        public static FloodThreshholds NotLoggedIn()
+        {
+            return new FloodThreshholds()
+            {
+                MaxPacketSize = 10240,
+                MaxPacketPerSec = 5,
+                KickAvgPacketPerSec = 3,
+            };
+        }
+
+    }
+
+}

--- a/Intersect (Core)/Config/SecurityOptions.cs
+++ b/Intersect (Core)/Config/SecurityOptions.cs
@@ -10,7 +10,7 @@ namespace Intersect.Config
 
         public List<string> IpBlacklist = new List<string>();
 
-        [JsonProperty("Packets")] public PacketOptions PacketOpts = new PacketOptions();
+        [JsonProperty("Packets")] public PacketSecurityOptions PacketOpts = new PacketSecurityOptions();
 
         public bool CheckIp(string ip)
         {

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -382,6 +382,7 @@
     <Compile Include="Network\Packets\Client\HotbarSwapPacket.cs" />
     <Compile Include="Network\Packets\Client\HotbarUpdatePacket.cs" />
     <Compile Include="Network\Packets\Client\LoginPacket.cs" />
+    <Compile Include="Network\Packets\Server\ActionMsgPackets.cs" />
     <Compile Include="Network\Packets\Server\EntityMovementPackets.cs" />
     <Compile Include="Network\Packets\Server\MapEntityStatusPacket.cs" />
     <Compile Include="Network\Packets\Server\MapEntityVitalsPacket.cs" />

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -219,6 +219,7 @@
     <Compile Include="Config\MetricsOptions.cs" />
     <Compile Include="Config\NpcOptions.cs" />
     <Compile Include="Config\PacketOptions.cs" />
+    <Compile Include="Config\PacketSecurityOptions.cs" />
     <Compile Include="Config\PartyOptions.cs" />
     <Compile Include="Config\ProcessingOptions.cs" />
     <Compile Include="Config\SecurityOptions.cs" />
@@ -389,6 +390,7 @@
     <Compile Include="Network\Packets\Client\LogoutPacket.cs" />
     <Compile Include="Network\Packets\Server\AnnouncementPacket.cs" />
     <Compile Include="Network\Packets\Server\CancelCastPacket.cs" />
+    <Compile Include="Network\Packets\Server\PlayAnimationPackets.cs" />
     <Compile Include="Network\Packets\SlotQuantityPacket.cs" />
     <Compile Include="Network\Packets\Client\SwapBankItemsPacket.cs" />
     <Compile Include="Network\Packets\Client\MovePacket.cs" />

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -382,6 +382,7 @@
     <Compile Include="Network\Packets\Client\HotbarSwapPacket.cs" />
     <Compile Include="Network\Packets\Client\HotbarUpdatePacket.cs" />
     <Compile Include="Network\Packets\Client\LoginPacket.cs" />
+    <Compile Include="Network\Packets\Server\EntityMovementPackets.cs" />
     <Compile Include="Network\Packets\Server\MapEntityStatusPacket.cs" />
     <Compile Include="Network\Packets\Server\MapEntityVitalsPacket.cs" />
     <Compile Include="Network\Packets\Client\LogoutPacket.cs" />

--- a/Intersect (Core)/Network/Packets/Server/ActionMsgPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/ActionMsgPackets.cs
@@ -1,0 +1,24 @@
+﻿using MessagePack;
+using System;
+
+namespace Intersect.Network.Packets.Server
+{
+    [MessagePackObject]
+    public class ActionMsgPackets : IntersectPacket
+    {
+        //Parameterless Constructor for MessagePack
+        public ActionMsgPackets()
+        {
+        }
+
+        public ActionMsgPackets(ActionMsgPacket[] packets)
+        {
+            Packets = packets;
+        }
+
+        [Key(0)]
+        public ActionMsgPacket[] Packets { get; set; }
+
+    }
+
+}

--- a/Intersect (Core)/Network/Packets/Server/EntityMovementPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityMovementPackets.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+using Intersect.Enums;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server
+{
+    [MessagePackObject]
+    public class EntityMovementPackets : IntersectPacket
+    {
+        //Parameterless Constructor for MessagePack
+        public EntityMovementPackets()
+        {
+        }
+
+        public EntityMovementPackets(EntityMovePacket[] globalMovements, EntityMovePacket[] localMovements)
+        {
+            GlobalMovements = globalMovements;
+            LocalMovements = localMovements;
+        }
+
+        [Key(0)]
+        public EntityMovePacket[] GlobalMovements { get; set; }
+
+        [Key(1)]
+        public EntityMovePacket[] LocalMovements { get; set; }
+
+    }
+
+}

--- a/Intersect (Core)/Network/Packets/Server/PlayAnimationPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/PlayAnimationPackets.cs
@@ -1,0 +1,24 @@
+﻿using MessagePack;
+using System;
+
+namespace Intersect.Network.Packets.Server
+{
+    [MessagePackObject]
+    public class PlayAnimationPackets : IntersectPacket
+    {
+        //Parameterless Constructor for MessagePack
+        public PlayAnimationPackets()
+        {
+        }
+
+        public PlayAnimationPackets(PlayAnimationPacket[] packets)
+        {
+            Packets = packets;
+        }
+
+        [Key(0)]
+        public PlayAnimationPacket[] Packets { get; set; }
+
+    }
+
+}

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -1341,6 +1341,15 @@ namespace Intersect.Client.Networking
             }
         }
 
+        //PlayAnimationPackets
+        public void HandlePacket(IPacketSender sender, PlayAnimationPackets packet)
+        {
+            foreach (var pkt in packet.Packets)
+            {
+                HandlePacket(pkt);
+            }
+        }
+
         //PlayAnimationPacket
         public void HandlePacket(IPacketSender packetSender, PlayAnimationPacket packet)
         {

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -517,6 +517,26 @@ namespace Intersect.Client.Networking
             //TODO ? If admin window is open update it
         }
 
+        //EntityMovementPackets
+        public void HandlePacket(IPacketSender packetSender, EntityMovementPackets packet)
+        {
+            if (packet.GlobalMovements != null)
+            {
+                foreach (var pkt in packet.GlobalMovements)
+                {
+                    HandlePacket(pkt);
+                }
+            }
+
+            if (packet.LocalMovements != null)
+            {
+                foreach (var pkt in packet.LocalMovements)
+                {
+                    HandlePacket(pkt);
+                }
+            }
+        }
+
         //EntityMovePacket
         public void HandlePacket(IPacketSender packetSender, EntityMovePacket packet)
         {

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -481,6 +481,15 @@ namespace Intersect.Client.Networking
             Interface.Interface.GameUi.AnnouncementWindow.ShowAnnouncement(packet.Message, packet.Duration);   
         }
 
+        //ActionMsgPackets
+        public void HandlePacket(IPacketSender packetSender, ActionMsgPackets packet)
+        {
+            foreach (var pkt in packet.Packets)
+            {
+                HandlePacket(pkt);
+            }
+        }
+
         //ActionMsgPacket
         public void HandlePacket(IPacketSender packetSender, ActionMsgPacket packet)
         {

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -504,6 +504,7 @@
     <Compile Include="General\Time.cs" />
     <Compile Include="Localization\CommandsNamespace.cs" />
     <Compile Include="Localization\Strings.cs" />
+    <Compile Include="Maps\MapActionMessages.cs" />
     <Compile Include="Maps\MapEntityMovements.cs" />
     <Compile Include="Maps\MapInstance.cs" />
     <Compile Include="Maps\MapItemInstance.cs" />

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -505,6 +505,7 @@
     <Compile Include="Localization\CommandsNamespace.cs" />
     <Compile Include="Localization\Strings.cs" />
     <Compile Include="Maps\MapActionMessages.cs" />
+    <Compile Include="Maps\MapAnimations.cs" />
     <Compile Include="Maps\MapEntityMovements.cs" />
     <Compile Include="Maps\MapInstance.cs" />
     <Compile Include="Maps\MapItemInstance.cs" />

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -504,6 +504,7 @@
     <Compile Include="General\Time.cs" />
     <Compile Include="Localization\CommandsNamespace.cs" />
     <Compile Include="Localization\Strings.cs" />
+    <Compile Include="Maps\MapEntityMovements.cs" />
     <Compile Include="Maps\MapInstance.cs" />
     <Compile Include="Maps\MapItemInstance.cs" />
     <Compile Include="Maps\MapItemSpawn.cs" />

--- a/Intersect.Server/Maps/MapActionMessages.cs
+++ b/Intersect.Server/Maps/MapActionMessages.cs
@@ -32,7 +32,7 @@ namespace Intersect.Server.Maps
                     };
                     foreach (var plyr in nearbyPlayers)
                     {
-                        plyr.SendPacket(pkt);
+                        plyr.SendPacket(pkt, Network.TransmissionMode.Any);
                     }
                     mActionMessages.Clear();
                 }

--- a/Intersect.Server/Maps/MapActionMessages.cs
+++ b/Intersect.Server/Maps/MapActionMessages.cs
@@ -1,0 +1,42 @@
+﻿using Intersect.Network.Packets.Server;
+using Intersect.Server.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Server.Maps
+{
+    public class MapActionMessages
+    {
+        public List<ActionMsgPacket> mActionMessages = new List<ActionMsgPacket>();
+
+        public void Add(ActionMsgPacket pkt)
+        {
+            lock (mActionMessages)
+            {
+                mActionMessages.Add(pkt);
+            }
+        }
+
+        public void SendPackets(HashSet<Player> nearbyPlayers)
+        {
+            if (mActionMessages.Count > 0)
+            {
+                lock (mActionMessages)
+                {
+                    var pkt = new ActionMsgPackets()
+                    {
+                        Packets = mActionMessages.ToArray()
+                    };
+                    foreach (var plyr in nearbyPlayers)
+                    {
+                        plyr.SendPacket(pkt);
+                    }
+                    mActionMessages.Clear();
+                }
+            }
+        }
+    }
+}

--- a/Intersect.Server/Maps/MapAnimations.cs
+++ b/Intersect.Server/Maps/MapAnimations.cs
@@ -4,33 +4,33 @@ using System.Collections.Generic;
 
 namespace Intersect.Server.Maps
 {
-    public class MapActionMessages
+    public class MapAnimations
     {
-        public List<ActionMsgPacket> mActionMessages = new List<ActionMsgPacket>();
+        public List<PlayAnimationPacket> mAnimations = new List<PlayAnimationPacket>();
 
-        public void Add(ActionMsgPacket pkt)
+        public void Add(PlayAnimationPacket pkt)
         {
-            lock (mActionMessages)
+            lock (mAnimations)
             {
-                mActionMessages.Add(pkt);
+                mAnimations.Add(pkt);
             }
         }
 
         public void SendPackets(HashSet<Player> nearbyPlayers)
         {
-            if (mActionMessages.Count > 0)
+            if (mAnimations.Count > 0)
             {
-                lock (mActionMessages)
+                lock (mAnimations)
                 {
-                    var pkt = new ActionMsgPackets()
+                    var pkt = new PlayAnimationPackets()
                     {
-                        Packets = mActionMessages.ToArray()
+                        Packets = mAnimations.ToArray()
                     };
                     foreach (var plyr in nearbyPlayers)
                     {
                         plyr.SendPacket(pkt, Network.TransmissionMode.Any);
                     }
-                    mActionMessages.Clear();
+                    mAnimations.Clear();
                 }
             }
         }

--- a/Intersect.Server/Maps/MapEntityMovements.cs
+++ b/Intersect.Server/Maps/MapEntityMovements.cs
@@ -1,0 +1,62 @@
+﻿using Intersect.Network.Packets.Server;
+using Intersect.Server.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Server.Maps
+{
+    public class MapEntityMovements
+    {
+        private Dictionary<Guid, List<EntityMovePacket>> mMovements = new Dictionary<Guid, List<EntityMovePacket>>();
+
+        public void Add(Entity en, bool correction, Player forPlayer = null)
+        {
+            lock (mMovements)
+            {
+                var id = forPlayer?.Id ?? Guid.Empty;
+                if (!mMovements.ContainsKey(id))
+                {
+                    mMovements.Add(id, new List<EntityMovePacket>());
+                }
+                mMovements[id].Add(new EntityMovePacket(en.Id, en.GetEntityType(), en.MapId, (byte)en.X, (byte)en.Y, (byte)en.Dir, correction));
+            }
+        }
+
+        public void SendPackets(MapInstance map)
+        {
+            if (mMovements.Count > 0)
+            {
+                lock (mMovements)
+                {
+                    var players = new HashSet<Player>();
+                    foreach (var surrMap in map.GetSurroundingMaps(true))
+                    {
+                        foreach (var plyr in surrMap.GetPlayersOnMap())
+                        {
+                            players.Add(plyr);
+                        }
+                    }
+
+                    var globalMovements = mMovements.ContainsKey(Guid.Empty) ? mMovements[Guid.Empty].ToArray() : null;
+                    foreach (var player in players)
+                    {
+                        var localMovements = mMovements.ContainsKey(player.Id) ? mMovements[player.Id].ToArray() : null;
+                        if (globalMovements != null || localMovements != null)
+                        {
+                            var pkt = new EntityMovementPackets()
+                            {
+                                GlobalMovements = globalMovements,
+                                LocalMovements = localMovements
+                            };
+                            player.SendPacket(pkt);
+                        }
+                    }
+                    mMovements.Clear();
+                }
+            }
+        }
+    }
+}

--- a/Intersect.Server/Maps/MapEntityMovements.cs
+++ b/Intersect.Server/Maps/MapEntityMovements.cs
@@ -25,23 +25,14 @@ namespace Intersect.Server.Maps
             }
         }
 
-        public void SendPackets(MapInstance map)
+        public void SendPackets(HashSet<Player> nearbyPlayers)
         {
             if (mMovements.Count > 0)
             {
                 lock (mMovements)
                 {
-                    var players = new HashSet<Player>();
-                    foreach (var surrMap in map.GetSurroundingMaps(true))
-                    {
-                        foreach (var plyr in surrMap.GetPlayersOnMap())
-                        {
-                            players.Add(plyr);
-                        }
-                    }
-
                     var globalMovements = mMovements.ContainsKey(Guid.Empty) ? mMovements[Guid.Empty].ToArray() : null;
-                    foreach (var player in players)
+                    foreach (var player in nearbyPlayers)
                     {
                         var localMovements = mMovements.ContainsKey(player.Id) ? mMovements[player.Id].ToArray() : null;
                         if (globalMovements != null || localMovements != null)

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -76,6 +76,7 @@ namespace Intersect.Server.Maps
         private Guid[] mSurroundingMapsIdsWithSelf = new Guid[0];
         private MapInstance[] mSurroundingMaps = new MapInstance[0];
         private MapInstance[] mSurroundingMapsWithSelf = new MapInstance[0];
+        private MapEntityMovements mEntityMovements = new MapEntityMovements();
 
         [JsonIgnore]
         [NotMapped]
@@ -1083,6 +1084,9 @@ namespace Intersect.Server.Maps
                     }
                 }
 
+                //Send Batched Movement Packet
+                mEntityMovements.SendPackets(this);
+
                 LastUpdateTime = timeMs;
             }
         }
@@ -1419,6 +1423,13 @@ namespace Intersect.Server.Maps
             return locations;
         }
 
+        #region"Packet Batching"
+        public void AddBatchedMovement(Entity en, bool correction, Player forPlayer)
+        {
+            mEntityMovements.Add(en, correction, forPlayer);
+        }
+
+        #endregion
     }
 
 }

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -77,6 +77,7 @@ namespace Intersect.Server.Maps
         private MapInstance[] mSurroundingMaps = new MapInstance[0];
         private MapInstance[] mSurroundingMapsWithSelf = new MapInstance[0];
         private MapEntityMovements mEntityMovements = new MapEntityMovements();
+        private MapActionMessages mActionMessages = new MapActionMessages();
 
         [JsonIgnore]
         [NotMapped]
@@ -1085,7 +1086,17 @@ namespace Intersect.Server.Maps
                 }
 
                 //Send Batched Movement Packet
-                mEntityMovements.SendPackets(this);
+                var nearbyPlayers = new HashSet<Player>();
+                foreach (var map in surrMaps)
+                {
+                    foreach (var plyr in map.GetPlayersOnMap())
+                    {
+                        nearbyPlayers.Add(plyr);
+                    }
+                }
+
+                mEntityMovements.SendPackets(nearbyPlayers);
+                mActionMessages.SendPackets(nearbyPlayers);
 
                 LastUpdateTime = timeMs;
             }
@@ -1427,6 +1438,11 @@ namespace Intersect.Server.Maps
         public void AddBatchedMovement(Entity en, bool correction, Player forPlayer)
         {
             mEntityMovements.Add(en, correction, forPlayer);
+        }
+
+        public void AddBatchedActionMessage(ActionMsgPacket packet)
+        {
+            mActionMessages.Add(packet);
         }
 
         #endregion

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -78,6 +78,7 @@ namespace Intersect.Server.Maps
         private MapInstance[] mSurroundingMapsWithSelf = new MapInstance[0];
         private MapEntityMovements mEntityMovements = new MapEntityMovements();
         private MapActionMessages mActionMessages = new MapActionMessages();
+        private MapAnimations mMapAnimations = new MapAnimations();
 
         [JsonIgnore]
         [NotMapped]
@@ -1097,6 +1098,7 @@ namespace Intersect.Server.Maps
 
                 mEntityMovements.SendPackets(nearbyPlayers);
                 mActionMessages.SendPackets(nearbyPlayers);
+                mMapAnimations.SendPackets(nearbyPlayers);
 
                 LastUpdateTime = timeMs;
             }
@@ -1443,6 +1445,11 @@ namespace Intersect.Server.Maps
         public void AddBatchedActionMessage(ActionMsgPacket packet)
         {
             mActionMessages.Add(packet);
+        }
+
+        public void AddBatchedAnimation(PlayAnimationPacket packet)
+        {
+            mMapAnimations.Add(packet);
         }
 
         #endregion

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -773,6 +773,14 @@ namespace Intersect.Server.Networking
         //EntityMovePacket
         public static void SendEntityMove(Entity en, bool correction = false)
         {
+            //TODO: Should we send player movements instantly? Maybe an option? In a local environment I really can't tell a difference.. might as well batch imo.
+            var map = en?.Map;
+            if (map != null)
+            {
+                map.AddBatchedMovement(en, correction, null);
+                return;
+            }
+
             SendDataToProximity(
                 en.MapId,
                 new EntityMovePacket(
@@ -784,6 +792,14 @@ namespace Intersect.Server.Networking
         //EntityMovePacket
         public static void SendEntityMoveTo(Player player, Entity en, bool correction = false)
         {
+            //TODO: Should we send player movements instantly? Maybe an option? In a local environment I really can't tell a difference.. might as well batch imo.
+            var map = en?.Map;
+            if (map != null)
+            {
+                map.AddBatchedMovement(en, correction, player);
+                return;
+            }
+
             player.SendPacket(
                 new EntityMovePacket(
                     en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, correction

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -773,7 +773,6 @@ namespace Intersect.Server.Networking
         //EntityMovePacket
         public static void SendEntityMove(Entity en, bool correction = false)
         {
-            //TODO: Should we send player movements instantly? Maybe an option? In a local environment I really can't tell a difference.. might as well batch imo.
             var map = en?.Map;
             if (map != null)
             {
@@ -781,18 +780,18 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            SendDataToProximity(
-                en.MapId,
-                new EntityMovePacket(
-                    en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, correction
-                ), null, TransmissionMode.Any
-            );
+            //TODO: Revisit and add options to send /some/ (potentially player) packets instantly if needed -- I can't tell a difference between instant/not running locally so this may never be required.
+            //SendDataToProximity(
+            //    en.MapId,
+            //    new EntityMovePacket(
+            //        en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, correction
+            //    ), null, TransmissionMode.Any
+            //);
         }
 
         //EntityMovePacket
         public static void SendEntityMoveTo(Player player, Entity en, bool correction = false)
         {
-            //TODO: Should we send player movements instantly? Maybe an option? In a local environment I really can't tell a difference.. might as well batch imo.
             var map = en?.Map;
             if (map != null)
             {
@@ -800,11 +799,12 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            player.SendPacket(
-                new EntityMovePacket(
-                    en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, correction
-                )
-            );
+            //TODO: Revisit and add options to send /some/ (potentially player) packets instantly if needed -- I can't tell a difference between instant/not running locally so this may never be required.
+            //player.SendPacket(
+            //    new EntityMovePacket(
+            //        en.Id, en.GetEntityType(), en.MapId, (byte) en.X, (byte) en.Y, (byte) en.Dir, correction
+            //    )
+            //);
         }
 
         //EntityVitalsPacket
@@ -1755,12 +1755,13 @@ namespace Intersect.Server.Networking
         //ActionMsgPacket
         public static void SendActionMsg(Entity en, string message, Color color)
         {
-            if (en == null || en.Map == null)
+            var map = en?.Map;
+            if (map == null)
             {
                 return;
             }
 
-            SendDataToProximity(en.MapId, new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
+            map.AddBatchedActionMessage(new ActionMsgPacket(en.MapId, en.X, en.Y, message, color));
         }
 
         //EnterMapPacket


### PR DESCRIPTION
Send entity movement, action message, and animation packets with each map update instead of in realtime (configurable).

This will reduce network and server load with minimal/no visual difference on the client end.