### PR TITLE
[Adds Game Settings] Overhead Information.

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -5,6 +5,7 @@ namespace Intersect.Client.Framework.Database
 
     public abstract class GameDatabase
     {
+        // Registry Database for Client Settings Preferences.
 
         public bool FullScreen;
 
@@ -12,7 +13,6 @@ namespace Intersect.Client.Framework.Database
 
         public bool TargetAccountDirection;
 
-        //Preferences
         public int MusicVolume;
 
         public int SoundVolume;
@@ -22,6 +22,18 @@ namespace Intersect.Client.Framework.Database
         public int TargetResolution;
 
         public bool StickyTarget;
+
+        public bool FriendOverheadInfo;
+
+        public bool GuildMemberOverheadInfo;
+
+        public bool MyOverheadInfo;
+
+        public bool NpcOverheadInfo;
+
+        public bool PartyMemberOverheadInfo;
+
+        public bool PlayerOverheadInfo;
 
         //Saving password, other stuff we don't want in the games directory
         public abstract void SavePreference(string key, object value);
@@ -50,6 +62,12 @@ namespace Intersect.Client.Framework.Database
             HideOthersOnWindowOpen = LoadPreference("HideOthersOnWindowOpen", true);
             TargetAccountDirection = LoadPreference("TargetAccountDirection", false);
             StickyTarget = LoadPreference("StickyTarget", true);
+            FriendOverheadInfo = LoadPreference("FriendOverheadInfo", true);
+            GuildMemberOverheadInfo = LoadPreference("GuildMemberOverheadInfo", true);
+            MyOverheadInfo = LoadPreference("MyOverheadInfo", true);
+            NpcOverheadInfo = LoadPreference("NpcOverheadInfo", true);
+            PartyMemberOverheadInfo = LoadPreference("PartyMemberOverheadInfo", true);
+            PlayerOverheadInfo = LoadPreference("PlayerOverheadInfo", true);
         }
 
         public virtual void SavePreferences()
@@ -62,6 +80,12 @@ namespace Intersect.Client.Framework.Database
             SavePreference("HideOthersOnWindowOpen", HideOthersOnWindowOpen.ToString());
             SavePreference("TargetAccountDirection", TargetAccountDirection.ToString());
             SavePreference("StickyTarget", StickyTarget.ToString());
+            SavePreference("FriendOverheadInfo", FriendOverheadInfo.ToString());
+            SavePreference("GuildMemberOverheadInfo", GuildMemberOverheadInfo.ToString());
+            SavePreference("MyOverheadInfo", MyOverheadInfo.ToString());
+            SavePreference("NpcOverheadInfo", NpcOverheadInfo.ToString());
+            SavePreference("PartyMemberOverheadInfo", PartyMemberOverheadInfo.ToString());
+            SavePreference("PlayerOverheadInfo", PlayerOverheadInfo.ToString());
         }
 
         public abstract bool LoadConfig();

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -52,7 +52,21 @@ namespace Intersect.Client.Interface.Shared
         private readonly Button mKeybindingSettingsTab;
 
         // Game Settings.
-        // TODO: Place our configurable gameplay related variables here!
+        private readonly Button mOverheadInformationSettings;
+
+        private readonly Button mOverheadInfoSettingsHelper;
+
+        private readonly LabeledCheckBox mFriendOverheadInfoCheckbox;
+
+        private readonly LabeledCheckBox mGuildMemberOverheadInfoCheckbox;
+
+        private readonly LabeledCheckBox mMyOverheadInfoCheckbox;
+
+        private readonly LabeledCheckBox mNpcOverheadInfoCheckbox;
+
+        private readonly LabeledCheckBox mPartyMemberOverheadInfoCheckbox;
+
+        private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
 
         // Video Settings.
         private readonly ImagePanel mResolutionBackground;
@@ -101,11 +115,11 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly Dictionary<Control, Button[]> mKeybindingBtns = new Dictionary<Control, Button[]>();
 
-        // Open settings
+        // Open Settings.
         private bool mReturnToMenu;
 
         // Initialize.
-        public SettingsWindow(Canvas parent, MainMenu mainMenu, EscapeMenu escapeMenu)
+        public SettingsWindow(Base parent, MainMenu mainMenu, EscapeMenu escapeMenu)
         {
             // Assign References.
             mMainMenu = mainMenu;
@@ -140,7 +154,35 @@ namespace Intersect.Client.Interface.Shared
             mGameSettingsContainer = new ScrollControl(mSettingsPanel, "GameSettingsContainer");
             mGameSettingsContainer.EnableScroll(false, true);
 
-            // TODO: Place our configurable gameplay related settings into their respective container for initialization here!
+            // Game Settings - Overhead Information.
+            mOverheadInformationSettings = new Button(mGameSettingsContainer, "OverheadInformationSettings");
+            mOverheadInformationSettings.Text = Strings.Settings.OverheadInformationSettings;
+            mOverheadInfoSettingsHelper = new Button(mGameSettingsContainer, "OverheadInfoSettingsHelper");
+            mOverheadInfoSettingsHelper.SetToolTipText(Strings.Settings.OverheadInfoSettingsHelper);
+
+            // Game Settings - Toggle for: Friends Overhead Information.
+            mFriendOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "FriendOverheadInfoCheckbox");
+            mFriendOverheadInfoCheckbox.Text = Strings.Settings.FriendOverheadInfo;
+
+            // Game Settings - Toggle for: Guild Members Overhead Information.
+            mGuildMemberOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "GuildMemberOverheadInfoCheckbox");
+            mGuildMemberOverheadInfoCheckbox.Text = Strings.Settings.GuildMemberOverheadInfo;
+
+            // Game Settings - Toggle for: My Overhead Information (Local Player).
+            mMyOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "MyOverheadInfoCheckbox");
+            mMyOverheadInfoCheckbox.Text = Strings.Settings.MyOverheadInfo;
+
+            // Game Settings - Toggle for: NPCs Overhead Information.
+            mNpcOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "NpcOverheadInfoCheckbox");
+            mNpcOverheadInfoCheckbox.Text = Strings.Settings.NpcOverheadInfo;
+
+            // Game Settings - Toggle for: Party Members Overhead Information.
+            mPartyMemberOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PartyMemberOverheadInfoCheckbox");
+            mPartyMemberOverheadInfoCheckbox.Text = Strings.Settings.PartyMemberOverheadInfo;
+
+            // Game Settings - Toggle for: Players Overhead Information.
+            mPlayerOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PlayerOverheadInfoCheckbox");
+            mPlayerOverheadInfoCheckbox.Text = Strings.Settings.PlayerOverheadInfo;
 
             #endregion
 
@@ -554,7 +596,12 @@ namespace Intersect.Client.Interface.Shared
             }
 
             // Game Settings.
-            //
+            mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
+            mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
+            mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
+            mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
+            mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
+            mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
 
             // Video Settings.
             mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
@@ -699,6 +746,36 @@ namespace Intersect.Client.Interface.Shared
             {
                 shouldReset = true;
                 Globals.Database.TargetFps = newFps;
+            }
+
+            if (Globals.Database.FriendOverheadInfo != mFriendOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
+            }
+
+            if (Globals.Database.GuildMemberOverheadInfo != mGuildMemberOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
+            }
+
+            if (Globals.Database.MyOverheadInfo != mMyOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
+            }
+
+            if (Globals.Database.NpcOverheadInfo != mNpcOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
+            }
+
+            if (Globals.Database.PartyMemberOverheadInfo != mPartyMemberOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
+            }
+
+            if (Globals.Database.PlayerOverheadInfo != mPlayerOverheadInfoCheckbox.IsChecked)
+            {
+                Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
             }
 
             // Save Settings.

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1259,16 +1259,41 @@ namespace Intersect.Client.Localization
             public static LocalizedString Fps90 = @"90";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString FriendOverheadInfo = @"Friends";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Fullscreen = @"Fullscreen";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GameSettingsTab = @"Game";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString GuildMemberOverheadInfo = @"Guild";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString KeyBindingSettingsTab = @"Controls";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString MusicVolume = @"Music Volume: {00}%";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString MyOverheadInfo = @"Myself";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString NpcOverheadInfo = @"NPCs";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString OverheadInformationSettings = @"Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString OverheadInfoSettingsHelper =
+                @"Overhead information may still be viewed by positioning the cursor over the hidden cases.";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PartyMemberOverheadInfo = @"Party";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PlayerOverheadInfo = @"Players";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Resolution = @"Resolution:";


### PR DESCRIPTION
### About This Pull Request
* This pull request pretends to continue with the implementation 
of few game settings that were previously mentioned in #936 

* This pull request should resolve #740 
* For testing, you will need to be up to date with the dev branch and the latest resources
 added to the development asset repo: #950 
* Adds 6 new Game Settings that allows users to toggle the visibility of entities overhead information (such as Names, Labels, Guild Name, etc.)
* Whenever any of the 6 new settings is toggled off, the overhead information may still be viewed by hovering the cursor over the hidden cases.
* The new overhead information settings include the following: Friends, Guild, Myself, NPCs, Party, Players.
* Prevented double drawing of the overhead information, whenever Friends are Guildies at the same time.
* Party member's overhead information rendering is isolated from any case whenever the player is not part of the party crew in order to prevent overlaping of names.

### [Preview Here](https://github.com/AscensionGameDev/Intersect-Engine/pull/968#issuecomment-950014999)

### [Resource Updates for this PR](https://github.com/AscensionGameDev/Intersect-Assets/pull/3)



