### PR TITLE
Add multiple stat allocation points

### DIFF
--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -395,6 +395,7 @@
     <Compile Include="Network\Packets\Client\RequestGuildPacket.cs" />
     <Compile Include="Network\Packets\Client\UpdateGuildMemberPacket.cs" />
     <Compile Include="Network\Packets\Client\PictureClosedPacket.cs" />
+    <Compile Include="Network\Packets\Client\UpgradeMultipleStatPacket.cs" />
     <Compile Include="Network\Packets\Server\ActionMsgPackets.cs" />
     <Compile Include="Network\Packets\Server\EntityMovementPackets.cs" />
     <Compile Include="Network\Packets\Server\GuildInvitePacket.cs" />

--- a/Intersect (Core)/Network/Packets/Client/UpgradeMultipleStatPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/UpgradeMultipleStatPacket.cs
@@ -1,0 +1,23 @@
+﻿using MessagePack;
+
+namespace Intersect.Network.Packets.Client
+{
+    [MessagePackObject]
+    public class UpgradeMultipleStatPacket : IntersectPacket
+    {
+        //Parameterless Constructor for MessagePack
+        public UpgradeMultipleStatPacket()
+        {
+        }
+
+        public UpgradeMultipleStatPacket(byte stat)
+        {
+            Stat = stat;
+        }
+
+        [Key(0)]
+        public byte Stat { get; set; }
+
+    }
+
+}

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -25,13 +25,23 @@ namespace Intersect.Client.Interface.Game.Character
 
         Button mAddAbilityPwrBtn;
 
+        Button mAddMultiAbilityPwrBtn;
+
         Button mAddAttackBtn;
+
+        Button mAddMultiAttackBtn;
 
         Button mAddDefenseBtn;
 
+        Button mAddMultiDefenseBtn;
+
         Button mAddMagicResistBtn;
 
+        Button mAddMultiMagicResistBtn;
+
         Button mAddSpeedBtn;
+
+        Button mAddMultiSpeedBtn;
 
         //Stats
         Label mAttackLabel;
@@ -102,25 +112,34 @@ namespace Intersect.Client.Interface.Game.Character
             statsLabel.SetText(Strings.Character.stats);
 
             mAttackLabel = new Label(mCharacterWindow, "AttackLabel");
-
             mAddAttackBtn = new Button(mCharacterWindow, "IncreaseAttackButton");
             mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
+            mAddMultiAttackBtn = new Button(mCharacterWindow, "IncreaseMultiAttackButton");
+            mAddMultiAttackBtn.Clicked += _addMultiAttackBtn_Clicked;
 
             mDefenseLabel = new Label(mCharacterWindow, "DefenseLabel");
             mAddDefenseBtn = new Button(mCharacterWindow, "IncreaseDefenseButton");
             mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
+            mAddMultiDefenseBtn = new Button(mCharacterWindow, "IncreaseMultiDefenseButton");
+            mAddMultiDefenseBtn.Clicked += _addMultiDefenseBtn_Clicked;
 
             mSpeedLabel = new Label(mCharacterWindow, "SpeedLabel");
             mAddSpeedBtn = new Button(mCharacterWindow, "IncreaseSpeedButton");
             mAddSpeedBtn.Clicked += _addSpeedBtn_Clicked;
+            mAddMultiSpeedBtn = new Button(mCharacterWindow, "IncreaseMultiSpeedButton");
+            mAddMultiSpeedBtn.Clicked += _addMultiSpeedBtn_Clicked;
 
             mAbilityPwrLabel = new Label(mCharacterWindow, "AbilityPowerLabel");
             mAddAbilityPwrBtn = new Button(mCharacterWindow, "IncreaseAbilityPowerButton");
             mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
+            mAddMultiAbilityPwrBtn = new Button(mCharacterWindow, "IncreaseMultiAbilityPowerButton");
+            mAddMultiAbilityPwrBtn.Clicked += _addMultiAbilityPwrBtn_Clicked;
 
             mMagicRstLabel = new Label(mCharacterWindow, "MagicResistLabel");
             mAddMagicResistBtn = new Button(mCharacterWindow, "IncreaseMagicResistButton");
             mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
+            mAddMultiMagicResistBtn = new Button(mCharacterWindow, "IncreaseMultiMagicResistButton");
+            mAddMultiMagicResistBtn.Clicked += _addMultiMagicResistBtn_Clicked;
 
             mPointsLabel = new Label(mCharacterWindow, "PointsLabel");
 
@@ -140,9 +159,19 @@ namespace Intersect.Client.Interface.Game.Character
             PacketSender.SendUpgradeStat((int) Stats.MagicResist);
         }
 
+        void _addMultiMagicResistBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            PacketSender.SendMultiUpgradeStat((int) Stats.MagicResist);
+        }
+
         void _addAbilityPwrBtn_Clicked(Base sender, ClickedEventArgs arguments)
         {
             PacketSender.SendUpgradeStat((int) Stats.AbilityPower);
+        }
+
+        void _addMultiAbilityPwrBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            PacketSender.SendMultiUpgradeStat((int) Stats.AbilityPower);
         }
 
         void _addSpeedBtn_Clicked(Base sender, ClickedEventArgs arguments)
@@ -150,14 +179,29 @@ namespace Intersect.Client.Interface.Game.Character
             PacketSender.SendUpgradeStat((int) Stats.Speed);
         }
 
+        void _addMultiSpeedBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            PacketSender.SendMultiUpgradeStat((int) Stats.Speed);
+        }
+
         void _addDefenseBtn_Clicked(Base sender, ClickedEventArgs arguments)
         {
             PacketSender.SendUpgradeStat((int) Stats.Defense);
         }
 
+        void _addMultiDefenseBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            PacketSender.SendMultiUpgradeStat((int) Stats.Defense);
+        }
+
         void _addAttackBtn_Clicked(Base sender, ClickedEventArgs arguments)
         {
             PacketSender.SendUpgradeStat((int) Stats.Attack);
+        }
+
+        void _addMultiAttackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            PacketSender.SendMultiUpgradeStat((int) Stats.Attack);
         }
 
         //Methods
@@ -301,20 +345,36 @@ namespace Intersect.Client.Interface.Game.Character
             );
 
             mPointsLabel.SetText(Strings.Character.points.ToString(Globals.Me.StatPoints));
-            mAddAbilityPwrBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                         Globals.Me.Stat[(int) Stats.AbilityPower] == Options.MaxStatValue;
+
+            mAddAbilityPwrBtn.IsHidden = 
+                Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stats.AbilityPower] == Options.MaxStatValue;
+
+            mAddMultiAbilityPwrBtn.IsHidden =
+                Globals.Me.StatPoints < 5 || Globals.Me.Stat[(int) Stats.AbilityPower] == Options.MaxStatValue - 5;
 
             mAddAttackBtn.IsHidden =
                 Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stats.Attack] == Options.MaxStatValue;
 
-            mAddDefenseBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                      Globals.Me.Stat[(int) Stats.Defense] == Options.MaxStatValue;
+            mAddMultiAttackBtn.IsHidden =
+                Globals.Me.StatPoints < 5 || Globals.Me.Stat[(int) Stats.Attack] == Options.MaxStatValue - 5;
 
-            mAddMagicResistBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                          Globals.Me.Stat[(int) Stats.MagicResist] == Options.MaxStatValue;
+            mAddDefenseBtn.IsHidden = 
+                Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stats.Defense] == Options.MaxStatValue;
+
+            mAddMultiDefenseBtn.IsHidden =
+                Globals.Me.StatPoints < 5 || Globals.Me.Stat[(int) Stats.Defense] == Options.MaxStatValue - 5;
+
+            mAddMagicResistBtn.IsHidden = 
+                Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stats.MagicResist] == Options.MaxStatValue;
+
+            mAddMultiMagicResistBtn.IsHidden =
+                Globals.Me.StatPoints < 5 || Globals.Me.Stat[(int) Stats.MagicResist] == Options.MaxStatValue - 5;
 
             mAddSpeedBtn.IsHidden =
                 Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stats.Speed] == Options.MaxStatValue;
+
+            mAddMultiSpeedBtn.IsHidden =
+                Globals.Me.StatPoints < 5 || Globals.Me.Stat[(int) Stats.Speed] == Options.MaxStatValue - 5;
 
             for (var i = 0; i < Options.EquipmentSlots.Count; i++)
             {

--- a/Intersect.Client/Networking/PacketSender.cs
+++ b/Intersect.Client/Networking/PacketSender.cs
@@ -156,6 +156,11 @@ namespace Intersect.Client.Networking
             Network.SendPacket(new UpgradeStatPacket(stat));
         }
 
+        public static void SendMultiUpgradeStat(byte stat)
+        {
+            Network.SendPacket(new UpgradeMultipleStatPacket(stat));
+        }
+
         public static void SendHotbarUpdate(byte hotbarSlot, sbyte type, int itemIndex)
         {
             Network.SendPacket(new HotbarUpdatePacket(hotbarSlot, type, itemIndex));

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -4655,6 +4655,18 @@ namespace Intersect.Server.Entities
             }
         }
 
+        // Multiple Stats
+        public void UpgradeMultiStat(int statIndex)
+        {
+            if (Stat[statIndex].BaseStat + StatPointAllocations[statIndex] < Options.MaxStatValue && StatPoints >= 5)
+            {
+                StatPointAllocations[statIndex] += 5;
+                StatPoints -= 5;
+                PacketSender.SendEntityStats(this);
+                PacketSender.SendPointsTo(this);
+            }
+        }
+
         //HotbarSlot
         public void HotbarChange(int index, int type, int slot)
         {

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1772,6 +1772,17 @@ namespace Intersect.Server.Networking
             player.UpgradeStat(packet.Stat);
         }
 
+        public void HandlePacket(Client client, UpgradeMultipleStatPacket packet)
+        {
+            var player = client?.Entity;
+            if (player == null)
+            {
+                return;
+            }
+
+            player.UpgradeMultiStat(packet.Stat);
+        }
+
         //HotbarUpdatePacket
         public void HandlePacket(Client client, HotbarUpdatePacket packet)
         {


### PR DESCRIPTION
Resolves #774 
Added new Multi Add buttons that by default adds 5 per click.
JSON edits are pretty much a must for this to work fully.
My CharacterWindow.json
https://pastebin.com/gLLYvdPp
My extra Stat Buttons are attached as well
![addmultistatclicked](https://user-images.githubusercontent.com/31571936/121176236-d6943080-c810-11eb-8e78-687b3dd2fe1f.png)
![addmultistathover](https://user-images.githubusercontent.com/31571936/121176239-d72cc700-c810-11eb-9f57-0155ee7efc5d.png)
![addmultistatnormal](https://user-images.githubusercontent.com/31571936/121176240-d72cc700-c810-11eb-9596-628938f341f3.png)


