### PR TITLE
Fix 807 by render crafting item and ingredient color hues

### DIFF
--- a/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
@@ -365,7 +365,7 @@ namespace Intersect.Client.Interface.Game.Crafting
                         continue;
                     }
 
-                    var tmpRow = mRecipes?.AddRow(i + 1 + ") " + ItemBase.GetName(activeCraft.ItemId));
+                    var tmpRow = mRecipes?.AddRow(i + 1 + ") " + activeCraft.Name);
                     if (tmpRow == null)
                     {
                         continue;

--- a/Intersect.Client/Interface/Game/Crafting/RecipeItem.cs
+++ b/Intersect.Client/Interface/Game/Crafting/RecipeItem.cs
@@ -64,6 +64,7 @@ namespace Intersect.Client.Interface.Game.Crafting
                 if (itemTex != null)
                 {
                     Pnl.Texture = itemTex;
+                    Pnl.RenderColor = item.Color;
                 }
                 else
                 {


### PR DESCRIPTION
Resolves #807 

Also uses the craft name in the crafting list instead of the item name.

In cases where the craft might make multiple quantities or something we give more control over the listing names to the developers.