### PR TITLE
[Fix]Chatbox (Blank|Empty)Msgs Behaviour with SpamCheck

### DIFF
--- a/Intersect.Client/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client/Interface/Game/Chat/Chatbox.cs
@@ -15,6 +15,7 @@ using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Enums;
 using Intersect.Localization;
+using Intersect.Utilities;
 
 namespace Intersect.Client.Interface.Game.Chat
 {
@@ -372,25 +373,26 @@ namespace Intersect.Client.Interface.Game.Chat
 
         void TrySendMessage()
         {
-            if (mLastChatTime > Globals.System.GetTimeMs())
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.toofast, Color.Red, ChatMessageType.Error));
-                mLastChatTime = Globals.System.GetTimeMs() + Options.MinChatInterval;
-
-                return;
-            }
-
-            mLastChatTime = Globals.System.GetTimeMs() + Options.MinChatInterval;
-
-            if (mChatboxInput.Text.Trim().Length <= 0 || mChatboxInput.Text == GetDefaultInputText())
+            var msg = mChatboxInput.Text.Trim();
+            if (string.IsNullOrWhiteSpace(msg) || string.Equals(msg, GetDefaultInputText(), StringComparison.Ordinal))
             {
                 mChatboxInput.Text = GetDefaultInputText();
 
                 return;
             }
+            
+            if (mLastChatTime > Timing.Global.MillisecondsUtc)
+            {
+                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.toofast, Color.Red, ChatMessageType.Error));
+                mLastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
+
+                return;
+            }
+
+            mLastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
 
             PacketSender.SendChatMsg(
-                mChatboxInput.Text.Trim(), byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString())
+                msg, byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString())
             );
 
             mChatboxInput.Text = GetDefaultInputText();

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -734,6 +734,12 @@ namespace Intersect.Server.Networking
 
             var msg = packet.Message;
             var channel = packet.Channel;
+            
+            if (string.IsNullOrWhiteSpace(msg))
+            {
+                return;
+            }
+            
             if (client?.User.IsMuted ?? false) //Don't let the tongueless toxic kids speak.
             {
                 PacketSender.SendChatMsg(player, client?.User?.Mute?.Reason, ChatMessageType.Notice);


### PR DESCRIPTION
### The Issue
I believe that the chat log's warnings towards spammers are being checked in the wrong moment / place, this is the current behaviour with blank/empty messages, which in my opinion doesn't makes much sense if no message is being send at all:

(Simply press the "Return"/"Enter" Key repeatedly to toggle on and off the chatbox input)

https://user-images.githubusercontent.com/17498701/133119051-095f0b57-d3e4-4a0c-94b1-cfd544cfcb76.mp4


### The Fix
This PR fixes that client side behaviour, in adition with a server side check in the packet handler, to basically do the same (nothing) if the message content is empty/blank or null (just in case that someone decides to mess with the client in order to send spammy empty messages):

https://user-images.githubusercontent.com/17498701/133118893-74ad6e2b-0c75-48dd-9f10-986346aceab8.mp4



https://user-images.githubusercontent.com/17498701/133119377-97e416e7-e61e-465c-becd-14c91b5f3801.mp4


