### PR TITLE
fix: editor should check for files

### DIFF
--- a/Intersect (Core)/Updater/Update.cs
+++ b/Intersect (Core)/Updater/Update.cs
@@ -1,12 +1,24 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Intersect.Updater
 {
     public class Update
     {
         public List<UpdateFile> Files { get; set; } = new List<UpdateFile>();
-        public bool TrustCache { get; set; } = true;
+        
         public string StreamingUrl { get; set; }
 
+        public bool TrustCache { get; set; } = true;
+
+        public Update Filter(bool isClient)
+        {
+            return new Update
+            {
+                Files = Files.Where(file => isClient ? !file.ClientIgnore : !file.EditorIgnore).ToList(),
+                StreamingUrl = StreamingUrl,
+                TrustCache = TrustCache,
+            };
+        }
     }
 }


### PR DESCRIPTION
If the client is run first the editor will not download the missing files