### PR TITLE
Generates a plugin JSON config file immediately if none exist

### DIFF
--- a/Intersect (Core)/Plugins/Loaders/PluginLoader.Configuration.cs
+++ b/Intersect (Core)/Plugins/Loaders/PluginLoader.Configuration.cs
@@ -53,6 +53,15 @@ namespace Intersect.Plugins.Loaders
             {
                 try
                 {
+                    if (!File.Exists(configurationFilePath))
+                    {
+                        File.WriteAllText(
+                            configurationFilePath,
+                            JsonConvert.SerializeObject(configuration, Formatting.Indented),
+                            Encoding.UTF8
+                        );
+                    }
+
                     if (File.Exists(configurationFilePath))
                     {
                         serializedOldConfiguration = File.ReadAllText(configurationFilePath, Encoding.UTF8);


### PR DESCRIPTION
At the moment, if the JSON config file doesn't exist in a given plugin subdirectory, a config file will be automatically generated as the base PluginConfiguration class. I.E. it would be missing the derived PluginConfiguration class's properties. Otherwise, you'd have to run the app twice to generate the proper config file or manually type it in, which obviously isn't ideal.

If you generate the JSON config file immediately as done in this commit, it will cause a backup to also be created immediately and the regular config file to be updated so that the derived class's properties are included.