### PR TITLE
[GWEN] FIX #1031: Control Base now keeps track of sound instance it plays

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -131,8 +131,6 @@ namespace Intersect.Client.Framework.Gwen.Control
 
         private object mUserData;
 
-        private Dictionary<string, GameAudioInstance> mSounds;
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="Base" /> class.
         /// </summary>
@@ -170,8 +168,6 @@ namespace Intersect.Client.Framework.Gwen.Control
             BoundsOutlineColor = Color.Red;
             MarginOutlineColor = Color.Green;
             PaddingOutlineColor = Color.Blue;
-
-            mSounds = new Dictionary<string, GameAudioInstance>();
         }
 
         /// <summary>
@@ -2178,15 +2174,10 @@ namespace Intersect.Client.Framework.Gwen.Control
             if (sound != null)
             {
                 var soundInstance = sound.CreateInstance();
-                // If this sound file hasn't been played by this UI element before
-                if (!mSounds.ContainsKey(filename))
+                if (soundInstance != null)
                 {
-                    // Add it to the list of playing sounds
-                    mSounds.Add(filename, soundInstance);
+                    Canvas.PlayAndAddSound(soundInstance);
                 }
-                // And play the sound
-                mSounds[filename].SetVolume(100, false);
-                mSounds[filename].Play();
             }
         }
 
@@ -2745,20 +2736,6 @@ namespace Intersect.Client.Framework.Gwen.Control
             UpdateColors();
             mCacheTextureDirty = true;
             mParent?.Redraw();
-
-            var keysToRemove = new List<string>();
-            foreach(var sound in mSounds.Keys)
-            {
-                if(mSounds[sound]?.State == GameAudioInstance.AudioInstanceState.Stopped)
-                {
-                    mSounds[sound].Dispose();
-                    keysToRemove.Add(sound);
-                }
-            }
-            foreach(var filename in keysToRemove)
-            {
-                mSounds.Remove(filename);
-            }
         }
 
         /// <summary>

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -130,6 +130,8 @@ namespace Intersect.Client.Framework.Gwen.Control
 
         private object mUserData;
 
+        private Audio.GameAudioInstance mSoundInstance;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="Base" /> class.
         /// </summary>
@@ -2172,11 +2174,11 @@ namespace Intersect.Client.Framework.Gwen.Control
             var sound = GameContentManager.Current.GetSound(filename);
             if (sound != null)
             {
-                var soundInstance = sound.CreateInstance();
-                if (soundInstance != null)
+                mSoundInstance = sound.CreateInstance();
+                if (mSoundInstance != null)
                 {
-                    soundInstance.SetVolume(100, false);
-                    soundInstance.Play();
+                    mSoundInstance.SetVolume(100, false);
+                    mSoundInstance.Play();
                 }
             }
         }
@@ -2736,6 +2738,10 @@ namespace Intersect.Client.Framework.Gwen.Control
             UpdateColors();
             mCacheTextureDirty = true;
             mParent?.Redraw();
+            if (mSoundInstance?.State == Audio.GameAudioInstance.AudioInstanceState.Stopped)
+            {
+                mSoundInstance.Dispose();
+            }
         }
 
         /// <summary>

--- a/Intersect.Client.Framework/Gwen/Control/Canvas.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Canvas.cs
@@ -5,6 +5,7 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen.Anim;
 using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
+using Intersect.Client.Framework.Audio;
 
 namespace Intersect.Client.Framework.Gwen.Control
 {
@@ -28,12 +29,15 @@ namespace Intersect.Client.Framework.Gwen.Control
 
         private float mScale;
 
+        private List<GameAudioInstance> mUISounds;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="Canvas" /> class.
         /// </summary>
         /// <param name="skin">Skin to use.</param>
         public Canvas(Skin.Base skin, string name) : base(null, name)
         {
+            mUISounds = new List<GameAudioInstance>();
             SetBounds(0, 0, 10000, 10000);
             SetSkin(skin);
             Scale = 1.0f;
@@ -173,6 +177,31 @@ namespace Intersect.Client.Framework.Gwen.Control
             InvalidateChildren(true);
         }
 
+        public void PlayAndAddSound(GameAudioInstance sound)
+        {
+            // Track the sound - we will check to see when it's done and dispose of it in DoThink()
+            mUISounds.Add(sound);
+            // And play the sound
+            sound.SetVolume(100, false);
+            sound.Play();
+        }
+
+        private void RemoveAndDisposeDeadSounds()
+        {
+            mUISounds.RemoveAll(item =>
+            {
+                if (item.State == GameAudioInstance.AudioInstanceState.Stopped || item.State == GameAudioInstance.AudioInstanceState.Disposed)
+                {
+                    item.Dispose();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            });
+        }
+
         /// <summary>
         ///     Processes input and layout. Also purges delayed delete queue.
         /// </summary>
@@ -182,6 +211,21 @@ namespace Intersect.Client.Framework.Gwen.Control
             {
                 return;
             }
+
+            mUISounds.RemoveAll(item =>
+            {
+                if (item.State == GameAudioInstance.AudioInstanceState.Stopped || item.State == GameAudioInstance.AudioInstanceState.Disposed)
+                {
+                    item.Dispose();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            });
+
+            RemoveAndDisposeDeadSounds();
 
             Animation.GlobalThink();
 

--- a/Intersect.Client.Framework/Gwen/Control/Canvas.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Canvas.cs
@@ -212,19 +212,6 @@ namespace Intersect.Client.Framework.Gwen.Control
                 return;
             }
 
-            mUISounds.RemoveAll(item =>
-            {
-                if (item.State == GameAudioInstance.AudioInstanceState.Stopped || item.State == GameAudioInstance.AudioInstanceState.Disposed)
-                {
-                    item.Dispose();
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            });
-
             RemoveAndDisposeDeadSounds();
 
             Animation.GlobalThink();


### PR DESCRIPTION
Resolves #1031 

This is me attempting to implement a fix for my theory as to why UI sounds get cutoff prematurely (see linked issue for details). I _haven't_ seen anything like memory leaks or weird issues/crashes come from this change, and while debugging I did see that sound instances I was creating through the UI were being disposed of in some fashion.