### PR TITLE
Add option in server to enable regeneration vitals in combat

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -17,6 +17,8 @@
         //Combat
         public int RegenTime = 3000; //3 seconds
 
+        public bool CombatRegen = false; // Enable or disable regeneration in combat.
+
         public bool EnableCombatChatMessages = false; // Enables or disables combat chat messages.
 
         //Spells

--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -16,9 +16,7 @@
 
         //Combat
         public int RegenTime = 3000; //3 seconds
-
-        public bool CombatRegen = false; // Enable or disable regeneration in combat.
-
+        
         public bool EnableCombatChatMessages = false; // Enables or disables combat chat messages.
 
         //Spells
@@ -62,6 +60,11 @@
         /// Configures the maximum distance a target is allowed to be from the player when auto targetting.
         /// </summary>
         public int MaxPlayerAutoTargetRadius = 15;
+        
+        /// <summary>
+        /// If enabled this allows regenerate vitals in combat
+        /// </summary>
+        public bool RegenVitalsInCombat = false;
     }
 
 }

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -128,6 +128,8 @@ namespace Intersect
 
         public static int RegenTime => Instance.CombatOpts.RegenTime;
 
+        public static bool CombatRegen => Instance.CombatOpts.CombatRegen;
+
         public static int CombatTime => Instance.CombatOpts.CombatTime;
 
         public static int MinAttackRate => Instance.CombatOpts.MinAttackRate;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -127,9 +127,7 @@ namespace Intersect
         public static List<string> AnimatedSprites => Instance._animatedSprites;
 
         public static int RegenTime => Instance.CombatOpts.RegenTime;
-
-        public static bool CombatRegen => Instance.CombatOpts.CombatRegen;
-
+        
         public static int CombatTime => Instance.CombatOpts.CombatTime;
 
         public static int MinAttackRate => Instance.CombatOpts.MinAttackRate;

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -325,7 +325,7 @@ namespace Intersect.Server.Entities
                     }
 
                     //Regen Timers and regen in combat validation
-                    if ((timeMs > CombatTimer || Options.CombatRegen) && timeMs > RegenTimer)
+                    if ((timeMs > CombatTimer || Options.Instance.CombatOpts.RegenVitalsInCombat) && timeMs > RegenTimer)
                     {
                         ProcessRegen();
                         RegenTimer = timeMs + Options.RegenTime;

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -324,8 +324,8 @@ namespace Intersect.Server.Entities
                         PacketSender.SendEntityStats(this);
                     }
 
-                    //Regen Timers
-                    if (timeMs > CombatTimer && timeMs > RegenTimer)
+                    //Regen Timers and regen in combat validation
+                    if ((timeMs > CombatTimer || Options.CombatRegen) && timeMs > RegenTimer)
                     {
                         ProcessRegen();
                         RegenTimer = timeMs + Options.RegenTime;


### PR DESCRIPTION
It is a very basic PR but it is linked to this issue https://github.com/AscensionGameDev/Intersect-Engine/issues/506, I have used the suggestions that they had written but without eliminating the default behavior.