### PR TITLE
Bonify XP Party for Each Member

### DIFF
--- a/Intersect (Core)/Config/PartyOptions.cs
+++ b/Intersect (Core)/Config/PartyOptions.cs
@@ -14,5 +14,11 @@
 
         public int NpcDeathCommonEventStartRange = 0;
 
+        /// <summary>
+        /// It will determine if you will have an XP bonus for each member, Eg 10, will give 10% more to the monster's total XP, then split equally to all members.
+        /// A monster that would give 100 XP, now gives 120, getting 60 for each member, when 2 in the party.
+        /// </summary>
+        public float BonifyExpPercentPerMember = 0;
+
     }
 }

--- a/Intersect (Core)/Config/PartyOptions.cs
+++ b/Intersect (Core)/Config/PartyOptions.cs
@@ -18,7 +18,7 @@
         /// It will determine if you will have an XP bonus for each member, Eg 10, will give 10% more to the monster's total XP, then split equally to all members.
         /// A monster that would give 100 XP, now gives 120, getting 60 for each member, when 2 in the party.
         /// </summary>
-        public float BonifyExpPercentPerMember = 0;
+        public float BonusExperiencePercentPerMember = 0;
 
     }
 }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1069,8 +1069,8 @@ namespace Intersect.Server.Entities
                         if (Party != null && Party.Count > 0)
                         {
                             var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange));
-                            float bonifyXp = Options.Party.BonifyExpPercentPerMember / 100;
-                            var multiplier = 1.0f + (partyMembersInXpRange.Count() * bonifyXp);
+                            float bonusExp = Options.Party.BonifyExpPercentPerMember / 100;
+                            var multiplier = 1.0f + (partyMembersInXpRange.Count() * bonusExp);
                             var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Count();
                             foreach (var partyMember in partyMembersInXpRange)
                             {

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1069,7 +1069,9 @@ namespace Intersect.Server.Entities
                         if (Party != null && Party.Count > 0)
                         {
                             var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange));
-                            var partyExperience = descriptor.Experience / partyMembersInXpRange.Count();
+                            float bonifyXp = Options.Party.BonifyExpPercentPerMember / 100;
+                            var multiplier = 1.0f + (partyMembersInXpRange.Count() * bonifyXp);
+                            var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Count();
                             foreach (var partyMember in partyMembersInXpRange)
                             {
                                 partyMember.GiveExperience(partyExperience);

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1068,10 +1068,10 @@ namespace Intersect.Server.Entities
                         // If in party, split the exp.
                         if (Party != null && Party.Count > 0)
                         {
-                            var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange));
+                            var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange)).ToArray();
                             float bonusExp = Options.Party.BonifyExpPercentPerMember / 100;
-                            var multiplier = 1.0f + (partyMembersInXpRange.Count() * bonusExp);
-                            var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Count();
+                            var multiplier = 1.0f + (partyMembersInXpRange.Length * bonusExp);
+                            var partyExperience = (int)(descriptor.Experience * multiplier) / partyMembersInXpRange.Length;
                             foreach (var partyMember in partyMembersInXpRange)
                             {
                                 partyMember.GiveExperience(partyExperience);


### PR DESCRIPTION
Its Resolves: #749

Percentage configured on the gain server.
Ex: 10 = 10%
Monster gives 1000 XP.
1 player, alone, without a party, will win 1000 by killing him.
2 players in a party, will kill this monster.
The Exp that will be divided will be +20%
Then, the monster will now divide 1200 XP, totaling a division of 600 XP for each member.
In short, for each additional member in a group you will gain + 10% xp on top of the xp to be divided for EVERYONE.
The particular EXP I cannot change because there is already a configuration in the items that can add XP individual bonus for each one.