### PR TITLE
chore: Simplify and Cache Entity / Paperdoll rendering

### DIFF
--- a/Intersect.Client.Framework/Entities/IEntity.cs
+++ b/Intersect.Client.Framework/Entities/IEntity.cs
@@ -19,7 +19,6 @@ namespace Intersect.Client.Framework.Entities
         Label HeaderLabel { get; }
         bool IsHidden { get; }
         string Sprite { get; }
-        string TransformedSprite { get; }
         string Face { get; }
         GameTexture Texture { get; }
         Color Color { get; }
@@ -31,6 +30,7 @@ namespace Intersect.Client.Framework.Entities
         bool IsStealthed { get; }
         bool IsBlocking { get; }
         bool IsDashing { get; }
+        bool IsTransformed { get; }
         IDash CurrentDash { get; }
         bool IsCasting { get; }
         bool InView { get; }

--- a/Intersect.Client.Framework/Entities/IEntity.cs
+++ b/Intersect.Client.Framework/Entities/IEntity.cs
@@ -48,6 +48,7 @@ namespace Intersect.Client.Framework.Entities
         IReadOnlyList<int> EquipmentSlots { get; }
         IReadOnlyList<Guid> Spells { get; }
         IReadOnlyList<IStatus> Status { get; }
+        IReadOnlyDictionary<SpriteAnimations, GameRenderTexture> TextureCache { get; }
         int Aggression { get; }
 
         void AddChatBubble(string text);

--- a/Intersect.Client.Framework/Entities/SpriteAnimations.cs
+++ b/Intersect.Client.Framework/Entities/SpriteAnimations.cs
@@ -8,5 +8,8 @@
         Shoot,
         Cast,
         Weapon,
+
+        // Always keep at the bottom if you value your sanity.
+        Count
     }
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -301,6 +301,8 @@ namespace Intersect.Client.Entities
 
         public Dictionary<SpriteAnimations, GameRenderTexture> TextureCache { get; set; } = new Dictionary<SpriteAnimations, GameRenderTexture>();
 
+        IReadOnlyDictionary<SpriteAnimations, GameRenderTexture> IEntity.TextureCache => TextureCache;
+
         public IMapInstance MapInstance => Maps.MapInstance.Get(MapId);
 
         public virtual Guid MapId { get; set; }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -266,10 +266,12 @@ namespace Intersect.Client.Entities
                 if (this == Globals.Me && playerPacket.Equipment.InventorySlots != null)
                 {
                     this.MyEquipment = playerPacket.Equipment.InventorySlots;
+                    ClearTextureCaches();
                 }
                 else if (playerPacket.Equipment.ItemIds != null)
                 {
                     this.Equipment = playerPacket.Equipment.ItemIds;
+                    ClearTextureCaches();
                 }
             }
 
@@ -1884,20 +1886,6 @@ namespace Intersect.Client.Entities
                     }
                 }
             }
-        }
-
-        public override void DrawEquipment(string filename, int alpha)
-        {
-            //check if player is stunned or snared, if so don't let them move.
-            for (var n = 0; n < Status.Count; n++)
-            {
-                if (Status[n].Type == StatusTypes.Transform)
-                {
-                    return;
-                }
-            }
-
-            base.DrawEquipment(filename, alpha);
         }
 
         //Override of the original function, used for rendering the color of a player based on rank

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -62,10 +62,6 @@ namespace Intersect.Client.Interface.Game.Character
 
         Label mSpeedLabel;
 
-        public ImagePanel[] PaperdollPanels;
-
-        public string[] PaperdollTextures;
-
         //Location
         public int X;
 
@@ -86,15 +82,6 @@ namespace Intersect.Client.Interface.Game.Character
             mCharacterContainer = new ImagePanel(mCharacterWindow, "CharacterContainer");
 
             mCharacterPortrait = new ImagePanel(mCharacterContainer);
-
-            PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count + 1];
-            PaperdollTextures = new string[Options.EquipmentSlots.Count + 1];
-            for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
-            {
-                PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
-                PaperdollTextures[i] = "";
-                PaperdollPanels[i].Hide();
-            }
 
             var equipmentLabel = new Label(mCharacterWindow, "EquipmentLabel");
             equipmentLabel.SetText(Strings.Character.equipment);
@@ -176,9 +163,7 @@ namespace Intersect.Client.Interface.Game.Character
 
             //Load Portrait
             //UNCOMMENT THIS LINE IF YOU'D RATHER HAVE A FACE HERE GameTexture faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, Globals.Me.Face);
-            var entityTex = Globals.ContentManager.GetTexture(
-                Framework.Content.TextureType.Entity, Globals.Me.Sprite
-            );
+            Globals.Me.TextureCache.TryGetValue(Framework.Entities.SpriteAnimations.Normal, out var entityTex);
 
             /* UNCOMMENT THIS BLOCK IF YOU"D RATHER HAVE A FACE HERE if (Globals.Me.Face != "" && Globals.Me.Face != _currentSprite && faceTex != null)
              {
@@ -187,98 +172,21 @@ namespace Intersect.Client.Interface.Game.Character
                  _characterPortrait.SizeToContents();
                  Align.Center(_characterPortrait);
                  _characterPortrait.IsHidden = false;
-                 for (int i = 0; i < Options.EquipmentSlots.Count; i++)
-                 {
-                     _paperdollPanels[i].Hide();
-                 }
              }
              else */
-            if (!string.IsNullOrWhiteSpace(Globals.Me.Sprite) && Globals.Me.Sprite != mCurrentSprite && entityTex != null)
+            if (entityTex != null && mCharacterPortrait.Texture != entityTex)
             {
-                for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
-                {
-                    var paperdoll = "";
-                    if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1)
-                    {
-                        var equipment = Globals.Me.MyEquipment;
-                        if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
-                            equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
-                            Options.MaxInvItems)
-                        {
-                            var itemNum = Globals.Me
-                                .Inventory[equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])]]
-                                .ItemId;
+                mCharacterPortrait.Texture = entityTex;
+                mCharacterPortrait.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
+                mCharacterPortrait.SizeToContents();
+                Align.Center(mCharacterPortrait);
+                mCurrentSprite = Globals.Me.Sprite;
+                mCharacterPortrait.IsHidden = false;
 
-                            if (ItemBase.Get(itemNum) != null)
-                            {
-                                var itemdata = ItemBase.Get(itemNum);
-                                if (Globals.Me.Gender == 0)
-                                {
-                                    paperdoll = itemdata.MalePaperdoll;
-                                }
-                                else
-                                {
-                                    paperdoll = itemdata.FemalePaperdoll;
-                                }
-                            }
-                        }
-                    }
-                    else if (Options.PaperdollOrder[1][z] == "Player")
-                    {
-                        PaperdollPanels[z].Show();
-                        PaperdollPanels[z].Texture = entityTex;
-                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SizeToContents();
-                        PaperdollPanels[z].RenderColor = Globals.Me.Color;
-                        Align.Center(PaperdollPanels[z]);
-                    }
-
-                    if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[z]) && Options.PaperdollOrder[1][z] != "Player")
-                    {
-                        PaperdollPanels[z].Texture = null;
-                        PaperdollPanels[z].Hide();
-                        PaperdollTextures[z] = "";
-                    }
-                    else if (paperdoll != "" && paperdoll != PaperdollTextures[z])
-                    {
-                        var paperdollTex = Globals.ContentManager.GetTexture(
-                            Framework.Content.TextureType.Paperdoll, paperdoll
-                        );
-
-                        PaperdollPanels[z].Texture = paperdollTex;
-                        if (paperdollTex != null)
-                        {
-                            PaperdollPanels[z]
-                                .SetTextureRect(
-                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            PaperdollPanels[z]
-                                .SetSize(
-                                    PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            PaperdollPanels[z]
-                                .SetPosition(
-                                    mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
-                                    mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
-                                );
-                        }
-
-                        PaperdollPanels[z].Show();
-                        PaperdollTextures[z] = paperdoll;
-                    }
-                }
             }
             else if (Globals.Me.Sprite != mCurrentSprite && Globals.Me.Face != mCurrentSprite)
             {
                 mCharacterPortrait.IsHidden = true;
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-                {
-                    PaperdollPanels[i].Hide();
-                }
             }
 
             mAttackLabel.SetText(

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -1212,10 +1212,12 @@ namespace Intersect.Client.Networking
                     if (entity == Globals.Me && packet.InventorySlots != null)
                     {
                         entity.MyEquipment = packet.InventorySlots;
+                        entity.ClearTextureCaches();
                     }
                     else if (packet.ItemIds != null)
                     {
                         entity.Equipment = packet.ItemIds;
+                        entity.ClearTextureCaches();
                     }
                 }
             }


### PR DESCRIPTION
Resolves #929 

By default we render paperdolls in various different ways..
1. On screen we render it every frame endlessly calculating what we need to render and where.
2. On the GUI we render it through endless UI elements that we need to hide/unhide on every change and its done in a slightly different way every single UI element that draws paperdolls.

This is super annoying and hard to work with.
In this PR I've made it so the client will cache textures of each animation type in memory for every entity and draw these to the screen, this way we won't be rendering and calculating the equipment and whatnot every frame for every player and we can easily re-use this texture on the GUI to render our entities in a quick easy to understand manner.

Tested this on my own system with a few characters with different equipment loads spamming them on and off and seems to work pretty well so far. 