### PR TITLE
Fix bank Interface memory leak

### DIFF
--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -34,6 +34,8 @@ namespace Intersect.Client.Interface.Game.Bank
 
         public int Y;
 
+        private bool mOpen;
+
         //Init
         public BankWindow(Canvas gameCanvas)
         {
@@ -46,11 +48,19 @@ namespace Intersect.Client.Interface.Game.Bank
 
             mBankWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
             InitItemContainer();
+            Close();
         }
 
         public void Close()
         {
-            mBankWindow.Close();
+            mBankWindow.IsHidden = true;
+            mOpen = false;
+        }
+
+        public void Open()
+        {
+            mBankWindow.IsHidden = false;
+            mOpen = true;
         }
 
         public bool IsVisible()
@@ -58,15 +68,15 @@ namespace Intersect.Client.Interface.Game.Bank
             return !mBankWindow.IsHidden;
         }
 
-        public void Hide()
-        {
-            mBankWindow.IsHidden = true;
-        }
-
         public void Update()
         {
             if (mBankWindow.IsHidden == true)
             {
+                if (mOpen)
+                {
+                    Interface.GameUi.NotifyCloseBank();
+                }
+
                 return;
             }
 
@@ -109,7 +119,7 @@ namespace Intersect.Client.Interface.Game.Bank
 
         private void InitItemContainer()
         {
-            for (var i = 0; i < Globals.BankSlots; i++)
+            for (var i = 0; i < Options.Player.MaxBank; i++)
             {
                 Items.Add(new BankItem(this, i));
                 Items[i].Container = new ImagePanel(mItemContainer, "BankItem");

--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -122,6 +122,7 @@ namespace Intersect.Client.Interface.Game
             mQuestOfferWindow = new QuestOfferWindow(GameCanvas);
             mDebugMenu = new DebugMenu(GameCanvas);
             mMapItemWindow = new MapItemWindow(GameCanvas);
+            mBankWindow = new BankWindow(GameCanvas);
         }
 
         //Chatbox
@@ -206,9 +207,7 @@ namespace Intersect.Client.Interface.Game
 
         public void OpenBank()
         {
-            mBankWindow?.Close();
-
-            mBankWindow = new BankWindow(GameCanvas);
+            mBankWindow.Open();
             mShouldOpenBank = false;
             Globals.InBank = true;
         }
@@ -401,20 +400,16 @@ namespace Intersect.Client.Interface.Game
                 OpenBank();
                 GameMenu.OpenInventory();
             }
-
-            if (mBankWindow != null)
+            else if (mShouldCloseBank)
             {
-                if (!mBankWindow.IsVisible() || mShouldCloseBank)
-                {
-                    CloseBank();
-                }
-                else
-                {
-                    mBankWindow.Update();
-                }
+                CloseBank();
+            }
+            else
+            { 
+                mBankWindow.Update();
             }
 
-            mShouldCloseBank = false;
+            
 
             //Bag Update
             if (mShouldOpenBag)
@@ -529,10 +524,10 @@ namespace Intersect.Client.Interface.Game
 
         private void CloseBank()
         {
-            mBankWindow?.Close();
-            mBankWindow = null;
+            mBankWindow.Close();
             Globals.InBank = false;
             PacketSender.SendCloseBank();
+            mShouldCloseBank = false;
         }
 
         private void CloseBagWindow()


### PR DESCRIPTION
Resolves #937

Stop (partially) destroying and fully recreating the bank window each use, was leaving orphaned Gwen objects around causing a memory leak.

We kept nulling this out but not disposing the actual window, so it was never removed (along with all of its children) from the Interface collections.. Oopsie. Though to be fair, why on earth are we endlessly recreating it anyway? Can just re-use it right. :)

I believe a similar issue may be happening elsewhere too, not sure?
Thanks Aesthethic for notifying me about this one. :)