### PR TITLE
Remove InviteRange from Parties

### DIFF
--- a/Intersect (Core)/Config/PartyOptions.cs
+++ b/Intersect (Core)/Config/PartyOptions.cs
@@ -8,8 +8,6 @@
         /// </summary>
         public int MaximumMembers = 4;
 
-        public int InviteRange = 40;
-
         public int SharedXpRange = 40;
 
         public int NpcDeathCommonEventStartRange = 0;

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1949,7 +1949,7 @@ namespace Intersect.Server.Networking
 
             var target = Player.FindOnline(packet.TargetId);
 
-            if (target != null && target.Id != player.Id && player.InRangeOf(target, Options.Party.InviteRange))
+            if (target != null && target.Id != player.Id)
             {
                 target.InviteToParty(player);
 


### PR DESCRIPTION
Resolves #962 

Removes the invite range setting from parties, it's honestly counterintuitive and makes grouping up tedious.
This genuinely doesn't fit in a modern game, and I even find it baffling for older games.

(Also counterintuitive with the changes in #959 and #964 since that allows invites by name, not proximity)