### PR TITLE
Don't delete our target as soon as we try and draw a hidden entity

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -221,6 +221,11 @@ namespace Intersect.Client.Entities
 
             if (TargetBox != null)
             {
+                if (!Globals.Entities.TryGetValue(TargetIndex, out var en) || (en.IsHidden || en.IsStealthed))
+                {
+                    ClearTarget();
+                }
+
                 TargetBox.Update();
             }
             else if (this == Globals.Me && TargetBox == null && Interface.Interface.GameUi != null)
@@ -2014,11 +2019,6 @@ namespace Intersect.Client.Entities
                             en.Value.DrawTarget((int)TargetTypes.Selected);
                         }
                     }
-                }
-                else
-                {
-                    //TODO: Completely wipe the stealthed player from memory and have server re-send once stealth ends.
-                    ClearTarget();
                 }
             }
 


### PR DESCRIPTION
Resolves #900 

The engine would try and instantly remove any target once it tried to draw a target hook for ANY entity that is hidden.
That's really not how it's supposed to work..

Removed the check from the draw method and moved it to the player Update method to check whether the current target is hidden or stealthed, if it is clear the target.