### PR TITLE
Chore: Attempt clean-up Stealth checks and whether we should render parts of entities

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -819,38 +819,12 @@ namespace Intersect.Client.Entities
         /// <summary>
         /// Returns whether this entity should be drawn.
         /// </summary>
-        public virtual bool ShouldDraw
-        {
-            get
-            {
-                if (IsHidden || (IsStealthed && this != Globals.Me && !Globals.Me.IsInMyParty(Id)))
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
-            }
-        }
+        public virtual bool ShouldDraw => !IsHidden && (!IsStealthed || this == Globals.Me || Globals.Me.IsInMyParty(Id));
 
         /// <summary>
         /// Returns whether the name of this entity should be drawn.
         /// </summary>
-        public virtual bool ShouldDrawName
-        {
-            get 
-            {
-                if (HideName || IsHidden || (IsStealthed && this != Globals.Me && !Globals.Me.IsInMyParty(Id)))
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
-            }
-        }
+        public virtual bool ShouldDrawName => !HideName && ShouldDraw;
 
         public virtual HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
         {


### PR DESCRIPTION
There was a LOT of repeated code on the Entity class regarding this despite us already having an IsStealthed check.
Also added two new bools that check whether we need to render the name or entity as a whole to avoid more repeated checks, simplifying the code.