### PR TITLE
Check whether Entities and MapGrid actually exist before pulling data to send to plugins

### DIFF
--- a/Intersect.Client/General/Globals.cs
+++ b/Intersect.Client/General/Globals.cs
@@ -80,32 +80,39 @@ namespace Intersect.Client.General
             // Gather all known entities before passing them on to the plugins!
             // The global entity list is incomplete and lacks events.
             var knownEntities = new Dictionary<Guid, IEntity>();
-            foreach(var en in Entities)
+
+            if (Entities != null)
             {
-                if (!knownEntities.ContainsKey(en.Key))
+                foreach (var en in Entities)
                 {
-                    knownEntities.Add(en.Key, en.Value);
+                    if (!knownEntities.ContainsKey(en.Key))
+                    {
+                        knownEntities.Add(en.Key, en.Value);
+                    }
                 }
             }
-
-            for (var x = 0; x < MapGridWidth; x++)
+            
+            if (MapGrid != null)
             {
-                for (var y = 0; y < MapGridHeight; y++)
+                for (var x = 0; x < MapGridWidth; x++)
                 {
-                    var map = MapInstance.Get(MapGrid[x, y]);
-                    if (map != null)
+                    for (var y = 0; y < MapGridHeight; y++)
                     {
-                        foreach (var en in map.LocalEntities)
+                        var map = MapInstance.Get(MapGrid[x, y]);
+                        if (map != null)
                         {
-                            if (!knownEntities.ContainsKey(en.Key))
+                            foreach (var en in map.LocalEntities)
                             {
-                                knownEntities.Add(en.Key, en.Value);
+                                if (!knownEntities.ContainsKey(en.Key))
+                                {
+                                    knownEntities.Add(en.Key, en.Value);
+                                }
                             }
                         }
                     }
                 }
             }
-
+            
             ClientLifecycleHelpers.ForEach(
                 clientLifecycleHelper => clientLifecycleHelper?.OnGameUpdate(GameState, Globals.Me, knownEntities, deltaTime)
             );


### PR DESCRIPTION
Resolves #917 

So, turns out I never checked whether the things I'm trying to pull data from to push to plugins exist.
When the gamestate changes this causes some.. issues.