### PR TITLE
FIX 864: Crafts Editor "Common Event" combobox now displays correct value when flipping between crafts in the editor

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmCrafts.cs
+++ b/Intersect.Editor/Forms/Editors/frmCrafts.cs
@@ -122,6 +122,8 @@ namespace Intersect.Editor.Forms.Editors
                     mChanged.Add(mEditorItem);
                     mEditorItem.MakeBackup();
                 }
+
+                cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
             }
             else
             {


### PR DESCRIPTION
Resolves #864 

UpdateEditor() was not updated with the change that introduced the craft common event.