### PR TITLE
Added partials to most classes that mods would want to expand on

### DIFF
--- a/Intersect.Client/Entities/Animation.cs
+++ b/Intersect.Client/Entities/Animation.cs
@@ -11,7 +11,7 @@ using Intersect.GameObjects;
 namespace Intersect.Client.Entities
 {
 
-    public class Animation
+    public partial class Animation
     {
 
         public bool AutoRotate;

--- a/Intersect.Client/Entities/ChatBubble.cs
+++ b/Intersect.Client/Entities/ChatBubble.cs
@@ -9,7 +9,7 @@ using Intersect.Client.General;
 namespace Intersect.Client.Entities
 {
 
-    public class ChatBubble
+    public partial class ChatBubble
     {
 
         private GameTexture mBubbleTex;

--- a/Intersect.Client/Entities/Critter.cs
+++ b/Intersect.Client/Entities/Critter.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Intersect.Client.Entities
 {
-    public class Critter : Entity
+    public partial class Critter : Entity
     {
         private MapCritterAttribute mAttribute;
         private long mLastMove = -1;

--- a/Intersect.Client/Entities/Dash.cs
+++ b/Intersect.Client/Entities/Dash.cs
@@ -6,7 +6,7 @@ using Intersect.Client.Maps;
 namespace Intersect.Client.Entities
 {
 
-    public class Dash
+    public partial class Dash
     {
 
         private int mChangeDirection = -1;

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -24,7 +24,7 @@ using Intersect.Utilities;
 namespace Intersect.Client.Entities
 {
 
-    public class Entity
+    public partial class Entity
     {
 
         public enum LabelType

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -14,7 +14,7 @@ using Intersect.Network.Packets.Server;
 namespace Intersect.Client.Entities.Events
 {
 
-    public class Event : Entity
+    public partial class Event : Entity
     {
 
         public string Desc = "";

--- a/Intersect.Client/Entities/PartyMember.cs
+++ b/Intersect.Client/Entities/PartyMember.cs
@@ -5,7 +5,7 @@ using Intersect.Enums;
 namespace Intersect.Client.Entities
 {
 
-    public class PartyMember
+    public partial class PartyMember
     {
 
         public Guid Id;

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -25,7 +25,7 @@ using Intersect.Client.Items;
 namespace Intersect.Client.Entities
 {
 
-    public class Player : Entity
+    public partial class Player : Entity
     {
 
         public delegate void InventoryUpdated();

--- a/Intersect.Client/Entities/Projectiles/Projectile.cs
+++ b/Intersect.Client/Entities/Projectiles/Projectile.cs
@@ -10,7 +10,7 @@ using Intersect.Network.Packets.Server;
 namespace Intersect.Client.Entities.Projectiles
 {
 
-    public class Projectile : Entity
+    public partial class Projectile : Entity
     {
 
         private bool mDisposing;

--- a/Intersect.Client/Entities/Projectiles/ProjectileSpawns.cs
+++ b/Intersect.Client/Entities/Projectiles/ProjectileSpawns.cs
@@ -6,7 +6,7 @@ using Intersect.GameObjects;
 namespace Intersect.Client.Entities.Projectiles
 {
 
-    public class ProjectileSpawns
+    public partial class ProjectileSpawns
     {
 
         public Animation Anim;

--- a/Intersect.Client/Entities/Resource.cs
+++ b/Intersect.Client/Entities/Resource.cs
@@ -13,7 +13,7 @@ using Intersect.Network.Packets.Server;
 namespace Intersect.Client.Entities
 {
 
-    public class Resource : Entity
+    public partial class Resource : Entity
     {
 
         private bool _waitingForTilesets;

--- a/Intersect.Client/Entities/Status.cs
+++ b/Intersect.Client/Entities/Status.cs
@@ -6,7 +6,7 @@ using Intersect.Enums;
 namespace Intersect.Client.Entities
 {
 
-    public class Status
+    public partial class Status
     {
 
         public string Data = "";

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Linq;
 namespace Intersect.Client.Localization
 {
 
-    public static class Strings
+    public static partial class Strings
     {
 
         private static char[] mQuantityTrimChars = new char[] {'.', '0'};

--- a/Intersect.Client/Maps/ActionMessage.cs
+++ b/Intersect.Client/Maps/ActionMessage.cs
@@ -3,7 +3,7 @@
 namespace Intersect.Client.Maps
 {
 
-    public class ActionMessage
+    public partial class ActionMessage
     {
 
         public Color Clr = new Color();

--- a/Intersect.Client/Maps/MapAnimation.cs
+++ b/Intersect.Client/Maps/MapAnimation.cs
@@ -5,7 +5,7 @@ using System;
 namespace Intersect.Client.Maps
 {
 
-    public class MapAnimation : Animation
+    public partial class MapAnimation : Animation
     {
         public Guid Id { get; } = Guid.NewGuid();
 

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -26,7 +26,7 @@ using Newtonsoft.Json;
 namespace Intersect.Client.Maps
 {
 
-    public class MapInstance : MapBase, IGameObject<Guid, MapInstance>
+    public partial class MapInstance : MapBase, IGameObject<Guid, MapInstance>
     {
 
         //Client Only Values

--- a/Intersect.Client/Maps/WeatherParticle.cs
+++ b/Intersect.Client/Maps/WeatherParticle.cs
@@ -10,7 +10,7 @@ using Intersect.GameObjects;
 namespace Intersect.Client.Maps
 {
 
-    public class WeatherParticle
+    public partial class WeatherParticle
     {
 
         private List<WeatherParticle> _RemoveParticle;

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -28,7 +28,7 @@ using System.Linq;
 namespace Intersect.Client.Networking
 {
 
-    internal sealed class PacketHandler
+    internal sealed partial class PacketHandler
     {
         private sealed class VirtualPacketSender : IPacketSender
         {

--- a/Intersect.Client/Networking/PacketSender.cs
+++ b/Intersect.Client/Networking/PacketSender.cs
@@ -10,7 +10,7 @@ using Intersect.Network.Packets.Client;
 namespace Intersect.Client.Networking
 {
 
-    public static class PacketSender
+    public static partial class PacketSender
     {
 
         public static void SendPing()

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json.Linq;
 namespace Intersect.Editor.Localization
 {
 
-    public static class Strings
+    public static partial class Strings
     {
 
         public static string GetEventConditionalDesc(VariableIsCondition condition)

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -18,7 +18,7 @@ using Intersect.Network.Packets.Server;
 
 namespace Intersect.Editor.Networking
 {
-    internal sealed class PacketHandler
+    internal sealed partial class PacketHandler
     {
         private sealed class VirtualPacketSender : IPacketSender
         {

--- a/Intersect.Editor/Networking/PacketSender.cs
+++ b/Intersect.Editor/Networking/PacketSender.cs
@@ -12,7 +12,7 @@ using MapListUpdates = Intersect.Enums.MapListUpdates;
 namespace Intersect.Editor.Networking
 {
 
-    public static class PacketSender
+    public static partial class PacketSender
     {
 
         public static void SendPing()

--- a/Intersect.Server/Entities/Combat/Buff.cs
+++ b/Intersect.Server/Entities/Combat/Buff.cs
@@ -4,7 +4,7 @@ using Intersect.Server.General;
 namespace Intersect.Server.Entities.Combat
 {
 
-    public class Buff
+    public partial class Buff
     {
 
         public int FlatStatcount;

--- a/Intersect.Server/Entities/Combat/Dash.cs
+++ b/Intersect.Server/Entities/Combat/Dash.cs
@@ -5,7 +5,7 @@ using Intersect.Server.Networking;
 namespace Intersect.Server.Entities.Combat
 {
 
-    public class Dash
+    public partial class Dash
     {
 
         public byte Direction;

--- a/Intersect.Server/Entities/Combat/DoT.cs
+++ b/Intersect.Server/Entities/Combat/DoT.cs
@@ -9,7 +9,7 @@ using Intersect.Server.General;
 namespace Intersect.Server.Entities.Combat
 {
 
-    public class DoT
+    public partial class DoT
     {
         public Guid Id = Guid.NewGuid();
 

--- a/Intersect.Server/Entities/Combat/Stat.cs
+++ b/Intersect.Server/Entities/Combat/Stat.cs
@@ -10,7 +10,7 @@ using Intersect.Server.General;
 namespace Intersect.Server.Entities.Combat
 {
 
-    public class Stat
+    public partial class Stat
     {
 
         private ConcurrentDictionary<SpellBase, Buff> mBuff = new ConcurrentDictionary<SpellBase, Buff>();

--- a/Intersect.Server/Entities/Combat/Status.cs
+++ b/Intersect.Server/Entities/Combat/Status.cs
@@ -12,7 +12,7 @@ using Intersect.Utilities;
 namespace Intersect.Server.Entities.Combat
 {
 
-    public class Status
+    public partial class Status
     {
 
         public string Data = "";

--- a/Intersect.Server/Entities/Events/CommandInstance.cs
+++ b/Intersect.Server/Entities/Events/CommandInstance.cs
@@ -7,7 +7,7 @@ using Intersect.GameObjects.Events.Commands;
 namespace Intersect.Server.Entities.Events
 {
 
-    public class CommandInstance
+    public partial class CommandInstance
     {
 
         public enum EventResponse

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -20,7 +20,7 @@ using Intersect.Utilities;
 namespace Intersect.Server.Entities.Events
 {
 
-    public static class CommandProcessing
+    public static partial class CommandProcessing
     {
 
         public static void ProcessCommand(EventCommand command, Player player, Event instance)

--- a/Intersect.Server/Entities/Events/Conditions.cs
+++ b/Intersect.Server/Entities/Events/Conditions.cs
@@ -13,7 +13,7 @@ using Intersect.Server.Maps;
 
 namespace Intersect.Server.Entities.Events
 {
-    public static class Conditions
+    public static partial class Conditions
     {
         public static bool CanSpawnPage(EventPage page, Player player, Event activeInstance)
         {

--- a/Intersect.Server/Entities/Events/Event.cs
+++ b/Intersect.Server/Entities/Events/Event.cs
@@ -13,7 +13,7 @@ using Intersect.Server.Networking;
 namespace Intersect.Server.Entities.Events
 {
 
-    public class Event
+    public partial class Event
     {
 
         public EventBase BaseEvent;

--- a/Intersect.Server/Entities/Events/EventPageInstance.cs
+++ b/Intersect.Server/Entities/Events/EventPageInstance.cs
@@ -13,7 +13,7 @@ using Intersect.Utilities;
 namespace Intersect.Server.Entities.Events
 {
 
-    public class EventPageInstance : Entity
+    public partial class EventPageInstance : Entity
     {
 
         public EventBase BaseEvent;

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -22,7 +22,7 @@ using Intersect.Utilities;
 namespace Intersect.Server.Entities
 {
 
-    public class Npc : Entity
+    public partial class Npc : Entity
     {
 
         //Spell casting

--- a/Intersect.Server/Entities/Projectile.cs
+++ b/Intersect.Server/Entities/Projectile.cs
@@ -14,7 +14,7 @@ using Intersect.Server.Networking;
 namespace Intersect.Server.Entities
 {
 
-    public class Projectile : Entity
+    public partial class Projectile : Entity
     {
 
         public ProjectileBase Base;

--- a/Intersect.Server/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server/Entities/ProjectileSpawn.cs
@@ -10,7 +10,7 @@ using Intersect.Server.Networking;
 namespace Intersect.Server.Entities
 {
 
-    public class ProjectileSpawn
+    public partial class ProjectileSpawn
     {
 
         public byte Dir;

--- a/Intersect.Server/Entities/Resource.cs
+++ b/Intersect.Server/Entities/Resource.cs
@@ -14,7 +14,7 @@ using Intersect.Utilities;
 namespace Intersect.Server.Entities
 {
 
-    public class Resource : Entity
+    public partial class Resource : Entity
     {
 
         // Resource Number

--- a/Intersect.Server/Maps/MapGrid.cs
+++ b/Intersect.Server/Maps/MapGrid.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 namespace Intersect.Server.Maps
 {
 
-    public class MapGrid
+    public partial class MapGrid
     {
 
         private readonly int mMyIndex;

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json;
 namespace Intersect.Server.Maps
 {
 
-    public class MapInstance : MapBase
+    public partial class MapInstance : MapBase
     {
 
         private static MapInstances sLookup;

--- a/Intersect.Server/Maps/MapItemInstance.cs
+++ b/Intersect.Server/Maps/MapItemInstance.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Intersect.Server.Maps
 {
 
-    public class MapItem : Item
+    public partial class MapItem : Item
     {
 
         [JsonIgnore] public int AttributeSpawnX = -1;

--- a/Intersect.Server/Maps/MapItemSpawn.cs
+++ b/Intersect.Server/Maps/MapItemSpawn.cs
@@ -3,7 +3,7 @@
 namespace Intersect.Server.Maps
 {
 
-    public class MapItemSpawn
+    public partial class MapItemSpawn
     {
         public Guid Id { get; } = Guid.NewGuid();
 

--- a/Intersect.Server/Maps/MapNpcSpawn.cs
+++ b/Intersect.Server/Maps/MapNpcSpawn.cs
@@ -3,7 +3,7 @@
 namespace Intersect.Server.Maps
 {
 
-    public class MapNpcSpawn
+    public partial class MapNpcSpawn
     {
 
         public Entity Entity;

--- a/Intersect.Server/Maps/MapResourceSpawn.cs
+++ b/Intersect.Server/Maps/MapResourceSpawn.cs
@@ -3,7 +3,7 @@
 namespace Intersect.Server.Maps
 {
 
-    public class MapResourceSpawn
+    public partial class MapResourceSpawn
     {
 
         public Resource Entity;

--- a/Intersect.Server/Maps/MapTrapInstance.cs
+++ b/Intersect.Server/Maps/MapTrapInstance.cs
@@ -9,7 +9,7 @@ using Intersect.Server.Maps;
 namespace Intersect.Server.Classes.Maps
 {
 
-    public class MapTrapInstance
+    public partial class MapTrapInstance
     {
         public Guid Id { get; } = Guid.NewGuid();
 

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -34,7 +34,7 @@ using System.Text;
 
 namespace Intersect.Server.Networking
 {
-    internal sealed class PacketHandler
+    internal sealed partial class PacketHandler
     {
         public IServerContext Context { get; }
 

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json;
 namespace Intersect.Server.Networking
 {
 
-    public static class PacketSender
+    public static partial class PacketSender
     {
 
         //Cached GameDataPacket that gets sent to clients


### PR DESCRIPTION
Having these classes being defined as partials would benefit mods so that they can add functions/variables to these classes in separate files.

For example if you added a packet for Keypress instead of adding a HandlePacket(KeyPress) in PacketHandler.cs you could create a PacketHandler.Keypress.cs and extend PacketHandler which would effectively be the same thing but there would be no possibility for merge conflicts with the base engine file.