### PR TITLE
Modify Asset Packing to pack by file size per batch rather than file count

### DIFF
--- a/Intersect (Core)/Compression/AssetPacker.cs
+++ b/Intersect (Core)/Compression/AssetPacker.cs
@@ -162,7 +162,7 @@ namespace Intersect.Compression
 		/// <param name="indexName">The filename for the index file.</param>
 		/// <param name="packPrefix">The file prefix for each asset pack.</param>
 		/// <param name="packExt">The file extension for each asset pack.</param>
-		/// <param name="batchSize">The maximum size in bytes of combined files to pack up in each asset pack.</param>
+		/// <param name="batchSize">The maximum size in Megabytes of combined files to pack up in each asset pack.</param>
 		public static void PackageAssets(string inputDir, string inputFilter, string outputDir, string indexName, string packPrefix, string packExt, int batchSize)
 		{
 			// We can't do less than one MB at a time.

--- a/Intersect (Core)/Compression/AssetPacker.cs
+++ b/Intersect (Core)/Compression/AssetPacker.cs
@@ -162,35 +162,74 @@ namespace Intersect.Compression
 		/// <param name="indexName">The filename for the index file.</param>
 		/// <param name="packPrefix">The file prefix for each asset pack.</param>
 		/// <param name="packExt">The file extension for each asset pack.</param>
-		/// <param name="batchSize">The maximum amount of files to pack up in each asset pack.</param>
+		/// <param name="batchSize">The maximum size in bytes of combined files to pack up in each asset pack.</param>
 		public static void PackageAssets(string inputDir, string inputFilter, string outputDir, string indexName, string packPrefix, string packExt, int batchSize)
 		{
-			// We can't do less than one file at a time.
+			// We can't do less than one MB at a time.
 			if (batchSize < 1)
 			{
 				batchSize = 1;
 			}
 
-			var fileBatches = Directory.GetFiles(inputDir, inputFilter).Split(batchSize).ToArray();
+			// Convert to Bytes.
+			batchSize = (batchSize * 1024) * 1024;
+
+			// Get our asset file layout so we can just loop through this to create our packs.
+			var packs = GeneratePackLayout(inputDir, inputFilter, packPrefix, packExt, batchSize);
+
 			var index = new List<PackageIndexEntry>();
-			for (var n = 0; n < fileBatches.Length; n++)
+			foreach (var pack in packs)
 			{
-				using (var stream = GzipCompression.CreateCompressedFileStream(Path.Combine(outputDir, string.Format("{00}{01}{02}", packPrefix, n, packExt))))
+				using (var stream = GzipCompression.CreateCompressedFileStream(Path.Combine(outputDir, pack.Key)))
 				{
 					int streamOffset = 0;
-					foreach (var item in fileBatches[n])
+					foreach (var item in pack.Value)
 					{
-						using (var file = File.OpenRead(item))
+						using (var file = File.OpenRead(item.FullPath))
 						{
 							file.CopyTo(stream);
-							index.Add(new PackageIndexEntry() { FileName = Path.GetFileName(item), PackName = string.Format("{00}{01}{02}", packPrefix, n, packExt), FileStartByte = streamOffset, FileEndByte = streamOffset + (int)file.Length });
+							index.Add(new PackageIndexEntry() { FileName = Path.GetFileName(item.Name), PackName = pack.Key, FileStartByte = streamOffset, FileEndByte = streamOffset + (int)file.Length });
 							streamOffset += (int)file.Length;
 						}
 					}
 				}
 			}
+
 			GzipCompression.WriteCompressedString(Path.Combine(outputDir, indexName), JsonConvert.SerializeObject(index));
 		}
+
+		private static Dictionary<string, List<PackFileEntry>> GeneratePackLayout(string inputDir, string inputFilter, string packPrefix, string packExt, long batchSize)
+        {
+			var cache = new Dictionary<string, List<PackFileEntry>>();
+			var currentPack = 0;
+			long currentSize = 0;
+
+			foreach (var file in new DirectoryInfo(inputDir).GetFiles(inputFilter).OrderByDescending(f => f.Length))
+            {
+				// Does this file make us go over our determined batch size, but is it not our first file?
+				if (currentSize + file.Length > batchSize && currentSize != 0)
+                {
+					// It's going over and is NOT our first file! Uh-Oh! Move on to the next pack!
+					currentSize = 0;
+					currentPack++;
+                }
+
+				// Get our pack name for simplicity.
+				var packname = $"{packPrefix}{currentPack}{packExt}";
+
+				// Check if we already have this pack name in our cache, if not add it!
+				if (!cache.ContainsKey(packname))
+                {
+					cache.Add(packname, new List<PackFileEntry>());
+                }
+
+				// Add the file to our cache here.
+				cache[packname].Add(new PackFileEntry() { Name = file.Name, FullPath = file.FullName });
+				currentSize += file.Length;
+            }
+
+			return cache;
+        }
 		#endregion
 
 		#region Internal classes
@@ -199,12 +238,19 @@ namespace Intersect.Compression
 			public long LastAccessTime { get; set; }
 			public MemoryStream StreamCache { get; set; }
 		}
+
 		private class PackageIndexEntry
 		{
 			public string FileName { get; set; }
 			public string PackName { get; set; }
 			public int FileStartByte { get; set; }
 			public int FileEndByte { get; set; }
+		}
+
+		private class PackFileEntry 
+		{ 
+			public string Name { get; set; }
+			public string FullPath { get; set; }
 		}
 		#endregion
 

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -1774,12 +1774,12 @@ namespace Intersect.Editor.Forms
             // Package up sounds!
             Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.sounds, 80, false);
             Application.DoEvents();
-            AssetPacker.PackageAssets(Path.Combine("resources", "sounds"), "*.wav", packsPath, "sound.index", "sound", ".asset", Convert.ToInt32(Preferences.LoadPreference("SoundBatchSize")));
+            AssetPacker.PackageAssets(Path.Combine("resources", "sounds"), "*.wav", packsPath, "sound.index", "sound", ".asset", Convert.ToInt32(Preferences.LoadPreference("SoundPackSize")));
 
             // Package up music!
             Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.music, 90, false);
             Application.DoEvents();
-            AssetPacker.PackageAssets(Path.Combine("resources", "music"), "*.ogg", packsPath, "music.index", "music", ".asset", Convert.ToInt32(Preferences.LoadPreference("MusicBatchSize")));
+            AssetPacker.PackageAssets(Path.Combine("resources", "music"), "*.ogg", packsPath, "music.index", "music", ".asset", Convert.ToInt32(Preferences.LoadPreference("MusicPackSize")));
 
             Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.done, 100, false);
             Application.DoEvents();

--- a/Intersect.Editor/Forms/frmOptions.Designer.cs
+++ b/Intersect.Editor/Forms/frmOptions.Designer.cs
@@ -184,7 +184,7 @@ namespace Intersect.Editor.Forms
             "2048",
             "4096",
             "8192"});
-            this.cmbTextureSize.Location = new System.Drawing.Point(104, 42);
+            this.cmbTextureSize.Location = new System.Drawing.Point(261, 14);
             this.cmbTextureSize.Name = "cmbTextureSize";
             this.cmbTextureSize.Size = new System.Drawing.Size(59, 21);
             this.cmbTextureSize.TabIndex = 52;
@@ -195,17 +195,17 @@ namespace Intersect.Editor.Forms
             // 
             this.lblTextureSize.AutoSize = true;
             this.lblTextureSize.ForeColor = System.Drawing.Color.White;
-            this.lblTextureSize.Location = new System.Drawing.Point(6, 48);
+            this.lblTextureSize.Location = new System.Drawing.Point(6, 20);
             this.lblTextureSize.Name = "lblTextureSize";
-            this.lblTextureSize.Size = new System.Drawing.Size(94, 13);
+            this.lblTextureSize.Size = new System.Drawing.Size(179, 13);
             this.lblTextureSize.TabIndex = 51;
-            this.lblTextureSize.Text = "Texture Pack Size";
+            this.lblTextureSize.Text = "Max Texture Pack Size (Resolution):";
             // 
             // nudMusicBatch
             // 
             this.nudMusicBatch.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
             this.nudMusicBatch.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMusicBatch.Location = new System.Drawing.Point(267, 16);
+            this.nudMusicBatch.Location = new System.Drawing.Point(261, 41);
             this.nudMusicBatch.Maximum = new decimal(new int[] {
             999999999,
             0,
@@ -220,7 +220,7 @@ namespace Intersect.Editor.Forms
             this.nudMusicBatch.Size = new System.Drawing.Size(59, 20);
             this.nudMusicBatch.TabIndex = 50;
             this.nudMusicBatch.Value = new decimal(new int[] {
-            20,
+            8,
             0,
             0,
             0});
@@ -229,7 +229,7 @@ namespace Intersect.Editor.Forms
             // 
             this.nudSoundBatch.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
             this.nudSoundBatch.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudSoundBatch.Location = new System.Drawing.Point(104, 16);
+            this.nudSoundBatch.Location = new System.Drawing.Point(261, 67);
             this.nudSoundBatch.Maximum = new decimal(new int[] {
             999999999,
             0,
@@ -244,30 +244,31 @@ namespace Intersect.Editor.Forms
             this.nudSoundBatch.Size = new System.Drawing.Size(59, 20);
             this.nudSoundBatch.TabIndex = 49;
             this.nudSoundBatch.Value = new decimal(new int[] {
-            10,
+            8,
             0,
             0,
             0});
+            this.nudSoundBatch.ValueChanged += new System.EventHandler(this.nudSoundBatch_ValueChanged);
             // 
             // lblMusicBatch
             // 
             this.lblMusicBatch.AutoSize = true;
             this.lblMusicBatch.ForeColor = System.Drawing.Color.White;
-            this.lblMusicBatch.Location = new System.Drawing.Point(169, 20);
+            this.lblMusicBatch.Location = new System.Drawing.Point(6, 43);
             this.lblMusicBatch.Name = "lblMusicBatch";
-            this.lblMusicBatch.Size = new System.Drawing.Size(89, 13);
+            this.lblMusicBatch.Size = new System.Drawing.Size(137, 13);
             this.lblMusicBatch.TabIndex = 8;
-            this.lblMusicBatch.Text = "Music Batch Size";
+            this.lblMusicBatch.Text = "Max Music Pack Size (MB):";
             // 
             // lblSoundBatch
             // 
             this.lblSoundBatch.AutoSize = true;
             this.lblSoundBatch.ForeColor = System.Drawing.Color.White;
-            this.lblSoundBatch.Location = new System.Drawing.Point(6, 20);
+            this.lblSoundBatch.Location = new System.Drawing.Point(6, 69);
             this.lblSoundBatch.Name = "lblSoundBatch";
-            this.lblSoundBatch.Size = new System.Drawing.Size(92, 13);
+            this.lblSoundBatch.Size = new System.Drawing.Size(140, 13);
             this.lblSoundBatch.TabIndex = 7;
-            this.lblSoundBatch.Text = "Sound Batch Size";
+            this.lblSoundBatch.Text = "Max Sound Pack Size (MB):";
             // 
             // chkPackageAssets
             // 

--- a/Intersect.Editor/Forms/frmOptions.cs
+++ b/Intersect.Editor/Forms/frmOptions.cs
@@ -49,13 +49,13 @@ namespace Intersect.Editor.Forms
                 chkPackageAssets.Checked = Convert.ToBoolean(packageUpdateAssets);
             }
 
-            var soundBatchSize = Preferences.LoadPreference("SoundBatchSize");
+            var soundBatchSize = Preferences.LoadPreference("SoundPackSize");
             if (soundBatchSize != "")
             {
                 nudSoundBatch.Value = Convert.ToInt32(soundBatchSize);
             }
 
-            var musicBatchSize = Preferences.LoadPreference("MusicBatchSize");
+            var musicBatchSize = Preferences.LoadPreference("MusicPackSize");
             if (musicBatchSize != "")
             {
                 nudMusicBatch.Value = Convert.ToInt32(musicBatchSize);
@@ -81,8 +81,8 @@ namespace Intersect.Editor.Forms
             btnBrowseClient.Text = Strings.Options.browsebtn;
             btnUpdateOptions.Text = Strings.Options.UpdateTab;
             grpAssetPackingOptions.Text = Strings.Options.PackageOptions;
-            lblMusicBatch.Text = Strings.Options.MusicBatch;
-            lblSoundBatch.Text = Strings.Options.SoundBatch;
+            lblMusicBatch.Text = Strings.Options.MusicPackSize;
+            lblSoundBatch.Text = Strings.Options.SoundPackSize;
             lblTextureSize.Text = Strings.Options.TextureSize;
 
         }
@@ -92,8 +92,8 @@ namespace Intersect.Editor.Forms
             Preferences.SavePreference("SuppressTextureWarning", chkSuppressTilesetWarning.Checked.ToString());
             Preferences.SavePreference("ClientPath", txtGamePath.Text);
             Preferences.SavePreference("PackageUpdateAssets", chkPackageAssets.Checked.ToString());
-            Preferences.SavePreference("SoundBatchSize", nudSoundBatch.Value.ToString());
-            Preferences.SavePreference("MusicBatchSize", nudMusicBatch.Value.ToString());
+            Preferences.SavePreference("SoundPackSize", nudSoundBatch.Value.ToString());
+            Preferences.SavePreference("MusicPackSize", nudMusicBatch.Value.ToString());
             Preferences.SavePreference("TexturePackSize", cmbTextureSize.GetItemText(cmbTextureSize.SelectedItem));
         }
 
@@ -137,6 +137,11 @@ namespace Intersect.Editor.Forms
             HidePanels();
 
             pnlUpdate.Visible = true;
+        }
+
+        private void nudSoundBatch_ValueChanged(object sender, EventArgs e)
+        {
+
         }
     }
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3995,13 +3995,13 @@ Tick timer saved in server config.json.";
             public static LocalizedString PackageOptions = @"Asset Packing Options";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MusicBatch = @"Music Batch Size";
+            public static LocalizedString MusicPackSize = @"Max Music Pack Size (MB):";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SoundBatch = @"Sound Batch Size";
+            public static LocalizedString SoundPackSize = @"Max Sound Pack Size (MB):";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TextureSize = @"Texture Pack Size";
+            public static LocalizedString TextureSize = @"Max Texture Pack Size (Resolution):";
         }
 
         public struct ProgressForm


### PR DESCRIPTION
Probably seems like the most pointless thing ever, but batching these by file count rather than size was always a bit of a silly oversight of mine.
Unlucky scenarios could cache like 50MB inside a single file, which takes.. a while to load.

This should let the user set an upper limit for pack file sizes.
Of course, trying to package files above the limit won't make the files magically smaller, it'll just put these in its own packs.