### PR TITLE
Chore: fixes 'wobbly' targetbox texture when entities move

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1704,20 +1704,22 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            var destRectangle = new FloatRect();
             var targetTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "target.png");
             if (targetTex != null)
             {
-                destRectangle.X = (float) Math.Ceiling(GetCenterPos().X - (float) targetTex.GetWidth() / 4);
-                destRectangle.Y = (float) Math.Ceiling(GetCenterPos().Y - (float) targetTex.GetHeight() / 2);
-
                 var srcRectangle = new FloatRect(
-                    priority * (float) targetTex.GetWidth() / 2, 0, (float) targetTex.GetWidth() / 2,
+                    priority * targetTex.GetWidth() / 2f,
+                    0,
+                    targetTex.GetWidth() / 2f,
                     targetTex.GetHeight()
                 );
 
-                destRectangle.Width = srcRectangle.Width;
-                destRectangle.Height = srcRectangle.Height;
+                var destRectangle = new FloatRect(
+                    (float) Math.Ceiling(GetCenterPos().X - targetTex.GetWidth() / 4f),
+                    (float) Math.Ceiling(GetCenterPos().Y - targetTex.GetHeight() / 2f),
+                    srcRectangle.Width,
+                    srcRectangle.Height
+                );
 
                 Graphics.DrawGameTexture(targetTex, srcRectangle, destRectangle, Color.White);
             }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1704,23 +1704,22 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            var srcRectangle = new FloatRect();
             var destRectangle = new FloatRect();
             var targetTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "target.png");
             if (targetTex != null)
             {
-                destRectangle.X = GetCenterPos().X - (int)targetTex.GetWidth() / 4;
-                destRectangle.Y = GetCenterPos().Y - (int)targetTex.GetHeight() / 2;
+                destRectangle.X = (float) Math.Ceiling(GetCenterPos().X - (float) targetTex.GetWidth() / 4);
+                destRectangle.Y = (float) Math.Ceiling(GetCenterPos().Y - (float) targetTex.GetHeight() / 2);
 
-                srcRectangle = new FloatRect(
-                    priority * (int)targetTex.GetWidth() / 2, 0, (int)targetTex.GetWidth() / 2,
-                    (int)targetTex.GetHeight()
+                var srcRectangle = new FloatRect(
+                    priority * (float) targetTex.GetWidth() / 2, 0, (float) targetTex.GetWidth() / 2,
+                    targetTex.GetHeight()
                 );
 
                 destRectangle.Width = srcRectangle.Width;
                 destRectangle.Height = srcRectangle.Height;
 
-                Graphics.DrawGameTexture(targetTex, srcRectangle, destRectangle, Intersect.Color.White);
+                Graphics.DrawGameTexture(targetTex, srcRectangle, destRectangle, Color.White);
             }
         }
 


### PR DESCRIPTION
* Should resolve #1095 
* Applied Lathander's idea to prevent the 'wobbly' (trembling looking) effect of the targetbox texture when entities move.
* Removed redundant casts within the 'DrawTarget' method.
* Moved the declaration 'srcRectangle' closer to it's usage.
* Converted to float values the fraction operations for targetTex's Width and Height in order to prevent possible loss of fraction.

### Before this commit:
![issue](https://ascensiongamedev.com/resources/filehost/54612aad61ecb90158fd7c1abab52d39.gif)


### After this commit:
![solution](https://ascensiongamedev.com/resources/filehost/a0318483afb021ddf066c75c1077af9e.gif)


PS: Thanks to [Lathander](https://www.ascensiongamedev.com/profile/5651-lathander/) for pointing this out!