### PR TITLE
fix: go back to using the default output paths

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -8,17 +8,15 @@
 
   <PropertyGroup>
     <IntersectProjectName>$(MSBuildProjectName.Substring(10))</IntersectProjectName>
-    <BaseOutputPath>$(IntersectRepoPath)\bin\$(IntersectProjectName.ToLower())</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(IntersectRepoPath)\obj\$(IntersectProjectName.ToLower())</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IntersectProjectName)' == 'Network' AND '$(Configuration.ToLower())' != ''">
     <GenerateEachBuild Condition="'$(INTERSECT_GENERATE_EACH_BUILD)' != ''">true</GenerateEachBuild>
-    <IntersectBuildingAssemblyFile>$(IntersectRepoPath)\bin\building\Debug\net462\Intersect.Building.dll</IntersectBuildingAssemblyFile>
+    <IntersectBuildingAssemblyFile>$(IntersectRepoPath)\Intersect.Building\bin\$(Configuration)\net462\Intersect.Building.dll</IntersectBuildingAssemblyFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <NetworkKeyOutputDir>$(IntersectRepoPath)\bin\$(Configuration.ToLower())-keys</NetworkKeyOutputDir>
+    <NetworkKeyOutputDir>$(IntersectRepoPath)\Intersect.Network\bin\$(Configuration)\keys</NetworkKeyOutputDir>
     <NetworkHandshakePublicKey>$(NetworkKeyOutputDir)\network.handshake.bkey.pub</NetworkHandshakePublicKey>
     <NetworkHandshakePrivateKey>$(NetworkKeyOutputDir)\network.handshake.bkey</NetworkHandshakePrivateKey>
   </PropertyGroup>

--- a/Intersect.props
+++ b/Intersect.props
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\assets\Intersect.png" Pack="true" PackagePath="\" />
+    <None Include="$(IntersectRepoPath)\assets\Intersect.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>
-


### PR DESCRIPTION
This is an attempt to avoid the annoying duplicate assembly attribute issues