### PR TITLE
fix: avoid RemoveAll

### DIFF
--- a/Intersect.Client.Framework/Content/ContentWatcher.cs
+++ b/Intersect.Client.Framework/Content/ContentWatcher.cs
@@ -106,7 +106,11 @@ namespace Intersect.Client.Framework.Content
             modificationAction();
             _ = Task.Delay(1000).ContinueWith(completedTask =>
             {
-                _ = _ignore.RemoveAll(ignored => string.Equals(path, ignored, StringComparison.Ordinal));
+                string found;
+                while ((found = _ignore.Find(ignored => string.Equals(path, ignored, StringComparison.Ordinal))) != default)
+                {
+                    _ignore.Remove(found);
+                }
             }, TaskScheduler.Current);
         }
 


### PR DESCRIPTION
RemoveAll occasionally hits a OOBE caused by a race condition, hopefully removing one-by-one avoids that