### PR TITLE
fix and chore: properly implements 'IsCasting'

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -45,7 +45,7 @@ namespace Intersect.Client.Entities
         //Combat Status
         public long CastTime { get; set; } = 0;
 
-        public bool IsCasting => CastTime > 0;
+        public bool IsCasting => CastTime > Timing.Global.Milliseconds;
 
         public bool IsDashing => Dashing != null;
 
@@ -1594,7 +1594,7 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            if (CastTime < Timing.Global.Milliseconds)
+            if (!IsCasting)
             {
                 return;
             }
@@ -1798,7 +1798,7 @@ namespace Intersect.Client.Entities
                     SpriteFrame = (int)Math.Floor((timeIn / (CalculateAttackTime() / (float)SpriteFrames)));
                 }
             }
-            else if (CastTime > Timing.Global.Milliseconds)
+            else if (IsCasting)
             {
                 var spell = SpellBase.Get(SpellCast);
                 if (spell != null)

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -79,6 +79,8 @@ namespace Intersect.Client.Entities
 
         public long CombatTimer { get; set; } = 0;
 
+        public long IsCastingCheckTimer { get; set; }
+
         // Target data
         private long mlastTargetScanTime = 0;
 
@@ -224,7 +226,17 @@ namespace Intersect.Client.Entities
 
                 if (Controls.KeyDown(Control.AttackInteract))
                 {
-                    if (!Globals.Me.TryAttack())
+                    if (IsCasting)
+                    {
+                        if (IsCastingCheckTimer < Timing.Global.Milliseconds &&
+                            Options.Combat.EnableCombatChatMessages)
+                        {
+                            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Combat.AttackWhileCastingDeny,
+                                CustomColors.Alerts.Declined, ChatMessageType.Combat));
+                            IsCastingCheckTimer = Timing.Global.Milliseconds + 350;
+                        }
+                    }
+                    else if (!Globals.Me.TryAttack())
                     {
                         if (Globals.Me.AttackTimer < Timing.Global.Ticks / TimeSpan.TicksPerMillisecond)
                         {
@@ -1804,7 +1816,7 @@ namespace Intersect.Client.Entities
             if (MoveDir > -1 && Globals.EventDialogs.Count == 0)
             {
                 //Try to move if able and not casting spells.
-                if (!IsMoving && MoveTimer < Timing.Global.Ticks / TimeSpan.TicksPerMillisecond && (Options.Combat.MovementCancelsCast || CastTime < Timing.Global.Milliseconds))
+                if (!IsMoving && MoveTimer < Timing.Global.Ticks / TimeSpan.TicksPerMillisecond && (Options.Combat.MovementCancelsCast || !IsCasting))
                 {
                     if (Options.Combat.MovementCancelsCast)
                     {

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -493,6 +493,7 @@ namespace Intersect.Client.Localization
 
         public struct Combat
         {
+            public static LocalizedString AttackWhileCastingDeny = @"You are currently casting a spell, you cannot attack.";
 
             public static LocalizedString exp = @"Experience";
 

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -590,7 +590,7 @@ namespace Intersect.Server.Entities
             }
 
             //Check if NPC is casting a spell
-            if (CastTime > Timing.Global.Milliseconds)
+            if (IsCasting)
             {
                 return; //can't move while casting
             }
@@ -1072,7 +1072,7 @@ namespace Intersect.Server.Entities
                             return;
                         }
 
-                        if (LastRandomMove >= Timing.Global.Milliseconds || CastTime > 0)
+                        if (LastRandomMove >= Timing.Global.Milliseconds || IsCasting)
                         {
                             return;
                         }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1250,7 +1250,7 @@ namespace Intersect.Server.Entities
 
         public void TryAttack(Entity target)
         {
-            if (CastTime >= Timing.Global.Milliseconds)
+            if (IsCasting)
             {
                 if (Options.Combat.EnableCombatChatMessages)
                 {
@@ -4469,10 +4469,10 @@ namespace Intersect.Server.Entities
                         ); //Target Type 1 will be global entity
                     }
 
-                //Check if cast should be instance
-                if (Timing.Global.Milliseconds >= CastTime)
+                // Check if the player isn't casting a spell already.
+                if (!IsCasting)
                 {
-                    //Cast now!
+                    // Player is not casting a spell, cast now!
                     CastTime = 0;
                     CastSpell(Spells[SpellCastSlot].SpellId, SpellCastSlot);
                     CastTarget = null;

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1084,7 +1084,7 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            if (player.CastTime > Timing.Global.Milliseconds)
+            if (player.IsCasting)
             {
                 if (Options.Combat.EnableCombatChatMessages)
                 {


### PR DESCRIPTION
* Properly implements and uses 'IsCasting' around both, server and client.
* Despite the fact that there's already a server-side check that prevents players to attack while casting, a client-side check has been added in order to fix the visual inconsistency of the character being animated as if they were attacking while casting.