### PR TITLE
Add item stack caps

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -215,6 +215,16 @@ namespace Intersect.GameObjects
 
         public bool Stackable { get; set; }
 
+        /// <summary>
+        /// Defines how high the item can stack in a player's inventory before starting a new stack.
+        /// </summary>
+        public int MaxInventoryStack { get; set; } = 1000000;
+
+        /// <summary>
+        /// Defines how high the item can stack in a player/guild's bank before starting a new stack.
+        /// </summary>
+        public int MaxBankStack { get; set; } = 1000000;
+
         public int StatGrowth { get; set; }
 
         public int Tool { get; set; } = -1;

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -41,6 +41,8 @@ namespace Intersect.Editor.Forms.Editors
             this.btnCancel = new DarkUI.Controls.DarkButton();
             this.btnSave = new DarkUI.Controls.DarkButton();
             this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
+            this.nudDeathDropChance = new DarkUI.Controls.DarkNumericUpDown();
+            this.lblDeathDropChance = new System.Windows.Forms.Label();
             this.chkCanSell = new DarkUI.Controls.DarkCheckBox();
             this.chkCanTrade = new DarkUI.Controls.DarkCheckBox();
             this.chkCanBag = new DarkUI.Controls.DarkCheckBox();
@@ -197,10 +199,13 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
-            this.lblDeathDropChance = new System.Windows.Forms.Label();
-            this.nudDeathDropChance = new DarkUI.Controls.DarkNumericUpDown();
+            this.lblInvStackLimit = new System.Windows.Forms.Label();
+            this.lblBankStackLimit = new System.Windows.Forms.Label();
+            this.nudInvStackLimit = new DarkUI.Controls.DarkNumericUpDown();
+            this.nudBankStackLimit = new DarkUI.Controls.DarkNumericUpDown();
             this.grpItems.SuspendLayout();
             this.grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaA)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaB)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaG)).BeginInit();
@@ -248,7 +253,8 @@ namespace Intersect.Editor.Forms.Editors
             this.grpBags.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudBag)).BeginInit();
             this.toolStrip.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudInvStackLimit)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudBankStackLimit)).BeginInit();
             this.SuspendLayout();
             // 
             // grpItems
@@ -331,6 +337,10 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.nudBankStackLimit);
+            this.grpGeneral.Controls.Add(this.nudInvStackLimit);
+            this.grpGeneral.Controls.Add(this.lblBankStackLimit);
+            this.grpGeneral.Controls.Add(this.lblInvStackLimit);
             this.grpGeneral.Controls.Add(this.nudDeathDropChance);
             this.grpGeneral.Controls.Add(this.lblDeathDropChance);
             this.grpGeneral.Controls.Add(this.chkCanSell);
@@ -376,10 +386,34 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpGeneral.Location = new System.Drawing.Point(2, 1);
             this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(439, 352);
+            this.grpGeneral.Size = new System.Drawing.Size(439, 427);
             this.grpGeneral.TabIndex = 2;
             this.grpGeneral.TabStop = false;
             this.grpGeneral.Text = "General";
+            // 
+            // nudDeathDropChance
+            // 
+            this.nudDeathDropChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudDeathDropChance.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudDeathDropChance.Location = new System.Drawing.Point(154, 300);
+            this.nudDeathDropChance.Name = "nudDeathDropChance";
+            this.nudDeathDropChance.Size = new System.Drawing.Size(48, 20);
+            this.nudDeathDropChance.TabIndex = 94;
+            this.nudDeathDropChance.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.nudDeathDropChance.ValueChanged += new System.EventHandler(this.nudDeathDropChance_ValueChanged);
+            // 
+            // lblDeathDropChance
+            // 
+            this.lblDeathDropChance.AutoSize = true;
+            this.lblDeathDropChance.Location = new System.Drawing.Point(12, 305);
+            this.lblDeathDropChance.Name = "lblDeathDropChance";
+            this.lblDeathDropChance.Size = new System.Drawing.Size(136, 13);
+            this.lblDeathDropChance.TabIndex = 93;
+            this.lblDeathDropChance.Text = "Drop chance on Death (%):";
             // 
             // chkCanSell
             // 
@@ -424,7 +458,7 @@ namespace Intersect.Editor.Forms.Editors
             // chkIgnoreCdr
             // 
             this.chkIgnoreCdr.AutoSize = true;
-            this.chkIgnoreCdr.Location = new System.Drawing.Point(262, 294);
+            this.chkIgnoreCdr.Location = new System.Drawing.Point(262, 296);
             this.chkIgnoreCdr.Name = "chkIgnoreCdr";
             this.chkIgnoreCdr.Size = new System.Drawing.Size(164, 17);
             this.chkIgnoreCdr.TabIndex = 87;
@@ -434,7 +468,7 @@ namespace Intersect.Editor.Forms.Editors
             // chkIgnoreGlobalCooldown
             // 
             this.chkIgnoreGlobalCooldown.AutoSize = true;
-            this.chkIgnoreGlobalCooldown.Location = new System.Drawing.Point(262, 275);
+            this.chkIgnoreGlobalCooldown.Location = new System.Drawing.Point(262, 277);
             this.chkIgnoreGlobalCooldown.Name = "chkIgnoreGlobalCooldown";
             this.chkIgnoreGlobalCooldown.Size = new System.Drawing.Size(145, 17);
             this.chkIgnoreGlobalCooldown.TabIndex = 53;
@@ -705,7 +739,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnEditRequirements
             // 
-            this.btnEditRequirements.Location = new System.Drawing.Point(13, 322);
+            this.btnEditRequirements.Location = new System.Drawing.Point(13, 396);
             this.btnEditRequirements.Name = "btnEditRequirements";
             this.btnEditRequirements.Padding = new System.Windows.Forms.Padding(5);
             this.btnEditRequirements.Size = new System.Drawing.Size(171, 23);
@@ -716,7 +750,7 @@ namespace Intersect.Editor.Forms.Editors
             // chkStackable
             // 
             this.chkStackable.AutoSize = true;
-            this.chkStackable.Location = new System.Drawing.Point(195, 326);
+            this.chkStackable.Location = new System.Drawing.Point(262, 326);
             this.chkStackable.Name = "chkStackable";
             this.chkStackable.Size = new System.Drawing.Size(80, 17);
             this.chkStackable.TabIndex = 27;
@@ -935,9 +969,9 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEquipment.Controls.Add(this.picMalePaperdoll);
             this.grpEquipment.Controls.Add(this.grpWeaponProperties);
             this.grpEquipment.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEquipment.Location = new System.Drawing.Point(2, 357);
+            this.grpEquipment.Location = new System.Drawing.Point(2, 435);
             this.grpEquipment.Name = "grpEquipment";
-            this.grpEquipment.Size = new System.Drawing.Size(439, 731);
+            this.grpEquipment.Size = new System.Drawing.Size(439, 742);
             this.grpEquipment.TabIndex = 12;
             this.grpEquipment.TabStop = false;
             this.grpEquipment.Text = "Equipment";
@@ -2198,7 +2232,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEvent.Controls.Add(this.chkSingleUseEvent);
             this.grpEvent.Controls.Add(this.cmbEvent);
             this.grpEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEvent.Location = new System.Drawing.Point(2, 357);
+            this.grpEvent.Location = new System.Drawing.Point(2, 435);
             this.grpEvent.Name = "grpEvent";
             this.grpEvent.Size = new System.Drawing.Size(200, 65);
             this.grpEvent.TabIndex = 42;
@@ -2251,7 +2285,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpConsumable.Controls.Add(this.cmbConsume);
             this.grpConsumable.Controls.Add(this.lblInterval);
             this.grpConsumable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpConsumable.Location = new System.Drawing.Point(2, 358);
+            this.grpConsumable.Location = new System.Drawing.Point(2, 436);
             this.grpConsumable.Name = "grpConsumable";
             this.grpConsumable.Size = new System.Drawing.Size(217, 125);
             this.grpConsumable.TabIndex = 12;
@@ -2371,7 +2405,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpSpell.Controls.Add(this.cmbTeachSpell);
             this.grpSpell.Controls.Add(this.lblSpell);
             this.grpSpell.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpell.Location = new System.Drawing.Point(2, 359);
+            this.grpSpell.Location = new System.Drawing.Point(2, 436);
             this.grpSpell.Name = "grpSpell";
             this.grpSpell.Size = new System.Drawing.Size(217, 127);
             this.grpSpell.TabIndex = 13;
@@ -2453,7 +2487,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpBags.Controls.Add(this.nudBag);
             this.grpBags.Controls.Add(this.lblBag);
             this.grpBags.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpBags.Location = new System.Drawing.Point(2, 359);
+            this.grpBags.Location = new System.Drawing.Point(2, 435);
             this.grpBags.Name = "grpBags";
             this.grpBags.Size = new System.Drawing.Size(222, 57);
             this.grpBags.TabIndex = 44;
@@ -2616,29 +2650,63 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemUndo.Text = "Undo";
             this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
             // 
-            // lblDeathDropChance
+            // lblInvStackLimit
             // 
-            this.lblDeathDropChance.AutoSize = true;
-            this.lblDeathDropChance.Location = new System.Drawing.Point(12, 305);
-            this.lblDeathDropChance.Name = "lblDeathDropChance";
-            this.lblDeathDropChance.Size = new System.Drawing.Size(136, 13);
-            this.lblDeathDropChance.TabIndex = 93;
-            this.lblDeathDropChance.Text = "Drop chance on Death (%):";
+            this.lblInvStackLimit.AutoSize = true;
+            this.lblInvStackLimit.Location = new System.Drawing.Point(259, 346);
+            this.lblInvStackLimit.Name = "lblInvStackLimit";
+            this.lblInvStackLimit.Size = new System.Drawing.Size(109, 13);
+            this.lblInvStackLimit.TabIndex = 95;
+            this.lblInvStackLimit.Text = "Inventory Stack Limit:";
             // 
-            // nudDeathDropChance
+            // lblBankStackLimit
             // 
-            this.nudDeathDropChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDeathDropChance.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDeathDropChance.Location = new System.Drawing.Point(154, 300);
-            this.nudDeathDropChance.Name = "nudDeathDropChance";
-            this.nudDeathDropChance.Size = new System.Drawing.Size(48, 20);
-            this.nudDeathDropChance.TabIndex = 94;
-            this.nudDeathDropChance.Value = new decimal(new int[] {
+            this.lblBankStackLimit.AutoSize = true;
+            this.lblBankStackLimit.Location = new System.Drawing.Point(259, 384);
+            this.lblBankStackLimit.Name = "lblBankStackLimit";
+            this.lblBankStackLimit.Size = new System.Drawing.Size(90, 13);
+            this.lblBankStackLimit.TabIndex = 96;
+            this.lblBankStackLimit.Text = "Bank Stack Limit:";
+            // 
+            // nudInvStackLimit
+            // 
+            this.nudInvStackLimit.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudInvStackLimit.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudInvStackLimit.Location = new System.Drawing.Point(262, 362);
+            this.nudInvStackLimit.Maximum = new decimal(new int[] {
+            2147483647,
+            0,
+            0,
+            0});
+            this.nudInvStackLimit.Name = "nudInvStackLimit";
+            this.nudInvStackLimit.Size = new System.Drawing.Size(171, 20);
+            this.nudInvStackLimit.TabIndex = 97;
+            this.nudInvStackLimit.Value = new decimal(new int[] {
             0,
             0,
             0,
             0});
-            this.nudDeathDropChance.ValueChanged += new System.EventHandler(this.nudDeathDropChance_ValueChanged);
+            this.nudInvStackLimit.ValueChanged += new System.EventHandler(this.nudInvStackLimit_ValueChanged);
+            // 
+            // nudBankStackLimit
+            // 
+            this.nudBankStackLimit.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudBankStackLimit.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudBankStackLimit.Location = new System.Drawing.Point(262, 401);
+            this.nudBankStackLimit.Maximum = new decimal(new int[] {
+            2147483647,
+            0,
+            0,
+            0});
+            this.nudBankStackLimit.Name = "nudBankStackLimit";
+            this.nudBankStackLimit.Size = new System.Drawing.Size(171, 20);
+            this.nudBankStackLimit.TabIndex = 98;
+            this.nudBankStackLimit.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.nudBankStackLimit.ValueChanged += new System.EventHandler(this.nudBankStackLimit_ValueChanged);
             // 
             // FrmItem
             // 
@@ -2665,6 +2733,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpItems.PerformLayout();
             this.grpGeneral.ResumeLayout(false);
             this.grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaA)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaB)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudRgbaG)).EndInit();
@@ -2723,7 +2792,8 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudBag)).EndInit();
             this.toolStrip.ResumeLayout(false);
             this.toolStrip.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDeathDropChance)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudInvStackLimit)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudBankStackLimit)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -2894,5 +2964,9 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkCanBank;
         private DarkNumericUpDown nudDeathDropChance;
         private Label lblDeathDropChance;
+        private DarkNumericUpDown nudBankStackLimit;
+        private DarkNumericUpDown nudInvStackLimit;
+        private Label lblBankStackLimit;
+        private Label lblInvStackLimit;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -199,6 +199,8 @@ namespace Intersect.Editor.Forms.Editors
             chkCanTrade.Text = Strings.ItemEditor.CanTrade;
             chkCanSell.Text = Strings.ItemEditor.CanSell;
             chkStackable.Text = Strings.ItemEditor.stackable;
+            lblInvStackLimit.Text = Strings.ItemEditor.InventoryStackLimit;
+            lblBankStackLimit.Text = Strings.ItemEditor.BankStackLimit;
             btnEditRequirements.Text = Strings.ItemEditor.requirements;
 
             cmbRarity.Items.Clear();
@@ -351,6 +353,8 @@ namespace Intersect.Editor.Forms.Editors
                 chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
                 chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
                 chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
+                nudInvStackLimit.Value = mEditorItem.MaxInventoryStack;
+                nudBankStackLimit.Value = mEditorItem.MaxBankStack;
                 nudDeathDropChance.Value = mEditorItem.DropChanceOnDeath;
                 cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
                 cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
@@ -494,12 +498,6 @@ namespace Intersect.Editor.Forms.Editors
 
                 // Whether this item type is stackable is not up for debate.
                 chkStackable.Checked = false;
-                chkStackable.Enabled = false;
-            }
-            else if (cmbType.SelectedIndex == (int)ItemTypes.Currency)
-            {
-                // Whether this item type is stackable is not up for debate.
-                chkStackable.Checked = true;
                 chkStackable.Enabled = false;
             }
             else if (cmbType.SelectedIndex == (int)ItemTypes.Currency)
@@ -847,6 +845,29 @@ namespace Intersect.Editor.Forms.Editors
         private void chkStackable_CheckedChanged(object sender, EventArgs e)
         {
             mEditorItem.Stackable = chkStackable.Checked;
+
+            if (chkStackable.Checked)
+            {
+                nudInvStackLimit.Enabled = true;
+                nudBankStackLimit.Enabled = true;
+            }
+            else
+            {
+                nudInvStackLimit.Enabled = false;
+                nudInvStackLimit.Value = 1;
+                nudBankStackLimit.Enabled = false;
+                nudBankStackLimit.Value = 1;
+            }
+        }
+
+        private void nudInvStackLimit_ValueChanged(object sender, EventArgs e)
+        {
+            mEditorItem.MaxInventoryStack = (int)nudInvStackLimit.Value;
+        }
+
+        private void nudBankStackLimit_ValueChanged(object sender, EventArgs e)
+        {
+            mEditorItem.MaxBankStack = (int)nudBankStackLimit.Value;
         }
 
         private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3222,6 +3222,12 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString stackable = @"Stackable?";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString InventoryStackLimit = @"Inventory Stack Limit:";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString BankStackLimit = @"Bank Stack Limit:";
+
             public static LocalizedString title = @"Item Editor";
 
             public static LocalizedString tooltype = @"Tool Type:";

--- a/Intersect.Server/Entities/BankInterface.cs
+++ b/Intersect.Server/Entities/BankInterface.cs
@@ -89,6 +89,183 @@ namespace Intersect.Server.Entities
         }
 
 
+        /// <summary>
+        /// Retrieves a list of open bank slots for this instance.
+        /// </summary>
+        /// <returns>Returns a list of open slots in this bank instance.</returns>
+        public List<int> FindOpenSlots()
+        {
+            var slots = new List<int>();
+            for (var i = 0; i < mMaxSlots; i++)
+            {
+                var bankSlot = mBank[i];
+
+                if (bankSlot != null && bankSlot.ItemId == Guid.Empty)
+                {
+                    slots.Add(i);
+                }
+            }
+
+            return slots;
+        }
+
+        /// <summary>
+        /// Retrieves a list of open bank slots for this instance.
+        /// </summary>
+        /// <returns>Returns the first open bank slot of this instance, or -1 if none are found.</returns>
+        public int FindOpenSlot()
+        {
+            var slots = FindOpenSlots();
+            if (slots.Count >= 1)
+            {
+                return slots.First();
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Finds a bank slot matching the desired item and quantity.
+        /// </summary>
+        /// <param name="itemId">The item Id to look for.</param>
+        /// <param name="quantity">The quantity of the item to look for.</param>
+        /// <returns>Returns a slot that contains the item, or -1 if none are found.</returns>
+        public int FindItemSlot(Guid itemId, int quantity = 1)
+        {
+            var slots = FindItemSlots(itemId, quantity);
+            if (slots.Count >= 1)
+            {
+                return slots.First();
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Finds all bank slots matching the desired item and quantity.
+        /// </summary>
+        /// <param name="itemId">The item Id to look for.</param>
+        /// <param name="quantity">The quantity of the item to look for.</param>
+        /// <returns>Returns a list of slots containing the requested item.</returns>
+        public List<int> FindItemSlots(Guid itemId, int quantity = 1)
+        {
+            var slots = new List<int>();
+            if (mBank == null)
+            {
+                return slots;
+            }
+
+            for (var i = 0; i < mMaxSlots; i++)
+            {
+                var item = mBank[i];
+                if (item?.ItemId != itemId)
+                {
+                    continue;
+                }
+
+                if (item.Quantity >= quantity)
+                {
+                    slots.Add(i);
+                }
+            }
+
+            return slots;
+        }
+
+        /// <summary>
+        /// Checks whether or not the bank instance can store this item.
+        /// </summary>
+        /// <param name="item">The <see cref="Item"/> to check for.</param>
+        /// <returns>Returns whether or not the bank instance can store this item.</returns>
+        public bool CanStoreItem(Item item)
+        {
+            if (item.Descriptor != null)
+            {
+                // Is the item stackable?
+                if (item.Descriptor.IsStackable)
+                {
+                    // Does the bank have this item already?
+                    var slot = FindItemSlot(item.ItemId);
+                    if (slot >= 0)
+                    {
+                        var existingSlot = mBank[slot];
+
+                        // Can we blindly add more to this stack?
+                        var untilFull = item.Descriptor.MaxBankStack - existingSlot.Quantity;
+                        if (untilFull >= item.Quantity)
+                        {
+                            return true;
+                        }
+
+                        // Check to see if we have the inventory spaces required to hand these items out AFTER filling up the existing slot!
+                        var toGive = item.Quantity - untilFull;
+                        if (Math.Ceiling((double)toGive / item.Descriptor.MaxBankStack) <= FindOpenSlots().Count)
+                        {
+                            return true;
+                        }
+                    }
+                    // User doesn't have this item yet.
+                    else
+                    {
+                        // Does the user have enough free space for these stacks?
+                        if (Math.Ceiling((double)item.Quantity / item.Descriptor.MaxBankStack) <= FindOpenSlots().Count)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                // Not a stacking item, so can we contain the amount we want to give them?
+                else
+                {
+                    if (FindOpenSlots().Count >= item.Quantity)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // Nothing matches in here, give up!
+            return false;
+        }
+
+        /// <summary>
+        /// Find the amount of a specific item this bank instance has.
+        /// </summary>
+        /// <param name="itemId">The item Id to look for.</param>
+        /// <returns>The amount of the requested item this bank instance contains.</returns>
+        public int FindItemQuantity(Guid itemId)
+        {
+            if (mBank == null)
+            {
+                return 0;
+            }
+
+            long itemCount = 0;
+            for (var i = 0; i < mMaxSlots; i++)
+            {
+                var item = mBank[i];
+                if (item.ItemId == itemId)
+                {
+                    itemCount = item.Descriptor.Stackable ? itemCount += item.Quantity : itemCount += 1;
+                }
+            }
+
+            // TODO: Stop using Int32 for item quantities
+            return itemCount >= Int32.MaxValue ? Int32.MaxValue : (int)itemCount;
+        }
+
+        /// <summary>
+        /// Checks whether or not this bank instance has enough items to accept a take operation.
+        /// </summary>
+        /// <param name="itemId">The ItemId to see if it can be taken away.</param>
+        /// <param name="quantity">The quantity of above item to see if we can take away.</param>
+        /// <returns>Whether or not the item can be taken away from the bank in the requested quantity.</returns>
+        public bool CanTakeItem(Guid itemId, int quantity) => FindItemQuantity(itemId) >= quantity;
+
         public bool TryDepositItem(int slot, int amount, bool sendUpdate = true)
         {
             //Permission Check
@@ -115,11 +292,12 @@ namespace Intersect.Server.Entities
 
                     lock (mLock)
                     {
+                        // if stackable, make sure the user actually has this many items or more.
                         if (itemBase.IsStackable)
                         {
-                            if (amount >= mPlayer.Items[slot].Quantity)
+                            if (!mPlayer.CanTakeItem(itemBase.Id, amount))
                             {
-                                amount = mPlayer.Items[slot].Quantity;
+                                amount = mPlayer.FindInventoryItemQuantity(itemBase.Id);
                             }
                         }
                         else
@@ -127,66 +305,30 @@ namespace Intersect.Server.Entities
                             amount = 1;
                         }
 
-                        //Find a spot in the bank for it!
-                        if (itemBase.IsStackable)
+                        if (CanStoreItem(new Item(itemBase.Id, amount)))
                         {
-                            for (var i = 0; i < mMaxSlots; i++)
+                            if (itemBase.IsStackable)
                             {
-                                if (mBank[i] != null && mBank[i].ItemId == mPlayer.Items[slot].ItemId)
+                                PutItem(new Item(itemBase.Id, amount), sendUpdate);
+                                mPlayer.TryTakeItem(itemBase.Id, amount, ItemHandling.Normal, sendUpdate);
+
+                                if (mGuild != null)
                                 {
-                                    amount = Math.Min(amount, int.MaxValue - mBank[i].Quantity);
-                                    mBank[i].Quantity += amount;
-
-                                    //Remove Items from inventory send updates
-                                    if (amount >= mPlayer.Items[slot].Quantity)
-                                    {
-                                        mPlayer.Items[slot].Set(Item.None);
-                                        mPlayer.EquipmentProcessItemLoss(slot);
-                                    }
-                                    else
-                                    {
-                                        mPlayer.Items[slot].Quantity -= amount;
-                                    }
-
-                                    if (sendUpdate)
-                                    {
-                                        PacketSender.SendInventoryItemUpdate(mPlayer, slot);
-                                        SendBankUpdate(i);
-                                    }
-
-                                    if (mGuild != null)
-                                    {
-                                        DbInterface.Pool.QueueWorkItem(mGuild.Save);
-                                    }
-
-                                    return true;
+                                    DbInterface.Pool.QueueWorkItem(mGuild.Save);
                                 }
+
+                                return true;
                             }
-                        }
-
-                        //Either a non stacking item, or we couldn't find the item already existing in the players inventory
-                        for (var i = 0; i < mMaxSlots; i++)
-                        {
-                            if (mBank[i] == null || mBank[i].ItemId == Guid.Empty)
+                            else
                             {
-                                mBank[i].Set(mPlayer.Items[slot]);
-                                mBank[i].Quantity = amount;
+                                PutItem(mPlayer.Items[slot], sendUpdate);
 
-                                //Remove Items from inventory send updates
-                                if (amount >= mPlayer.Items[slot].Quantity)
-                                {
-                                    mPlayer.Items[slot].Set(Item.None);
-                                    mPlayer.EquipmentProcessItemLoss(slot);
-                                }
-                                else
-                                {
-                                    mPlayer.Items[slot].Quantity -= amount;
-                                }
+                                mPlayer.Items[slot].Set(Item.None);
+                                mPlayer.EquipmentProcessItemLoss(slot);
 
                                 if (sendUpdate)
                                 {
                                     PacketSender.SendInventoryItemUpdate(mPlayer, slot);
-                                    SendBankUpdate(i);
                                 }
 
                                 if (mGuild != null)
@@ -197,8 +339,10 @@ namespace Intersect.Server.Entities
                                 return true;
                             }
                         }
-
-                        PacketSender.SendChatMsg(mPlayer, Strings.Banks.banknospace, ChatMessageType.Bank, CustomColors.Alerts.Error);
+                        else
+                        {
+                            PacketSender.SendChatMsg(mPlayer, Strings.Banks.banknospace, ChatMessageType.Bank, CustomColors.Alerts.Error);
+                        }  
                     }
                 }
                 else
@@ -232,61 +376,24 @@ namespace Intersect.Server.Entities
 
             if (item.ItemId != Guid.Empty)
             {
-                lock (mLock)
+                if (!itemBase.CanBank)
                 {
-                    // Find a spot in the bank for it!
-                    if (itemBase.IsStackable)
-                    {
-                        for (var i = 0; i < mMaxSlots; i++)
-                        {
-                            var bankSlot = mBank[i];
-                            if (bankSlot != null && bankSlot.ItemId == item.ItemId)
-                            {
-                                if (item.Quantity <= int.MaxValue - bankSlot.Quantity)
-                                {
-                                    bankSlot.Quantity += item.Quantity;
-
-                                    if (sendUpdate)
-                                    {
-                                        SendBankUpdate(i);
-                                    }
-
-                                    if (mGuild != null)
-                                    {
-                                        DbInterface.Pool.QueueWorkItem(mGuild.Save);
-                                    }
-
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-
-                    // Either a non stacking item, or we couldn't find the item already existing in the players inventory
-                    for (var i = 0; i < mMaxSlots; i++)
-                    {
-                        var bankSlot = mBank[i];
-
-                        if (bankSlot == null || bankSlot.ItemId == Guid.Empty)
-                        {
-                            bankSlot.Set(item);
-
-                            if (sendUpdate)
-                            {
-                                SendBankUpdate(i);
-                            }
-
-                            if (mGuild != null)
-                            {
-                                DbInterface.Pool.QueueWorkItem(mGuild.Save);
-                            }
-
-                            return true;
-                        }
-                    }
+                    PacketSender.SendChatMsg(mPlayer, Strings.Items.nobank, ChatMessageType.Bank, CustomColors.Items.Bound);
+                    return false;
                 }
 
-                PacketSender.SendChatMsg(mPlayer, Strings.Banks.banknospace, ChatMessageType.Bank, CustomColors.Alerts.Error);
+                lock (mLock)
+                {
+                    if (CanStoreItem(item))
+                    {
+                        PutItem(item, sendUpdate);
+                        return true;
+                    }
+                    else
+                    {
+                        PacketSender.SendChatMsg(mPlayer, Strings.Banks.banknospace, ChatMessageType.Bank, CustomColors.Alerts.Error);
+                    }
+                }
             }
             else
             {
@@ -294,6 +401,104 @@ namespace Intersect.Server.Entities
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Puts an item in the bank. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
+        /// Use TryDepositItem where possible!
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="sendUpdate"></param>
+        private void PutItem(Item item, bool sendUpdate)
+        {
+
+            // Decide how we're going to handle this item.
+            var existingSlots = FindItemSlots(item.Descriptor.Id);
+            var updateSlots = new List<int>();
+            if (item.Descriptor.Stackable && existingSlots.Count > 0) // Stackable, but already exists in the inventory.
+            {
+                // So this gets complicated.. First let's hand out the quantity we can hand out before we hit a stack limit.
+                var toGive = item.Quantity;
+                foreach (var slot in existingSlots)
+                {
+                    if (mBank[slot].Quantity >= item.Descriptor.MaxBankStack)
+                    {
+                        continue;
+                    }
+
+                    var canAdd = item.Descriptor.MaxBankStack - mBank[slot].Quantity;
+                    mBank[slot].Quantity += canAdd;
+                    updateSlots.Add(slot);
+                    toGive -= canAdd;
+                }
+
+                // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!
+                if (toGive > 0)
+                {
+                    var openSlots = FindOpenSlots();
+                    var total = toGive; // Copy this as we're going to be editing toGive.
+                    for (var slot = 0; slot < Math.Ceiling((double)total / item.Descriptor.MaxBankStack); slot++)
+                    {
+                        var quantity = item.Descriptor.MaxBankStack <= toGive ?
+                            item.Descriptor.MaxBankStack :
+                            toGive;
+
+                        toGive -= quantity;
+                        mBank[openSlots[slot]].Set(new Item(item.ItemId, quantity));
+                        updateSlots.Add(openSlots[slot]);
+                    }
+                }
+            }
+            else if (!item.Descriptor.Stackable && item.Quantity > 1) // Not stackable, but multiple items.
+            {
+                var openSlots = FindOpenSlots();
+                for (var slot = 0; slot < item.Quantity; slot++)
+                {
+                    mBank[openSlots[slot]].Set(new Item(item.ItemId, 1));
+                    updateSlots.Add(openSlots[slot]);
+                }
+            }
+            else // Hand out without any special treatment. Either a single item or a stackable item we don't have yet.
+            {
+                // If the item is not stackable, or the amount is below our stack cap just blindly hand it out.
+                if (!item.Descriptor.Stackable || item.Quantity < item.Descriptor.MaxBankStack)
+                {
+                    var newSlot = FindOpenSlot();
+                    mBank[newSlot].Set(item);
+                    updateSlots.Add(newSlot);
+                }
+                // The item is above our stack cap.. Let's start handing them phat stacks out!
+                else
+                {
+                    var toGive = item.Quantity;
+                    var openSlots = FindOpenSlots();
+                    for (var slot = 0; slot < Math.Ceiling((double)item.Quantity / item.Descriptor.MaxBankStack); slot++)
+                    {
+                        var quantity = item.Descriptor.MaxBankStack <= toGive ?
+                            item.Descriptor.MaxBankStack :
+                            toGive;
+
+                        toGive -= quantity;
+                        mBank[openSlots[slot]].Set(new Item(item.ItemId, quantity));
+                        updateSlots.Add(openSlots[slot]);
+                    }
+                }
+
+            }
+
+            // Do we need to update the bank display?
+            if (sendUpdate)
+            {
+                foreach (var slot in updateSlots)
+                {
+                    SendBankUpdate(slot);
+                }
+
+                if (mGuild != null)
+                {
+                    DbInterface.Pool.QueueWorkItem(mGuild.Save);
+                }
+            }
         }
 
         public void WithdrawItem(int slot, int amount)
@@ -332,9 +537,9 @@ namespace Intersect.Server.Entities
                 {
                     if (itemBase.IsStackable)
                     {
-                        if (amount >= bankSlotItem.Quantity)
+                        if (!CanTakeItem(itemBase.Id, amount))
                         {
-                            amount = bankSlotItem.Quantity;
+                            amount = FindItemQuantity(itemBase.Id);
                         }
                     }
                     else
@@ -342,77 +547,43 @@ namespace Intersect.Server.Entities
                         amount = 1;
                     }
 
-                    //Find a spot in the inventory for it!
-                    if (itemBase.IsStackable)
-                    {
-                        /* Find an existing stack */
-                        for (var i = 0; i < Options.MaxInvItems; i++)
-                        {
-                            var inventorySlotItem = mPlayer.Items[i];
-                            if (inventorySlotItem == null)
-                            {
-                                continue;
-                            }
-
-                            if (inventorySlotItem.ItemId != bankSlotItem.ItemId)
-                            {
-                                continue;
-                            }
-
-                            inventorySlot = i;
-
-                            break;
-                        }
-                    }
-
-                    if (inventorySlot < 0)
-                    {
-                        /* Find a free slot if we don't have one already */
-                        for (var j = 0; j < Options.MaxInvItems; j++)
-                        {
-                            if (mPlayer.Items[j] != null && mPlayer.Items[j].ItemId != Guid.Empty)
-                            {
-                                continue;
-                            }
-
-                            inventorySlot = j;
-
-                            break;
-                        }
-                    }
-
-                    /* If we don't have a slot send an error. */
-                    if (inventorySlot < 0)
+                    if (!mPlayer.CanGiveItem(itemBase.Id, amount))
                     {
                         PacketSender.SendChatMsg(mPlayer, Strings.Banks.inventorynospace, ChatMessageType.Inventory, CustomColors.Alerts.Error);
-
-                        return; //Panda forgot this :P
+                        return;
                     }
 
-                    /* Move the items to the inventory */
-                    Debug.Assert(mPlayer.Items[inventorySlot] != null, "Inventory[inventorySlot] != null");
-                    amount = Math.Min(amount, int.MaxValue - mPlayer.Items[inventorySlot].Quantity);
-
-                    if (mPlayer.Items[inventorySlot] == null ||
-                        mPlayer.Items[inventorySlot].ItemId == Guid.Empty ||
-                        mPlayer.Items[inventorySlot].Quantity < 0)
+                    var toTake = amount;
+                    if (itemBase.IsStackable)
                     {
-                        mPlayer.Items[inventorySlot].Set(bankSlotItem);
-                        mPlayer.Items[inventorySlot].Quantity = 0;
-                    }
+                        mPlayer.TryGiveItem(itemBase.Id, amount, ItemHandling.Normal, false, true);
 
-                    mPlayer.Items[inventorySlot].Quantity += amount;
-                    if (amount >= bankSlotItem.Quantity)
-                    {
-                        mBank[slot].Set(Item.None);
+                        // Go through our bank and take what we need!
+                        foreach (var s in FindItemSlots(itemBase.Id))
+                        {
+                            // Do we still have items to take? If not leave the loop!
+                            if (toTake == 0)
+                            {
+                                break;
+                            }
+
+                            if (mBank[s].Quantity >= toTake)
+                            {
+                                TakeItem(s, toTake, true);
+                                toTake = 0;
+                            }
+                            else // Take away the entire quantity of the item and lower our items that we still need to take!
+                            {
+                                toTake -= mBank[s].Quantity;
+                                TakeItem(s, mBank[s].Quantity, true);
+                            }
+                        }
                     }
                     else
                     {
-                        bankSlotItem.Quantity -= amount;
+                        mPlayer.TryGiveItem(mBank[slot]);
+                        mBank[slot].Set(Item.None);
                     }
-
-                    PacketSender.SendInventoryItemUpdate(mPlayer, inventorySlot);
-                    SendBankUpdate(slot);
 
                     if (mGuild != null)
                     {
@@ -423,6 +594,30 @@ namespace Intersect.Server.Entities
             else
             {
                 PacketSender.SendChatMsg(mPlayer, Strings.Banks.withdrawinvalid, ChatMessageType.Bank, CustomColors.Alerts.Error);
+            }
+        }
+
+        /// <summary>
+        /// Take an item away from the bank, or an amount of it if they have more. NOTE: This method MAKES ZERO CHECKS to see if this is possible!
+        /// Use WithdrawItem where possible!
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <param name="amount"></param>
+        /// <param name="sendUpdate"></param>
+        private void TakeItem(int slot, int amount, bool sendUpdate = true)
+        {
+            if (mBank[slot].Quantity > amount) // This slot contains more than what we're trying to take away here. Update the quantity.
+            {
+                mBank[slot].Quantity -= amount;
+            }
+            else // Take the entire thing away!
+            {
+                mBank[slot].Set(Item.None);
+            }
+
+            if (sendUpdate)
+            {
+                SendBankUpdate(slot);
             }
         }
 

--- a/Intersect.Server/Entities/BankInterface.cs
+++ b/Intersect.Server/Entities/BankInterface.cs
@@ -411,7 +411,6 @@ namespace Intersect.Server.Entities
         /// <param name="sendUpdate"></param>
         private void PutItem(Item item, bool sendUpdate)
         {
-
             // Decide how we're going to handle this item.
             var existingSlots = FindItemSlots(item.Descriptor.Id);
             var updateSlots = new List<int>();
@@ -421,15 +420,30 @@ namespace Intersect.Server.Entities
                 var toGive = item.Quantity;
                 foreach (var slot in existingSlots)
                 {
+                    if (toGive == 0)
+                    {
+                        break;
+                    }
+
                     if (mBank[slot].Quantity >= item.Descriptor.MaxBankStack)
                     {
                         continue;
                     }
 
                     var canAdd = item.Descriptor.MaxBankStack - mBank[slot].Quantity;
-                    mBank[slot].Quantity += canAdd;
-                    updateSlots.Add(slot);
-                    toGive -= canAdd;
+                    if (canAdd > toGive)
+                    {
+                        mBank[slot].Quantity += toGive;
+                        updateSlots.Add(slot);
+                        toGive = 0;
+                    }
+                    else
+                    {
+                        mBank[slot].Quantity += canAdd;
+                        updateSlots.Add(slot);
+                        toGive -= canAdd;
+                    }
+                    
                 }
 
                 // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1821,15 +1821,29 @@ namespace Intersect.Server.Entities
                 var toGive = item.Quantity;
                 foreach (var slot in existingSlots)
                 {
+                    if (toGive == 0)
+                    {
+                        break;
+                    }
+
                     if (slot.Quantity >= item.Descriptor.MaxInventoryStack)
                     {
                         continue;
                     }
 
-                    var canAdd = item.Descriptor.MaxInventoryStack - slot.Quantity;
-                    slot.Quantity += canAdd;
-                    updateSlots.Add(slot.Slot);
-                    toGive -= canAdd;
+                    var canAdd = item.Descriptor.MaxBankStack - slot.Quantity;
+                    if (canAdd > toGive)
+                    {
+                        slot.Quantity += toGive;
+                        updateSlots.Add(slot.Slot);
+                        toGive = 0;
+                    }
+                    else
+                    {
+                        slot.Quantity += canAdd;
+                        updateSlots.Add(slot.Slot);
+                        toGive -= canAdd;
+                    }
                 }
 
                 // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1583,20 +1583,36 @@ namespace Intersect.Server.Entities
                 if (item.Descriptor.IsStackable)
                 {
                     // Does the user have this item already?
-                    if (FindInventoryItemSlot(item.ItemId) != null)
+                    var existingSlot = FindInventoryItemSlot(item.ItemId);
+                    if (existingSlot != null)
                     {
-                        return true;
-                    }
+                        // Can we blindly add more to this stack?
+                        var untilFull = item.Descriptor.MaxInventoryStack - existingSlot.Quantity;
+                        if (untilFull >= item.Quantity)
+                        {
+                            return true;
+                        }
 
-                    // Does the user have a free space?
-                    if (FindOpenInventorySlots().Count >= 1)
+                        // Check to see if we have the inventory spaces required to hand these items out AFTER filling up the existing slot!
+                        var toGive = item.Quantity - untilFull;
+                        if (Math.Ceiling((double) toGive / item.Descriptor.MaxInventoryStack) <= FindOpenInventorySlots().Count)
+                        {
+                            return true;
+                        }
+                    }
+                    // User doesn't have this item yet.
+                    else
                     {
-                        return true;
+                        // Does the user have enough free space for these stacks?
+                        if (Math.Ceiling((double) item.Quantity / item.Descriptor.MaxInventoryStack) <= FindOpenInventorySlots().Count)
+                        {
+                            return true;
+                        }
                     }
                 }
+                // Not a stacking item, so can we contain the amount we want to give them?
                 else
                 {
-                    // Not a stacking item, so can we contain the amount we want to give them?
                     if (FindOpenInventorySlots().Count >= item.Quantity)
                     {
                         return true;
@@ -1721,7 +1737,6 @@ namespace Intersect.Server.Entities
 
             // Get this information so we can use it later.
             var openSlots = FindOpenInventorySlots().Count;
-            var hasItem = FindInventoryItemSlot(item.ItemId) != null;
             int spawnAmount = 0;
 
             // How are we going to be handling this?
@@ -1798,12 +1813,41 @@ namespace Intersect.Server.Entities
         {
 
             // Decide how we're going to handle this item.
-            var existingSlot = FindInventoryItemSlot(item.Descriptor.Id);
+            var existingSlots = FindInventoryItemSlots(item.Descriptor.Id);
             var updateSlots = new List<int>();
-            if (item.Descriptor.Stackable && existingSlot != null) // Stackable, but already exists in the inventory.
+            if (item.Descriptor.Stackable && existingSlots.Count > 0) // Stackable, but already exists in the inventory.
             {
-                Items[existingSlot.Slot].Quantity += item.Quantity;
-                updateSlots.Add(existingSlot.Slot);
+                // So this gets complicated.. First let's hand out the quantity we can hand out before we hit a stack limit.
+                var toGive = item.Quantity;
+                foreach (var slot in existingSlots)
+                {
+                    if (slot.Quantity >= item.Descriptor.MaxInventoryStack)
+                    {
+                        continue;
+                    }
+
+                    var canAdd = item.Descriptor.MaxInventoryStack - slot.Quantity;
+                    slot.Quantity += canAdd;
+                    updateSlots.Add(slot.Slot);
+                    toGive -= canAdd;
+                }
+
+                // Is there anything left to hand out? If so, hand out max stacks and what remains until we run out!
+                if (toGive > 0)
+                {
+                    var openSlots = FindOpenInventorySlots();
+                    var total = toGive; // Copy this as we're going to be editing toGive.
+                    for (var slot = 0; slot < Math.Ceiling((double)total / item.Descriptor.MaxInventoryStack); slot++)
+                    {
+                        var quantity = item.Descriptor.MaxInventoryStack <= toGive ?
+                            item.Descriptor.MaxInventoryStack :
+                            toGive;
+
+                        toGive -= quantity;
+                        openSlots[slot].Set(new Item(item.ItemId, quantity));
+                        updateSlots.Add(openSlots[slot].Slot);
+                    }
+                }
             }
             else if (!item.Descriptor.Stackable && item.Quantity > 1) // Not stackable, but multiple items.
             {
@@ -1816,9 +1860,30 @@ namespace Intersect.Server.Entities
             }
             else // Hand out without any special treatment. Either a single item or a stackable item we don't have yet.
             {
-                var newSlot = FindOpenInventorySlot();
-                newSlot.Set(item);
-                updateSlots.Add(newSlot.Slot);
+                // If the item is not stackable, or the amount is below our stack cap just blindly hand it out.
+                if (!item.Descriptor.Stackable || item.Quantity < item.Descriptor.MaxInventoryStack)
+                {
+                    var newSlot = FindOpenInventorySlot();
+                    newSlot.Set(item);
+                    updateSlots.Add(newSlot.Slot);
+                }
+                // The item is above our stack cap.. Let's start handing them phat stacks out!
+                else
+                {
+                    var toGive = item.Quantity;
+                    var openSlots = FindOpenInventorySlots();
+                    for (var slot = 0; slot < Math.Ceiling((double) item.Quantity / item.Descriptor.MaxInventoryStack); slot++)
+                    {
+                        var quantity = item.Descriptor.MaxInventoryStack <= toGive ?
+                            item.Descriptor.MaxInventoryStack :
+                            toGive;
+
+                        toGive -= quantity;
+                        openSlots[slot].Set(new Item(item.ItemId, quantity));
+                        updateSlots.Add(openSlots[slot].Slot);
+                    }
+                }
+
             }
 
             // Do we need to update the player's inventory?
@@ -2380,7 +2445,7 @@ namespace Intersect.Server.Entities
                 return 0;
             }
 
-            var itemCount = 0;
+            long itemCount = 0;
             for (var i = 0; i < Options.MaxInvItems; i++)
             {
                 var item = Items[i];
@@ -2390,7 +2455,8 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            return itemCount;
+            // TODO: Stop using Int32 for item quantities
+            return itemCount >= Int32.MaxValue ? Int32.MaxValue : (int) itemCount;
         }
 
         /// <summary>

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -578,6 +578,10 @@
     <Compile Include="Migrations\Game\20210512071349_BoundItemExtension.designer.cs">
       <DependentUpon>20210512071349_BoundItemExtension.cs</DependentUpon>
     </Compile>
+    <Compile Include="Migrations\Game\20210513080440_AddItemStackCaps.cs" />
+    <Compile Include="Migrations\Game\20210513080440_AddItemStackCaps.designer.cs">
+      <DependentUpon>20210513080440_AddItemStackCaps.cs</DependentUpon>
+    </Compile>
     <Compile Include="Migrations\Logging\20201119230003_AddUserActivityHistory.cs" />
     <Compile Include="Migrations\Logging\20201119230003_AddUserActivityHistory.Designer.cs">
       <DependentUpon>20201119230003_AddUserActivityHistory.cs</DependentUpon>

--- a/Intersect.Server/Migrations/Game/20210513080440_AddItemStackCaps.Designer.cs
+++ b/Intersect.Server/Migrations/Game/20210513080440_AddItemStackCaps.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations.Game
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20210513080440_AddItemStackCaps")]
+    partial class AddItemStackCaps
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/Game/20210513080440_AddItemStackCaps.cs
+++ b/Intersect.Server/Migrations/Game/20210513080440_AddItemStackCaps.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Game
+{
+    public partial class AddItemStackCaps : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxBankStack",
+                table: "Items",
+                nullable: false,
+                defaultValue: 2147483647);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxInventoryStack",
+                table: "Items",
+                nullable: false,
+                defaultValue: 2147483647);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxBankStack",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "MaxInventoryStack",
+                table: "Items");
+        }
+    }
+}


### PR DESCRIPTION
Resolves #727 

Add configurable options to the item editor that allows the admin to set a limit as to how many items are allowed on a stack of an item in both the bank and inventory.
Had to rewrite a fair chunk of the bank logic for this, replaced it with the basis of the inventory logic since that seems to work fine.

Existing items will get a stack cap of the Int32 limit.
New items start with a default stack cap of 1.000.000

![Image1](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/ce87835a78b9b1f725c7b0980e6a4f91.png)
![Image2](https://s3.us-east-2.amazonaws.com/ascensiongamedev/filehost/e5bb0aced7f988d4f6199f3e7df876e3.gif)
