### PR TITLE
Don't allow a reset radius to be set over the maximum value the pathfinder accepts.

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -908,8 +908,12 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudResetRadius_ValueChanged(object sender, EventArgs e)
         {
-            // Set to either default or higher.
-            nudResetRadius.Value = Math.Max(Options.Npc.ResetRadius, nudResetRadius.Value);
+            // So, the pathfinder on the server maintains a set max distance of whichever the largest value is, map height or width. Limit ourselves to this!
+            var maxPathFindingDistance = Math.Max(Options.MapWidth, Options.MapHeight);
+            var maxUserEnteredValue = Math.Max(Options.Npc.ResetRadius, nudResetRadius.Value);
+
+            // Use whatever is the lowest, either the maximum path find distance or the user entered value.
+            nudResetRadius.Value = Math.Min(maxPathFindingDistance, maxUserEnteredValue);
             mEditorItem.ResetRadius = (int)nudResetRadius.Value;
         }
 

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -1188,7 +1188,7 @@ namespace Intersect.Server.Entities
         {
             // Check if we've moved out of our range we're allowed to move from after being "aggro'd" by something.
             // If so, remove target and move back to the origin point.
-            if (Options.Npc.AllowResetRadius && AggroCenterMap != null && (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Npc.ResetRadius, Base.ResetRadius) || forceDistance))
+            if (Options.Npc.AllowResetRadius && AggroCenterMap != null && (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Npc.ResetRadius, Math.Min(Base.ResetRadius, Math.Max(Options.MapWidth, Options.MapHeight))) || forceDistance))
             {
                 ResetNpc(Options.Npc.ResetVitalsAndStatusses);
 


### PR DESCRIPTION
Resolves #844 

The input accepts values the pathfinder class does not, so going to have to limit that to what the pathfinder can accept.