### PR TITLE
Moves 'MaxHotBar' setting to Server's PlayerOptions.

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -29,11 +29,9 @@ namespace Intersect
         [JsonProperty("OpenPortChecker", Order = 0)]
         protected bool _portChecker = true;
 
-        [JsonProperty("MaxClientConnections")]
-        protected int _maxConnections = 100;
+        [JsonProperty("MaxClientConnections")] protected int _maxConnections = 100;
 
-        [JsonProperty("MaximumLoggedinUsers")]
-        protected int _maxUsers = 50;
+        [JsonProperty("MaximumLoggedinUsers")] protected int _maxUsers = 50;
 
         [JsonProperty("UPnP", Order = -1)] protected bool _upnp = true;
 
@@ -84,7 +82,11 @@ namespace Intersect
         public bool SendingToClient { get; set; } = true;
 
         //Public Getters
-        public static ushort ServerPort { get => Instance._serverPort; set => Instance._serverPort = value; }
+        public static ushort ServerPort
+        {
+            get => Instance._serverPort;
+            set => Instance._serverPort = value;
+        }
 
         /// <summary>
         /// Defines the maximum amount of network connections our server is allowed to handle.
@@ -113,8 +115,6 @@ namespace Intersect
         public static int RequestTimeout => Instance.PlayerOpts.RequestTimeout;
 
         public static int TradeRange => Instance.PlayerOpts.TradeRange;
-        
-        public static int MaxHotbar => Instance.PlayerOpts.MaxHotbar;
 
         public static int WeaponIndex => Instance.EquipmentOpts.WeaponSlot;
 
@@ -129,7 +129,7 @@ namespace Intersect
         public static List<string> AnimatedSprites => Instance._animatedSprites;
 
         public static int RegenTime => Instance.CombatOpts.RegenTime;
-        
+
         public static int CombatTime => Instance.CombatOpts.CombatTime;
 
         public static int MinAttackRate => Instance.CombatOpts.MinAttackRate;
@@ -174,7 +174,11 @@ namespace Intersect
 
         public static int PasswordResetExpirationMinutes => Instance._passResetExpirationMin;
 
-        public static bool AdminOnly { get => Instance._adminOnly; set => Instance._adminOnly = value; }
+        public static bool AdminOnly
+        {
+            get => Instance._adminOnly;
+            set => Instance._adminOnly = value;
+        }
 
         public static bool BlockClientRegistrations
         {

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -113,6 +113,8 @@ namespace Intersect
         public static int RequestTimeout => Instance.PlayerOpts.RequestTimeout;
 
         public static int TradeRange => Instance.PlayerOpts.TradeRange;
+        
+        public static int MaxHotbar => Instance.PlayerOpts.MaxHotbar;
 
         public static int WeaponIndex => Instance.EquipmentOpts.WeaponSlot;
 
@@ -295,8 +297,6 @@ namespace Intersect
 
         // TODO: Clean these up
         //Values that cannot easily be changed:
-
-        public const int MaxHotbar = 10;
 
         public const string DEFAULT_GAME_NAME = "Intersect";
 

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -5,6 +5,21 @@
     {
 
         /// <summary>
+        /// Unlinks the timers for combat and movement to facilitate complex combat (e.g. kiting)
+        /// </summary>
+        public bool AllowCombatMovement = true;
+
+        /// <summary>
+        /// If true, it will remove the associated exp, otherwise you will lose the exp based on the exp required to level up.
+        /// </summary>
+        public bool ExpLossFromCurrentExp = true;
+
+        /// <summary>
+        /// First thanks for letting me share an idea, of losing XP when dying <3
+        /// </summary>
+        public int ExpLossOnDeathPercent = 0;
+
+        /// <summary>
         /// A percentage between 0 and 100 which determines the chance in which they will lose any given item in their inventory when killed.
         /// </summary>
         public int ItemDropChance = 0;
@@ -18,6 +33,12 @@
         /// Number of characters an account may create.
         /// </summary>
         public int MaxCharacters = 1;
+
+        /// <summary>
+        /// Number of hotbar slots a player has.
+        /// Default value is 10. If you change this, make sure to properly modify the HotbarWindow layout at 'resources\gui\layouts\game\HotbarWindow.json'.
+        /// </summary>
+        public int MaxHotbar = 10;
 
         /// <summary>
         /// Number of inventory slots a player has.
@@ -45,29 +66,14 @@
         public int RequestTimeout = 300000;
 
         /// <summary>
-        /// Distance (in tiles) between players in which a trade offer can be sent and accepted.
-        /// </summary>
-        public int TradeRange = 6;
-
-        /// <summary>
-        /// Unlinks the timers for combat and movement to facilitate complex combat (e.g. kiting)
-        /// </summary>
-        public bool AllowCombatMovement = true;
-
-        /// <summary>
         /// Configures whether or not the level of a player is shown next to their name.
         /// </summary>
         public bool ShowLevelByName = false;
 
         /// <summary>
-        /// First thanks for letting me share an idea, of losing XP when dying <3
+        /// Distance (in tiles) between players in which a trade offer can be sent and accepted.
         /// </summary>
-        public int ExpLossOnDeathPercent = 0;
-
-        /// <summary>
-        /// If true, it will remove the associated exp, otherwise you will lose the exp based on the exp required to level up.
-        /// </summary>
-        public bool ExpLossFromCurrentExp = true;
+        public int TradeRange = 6;
 
     }
 

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -1,6 +1,8 @@
 ﻿namespace Intersect.Config
 {
-
+    /// <summary>
+    /// Contains configurable options pertaining to the way Players are handled by the engine.
+    /// </summary>
     public class PlayerOptions
     {
 
@@ -36,7 +38,8 @@
 
         /// <summary>
         /// Number of hotbar slots a player has.
-        /// Default value is 10. If you change this, make sure to properly modify the HotbarWindow layout at 'resources\gui\layouts\game\HotbarWindow.json'.
+        /// Default value is 10. If you change the default value (e.g. 16 slots), make sure to properly
+        /// modify the Client's HotbarWindow layout at: 'resources\gui\layouts\game\HotbarWindow.json'.
         /// </summary>
         public int MaxHotbar = 10;
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -20,10 +20,8 @@ using Intersect.Network.Packets.Server;
 using Newtonsoft.Json;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Utilities;
-using Intersect.Client.Items;
 using Intersect.Client.Interface.Game.Chat;
 using Intersect.Config.Guilds;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Entities;
 
 namespace Intersect.Client.Entities
@@ -42,7 +40,7 @@ namespace Intersect.Client.Entities
 
         public List<FriendInstance> Friends = new List<FriendInstance>();
 
-        public HotbarInstance[] Hotbar = new HotbarInstance[Options.MaxHotbar];
+        public HotbarInstance[] Hotbar = new HotbarInstance[Options.Instance.PlayerOpts.MaxHotbar];
 
         public InventoryUpdated InventoryUpdatedDelegate;
 
@@ -111,7 +109,7 @@ namespace Intersect.Client.Entities
 
         public Player(Guid id, PlayerEntityPacket packet) : base(id, packet)
         {
-            for (var i = 0; i < Options.MaxHotbar; i++)
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
             {
                 Hotbar[i] = new HotbarInstance();
             }
@@ -937,7 +935,7 @@ namespace Intersect.Client.Entities
             }
 
             var castInput = -1;
-            for (var barSlot = 0; barSlot < Options.MaxHotbar; barSlot++)
+            for (var barSlot = 0; barSlot < Options.Instance.PlayerOpts.MaxHotbar; barSlot++)
             {
                 if (!mLastHotbarUseTime.ContainsKey(barSlot))
                 {

--- a/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
@@ -5,7 +5,6 @@ using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
@@ -42,7 +41,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
         private void InitHotbarItems()
         {
             var x = 12;
-            for (var i = 0; i < Options.MaxHotbar; i++)
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
             {
                 Items.Add(new HotbarItem((byte) i, HotbarWindow));
                 Items[i].Pnl = new ImagePanel(HotbarWindow, "HotbarContainer" + i);
@@ -64,7 +63,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
                 return;
             }
 
-            for (var i = 0; i < Options.MaxHotbar; i++)
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
             {
                 Items[i].Update();
             }

--- a/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
@@ -2,9 +2,7 @@
 
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
-using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
@@ -521,7 +519,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
 
                         if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
                         {
-                            for (var i = 0; i < Options.MaxHotbar; i++)
+                            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
                             {
                                 if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
                                 {

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 
 using Intersect.Client.Core;
-using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
@@ -407,7 +405,7 @@ namespace Intersect.Client.Interface.Game.Inventory
                     }
                     else if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
                     {
-                        for (var i = 0; i < Options.MaxHotbar; i++)
+                        for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
                         {
                             if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
                             {

--- a/Intersect.Client/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellItem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 
-using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
@@ -297,7 +296,7 @@ namespace Intersect.Client.Interface.Game.Spells
                     }
                     else if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
                     {
-                        for (var i = 0; i < Options.MaxHotbar; i++)
+                        for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
                         {
                             if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
                             {

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -21,7 +21,6 @@ using Intersect.Network;
 using Intersect.Network.Packets;
 using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
-using Newtonsoft.Json;
 
 using System;
 using System.Collections.Generic;
@@ -1233,7 +1232,7 @@ namespace Intersect.Client.Networking
         //HotbarPacket
         public void HandlePacket(IPacketSender packetSender, HotbarPacket packet)
         {
-            for (var i = 0; i < Options.MaxHotbar; i++)
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
             {
                 if (Globals.Me == null)
                 {

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3,11 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-using Amib.Threading;
+
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
@@ -202,10 +200,10 @@ namespace Intersect.Server.Entities
             changes |= SlotHelper.ValidateSlots(Items, Options.MaxInvItems);
             changes |= SlotHelper.ValidateSlots(Bank, Options.MaxBankSlots);
 
-            if (Hotbar.Count < Options.MaxHotbar)
+            if (Hotbar.Count < Options.Instance.PlayerOpts.MaxHotbar)
             {
                 Hotbar.Sort((a, b) => a?.Slot - b?.Slot ?? 0);
-                for (var i = Hotbar.Count; i < Options.MaxHotbar; i++)
+                for (var i = Hotbar.Count; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
                 {
                     Hotbar.Add(new HotbarSlot(i));
                 }

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
+
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
@@ -12,7 +12,6 @@ using Intersect.Logging;
 using Intersect.Models;
 using Intersect.Network;
 using Intersect.Network.Packets.Server;
-using Intersect.Server.Core;
 using Intersect.Server.Database;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData.Players;
@@ -23,7 +22,6 @@ using Intersect.Server.General;
 using Intersect.Server.Localization;
 using Intersect.Server.Maps;
 using Intersect.Utilities;
-using Newtonsoft.Json;
 
 namespace Intersect.Server.Networking
 {
@@ -1187,8 +1185,8 @@ namespace Intersect.Server.Networking
         //HotbarPacket
         public static void SendHotbarSlots(Player player)
         {
-            var hotbarData = new string[Options.MaxHotbar];
-            for (var i = 0; i < Options.MaxHotbar; i++)
+            var hotbarData = new string[Options.Instance.PlayerOpts.MaxHotbar];
+            for (var i = 0; i < Options.Instance.PlayerOpts.MaxHotbar; i++)
             {
                 hotbarData[i] = player.Hotbar[i].Data();
             }


### PR DESCRIPTION
This Pull Request should solve the issue #896 

Also: 

- Re-ordered Server's PlayerOptions Alphabetically.
- Added an XML documentation comment for the class PlayerOptions.
- Completely Removed 'MaxHotBar' setting from Core's Config.Options.
- Removed some unused imports.

Preview/Example:

![imagen](https://user-images.githubusercontent.com/17498701/131237507-3879d141-d7d4-44f7-9b23-055631967fb3.png)

![imagen](https://user-images.githubusercontent.com/17498701/131237519-9259e4be-4ac9-45b4-a0d6-b07ec688c639.png)




