### PR TITLE
Make the engine not dependent upon default text values in the db

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -153,7 +153,7 @@ namespace Intersect.GameObjects
         public string JsonColor
         {
             get => JsonConvert.SerializeObject(Color);
-            set => Color = JsonConvert.DeserializeObject<Color>(value);
+            set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
         }
 
         /// <summary>

--- a/Intersect (Core)/GameObjects/NpcBase.cs
+++ b/Intersect (Core)/GameObjects/NpcBase.cs
@@ -203,7 +203,7 @@ namespace Intersect.GameObjects
         public string JsonColor
         {
             get => JsonConvert.SerializeObject(Color);
-            set => Color = JsonConvert.DeserializeObject<Color>(value);
+            set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
         }
 
         /// <summary>

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -86,7 +86,7 @@ namespace Intersect.Server.Entities
         public string JsonColor
         {
             get => JsonConvert.SerializeObject(Color);
-            set => Color = JsonConvert.DeserializeObject<Color>(value);
+            set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
         }
 
         /// <summary>

--- a/Intersect.Server/Migrations/20201017065035_AddColorToEntities.cs
+++ b/Intersect.Server/Migrations/20201017065035_AddColorToEntities.cs
@@ -9,8 +9,7 @@ namespace Intersect.Server.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "Color",
                 table: "Players",
-                nullable: false,
-                defaultValue: "{\"A\":255,\"R\":255,\"G\":255,\"B\":255}");
+                nullable: false);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Intersect.Server/Migrations/Game/20201016122614_AddItemAndNpcColors.cs
+++ b/Intersect.Server/Migrations/Game/20201016122614_AddItemAndNpcColors.cs
@@ -9,14 +9,12 @@ namespace Intersect.Server.Migrations.Game
             migrationBuilder.AddColumn<string>(
                 name: "Color",
                 table: "Npcs",
-                nullable: false,
-                defaultValue: "{\"A\":255,\"R\":255,\"G\":255,\"B\":255}");
+                nullable: false);
 
             migrationBuilder.AddColumn<string>(
                 name: "Color",
                 table: "Items",
-                nullable: false,
-                defaultValue: "{\"A\":255,\"R\":255,\"G\":255,\"B\":255}");
+                nullable: false);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
This resolves migration issues adding color columns in Mysql environments -- #459 