### PR TITLE
fix: removes unnecessary check in LogicService.LogicThread.cs

### DIFF
--- a/Intersect.Server/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server/Core/LogicService.LogicThread.cs
@@ -372,11 +372,6 @@ namespace Intersect.Server.Core
                         {
                             MapInstanceUpdateQueue.Enqueue(mapInstance);
                         }
-
-                        if (ActiveMaps.Contains(map.Id))
-                        {
-                            MapUpdateQueue.Enqueue(map);
-                        }
                     }
                 }
                 catch (ThreadAbortException)


### PR DESCRIPTION
* The commit 33de35cd4cf45e2aca60624580bd42852f2d15c1 re-added the old "ActiveMaps" check, which is no longer used in the dev branch and prevents the solution to compile due to unresolvable declared symbols.
* Since the addition of instances, we've been checking this up with ActiveMapInstances at LogicService.LogicThread.cs (L:371)