### PR TITLE
Forcibly reset Npcs on a map once we stop processing it

### DIFF
--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -155,8 +155,8 @@ namespace Intersect.Server.Core
                                     var mapInstance = MapInstance.Get(map);
                                     if (mapInstance != null)
                                     {
-                                        mapInstance.DespawnEverything();
-                                        mapInstance.RespawnEverything();
+                                        mapInstance.DespawnNpcs();
+                                        mapInstance.SpawnMapNpcs();
                                     }
                                 }
                             }

--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -150,6 +150,14 @@ namespace Intersect.Server.Core
                                 if (!processedMaps.Contains(map))
                                 {
                                     ActiveMaps.Remove(map);
+                                    
+                                    // Reset all Npcs and resources so nothing is half-destroyed or gets stuck at the entrance/exit to an area while we're not processing..
+                                    var mapInstance = MapInstance.Get(map);
+                                    if (mapInstance != null)
+                                    {
+                                        mapInstance.DespawnEverything();
+                                        mapInstance.RespawnEverything();
+                                    }
                                 }
                             }
 

--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -151,12 +151,11 @@ namespace Intersect.Server.Core
                                 {
                                     ActiveMaps.Remove(map);
                                     
-                                    // Reset all Npcs and resources so nothing is half-destroyed or gets stuck at the entrance/exit to an area while we're not processing..
+                                    // Reset all Npcs so none of them get stuck at the entrance/exit to an area while we're not processing.
                                     var mapInstance = MapInstance.Get(map);
                                     if (mapInstance != null)
                                     {
-                                        mapInstance.DespawnNpcs();
-                                        mapInstance.SpawnMapNpcs();
+                                        mapInstance.ResetNpcSpawns();
                                     }
                                 }
                             }

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2594,7 +2594,7 @@ namespace Intersect.Server.Entities
             return Dead;
         }
 
-        public void Reset()
+        public virtual void Reset()
         {
             for (var i = 0; i < (int) Vitals.VitalCount; i++)
             {

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -823,7 +823,7 @@ namespace Intersect.Server.Entities
                                 mResetting = false;
                             }
 
-                            ResetNpc(Options.Instance.NpcOpts.ContinuouslyResetVitalsAndStatuses);
+                            Reset(Options.Instance.NpcOpts.ContinuouslyResetVitalsAndStatuses);
                             tempTarget = Target;
 
                             if (distance != mResetDistance)
@@ -1190,7 +1190,7 @@ namespace Intersect.Server.Entities
             // If so, remove target and move back to the origin point.
             if (Options.Npc.AllowResetRadius && AggroCenterMap != null && (GetDistanceTo(AggroCenterMap, AggroCenterX, AggroCenterY) > Math.Max(Options.Npc.ResetRadius, Base.ResetRadius) || forceDistance))
             {
-                ResetNpc(Options.Npc.ResetVitalsAndStatusses);
+                Reset(Options.Npc.ResetVitalsAndStatusses);
 
                 mResetCounter = 0;
                 mResetDistance = 0;
@@ -1203,7 +1203,7 @@ namespace Intersect.Server.Entities
             return false;
         }
 
-        private void ResetNpc(bool resetVitals = true, bool clearLocation = false)
+        private void Reset(bool resetVitals, bool clearLocation = false)
         {
             // Remove our target.
             RemoveTarget();
@@ -1233,6 +1233,17 @@ namespace Intersect.Server.Entities
                     RestoreVital((Vitals)v);
                 }
             }
+        }
+
+        // Completely resets an Npc to full health and its spawnpoint if it's current chasing something.
+        public override void Reset()
+        {
+            if (AggroCenterMap != null)
+            {
+                Warp(AggroCenterMap.Id, AggroCenterX, AggroCenterY);
+            }
+            
+            Reset(true, true);
         }
 
         public override void NotifySwarm(Entity attacker)

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -619,7 +619,7 @@ namespace Intersect.Server.Maps
         }
 
         //Npcs
-        public void SpawnMapNpcs()
+        private void SpawnMapNpcs()
         {
             for (var i = 0; i < Spawns.Count; i++)
             {
@@ -679,7 +679,7 @@ namespace Intersect.Server.Maps
             }
         }
 
-        public void DespawnNpcs()
+        private void DespawnNpcs()
         {
             //Kill all npcs spawned from this map
             lock (GetMapLock())
@@ -1307,6 +1307,14 @@ namespace Intersect.Server.Maps
             SpawnMapResources();
         }
 
+        /// <summary>
+        /// Despawn and respawn all map Npcs to fully reset them on this map.
+        /// </summary>
+        public void ResetNpcSpawns()
+        {
+            DespawnNpcs();
+            SpawnMapNpcs();
+        }
 
 
         public static MapInstance Get(Guid id)

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -619,7 +619,7 @@ namespace Intersect.Server.Maps
         }
 
         //Npcs
-        private void SpawnMapNpcs()
+        public void SpawnMapNpcs()
         {
             for (var i = 0; i < Spawns.Count; i++)
             {
@@ -679,7 +679,7 @@ namespace Intersect.Server.Maps
             }
         }
 
-        private void DespawnNpcs()
+        public void DespawnNpcs()
         {
             //Kill all npcs spawned from this map
             lock (GetMapLock())
@@ -1306,6 +1306,8 @@ namespace Intersect.Server.Maps
             SpawnMapNpcs();
             SpawnMapResources();
         }
+
+
 
         public static MapInstance Get(Guid id)
         {


### PR DESCRIPTION
Resolves #988 

This should stop Npcs from hugging corners, entrances, walls etc. when a player joins a map somebody managed to lure all Npcs into one corner for.

When a reset radius is allowed and configured, the Npc will simply reset to the location it was pulled from, assuming it has one.
When no reset radius is configured or allowed.. things get a little trickier and we check if the Npc is in combat or not, if it is we forcibly kill it dropping no items and respawn it in its designated spawn location or randomly.