### PR TITLE
Client performance tweaks

### DIFF
--- a/Intersect (Core)/GameObjects/LightBase.cs
+++ b/Intersect (Core)/GameObjects/LightBase.cs
@@ -63,6 +63,28 @@
 
         public int TileY { get; set; }
 
+
+        /// <summary>
+        /// Only checks for matching colors, intensity, and expand values... so we know if we can group lights and render them with the same shader values to boost performance.
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return Intensity ^ (int)Expand ^ Color?.A ?? 0 ^ Color?.R ?? 0 ^ Color?.G ?? 0 ^ Color?.B ?? 0;
+        }
+
+        /// <summary>
+        /// Only checks for matching colors, intensity, and expand values... so we know if we can group lights and render them with the same shader values to boost performance.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is LightBase light)
+                return Intensity == light.Intensity && Color == light.Color && Expand == light.Expand;
+            return false;
+        }
+
     }
 
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -228,12 +228,15 @@ namespace Intersect.Client.Entities
             get => mTransformedSprite;
             set
             {
-                mTransformedSprite = value;
-                Texture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, mTransformedSprite);
-                LoadAnimationTextures(mTransformedSprite);
-                if (value == "")
+                if (mTransformedSprite != value)
                 {
-                    MySprite = mMySprite;
+                    mTransformedSprite = value;
+                    Texture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, mTransformedSprite);
+                    LoadAnimationTextures(mTransformedSprite);
+                    if (value == "")
+                    {
+                        MySprite = mMySprite;
+                    }
                 }
             }
         }
@@ -243,9 +246,12 @@ namespace Intersect.Client.Entities
             get => mMySprite;
             set
             {
-                mMySprite = value;
-                Texture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, mMySprite);
-                LoadAnimationTextures(mMySprite);
+                if (mMySprite != value)
+                {
+                    mMySprite = value;
+                    Texture = Globals.ContentManager.GetTexture(GameContentManager.TextureType.Entity, mMySprite);
+                    LoadAnimationTextures(mMySprite);
+                }
             }
         }
 

--- a/Intersect.Client/Interface/Game/DebugMenu.cs
+++ b/Intersect.Client/Interface/Game/DebugMenu.cs
@@ -131,12 +131,14 @@ namespace Intersect.Client.Interface.Game
             mEntitiesDrawnLabel.Text = Strings.Debug.entitiesdrawn.ToString(+Graphics.EntitiesDrawn);
             mLightsDrawnLabel.Text = Strings.Debug.lightsdrawn.ToString(Graphics.LightsDrawn);
             mTimeLabel.Text = Strings.Debug.time.ToString(Time.GetTime());
-            mInterfaceObjectsLabel.Text = Strings.Debug.interfaceobjects.ToString(Interface.GameUi.GameCanvas.Children.ToArray().SelectManyRecursive(x => x.Children).ToArray().Length);
         }
 
         public void Show()
         {
             mDebugWindow.IsHidden = false;
+
+            //This linq query takes too long and hurts fps, so let's only update this label when opening the debug menu
+            mInterfaceObjectsLabel.Text = Strings.Debug.interfaceobjects.ToString(Interface.GameUi.GameCanvas.Children.ToArray().SelectManyRecursive(x => x.Children).ToArray().Length);
         }
 
         public bool IsVisible()

--- a/Intersect.Client/MonoGame/Graphics/MonoShader.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoShader.cs
@@ -5,7 +5,7 @@ using Intersect.IO.Files;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-
+using System.Collections.Generic;
 using System.IO;
 
 namespace Intersect.Client.MonoGame.Graphics
@@ -18,6 +18,10 @@ namespace Intersect.Client.MonoGame.Graphics
 
         private bool mValuesChanged = false;
 
+        private Dictionary<string, Color> Colors = new Dictionary<string, Color>();
+
+        private Dictionary<string, float> Floats = new Dictionary<string, float>();
+
         public MonoShader(string shaderName, ContentManager contentManager) : base(shaderName)
         {
             using (var resourceStream = typeof(MonoShader).Assembly.GetManifestResourceStream(shaderName))
@@ -29,8 +33,19 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override void SetFloat(string key, float val)
         {
-            mShader.Parameters[key].SetValue(val);
-            mValuesChanged = true;
+            if (!Floats.ContainsKey(key))
+            {
+                Floats.Add(key, val);
+                mValuesChanged = true;
+            }
+            else
+            {
+                if (Floats[key] != val)
+                {
+                    Floats[key] = val;
+                    mValuesChanged = true;
+                }
+            }
         }
 
         public override void SetInt(string key, int val)
@@ -40,9 +55,19 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override void SetColor(string key, Color val)
         {
-            var vec = new Vector4(val.R / 255f, val.G / 255f, val.B / 255f, val.A / 255f);
-            mShader.Parameters[key].SetValue(vec);
-            mValuesChanged = true;
+            if (!Colors.ContainsKey(key))
+            {
+                Colors.Add(key, val);
+                mValuesChanged = true;
+            }
+            else
+            {
+                if (Colors[key].A != val.A || Colors[key].R != val.R || Colors[key].G != val.G || Colors[key].B != val.B)
+                {
+                    Colors[key] = val;
+                    mValuesChanged = true;
+                }
+            }
         }
 
         public override void SetVector2(string key, Pointf val)
@@ -58,6 +83,18 @@ namespace Intersect.Client.MonoGame.Graphics
         public override void ResetChanged()
         {
             mValuesChanged = false;
+
+            //Set Pending
+            foreach (var clr in Colors)
+            {
+                var vec = new Vector4(clr.Value.R / 255f, clr.Value.G / 255f, clr.Value.B / 255f, clr.Value.A / 255f);
+                mShader.Parameters[clr.Key].SetValue(vec);
+            }
+
+            foreach (var f in Floats)
+            {
+                mShader.Parameters[f.Key].SetValue(f.Value);
+            }
         }
 
         public override object GetShader()


### PR DESCRIPTION
Few client sided performance tweaks to pump out a few more fps
- Fix excessive disk usage loading assets when sprites haven't changed
- Only set the interface count debug label when opening the window, because the linq query takes a lot of processing time
- Tweaks to shaders & lighting so we can batch lights with matching settings and improve rendering performance.