### PR TITLE
Fix item names drawing when hovering over the proper coordinates on ANY map

### DIFF
--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -754,7 +754,7 @@ namespace Intersect.Client.Maps
             var mapId = Id;
 
             // Is this an actual location on this map?
-            if (Globals.Me.GetRealLocation(ref x, ref y, ref mapId))
+            if (Globals.Me.GetRealLocation(ref x, ref y, ref mapId) && mapId == Id)
             {
                 // Apparently it is! Do we have any items to render here?
                 var tileItems = new List<MapItemInstance>();


### PR DESCRIPTION
TODO: Make issue

Basically when you have an item on Tile 15, 15, and you over hover tile 15,15 on an adjacent map the item name will draw as if we are hovering over it. This small edit fixes that.