### PR TITLE
Make item binding options more granular

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -65,7 +65,36 @@ namespace Intersect.GameObjects
             set => EquipmentAnimationId = value?.Id ?? Guid.Empty;
         }
 
-        public bool Bound { get; set; }
+        /// <summary>
+        /// Defines whether or not this item can be dropped by a player.
+        /// </summary>
+        [Column("Bound")]   // Not exactly the cleanest solution, since CanDrop and Bound set to true will do the opposite.. But don't want to leave a bogus field!
+        public bool CanDrop { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether or not this item can be dropped by a player on death.
+        /// </summary>
+        public bool CanDropOnDeath { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether or not this item can be traded by a player to another player.
+        /// </summary>
+        public bool CanTrade { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether or not this item can be sold by a player to a shop.
+        /// </summary>
+        public bool CanSell { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether or not this item can be banked by a player.
+        /// </summary>
+        public bool CanBank { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether or not this item can be placed in a bag by a player.
+        /// </summary>
+        public bool CanBag { get; set; } = true;
 
         public int CritChance { get; set; }
 

--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -72,9 +72,9 @@ namespace Intersect.GameObjects
         public bool CanDrop { get; set; } = true;
 
         /// <summary>
-        /// Defines whether or not this item can be dropped by a player on death.
+        /// Defines the percentage chance an item will drop upon player Death.
         /// </summary>
-        public bool CanDropOnDeath { get; set; } = true;
+        public int DropChanceOnDeath { get; set; }
 
         /// <summary>
         /// Defines whether or not this item can be traded by a player to another player.

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -45,7 +45,6 @@ namespace Intersect.Editor.Forms.Editors
             this.chkCanTrade = new DarkUI.Controls.DarkCheckBox();
             this.chkCanBag = new DarkUI.Controls.DarkCheckBox();
             this.chkCanBank = new DarkUI.Controls.DarkCheckBox();
-            this.chkCanDropOnDeath = new DarkUI.Controls.DarkCheckBox();
             this.chkIgnoreCdr = new DarkUI.Controls.DarkCheckBox();
             this.chkIgnoreGlobalCooldown = new DarkUI.Controls.DarkCheckBox();
             this.btnAddCooldownGroup = new DarkUI.Controls.DarkButton();
@@ -198,6 +197,8 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
+            this.lblDeathDropChance = new System.Windows.Forms.Label();
+            this.nudDeathDropChance = new DarkUI.Controls.DarkNumericUpDown();
             this.grpItems.SuspendLayout();
             this.grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaA)).BeginInit();
@@ -247,6 +248,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpBags.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudBag)).BeginInit();
             this.toolStrip.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).BeginInit();
             this.SuspendLayout();
             // 
             // grpItems
@@ -329,11 +331,12 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.nudDeathDropChance);
+            this.grpGeneral.Controls.Add(this.lblDeathDropChance);
             this.grpGeneral.Controls.Add(this.chkCanSell);
             this.grpGeneral.Controls.Add(this.chkCanTrade);
             this.grpGeneral.Controls.Add(this.chkCanBag);
             this.grpGeneral.Controls.Add(this.chkCanBank);
-            this.grpGeneral.Controls.Add(this.chkCanDropOnDeath);
             this.grpGeneral.Controls.Add(this.chkIgnoreCdr);
             this.grpGeneral.Controls.Add(this.chkIgnoreGlobalCooldown);
             this.grpGeneral.Controls.Add(this.btnAddCooldownGroup);
@@ -417,16 +420,6 @@ namespace Intersect.Editor.Forms.Editors
             this.chkCanBank.TabIndex = 89;
             this.chkCanBank.Text = "Can Bank?";
             this.chkCanBank.CheckedChanged += new System.EventHandler(this.chkCanBank_CheckedChanged);
-            // 
-            // chkCanDropOnDeath
-            // 
-            this.chkCanDropOnDeath.AutoSize = true;
-            this.chkCanDropOnDeath.Location = new System.Drawing.Point(121, 241);
-            this.chkCanDropOnDeath.Name = "chkCanDropOnDeath";
-            this.chkCanDropOnDeath.Size = new System.Drawing.Size(124, 17);
-            this.chkCanDropOnDeath.TabIndex = 88;
-            this.chkCanDropOnDeath.Text = "Can Drop on Death?";
-            this.chkCanDropOnDeath.CheckedChanged += new System.EventHandler(this.chkCanDropOnDeath_CheckedChanged);
             // 
             // chkIgnoreCdr
             // 
@@ -2623,6 +2616,30 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemUndo.Text = "Undo";
             this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
             // 
+            // lblDeathDropChance
+            // 
+            this.lblDeathDropChance.AutoSize = true;
+            this.lblDeathDropChance.Location = new System.Drawing.Point(12, 305);
+            this.lblDeathDropChance.Name = "lblDeathDropChance";
+            this.lblDeathDropChance.Size = new System.Drawing.Size(136, 13);
+            this.lblDeathDropChance.TabIndex = 93;
+            this.lblDeathDropChance.Text = "Drop chance on Death (%):";
+            // 
+            // nudDeathDropChance
+            // 
+            this.nudDeathDropChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudDeathDropChance.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudDeathDropChance.Location = new System.Drawing.Point(154, 300);
+            this.nudDeathDropChance.Name = "nudDeathDropChance";
+            this.nudDeathDropChance.Size = new System.Drawing.Size(48, 20);
+            this.nudDeathDropChance.TabIndex = 94;
+            this.nudDeathDropChance.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.nudDeathDropChance.ValueChanged += new System.EventHandler(this.nudDeathDropChance_ValueChanged);
+            // 
             // FrmItem
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2706,6 +2723,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudBag)).EndInit();
             this.toolStrip.ResumeLayout(false);
             this.toolStrip.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -2874,6 +2892,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkCanTrade;
         private DarkCheckBox chkCanBag;
         private DarkCheckBox chkCanBank;
-        private DarkCheckBox chkCanDropOnDeath;
+        private DarkNumericUpDown nudDeathDropChance;
+        private Label lblDeathDropChance;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -41,6 +41,11 @@ namespace Intersect.Editor.Forms.Editors
             this.btnCancel = new DarkUI.Controls.DarkButton();
             this.btnSave = new DarkUI.Controls.DarkButton();
             this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
+            this.chkCanSell = new DarkUI.Controls.DarkCheckBox();
+            this.chkCanTrade = new DarkUI.Controls.DarkCheckBox();
+            this.chkCanBag = new DarkUI.Controls.DarkCheckBox();
+            this.chkCanBank = new DarkUI.Controls.DarkCheckBox();
+            this.chkCanDropOnDeath = new DarkUI.Controls.DarkCheckBox();
             this.chkIgnoreCdr = new DarkUI.Controls.DarkCheckBox();
             this.chkIgnoreGlobalCooldown = new DarkUI.Controls.DarkCheckBox();
             this.btnAddCooldownGroup = new DarkUI.Controls.DarkButton();
@@ -64,7 +69,7 @@ namespace Intersect.Editor.Forms.Editors
             this.btnEditRequirements = new DarkUI.Controls.DarkButton();
             this.chkStackable = new DarkUI.Controls.DarkCheckBox();
             this.nudPrice = new DarkUI.Controls.DarkNumericUpDown();
-            this.chkBound = new DarkUI.Controls.DarkCheckBox();
+            this.chkCanDrop = new DarkUI.Controls.DarkCheckBox();
             this.cmbAnimation = new DarkUI.Controls.DarkComboBox();
             this.lblDesc = new System.Windows.Forms.Label();
             this.txtDesc = new DarkUI.Controls.DarkTextBox();
@@ -324,6 +329,11 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.chkCanSell);
+            this.grpGeneral.Controls.Add(this.chkCanTrade);
+            this.grpGeneral.Controls.Add(this.chkCanBag);
+            this.grpGeneral.Controls.Add(this.chkCanBank);
+            this.grpGeneral.Controls.Add(this.chkCanDropOnDeath);
             this.grpGeneral.Controls.Add(this.chkIgnoreCdr);
             this.grpGeneral.Controls.Add(this.chkIgnoreGlobalCooldown);
             this.grpGeneral.Controls.Add(this.btnAddCooldownGroup);
@@ -347,7 +357,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.Controls.Add(this.btnEditRequirements);
             this.grpGeneral.Controls.Add(this.chkStackable);
             this.grpGeneral.Controls.Add(this.nudPrice);
-            this.grpGeneral.Controls.Add(this.chkBound);
+            this.grpGeneral.Controls.Add(this.chkCanDrop);
             this.grpGeneral.Controls.Add(this.cmbAnimation);
             this.grpGeneral.Controls.Add(this.lblDesc);
             this.grpGeneral.Controls.Add(this.txtDesc);
@@ -363,10 +373,60 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpGeneral.Location = new System.Drawing.Point(2, 1);
             this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(439, 313);
+            this.grpGeneral.Size = new System.Drawing.Size(439, 352);
             this.grpGeneral.TabIndex = 2;
             this.grpGeneral.TabStop = false;
             this.grpGeneral.Text = "General";
+            // 
+            // chkCanSell
+            // 
+            this.chkCanSell.AutoSize = true;
+            this.chkCanSell.Location = new System.Drawing.Point(121, 281);
+            this.chkCanSell.Name = "chkCanSell";
+            this.chkCanSell.Size = new System.Drawing.Size(71, 17);
+            this.chkCanSell.TabIndex = 92;
+            this.chkCanSell.Text = "Can Sell?";
+            this.chkCanSell.CheckedChanged += new System.EventHandler(this.chkCanSell_CheckedChanged);
+            // 
+            // chkCanTrade
+            // 
+            this.chkCanTrade.AutoSize = true;
+            this.chkCanTrade.Location = new System.Drawing.Point(13, 281);
+            this.chkCanTrade.Name = "chkCanTrade";
+            this.chkCanTrade.Size = new System.Drawing.Size(82, 17);
+            this.chkCanTrade.TabIndex = 91;
+            this.chkCanTrade.Text = "Can Trade?";
+            this.chkCanTrade.CheckedChanged += new System.EventHandler(this.chkCanTrade_CheckedChanged);
+            // 
+            // chkCanBag
+            // 
+            this.chkCanBag.AutoSize = true;
+            this.chkCanBag.Location = new System.Drawing.Point(121, 261);
+            this.chkCanBag.Name = "chkCanBag";
+            this.chkCanBag.Size = new System.Drawing.Size(73, 17);
+            this.chkCanBag.TabIndex = 90;
+            this.chkCanBag.Text = "Can Bag?";
+            this.chkCanBag.CheckedChanged += new System.EventHandler(this.chkCanBag_CheckedChanged);
+            // 
+            // chkCanBank
+            // 
+            this.chkCanBank.AutoSize = true;
+            this.chkCanBank.Location = new System.Drawing.Point(13, 261);
+            this.chkCanBank.Name = "chkCanBank";
+            this.chkCanBank.Size = new System.Drawing.Size(79, 17);
+            this.chkCanBank.TabIndex = 89;
+            this.chkCanBank.Text = "Can Bank?";
+            this.chkCanBank.CheckedChanged += new System.EventHandler(this.chkCanBank_CheckedChanged);
+            // 
+            // chkCanDropOnDeath
+            // 
+            this.chkCanDropOnDeath.AutoSize = true;
+            this.chkCanDropOnDeath.Location = new System.Drawing.Point(121, 241);
+            this.chkCanDropOnDeath.Name = "chkCanDropOnDeath";
+            this.chkCanDropOnDeath.Size = new System.Drawing.Size(124, 17);
+            this.chkCanDropOnDeath.TabIndex = 88;
+            this.chkCanDropOnDeath.Text = "Can Drop on Death?";
+            this.chkCanDropOnDeath.CheckedChanged += new System.EventHandler(this.chkCanDropOnDeath_CheckedChanged);
             // 
             // chkIgnoreCdr
             // 
@@ -652,7 +712,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnEditRequirements
             // 
-            this.btnEditRequirements.Location = new System.Drawing.Point(13, 275);
+            this.btnEditRequirements.Location = new System.Drawing.Point(13, 322);
             this.btnEditRequirements.Name = "btnEditRequirements";
             this.btnEditRequirements.Padding = new System.Windows.Forms.Padding(5);
             this.btnEditRequirements.Size = new System.Drawing.Size(171, 23);
@@ -663,7 +723,7 @@ namespace Intersect.Editor.Forms.Editors
             // chkStackable
             // 
             this.chkStackable.AutoSize = true;
-            this.chkStackable.Location = new System.Drawing.Point(82, 241);
+            this.chkStackable.Location = new System.Drawing.Point(195, 326);
             this.chkStackable.Name = "chkStackable";
             this.chkStackable.Size = new System.Drawing.Size(80, 17);
             this.chkStackable.TabIndex = 27;
@@ -690,15 +750,15 @@ namespace Intersect.Editor.Forms.Editors
             0});
             this.nudPrice.ValueChanged += new System.EventHandler(this.nudPrice_ValueChanged);
             // 
-            // chkBound
+            // chkCanDrop
             // 
-            this.chkBound.AutoSize = true;
-            this.chkBound.Location = new System.Drawing.Point(13, 241);
-            this.chkBound.Name = "chkBound";
-            this.chkBound.Size = new System.Drawing.Size(63, 17);
-            this.chkBound.TabIndex = 26;
-            this.chkBound.Text = "Bound?";
-            this.chkBound.CheckedChanged += new System.EventHandler(this.chkBound_CheckedChanged);
+            this.chkCanDrop.AutoSize = true;
+            this.chkCanDrop.Location = new System.Drawing.Point(13, 241);
+            this.chkCanDrop.Name = "chkCanDrop";
+            this.chkCanDrop.Size = new System.Drawing.Size(77, 17);
+            this.chkCanDrop.TabIndex = 26;
+            this.chkCanDrop.Text = "Can Drop?";
+            this.chkCanDrop.CheckedChanged += new System.EventHandler(this.chkBound_CheckedChanged);
             // 
             // cmbAnimation
             // 
@@ -882,7 +942,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEquipment.Controls.Add(this.picMalePaperdoll);
             this.grpEquipment.Controls.Add(this.grpWeaponProperties);
             this.grpEquipment.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEquipment.Location = new System.Drawing.Point(2, 320);
+            this.grpEquipment.Location = new System.Drawing.Point(2, 357);
             this.grpEquipment.Name = "grpEquipment";
             this.grpEquipment.Size = new System.Drawing.Size(439, 731);
             this.grpEquipment.TabIndex = 12;
@@ -2145,7 +2205,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEvent.Controls.Add(this.chkSingleUseEvent);
             this.grpEvent.Controls.Add(this.cmbEvent);
             this.grpEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEvent.Location = new System.Drawing.Point(2, 320);
+            this.grpEvent.Location = new System.Drawing.Point(2, 357);
             this.grpEvent.Name = "grpEvent";
             this.grpEvent.Size = new System.Drawing.Size(200, 65);
             this.grpEvent.TabIndex = 42;
@@ -2198,7 +2258,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpConsumable.Controls.Add(this.cmbConsume);
             this.grpConsumable.Controls.Add(this.lblInterval);
             this.grpConsumable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpConsumable.Location = new System.Drawing.Point(2, 320);
+            this.grpConsumable.Location = new System.Drawing.Point(2, 358);
             this.grpConsumable.Name = "grpConsumable";
             this.grpConsumable.Size = new System.Drawing.Size(217, 125);
             this.grpConsumable.TabIndex = 12;
@@ -2318,7 +2378,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpSpell.Controls.Add(this.cmbTeachSpell);
             this.grpSpell.Controls.Add(this.lblSpell);
             this.grpSpell.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpell.Location = new System.Drawing.Point(2, 320);
+            this.grpSpell.Location = new System.Drawing.Point(2, 359);
             this.grpSpell.Name = "grpSpell";
             this.grpSpell.Size = new System.Drawing.Size(217, 127);
             this.grpSpell.TabIndex = 13;
@@ -2400,7 +2460,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpBags.Controls.Add(this.nudBag);
             this.grpBags.Controls.Add(this.lblBag);
             this.grpBags.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpBags.Location = new System.Drawing.Point(2, 320);
+            this.grpBags.Location = new System.Drawing.Point(2, 359);
             this.grpBags.Name = "grpBags";
             this.grpBags.Size = new System.Drawing.Size(222, 57);
             this.grpBags.TabIndex = 44;
@@ -2737,7 +2797,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkNumericUpDown nudCritChance;
         private DarkNumericUpDown nudDamage;
         private DarkCheckBox chkStackable;
-        private DarkCheckBox chkBound;
+        private DarkCheckBox chkCanDrop;
         private DarkGroupBox grpVitalBonuses;
         private DarkNumericUpDown nudManaBonus;
         private DarkNumericUpDown nudHealthBonus;
@@ -2810,5 +2870,10 @@ namespace Intersect.Editor.Forms.Editors
         private DarkNumericUpDown nudRgbaR;
         private DarkCheckBox chkIgnoreCdr;
         private Controls.GameObjectList lstGameObjects;
+        private DarkCheckBox chkCanSell;
+        private DarkCheckBox chkCanTrade;
+        private DarkCheckBox chkCanBag;
+        private DarkCheckBox chkCanBank;
+        private DarkCheckBox chkCanDropOnDeath;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -192,7 +192,12 @@ namespace Intersect.Editor.Forms.Editors
             lblAlpha.Text = Strings.ItemEditor.Alpha;
             lblPrice.Text = Strings.ItemEditor.price;
             lblAnim.Text = Strings.ItemEditor.animation;
-            chkBound.Text = Strings.ItemEditor.bound;
+            chkCanDrop.Text = Strings.ItemEditor.CanDrop;
+            chkCanDropOnDeath.Text = Strings.ItemEditor.CanDropOnDeath;
+            chkCanBank.Text = Strings.ItemEditor.CanBank;
+            chkCanBag.Text = Strings.ItemEditor.CanBag;
+            chkCanTrade.Text = Strings.ItemEditor.CanTrade;
+            chkCanSell.Text = Strings.ItemEditor.CanSell;
             chkStackable.Text = Strings.ItemEditor.stackable;
             btnEditRequirements.Text = Strings.ItemEditor.requirements;
 
@@ -340,7 +345,12 @@ namespace Intersect.Editor.Forms.Editors
                 nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
                 nudScaling.Value = mEditorItem.Scaling;
                 nudRange.Value = mEditorItem.StatGrowth;
-                chkBound.Checked = Convert.ToBoolean(mEditorItem.Bound);
+                chkCanDrop.Checked = Convert.ToBoolean(mEditorItem.CanDrop);
+                chkCanDropOnDeath.Checked = Convert.ToBoolean(mEditorItem.CanDropOnDeath);
+                chkCanBank.Checked = Convert.ToBoolean(mEditorItem.CanBank);
+                chkCanBag.Checked = Convert.ToBoolean(mEditorItem.CanBag);
+                chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
+                chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
                 chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
                 cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
                 cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
@@ -806,7 +816,32 @@ namespace Intersect.Editor.Forms.Editors
 
         private void chkBound_CheckedChanged(object sender, EventArgs e)
         {
-            mEditorItem.Bound = chkBound.Checked;
+            mEditorItem.CanDrop = chkCanDrop.Checked;
+        }
+
+        private void chkCanDropOnDeath_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CanDropOnDeath = chkCanDropOnDeath.Checked;
+        }
+
+        private void chkCanBank_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CanBank = chkCanBank.Checked;
+        }
+
+        private void chkCanBag_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CanBag = chkCanBag.Checked;
+        }
+
+        private void chkCanTrade_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CanTrade = chkCanTrade.Checked;
+        }
+
+        private void chkCanSell_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CanSell = chkCanSell.Checked;
         }
 
         private void chkStackable_CheckedChanged(object sender, EventArgs e)
@@ -1187,6 +1222,7 @@ namespace Intersect.Editor.Forms.Editors
 
 
         #endregion
+
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -193,7 +193,7 @@ namespace Intersect.Editor.Forms.Editors
             lblPrice.Text = Strings.ItemEditor.price;
             lblAnim.Text = Strings.ItemEditor.animation;
             chkCanDrop.Text = Strings.ItemEditor.CanDrop;
-            chkCanDropOnDeath.Text = Strings.ItemEditor.CanDropOnDeath;
+            lblDeathDropChance.Text = Strings.ItemEditor.DeathDropChance;
             chkCanBank.Text = Strings.ItemEditor.CanBank;
             chkCanBag.Text = Strings.ItemEditor.CanBag;
             chkCanTrade.Text = Strings.ItemEditor.CanTrade;
@@ -346,12 +346,12 @@ namespace Intersect.Editor.Forms.Editors
                 nudScaling.Value = mEditorItem.Scaling;
                 nudRange.Value = mEditorItem.StatGrowth;
                 chkCanDrop.Checked = Convert.ToBoolean(mEditorItem.CanDrop);
-                chkCanDropOnDeath.Checked = Convert.ToBoolean(mEditorItem.CanDropOnDeath);
                 chkCanBank.Checked = Convert.ToBoolean(mEditorItem.CanBank);
                 chkCanBag.Checked = Convert.ToBoolean(mEditorItem.CanBag);
                 chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
                 chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
                 chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
+                nudDeathDropChance.Value = mEditorItem.DropChanceOnDeath;
                 cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
                 cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
                 RefreshExtendedData();
@@ -819,11 +819,6 @@ namespace Intersect.Editor.Forms.Editors
             mEditorItem.CanDrop = chkCanDrop.Checked;
         }
 
-        private void chkCanDropOnDeath_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanDropOnDeath = chkCanDropOnDeath.Checked;
-        }
-
         private void chkCanBank_CheckedChanged(object sender, EventArgs e)
         {
             mEditorItem.CanBank = chkCanBank.Checked;
@@ -842,6 +837,11 @@ namespace Intersect.Editor.Forms.Editors
         private void chkCanSell_CheckedChanged(object sender, EventArgs e)
         {
             mEditorItem.CanSell = chkCanSell.Checked;
+        }
+
+        private void nudDeathDropChance_ValueChanged(object sender, EventArgs e)
+        {
+            mEditorItem.DropChanceOnDeath = (int)nudDeathDropChance.Value;
         }
 
         private void chkStackable_CheckedChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3067,7 +3067,7 @@ Tick timer saved in server config.json.";
             public static LocalizedString CanDrop = @"Can Drop?";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanDropOnDeath = @"Can Drop on Death?";
+            public static LocalizedString DeathDropChance = @"Drop chance on Death (%):";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString CanBag = @"Can Bag?";

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3063,7 +3063,23 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString bonusrange = @"Stat Bonus Range (+-):";
 
-            public static LocalizedString bound = @"Bound?";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanDrop = @"Can Drop?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanDropOnDeath = @"Can Drop on Death?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanBag = @"Can Bag?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanBank = @"Can Bank?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanTrade = @"Can Trade?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CanSell = @"Can Sell?";
 
             public static LocalizedString cancel = @"Cancel";
 

--- a/Intersect.Server/Database/GameData/GameContext.cs
+++ b/Intersect.Server/Database/GameData/GameContext.cs
@@ -106,6 +106,12 @@ namespace Intersect.Server.Database.GameData
             {
                 CerasVersionToleranceMigration.Run(this);
             }
+
+            if (migrations.IndexOf("20210512071349_BoundItemExtension") > -1)
+            {
+                BoundItemExtensionMigration.Run(this);
+            }
+            
         }
 
         internal static class Queries

--- a/Intersect.Server/Database/GameData/Migrations/BoundItemExtensionMigration.cs
+++ b/Intersect.Server/Database/GameData/Migrations/BoundItemExtensionMigration.cs
@@ -1,0 +1,34 @@
+﻿namespace Intersect.Server.Database.GameData.Migrations
+{
+    public class BoundItemExtensionMigration
+    {
+
+        public static void Run(GameContext context)
+        {
+            MigrateBoundItems(context);
+        }
+
+        public static void MigrateBoundItems(GameContext context)
+        {
+            // Go through all of our items and determine whether or not the Bound property (now CanDrop) was true, if so set all the Cans to false because it's a bound item!
+            // The user will have to set the granularity later.
+            foreach(var item in context.Items)
+            {
+                if (item.CanDrop == true)
+                {
+                    item.CanDrop = false;
+                    item.CanDropOnDeath = false;
+                    item.CanTrade = false;
+                    item.CanSell = false;
+                    item.CanBank = false;
+                    item.CanBag = false;
+                }
+            }
+
+            // Track our changes and save them or the work we've just done is lost.
+            context.ChangeTracker.DetectChanges();
+            context.SaveChanges();
+        }
+
+    }
+}

--- a/Intersect.Server/Database/GameData/Migrations/BoundItemExtensionMigration.cs
+++ b/Intersect.Server/Database/GameData/Migrations/BoundItemExtensionMigration.cs
@@ -10,18 +10,32 @@
 
         public static void MigrateBoundItems(GameContext context)
         {
-            // Go through all of our items and determine whether or not the Bound property (now CanDrop) was true, if so set all the Cans to false because it's a bound item!
-            // The user will have to set the granularity later.
+            // Go through all of our items to reconfigure the new item binding properties.
             foreach(var item in context.Items)
             {
+
+                // Determine whether or not the Bound property(now CanDrop) was true, if so set all the binding options to not allow item drops.
                 if (item.CanDrop == true)
                 {
                     item.CanDrop = false;
-                    item.CanDropOnDeath = false;
                     item.CanTrade = false;
                     item.CanSell = false;
                     item.CanBank = false;
                     item.CanBag = false;
+
+                    item.DropChanceOnDeath = 0;
+                }
+                // If it wasn't bound before, unbind all the new options!
+                else
+                {
+                    item.CanDrop = true;
+                    item.CanTrade = true;
+                    item.CanSell = true;
+                    item.CanBank = true;
+                    item.CanBag = true;
+
+                    // Set item drop chance to the default configuration option.
+                    item.DropChanceOnDeath = Options.ItemDropChance;
                 }
             }
 

--- a/Intersect.Server/Entities/BankInterface.cs
+++ b/Intersect.Server/Entities/BankInterface.cs
@@ -107,14 +107,14 @@ namespace Intersect.Server.Entities
             {
                 if (mPlayer.Items[slot].ItemId != Guid.Empty)
                 {
+                    if (!itemBase.CanBank)
+                    {
+                        PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
+                        return false;
+                    }
+
                     lock (mLock)
                     {
-                        if (!itemBase.CanBank)
-                        {
-                            PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
-                            return false;
-                        }
-
                         if (itemBase.IsStackable)
                         {
                             if (amount >= mPlayer.Items[slot].Quantity)

--- a/Intersect.Server/Entities/BankInterface.cs
+++ b/Intersect.Server/Entities/BankInterface.cs
@@ -109,6 +109,12 @@ namespace Intersect.Server.Entities
                 {
                     lock (mLock)
                     {
+                        if (!itemBase.CanBank)
+                        {
+                            PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
+                            return false;
+                        }
+
                         if (itemBase.IsStackable)
                         {
                             if (amount >= mPlayer.Items[slot].Quantity)

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2532,7 +2532,7 @@ namespace Intersect.Server.Entities
                 //Don't lose bound items on death for players.
                 if (this.GetType() == typeof(Player))
                 {
-                    if (itemBase.Bound)
+                    if (!itemBase.CanDropOnDeath)
                     {
                         continue;
                     }

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1863,7 +1863,7 @@ namespace Intersect.Server.Entities
                 {
                     lock (enemy.EntityLock)
                     {
-                        enemy.Die(100, this);
+                        enemy.Die(true, this);
                     }
                 }
                 else
@@ -1877,7 +1877,7 @@ namespace Intersect.Server.Entities
 
                     lock (enemy.EntityLock)
                     {
-                        enemy.Die(Options.ItemDropChance, this);
+                        enemy.Die(true, this);
                     }
                 }
 
@@ -2432,7 +2432,7 @@ namespace Intersect.Server.Entities
         }
 
         //Spawning/Dying
-        public virtual void Die(int dropitems = 0, Entity killer = null)
+        public virtual void Die(bool dropItems = true, Entity killer = null)
         {
             if (IsDead() || Items == null)
             {
@@ -2442,9 +2442,9 @@ namespace Intersect.Server.Entities
             // Run events and other things.
             killer?.KilledEntity(this);
 
-            var lootGenerated = new List<Player>();
-            if (dropitems > 0)
+            if (dropItems)
             {
+                var lootGenerated = new List<Player>();
                 // If this is an NPC, drop loot for every single player that participated in the fight.
                 if (this is Npc npc && npc.Base.IndividualizedLoot)
                 {
@@ -2463,7 +2463,7 @@ namespace Intersect.Server.Entities
                                 {
                                     if (!lootGenerated.Contains(partyMember))
                                     {
-                                        DropItems(dropitems, partyMember);
+                                        DropItems(partyMember);
                                         lootGenerated.Add(partyMember);
                                     }
                                 }
@@ -2473,7 +2473,7 @@ namespace Intersect.Server.Entities
                                 // They're not in a party, so drop the item if still eligible!
                                 if (!lootGenerated.Contains(player))
                                 {
-                                    DropItems(dropitems, player);
+                                    DropItems(player);
                                     lootGenerated.Add(player);
                                 }
                             }
@@ -2488,10 +2488,10 @@ namespace Intersect.Server.Entities
                 else
                 {
                     // Drop as normal.
-                    DropItems(dropitems, killer);
+                    DropItems(killer);
                 }
             }
-
+            
             var currentMap = MapInstance.Get(MapId);
             if (currentMap != null)
             {
@@ -2510,7 +2510,7 @@ namespace Intersect.Server.Entities
             Dead = true;
         }
 
-        private void DropItems(int chance, Entity killer, bool sendUpdate = true)
+        private void DropItems(Entity killer, bool sendUpdate = true)
         {
             // Drop items
             for (var n = 0; n < Items.Count; n++)
@@ -2532,7 +2532,7 @@ namespace Intersect.Server.Entities
                 //Don't lose bound items on death for players.
                 if (this.GetType() == typeof(Player))
                 {
-                    if (!itemBase.CanDropOnDeath)
+                    if (itemBase.DropChanceOnDeath == 0)
                     {
                         continue;
                     }
@@ -2546,7 +2546,7 @@ namespace Intersect.Server.Entities
                 if (this is Player)
                 {
                     //Player drop rates
-                    if (Randomization.Next(1, 101) <= chance * luck)
+                    if (Randomization.Next(1, 101) >= itemBase.DropChanceOnDeath * luck)
                     {
                         continue;
                     }

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -301,7 +301,7 @@ namespace Intersect.Server.Entities.Events
                 {
                     lock (player.EntityLock)
                     {
-                        player.Die(Options.ItemDropChance);
+                        player.Die();
                     }
                 }
             }
@@ -845,7 +845,7 @@ namespace Intersect.Server.Entities.Events
                     {
                         lock (player.EntityLock)
                         {
-                            ((Npc)entities[i]).Die(100);
+                            ((Npc)entities[i]).Die();
                         }
                     }
                 }

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -158,10 +158,10 @@ namespace Intersect.Server.Entities
             return EntityTypes.GlobalEntity;
         }
 
-        public override void Die(int dropitems = 100, Entity killer = null)
+        public override void Die(bool generateLoot = true, Entity killer = null)
         {
             lock (EntityLock) {
-                base.Die(dropitems, killer);
+                base.Die(generateLoot, killer);
 
                 AggroCenterMap = null;
                 AggroCenterX = 0;
@@ -772,7 +772,7 @@ namespace Intersect.Server.Entities
                                 if (mResetCounter > mResetMax)
                                 {
                                     // Kill the Npc, and simply do not drop any loot or give any credit.
-                                    Die(0, null);
+                                    Die(false, null);
                                     mResetCounter = 0;
                                     mResetDistance = 0;
                                 }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1913,7 +1913,7 @@ namespace Intersect.Server.Entities
                 return false;
             }
 
-            if (itemDescriptor.Bound)
+            if (!itemDescriptor.CanDrop)
             {
                 PacketSender.SendChatMsg(this, Strings.Items.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
                 return false;
@@ -2662,7 +2662,7 @@ namespace Intersect.Server.Entities
                 var itemDescriptor = Items[slot].Descriptor;
                 if (itemDescriptor != null)
                 {
-                    if (itemDescriptor.Bound)
+                    if (!itemDescriptor.CanSell)
                     {
                         PacketSender.SendChatMsg(this, Strings.Shops.bound, ChatMessageType.Inventory, CustomColors.Items.Bound);
 
@@ -3116,6 +3116,12 @@ namespace Intersect.Server.Entities
             {
                 if (Items[slot].ItemId != Guid.Empty)
                 {
+                    if (!itemBase.CanBag)
+                    {
+                        PacketSender.SendChatMsg(this, Strings.Items.nobag, ChatMessageType.Inventory, CustomColors.Items.Bound);
+                        return;
+                    }
+
                     if (itemBase.IsStackable)
                     {
                         if (amount >= Items[slot].Quantity)
@@ -3471,7 +3477,7 @@ namespace Intersect.Server.Entities
                     }
 
                     //Check if the item is bound.. if so don't allow trade
-                    if (itemBase.Bound)
+                    if (!itemBase.CanTrade)
                     {
                         PacketSender.SendChatMsg(this, Strings.Bags.tradebound, ChatMessageType.Trading, CustomColors.Items.Bound);
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -344,7 +344,7 @@ namespace Intersect.Server.Entities
                 {
                     lock (t.EntityLock)
                     {
-                        t.Die(0);
+                        t.Die();
                     }
                 }
             }
@@ -781,7 +781,7 @@ namespace Intersect.Server.Entities
             StartCommonEventsWithTrigger(CommonEventTrigger.OnRespawn);
         }
 
-        public override void Die(int dropitems = 0, Entity killer = null)
+        public override void Die(bool dropItems = true, Entity killer = null)
         {
             CastTime = 0;
             CastTarget = null;
@@ -810,7 +810,7 @@ namespace Intersect.Server.Entities
             
             lock (EntityLock)
             {
-                base.Die(dropitems, killer);
+                base.Die(dropItems, killer);
             }
             
             PacketSender.SendEntityDie(this);
@@ -2080,7 +2080,7 @@ namespace Intersect.Server.Entities
                         {
                             lock (EntityLock)
                             {
-                                Die(Options.ItemDropChance, this);
+                                Die(true, this);
                             }
                         }
 

--- a/Intersect.Server/Entities/Projectile.cs
+++ b/Intersect.Server/Entities/Projectile.cs
@@ -328,7 +328,7 @@ namespace Intersect.Server.Entities
                 lock (EntityLock)
                 {
                     projDeaths.Add(Id);
-                    Die(0, null);
+                    Die(false);
                 }
             }
         }
@@ -495,7 +495,7 @@ namespace Intersect.Server.Entities
             return killSpawn;
         }
 
-        public override void Die(int dropitems = 0, Entity killer = null)
+        public override void Die(bool dropItems = true, Entity killer = null)
         {
             for (var i = 0; i < Spawns.Length; i++)
             {

--- a/Intersect.Server/Entities/Resource.cs
+++ b/Intersect.Server/Entities/Resource.cs
@@ -40,28 +40,29 @@ namespace Intersect.Server.Entities
             HideName = true;
         }
 
-        public void Destroy(int dropitems = 0, Entity killer = null)
+        public void Destroy(bool dropItems = false, Entity killer = null)
         {
             lock (EntityLock)
             {
-                Die(dropitems, killer);
+                Die(dropItems, killer);
             }
             
             PacketSender.SendEntityDie(this);
             PacketSender.SendEntityLeave(this);
         }
 
-        public override void Die(int dropitems = 100, Entity killer = null)
+        public override void Die(bool dropItems = true, Entity killer = null)
         {
             lock (EntityLock)
             {
-                base.Die(0, killer);
+                base.Die(false, killer);
             }
             
             Sprite = Base.Exhausted.Graphic;
             Passable = Base.WalkableAfter;
             Dead = true;
-            if (dropitems > 0)
+
+            if (dropItems)
             {
                 SpawnResourceItems(killer);
                 if (Base.AnimationId != Guid.Empty)
@@ -71,7 +72,7 @@ namespace Intersect.Server.Entities
                     );
                 }
             }
-
+ 
             PacketSender.SendEntityDataToProximity(this);
             PacketSender.SendEntityPositionToAll(this);
         }

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -450,6 +450,7 @@
     <Compile Include="Database\GameData\GameContext.cs" />
     <Compile Include="Database\GameData\IGameContext.cs" />
     <Compile Include="Database\GameData\Migrations\Beta6Migration.cs" />
+    <Compile Include="Database\GameData\Migrations\BoundItemExtensionMigration.cs" />
     <Compile Include="Database\GameData\Migrations\CerasVersionToleranceMigration.cs" />
     <Compile Include="Database\ContextInterface.cs" />
     <Compile Include="Database\IDbContext.cs" />
@@ -572,6 +573,10 @@
     <Compile Include="Migrations\Game\20210509070229_AddingQuestCategoriesAndOrderValues.cs" />
     <Compile Include="Migrations\Game\20210509070229_AddingQuestCategoriesAndOrderValues.designer.cs">
       <DependentUpon>20210509070229_AddingQuestCategoriesAndOrderValues.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Migrations\Game\20210512071349_BoundItemExtension.cs" />
+    <Compile Include="Migrations\Game\20210512071349_BoundItemExtension.designer.cs">
+      <DependentUpon>20210512071349_BoundItemExtension.cs</DependentUpon>
     </Compile>
     <Compile Include="Migrations\Logging\20201119230003_AddUserActivityHistory.cs" />
     <Compile Include="Migrations\Logging\20201119230003_AddUserActivityHistory.Designer.cs">

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -777,6 +777,12 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString bound = @"You cannot drop this item.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString nobag = @"You cannot store this item in a bag.";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString nobank = @"You cannot store this item in a bank.";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString cannotuse = @"You cannot use this item!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -488,7 +488,7 @@ namespace Intersect.Server.Maps
                 {
                     lock (npc.EntityLock)
                     {
-                        npc.Die(0);
+                        npc.Die(false);
                     }
                 }
             }
@@ -502,7 +502,7 @@ namespace Intersect.Server.Maps
                 {
                     lock (res.EntityLock)
                     {
-                        res.Die(0);
+                        res.Die(false);
                     }
                 }
             }
@@ -518,7 +518,7 @@ namespace Intersect.Server.Maps
                     lock (proj.EntityLock)
                     {
                         guids.Add(proj.Id);
-                        proj.Die(0);
+                        proj.Die(false);
                     }
                 }
             }
@@ -609,7 +609,7 @@ namespace Intersect.Server.Maps
                 {
                     if (resourceSpawn.Value != null && resourceSpawn.Value.Entity != null)
                     {
-                        resourceSpawn.Value.Entity.Destroy(0);
+                        resourceSpawn.Value.Entity.Destroy();
                         RemoveEntity(resourceSpawn.Value.Entity);
                     }
                 }
@@ -688,7 +688,7 @@ namespace Intersect.Server.Maps
                 {
                     lock (npcSpawn.Value.Entity.EntityLock)
                     {
-                        npcSpawn.Value.Entity.Die(0);
+                        npcSpawn.Value.Entity.Die(false);
                     }
                 }
 
@@ -701,7 +701,7 @@ namespace Intersect.Server.Maps
                     {
                         lock (npc.EntityLock)
                         {
-                            npc.Die(0);
+                            npc.Die(false);
                         }
                     }
                 }

--- a/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.Designer.cs
+++ b/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations.Game
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20210512071349_BoundItemExtension")]
+    partial class BoundItemExtension
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
+++ b/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
@@ -18,11 +18,11 @@ namespace Intersect.Server.Migrations.Game
                 nullable: false,
                 defaultValue: true);
 
-            migrationBuilder.AddColumn<bool>(
-                name: "CanDropOnDeath",
+            migrationBuilder.AddColumn<int>(
+                name: "DropChanceOnDeath",
                 table: "Items",
                 nullable: false,
-                defaultValue: true);
+                defaultValue: 0);
 
             migrationBuilder.AddColumn<bool>(
                 name: "CanSell",

--- a/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
+++ b/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Game
+{
+    public partial class BoundItemExtension : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "CanBag",
+                table: "Items",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanBank",
+                table: "Items",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanDropOnDeath",
+                table: "Items",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanSell",
+                table: "Items",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanTrade",
+                table: "Items",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CanBag",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "CanBank",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "CanDropOnDeath",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "CanSell",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "CanTrade",
+                table: "Items");
+        }
+    }
+}

--- a/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
+++ b/Intersect.Server/Migrations/Game/20210512071349_BoundItemExtension.cs
@@ -48,7 +48,7 @@ namespace Intersect.Server.Migrations.Game
                 table: "Items");
 
             migrationBuilder.DropColumn(
-                name: "CanDropOnDeath",
+                name: "DropChanceOnDeath",
                 table: "Items");
 
             migrationBuilder.DropColumn(

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -3531,9 +3531,24 @@ namespace Intersect.Server.Networking
 
             var type = packet.Type;
             var obj = DbInterface.AddGameObject(type);
-            if (type == GameObjectType.Event)
+
+            var changed = false;
+            switch(type)
             {
-                ((EventBase)obj).CommonEvent = true;
+                case GameObjectType.Event:
+                    ((EventBase)obj).CommonEvent = true;
+                    changed = true;
+
+                    break;
+                case GameObjectType.Item:
+                    ((ItemBase)obj).DropChanceOnDeath = Options.ItemDropChance;
+                    changed = true;
+
+                    break;
+            }
+
+            if (changed)
+            {
                 DbInterface.SaveGameObject(obj);
             }
 


### PR DESCRIPTION
Resolves #684 
Resolves #670

Added the following options to replace the singular Bound property on individual tems:
- CanDrop
- CanTrade
- CanSell
- CanBank
- CanBag
- Drop Chance on Death (%)

If an Item was bound prior to this update then a custom migration will make sure that **ALL** these options are disabled.
The global option for item Drop Chance on player death from the server configuration is no longer used globally, but rather as a default configuration value for new items (and existing non-bound items upon running the migration)

Also fixed a minor issue with a typo regarding item drop rates from players.

![Image1](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/0eb6701b53ca23a1acf3d8559e806683.png)