### PR TITLE
Fix Spell editor windows being misaligned

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
@@ -66,6 +66,8 @@ namespace Intersect.Editor.Forms.Editors
             this.lblCastDuration = new System.Windows.Forms.Label();
             this.lblCooldownDuration = new System.Windows.Forms.Label();
             this.grpRequirements = new DarkUI.Controls.DarkGroupBox();
+            this.lblCannotCast = new System.Windows.Forms.Label();
+            this.txtCannotCast = new DarkUI.Controls.DarkTextBox();
             this.btnDynamicRequirements = new DarkUI.Controls.DarkButton();
             this.grpTargetInfo = new DarkUI.Controls.DarkGroupBox();
             this.nudDuration = new DarkUI.Controls.DarkNumericUpDown();
@@ -78,8 +80,6 @@ namespace Intersect.Editor.Forms.Editors
             this.nudCastRange = new DarkUI.Controls.DarkNumericUpDown();
             this.lblProjectile = new System.Windows.Forms.Label();
             this.cmbProjectile = new DarkUI.Controls.DarkComboBox();
-            this.grpEvent = new DarkUI.Controls.DarkGroupBox();
-            this.cmbEvent = new DarkUI.Controls.DarkComboBox();
             this.grpCombat = new DarkUI.Controls.DarkGroupBox();
             this.grpStats = new DarkUI.Controls.DarkGroupBox();
             this.lblPercentage5 = new System.Windows.Forms.Label();
@@ -136,6 +136,8 @@ namespace Intersect.Editor.Forms.Editors
             this.lblDamageType = new System.Windows.Forms.Label();
             this.lblHPDamage = new System.Windows.Forms.Label();
             this.lblManaDamage = new System.Windows.Forms.Label();
+            this.grpEvent = new DarkUI.Controls.DarkGroupBox();
+            this.cmbEvent = new DarkUI.Controls.DarkComboBox();
             this.grpDash = new DarkUI.Controls.DarkGroupBox();
             this.grpDashCollisions = new DarkUI.Controls.DarkGroupBox();
             this.chkIgnoreInactiveResources = new DarkUI.Controls.DarkCheckBox();
@@ -171,8 +173,6 @@ namespace Intersect.Editor.Forms.Editors
             this.btnClearSearch = new DarkUI.Controls.DarkButton();
             this.txtSearch = new DarkUI.Controls.DarkTextBox();
             this.lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
-            this.lblCannotCast = new System.Windows.Forms.Label();
-            this.txtCannotCast = new DarkUI.Controls.DarkTextBox();
             this.pnlContainer.SuspendLayout();
             this.grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picSpell)).BeginInit();
@@ -186,7 +186,6 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudDuration)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudHitRadius)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudCastRange)).BeginInit();
-            this.grpEvent.SuspendLayout();
             this.grpCombat.SuspendLayout();
             this.grpStats.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudSpdPercentage)).BeginInit();
@@ -211,6 +210,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudScaling)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMPDamage)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudHPDamage)).BeginInit();
+            this.grpEvent.SuspendLayout();
             this.grpDash.SuspendLayout();
             this.grpDashCollisions.SuspendLayout();
             this.grpWarp.SuspendLayout();
@@ -227,8 +227,8 @@ namespace Intersect.Editor.Forms.Editors
             this.pnlContainer.Controls.Add(this.grpSpellCost);
             this.pnlContainer.Controls.Add(this.grpRequirements);
             this.pnlContainer.Controls.Add(this.grpTargetInfo);
-            this.pnlContainer.Controls.Add(this.grpEvent);
             this.pnlContainer.Controls.Add(this.grpCombat);
+            this.pnlContainer.Controls.Add(this.grpEvent);
             this.pnlContainer.Controls.Add(this.grpDash);
             this.pnlContainer.Controls.Add(this.grpWarp);
             this.pnlContainer.Location = new System.Drawing.Point(221, 40);
@@ -514,7 +514,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpSpellCost.Controls.Add(this.lblCastDuration);
             this.grpSpellCost.Controls.Add(this.lblCooldownDuration);
             this.grpSpellCost.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpellCost.Location = new System.Drawing.Point(3, 362);
+            this.grpSpellCost.Location = new System.Drawing.Point(3, 301);
             this.grpSpellCost.Name = "grpSpellCost";
             this.grpSpellCost.Size = new System.Drawing.Size(438, 143);
             this.grpSpellCost.TabIndex = 36;
@@ -722,6 +722,26 @@ namespace Intersect.Editor.Forms.Editors
             this.grpRequirements.TabStop = false;
             this.grpRequirements.Text = "Casting Requirements";
             // 
+            // lblCannotCast
+            // 
+            this.lblCannotCast.AutoSize = true;
+            this.lblCannotCast.Location = new System.Drawing.Point(8, 51);
+            this.lblCannotCast.Name = "lblCannotCast";
+            this.lblCannotCast.Size = new System.Drawing.Size(114, 13);
+            this.lblCannotCast.TabIndex = 56;
+            this.lblCannotCast.Text = "Cannot Cast Message:";
+            // 
+            // txtCannotCast
+            // 
+            this.txtCannotCast.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.txtCannotCast.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCannotCast.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.txtCannotCast.Location = new System.Drawing.Point(11, 67);
+            this.txtCannotCast.Name = "txtCannotCast";
+            this.txtCannotCast.Size = new System.Drawing.Size(207, 20);
+            this.txtCannotCast.TabIndex = 55;
+            this.txtCannotCast.TextChanged += new System.EventHandler(this.txtCannotCast_TextChanged);
+            // 
             // btnDynamicRequirements
             // 
             this.btnDynamicRequirements.Location = new System.Drawing.Point(11, 18);
@@ -905,41 +925,6 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbProjectile.Visible = false;
             this.cmbProjectile.SelectedIndexChanged += new System.EventHandler(this.cmbProjectile_SelectedIndexChanged);
             // 
-            // grpEvent
-            // 
-            this.grpEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpEvent.Controls.Add(this.cmbEvent);
-            this.grpEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEvent.Location = new System.Drawing.Point(0, 305);
-            this.grpEvent.Name = "grpEvent";
-            this.grpEvent.Size = new System.Drawing.Size(441, 48);
-            this.grpEvent.TabIndex = 40;
-            this.grpEvent.TabStop = false;
-            this.grpEvent.Text = "Event";
-            this.grpEvent.Visible = false;
-            // 
-            // cmbEvent
-            // 
-            this.cmbEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbEvent.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbEvent.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbEvent.DrawDropdownHoverOutline = false;
-            this.cmbEvent.DrawFocusRectangle = false;
-            this.cmbEvent.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbEvent.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbEvent.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbEvent.FormattingEnabled = true;
-            this.cmbEvent.Location = new System.Drawing.Point(9, 17);
-            this.cmbEvent.Name = "cmbEvent";
-            this.cmbEvent.Size = new System.Drawing.Size(425, 21);
-            this.cmbEvent.TabIndex = 17;
-            this.cmbEvent.Text = null;
-            this.cmbEvent.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbEvent.SelectedIndexChanged += new System.EventHandler(this.cmbEvent_SelectedIndexChanged);
-            // 
             // grpCombat
             // 
             this.grpCombat.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
@@ -950,10 +935,10 @@ namespace Intersect.Editor.Forms.Editors
             this.grpCombat.Controls.Add(this.grpEffectDuration);
             this.grpCombat.Controls.Add(this.grpDamage);
             this.grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpCombat.Location = new System.Drawing.Point(3, 513);
+            this.grpCombat.Location = new System.Drawing.Point(3, 448);
             this.grpCombat.Name = "grpCombat";
             this.grpCombat.Size = new System.Drawing.Size(440, 432);
-            this.grpCombat.TabIndex = 39;
+            this.grpCombat.TabIndex = 41;
             this.grpCombat.TabStop = false;
             this.grpCombat.Text = "Combat Spell";
             this.grpCombat.Visible = false;
@@ -1068,7 +1053,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudSpdPercentage.ValueChanged += new System.EventHandler(this.nudSpdPercentage_ValueChanged);
             // 
             // nudMRPercentage
             // 
@@ -1093,7 +1077,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudMRPercentage.ValueChanged += new System.EventHandler(this.nudMRPercentage_ValueChanged);
             // 
             // nudDefPercentage
             // 
@@ -1118,7 +1101,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudDefPercentage.ValueChanged += new System.EventHandler(this.nudDefPercentage_ValueChanged);
             // 
             // nudMagPercentage
             // 
@@ -1143,7 +1125,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudMagPercentage.ValueChanged += new System.EventHandler(this.nudMagPercentage_ValueChanged);
             // 
             // nudStrPercentage
             // 
@@ -1168,7 +1149,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudStrPercentage.ValueChanged += new System.EventHandler(this.nudStrPercentage_ValueChanged);
             // 
             // lblPlus5
             // 
@@ -1243,7 +1223,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudSpd.ValueChanged += new System.EventHandler(this.nudSpd_ValueChanged);
             // 
             // nudMR
             // 
@@ -1268,7 +1247,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudMR.ValueChanged += new System.EventHandler(this.nudMR_ValueChanged);
             // 
             // nudDef
             // 
@@ -1293,7 +1271,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudDef.ValueChanged += new System.EventHandler(this.nudDef_ValueChanged);
             // 
             // nudMag
             // 
@@ -1318,7 +1295,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudMag.ValueChanged += new System.EventHandler(this.nudMag_ValueChanged);
             // 
             // nudStr
             // 
@@ -1343,7 +1319,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudStr.ValueChanged += new System.EventHandler(this.nudStr_ValueChanged);
             // 
             // lblSpd
             // 
@@ -1428,7 +1403,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudTick.ValueChanged += new System.EventHandler(this.nudTick_ValueChanged);
             // 
             // chkHOTDOT
             // 
@@ -1438,7 +1412,6 @@ namespace Intersect.Editor.Forms.Editors
             this.chkHOTDOT.Size = new System.Drawing.Size(86, 24);
             this.chkHOTDOT.TabIndex = 22;
             this.chkHOTDOT.Text = "HOT/DOT?";
-            this.chkHOTDOT.CheckedChanged += new System.EventHandler(this.chkHOTDOT_CheckedChanged);
             // 
             // lblTick
             // 
@@ -1508,7 +1481,6 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbExtraEffect.TabIndex = 36;
             this.cmbExtraEffect.Text = "None";
             this.cmbExtraEffect.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbExtraEffect.SelectedIndexChanged += new System.EventHandler(this.cmbExtraEffect_SelectedIndexChanged);
             // 
             // picSprite
             // 
@@ -1541,7 +1513,6 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbTransform.TabIndex = 44;
             this.cmbTransform.Text = "None";
             this.cmbTransform.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbTransform.SelectedIndexChanged += new System.EventHandler(this.cmbTransform_SelectedIndexChanged);
             // 
             // lblSprite
             // 
@@ -1584,7 +1555,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudBuffDuration.ValueChanged += new System.EventHandler(this.nudBuffDuration_ValueChanged);
             // 
             // lblBuffDuration
             // 
@@ -1646,7 +1616,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudCritMultiplier.ValueChanged += new System.EventHandler(this.nudCritMultiplier_ValueChanged);
             // 
             // lblCritMultiplier
             // 
@@ -1670,7 +1639,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudCritChance.ValueChanged += new System.EventHandler(this.nudCritChance_ValueChanged);
             // 
             // nudScaling
             // 
@@ -1690,7 +1658,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudScaling.ValueChanged += new System.EventHandler(this.nudScaling_ValueChanged);
             // 
             // nudMPDamage
             // 
@@ -1715,7 +1682,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudMPDamage.ValueChanged += new System.EventHandler(this.nudMPDamage_ValueChanged);
             // 
             // nudHPDamage
             // 
@@ -1740,7 +1706,6 @@ namespace Intersect.Editor.Forms.Editors
             0,
             0,
             0});
-            this.nudHPDamage.ValueChanged += new System.EventHandler(this.nudHPDamage_ValueChanged);
             // 
             // cmbScalingStat
             // 
@@ -1761,7 +1726,6 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbScalingStat.TabIndex = 57;
             this.cmbScalingStat.Text = null;
             this.cmbScalingStat.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbScalingStat.SelectedIndexChanged += new System.EventHandler(this.cmbScalingStat_SelectedIndexChanged);
             // 
             // lblScalingStat
             // 
@@ -1780,7 +1744,6 @@ namespace Intersect.Editor.Forms.Editors
             this.chkFriendly.Size = new System.Drawing.Size(62, 17);
             this.chkFriendly.TabIndex = 55;
             this.chkFriendly.Text = "Friendly";
-            this.chkFriendly.CheckedChanged += new System.EventHandler(this.chkFriendly_CheckedChanged);
             // 
             // lblCritChance
             // 
@@ -1823,7 +1786,6 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbDamageType.TabIndex = 50;
             this.cmbDamageType.Text = "Physical";
             this.cmbDamageType.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbDamageType.SelectedIndexChanged += new System.EventHandler(this.cmbDamageType_SelectedIndexChanged);
             // 
             // lblDamageType
             // 
@@ -1852,6 +1814,41 @@ namespace Intersect.Editor.Forms.Editors
             this.lblManaDamage.TabIndex = 47;
             this.lblManaDamage.Text = "Mana Damage:";
             // 
+            // grpEvent
+            // 
+            this.grpEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpEvent.Controls.Add(this.cmbEvent);
+            this.grpEvent.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpEvent.Location = new System.Drawing.Point(3, 448);
+            this.grpEvent.Name = "grpEvent";
+            this.grpEvent.Size = new System.Drawing.Size(438, 48);
+            this.grpEvent.TabIndex = 40;
+            this.grpEvent.TabStop = false;
+            this.grpEvent.Text = "Event";
+            this.grpEvent.Visible = false;
+            // 
+            // cmbEvent
+            // 
+            this.cmbEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbEvent.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbEvent.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbEvent.DrawDropdownHoverOutline = false;
+            this.cmbEvent.DrawFocusRectangle = false;
+            this.cmbEvent.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbEvent.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbEvent.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbEvent.FormattingEnabled = true;
+            this.cmbEvent.Location = new System.Drawing.Point(9, 17);
+            this.cmbEvent.Name = "cmbEvent";
+            this.cmbEvent.Size = new System.Drawing.Size(425, 21);
+            this.cmbEvent.TabIndex = 17;
+            this.cmbEvent.Text = null;
+            this.cmbEvent.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbEvent.SelectedIndexChanged += new System.EventHandler(this.cmbEvent_SelectedIndexChanged);
+            // 
             // grpDash
             // 
             this.grpDash.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
@@ -1860,7 +1857,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpDash.Controls.Add(this.lblRange);
             this.grpDash.Controls.Add(this.scrlRange);
             this.grpDash.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpDash.Location = new System.Drawing.Point(3, 456);
+            this.grpDash.Location = new System.Drawing.Point(3, 448);
             this.grpDash.Name = "grpDash";
             this.grpDash.Size = new System.Drawing.Size(200, 181);
             this.grpDash.TabIndex = 38;
@@ -1957,7 +1954,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpWarp.Controls.Add(this.lblX);
             this.grpWarp.Controls.Add(this.lblMap);
             this.grpWarp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpWarp.Location = new System.Drawing.Point(3, 456);
+            this.grpWarp.Location = new System.Drawing.Point(3, 448);
             this.grpWarp.Name = "grpWarp";
             this.grpWarp.Size = new System.Drawing.Size(247, 182);
             this.grpWarp.TabIndex = 35;
@@ -2286,26 +2283,6 @@ namespace Intersect.Editor.Forms.Editors
             this.lstGameObjects.Size = new System.Drawing.Size(191, 422);
             this.lstGameObjects.TabIndex = 32;
             // 
-            // lblCannotCast
-            // 
-            this.lblCannotCast.AutoSize = true;
-            this.lblCannotCast.Location = new System.Drawing.Point(8, 51);
-            this.lblCannotCast.Name = "lblCannotCast";
-            this.lblCannotCast.Size = new System.Drawing.Size(114, 13);
-            this.lblCannotCast.TabIndex = 56;
-            this.lblCannotCast.Text = "Cannot Cast Message:";
-            // 
-            // txtCannotCast
-            // 
-            this.txtCannotCast.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtCannotCast.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtCannotCast.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtCannotCast.Location = new System.Drawing.Point(11, 67);
-            this.txtCannotCast.Name = "txtCannotCast";
-            this.txtCannotCast.Size = new System.Drawing.Size(207, 20);
-            this.txtCannotCast.TabIndex = 55;
-            this.txtCannotCast.TextChanged += new System.EventHandler(this.txtCannotCast_TextChanged);
-            // 
             // FrmSpell
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2345,7 +2322,6 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudDuration)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudHitRadius)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudCastRange)).EndInit();
-            this.grpEvent.ResumeLayout(false);
             this.grpCombat.ResumeLayout(false);
             this.grpStats.ResumeLayout(false);
             this.grpStats.PerformLayout();
@@ -2375,6 +2351,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)(this.nudScaling)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMPDamage)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudHPDamage)).EndInit();
+            this.grpEvent.ResumeLayout(false);
             this.grpDash.ResumeLayout(false);
             this.grpDash.PerformLayout();
             this.grpDashCollisions.ResumeLayout(false);
@@ -2422,20 +2399,11 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblRange;
         private DarkScrollBar scrlRange;
         private System.Windows.Forms.Label lblProjectile;
-        private DarkGroupBox grpCombat;
-        private DarkComboBox cmbExtraEffect;
-        private System.Windows.Forms.Label lblEffect;
-        private System.Windows.Forms.Label lblBuffDuration;
-        private DarkCheckBox chkHOTDOT;
-        private System.Windows.Forms.Label lblTick;
         private DarkGroupBox grpDashCollisions;
         private DarkCheckBox chkIgnoreInactiveResources;
         private DarkCheckBox chkIgnoreZDimensionBlocks;
         private DarkCheckBox chkIgnoreMapBlocks;
         private DarkCheckBox chkIgnoreActiveResources;
-        private DarkComboBox cmbTransform;
-        private System.Windows.Forms.PictureBox picSprite;
-        private System.Windows.Forms.Label lblSprite;
         private DarkGroupBox grpEvent;
         private System.Windows.Forms.Panel pnlContainer;
         private DarkButton btnSave;
@@ -2449,20 +2417,6 @@ namespace Intersect.Editor.Forms.Editors
         public System.Windows.Forms.ToolStripButton toolStripItemPaste;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         public System.Windows.Forms.ToolStripButton toolStripItemUndo;
-        private DarkUI.Controls.DarkGroupBox grpStats;
-        private DarkUI.Controls.DarkGroupBox grpDamage;
-        private System.Windows.Forms.Label lblHPDamage;
-        private System.Windows.Forms.Label lblManaDamage;
-        private System.Windows.Forms.Label lblScaling;
-        private DarkComboBox cmbDamageType;
-        private System.Windows.Forms.Label lblDamageType;
-        private DarkUI.Controls.DarkGroupBox grpHotDot;
-        private DarkUI.Controls.DarkGroupBox grpEffect;
-        private DarkUI.Controls.DarkGroupBox grpEffectDuration;
-        private System.Windows.Forms.Label lblCritChance;
-        private DarkUI.Controls.DarkCheckBox chkFriendly;
-        private DarkComboBox cmbScalingStat;
-        private System.Windows.Forms.Label lblScalingStat;
         private DarkButton btnDynamicRequirements;
         private DarkComboBox cmbHitAnimation;
         private DarkComboBox cmbCastAnimation;
@@ -2482,25 +2436,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkNumericUpDown nudMpCost;
         private DarkNumericUpDown nudHPCost;
         private DarkNumericUpDown nudHitRadius;
-        private DarkNumericUpDown nudCritChance;
-        private DarkNumericUpDown nudScaling;
-        private DarkNumericUpDown nudMPDamage;
-        private DarkNumericUpDown nudHPDamage;
-        private DarkNumericUpDown nudTick;
-        private DarkNumericUpDown nudBuffDuration;
-        private DarkNumericUpDown nudSpd;
-        private DarkNumericUpDown nudMR;
-        private DarkNumericUpDown nudDef;
-        private DarkNumericUpDown nudMag;
-        private DarkNumericUpDown nudStr;
-        private System.Windows.Forms.Label lblSpd;
-        private System.Windows.Forms.Label lblMR;
-        private System.Windows.Forms.Label lblDef;
-        private System.Windows.Forms.Label lblMag;
-        private System.Windows.Forms.Label lblStr;
         private DarkNumericUpDown nudCastRange;
-        private DarkNumericUpDown nudCritMultiplier;
-        private System.Windows.Forms.Label lblCritMultiplier;
         private DarkNumericUpDown nudDuration;
         private System.Windows.Forms.Label lblDuration;
         private DarkCheckBox chkBound;
@@ -2511,6 +2447,16 @@ namespace Intersect.Editor.Forms.Editors
         private DarkComboBox cmbFolder;
         private System.Windows.Forms.ToolStripButton btnAlphabetical;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private DarkButton btnAddCooldownGroup;
+        private DarkComboBox cmbCooldownGroup;
+        private System.Windows.Forms.Label lblCooldownGroup;
+        private DarkCheckBox chkIgnoreGlobalCooldown;
+        private DarkCheckBox chkIgnoreCdr;
+        private Controls.GameObjectList lstGameObjects;
+        private System.Windows.Forms.Label lblCannotCast;
+        private DarkTextBox txtCannotCast;
+        private DarkGroupBox grpCombat;
+        private DarkGroupBox grpStats;
         private System.Windows.Forms.Label lblPercentage5;
         private System.Windows.Forms.Label lblPercentage4;
         private System.Windows.Forms.Label lblPercentage3;
@@ -2526,13 +2472,44 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblPlus3;
         private System.Windows.Forms.Label lblPlus2;
         private System.Windows.Forms.Label lblPlus1;
-        private DarkButton btnAddCooldownGroup;
-        private DarkComboBox cmbCooldownGroup;
-        private System.Windows.Forms.Label lblCooldownGroup;
-        private DarkCheckBox chkIgnoreGlobalCooldown;
-        private DarkCheckBox chkIgnoreCdr;
-        private Controls.GameObjectList lstGameObjects;
-        private System.Windows.Forms.Label lblCannotCast;
-        private DarkTextBox txtCannotCast;
+        private DarkNumericUpDown nudSpd;
+        private DarkNumericUpDown nudMR;
+        private DarkNumericUpDown nudDef;
+        private DarkNumericUpDown nudMag;
+        private DarkNumericUpDown nudStr;
+        private System.Windows.Forms.Label lblSpd;
+        private System.Windows.Forms.Label lblMR;
+        private System.Windows.Forms.Label lblDef;
+        private System.Windows.Forms.Label lblMag;
+        private System.Windows.Forms.Label lblStr;
+        private DarkGroupBox grpHotDot;
+        private DarkNumericUpDown nudTick;
+        private DarkCheckBox chkHOTDOT;
+        private System.Windows.Forms.Label lblTick;
+        private DarkGroupBox grpEffect;
+        private System.Windows.Forms.Label lblEffect;
+        private DarkComboBox cmbExtraEffect;
+        private System.Windows.Forms.PictureBox picSprite;
+        private DarkComboBox cmbTransform;
+        private System.Windows.Forms.Label lblSprite;
+        private DarkGroupBox grpEffectDuration;
+        private DarkNumericUpDown nudBuffDuration;
+        private System.Windows.Forms.Label lblBuffDuration;
+        private DarkGroupBox grpDamage;
+        private DarkNumericUpDown nudCritMultiplier;
+        private System.Windows.Forms.Label lblCritMultiplier;
+        private DarkNumericUpDown nudCritChance;
+        private DarkNumericUpDown nudScaling;
+        private DarkNumericUpDown nudMPDamage;
+        private DarkNumericUpDown nudHPDamage;
+        private DarkComboBox cmbScalingStat;
+        private System.Windows.Forms.Label lblScalingStat;
+        private DarkCheckBox chkFriendly;
+        private System.Windows.Forms.Label lblCritChance;
+        private System.Windows.Forms.Label lblScaling;
+        private DarkComboBox cmbDamageType;
+        private System.Windows.Forms.Label lblDamageType;
+        private System.Windows.Forms.Label lblHPDamage;
+        private System.Windows.Forms.Label lblManaDamage;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -324,6 +324,9 @@ namespace Intersect.Editor.Forms.Editors
             grpEvent.Hide();
             cmbTargetType.Enabled = true;
 
+            // Reset our combat data location, since event type spells can move it.
+            grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y);
+
             if (cmbType.SelectedIndex == (int) SpellTypes.CombatSpell ||
                 cmbType.SelectedIndex == (int) SpellTypes.WarpTo ||
                 cmbType.SelectedIndex == (int) SpellTypes.Event)
@@ -393,6 +396,8 @@ namespace Intersect.Editor.Forms.Editors
             {
                 grpEvent.Show();
                 cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
+                // Move our combat data down a little bit, it's not a very clean solution but it'll let us display it properly.
+                grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y + grpEvent.Size.Height + 5);
             }
 
             if (cmbType.SelectedIndex == (int) SpellTypes.WarpTo)


### PR DESCRIPTION
Resolves #921 

Turns out the windows on the spell editor form were misaligned a bit.
Someone probably had good intentions somewhere but things were a bit.. messy.

Returned all the spell data types back to the same location, but because Event spells have both event and combat data groups up the combat data group will move down a bit to make space for it when selected.