### PR TITLE
Fix Crafting and QuestWindow Colors

### DIFF
--- a/Intersect (Core)/CustomColors.cs
+++ b/Intersect (Core)/CustomColors.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -127,7 +127,7 @@ namespace Intersect
 
         }
 
-        public sealed class QuestsNamespace
+        public sealed class QuestAlertNamespace
         {
 
             public Color Abandoned = Color.Red;
@@ -139,6 +139,19 @@ namespace Intersect
             public Color Started = Color.Cyan;
 
             public Color TaskUpdated = Color.Cyan;
+
+        }
+
+        public sealed class QuestWindowNamespace
+        {
+
+            public Color Completed = Color.Green;
+
+            public Color InProgress = Color.Yellow;
+
+            public Color NotStarted = Color.Red;
+
+            public Color QuestDesc = Color.White;
 
         }
 
@@ -307,7 +320,9 @@ namespace Intersect
 
             public readonly NamesNamespace Names = new NamesNamespace();
 
-            public readonly QuestsNamespace Quests = new QuestsNamespace();
+            public readonly QuestAlertNamespace QuestAlert = new QuestAlertNamespace();
+
+            public readonly QuestWindowNamespace QuestWindow = new QuestWindowNamespace();
 
         }
 
@@ -321,7 +336,9 @@ namespace Intersect
 
         public static ChatNamespace Chat => Root.Chat;
 
-        public static QuestsNamespace Quests => Root.Quests;
+        public static QuestAlertNamespace QuestAlert => Root.QuestAlert;
+
+        public static QuestWindowNamespace QuestWindow => Root.QuestWindow;
 
         public static AlertsNamespace Alerts => Root.Alerts;
 

--- a/Intersect.Client.Framework/Gwen/Control/ListBox.cs
+++ b/Intersect.Client.Framework/Gwen/Control/ListBox.cs
@@ -42,6 +42,10 @@ namespace Intersect.Client.Framework.Gwen.Control
 
         private bool mSizeToContents;
 
+        private Color mTextColor;
+
+        private Color mTextColorOverride;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ListBox" /> class.
         /// </summary>
@@ -54,6 +58,9 @@ namespace Intersect.Client.Framework.Gwen.Control
             EnableScroll(false, true);
             AutoHideBars = true;
             Margin = Margin.One;
+
+            mTextColor = Color.White;
+            mTextColorOverride = Color.Transparent;
 
             mTable = new Table(this)
             {
@@ -191,6 +198,30 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// </summary>
         public event GwenEventHandler<ItemSelectedEventArgs> RowUnselected;
 
+        public Color TextColor
+        {
+            get => mTextColor;
+            set => SetAndDoIfChanged(ref mTextColor, value, () =>
+            {
+                foreach (IColorableText colorableText in Children)
+                {
+                    colorableText.TextColor = value;
+                }
+            });
+        }
+
+        public Color TextColorOverride
+        {
+            get => mTextColorOverride;
+            set => SetAndDoIfChanged(ref mTextColorOverride, value, () =>
+            {
+                foreach (IColorableText colorableText in Children)
+                {
+                    colorableText.TextColorOverride = value;
+                }
+            });
+        }
+
         public override JObject GetJson()
         {
             var obj = base.GetJson();
@@ -201,6 +232,8 @@ namespace Intersect.Client.Framework.Gwen.Control
             obj.Add("ItemHoverSound", mItemHoverSound);
             obj.Add("ItemClickSound", mItemClickSound);
             obj.Add("ItemRightClickSound", mItemRightClickSound);
+            obj.Add(nameof(TextColor), TextColor.ToString());
+            obj.Add(nameof(TextColorOverride), TextColorOverride.ToString());
 
             return base.FixJson(obj);
         }
@@ -243,6 +276,16 @@ namespace Intersect.Client.Framework.Gwen.Control
                 var fontArr = ((string) obj["Font"]).Split(',');
                 mFontInfo = (string) obj["Font"];
                 mFont = GameContentManager.Current.GetFont(fontArr[0], int.Parse(fontArr[1]));
+            }
+
+            if (obj[nameof(TextColor)] != null)
+            {
+                TextColor = Color.FromString((string)obj[nameof(TextColor)]);
+            }
+
+            if (obj[nameof(TextColorOverride)] != null)
+            {
+                TextColorOverride = Color.FromString((string)obj[nameof(TextColorOverride)]);
             }
 
             foreach (var itm in mTable.Children)
@@ -388,6 +431,8 @@ namespace Intersect.Client.Framework.Gwen.Control
                 HoverSound = mItemHoverSound,
                 Name = name,
                 RightClickSound = mItemRightClickSound,
+                TextColor = TextColor,
+                TextColorOverride = TextColorOverride,
                 UserData = userData
             };
             mTable.AddRow(row);

--- a/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Intersect.Client.Core;
@@ -278,7 +278,7 @@ namespace Intersect.Client.Interface.Game.Crafting
                     Crafting = false;
                     mCraftWindow.IsClosable = true;
                     mBar.Width = 0;
-                    ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, Color.Red, Enums.ChatMessageType.Crafting));
+                    ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
 
                     return;
                 }
@@ -425,7 +425,7 @@ namespace Intersect.Client.Interface.Game.Crafting
                 return;
             }
 
-            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, Color.Red, Enums.ChatMessageType.Crafting));
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
         }
 
         //Craft all the items
@@ -440,7 +440,7 @@ namespace Intersect.Client.Interface.Game.Crafting
             }
             else
             {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, Color.Red, Enums.ChatMessageType.Crafting));
+                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.incorrectresources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
             }
         }
 
@@ -466,8 +466,6 @@ namespace Intersect.Client.Interface.Game.Crafting
                     tmpRow.UserData = Globals.ActiveCraftingTable.Crafts[i];
                     tmpRow.DoubleClicked += tmpNode_DoubleClicked;
                     tmpRow.Clicked += tmpNode_DoubleClicked;
-                    tmpRow.SetTextColor(Color.White);
-                    tmpRow.RenderColor = new Color(50, 255, 255, 255);
                 }
 
                 //Load the craft data

--- a/Intersect.Client/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client/Interface/Game/QuestsWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Intersect.Client.Core;
@@ -205,7 +205,7 @@ namespace Intersect.Client.Interface.Game
                 {
                     add = true;
                     category = !TextUtils.IsNone(quest.InProgressCategory) ? quest.InProgressCategory : "";
-                    color = Color.Yellow;
+                    color = CustomColors.QuestWindow.InProgress;
                     orderVal = 1;
                 }
                 else
@@ -216,7 +216,7 @@ namespace Intersect.Client.Interface.Game
                         {
                             add = true;
                             category = !TextUtils.IsNone(quest.CompletedCategory) ? quest.CompletedCategory : "";
-                            color = Color.Green;
+                            color = CustomColors.QuestWindow.Completed;
                             orderVal = 3;
                         }
                     }
@@ -226,7 +226,7 @@ namespace Intersect.Client.Interface.Game
                         {
                             add = true;
                             category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
-                            color = Color.Red;
+                            color = CustomColors.QuestWindow.NotStarted;
                             orderVal = 2;
                         }
                     }
@@ -238,7 +238,7 @@ namespace Intersect.Client.Interface.Game
                 {
                     add = true;
                     category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
-                    color = Color.Red;
+                    color = CustomColors.QuestWindow.NotStarted;
                     orderVal = 2;
                 }
             }
@@ -314,11 +314,11 @@ namespace Intersect.Client.Interface.Game
                     {
                         //In Progress
                         mQuestStatus.SetText(Strings.QuestLog.inprogress);
-                        mQuestStatus.SetTextColor(Color.Yellow, Label.ControlState.Normal);
+                        mQuestStatus.SetTextColor(CustomColors.QuestWindow.InProgress, Label.ControlState.Normal);
                         if (mSelectedQuest.InProgressDescription.Length > 0)
                         {
                             mQuestDescLabel.AddText(
-                                mSelectedQuest.InProgressDescription, Color.White, Alignments.Left,
+                                mSelectedQuest.InProgressDescription, CustomColors.QuestWindow.QuestDesc, Alignments.Left,
                                 mQuestDescTemplateLabel.Font
                             );
 
@@ -327,7 +327,7 @@ namespace Intersect.Client.Interface.Game
                         }
 
                         mQuestDescLabel.AddText(
-                            Strings.QuestLog.currenttask, Color.White, Alignments.Left, mQuestDescTemplateLabel.Font
+                            Strings.QuestLog.currenttask, CustomColors.QuestWindow.QuestDesc, Alignments.Left, mQuestDescTemplateLabel.Font
                         );
 
                         mQuestDescLabel.AddLineBreak();
@@ -338,7 +338,7 @@ namespace Intersect.Client.Interface.Game
                                 if (mSelectedQuest.Tasks[i].Description.Length > 0)
                                 {
                                     mQuestDescLabel.AddText(
-                                        mSelectedQuest.Tasks[i].Description, Color.White, Alignments.Left,
+                                        mSelectedQuest.Tasks[i].Description, CustomColors.QuestWindow.QuestDesc, Alignments.Left,
                                         mQuestDescTemplateLabel.Font
                                     );
 
@@ -353,7 +353,7 @@ namespace Intersect.Client.Interface.Game
                                             Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
                                             mSelectedQuest.Tasks[i].Quantity,
                                             ItemBase.GetName(mSelectedQuest.Tasks[i].TargetId)
-                                        ), Color.White, Alignments.Left, mQuestDescTemplateLabel.Font
+                                        ), CustomColors.QuestWindow.QuestDesc, Alignments.Left, mQuestDescTemplateLabel.Font
                                     );
                                 }
                                 else if (mSelectedQuest.Tasks[i].Objective == QuestObjective.KillNpcs) //Kill Npcs
@@ -363,7 +363,7 @@ namespace Intersect.Client.Interface.Game
                                             Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
                                             mSelectedQuest.Tasks[i].Quantity,
                                             NpcBase.GetName(mSelectedQuest.Tasks[i].TargetId)
-                                        ), Color.White, Alignments.Left, mQuestDescTemplateLabel.Font
+                                        ), CustomColors.QuestWindow.QuestDesc, Alignments.Left, mQuestDescTemplateLabel.Font
                                     );
                                 }
                             }
@@ -379,9 +379,9 @@ namespace Intersect.Client.Interface.Game
                             if (mSelectedQuest.LogAfterComplete)
                             {
                                 mQuestStatus.SetText(Strings.QuestLog.completed);
-                                mQuestStatus.SetTextColor(Color.Green, Label.ControlState.Normal);
+                                mQuestStatus.SetTextColor(CustomColors.QuestWindow.Completed, Label.ControlState.Normal);
                                 mQuestDescLabel.AddText(
-                                    mSelectedQuest.EndDescription, Color.White, Alignments.Left,
+                                    mSelectedQuest.EndDescription, CustomColors.QuestWindow.QuestDesc, Alignments.Left,
                                     mQuestDescTemplateLabel.Font
                                 );
                             }
@@ -392,9 +392,9 @@ namespace Intersect.Client.Interface.Game
                             if (mSelectedQuest.LogBeforeOffer)
                             {
                                 mQuestStatus.SetText(Strings.QuestLog.notstarted);
-                                mQuestStatus.SetTextColor(Color.Red, Label.ControlState.Normal);
+                                mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
                                 mQuestDescLabel.AddText(
-                                    mSelectedQuest.BeforeDescription, Color.White, Alignments.Left,
+                                    mSelectedQuest.BeforeDescription, CustomColors.QuestWindow.QuestDesc, Alignments.Left,
                                     mQuestDescTemplateLabel.Font
                                 );
 
@@ -409,9 +409,9 @@ namespace Intersect.Client.Interface.Game
                     if (mSelectedQuest.LogBeforeOffer)
                     {
                         mQuestStatus.SetText(Strings.QuestLog.notstarted);
-                        mQuestStatus.SetTextColor(Color.Red, Label.ControlState.Normal);
+                        mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
                         mQuestDescLabel.AddText(
-                            mSelectedQuest.BeforeDescription, Color.White, Alignments.Left, mQuestDescTemplateLabel.Font
+                            mSelectedQuest.BeforeDescription, CustomColors.QuestWindow.QuestDesc, Alignments.Left, mQuestDescTemplateLabel.Font
                         );
                     }
                 }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -5433,7 +5433,7 @@ namespace Intersect.Server.Entities
 
                 StartCommonEvent(EventBase.Get(quest.StartEventId));
                 PacketSender.SendChatMsg(
-                    this, Strings.Quests.started.ToString(quest.Name), ChatMessageType.Quest, CustomColors.Quests.Started
+                    this, Strings.Quests.started.ToString(quest.Name), ChatMessageType.Quest, CustomColors.QuestAlert.Started
                 );
 
                 PacketSender.SendQuestsProgress(this);
@@ -5484,7 +5484,7 @@ namespace Intersect.Server.Entities
                 {
                     QuestOffers.Remove(questId);
                     PacketSender.SendChatMsg(
-                        this, Strings.Quests.declined.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest, CustomColors.Quests.Declined
+                        this, Strings.Quests.declined.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest, CustomColors.QuestAlert.Declined
                     );
 
                     foreach (var evt in EventLookup)
@@ -5527,7 +5527,7 @@ namespace Intersect.Server.Entities
                         questProgress.TaskProgress = -1;
                         PacketSender.SendChatMsg(
                             this, Strings.Quests.abandoned.ToString(QuestBase.GetName(questId)), ChatMessageType.Quest,
-                            CustomColors.Quests.Abandoned
+                            CustomColors.QuestAlert.Abandoned
                         );
 
                         PacketSender.SendQuestsProgress(this);
@@ -5566,7 +5566,7 @@ namespace Intersect.Server.Entities
                                     StartCommonEvent(EventBase.Get(quest.EndEventId));
                                     PacketSender.SendChatMsg(
                                         this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
-                                        CustomColors.Quests.Completed
+                                        CustomColors.QuestAlert.Completed
                                     );
                                 }
                                 else
@@ -5587,7 +5587,7 @@ namespace Intersect.Server.Entities
                                     PacketSender.SendChatMsg(
                                         this, Strings.Quests.updated.ToString(quest.Name),
                                         ChatMessageType.Quest,
-                                        CustomColors.Quests.TaskUpdated
+                                        CustomColors.QuestAlert.TaskUpdated
                                     );
                                 }
                             }
@@ -5616,7 +5616,7 @@ namespace Intersect.Server.Entities
                         StartCommonEvent(EventBase.Get(quest.EndEventId));
                         PacketSender.SendChatMsg(
                             this, Strings.Quests.completed.ToString(quest.Name), ChatMessageType.Quest,
-                            CustomColors.Quests.Completed
+                            CustomColors.QuestAlert.Completed
                         );
                     }
                     PacketSender.SendQuestsProgress(this);


### PR DESCRIPTION
Fix #1246 

To give more customization to the text colors of the crafting and quest windows that are hardcoded.
![image](https://user-images.githubusercontent.com/63019821/166144883-93be9b18-cde8-424e-814c-db9c90779905.png)