### PR TITLE
Small UI Tweaks

### DIFF
--- a/Intersect.Client.Framework/File Management/GameContentManager.cs
+++ b/Intersect.Client.Framework/File Management/GameContentManager.cs
@@ -85,6 +85,8 @@ namespace Intersect.Client.Framework.File_Management
 
         protected Dictionary<string, GameAudioSource> mSoundDict = new Dictionary<string, GameAudioSource>();
 
+        protected Dictionary<KeyValuePair<UI, string>, string> mUiDict = new Dictionary<KeyValuePair<UI, string>, string>();
+
         /// <summary>
         /// Contains all indexed files and their caches from sound pack files.
         /// </summary>
@@ -364,8 +366,17 @@ namespace Intersect.Client.Framework.File_Management
             return mSoundDict.TryGetValue(name.ToLower(), out var sound) ? sound : null;
         }
 
-        public virtual string GetUIJson(UI stage, string name, string resolution)
+        public virtual string GetUIJson(UI stage, string name, string resolution, out bool loadedCachedJson)
         {
+            var key = new KeyValuePair<UI, string>(stage, $"{name}.{resolution}.json");
+            if (mUiDict.TryGetValue(key, out string uiJson))
+            {
+                loadedCachedJson = true;
+                return uiJson;
+            }
+
+            loadedCachedJson = false;
+
             var layouts = Path.Combine("resources", "gui", "layouts");
             if (!Directory.Exists(layouts))
             {
@@ -396,7 +407,9 @@ namespace Intersect.Client.Framework.File_Management
                 {
                     try
                     {
-                        return File.ReadAllText(path);
+                        var json = File.ReadAllText(path);
+                        mUiDict.Add(key, json);
+                        return json;
                     }
                     catch (Exception ex)
                     {

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -827,8 +827,9 @@ namespace Intersect.Client.Framework.Gwen.Control
         {
             try
             {
+                bool cacheUsed = false;
                 var obj = JsonConvert.DeserializeObject<JObject>(
-                    GameContentManager.Current?.GetUIJson(stage, Name, resolution)
+                    GameContentManager.Current?.GetUIJson(stage, Name, resolution, out cacheUsed)
                 );
 
                 if (obj != null)
@@ -836,6 +837,12 @@ namespace Intersect.Client.Framework.Gwen.Control
                     LoadJson(obj);
                     ProcessAlignments();
                 }
+
+                if (obj == null || cacheUsed)
+                {
+                    saveOutput = false;
+                }
+
             }
             catch (Exception exception)
             {
@@ -843,7 +850,10 @@ namespace Intersect.Client.Framework.Gwen.Control
                 throw new Exception("Error loading json ui for " + CanonicalName, exception);
             }
 
-            GameContentManager.Current?.SaveUIJson(stage, Name, GetJsonUI(), resolution);
+            if (saveOutput)
+            {
+                GameContentManager.Current?.SaveUIJson(stage, Name, GetJsonUI(), resolution);
+            }
         }
 
         public virtual void LoadJson(JToken obj)

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -37,7 +37,7 @@ namespace Intersect.Client.Framework.Gwen.Control
         ///     Initializes a new instance of the <see cref="Menu" /> class.
         /// </summary>
         /// <param name="parent">Parent control.</param>
-        public Menu(Base parent, string name) : base(parent, name)
+        public Menu(Base parent, string name = "") : base(parent, name)
         {
             SetBounds(0, 0, 10, 10);
             Padding = Padding.Two;

--- a/Intersect.Client.Framework/Gwen/Control/Menu.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Menu.cs
@@ -37,7 +37,7 @@ namespace Intersect.Client.Framework.Gwen.Control
         ///     Initializes a new instance of the <see cref="Menu" /> class.
         /// </summary>
         /// <param name="parent">Parent control.</param>
-        public Menu(Base parent) : base(parent)
+        public Menu(Base parent, string name) : base(parent, name)
         {
             SetBounds(0, 0, 10, 10);
             Padding = Padding.Two;
@@ -46,6 +46,7 @@ namespace Intersect.Client.Framework.Gwen.Control
             AutoHideBars = true;
             EnableScroll(false, true);
             DeleteOnClose = false;
+            Name = name;
         }
 
         internal override bool IsMenuComponent => true;

--- a/Intersect.Client/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client/Interface/Game/Chat/Chatbox.cs
@@ -305,6 +305,8 @@ namespace Intersect.Client.Interface.Game.Chat
         {
             mChatboxInput.Text = msg;
             mChatboxInput.Focus();
+            mChatboxInput.CursorEnd = mChatboxInput.Text.Length;
+            mChatboxInput.CursorPos = mChatboxInput.Text.Length;
         }
 
         private void ChatboxRow_Clicked(Base sender, ClickedEventArgs arguments)


### PR DESCRIPTION
- [Bug Fix] When chatbox input text is set (for sending pms and such) the text input carot moves to the end of the line
- [Extension?] Gwen Menus can now be assigned names via a constructor parameter which will allow us to load uis for them via json files
- [Performance Fix] UI json files are cached in memory upon loading, so we reduce disk reads if we need to load them again (like we do for bank slots)