### PR TITLE
Fix resource editor & event editor icon

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -786,6 +786,8 @@ namespace Intersect.Editor.Forms.Editors.Events
         {
             InitializeComponent();
             mCurrentMap = currentMap;
+			
+			this.Icon = Properties.Resources.Icon;
         }
 
         private void frmEvent_Load(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -48,6 +48,13 @@ namespace Intersect.Editor.Forms.Editors
             ApplyHooks();
             InitializeComponent();
 
+            cmbToolType.Items.Clear();
+            cmbToolType.Items.Add(Strings.General.none);
+            cmbToolType.Items.AddRange(Options.ToolTypes.ToArray());
+            cmbEvent.Items.Clear();
+            cmbEvent.Items.Add(Strings.General.none);
+            cmbEvent.Items.AddRange(EventBase.Names);
+
             lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
         }
         private void AssignEditorItem(Guid id)


### PR DESCRIPTION
Despite the invalid report, this fixes the resource editor crashing upon opening up #709 