### PR TITLE
chore: Moves 'Auto-close Windows' to Game Settings

### DIFF
--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -53,7 +53,7 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly Button mKeybindingSettingsTab;
 
-        // Game Settings.
+        // Game Settings - OverheadInformation.
         private readonly Button mOverheadInformationSettings;
 
         private readonly Button mOverheadInfoSettingsHelper;
@@ -70,6 +70,13 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
 
+        // Game Settings - Graphical User Interface.
+        private readonly Button mGraphicalUserInterfaceSettings;
+
+        private readonly Button mGraphicalUserInterfaceSettingsHelper;
+
+        private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
+
         // Video Settings.
         private readonly ImagePanel mResolutionBackground;
 
@@ -84,8 +91,6 @@ namespace Intersect.Client.Interface.Shared
         private readonly Label mFpsLabel;
 
         private readonly ComboBox mFpsList;
-
-        private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
         private readonly LabeledCheckBox mFullscreenCheckbox;
 
@@ -188,6 +193,17 @@ namespace Intersect.Client.Interface.Shared
             mPlayerOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PlayerOverheadInfoCheckbox");
             mPlayerOverheadInfoCheckbox.Text = Strings.Settings.PlayerOverheadInfo;
 
+            // Game Settings - Game User Interface (GUI)
+            mGraphicalUserInterfaceSettings = new Button(mGameSettingsContainer, "GraphicalUserInterfaceSettings");
+            mGraphicalUserInterfaceSettings.Text = Strings.Settings.GraphicalUserInterfaceSettings;
+            mGraphicalUserInterfaceSettingsHelper =
+                new Button(mGameSettingsContainer, "GraphicalUserInterfaceSettingsHelper");
+            mGraphicalUserInterfaceSettingsHelper.SetToolTipText(Strings.Settings.GraphicalUserInterfaceSettingsHelper);
+
+            // Game Settings - Toggle for: Interface Auto-close Windows.
+            mAutoCloseWindowsCheckbox = new LabeledCheckBox(mGameSettingsContainer, "AutoCloseWindowsCheckbox");
+            mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
+
             #endregion
 
             #region InitVideoSettings
@@ -241,13 +257,7 @@ namespace Intersect.Client.Interface.Shared
                 Text = Strings.Settings.Fullscreen
             };
 
-            // Video Settings - AutoCloseWindows Checkbox.
-            mAutoCloseWindowsCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "AutoCloseWindowsCheckbox")
-            {
-                Text = Strings.Settings.AutoCloseWindows
-            };
-
-            // Video Settinbgs - Enable Lighting Checkbox
+            // Video Settings - Enable Lighting Checkbox
             mLightingEnabledCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "EnableLightingCheckbox")
             {
                 Text = Strings.Settings.EnableLighting

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -53,7 +53,7 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly Button mKeybindingSettingsTab;
 
-        // Game Settings - OverheadInformation.
+        // Game Settings - Overhead Information.
         private readonly Button mOverheadInformationSettings;
 
         private readonly Button mOverheadInfoSettingsHelper;
@@ -70,10 +70,10 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
 
-        // Game Settings - Graphical User Interface.
-        private readonly Button mGraphicalUserInterfaceSettings;
+        // Game Settings - Interface.
+        private readonly Button mInterfaceSettings;
 
-        private readonly Button mGraphicalUserInterfaceSettingsHelper;
+        private readonly Button mInterfaceSettingsHelper;
 
         private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
@@ -193,12 +193,12 @@ namespace Intersect.Client.Interface.Shared
             mPlayerOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PlayerOverheadInfoCheckbox");
             mPlayerOverheadInfoCheckbox.Text = Strings.Settings.PlayerOverheadInfo;
 
-            // Game Settings - Game User Interface (GUI)
-            mGraphicalUserInterfaceSettings = new Button(mGameSettingsContainer, "GraphicalUserInterfaceSettings");
-            mGraphicalUserInterfaceSettings.Text = Strings.Settings.GraphicalUserInterfaceSettings;
-            mGraphicalUserInterfaceSettingsHelper =
-                new Button(mGameSettingsContainer, "GraphicalUserInterfaceSettingsHelper");
-            mGraphicalUserInterfaceSettingsHelper.SetToolTipText(Strings.Settings.GraphicalUserInterfaceSettingsHelper);
+            // Game Settings - Interface.
+            mInterfaceSettings = new Button(mGameSettingsContainer, "InterfaceSettings");
+            mInterfaceSettings.Text = Strings.Settings.InterfaceSettings;
+            mInterfaceSettingsHelper =
+                new Button(mGameSettingsContainer, "InterfaceSettingsHelper");
+            mInterfaceSettingsHelper.SetToolTipText(Strings.Settings.InterfaceSettingsHelper);
 
             // Game Settings - Toggle for: Interface Auto-close Windows.
             mAutoCloseWindowsCheckbox = new LabeledCheckBox(mGameSettingsContainer, "AutoCloseWindowsCheckbox");

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1551,15 +1551,15 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GameSettingsTab = @"Game";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GraphicalUserInterfaceSettings = @"Interface";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GraphicalUserInterfaceSettingsHelper = @"Graphical User Interface (GUI) related settings.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GuildMemberOverheadInfo = @"Guild";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString InterfaceSettings = @"Interface";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString InterfaceSettingsHelper = @"Game Interface related settings.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString KeyBindingSettingsTab = @"Controls";

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1551,6 +1551,12 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GameSettingsTab = @"Game";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString GraphicalUserInterfaceSettings = @"Interface";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString GraphicalUserInterfaceSettingsHelper = @"Graphical User Interface (GUI) related settings.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GuildMemberOverheadInfo = @"Guild";


### PR DESCRIPTION
* [As previously discussed](https://github.com/AscensionGameDev/Intersect-Engine/pull/968#issuecomment-948507217): 
Moves the Auto-close Windows checkbox into a new 'Interface' sub-category within the Game Settings.

* [Assets PR related to this](https://github.com/AscensionGameDev/Intersect-Assets/pull/15)


![imagen](https://user-images.githubusercontent.com/17498701/163691331-e34b7a43-d67c-4201-92b4-05286b2d6b8a.png)
