### PR TITLE
Scale feature

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -46,7 +46,11 @@ namespace Intersect.Configuration
 
         public const string DEFAULT_MENU_BACKGROUND = "background.png";
 
+        public const string DEFAULT_MENU_BACKGROUND_TALL = "background2.png";
+
         public const string DEFAULT_MENU_MUSIC = "RPG-Theme_v001_Looping.ogg";
+
+        public const bool DEFAULT_SCALE_BACKGROUND_IMAGE = false;
 
         #endregion
 
@@ -117,6 +121,17 @@ namespace Intersect.Configuration
         /// Menu background art
         /// </summary>
         public string MenuBackground { get; set; } = DEFAULT_MENU_BACKGROUND;
+
+
+        /// <summary>
+        /// Menu background art tall version
+        /// </summary>
+        public string MenuBackgroundTall { get; set; } = DEFAULT_MENU_BACKGROUND_TALL;
+
+        /// <summary>
+        /// Fits menu background to screen
+        /// </summary>
+        public bool MenuBackgroundFitToScreen { get; set; } = DEFAULT_SCALE_BACKGROUND_IMAGE;
 
         // TODO: What is this for?
         public List<string> IntroImages { get; set; } = new List<string>();

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -143,13 +143,28 @@ namespace Intersect.Client.Core
 
         public static void DrawMenu()
         {
-            var imageTex = sContentManager.GetTexture(
-                GameContentManager.TextureType.Gui, ClientConfiguration.Instance.MenuBackground
-            );
+            double scale = Math.Round((double)Renderer.GetScreenWidth() / Renderer.GetScreenHeight(), 2);
+            GameTexture imageTex;
+
+            if (scale >= 1.34)
+            {
+                imageTex = sContentManager.GetTexture(
+                   GameContentManager.TextureType.Gui, ClientConfiguration.Instance.MenuBackground
+               );
+            }
+            else
+            {
+                imageTex = sContentManager.GetTexture(
+                    GameContentManager.TextureType.Gui, ClientConfiguration.Instance.MenuBackgroundTall
+                );
+            }
 
             if (imageTex != null)
-            {
-                DrawFullScreenTexture(imageTex);
+            {              
+                if (ClientConfiguration.Instance.MenuBackgroundFitToScreen)
+                    DrawFullScreenTextureFitScreen(imageTex);
+                else
+                    DrawFullScreenTexture(imageTex);
             }
         }
 
@@ -714,6 +729,23 @@ namespace Intersect.Client.Core
                 tex, GetSourceRect(tex),
                 new FloatRect(
                     Renderer.GetView().X + offsetX, Renderer.GetView().Y, scaledWidth, Renderer.GetScreenHeight()
+                ), Color.White
+            );
+        }
+
+        public static void DrawFullScreenTextureFitScreen(GameTexture tex)
+        {
+            var scale = Renderer.GetScreenHeight() / (float)tex.GetHeight();
+            var scaledWidth = tex.GetWidth() * scale;
+            var offsetX = (Renderer.GetScreenWidth() - scaledWidth) / 2f;
+            scale = Renderer.GetScreenWidth() / (float)tex.GetWidth();
+            var scaledHeight = tex.GetHeight() * scale;
+            var offsetY = (Renderer.GetScreenHeight() - scaledHeight) / 2f;
+
+            DrawGameTexture(
+                tex, GetSourceRect(tex),
+                new FloatRect(
+                    Renderer.GetView().X + offsetX, Renderer.GetView().Y + offsetY, scaledWidth, scaledHeight
                 ), Color.White
             );
         }


### PR DESCRIPTION
This adds a much-needed feature to Intersect. I like to have the logo bigger than what Intersect provides and the logo deserves to be part of the background image in my honest opinion rather than a separate image. It is much harder to scale the logo and position it in the background. This pull request adds a scale feature to the menu with two supported aspect ratios for the background, 16 by 9 and 4 by 3. If this is not accepted it is okay, I just didn't want to mess with my logo at the top of the GUI and change the entire layout to position the logo to the right of the GUI.