### PR TITLE
Restore Fill and Erase functionality for Attributes in the map editor

### DIFF
--- a/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
@@ -309,16 +309,13 @@ namespace Intersect.Editor.Forms.DockingElements
                     }
                     else if (Globals.CurrentTool == (int) EditingTool.Erase)
                     {
-                        if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
+                        if (Globals.CurrentLayer == LayerOptions.Attributes)
                         {
-                            if (Globals.CurrentLayer == LayerOptions.Attributes)
-                            {
-                                Globals.MapEditorWindow.SmartEraseAttributes(Globals.CurTileX, Globals.CurTileY);
-                            }
-                            else if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
-                            {
-                                Globals.MapEditorWindow.SmartEraseLayer(Globals.CurTileX, Globals.CurTileY);
-                            }
+                            Globals.MapEditorWindow.SmartEraseAttributes(Globals.CurTileX, Globals.CurTileY);
+                        }
+                        else if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
+                        {
+                            Globals.MapEditorWindow.SmartEraseLayer(Globals.CurTileX, Globals.CurTileY);
                         }
 
                         Globals.MouseButton = -1;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -516,8 +516,8 @@ namespace Intersect.Editor.Forms
                 redoToolStripMenuItem.Enabled = false;
             }
 
-            //Process the Fill/Erase Buttons
-            if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
+            //Process the Fill/Erase Buttons, these should display for all valid map layers as well as Attributes.
+            if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer) || Globals.CurrentLayer == LayerOptions.Attributes)
             {
                 toolStripBtnFill.Enabled = true;
                 fillToolStripMenuItem.Enabled = true;


### PR DESCRIPTION
Resolves #843 

This was likely disabled unintentionally when the map layers became dynamically configured through the server configuration.