### PR TITLE
[MainMenu] Adds Animated Background & DisplayMode Settings.

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -46,11 +46,7 @@ namespace Intersect.Configuration
 
         public const int DEFAULT_CHAT_LINES = 100;
 
-        public const string DEFAULT_MENU_BACKGROUND = "background";
-
         public const DisplayModes DEFAULT_MENU_BACKGROUND_DISPLAY_MODE = DisplayModes.Default;
-
-        public const bool DEFAULT_MENU_BACKGROUND_ANIMATED = false;
 
         public const long DEFAULT_MENU_BACKGROUND_FRAME_INTERVAL = 50;
 
@@ -69,6 +65,7 @@ namespace Intersect.Configuration
             GameFont = string.IsNullOrWhiteSpace(GameFont) ? DEFAULT_FONT : GameFont.Trim();
             UIFont = string.IsNullOrWhiteSpace(UIFont) ? DEFAULT_UI_FONT : UIFont.Trim();
             ChatLines = Math.Min(Math.Max(ChatLines, 10), 500);
+            MenuBackground = new List<string>(MenuBackground?.Distinct() ?? new List<string> {"background.png"});
             IntroImages = new List<string>(IntroImages?.Distinct() ?? new List<string>());
         }
 
@@ -122,25 +119,20 @@ namespace Intersect.Configuration
         public string MenuMusic { get; set; } = DEFAULT_MENU_MUSIC;
 
         /// <summary>
-        /// Menu background art
+        /// Sets the main menu's background texture, if the the index of the list is bigger than 1,
+        /// the background will be animated by sequentially drawing the texture files from the list.
+        /// Static background Example: { "background.png" }, 
+        /// Animated background Example: { "background_0.png", "background_1.png", "background_2.png" },
         /// </summary>
-        public string MenuBackground { get; set; } = DEFAULT_MENU_BACKGROUND;
+        public List<string> MenuBackground { get; set; } = new List<string> {"background.png"};
 
         /// <summary>
-        /// Sets the display mode of the background in the main menu.
+        /// Sets the display mode of the main menu's background.
         /// </summary>
         public DisplayModes MenuBackgroundDisplayMode { get; set; } = DEFAULT_MENU_BACKGROUND_DISPLAY_MODE;
 
         /// <summary>
-        /// Toggles the ability to draw an animated background in the main menu.
-        /// Example: when enabled, if you set "background" as MenuBackground, you will need to
-        /// place your animation frames inside the animation resources folder and name them
-        /// sequentially like this:  "background_0.png", "background_1.png", etc..
-        /// </summary>
-        public bool MenuBackgroundAnimated { get; set; } = DEFAULT_MENU_BACKGROUND_ANIMATED;
-
-        /// <summary>
-        /// Sets the frames interval (milliseconds) of the animated background in the main menu.
+        /// Sets the frames interval (milliseconds) of the main menu's animated background.
         /// </summary>
         public long MenuBackgroundFrameInterval { get; set; } = DEFAULT_MENU_BACKGROUND_FRAME_INTERVAL;
 
@@ -166,6 +158,7 @@ namespace Intersect.Configuration
         [OnDeserializing]
         internal void OnDeserializing(StreamingContext context)
         {
+            MenuBackground?.Clear();
             IntroImages?.Clear();
         }
 

--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -46,6 +46,18 @@ namespace Intersect.Configuration
 
         public const string DEFAULT_MENU_BACKGROUND = "background.png";
 
+        public const bool DEFAULT_MENUBG_STRETCH = true;
+
+        public const bool DEFAULT_ANIM_MENUBG_TOGGLE = false;
+
+        public const bool DEFAULT_ANIM_MENUBG_STRETCH = true;
+
+        public const string DEFAULT_ANIM_MENUBG_TEXTURE = "main_menu";
+
+        public const int DEFAULT_ANIM_MENUBG_FRAMECOUNT = 11;
+
+        public const long DEFAULT_ANIM_MENUBG_FRAMESPEED = 50;
+
         public const string DEFAULT_MENU_MUSIC = "RPG-Theme_v001_Looping.ogg";
 
         #endregion
@@ -69,58 +81,98 @@ namespace Intersect.Configuration
         #region Options
 
         /// <summary>
-        /// Hostname of the server to connect to
+        /// Hostname of the server that the client will connect to.
         /// </summary>
         public string Host { get; set; } = DEFAULT_HOST;
 
         /// <summary>
-        /// Port of the server to connect to
+        /// Port of the server that the client will connect to.
         /// </summary>
         public ushort Port { get; set; } = DEFAULT_PORT;
 
         /// <summary>
-        /// The font family to use on misc non-ui rendering
+        /// The font family to use on misc non-ui rendering.
         /// </summary>
         public string GameFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on entity names
+        /// The font family to use on entity names.
         /// </summary>
         public string EntityNameFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on chat bubbles
+        /// The font family to use on chat bubbles.
         /// </summary>
         public string ChatBubbleFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on action messages
+        /// The font family to use on action messages.
         /// </summary>
         public string ActionMsgFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on unstyled windows such as the debug menu/admin window
+        /// The font family to use on un-styled windows such as the debug menu/admin window.
         /// </summary>
         public string UIFont { get; set; } = DEFAULT_UI_FONT;
 
         /// <summary>
-        /// Number of lines to save for chat scrollback
+        /// Number of lines to save for chat scrollback.
         /// </summary>
         public int ChatLines { get; set; } = DEFAULT_CHAT_LINES;
 
         /// <summary>
-        /// Menu music file name
+        /// Sets a music file to be played in the main menu.
         /// </summary>
         public string MenuMusic { get; set; } = DEFAULT_MENU_MUSIC;
 
         /// <summary>
-        /// Menu background art
+        /// Sets a list from which introductory images will be drawn when the game client starts.
+        /// </summary>
+        public List<string> IntroImages { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Sets a texture to be used as static background in the main menu.
         /// </summary>
         public string MenuBackground { get; set; } = DEFAULT_MENU_BACKGROUND;
 
-        // TODO: What is this for?
-        public List<string> IntroImages { get; set; } = new List<string>();
+        /// <summary>
+        /// Toggles the ability to stretch the static background in the main menu.
+        /// </summary>
+        public bool MenuBackgroundStretched { get; set; } = DEFAULT_MENUBG_STRETCH;
 
+        /// <summary>
+        /// Toggles the ability to draw an animated background in the main menu.
+        /// When enabled, the static background in the main menu won't be drawn.
+        /// </summary>
+        public bool AnimatedMenuBgEnabled { get; set; } = DEFAULT_ANIM_MENUBG_TOGGLE;
+
+        /// <summary>
+        /// Toggles the ability to stretch the animated background in the main menu.
+        /// </summary>
+        public bool AnimatedMenuBgStretched { get; set; } = DEFAULT_ANIM_MENUBG_STRETCH;
+
+        /// <summary>
+        /// Sets the base name for the files to be used as frames in the animated background of the main menu.
+        /// ie: if you set "main_menu", you will need to place your animation frames inside the animation folder
+        /// and name them like this:  "main_menu_0.png, main_menu_1.png, main_menu_2.png, etc".
+        /// </summary>
+        public string AnimatedMenuBgTexture { get; set; } = DEFAULT_ANIM_MENUBG_TEXTURE;
+
+        /// <summary>
+        /// Sets the frame count of the animated background in the main menu.
+        /// Make sure to set this value depending on the amount of files to be used from the animation resources.
+        /// </summary>
+        public int AnimatedMenuBgFrameCount { get; set; } = DEFAULT_ANIM_MENUBG_FRAMECOUNT;
+
+        /// <summary>
+        /// Sets the frame speed (milliseconds) of the animated background in the main menu.
+        /// </summary>
+        public long AnimatedMenuBgFrameSpeed { get; set; } = DEFAULT_ANIM_MENUBG_FRAMESPEED;
+
+        /// <summary>
+        /// Optional - built in updater system.
+        /// Sets an URL to Package Updates (ie: https://freemmorpgmaker.com/updater/update.json).
+        /// </summary>
         public string UpdateUrl { get; set; } = "";
 
         /// <summary>

--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
+using Intersect.Enums;
+
 namespace Intersect.Configuration
 {
 
@@ -44,19 +46,13 @@ namespace Intersect.Configuration
 
         public const int DEFAULT_CHAT_LINES = 100;
 
-        public const string DEFAULT_MENU_BACKGROUND = "background.png";
+        public const string DEFAULT_MENU_BACKGROUND = "background";
 
-        public const bool DEFAULT_MENUBG_STRETCH = true;
+        public const DisplayModes DEFAULT_MENU_BACKGROUND_DISPLAY_MODE = DisplayModes.Default;
 
-        public const bool DEFAULT_ANIM_MENUBG_TOGGLE = false;
+        public const bool DEFAULT_MENU_BACKGROUND_ANIMATED = false;
 
-        public const bool DEFAULT_ANIM_MENUBG_STRETCH = true;
-
-        public const string DEFAULT_ANIM_MENUBG_TEXTURE = "main_menu";
-
-        public const int DEFAULT_ANIM_MENUBG_FRAMECOUNT = 11;
-
-        public const long DEFAULT_ANIM_MENUBG_FRAMESPEED = 50;
+        public const long DEFAULT_MENU_BACKGROUND_FRAME_INTERVAL = 50;
 
         public const string DEFAULT_MENU_MUSIC = "RPG-Theme_v001_Looping.ogg";
 
@@ -81,98 +77,76 @@ namespace Intersect.Configuration
         #region Options
 
         /// <summary>
-        /// Hostname of the server that the client will connect to.
+        /// Hostname of the server to connect to
         /// </summary>
         public string Host { get; set; } = DEFAULT_HOST;
 
         /// <summary>
-        /// Port of the server that the client will connect to.
+        /// Port of the server to connect to
         /// </summary>
         public ushort Port { get; set; } = DEFAULT_PORT;
 
         /// <summary>
-        /// The font family to use on misc non-ui rendering.
+        /// The font family to use on misc non-ui rendering
         /// </summary>
         public string GameFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on entity names.
+        /// The font family to use on entity names
         /// </summary>
         public string EntityNameFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on chat bubbles.
+        /// The font family to use on chat bubbles
         /// </summary>
         public string ChatBubbleFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on action messages.
+        /// The font family to use on action messages
         /// </summary>
         public string ActionMsgFont { get; set; } = DEFAULT_FONT;
 
         /// <summary>
-        /// The font family to use on un-styled windows such as the debug menu/admin window.
+        /// The font family to use on unstyled windows such as the debug menu/admin window
         /// </summary>
         public string UIFont { get; set; } = DEFAULT_UI_FONT;
 
         /// <summary>
-        /// Number of lines to save for chat scrollback.
+        /// Number of lines to save for chat scrollback
         /// </summary>
         public int ChatLines { get; set; } = DEFAULT_CHAT_LINES;
 
         /// <summary>
-        /// Sets a music file to be played in the main menu.
+        /// Menu music file name
         /// </summary>
         public string MenuMusic { get; set; } = DEFAULT_MENU_MUSIC;
 
         /// <summary>
-        /// Sets a list from which introductory images will be drawn when the game client starts.
-        /// </summary>
-        public List<string> IntroImages { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Sets a texture to be used as static background in the main menu.
+        /// Menu background art
         /// </summary>
         public string MenuBackground { get; set; } = DEFAULT_MENU_BACKGROUND;
 
         /// <summary>
-        /// Toggles the ability to stretch the static background in the main menu.
+        /// Sets the display mode of the background in the main menu.
         /// </summary>
-        public bool MenuBackgroundStretched { get; set; } = DEFAULT_MENUBG_STRETCH;
+        public DisplayModes MenuBackgroundDisplayMode { get; set; } = DEFAULT_MENU_BACKGROUND_DISPLAY_MODE;
 
         /// <summary>
         /// Toggles the ability to draw an animated background in the main menu.
-        /// When enabled, the static background in the main menu won't be drawn.
+        /// Example: when enabled, if you set "background" as MenuBackground, you will need to
+        /// place your animation frames inside the animation resources folder and name them
+        /// sequentially like this:  "background_0.png", "background_1.png", etc..
         /// </summary>
-        public bool AnimatedMenuBgEnabled { get; set; } = DEFAULT_ANIM_MENUBG_TOGGLE;
+        public bool MenuBackgroundAnimated { get; set; } = DEFAULT_MENU_BACKGROUND_ANIMATED;
 
         /// <summary>
-        /// Toggles the ability to stretch the animated background in the main menu.
+        /// Sets the frames interval (milliseconds) of the animated background in the main menu.
         /// </summary>
-        public bool AnimatedMenuBgStretched { get; set; } = DEFAULT_ANIM_MENUBG_STRETCH;
+        public long MenuBackgroundFrameInterval { get; set; } = DEFAULT_MENU_BACKGROUND_FRAME_INTERVAL;
 
-        /// <summary>
-        /// Sets the base name for the files to be used as frames in the animated background of the main menu.
-        /// ie: if you set "main_menu", you will need to place your animation frames inside the animation folder
-        /// and name them like this:  "main_menu_0.png, main_menu_1.png, main_menu_2.png, etc".
-        /// </summary>
-        public string AnimatedMenuBgTexture { get; set; } = DEFAULT_ANIM_MENUBG_TEXTURE;
+        // TODO: What is this for?
+        public List<string> IntroImages { get; set; } = new List<string>();
 
-        /// <summary>
-        /// Sets the frame count of the animated background in the main menu.
-        /// Make sure to set this value depending on the amount of files to be used from the animation resources.
-        /// </summary>
-        public int AnimatedMenuBgFrameCount { get; set; } = DEFAULT_ANIM_MENUBG_FRAMECOUNT;
-
-        /// <summary>
-        /// Sets the frame speed (milliseconds) of the animated background in the main menu.
-        /// </summary>
-        public long AnimatedMenuBgFrameSpeed { get; set; } = DEFAULT_ANIM_MENUBG_FRAMESPEED;
-
-        /// <summary>
-        /// Optional - built in updater system.
-        /// Sets an URL to Package Updates (ie: https://freemmorpgmaker.com/updater/update.json).
-        /// </summary>
         public string UpdateUrl { get; set; } = "";
 
         /// <summary>

--- a/Intersect (Core)/Enums/DisplayModes.cs
+++ b/Intersect (Core)/Enums/DisplayModes.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Intersect.Enums
+{
+    /// <summary> Used for switching the display mode of fullscreen textures. </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum DisplayModes
+    {
+        /// <summary> Default display mode of fullscreen textures. </summary>
+        Default,
+        
+        /// <summary> Positions the sprite in the center of the game window. </summary>
+        Center,
+
+        /// <summary> Stretches the sprite to the game window size. </summary>
+        Stretch,
+
+        /// <summary> Fits the sprite to the game window height. </summary>
+        FitHeight,
+
+        /// <summary> Fits the sprite to the game window width. </summary>
+        FitWidth
+    }
+}

--- a/Intersect (Core)/Enums/DisplayModes.cs
+++ b/Intersect (Core)/Enums/DisplayModes.cs
@@ -9,17 +9,23 @@ namespace Intersect.Enums
     {
         /// <summary> Default display mode of fullscreen textures. </summary>
         Default,
-        
-        /// <summary> Positions the sprite in the center of the game window. </summary>
+
+        /// <summary> Positions the texture in the center of the game window. </summary>
         Center,
 
-        /// <summary> Stretches the sprite to the game window size. </summary>
+        /// <summary> Stretches the texture to the game window size. </summary>
         Stretch,
 
-        /// <summary> Fits the sprite to the game window height. </summary>
+        /// <summary> Fits the texture to the game window height. </summary>
         FitHeight,
 
-        /// <summary> Fits the sprite to the game window width. </summary>
-        FitWidth
+        /// <summary> Fits the texture to the game window width. </summary>
+        FitWidth,
+
+        /// <summary> Fits the texture to the game window by using the DrawFullScreenTextureFitMaximum method. </summary>
+        Fit,
+
+        /// <summary> Fits the texture to the game window by using the DrawFullScreenTextureFitMinimum method. </summary>
+        Cover
     }
 }

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -269,6 +269,7 @@
     <Compile Include="CustomColors.cs" />
     <Compile Include="Enums\ChatboxTab.cs" />
     <Compile Include="Enums\ChatMessageType.cs" />
+    <Compile Include="Enums\DisplayModes.cs" />
     <Compile Include="Enums\GuildMemberUpdateActions.cs" />
     <Compile Include="Enums\ItemHandling.cs" />
     <Compile Include="ErrorHandling\ExceptionInfo.cs" />

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -177,23 +177,30 @@ namespace Intersect.Client.Core
                 {
                     case DisplayModes.Default:
                         DrawFullScreenTexture(imageTex);
-
                         break;
+
                     case DisplayModes.Center:
                         DrawFullScreenTextureCentered(imageTex);
-
                         break;
+
                     case DisplayModes.Stretch:
                         DrawFullScreenTextureStretched(imageTex);
-
                         break;
+
                     case DisplayModes.FitHeight:
                         DrawFullScreenTextureFitHeight(imageTex);
-
                         break;
+
                     case DisplayModes.FitWidth:
                         DrawFullScreenTextureFitWidth(imageTex);
+                        break;
 
+                    case DisplayModes.Fit:
+                        DrawFullScreenTextureFitMaximum(imageTex);
+                        break;
+
+                    case DisplayModes.Cover:
+                        DrawFullScreenTextureFitMinimum(imageTex);
                         break;
                 }
             }
@@ -860,23 +867,30 @@ namespace Intersect.Client.Core
             {
                 case DisplayModes.Default:
                     DrawFullScreenTexture(animTex);
-
                     break;
+
                 case DisplayModes.Center:
                     DrawFullScreenTextureCentered(animTex);
-
                     break;
+
                 case DisplayModes.Stretch:
                     DrawFullScreenTextureStretched(animTex);
-
                     break;
+
                 case DisplayModes.FitHeight:
                     DrawFullScreenTextureFitHeight(animTex);
-
                     break;
+
                 case DisplayModes.FitWidth:
                     DrawFullScreenTextureFitWidth(animTex);
+                    break;
 
+                case DisplayModes.Fit:
+                    DrawFullScreenTextureFitMaximum(animTex);
+                    break;
+
+                case DisplayModes.Cover:
+                    DrawFullScreenTextureFitMinimum(animTex);
                     break;
             }
         }

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -149,8 +149,14 @@ namespace Intersect.Client.Core
             }
         }
 
-        public static void DrawMenu()
+        private static void DrawMenu()
         {
+            // No background in the main menu.
+            if (ClientConfiguration.Instance.MenuBackground.Count == 0)
+            {
+                return;
+            }
+
             // Animated background in the main menu.
             if (ClientConfiguration.Instance.MenuBackground.Count > 1)
             {
@@ -163,16 +169,14 @@ namespace Intersect.Client.Core
                     return;
                 }
 
-                if (sMenuBackgroundInterval < Timing.Global.Milliseconds)
-                {
-                    sMenuBackgroundIndex++;
-                    sMenuBackgroundInterval = Timing.Global.Milliseconds +
-                                              ClientConfiguration.Instance.MenuBackgroundFrameInterval;
-                }
+                var currentTimeMs = Timing.Global.Milliseconds;
 
-                if (sMenuBackgroundIndex >= ClientConfiguration.Instance.MenuBackground.Count)
+                if (sMenuBackgroundInterval < currentTimeMs)
                 {
-                    sMenuBackgroundIndex = 0;
+                    sMenuBackgroundIndex =
+                        (sMenuBackgroundIndex + 1) % ClientConfiguration.Instance.MenuBackground.Count;
+
+                    sMenuBackgroundInterval = currentTimeMs + ClientConfiguration.Instance.MenuBackgroundFrameInterval;
                 }
             }
 

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -181,7 +181,7 @@ namespace Intersect.Client.Core
             }
 
             // Static background in the main menu.
-            else if (ClientConfiguration.Instance.MenuBackground.Count == 1)
+            else
             {
                 sMenuBackground = sContentManager.GetTexture(
                     TextureType.Gui, ClientConfiguration.Instance.MenuBackground[0]

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -34,6 +34,8 @@ namespace Intersect.Client.Core
         public static GameShader DefaultShader;
 
         //Rendering Variables
+        private static GameTexture sMenuBackground;
+
         public static int DrawCalls;
 
         public static int EntitiesDrawn;
@@ -55,11 +57,9 @@ namespace Intersect.Client.Core
 
         public static int MapsDrawn;
 
-        private static int sAnimTextureFrame;
+        private static int sMenuBackgroundIndex;
 
-        private static long sAnimTextureTime;
-        
-        private static int sAnimFrameCount;
+        private static long sMenuBackgroundInterval;
 
         //Overlay Stuff
         public static Color OverlayColor = Color.Transparent;
@@ -151,58 +151,74 @@ namespace Intersect.Client.Core
 
         public static void DrawMenu()
         {
-            // Draw an animated background in the main menu.
-            if (ClientConfiguration.Instance.MenuBackgroundAnimated)
+            // Animated background in the main menu.
+            if (ClientConfiguration.Instance.MenuBackground.Count > 1)
             {
-                DrawFullScreenTextureAnimated(
-                    ClientConfiguration.Instance.MenuBackground,
-                    ClientConfiguration.Instance.MenuBackgroundFrameInterval,
-                    ClientConfiguration.Instance.MenuBackgroundDisplayMode
-                );
-            }
-
-            // Draw an static background in the main menu.
-            else
-            {
-                var imageTex = sContentManager.GetTexture(
-                    TextureType.Gui, ClientConfiguration.Instance.MenuBackground + ".png"
+                sMenuBackground = sContentManager.GetTexture(
+                    TextureType.Gui, ClientConfiguration.Instance.MenuBackground[sMenuBackgroundIndex]
                 );
 
-                if (imageTex == null)
+                if (sMenuBackground == null)
                 {
                     return;
                 }
 
-                switch (ClientConfiguration.Instance.MenuBackgroundDisplayMode)
+                if (sMenuBackgroundInterval < Timing.Global.Milliseconds)
                 {
-                    case DisplayModes.Default:
-                        DrawFullScreenTexture(imageTex);
-                        break;
-
-                    case DisplayModes.Center:
-                        DrawFullScreenTextureCentered(imageTex);
-                        break;
-
-                    case DisplayModes.Stretch:
-                        DrawFullScreenTextureStretched(imageTex);
-                        break;
-
-                    case DisplayModes.FitHeight:
-                        DrawFullScreenTextureFitHeight(imageTex);
-                        break;
-
-                    case DisplayModes.FitWidth:
-                        DrawFullScreenTextureFitWidth(imageTex);
-                        break;
-
-                    case DisplayModes.Fit:
-                        DrawFullScreenTextureFitMaximum(imageTex);
-                        break;
-
-                    case DisplayModes.Cover:
-                        DrawFullScreenTextureFitMinimum(imageTex);
-                        break;
+                    sMenuBackgroundIndex++;
+                    sMenuBackgroundInterval = Timing.Global.Milliseconds +
+                                              ClientConfiguration.Instance.MenuBackgroundFrameInterval;
                 }
+
+                if (sMenuBackgroundIndex >= ClientConfiguration.Instance.MenuBackground.Count)
+                {
+                    sMenuBackgroundIndex = 0;
+                }
+            }
+
+            // Static background in the main menu.
+            else if (ClientConfiguration.Instance.MenuBackground.Count == 1)
+            {
+                sMenuBackground = sContentManager.GetTexture(
+                    TextureType.Gui, ClientConfiguration.Instance.MenuBackground[0]
+                );
+
+                if (sMenuBackground == null)
+                {
+                    return;
+                }
+            }
+
+            // Switch between the preferred display mode, then render the fullscreen texture.
+            switch (ClientConfiguration.Instance.MenuBackgroundDisplayMode)
+            {
+                case DisplayModes.Default:
+                    DrawFullScreenTexture(sMenuBackground);
+                    break;
+
+                case DisplayModes.Center:
+                    DrawFullScreenTextureCentered(sMenuBackground);
+                    break;
+
+                case DisplayModes.Stretch:
+                    DrawFullScreenTextureStretched(sMenuBackground);
+                    break;
+
+                case DisplayModes.FitHeight:
+                    DrawFullScreenTextureFitHeight(sMenuBackground);
+                    break;
+
+                case DisplayModes.FitWidth:
+                    DrawFullScreenTextureFitWidth(sMenuBackground);
+                    break;
+
+                case DisplayModes.Fit:
+                    DrawFullScreenTextureFitMaximum(sMenuBackground);
+                    break;
+
+                case DisplayModes.Cover:
+                    DrawFullScreenTextureFitMinimum(sMenuBackground);
+                    break;
             }
         }
 
@@ -831,67 +847,6 @@ namespace Intersect.Client.Core
             else
             {
                 DrawFullScreenTextureFitWidth(tex);
-            }
-        }
-
-        public static void DrawFullScreenTextureAnimated(
-            string animFrameName,
-            long animFrameInterval,
-            Enum displayMode
-        )
-        {
-            sAnimFrameCount = Globals.ContentManager.GetTextureNames(TextureType.Animation)
-                .Count(s => s.Contains(animFrameName));
-
-            if (sAnimTextureTime < Timing.Global.Milliseconds)
-            {
-                sAnimTextureFrame += 1;
-                sAnimTextureTime = Timing.Global.Milliseconds + animFrameInterval;
-            }
-
-            if (sAnimTextureFrame >= sAnimFrameCount - 1)
-            {
-                sAnimTextureFrame = 0;
-            }
-
-            var animTex = Globals.ContentManager.GetTexture(
-                TextureType.Animation, animFrameName + "_" + sAnimTextureFrame + ".png"
-            );
-
-            if (animTex == null)
-            {
-                return;
-            }
-
-            switch (displayMode)
-            {
-                case DisplayModes.Default:
-                    DrawFullScreenTexture(animTex);
-                    break;
-
-                case DisplayModes.Center:
-                    DrawFullScreenTextureCentered(animTex);
-                    break;
-
-                case DisplayModes.Stretch:
-                    DrawFullScreenTextureStretched(animTex);
-                    break;
-
-                case DisplayModes.FitHeight:
-                    DrawFullScreenTextureFitHeight(animTex);
-                    break;
-
-                case DisplayModes.FitWidth:
-                    DrawFullScreenTextureFitWidth(animTex);
-                    break;
-
-                case DisplayModes.Fit:
-                    DrawFullScreenTextureFitMaximum(animTex);
-                    break;
-
-                case DisplayModes.Cover:
-                    DrawFullScreenTextureFitMinimum(animTex);
-                    break;
             }
         }
 


### PR DESCRIPTION
**Preview of Animated Background (DisplayMode: Stretch)**



https://user-images.githubusercontent.com/17498701/149450094-8ee3c759-cba1-4d5a-aee6-b7149f977f93.mp4



This Pull Request should resolve #815

**11-01-2022 ~ 12-01-2022**
* Adds the ability to to stretch the main menu's static background to the game client's window size though a new boolean property at Client's Config.json.
* Adds the ability to set an animated background in the main menu. Frames and their speed (Milliseconds) are configurable though new properties at Client's Config.json.
* Created the method "DrawFullScreenAnimatedTextureStretched", which draws a full screen animation as background, stretching it's size to the game client's window size.
* Created the method "DrawFullScreenAnimatedTexture", which draws a full screen animation as background, without stretching it's size to the game client's window size.
* Added an extra property to the client config that allows to toggle between stretched or not full screen animated background.
* [ClientConfig TODOs] Resolved a TODO with the property 'IntroImages', commented the property 'UpdateUrl' and did few minor improvements to some comments.
* As suggested by Cheshire92, drawing from a single giant sheet isn't very performance wise, so instead we will now load and animate from multiple frame files inside the animation resources folder. (ie: "main_menu_0.png, main_menu_1.png, main_menu_2.png, etc").
* The string property AnimatedMenuBgTexture doesn't needs to be set with the file the extension suffix (".png").


**13-01-2022**
* Undid unnecessary comments and TODOs.
* Removed unnecessary and redundant code.
* Renamed 'DrawFullScreenAnimatedTexture' to 'DrawFullScreenTextureAnimated' (in order to maintain consistency).
* 'DrawFullScreenTextureAnimated' is now capable to count the amount of frames required by animations. (no manual setup is required anymore)
* Created an Enum for 'DisplayModes'.
* Created the Method 'DrawFullScreenTextureCentered'.
* The Client is now capable to display full screen textures and animations in 5 different display modes.


[**Checkout the required resources to test this PR!**](https://github.com/AscensionGameDev/Intersect-Assets/pull/4)