### PR TITLE
Adds configurable custom colour for chat bubble text's outline.

### DIFF
--- a/Intersect (Core)/CustomColors.cs
+++ b/Intersect (Core)/CustomColors.cs
@@ -101,6 +101,8 @@ namespace Intersect
 
             public Color ChatBubbleText = Color.Black;
 
+            public Color ChatBubbleTextOutline = Color.Transparent;
+
             public Color GlobalChat = new Color(255, 220, 220, 220);
 
             public Color GlobalMsg = new Color(255, 220, 220, 220);

--- a/Intersect.Client/Entities/ChatBubble.cs
+++ b/Intersect.Client/Entities/ChatBubble.cs
@@ -188,7 +188,8 @@ namespace Intersect.Client.Entities
                         mText[i], Graphics.ChatBubbleFont,
                         (int) (x - mTextureBounds.Width / 2 + (mTextureBounds.Width - textSize.X) / 2f),
                         (int) (y - mTextureBounds.Height - yoffset + 8 + i * 16), 1,
-                        Color.FromArgb(CustomColors.Chat.ChatBubbleText.ToArgb()), true, null
+                        Color.FromArgb(CustomColors.Chat.ChatBubbleText.ToArgb()), true, null,
+                        Color.FromArgb(CustomColors.Chat.ChatBubbleTextOutline.ToArgb())
                     );
                 }
             }


### PR DESCRIPTION
* Should resolve #1007 
* Transparent by default, in order to keep the original graphic concept of intersect's chat bubbles.
* Users are now able to set any specific colour to render as the text's outline inside chat bubbles by following the ARGB format.

**Example**
( rebuild core, client and server when testing )
![imagen](https://user-images.githubusercontent.com/17498701/139335727-4afce251-a3a3-4d6e-9b09-86beee2db91f.png)
![imagen](https://user-images.githubusercontent.com/17498701/139335689-34a4fb8b-fad4-45e7-b341-61a173b7e811.png)
