### PR TITLE
Fix: Hides the Main Menu Window while in the character select screen.

### DIFF
--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -602,7 +602,9 @@ namespace Intersect.Client.Interface.Shared
                     default:
                         throw new NotImplementedException();
                 }
-            }    
+
+                mReturnToMenu = false;
+            }
         }
 
         // Input Handlers


### PR DESCRIPTION
The issue was triggered by a mistake i previously made with the Settings Revamp commit (#950): 

### **The Issue:**

If we navigated to the Settings Window, applied changes or navigated back to the main menu and then we decided to log-in in order to see the character select screen, the Main Menu Window would show up behind the character select window.

![imagen](https://user-images.githubusercontent.com/17498701/153721257-9bde7844-8036-4eeb-a9fc-a1023601733c.png)

(Test purposes) Made the character select windows transparent to see what the heck was behind:
![imagen](https://user-images.githubusercontent.com/17498701/153721277-6fdbf0e5-6edb-4c79-96a5-e2f76313bcd2.png)


### **The Fix:**
The previously explained behavior should be corrected with the commit from this pull request.

![imagen](https://user-images.githubusercontent.com/17498701/153721295-0640c917-bf39-4ffe-ab5d-1e7879d848e8.png)

(Test purposes) with transparent character select window
![imagen](https://user-images.githubusercontent.com/17498701/153721324-55ad16be-44aa-42e6-8fde-0f7d8f3200c8.png)

