### PR TITLE
Fixes Chatbox Scrolling Issues (#618)

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -44,6 +44,8 @@ namespace Intersect.Configuration
 
         public const int DEFAULT_CHAT_LINES = 100;
 
+        public const int CHAT_LINES_TO_INIT_SCROLL = 6;
+
         public const string DEFAULT_MENU_BACKGROUND = "background.png";
 
         public const string DEFAULT_MENU_MUSIC = "RPG-Theme_v001_Looping.ogg";
@@ -107,6 +109,11 @@ namespace Intersect.Configuration
         /// Number of lines to save for chat scrollback
         /// </summary>
         public int ChatLines { get; set; } = DEFAULT_CHAT_LINES;
+
+        /// <summary>
+        /// Number of lines/rows required in the chat log to init the scrollbar and position it down to the bottom of the chat log.
+        /// </summary>
+        public int ChatLinesToInitScroll { get; set; } = CHAT_LINES_TO_INIT_SCROLL;
 
         /// <summary>
         /// Menu music file name

--- a/Intersect.Client/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client/Interface/Game/Chat/Chatbox.cs
@@ -237,7 +237,7 @@ namespace Intersect.Client.Interface.Game.Chat
             // TODO: Find a cleaner way to do this logic, right now this will only start working properly (ie not resetting scroll height) after a few chat messages.
             // Can't seem to find a cleaner way yet. But works in longer chat convos.
             var scrollAmount = mChatboxMessages.GetVerticalScrollBar().ScrollAmount;
-            var scrollToBottom = mChatboxMessages.GetVerticalScrollBar().ScrollAmount == 1 || (mChatboxMessages.RowCount <= 10 && mChatboxMessages.GetVerticalScrollBar().ScrollAmount <= 1);
+            var scrollToBottom = mChatboxMessages.GetVerticalScrollBar().ScrollAmount == 1 || (mChatboxMessages.RowCount <= ClientConfiguration.Instance.ChatLinesToInitScroll && mReceivedMessage && mChatboxMessages.GetVerticalScrollBar().ScrollAmount <= 1);
 
             // Did the tab change recently? If so, we need to reset a few things to make it work...
             if (mLastTab != mCurrentTab)


### PR DESCRIPTION
Should solve #618.

- Added a client configuration setting that will allow devs to set the row/line at which the scrollbar will initiate (default is 6th row - see L:10 at client's config.json "ChatLinesToInitScroll"). This should allow more flexibility for those who wish to have smaller or taller chatlogs working properly with the scrollbar.
- Added an extra condition so the scrollbar its placed at the Bottom only if a message has been received as the (default) 6th row of strings in the chat log, this allows now to scroll up normally even after the scrollbar has been automatically set to bottom.


Results:

https://user-images.githubusercontent.com/17498701/123724328-26877580-d85a-11eb-92f6-b151329aea13.mp4

