### PR TITLE
chore: rename player options

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -120,11 +120,11 @@ namespace Intersect
 
         public static int MaxLevel => Instance.PlayerOpts.MaxLevel;
 
-        public static int MaxInvItems => Instance.PlayerOpts.MaxInventory;
+        public static int MaxInventorySlots => Instance.PlayerOpts.MaxInventorySlots;
 
-        public static int MaxPlayerSkills => Instance.PlayerOpts.MaxSpells;
+        public static int MaxSpellSlots => Instance.PlayerOpts.MaxSpellSlots;
 
-        public static int MaxCharacters => Instance.PlayerOpts.MaxCharacters;
+        public static int MaxCharacterSlots => Instance.PlayerOpts.MaxCharacterSlots;
 
         public static int ItemDropChance => Instance.PlayerOpts.ItemDropChance;
 

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -62,12 +62,12 @@
         /// <summary>
         /// Number of characters an account may create.
         /// </summary>
-        public int MaxCharacters { get; set; } = 1;
+        public int MaxCharacterSlots { get; set; } = 1;
 
         /// <summary>
         /// Number of inventory slots a player has.
         /// </summary>
-        public int MaxInventory { get; set; } = 35;
+        public int MaxInventorySlots { get; set; } = 35;
 
         /// <summary>
         /// Max level a player can achieve.
@@ -77,7 +77,7 @@
         /// <summary>
         /// Number of spell slots a player has.
         /// </summary>
-        public int MaxSpells { get; set; } = 35;
+        public int MaxSpellSlots { get; set; } = 35;
 
         /// <summary>
         /// The highest value a single stat can be for a player.

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -102,7 +102,7 @@ namespace Intersect.Client.Entities
         public Guid Id { get; set; }
 
         //Inventory/Spells/Equipment
-        public IItem[] Inventory { get; set; } = new IItem[Options.MaxInvItems];
+        public IItem[] Inventory { get; set; } = new IItem[Options.MaxInventorySlots];
 
         IReadOnlyList<IItem> IEntity.Items => Inventory.ToList();
 
@@ -177,7 +177,7 @@ namespace Intersect.Client.Entities
             }
         }
 
-        public Spell[] Spells { get; set; } = new Spell[Options.MaxPlayerSkills];
+        public Spell[] Spells { get; set; } = new Spell[Options.MaxSpellSlots];
 
         IReadOnlyList<Guid> IEntity.Spells => Spells.Select(x => x.Id).ToList();
 
@@ -233,12 +233,12 @@ namespace Intersect.Client.Entities
 
             if (Id != Guid.Empty && Type != EntityType.Event)
             {
-                for (var i = 0; i < Options.MaxInvItems; i++)
+                for (var i = 0; i < Options.MaxInventorySlots; i++)
                 {
                     Inventory[i] = new Item();
                 }
 
-                for (var i = 0; i < Options.MaxPlayerSkills; i++)
+                for (var i = 0; i < Options.MaxSpellSlots; i++)
                 {
                     Spells[i] = new Spell();
                 }
@@ -741,7 +741,7 @@ namespace Intersect.Client.Entities
             {
                 for (var z = 0; z < Options.EquipmentSlots.Count; z++)
                 {
-                    if (Equipment[z] != Guid.Empty && (this != Globals.Me || MyEquipment[z] < Options.MaxInvItems))
+                    if (Equipment[z] != Guid.Empty && (this != Globals.Me || MyEquipment[z] < Options.MaxInventorySlots))
                     {
                         var itemId = Guid.Empty;
                         if (this == Globals.Me)
@@ -1163,7 +1163,7 @@ namespace Intersect.Client.Entities
                     if (sprite == Sprite && Equipment.Length == Options.EquipmentSlots.Count)
                     {
                         if (Equipment[equipSlot] != Guid.Empty && this != Globals.Me ||
-                            MyEquipment[equipSlot] < Options.MaxInvItems)
+                            MyEquipment[equipSlot] < Options.MaxInventorySlots)
                         {
                             var itemId = Guid.Empty;
                             if (this == Globals.Me)
@@ -1951,7 +1951,7 @@ namespace Intersect.Client.Entities
                 if (Options.WeaponIndex > -1 && Options.WeaponIndex < Equipment.Length)
                 {
                     if (Equipment[Options.WeaponIndex] != Guid.Empty && this != Globals.Me ||
-                        MyEquipment[Options.WeaponIndex] < Options.MaxInvItems)
+                        MyEquipment[Options.WeaponIndex] < Options.MaxInventorySlots)
                     {
                         var itemId = Guid.Empty;
                         if (this == Globals.Me)

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -399,7 +399,7 @@ namespace Intersect.Client.Entities
 
         public int FindItem(Guid itemId, int itemVal = 1)
         {
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 if (Inventory[i].ItemId == itemId && Inventory[i].Quantity >= itemVal)
                 {

--- a/Intersect.Client/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagItem.cs
@@ -274,7 +274,7 @@ namespace Intersect.Client.Interface.Game.Bag
 
                         if (invWindow.RenderBounds().IntersectsWith(dragRect))
                         {
-                            for (var i = 0; i < Options.MaxInvItems; i++)
+                            for (var i = 0; i < Options.MaxInventorySlots; i++)
                             {
                                 if (invWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
                                 {

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -253,7 +253,7 @@ namespace Intersect.Client.Interface.Game.Character
                         var equipment = Globals.Me.MyEquipment;
                         if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
                             equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
-                            Options.MaxInvItems)
+                            Options.MaxInventorySlots)
                         {
                             var itemNum = Globals.Me
                                 .Inventory[equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])]]
@@ -365,7 +365,7 @@ namespace Intersect.Client.Interface.Game.Character
 
             for (var i = 0; i < Options.EquipmentSlots.Count; i++)
             {
-                if (Globals.Me.MyEquipment[i] > -1 && Globals.Me.MyEquipment[i] < Options.MaxInvItems)
+                if (Globals.Me.MyEquipment[i] > -1 && Globals.Me.MyEquipment[i] < Options.MaxInventorySlots)
                 {
                     if (Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId != Guid.Empty)
                     {

--- a/Intersect.Client/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client/Interface/Game/Character/EquipmentItem.cs
@@ -60,7 +60,7 @@ namespace Intersect.Client.Interface.Game.Character
                 if (window != null)
                 {
                     var invSlot = Globals.Me.MyEquipment[mYindex];
-                    if (invSlot >= 0 && invSlot < Options.MaxInvItems)
+                    if (invSlot >= 0 && invSlot < Options.MaxInventorySlots)
                     {
                         window.OpenContextMenu(invSlot);
                     }

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -892,7 +892,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     for (var i = 0; i < MyEntity.MyEquipment.Length; i++)
                     {
                         var eqp = MyEntity.MyEquipment[i];
-                        if (eqp > -1 && eqp < Options.MaxInvItems)
+                        if (eqp > -1 && eqp < Options.MaxInventorySlots)
                         {
                             equipment[i] = MyEntity.Inventory[eqp].ItemId;
                         }

--- a/Intersect.Client/Interface/Game/EscapeMenu.cs
+++ b/Intersect.Client/Interface/Game/EscapeMenu.cs
@@ -84,7 +84,7 @@ namespace Intersect.Client.Interface.Game
 
             mContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-            if (Options.Player.MaxCharacters <= 1)
+            if (Options.Player.MaxCharacterSlots <= 1)
             {
                 mGoToCharacterSelect.IsDisabled = true;
             }

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -425,7 +425,7 @@ namespace Intersect.Client.Interface.Game.Inventory
                     //Check inventory first.
                     if (mInventoryWindow.RenderBounds().IntersectsWith(dragRect))
                     {
-                        for (var i = 0; i < Options.MaxInvItems; i++)
+                        for (var i = 0; i < Options.MaxInventorySlots; i++)
                         {
                             if (mInventoryWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
                             {

--- a/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
@@ -209,7 +209,7 @@ namespace Intersect.Client.Interface.Game.Inventory
 
             mInventoryWindow.IsClosable = Globals.CanCloseInventory;
 
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 var item = ItemBase.Get(Globals.Me.Inventory[i].ItemId);
                 if (item != null)
@@ -243,7 +243,7 @@ namespace Intersect.Client.Interface.Game.Inventory
 
         private void InitItemContainer()
         {
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 Items.Add(new InventoryItem(this, i));
                 Items[i].Container = new ImagePanel(mItemContainer, "InventoryItem");

--- a/Intersect.Client/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellItem.cs
@@ -280,7 +280,7 @@ namespace Intersect.Client.Interface.Game.Spells
                     //Check spell first.
                     if (mSpellWindow.RenderBounds().IntersectsWith(dragRect))
                     {
-                        for (var i = 0; i < Options.MaxInvItems; i++)
+                        for (var i = 0; i < Options.MaxInventorySlots; i++)
                         {
                             if (i < mSpellWindow.Items.Count &&
                                 mSpellWindow.Items[i].RenderBounds().IntersectsWith(dragRect))

--- a/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
@@ -124,7 +124,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
             X = mSpellWindow.X;
             Y = mSpellWindow.Y;
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 var spell = SpellBase.Get(Globals.Me.Spells[i].Id);
                 Items[i].Pnl.IsHidden = spell == null || Items[i].IsDragging;
@@ -137,7 +137,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
         private void InitItemContainer()
         {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 Items.Add(new SpellItem(this, i));
                 Items[i].Container = new ImagePanel(mItemContainer, "Spell");

--- a/Intersect.Client/Interface/Game/Trades/TradeSegment.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradeSegment.cs
@@ -58,7 +58,7 @@ namespace Intersect.Client.Interface.Game.Trades
                 prefix = "Their";
             }
 
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 Items.Add(new TradeItem(mParent, i, index));
                 Items[i].Container = new ImagePanel(ItemContainer, prefix + "TradeItem");

--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -146,7 +146,7 @@ namespace Intersect.Client.Interface.Game.Trades
 
             for (var n = 0; n < 2; n++)
             {
-                for (var i = 0; i < Options.MaxInvItems; i++)
+                for (var i = 0; i < Options.MaxInventorySlots; i++)
                 {
                     if (Globals.Trade[n, i] != null && Globals.Trade[n, i].ItemId != Guid.Empty)
                     {

--- a/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
@@ -551,7 +551,7 @@ namespace Intersect.Client.Interface.Menu
         private void BackButton_Clicked(Base sender, ClickedEventArgs arguments)
         {
             Hide();
-            if (Options.Player.MaxCharacters <= 1)
+            if (Options.Player.MaxCharacterSlots <= 1)
             {
                 //Logout
                 mMainMenu.Show();

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -1874,12 +1874,12 @@ namespace Intersect.Client.Networking
         {
             if (!string.IsNullOrEmpty(packet.TradePartner))
             {
-                Globals.Trade = new Item[2, Options.MaxInvItems];
+                Globals.Trade = new Item[2, Options.MaxInventorySlots];
 
                 //Gotta initialize the trade values
                 for (var x = 0; x < 2; x++)
                 {
-                    for (var y = 0; y < Options.MaxInvItems; y++)
+                    for (var y = 0; y < Options.MaxInventorySlots; y++)
                     {
                         Globals.Trade[x, y] = new Item();
                     }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2475,7 +2475,7 @@ namespace Intersect.Server.Entities
                         break;
                 }
 
-                if (spellSlot >= 0 && spellSlot < Options.MaxPlayerSkills)
+                if (spellSlot >= 0 && spellSlot < Options.MaxSpellSlots)
                 {
                     // Player cooldown handling is done elsewhere!
                     if (this is Player player)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -273,8 +273,8 @@ namespace Intersect.Server.Entities
         {
             var changes = false;
 
-            changes |= SlotHelper.ValidateSlots(Spells, Options.MaxPlayerSkills);
-            changes |= SlotHelper.ValidateSlots(Items, Options.MaxInvItems);
+            changes |= SlotHelper.ValidateSlots(Spells, Options.MaxSpellSlots);
+            changes |= SlotHelper.ValidateSlots(Items, Options.MaxInventorySlots);
             changes |= SlotHelper.ValidateSlots(Bank, Options.Instance.PlayerOpts.InitialBankslots);
 
             if (Hotbar.Count < Options.Instance.PlayerOpts.HotbarSlotCount)
@@ -2696,7 +2696,7 @@ namespace Intersect.Server.Entities
         public List<InventorySlot> FindOpenInventorySlots()
         {
             var slots = new List<InventorySlot>();
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 var inventorySlot = Items[i];
 
@@ -3279,7 +3279,7 @@ namespace Intersect.Server.Entities
             }
 
             long itemCount = 0;
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 var item = Items[i];
                 if (item.ItemId == itemId)
@@ -3324,7 +3324,7 @@ namespace Intersect.Server.Entities
                 return slots;
             }
 
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 var item = Items[i];
                 if (item?.ItemId != itemId)
@@ -4473,7 +4473,7 @@ namespace Intersect.Server.Entities
                     //Find a spot in the trade for it!
                     if (itemBase.IsStackable)
                     {
-                        for (var i = 0; i < Options.MaxInvItems; i++)
+                        for (var i = 0; i < Options.MaxInventorySlots; i++)
                         {
                             if (Trading.Offer[i] != null && Trading.Offer[i].ItemId == Items[slot].ItemId)
                             {
@@ -4501,7 +4501,7 @@ namespace Intersect.Server.Entities
                     }
 
                     //Either a non stacking item, or we couldn't find the item already existing in the players inventory
-                    for (var i = 0; i < Options.MaxInvItems; i++)
+                    for (var i = 0; i < Options.MaxInventorySlots; i++)
                     {
                         if (Trading.Offer[i] == null || Trading.Offer[i].ItemId == Guid.Empty)
                         {
@@ -4823,10 +4823,10 @@ namespace Intersect.Server.Entities
             target.Trading.Counterparty = this;
             Trading.Accepted = false;
             target.Trading.Accepted = false;
-            Trading.Offer = new Item[Options.MaxInvItems];
-            target.Trading.Offer = new Item[Options.MaxInvItems];
+            Trading.Offer = new Item[Options.MaxInventorySlots];
+            target.Trading.Offer = new Item[Options.MaxInventorySlots];
 
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 Trading.Offer[i] = new Item();
                 target.Trading.Offer[i] = new Item();
@@ -4855,7 +4855,7 @@ namespace Intersect.Server.Entities
                 return false;
             }
 
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 if (Spells[i].SpellId == Guid.Empty)
                 {
@@ -4877,7 +4877,7 @@ namespace Intersect.Server.Entities
 
         public bool KnowsSpell(Guid spellId)
         {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 if (Spells[i].SpellId == spellId)
                 {
@@ -4890,7 +4890,7 @@ namespace Intersect.Server.Entities
 
         public int FindSpell(Guid spellId)
         {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 if (Spells[i].SpellId == spellId)
                 {
@@ -5270,7 +5270,7 @@ namespace Intersect.Server.Entities
             // Find the appropriate slot if not passed in
             if (slot == -1)
             {
-                for (var i = 0; i < Options.MaxInvItems; i++)
+                for (var i = 0; i < Options.MaxInventorySlots; i++)
                 {
                     if (itemBase == Items[i].Descriptor)
                     {

--- a/Intersect.Server.Core/Entities/Trading.cs
+++ b/Intersect.Server.Core/Entities/Trading.cs
@@ -29,7 +29,7 @@ namespace Intersect.Server.Entities
 
             Accepted = false;
             Counterparty = null;
-            Offer = new Item[Options.MaxInvItems];
+            Offer = new Item[Options.MaxInventorySlots];
             Requester = null;
             Requests = new Dictionary<Player, long>();
         }

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -611,7 +611,7 @@ namespace Intersect.Server.Networking
             }
 
             // Show character select menu or login right away by following configuration preferences.
-            if (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect)
+            if (Options.MaxCharacterSlots > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect)
             {
                 PacketSender.SendPlayerCharacters(client);
             }
@@ -638,7 +638,7 @@ namespace Intersect.Server.Networking
                     : UserActivityHistory.UserAction.DisconnectLogout, $"{client.Name},{client.Entity?.Name}");
 
             if (packet.ReturningToCharSelect &&
-                (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
+                (Options.MaxCharacterSlots > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
             {
                 client.Entity?.TryLogout(false, true);
                 client.Entity = null;
@@ -2482,7 +2482,7 @@ namespace Intersect.Server.Networking
         //NewCharacterPacket
         public void HandlePacket(Client client, NewCharacterPacket packet)
         {
-            if (client?.Characters?.Count < Options.MaxCharacters)
+            if (client?.Characters?.Count < Options.MaxCharacterSlots)
             {
                 PacketSender.SendGameObjects(client, GameObjectType.Class);
                 PacketSender.SendCreateCharacter(client);

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1123,8 +1123,8 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            var invItems = new InventoryUpdatePacket[Options.MaxInvItems];
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            var invItems = new InventoryUpdatePacket[Options.MaxInventorySlots];
+            for (var i = 0; i < Options.MaxInventorySlots; i++)
             {
                 invItems[i] = new InventoryUpdatePacket(
                     i, player.Items[i].ItemId, player.Items[i].Quantity, player.Items[i].BagId,
@@ -1159,8 +1159,8 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            var spells = new SpellUpdatePacket[Options.MaxPlayerSkills];
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            var spells = new SpellUpdatePacket[Options.MaxSpellSlots];
+            for (var i = 0; i < Options.MaxSpellSlots; i++)
             {
                 spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId);
             }
@@ -1280,7 +1280,7 @@ namespace Intersect.Server.Networking
                         {
                             if (equipmentArray[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
                                 equipmentArray[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
-                                Options.MaxInvItems)
+                                Options.MaxInventorySlots)
                             {
                                 var paperdollOrder = Options.PaperdollOrder[1][z];
                                 var equipmentSlot = Options.EquipmentSlots.IndexOf(paperdollOrder);
@@ -1321,7 +1321,7 @@ namespace Intersect.Server.Networking
 
             CharactersPacket packet = new(
                 characters.ToArray(),
-                client.Characters.Count < Options.MaxCharacters
+                client.Characters.Count < Options.MaxCharacterSlots
             );
 
             if (!client.Send(packet))


### PR DESCRIPTION
* Chore: as previously discussed, this PR simply renames some player option properties so it doesn't requires an issue report.

* Followed the Pascal Format for Coding naming Convention.

* Renames the following properties, as previously discussed [here ](https://github.com/AscensionGameDev/Intersect-Engine/pull/928#issuecomment-910510279) with @lodicolo:

> MaxCharacters -> MaxCharacterSlots
> MaxInventory -> MaxInventorySlots
> ~~MaxBank -> MaxBankSlots~~ ( we use InitialBankslots now)
> MaxSpells -> MaxSpellSlots (this one wasn't really discussed previously, let me know if i should undo this one!)


_Note: for devs testing with this PR, **always** make sure to have a backup of your config files. 3 player options have been renamed, so make sure to carefully check what to change in order to have your previous setup fully operational !_