### PR TITLE
Chore: clean up CanCastSpell on Entity and Player.

### DIFF
--- a/Intersect (Core)/Enums/SpellCastFailureReason.cs
+++ b/Intersect (Core)/Enums/SpellCastFailureReason.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Enums
+{
+    public enum SpellCastFailureReason
+    {
+        None,
+
+        InvalidSpell,
+
+        InsufficientHP,
+
+        InsufficientMP,
+
+        InvalidTarget,
+
+        Silenced,
+
+        Stunned,
+
+        Asleep,
+
+        InvalidProjectile,
+
+        InsufficientItems,
+
+        Snared,
+
+        OutOfRange,
+
+        ConditionsNotMet,
+
+        OnCooldown
+    }
+}

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.0.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.0.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
   <Import Project="..\packages\Microsoft.NetFramework.Analyzers.3.0.0\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.3.0.0\build\Microsoft.NetFramework.Analyzers.props')" />
@@ -271,6 +271,7 @@
     <Compile Include="Enums\ChatMessageType.cs" />
     <Compile Include="Enums\GuildMemberUpdateActions.cs" />
     <Compile Include="Enums\ItemHandling.cs" />
+    <Compile Include="Enums\SpellCastFailureReason.cs" />
     <Compile Include="ErrorHandling\ExceptionInfo.cs" />
     <Compile Include="Extensions\ArrayExtensions.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1959,12 +1959,6 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (!CanAttack(target, spell))
-            {
-                reason = SpellCastFailureReason.InvalidTarget;
-                return false;
-            }
-
             // Check if the caster has any status effects that need to apply.
             // Ignore if the current spell is a Cleanse, this will ignore any and all status effects.
             if (spell.Combat.Effect != StatusTypes.Cleanse)
@@ -2001,6 +1995,7 @@ namespace Intersect.Server.Entities
                 }
             }
 
+            // Check for target validity
             var singleTargetSpell = (spell.SpellType == SpellTypes.CombatSpell && spell.Combat.TargetType == SpellTargetTypes.Single) || spell.SpellType == SpellTypes.WarpTo;
             if (target == null && singleTargetSpell)
             {
@@ -2016,7 +2011,7 @@ namespace Intersect.Server.Entities
 
             if (target != null && singleTargetSpell)
             {
-                if (spell.Combat.Friendly != IsAllyOf(target))
+                if ((spell.Combat.Friendly != IsAllyOf(target)) || !CanAttack(target, spell))
                 {
                     reason = SpellCastFailureReason.InvalidTarget;
                     return false;

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -621,6 +621,12 @@ namespace Intersect.Server.Entities
                 Log.Warn($"Combat data missing for {spellBase.Id}.");
             }
 
+            // Check if we are even allowed to cast this spell.
+            if (!CanCastSpell(spellBase, target, true, out var _))
+            {
+                return;
+            }
+
             var range = spellBase.Combat?.CastRange ?? 0;
             var targetType = spellBase.Combat?.TargetType ?? SpellTargetTypes.Single;
             var projectileBase = spellBase.Combat?.Projectile;
@@ -647,57 +653,7 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (spellBase.VitalCost == null)
-            {
-                return;
-            }
-
-            if (spellBase.VitalCost[(int) Vitals.Mana] > GetVital(Vitals.Mana))
-            {
-                return;
-            }
-
-            if (spellBase.VitalCost[(int) Vitals.Health] > GetVital(Vitals.Health))
-            {
-                return;
-            }
-
-            var spell = Spells[spellIndex];
-            if (spell == null)
-            {
-                return;
-            }
-
-            if (SpellCooldowns.ContainsKey(spell.SpellId) && SpellCooldowns[spell.SpellId] >= Timing.Global.MillisecondsUtc)
-            {
-                return;
-            }
-
-            if (!InRangeOf(target, range) && targetType == SpellTargetTypes.Single)
-            {
-                // ReSharper disable once SwitchStatementMissingSomeCases
-                return;
-            }
-
             CastTime = Timing.Global.Milliseconds + spellBase.CastDuration;
-
-            if (spellBase.VitalCost[(int) Vitals.Mana] > 0)
-            {
-                SubVital(Vitals.Mana, spellBase.VitalCost[(int) Vitals.Mana]);
-            }
-            else
-            {
-                AddVital(Vitals.Mana, -spellBase.VitalCost[(int) Vitals.Mana]);
-            }
-
-            if (spellBase.VitalCost[(int) Vitals.Health] > 0)
-            {
-                SubVital(Vitals.Health, spellBase.VitalCost[(int) Vitals.Health]);
-            }
-            else
-            {
-                AddVital(Vitals.Health, -spellBase.VitalCost[(int) Vitals.Health]);
-            }
 
             if ((spellBase.Combat?.Friendly ?? false) && spellBase.SpellType != SpellTypes.WarpTo)
             {

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1321,7 +1321,6 @@ namespace Intersect.Server.Entities
         {
             // If self-cast, AoE, Projectile or Dash.. always accept.
             if (spell?.Combat.TargetType == SpellTargetTypes.Self ||
-                spell?.Combat.TargetType == SpellTargetTypes.AoE ||
                 spell?.Combat.TargetType == SpellTargetTypes.Projectile ||
                 spell?.SpellType == SpellTypes.Dash
                 )

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1338,13 +1338,31 @@ namespace Intersect.Server.Entities
             {
                 return false;
             }
-
+            
             var friendly = spell?.Combat != null && spell.Combat.Friendly;
             if (entity is Player player)
             {
                 if (player.InParty(this) || this == player || (!Options.Instance.Guild.AllowGuildMemberPvp && friendly != (player.Guild != null && player.Guild == this.Guild)))
                 {
                     return friendly;
+                }
+
+                // Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
+                // Projectiles are ignored here, because we can always fire those.. Whether they hit or not is a problem for later.
+                if (!friendly && (spell.Combat.TargetType != SpellTargetTypes.Self && spell.Combat.TargetType != SpellTargetTypes.AoE && spell.SpellType == SpellTypes.CombatSpell))
+                {
+                    // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
+                    if (MapInstance.Get(MapId).ZoneType == MapZones.Safe || MapInstance.Get(player.MapId).ZoneType == MapZones.Safe)
+                    {
+                        return false;
+                    }
+
+                    // Also consider this an issue if either player is in a different map zone type.
+                    if (MapInstance.Get(MapId).ZoneType != MapInstance.Get(player.MapId).ZoneType)
+                    {
+                        return false;
+                    }
+
                 }
             }
 
@@ -2253,7 +2271,7 @@ namespace Intersect.Server.Entities
 
                         if (itemBase.QuickCast)
                         {
-                            if (!CanSpellCast(itemBase.Spell, target, false))
+                            if (!CanCastSpell(itemBase.Spell, target, false, out var _))
                             {
                                 return;
                             }
@@ -4188,8 +4206,49 @@ namespace Intersect.Server.Entities
             return this.InParty(otherPlayer) || this == otherPlayer;
         }
 
-        public bool CanSpellCast(SpellBase spell, Entity target, bool checkVitalReqs)
+        public override bool CanCastSpell(SpellBase spell, Entity target, bool checkVitalReqs, out SpellCastFailureReason reason)
         {
+            // Do we fail our base class check? If so cancel out with a reason!
+            if (!base.CanCastSpell(spell, target, checkVitalReqs, out reason))
+            {
+                // Let our user know the reason if configured.
+                if (Options.Combat.EnableCombatChatMessages)
+                {
+                    switch (reason)
+                    {
+                        case SpellCastFailureReason.InsufficientMP:
+                            PacketSender.SendChatMsg(this, Strings.Combat.lowmana, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.InsufficientHP:
+                            PacketSender.SendChatMsg(this, Strings.Combat.lowhealth, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.InvalidTarget:
+                            PacketSender.SendChatMsg(this, Strings.Combat.InvalidTarget, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.Silenced:
+                            PacketSender.SendChatMsg(this, Strings.Combat.silenced, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.Stunned:
+                            PacketSender.SendChatMsg(this, Strings.Combat.stunned, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.Asleep:
+                            PacketSender.SendChatMsg(this, Strings.Combat.sleep, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.Snared:
+                            PacketSender.SendChatMsg(this, Strings.Combat.Snared, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.OutOfRange:
+                            PacketSender.SendChatMsg(this, Strings.Combat.targetoutsiderange, ChatMessageType.Combat);
+                            break;
+                        case SpellCastFailureReason.OnCooldown:
+                            PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
+                            break;
+                    }
+                }
+                return false;
+            }
+
+            // Check for dynamic conditions.
             if (!Conditions.MeetsConditionLists(spell.CastingRequirements, this, null))
             {
                 if (!string.IsNullOrWhiteSpace(spell.CannotCastMessage))
@@ -4201,79 +4260,11 @@ namespace Intersect.Server.Entities
                     PacketSender.SendChatMsg(this, Strings.Combat.dynamicreq, ChatMessageType.Spells);
                 }
 
+                reason = SpellCastFailureReason.ConditionsNotMet;
                 return false;
             }
 
-
-            if (!CanAttack(target, spell))
-            {
-                return false;
-            }
-
-            //Check if the caster is silenced or stunned. Clense casts break the rule.
-            if (spell.Combat.Effect != StatusTypes.Cleanse)
-            {
-                foreach (var status in CachedStatuses)
-                {
-                    if (status.Type == StatusTypes.Silence)
-                    {
-                        if (Options.Combat.EnableCombatChatMessages)
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Combat.silenced, ChatMessageType.Combat);
-                        }
-
-                        return false;
-                    }
-
-                    if (status.Type == StatusTypes.Stun)
-                    {
-                        if (Options.Combat.EnableCombatChatMessages)
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Combat.stunned, ChatMessageType.Combat);
-                        }
-
-                        return false;
-                    }
-
-                    if (status.Type == StatusTypes.Sleep)
-                    {
-                        if (Options.Combat.EnableCombatChatMessages)
-                        {
-                            PacketSender.SendChatMsg(this, Strings.Combat.sleep, ChatMessageType.Combat);
-                        }
-
-                        return false;
-                    }
-                }
-            }
-
-            if (target is Player)
-            {
-                //Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
-                if (!spell.Combat.Friendly &&
-                    (spell.Combat.TargetType != SpellTargetTypes.Self &&
-                    spell.Combat.TargetType != SpellTargetTypes.AoE &&
-                    (spell.Combat.TargetType == SpellTargetTypes.Projectile && spell.Combat.Projectile != null && target != this) &&
-                    spell.SpellType == SpellTypes.CombatSpell
-                    )
-                 )
-                {
-                    // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
-                    if (MapInstance.Get(MapId).ZoneType == MapZones.Safe || MapInstance.Get(target.MapId).ZoneType == MapZones.Safe)
-                    {
-                        return false;
-                    }
-
-                    // Also consider this an issue if either player is in a different map zone type.
-                    if (MapInstance.Get(MapId).ZoneType != MapInstance.Get(target.MapId).ZoneType)
-                    {
-                        return false;
-                    }
-
-                }
-            }
-
-            //Check if the caster has the right ammunition if a projectile
+            // If this is a projectile, check if the user has the corresponding item.
             if (spell.SpellType == SpellTypes.CombatSpell &&
                 spell.Combat.TargetType == SpellTargetTypes.Projectile &&
                 spell.Combat.ProjectileId != Guid.Empty)
@@ -4281,6 +4272,7 @@ namespace Intersect.Server.Entities
                 var projectileBase = spell.Combat.Projectile;
                 if (projectileBase == null)
                 {
+                    reason = SpellCastFailureReason.InvalidProjectile;
                     return false;
                 }
 
@@ -4288,88 +4280,22 @@ namespace Intersect.Server.Entities
                 {
                     if (FindInventoryItemSlot(projectileBase.AmmoItemId, projectileBase.AmmoRequired) == null)
                     {
-                        PacketSender.SendChatMsg(
-                            this, Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
-                            ChatMessageType.Inventory,
-                            CustomColors.Alerts.Error
-                        );
-
+                        if (Options.Combat.EnableCombatChatMessages)
+                        {
+                            PacketSender.SendChatMsg(
+                                this, Strings.Items.notenough.ToString(ItemBase.GetName(projectileBase.AmmoItemId)),
+                                ChatMessageType.Inventory,
+                                CustomColors.Alerts.Error
+                            );
+                        }
+                            
+                        reason = SpellCastFailureReason.InsufficientItems;
                         return false;
                     }
                 }
             }
 
-            //Check if snared and spell is a dash or warp
-            if (spell.SpellType == SpellTypes.Dash || 
-                spell.SpellType == SpellTypes.Warp ||
-                spell.SpellType == SpellTypes.WarpTo)
-            {
-                // Don't cast if on snare status
-                foreach (var status in CachedStatuses)
-                {
-                    if (status.Type == StatusTypes.Snare)
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            var singleTargetSpell = (spell.SpellType == SpellTypes.CombatSpell && spell.Combat.TargetType == SpellTargetTypes.Single) || spell.SpellType == SpellTypes.WarpTo;
-
-            if (target == null && singleTargetSpell)
-            {
-                return false;
-            }
-
-            if (target == this && spell.SpellType == SpellTypes.WarpTo)
-            {
-                return false;
-            }
-
-            if (target != null && singleTargetSpell)
-            {
-                if (spell.Combat.Friendly != IsAllyOf(target))
-                {
-                    return false;
-                }
-            }
-
-            //Check for range of a single target spell
-            if (singleTargetSpell && target != this)
-            {
-                if (!InRangeOf(target, spell.Combat.CastRange))
-                {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Combat.targetoutsiderange, ChatMessageType.Combat);
-                    }
-                    return false;
-                }
-            }
-
-            if (checkVitalReqs)
-            {
-                if (spell.VitalCost[(int)Vitals.Mana] > GetVital(Vitals.Mana))
-                {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Combat.lowmana, ChatMessageType.Combat);
-                    }
-
-                    return false;
-                }
-
-                if (spell.VitalCost[(int)Vitals.Health] > GetVital(Vitals.Health))
-                {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Combat.lowhealth, ChatMessageType.Combat);
-                    }
-
-                    return false;
-                }
-            }
-
+            // We have no reason to stop this player from casting!
             return true;
         }
 
@@ -4383,76 +4309,66 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            if (!CanSpellCast(spell, target, true))
+            if (!CanCastSpell(spell, target, true, out var _))
             {
                 return;
             }
 
-            if (!SpellCooldowns.ContainsKey(Spells[spellSlot].SpellId) ||
-                SpellCooldowns[Spells[spellSlot].SpellId] < Timing.Global.MillisecondsUtc)
+            
+            if (CastTime == 0)
             {
-                if (CastTime == 0)
+                CastTime = Timing.Global.Milliseconds + spell.CastDuration;
+
+                //Remove stealth status.
+                foreach (var status in CachedStatuses)
                 {
-                    CastTime = Timing.Global.Milliseconds + spell.CastDuration;
-
-                    //Remove stealth status.
-                    foreach (var status in CachedStatuses)
+                    if (status.Type == StatusTypes.Stealth)
                     {
-                        if (status.Type == StatusTypes.Stealth)
-                        {
-                            status.RemoveStatus();
-                        }
+                        status.RemoveStatus();
                     }
+                }
 
-                    SpellCastSlot = spellSlot;
-                    CastTarget = Target;
+                SpellCastSlot = spellSlot;
+                CastTarget = Target;
 
-                    //Check if the caster has the right ammunition if a projectile
-                    if (spell.SpellType == SpellTypes.CombatSpell &&
-                        spell.Combat.TargetType == SpellTargetTypes.Projectile &&
-                        spell.Combat.ProjectileId != Guid.Empty)
+                //Check if the caster has the right ammunition if a projectile
+                if (spell.SpellType == SpellTypes.CombatSpell &&
+                    spell.Combat.TargetType == SpellTargetTypes.Projectile &&
+                    spell.Combat.ProjectileId != Guid.Empty)
+                {
+                    var projectileBase = spell.Combat.Projectile;
+                    if (projectileBase != null && projectileBase.AmmoItemId != Guid.Empty)
                     {
-                        var projectileBase = spell.Combat.Projectile;
-                        if (projectileBase != null && projectileBase.AmmoItemId != Guid.Empty)
-                        {
-                            TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired);
-                        }
+                        TryTakeItem(projectileBase.AmmoItemId, projectileBase.AmmoRequired);
                     }
+                }
 
-                    if (spell.CastAnimationId != Guid.Empty)
-                    {
-                        PacketSender.SendAnimationToProximity(
-                            spell.CastAnimationId, 1, base.Id, MapId, 0, 0, (sbyte) Dir
-                        ); //Target Type 1 will be global entity
-                    }
+                if (spell.CastAnimationId != Guid.Empty)
+                {
+                    PacketSender.SendAnimationToProximity(
+                        spell.CastAnimationId, 1, base.Id, MapId, 0, 0, (sbyte) Dir
+                    ); //Target Type 1 will be global entity
+                }
 
-                    //Check if cast should be instance
-                    if (Timing.Global.Milliseconds >= CastTime)
-                    {
-                        //Cast now!
-                        CastTime = 0;
-                        CastSpell(Spells[SpellCastSlot].SpellId, SpellCastSlot);
-                        CastTarget = null;
-                    }
-                    else
-                    {
-                        //Tell the client we are channeling the spell
-                        PacketSender.SendEntityCastTime(this, spellNum);
-                    }
+                //Check if cast should be instance
+                if (Timing.Global.Milliseconds >= CastTime)
+                {
+                    //Cast now!
+                    CastTime = 0;
+                    CastSpell(Spells[SpellCastSlot].SpellId, SpellCastSlot);
+                    CastTarget = null;
                 }
                 else
                 {
-                    if (Options.Combat.EnableCombatChatMessages)
-                    {
-                        PacketSender.SendChatMsg(this, Strings.Combat.channeling, ChatMessageType.Combat);
-                    }
+                    //Tell the client we are channeling the spell
+                    PacketSender.SendEntityCastTime(this, spellNum);
                 }
             }
             else
             {
                 if (Options.Combat.EnableCombatChatMessages)
                 {
-                    PacketSender.SendChatMsg(this, Strings.Combat.cooldown, ChatMessageType.Combat);
+                    PacketSender.SendChatMsg(this, Strings.Combat.channeling, ChatMessageType.Combat);
                 }
             }
         }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1320,8 +1320,8 @@ namespace Intersect.Server.Entities
         public override bool CanAttack(Entity entity, SpellBase spell)
         {
             // If self-cast, AoE, Projectile or Dash.. always accept.
-            if (spell?.Combat.TargetType == SpellTargetTypes.Self ||
-                spell?.Combat.TargetType == SpellTargetTypes.Projectile ||
+            if (spell?.Combat?.TargetType == SpellTargetTypes.Self ||
+                spell?.Combat?.TargetType == SpellTargetTypes.Projectile ||
                 spell?.SpellType == SpellTypes.Dash
                 )
             {
@@ -1348,7 +1348,7 @@ namespace Intersect.Server.Entities
 
                 // Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
                 // Projectiles are ignored here, because we can always fire those.. Whether they hit or not is a problem for later.
-                if (!friendly && (spell.Combat.TargetType != SpellTargetTypes.Self && spell.Combat.TargetType != SpellTargetTypes.AoE && spell.SpellType == SpellTypes.CombatSpell))
+                if (!friendly && (spell?.Combat?.TargetType != SpellTargetTypes.Self && spell?.Combat?.TargetType != SpellTargetTypes.AoE && spell?.SpellType == SpellTypes.CombatSpell))
                 {
                     // Check if either the attacker or the defender is in a "safe zone" (Only apply if combat is PVP)
                     if (MapInstance.Get(MapId).ZoneType == MapZones.Safe || MapInstance.Get(player.MapId).ZoneType == MapZones.Safe)

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -302,6 +302,9 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString sleep = @"You cannot cast this ability whilst asleep";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString Snared = @"You cannot cast this ability whilst snared";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString sleepattacking = @"You are asleep and can't attack.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -370,6 +373,9 @@ namespace Intersect.Server.Localization
                 }
             );
 
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString InvalidTarget = @"Invalid target for this spell.";
         }
 
         public sealed class CommandoutputNamespace : LocaleNamespace


### PR DESCRIPTION
Resolves #972  #940 

No idea why the spell system in general is in as sore a state as it is right now, but I figured I'd start cleaning SOMEWHERE.

Entities, Npcs and Players each had their own ways of checking the same things.
This really shouldn't be the case, generic checks should be done on the Entity class and Npc and Player specific checks on their respective classes.

I've tried to reduce it down to something resembling some form of coherence, got rid of the out of place checks on Npc and Player classes and replaced them with inherited methods, an override and some semblance of logic.

Also made sure all entities have to pass the same basic checks before allowing them to cast spells, Entities other than  players were allowed to bypass certain checks entirely.

Also fixes the following bug(s):
- AoE spells ignore attack conditions.
- Targets could influence Projectile casts.