### PR TITLE
Fix: removes hardcoded ComboBox sound effects

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ComboBox.cs
@@ -165,12 +165,6 @@ namespace Intersect.Client.Framework.Gwen.Control
                 mSelectItemSound = (string) obj["SelectItemSound"];
             }
 
-            mOpenMenuSound = "octave-tap-warm.wav";
-            mCloseMenuSound = "octave-beep-tapped.wav";
-            mHoverMenuSound = "octave-tap-resonant.wav";
-            mHoverItemSound = "octave-tap-resonant.wav";
-            mSelectItemSound = "octave-tap-warm.wav";
-
             foreach (var mnu in Children)
             {
                 if (mnu.GetType() == typeof(Menu))


### PR DESCRIPTION
* Removes default hardcoded values of ComboBox sound effects.
* Resolves #1097 

Explanation: ComboBox sound effects shouldn't be overwritten by default hardcoded values, they should consider the user's input from the Json files, it doesn't matter if the value is null or the established sound effect doesn't exists since this isn't an issue for Gwen.