### PR TITLE
Fix at secondaryDamage

### DIFF
--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1700,6 +1700,7 @@ namespace Intersect.Server.Entities
         {
             var originalBaseDamage = baseDamage;
             var damagingAttack = baseDamage > 0;
+            var secondaryDamagingAttack = secondaryDamage > 0;
             if (enemy == null)
             {
                 return;
@@ -1808,7 +1809,7 @@ namespace Intersect.Server.Entities
                     secondaryDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
                 );
 
-                if (secondaryDamage < 0 && damagingAttack)
+                if (secondaryDamage < 0 && secondaryDamagingAttack)
                 {
                     secondaryDamage = 0;
                 }


### PR DESCRIPTION
Resolves #957 

Fix when trying to swap targets HP and MP and when target MPs defense transform MP damaging in MP healing.
Basically that baseDamage is setted by HP damage only. So when trying to swap targets HP into MP, the damagingAttack is **true** since **HP damage > 0** and **MP is < 0**, then MP is just setted to 0.
In another case, if the damage calculation brings an damaging MP attack below 0, the **damagingAttack is false** because there is no HP damage, so the **secondaryDamage is not setted to 0** turning an **MP damage in a MP healing**. 