### PR TITLE
Fix 794 Cont: Fix item duplication angle when trying to pickup map items with a full inventory

### DIFF
--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1768,8 +1768,10 @@ namespace Intersect.Server.Entities
         /// <param name="handler">The way to handle handing out this item.</param>
         /// <param name="bankOverflow">Should we allow the items to overflow into the player's bank when their inventory is full.</param>
         /// <param name="sendUpdate">Should we send an inventory update when we are done changing the player's items.</param>
+        /// <param name="overflowTileX">The x coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
+        /// <param name="overflowTileY">The y coordinate of the tile in which overflow should spawn on, if the player cannot hold the full amount.</param>
         /// <returns>Whether the player received the item or not.</returns>
-        public bool TryGiveItem(Item item, ItemHandling handler = ItemHandling.Normal, bool bankOverflow = false, bool sendUpdate = true)
+        public bool TryGiveItem(Item item, ItemHandling handler = ItemHandling.Normal, bool bankOverflow = false, bool sendUpdate = true, int overflowTileX = -1, int overflowTileY = -1)
         {
             // Is this a valid item?
             if (item.Descriptor == null)
@@ -1821,8 +1823,8 @@ namespace Intersect.Server.Entities
                     // Do we have any items to spawn to the map?
                     if (spawnAmount > 0)
                     {
-                        Map.SpawnItem(X, Y, item, spawnAmount, Id);
-                        return true;
+                        Map.SpawnItem(overflowTileX > -1 ? overflowTileX : X, overflowTileY > -1 ? overflowTileY : Y, item, spawnAmount, Id);
+                        return spawnAmount != item.Quantity;
                     }
 
                     break;

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1614,18 +1614,17 @@ namespace Intersect.Server.Networking
 
                     if (canTake)
                     {
+                        //Remove the item from the map now, because otherwise the overflow would just add to the existing quantity
+                        tempMap.RemoveItem(mapItem);
+
                         // Try to give the item to our player.
-                        if (player.TryGiveItem(mapItem, ItemHandling.Overflow))
+                        if (player.TryGiveItem(mapItem, ItemHandling.Overflow, false, true, mapItem.X, mapItem.Y))
                         {
                             var item = ItemBase.Get(mapItem.ItemId);
                             if (item != null)
                             {
                                 PacketSender.SendActionMsg(player, item.Name, CustomColors.Items.Rarities[item.Rarity]);
                             }
-
-                            // Mark this item for map removal.
-                            // If we remove them right now we'll cause an exception because the collection changed. :) Bad voodoo mon
-                            toRemove.Add(mapItem);
                         }
                         else
                         {


### PR DESCRIPTION
So #795 wasn't as simple as I had thought. When items failed to pick up, the overflow logic would take the map items and combine them into a new map item. And then the logic after the pickup code would fail to remove the original map item. Items would duplicate on the map and then you could clear up inventory space and get the unlimited items. This fixes all of that.



Should fully resolve #794 