### PR TITLE
FEATURE #911: Scale Background Images

### DIFF
--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -769,6 +769,22 @@ namespace Intersect.Client.Core
             }
         }
 
+        public static void DrawFullScreenTextureFitScreen(GameTexture tex)
+        {
+            var scale = Renderer.GetScreenHeight() / (float)tex.GetHeight();
+            var scaledWidth = tex.GetWidth() * scale;
+            var offsetX = (Renderer.GetScreenWidth() - scaledWidth) / 2f;
+            scale = Renderer.GetScreenWidth() / (float)tex.GetWidth();
+            var scaledHeight = tex.GetHeight() * scale;
+            var offsetY = (Renderer.GetScreenHeight() - scaledHeight) / 2f;
+            DrawGameTexture(
+                tex, GetSourceRect(tex),
+                new FloatRect(
+                    Renderer.GetView().X + offsetX, Renderer.GetView().Y + offsetY, scaledWidth, scaledHeight
+                ), Color.White
+            );
+        }
+
         private static void UpdateView()
         {
             if (Globals.Me == null)


### PR DESCRIPTION
This is the initial commit, with just the drawing function of textures which scales the x and y, I was seeing if the development team was interested in this for background to scale based on the resolution, because right now the background images in Intersect are very boring with how it draws them. You can't really have background images with like characters or anything.