### PR TITLE
Fix #946 - Formula to be considered before verification of base damage

### DIFF
--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1698,8 +1698,8 @@ namespace Intersect.Server.Entities
             bool isAutoAttack = false
         )
         {
-            var originalBaseDamage = baseDamage;
             var damagingAttack = baseDamage > 0;
+
             if (enemy == null)
             {
                 return;
@@ -1718,21 +1718,18 @@ namespace Intersect.Server.Entities
                 isCrit = true;
             }
 
+            //If the enemy is a resource, the original base damage value will be used on "Calculate Damages", if not, we need change...
+            if (!(enemy is Resource))
+            {
+                baseDamage = Formulas.CalculateDamage(
+                baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
+            );
+            }
+
             //Calculate Damages
             if (baseDamage != 0)
             {
 
-                if (enemy is Resource)
-                {
-                    baseDamage = originalBaseDamage;
-                }
-                else
-                {
-                    baseDamage = Formulas.CalculateDamage(
-                    baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
-                );
-                }
-                
                 if (baseDamage < 0 && damagingAttack)
                 {
                     baseDamage = 0;


### PR DESCRIPTION
Resolves #946

First of all, it's my first time creating this, any change I accept helps

In [1701](https://github.com/AscensionGameDev/Intersect-Engine/blob/d39d457c04c81323827d33ca0d74e3cdf2a7db1a/Intersect.Server/Entities/Entity.cs#L1701) a variable is created to store the original value of the baseDamage variable. Until [1731](https://github.com/AscensionGameDev/Intersect-Engine/blob/d39d457c04c81323827d33ca0d74e3cdf2a7db1a/Intersect.Server/Entities/Entity.cs#L1731) the value does not change what makes [1727](https://github.com/AscensionGameDev/Intersect-Engine/blob/d39d457c04c81323827d33ca0d74e3cdf2a7db1a/Intersect.Server/Entities/Entity.cs#L1727) meaningless (in my opinion, I may not understand the whole context). In addition, the verification made [1722](https://github.com/AscensionGameDev/Intersect-Engine/blob/d39d457c04c81323827d33ca0d74e3cdf2a7db1a/Intersect.Server/Entities/Entity.cs#L1722) only considers the value entered in the editor, not the "final damage" (after calculate is invoked).

My solution is to remove the originalBaseDamage variable, and bring the modification of the baseDamage variable to before checking if it is different from 0, considering if the enemy is resource or not. If enemy is resource, the value remains original because it has not been changed since the beginning, discarding the use of variable originalBaseDamage in this method, if not resource, it must be changed before verification, if it results in 0, the method ends, if it is different then continue.

Tests performed by me:
1 - Base damage 0 in editor, Attack 10 from class, 100% scaling.
Unarmed attack, armed attack, spells, worked normally. The final damage is the attack value.
Resources do not take damage.

2 - Base damage 0 in editor, Attack 10 from class, 0% scaling.
Unarmed attack, armed attack, spells, worked normally. The final damage is 0.
Resources do not take damage.

3 - Base damage > 0 in editor, Attack 10 from class, 100% scaling.
Unarmed attack, armed attack, spells, worked normally. The final damage is Base damage + attack value.
Resources take damage = Base damage only.

4 - Base damage => 0 (I tested the value 0 and higher values too) , Attack 10 from class, 100% scaling. Enemy Defense greater damage (calculateDamage returning negative number)
Unarmed attack, armed attack, spells, worked normally. The final damage is 0. (I tested [1736](https://github.com/AscensionGameDev/Intersect-Engine/blob/d39d457c04c81323827d33ca0d74e3cdf2a7db1a/Intersect.Server/Entities/Entity.cs#L1736))

5 - Base damage < 0 in editor, Attack 10 from class, 100% scaling.
Only spells, to test healing, and the values were also correct.

If I lost something to test case let me know I can do it