### PR TITLE
Fixes map updates when metrics is false. (#855)

### DIFF
--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -355,15 +355,15 @@ namespace Intersect.Server.Core
                             var timeAfterUpdate = Timing.Global.Milliseconds;
                             MetricsRoot.Instance.Game.MapUpdateProcessingTime.Record(timeAfterUpdate - timeBeforeUpdate);
                             MetricsRoot.Instance.Game.MapTotalUpdateTime.Record(timeAfterUpdate - desiredMapUpdateTime);
-
-                            if (ActiveMaps.Contains(map.Id))
-                            {
-                                MapUpdateQueue.Enqueue(map);
-                            }
                         }
                         else
                         {
                             map.Update(Timing.Global.Milliseconds);
+                        }
+
+                        if (ActiveMaps.Contains(map.Id))
+                        {
+                            MapUpdateQueue.Enqueue(map);
                         }
                     }
                 }


### PR DESCRIPTION
MapUpdateQueue was updating the map within the ActiveMaps check, while **inside the enabled check for metrics only**.
By moving this check for active maps along with MapUpdateQueue, **out of this previously mentioned check** for enabled metrics, we can now still enjoy metrics doing it's job properly (to work or not) whenever it's enabled or disabled, _without interrupting the gameplay map updates_. 
Should resolve #855 