### PR TITLE
Admin Actions: Improves Feedback and Authority checks

### DIFF
--- a/Intersect.Server/Admin/Actions/ActionProcessing.cs
+++ b/Intersect.Server/Admin/Actions/ActionProcessing.cs
@@ -30,19 +30,16 @@ namespace Intersect.Server.Admin.Actions
             {
                 // Inform the banner that the user is already banned.
                 PacketSender.SendChatMsg(
-                    player, Strings.Account.alreadybanned.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red
-                );
+                    player, Strings.Account.alreadybanned.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
             }
             else if (player?.Power.IsModerator.CompareTo(target.Power.IsAdmin) < 1)
             {
                 // Inform the banner that the ban attempt failed.
                 PacketSender.SendChatMsg(
-                    player, Strings.Account.BanFailed.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red
-                );
+                    player, Strings.Account.BanFailed.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
 
                 // Log the ban attempt and why it failed.
-                Log.Error("'" + player.Name + "' (Moderator) failed to ban '" +
-                          target.Name + "' (Administrator). The banner doesn't have authority over their target.");
+                Log.Error($"'{player.Name}' failed to ban '{target.Name}'. The banner doesn't have authority over their target.");
             }
             else
             {
@@ -56,21 +53,15 @@ namespace Intersect.Server.Admin.Actions
 
                 // Log ban
                 UserActivityHistory.LogActivity(
-                    target?.UserId ?? Guid.Empty, target?.Id ?? Guid.Empty, target?.Client?.GetIp(),
+                    (Guid) target?.UserId, (Guid) target?.Id, target?.Client?.GetIp(),
                     UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectBan,
-                    $"{target.User?.Name},{target.Name}"
-                );
+                    $"{target.User?.Name},{target.Name}");
 
                 // Disconnect the banned user.
                 target.Client?.Disconnect();
 
                 // Sends a global chat message to every user online about the banned player.
                 PacketSender.SendGlobalMsg(Strings.Account.banned.ToString(target.Name));
-
-                //  Inform the banner about the successful ban.
-                PacketSender.SendChatMsg(
-                    player, Strings.Account.banned.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Orange
-                );
             }
         }
 

--- a/Intersect.Server/Admin/Actions/ActionProcessing.cs
+++ b/Intersect.Server/Admin/Actions/ActionProcessing.cs
@@ -33,7 +33,7 @@ namespace Intersect.Server.Admin.Actions
                     player, Strings.Account.alreadybanned.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red
                 );
             }
-            else if (player?.Power.GetHashCode().CompareTo(target.Power) < 1)
+            else if (player?.Power.IsModerator.CompareTo(target.Power.IsAdmin) < 1)
             {
                 // Inform the banner that the ban attempt failed.
                 PacketSender.SendChatMsg(
@@ -41,8 +41,8 @@ namespace Intersect.Server.Admin.Actions
                 );
 
                 // Log the ban attempt and why it failed.
-                Log.Error("'" + player.Name + "' (" + player.Power + ") failed to ban '" +
-                          target.Name + "' (" + target.Power + "). The banner doesn't have authority over their target.");
+                Log.Error("'" + player.Name + "' (Moderator) failed to ban '" +
+                          target.Name + "' (Administrator). The banner doesn't have authority over their target.");
             }
             else
             {

--- a/Intersect.Server/Admin/Actions/ActionProcessing.cs
+++ b/Intersect.Server/Admin/Actions/ActionProcessing.cs
@@ -1,61 +1,73 @@
-﻿
-using Intersect.Admin.Actions;
-using Intersect.Server.Database;
+﻿using Intersect.Admin.Actions;
+using Intersect.Enums;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData;
 using Intersect.Server.Database.PlayerData.Security;
 using Intersect.Server.Entities;
 using Intersect.Server.Localization;
 using Intersect.Server.Networking;
-using System;
-
-using Intersect.Logging;
 
 namespace Intersect.Server.Admin.Actions
 {
-
     public static class ActionProcessing
     {
-
         //BanAction
-        public static void ProcessAction(Client client, Player player, BanAction action)
+        public static void ProcessAction(Player player, BanAction action)
         {
             var target = Player.Find(action.Name);
-            if (target == null)
+            if (!player.Power.Ban) // Ban Permission Check.
             {
-                // Inform the banner that the user is offline.
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
-            }
-            else if (!string.IsNullOrEmpty(Ban.CheckBan(target.User, string.Empty)))
-            {
-                // Inform the banner that the user is already banned.
-                PacketSender.SendChatMsg(
-                    player, Strings.Account.alreadybanned.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
-            }
-            else if (player?.Power.IsModerator.CompareTo(target.Power.IsAdmin) < 1)
-            {
-                // Inform the banner that the ban attempt failed.
-                PacketSender.SendChatMsg(
-                    player, Strings.Account.BanFailed.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
 
-                // Log the ban attempt and why it failed.
-                Log.Error($"'{player.Name}' failed to ban '{target.Name}'. The banner doesn't have authority over their target.");
+                return;
             }
+
+            if (target == null) // If the target can't be found.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Player.PlayerNotFound.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            var targetUsername = User.Find(target.UserId);
+            if (player.Power.CompareTo(target.Power) < 1) // Authority Comparison.
+            {
+                // Inform to whoever performed the action that they are
+                // not allowed to do this due to the lack of authority over their target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                // Log the failed ban attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectBanFail,
+                    $"{target.User?.Name},{target.Name}");
+            }
+            else if (Ban.Find(targetUsername) != null) // If the target is already banned.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.alreadybanned.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+            }
+
+            // If target is online, not yet banned and the banner has the authority to ban.
             else
             {
-                // If target is online, not yet banned, and the banner has the authority to ban them: issue the ban.
-
                 // If BanIp is false, Client is null, or GetIp() returns null: resolve to string.Empty (no IP).
                 var ip = (action.BanIp ? target.Client?.GetIp() : default) ?? string.Empty;
 
-                // Add ban
-                Ban.Add(target.User, action.DurationDays, action.Reason, player.Name, ip);
+                // Ban the targeted user.
+                Ban.Add(targetUsername, action.DurationDays, action.Reason ?? string.Empty, player.Name, ip);
 
-                // Log ban
+                // Log the successful ban attempt.
                 UserActivityHistory.LogActivity(
-                    (Guid) target?.UserId, (Guid) target?.Id, target?.Client?.GetIp(),
+                    target.UserId, target.Id, target.Client?.GetIp(),
                     UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectBan,
-                    $"{target.User?.Name},{target.Name}");
+                    $"{target.User?.Name},{target.Name}"
+                );
 
                 // Disconnect the banned user.
                 target.Client?.Disconnect();
@@ -66,87 +78,175 @@ namespace Intersect.Server.Admin.Actions
         }
 
         //KickAction
-        public static void ProcessAction(Client client, Player player, KickAction action)
+        public static void ProcessAction(Player player, KickAction action)
         {
             var target = Player.FindOnline(action.Name);
-            if (target != null)
+            if (!player.Power.Kick) // Kick permission check.
             {
-                UserActivityHistory.LogActivity(target?.UserId ?? Guid.Empty, target?.Id ?? Guid.Empty, target?.Client?.GetIp(), UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectKick, $"{target.User?.Name},{target.Name}");
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
 
-                PacketSender.SendGlobalMsg(Strings.Player.kicked.ToString(target.Name, player.Name));
-                target.Client?.Disconnect(); //Kick em'
+                return;
+            }
+
+            if (target == null) // If the target is offline.
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
+            }
+            else if (player.Power.CompareTo(target.Power) < 1) // Authority Comparison.
+            {
+                // Inform to whoever performed the action that they are
+                // not allowed to do this due to the lack of authority over their target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                // Log the failed kick attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectKickFail,
+                    $"{target.User?.Name},{target.Name}");
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                // Log the successful kick attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.DisconnectKick,
+                    $"{target.User?.Name},{target.Name}");
+
+                // Sends a global chat message to every user online about the kicked player.
+                PacketSender.SendGlobalMsg(Strings.Player.kicked.ToString(target.Name, player.Name));
+
+                // Kick the target.
+                target.Client?.Disconnect();
             }
         }
 
         //KillAction
-        public static void ProcessAction(Client client, Player player, KillAction action)
+        public static void ProcessAction(Player player, KillAction action)
         {
             var target = Player.FindOnline(action.Name);
-            if (target != null)
+            if (!player.Power.IsAdmin) // Admin permission check.
             {
-                lock (target.EntityLock)
-                {
-                    target.Die(); //Kill em'
-                }
-                
-                PacketSender.SendGlobalMsg(Strings.Player.killed.ToString(target.Name, player.Name));
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (target == null) // If the target is offline.
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
+            }
+            else if (player.Power.CompareTo(target.Power) < 1) // Authority Comparison.
+            {
+                // Inform to whoever performed the action that they are
+                // not allowed to do this due to the lack of authority over their target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                // Log the failed kill attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.KillFail,
+                    $"{target.User?.Name},{target.Name}");
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                // Log the successful kill attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Kill,
+                    $"{target.User?.Name},{target.Name}");
+
+                // Sends a global chat message to every user online about the killed player.
+                PacketSender.SendGlobalMsg(Strings.Player.killed.ToString(target.Name, player.Name));
+
+                lock (target.EntityLock)
+                {
+                    // Kill the target.
+                    target.Die();
+                }
             }
         }
 
         //MuteAction
-        public static void ProcessAction(Client client, Player player, MuteAction action)
+        public static void ProcessAction(Player player, MuteAction action)
         {
             var target = Player.Find(action.Name);
-            if (target != null)
+            if (!player.Power.Mute) // Mute permission check.
             {
-                if (string.IsNullOrEmpty(Mute.FindMuteReason(target.UserId, "")))
-                {
-                    if (action.BanIp == true)
-                    {
-                        Mute.Add(
-                            target.User, action.DurationDays, action.Reason, player.Name, target.Client?.GetIp() ?? ""
-                        );
-                    }
-                    else
-                    {
-                        Mute.Add(target.User, action.DurationDays, action.Reason, player.Name, "");
-                    }
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
 
-                    PacketSender.SendChatMsg(player, Strings.Account.muted.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Account.alreadymuted.ToString(target.Name), Enums.ChatMessageType.Admin, Color.Red);
-                }
+                return;
             }
+
+            if (target == null) // If the target can't be found.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Player.PlayerNotFound.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            var targetUsername = User.Find(target.UserId);
+            if (player.Power.CompareTo(target.Power) < 1) // Authority Comparison.
+            {
+                // Inform to whoever performed the action that they are
+                // not allowed to do this due to the lack of authority over their target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                // Log the failed mute attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.MuteFail,
+                    $"{target.User?.Name},{target.Name}");
+            }
+            else if (Mute.Find(targetUsername) != null) // If the target is already muted.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.alreadymuted.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+            }
+
+            // If target is online, not yet muted and the action performer has the authority to mute.
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                // If BanIp is false, Client is null, or GetIp() returns null: resolve to string.Empty (no IP).
+                var ip = (action.BanIp ? target.Client?.GetIp() : default) ?? string.Empty;
+
+                // Mute the targeted user.
+                Mute.Add(targetUsername, action.DurationDays, action.Reason ?? string.Empty, player.Name, ip);
+
+                // Log the successful mute attempt.
+                UserActivityHistory.LogActivity(
+                    target.UserId, target.Id, target.Client?.GetIp(),
+                    UserActivityHistory.PeerType.Client, UserActivityHistory.UserAction.Mute,
+                    $"{target.User?.Name},{target.Name}"
+                );
+
+                // Sends a global chat message to every user online about the muted player.
+                PacketSender.SendGlobalMsg(Strings.Account.muted.ToString(target.Name));
             }
         }
 
         //SetAccessAction
-        public static void ProcessAction(Client client, Player player, SetAccessAction action)
+        public static void ProcessAction(Player player, SetAccessAction action)
         {
             var target = Player.FindOnline(action.Name);
-            if (client == null || target == null || target.Client == null)
+            if (target == null || target.Client == null)
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
 
                 return;
             }
 
             if (action.Name.Trim().ToLower() != player.Name.Trim().ToLower())
             {
-                if (client.Power.IsAdmin)
+                if (player.Power.IsAdmin)
                 {
                     var power = UserRights.None;
                     if (action.Power == "Admin")
@@ -175,17 +275,17 @@ namespace Intersect.Server.Admin.Actions
                 }
                 else
                 {
-                    PacketSender.SendChatMsg(player, Strings.Player.adminsetpower, Enums.ChatMessageType.Admin);
+                    PacketSender.SendChatMsg(player, Strings.Player.adminsetpower, ChatMessageType.Admin);
                 }
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.changeownpower, Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Player.changeownpower, ChatMessageType.Admin);
             }
         }
 
         //SetFaceAction
-        public static void ProcessAction(Client client, Player player, SetFaceAction action)
+        public static void ProcessAction(Player player, SetFaceAction action)
         {
             var target = Player.FindOnline(action.Name);
             if (target != null)
@@ -195,12 +295,12 @@ namespace Intersect.Server.Admin.Actions
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
             }
         }
 
         //SetSpriteAction
-        public static void ProcessAction(Client client, Player player, SetSpriteAction action)
+        public static void ProcessAction(Player player, SetSpriteAction action)
         {
             var target = Player.FindOnline(action.Name);
             if (target != null)
@@ -210,93 +310,142 @@ namespace Intersect.Server.Admin.Actions
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
             }
         }
 
         //UnbanAction
-        public static void ProcessAction(Client client, Player player, UnbanAction action)
+        public static void ProcessAction(Player player, UnbanAction action)
         {
-            var unbannedUser = User.Find(action.Name);
-            if (unbannedUser != null)
+            var unbannedPlayer = Player.Find(action.Name);
+            if (!player.Power.Ban) // Should have ban authority permission in order to unban.
             {
-                Ban.Remove(unbannedUser);
-                PacketSender.SendChatMsg(player, Strings.Account.unbanned.ToString(unbannedUser.Name), Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (unbannedPlayer == null) // Does the target exists?
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Player.PlayerNotFound.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            var targetUsername = User.Find(unbannedPlayer.UserId);
+            if (Ban.Find(targetUsername) == null) // If the target is not banned.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.UnbanFail.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Account.notfound.ToString(action.Name), Enums.ChatMessageType.Admin);
+                Ban.Remove(targetUsername); // Unban the target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.UnbanSuccess.ToString(action.Name), ChatMessageType.Admin, Color.Green
+                );
             }
         }
 
         //UnmuteAction
-        public static void ProcessAction(Client client, Player player, UnmuteAction action)
+        public static void ProcessAction(Player player, UnmuteAction action)
         {
-            var unmutedUser = User.Find(action.Name);
-            if (unmutedUser != null)
+            var unmuteUser = Player.Find(action.Name);
+            if (!player.Power.Mute) // Should have mute authority permission in order to unmute.
             {
-                Mute.Remove(unmutedUser);
-                PacketSender.SendChatMsg(player, Strings.Account.unmuted.ToString(unmutedUser.Name), Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (unmuteUser == null) // Does the target exists?
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Player.PlayerNotFound.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            var targetUsername = User.Find(unmuteUser.UserId);
+            if (Mute.Find(targetUsername) == null) // If the target is not muted.
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.UnmuteFail.ToString(action.Name), ChatMessageType.Admin, Color.Red
+                );
             }
             else
             {
-                var target = Player.FindOnline(action.Name);
-                if (target != null)
-                {
-                    Mute.Remove(target.User);
-                    PacketSender.SendChatMsg(player, Strings.Account.unmuted.ToString(target.Name), Enums.ChatMessageType.Admin);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(player, Strings.Account.notfound.ToString(action.Name), Enums.ChatMessageType.Admin);
-                }
+                Mute.Remove(targetUsername); // Unmute the target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.UnmuteSuccess.ToString(action.Name), ChatMessageType.Admin, Color.Green
+                );
             }
         }
 
         //WarpMeToAction
-        public static void ProcessAction(Client client, Player player, WarpMeToAction action)
+        public static void ProcessAction(Player player, WarpMeToAction action)
         {
             var target = Player.FindOnline(action.Name);
             if (target != null)
             {
                 player.Warp(target.MapId, (byte) target.X, (byte) target.Y);
-                PacketSender.SendChatMsg(player, Strings.Player.warpedto.ToString(target.Name), Enums.ChatMessageType.Admin);
-                PacketSender.SendChatMsg(target, Strings.Player.warpedtoyou.ToString(player.Name), Enums.ChatMessageType.Notice);
+                PacketSender.SendChatMsg(player, Strings.Player.warpedto.ToString(target.Name), ChatMessageType.Admin);
+                PacketSender.SendChatMsg(
+                    target, Strings.Player.warpedtoyou.ToString(player.Name), ChatMessageType.Notice
+                );
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
             }
         }
 
         //WarpToLocationAction
-        public static void ProcessAction(Client client, Player player, WarpToLocationAction action)
+        public static void ProcessAction(Player player, WarpToLocationAction action)
         {
             player.Warp(action.MapId, action.X, action.Y, 0, true);
         }
 
         //WarpToMapAction
-        public static void ProcessAction(Client client, Player player, WarpToMapAction action)
+        public static void ProcessAction(Player player, WarpToMapAction action)
         {
             player.Warp(action.MapId, (byte) player.X, (byte) player.Y);
         }
 
         //WarpToMeAction
-        public static void ProcessAction(Client client, Player player, WarpToMeAction action)
+        public static void ProcessAction(Player player, WarpToMeAction action)
         {
             var target = Player.FindOnline(action.Name);
-            if (target != null)
+            if (target == null)
             {
-                target.Warp(player.MapId, (byte) player.X, (byte) player.Y);
-                PacketSender.SendChatMsg(player, Strings.Player.haswarpedto.ToString(target.Name), Enums.ChatMessageType.Admin, player.Name);
-                PacketSender.SendChatMsg(target, Strings.Player.beenwarpedto.ToString(player.Name), Enums.ChatMessageType.Notice, player.Name);
+                PacketSender.SendChatMsg(player, Strings.Player.offline, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (player.Power.CompareTo(target.Power) < 1) // Authority Comparison.
+            {
+                // Inform to whoever performed the action that they are
+                // not allowed to do this due to the lack of authority over their target.
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
             }
             else
             {
-                PacketSender.SendChatMsg(player, Strings.Player.offline, Enums.ChatMessageType.Admin);
+                target.Warp(player.MapId, (byte) player.X, (byte) player.Y);
+                PacketSender.SendChatMsg(
+                    player, Strings.Player.haswarpedto.ToString(target.Name), ChatMessageType.Admin, player.Name
+                );
+
+                PacketSender.SendChatMsg(
+                    target, Strings.Player.beenwarpedto.ToString(player.Name), ChatMessageType.Notice, player.Name
+                );
             }
         }
-
     }
-
 }

--- a/Intersect.Server/Core/Commands/UnbanCommand.cs
+++ b/Intersect.Server/Core/Commands/UnbanCommand.cs
@@ -22,7 +22,7 @@ namespace Intersect.Server.Core.Commands
             }
 
             Ban.Remove(target);
-            Console.WriteLine($@"    {Strings.Account.unbanned.ToString(target.Name)}");
+            Console.WriteLine($@"    {Strings.Account.UnbanSuccess.ToString(target.Name)}");
         }
 
     }

--- a/Intersect.Server/Core/Commands/UnmuteCommand.cs
+++ b/Intersect.Server/Core/Commands/UnmuteCommand.cs
@@ -22,7 +22,7 @@ namespace Intersect.Server.Core.Commands
             }
 
             Mute.Remove(target);
-            Console.WriteLine($@"    {Strings.Account.unmuted.ToString(target.Name)}");
+            Console.WriteLine($@"    {Strings.Account.UnmuteSuccess.ToString(target.Name)}");
         }
 
     }

--- a/Intersect.Server/Database/Logging/Entities/UserActivityHistory.cs
+++ b/Intersect.Server/Database/Logging/Entities/UserActivityHistory.cs
@@ -75,8 +75,20 @@ namespace Intersect.Server.Database.Logging.Entities
             DisconnectTimeout,
 
             DisconnectBan,
+            
+            DisconnectBanFail,
 
             DisconnectKick,
+            
+            DisconnectKickFail,
+            
+            Kill,
+            
+            KillFail,
+            
+            Mute,
+            
+            MuteFail,
 
             CreatePlayer,
 

--- a/Intersect.Server/Database/PlayerData/Security/UserRights.cs
+++ b/Intersect.Server/Database/PlayerData/Security/UserRights.cs
@@ -10,10 +10,8 @@ using Newtonsoft.Json;
 
 namespace Intersect.Server.Database.PlayerData.Security
 {
-
-    public class UserRights
+    public sealed class UserRights : IComparable<UserRights>, IEquatable<UserRights>
     {
-
         private static readonly Type ApiRolesType = typeof(ApiRoles);
 
         private static readonly List<PropertyInfo> ApiRolesPermissions = ApiRolesType
@@ -85,12 +83,33 @@ namespace Intersect.Server.Database.PlayerData.Security
             return !(b1 == b2);
         }
 
+        protected int ComputePowerScore()
+        {
+            var score = 0;
+            score |= Convert.ToInt32(Editor) << 0;
+            score |= Convert.ToInt32(Mute) << 1;
+            score |= Convert.ToInt32(Kick) << 2;
+            score |= Convert.ToInt32(Ban) << 3;
+
+            return score;
+        }
+
+        public int CompareTo(UserRights other)
+        {
+            if (other == default)
+            {
+                return 1;
+            }
+
+            return ComputePowerScore() - other.ComputePowerScore();
+        }
+
         public override bool Equals(object obj)
         {
             return obj is UserRights userRights && Equals(userRights);
         }
 
-        protected bool Equals(UserRights other)
+        public bool Equals(UserRights other)
         {
             var permissions = EnumeratePermissions();
             var otherPermissions = other.EnumeratePermissions();
@@ -128,12 +147,10 @@ namespace Intersect.Server.Database.PlayerData.Security
 
             return userRights.ToImmutableList();
         }
-
     }
 
     public static class AccessExtensions
     {
-
         public static UserRights AsUserRights(this Access access)
         {
             switch (access)
@@ -151,16 +168,12 @@ namespace Intersect.Server.Database.PlayerData.Security
                     throw new ArgumentOutOfRangeException(nameof(access), access, null);
             }
         }
-
     }
 
     public class ApiRoles
     {
-
         public bool UserQuery { get; set; }
 
         public bool UserManage { get; set; }
-
     }
-
 }

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -29,6 +29,9 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString badlogin = @"Username or password incorrect.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString banned = @"{00} has been banned!";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString BanFailed = @"Failed to ban '{00}'.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString banstatus =
                 @"Your account has been banned since: {00} (UTC) by {01}. Ban expires: {02} (UTC). Reason for ban: {03}";

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -29,9 +29,15 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString badlogin = @"Username or password incorrect.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString banned = @"{00} has been banned!";
-            
+
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString BanFailed = @"Failed to ban '{00}'.";
+            public readonly LocalizedString UnbanSuccess = @"{00} has been unbanned!";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString UnbanFail = @"Failed to unban {00}. The user is not banned!";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString NotAllowed = @"You do not have the permission to do this.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString banstatus =
                 @"Your account has been banned since: {00} (UTC) by {01}. Ban expires: {02} (UTC). Reason for ban: {03}";
@@ -68,6 +74,12 @@ namespace Intersect.Server.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString muted = @"{00} has been muted!";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString UnmuteSuccess = @"{00} has been unmuted!";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString UnmuteFail = @"Failed to unmute {00}. The user is not muted!";
+
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString mutestatus =
                 @"Your account has been muted since: {00} by {01}. Mute expires: {02}. Reason for mute: {03}";
 
@@ -75,10 +87,6 @@ namespace Intersect.Server.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString registrationsblocked =
                 @"Account registrations are currently blocked by the server.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString unbanned = @"Account {00} has been unbanned!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString unmuted = @"{00} has been unmuted!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString emailfail = @"Failed to send your password reset email at this time. Please try again later.";
         }
@@ -1059,6 +1067,9 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString notarget = @"You need to select a valid target.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString offline = @"User not online!";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString PlayerNotFound = @"The player '{00}' was not found!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]            public readonly LocalizedString powerchanged = @"Your power has been modified!";
 

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1821,12 +1821,12 @@ namespace Intersect.Server.Networking
         public void HandlePacket(Client client, AdminActionPacket packet)
         {
             var player = client?.Entity;
-            if (!client.Power.Editor && !client.Power.IsModerator)
+            if (player == null || client.Power == UserRights.None)
             {
                 return;
             }
 
-            ActionProcessing.ProcessAction(client, player, (dynamic) packet.Action);
+            ActionProcessing.ProcessAction(player, (dynamic) packet.Action);
         }
 
         //BuyItemPacket

--- a/Intersect.Server/Web/RestApi/Routes/V1/PlayerController.cs
+++ b/Intersect.Server/Web/RestApi/Routes/V1/PlayerController.cs
@@ -927,7 +927,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     }
 
                     // Check if banner has the proper authority over their target.
-                    else if (banner?.Power.GetHashCode().CompareTo(player.Power) < 0)
+                    else if (banner?.Power.IsModerator.CompareTo(player.Power.IsAdmin) < 0)
                     {
                         // Inform the banner that the ban attempt failed.
                         return Request.CreateMessageResponse(

--- a/Intersect.Server/Web/RestApi/Routes/V1/PlayerController.cs
+++ b/Intersect.Server/Web/RestApi/Routes/V1/PlayerController.cs
@@ -922,8 +922,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     {
                         // Inform the banner that the user is already banned.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(player.Name)
-                        );
+                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(player.Name));
                     }
 
                     // Check if banner has the proper authority over their target.
@@ -931,8 +930,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     {
                         // Inform the banner that the ban attempt failed.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.BadRequest, Strings.Account.BanFailed.ToString(player.Name)
-                        );
+                            HttpStatusCode.BadRequest, Strings.Account.BanFailed.ToString(player.Name));
                     }
 
                     else
@@ -945,8 +943,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                         // Add ban
                         Ban.Add(
                             userId, actionParameters.Duration, actionParameters.Reason ?? string.Empty,
-                            actionParameters.Moderator ?? @"api", targetIp
-                        );
+                            actionParameters.Moderator ?? @"api", targetIp);
 
                         // Disconnect the banned player.
                         client?.Disconnect();
@@ -954,9 +951,9 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                         // Sends a global chat message to every user online about the banned player.
                         PacketSender.SendGlobalMsg(Strings.Account.banned.ToString(player.Name));
 
+                        //  Inform the API banner about the successful ban.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.OK, Strings.Account.banned.ToString(player.Name)
-                        );
+                            HttpStatusCode.OK, Strings.Account.banned.ToString(player.Name));
                     }
 
                 case AdminActions.UnBan:

--- a/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
+++ b/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
@@ -819,7 +819,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     }
 
                     // Check if banner has the proper authority over their target.
-                    else if (banner?.Power.GetHashCode().CompareTo(user.Power) < 0)
+                    else if (banner?.Power.IsModerator.CompareTo(user.Power.IsAdmin) < 0)
                     {
                         // Inform the banner that the ban attempt failed.
                         return Request.CreateMessageResponse(

--- a/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
+++ b/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
@@ -814,8 +814,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     {
                         // Inform the banner that the user is already banned.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(user.Name)
-                        );
+                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(user.Name));
                     }
 
                     // Check if banner has the proper authority over their target.
@@ -823,8 +822,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                     {
                         // Inform the banner that the ban attempt failed.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.BadRequest, Strings.Account.BanFailed.ToString(user.Name)
-                        );
+                            HttpStatusCode.BadRequest, Strings.Account.BanFailed.ToString(user.Name));
                     }
 
                     else
@@ -837,8 +835,7 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                         // Add ban
                         Ban.Add(
                             user.Id, actionParameters.Duration, actionParameters.Reason ?? string.Empty,
-                            actionParameters.Moderator ?? @"api", targetIp
-                        );
+                            actionParameters.Moderator ?? @"api", targetIp);
 
                         // Disconnect the banned player.
                         client?.Disconnect();
@@ -846,9 +843,9 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
                         // Sends a global chat message to every user online about the banned player.
                         PacketSender.SendGlobalMsg(Strings.Account.banned.ToString(user.Name));
 
+                        //  Inform the API banner about the successful ban.
                         return Request.CreateMessageResponse(
-                            HttpStatusCode.OK, Strings.Account.banned.ToString(user.Name)
-                        );
+                            HttpStatusCode.OK, Strings.Account.banned.ToString(user.Name));
                     }
 
                 case AdminActions.UnBan:

--- a/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
+++ b/Intersect.Server/Web/RestApi/Routes/V1/UserController.cs
@@ -805,28 +805,49 @@ namespace Intersect.Server.Web.RestApi.Routes.V1
 
             var player = client?.Entity;
             var targetIp = client?.GetIp() ?? "";
+            var banner = Player.Find(actionParameters.Moderator);
 
             switch (adminAction)
             {
                 case AdminActions.Ban:
-                    if (string.IsNullOrEmpty(Ban.CheckBan(user, "")))
+                    if (!string.IsNullOrEmpty(Ban.CheckBan(user, string.Empty)))
                     {
+                        // Inform the banner that the user is already banned.
+                        return Request.CreateMessageResponse(
+                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(user.Name)
+                        );
+                    }
+
+                    // Check if banner has the proper authority over their target.
+                    else if (banner?.Power.GetHashCode().CompareTo(user.Power) < 0)
+                    {
+                        // Inform the banner that the ban attempt failed.
+                        return Request.CreateMessageResponse(
+                            HttpStatusCode.BadRequest, Strings.Account.BanFailed.ToString(user.Name)
+                        );
+                    }
+
+                    else
+                    {
+                        // If target is online, not yet banned, and the banner has the authority to ban them: issue the ban.
+
+                        // If BanIp is false, Client is null, or GetIp() returns null: resolve to string.Empty (no IP).
+                        targetIp = (actionParameters.Ip ? client?.GetIp() : default) ?? string.Empty;
+
+                        // Add ban
                         Ban.Add(
-                            user.Id, actionParameters.Duration, actionParameters.Reason ?? "",
-                            actionParameters.Moderator ?? @"api", actionParameters.Ip ? targetIp : ""
+                            user.Id, actionParameters.Duration, actionParameters.Reason ?? string.Empty,
+                            actionParameters.Moderator ?? @"api", targetIp
                         );
 
+                        // Disconnect the banned player.
                         client?.Disconnect();
+
+                        // Sends a global chat message to every user online about the banned player.
                         PacketSender.SendGlobalMsg(Strings.Account.banned.ToString(user.Name));
 
                         return Request.CreateMessageResponse(
                             HttpStatusCode.OK, Strings.Account.banned.ToString(user.Name)
-                        );
-                    }
-                    else
-                    {
-                        return Request.CreateMessageResponse(
-                            HttpStatusCode.BadRequest, Strings.Account.alreadybanned.ToString(user.Name)
                         );
                     }
 


### PR DESCRIPTION
* Applied panda's [partial re-implementation](https://github.com/AscensionGameDev/Intersect-Engine/commit/04673626e0d0324733ead22d2607dd09a08970fa) (with somes changes).

* Removed unreachable code from the UserActivityHistory (??' left operand is never null, so we don't need Guid.Empty).

* From now on, bans are always announced globally.

* From now on, mutes are always announced globally.

* Adds ability to Ban/Unban & Mute/Unmute **even** if the target is Offline.

* Adds ability to Unban/Unmute in game by using the target's **player name**. 
  (Unban/Unmute doesn't requires you to know the username of the player anymore.)
  
* Added feedback messages for whenever we try to Unban/Unmute a player that's not Banned/Muted.

* Improved feedback messages by adding colours to their font.
  (   Warning/errors > Red    **|**     Sucess > Green or Global Msgs )

* Added UserActivityHistory for ingame BanFail, Kill, KillFail, Mute, MuteFail, Kick and KickFail.
  
* Added authority level checks with feedback messages for in game actions: WarpToMeAction, Ban, Kick, Kill and Mute
  (Should resolve #1061)
  
* **[NOT TESTED]** Added authority level checks with feedback messages for the **API**: Ban, Kick, Kill and Mute.
  (Need help from experienced users/devs with testing this one !)



### In game authority level checks for: WarpToMeAction, Ban, Kick, Kill and Mute (Solves #1061)
![imagen](https://user-images.githubusercontent.com/17498701/154867824-f77a447c-691a-4269-a2dd-e3ac1baf7f96.png)
(Example: Mods are unable to Ban, Kick, Kill, Mute nor warp Admins to them, due to the lack of authority they have over them.)

### Feedback improvements for Ban/Unban.
![imagen](https://user-images.githubusercontent.com/17498701/154864254-c56ca29c-16d0-44da-9d50-121d3c0146fb.png)
This PR also allows us to Un-ban players by using their player's _Names_ instead of their _Usernames_! this feels more consistent and allows it for an easier management since we won't have to look over the database anymore for the banned player's Username. Uban action will also check up if the target is not banned, sending a proper informative message since we can't "unban" someone that's not banned.

### Feedback improvements for Mute/Umute.
![imagen](https://user-images.githubusercontent.com/17498701/154864266-a5128473-aa25-4ed5-baf7-cb56326121a7.png)
Same as before, unmute will check wether the target is muted or not, if is not muted, we don't need to unmute the target.

Also, with this update, we won't see error logs in the server since we won't hit into this issue anymore:
![imagen](https://user-images.githubusercontent.com/17498701/155863873-7d31f50e-22a7-40df-bac2-acaf75c7f671.png)


### In both of the previously mentioned cases ^, we now check up if the player _exists_ 
(Ban and Mute can be performed despite the online status of players now. so instead of checking and announcing their online status to whoever is performing the action, we are going to simply check and inform to the action performer if they exist.)
![imagen](https://user-images.githubusercontent.com/17498701/154864317-0e9ad629-6fd0-40dc-9f61-e1391ef3120a.png)

