### PR TITLE
feat: New options for condition: NoNpcsOnMap

### DIFF
--- a/Intersect (Core)/GameObjects/Events/Condition.cs
+++ b/Intersect (Core)/GameObjects/Events/Condition.cs
@@ -203,6 +203,10 @@ namespace Intersect.GameObjects.Events
 
         public override ConditionTypes Type { get; } = ConditionTypes.NoNpcsOnMap;
 
+        public bool SpecificNpc { get; set; }
+
+        public Guid NpcId { get; set; }
+
     }
 
     public class GenderIsCondition : Condition

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.Designer.cs
@@ -145,6 +145,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpCheckEquippedSlot = new DarkUI.Controls.DarkGroupBox();
             this.cmbCheckEquippedSlot = new DarkUI.Controls.DarkComboBox();
             this.lblCheckEquippedSlot = new System.Windows.Forms.Label();
+            this.grpNpc = new DarkUI.Controls.DarkGroupBox();
+            this.cmbNpcs = new DarkUI.Controls.DarkComboBox();
+            this.lblNpc = new System.Windows.Forms.Label();
+            this.chkNpc = new DarkUI.Controls.DarkCheckBox();
             this.grpConditional.SuspendLayout();
             this.grpInventoryConditions.SuspendLayout();
             this.grpVariableAmount.SuspendLayout();
@@ -173,12 +177,14 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpGender.SuspendLayout();
             this.grpEquippedItem.SuspendLayout();
             this.grpCheckEquippedSlot.SuspendLayout();
+            this.grpNpc.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpConditional
             // 
             this.grpConditional.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpConditional.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpConditional.Controls.Add(this.grpNpc);
             this.grpConditional.Controls.Add(this.grpInventoryConditions);
             this.grpConditional.Controls.Add(this.grpVariable);
             this.grpConditional.Controls.Add(this.grpMapZoneType);
@@ -1859,6 +1865,60 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.lblCheckEquippedSlot.TabIndex = 2;
             this.lblCheckEquippedSlot.Text = "Slot:";
             // 
+            // grpNpc
+            // 
+            this.grpNpc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpNpc.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpNpc.Controls.Add(this.chkNpc);
+            this.grpNpc.Controls.Add(this.cmbNpcs);
+            this.grpNpc.Controls.Add(this.lblNpc);
+            this.grpNpc.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpNpc.Location = new System.Drawing.Point(10, 48);
+            this.grpNpc.Name = "grpNpc";
+            this.grpNpc.Size = new System.Drawing.Size(260, 74);
+            this.grpNpc.TabIndex = 40;
+            this.grpNpc.TabStop = false;
+            this.grpNpc.Text = "NPCs";
+            this.grpNpc.Visible = false;
+            // 
+            // cmbNpcs
+            // 
+            this.cmbNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbNpcs.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbNpcs.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbNpcs.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbNpcs.DrawDropdownHoverOutline = false;
+            this.cmbNpcs.DrawFocusRectangle = false;
+            this.cmbNpcs.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbNpcs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbNpcs.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbNpcs.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbNpcs.FormattingEnabled = true;
+            this.cmbNpcs.Location = new System.Drawing.Point(67, 45);
+            this.cmbNpcs.Name = "cmbNpcs";
+            this.cmbNpcs.Size = new System.Drawing.Size(177, 21);
+            this.cmbNpcs.TabIndex = 39;
+            this.cmbNpcs.Text = null;
+            this.cmbNpcs.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // lblNpc
+            // 
+            this.lblNpc.AutoSize = true;
+            this.lblNpc.Location = new System.Drawing.Point(6, 49);
+            this.lblNpc.Name = "lblNpc";
+            this.lblNpc.Size = new System.Drawing.Size(32, 13);
+            this.lblNpc.TabIndex = 38;
+            this.lblNpc.Text = "NPC:";
+            // 
+            // chkNpc
+            // 
+            this.chkNpc.Location = new System.Drawing.Point(7, 22);
+            this.chkNpc.Name = "chkNpc";
+            this.chkNpc.Size = new System.Drawing.Size(98, 17);
+            this.chkNpc.TabIndex = 60;
+            this.chkNpc.Text = "Specify NPC?";
+            this.chkNpc.CheckedChanged += new System.EventHandler(this.chkNpc_CheckedChanged);
+            // 
             // EventCommandConditionalBranch
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1919,6 +1979,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpEquippedItem.PerformLayout();
             this.grpCheckEquippedSlot.ResumeLayout(false);
             this.grpCheckEquippedSlot.PerformLayout();
+            this.grpNpc.ResumeLayout(false);
+            this.grpNpc.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -2040,5 +2102,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private DarkGroupBox grpCheckEquippedSlot;
         private DarkComboBox cmbCheckEquippedSlot;
         private System.Windows.Forms.Label lblCheckEquippedSlot;
+        private DarkGroupBox grpNpc;
+        private DarkCheckBox chkNpc;
+        private DarkComboBox cmbNpcs;
+        private System.Windows.Forms.Label lblNpc;
     }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -1462,14 +1462,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private void SaveFormValues(NoNpcsOnMapCondition condition)
         {
             condition.SpecificNpc = chkNpc.Checked;
-            if (condition.SpecificNpc)
-            {
-                condition.NpcId = NpcBase.IdFromList(cmbNpcs.SelectedIndex);
-            }
-            else
-            {
-                condition.NpcId = default;
-            }
+            condition.NpcId = condition.SpecificNpc ? NpcBase.IdFromList(cmbNpcs.SelectedIndex) : default;
         }
 
         private void SaveFormValues(GenderIsCondition condition)
@@ -1529,19 +1522,19 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void chkNpc_CheckedChanged(object sender, EventArgs e)
         {
-            if (chkNpc.Checked)
-            {
-                lblNpc.Show();
-                cmbNpcs.Show();
-                if (cmbNpcs.Items.Count > 0)
-                {
-                    cmbNpcs.SelectedIndex = 0;
-                }
-            }
-            else
+            if (!chkNpc.Checked)
             {
                 lblNpc.Hide();
                 cmbNpcs.Hide();
+                
+                return;   
+            }
+
+            lblNpc.Show();
+            cmbNpcs.Show();
+            if (cmbNpcs.Items.Count > 0)
+            {
+                cmbNpcs.SelectedIndex = 0;
             }
         }
     }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -256,6 +256,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             grpCheckEquippedSlot.Text = Strings.EventConditional.CheckEquipment;
             lblCheckEquippedSlot.Text = Strings.EventConditional.EquipmentSlot;
 
+            // NPC Group
+            grpNpc.Text = Strings.EventConditional.NpcGroup;
+            lblNpc.Text = Strings.EventConditional.NpcLabel;
+            chkNpc.Text = Strings.EventConditional.SpecificNpcCheck;
+
             btnSave.Text = Strings.EventConditional.okay;
             btnCancel.Text = Strings.EventConditional.cancel;
         }
@@ -350,6 +355,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     break;
                 case ConditionTypes.NoNpcsOnMap:
                     Condition = new NoNpcsOnMapCondition();
+                    if (cmbNpcs.Items.Count > 0)
+                    {
+                        cmbNpcs.SelectedIndex = 0;
+                    }
 
                     break;
                 case ConditionTypes.GenderIs:
@@ -419,6 +428,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             grpEquippedItem.Hide();
             grpInGuild.Hide();
             grpMapZoneType.Hide();
+            grpNpc.Hide();
             grpCheckEquippedSlot.Hide();
             switch (type)
             {
@@ -508,6 +518,13 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
                 case ConditionTypes.NoNpcsOnMap:
+                    grpNpc.Show();
+                    cmbNpcs.Items.Clear();
+                    cmbNpcs.Items.AddRange(NpcBase.Names);
+
+                    chkNpc.Checked = false;
+                    cmbNpcs.Hide();
+                    lblNpc.Hide();
                     break;
                 case ConditionTypes.GenderIs:
                     grpGender.Show();
@@ -1248,7 +1265,18 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void SetupFormValues(NoNpcsOnMapCondition condition)
         {
-            //Nothing to do but we need this here so the dynamic will work :) 
+            chkNpc.Checked = condition.SpecificNpc;
+            if (condition.SpecificNpc)
+            {
+                lblNpc.Show();
+                cmbNpcs.Show();
+                cmbNpcs.SelectedIndex = NpcBase.ListIndex(condition.NpcId);
+            }
+            else
+            {
+                lblNpc.Hide();
+                cmbNpcs.Hide();
+            }
         }
 
         private void SetupFormValues(QuestCompletedCondition condition)
@@ -1433,7 +1461,15 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void SaveFormValues(NoNpcsOnMapCondition condition)
         {
-            //Nothing to do but we need this here so the dynamic will work :) 
+            condition.SpecificNpc = chkNpc.Checked;
+            if (condition.SpecificNpc)
+            {
+                condition.NpcId = NpcBase.IdFromList(cmbNpcs.SelectedIndex);
+            }
+            else
+            {
+                condition.NpcId = default;
+            }
         }
 
         private void SaveFormValues(GenderIsCondition condition)
@@ -1489,8 +1525,25 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         {
             condition.Name = Options.EquipmentSlots[cmbCheckEquippedSlot.SelectedIndex];
         }
-
         #endregion
+
+        private void chkNpc_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkNpc.Checked)
+            {
+                lblNpc.Show();
+                cmbNpcs.Show();
+                if (cmbNpcs.Items.Count > 0)
+                {
+                    cmbNpcs.SelectedIndex = 0;
+                }
+            }
+            else
+            {
+                lblNpc.Hide();
+                cmbNpcs.Hide();
+            }
+        }
     }
 
 }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -244,7 +244,9 @@ namespace Intersect.Editor.Localization
 
         public static string GetEventConditionalDesc(NoNpcsOnMapCondition condition)
         {
-            return Strings.EventConditionDesc.nonpcsonmap;
+            return condition.SpecificNpc ?
+                Strings.EventConditionDesc.NoNpcsOfTypeOnMap.ToString(NpcBase.GetName(condition.NpcId)) :
+                Strings.EventConditionDesc.NoNpcsOnMap.ToString();
         }
 
         public static string GetEventConditionalDesc(GenderIsCondition condition)
@@ -2089,14 +2091,14 @@ Tick timer saved in server config.json.";
                 {4, @"Has item..."},
                 {5, @"Class is..."},
                 {6, @"Knows spell..."},
-                {7, @"Level or Stat is...."},
-                {8, @"Self Switch is...."},
-                {9, @"Power level is...."},
-                {10, @"Time is between...."},
-                {11, @"Can Start Quest...."},
-                {12, @"Quest In Progress...."},
-                {13, @"Quest Completed...."},
-                {14, @"No NPCs on Map"},
+                {7, @"Level or Stat is..."},
+                {8, @"Self Switch is..."},
+                {9, @"Power level is..."},
+                {10, @"Time is between..."},
+                {11, @"Can Start Quest..."},
+                {12, @"Quest In Progress..."},
+                {13, @"Quest Completed..."},
+                {14, @"No NPCs on Map..."},
                 {15, @"Gender is..."},
                 {16, @"Map is..."},
                 {17, @"Item Equipped is..."},
@@ -2155,6 +2157,12 @@ Tick timer saved in server config.json.";
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString HasElse = @"Has Else";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString NpcGroup = @"NPCs";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString NpcLabel = @"NPC:";
+
             public static LocalizedString numericvariable = @"Numeric Variable:";
 
             public static LocalizedString okay = @"Ok";
@@ -2204,6 +2212,9 @@ Tick timer saved in server config.json.";
             };
 
             public static LocalizedString selfswitchis = @"Self Switch Is";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString SpecificNpcCheck = @"Specify NPC?";
 
             public static LocalizedString spell = @"Spell:";
 
@@ -2318,7 +2329,9 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString negated = @"NOT [{00}]";
 
-            public static LocalizedString nonpcsonmap = @"No NPCs on the map";
+            public static LocalizedString NoNpcsOnMap = @"No NPCs on the map";
+
+            public static LocalizedString NoNpcsOfTypeOnMap = @"No NPCs of type {00} on the map";
 
             public static LocalizedString notequal = @"does not equal {00}";
 

--- a/Intersect.Server/Entities/Events/Conditions.cs
+++ b/Intersect.Server/Entities/Events/Conditions.cs
@@ -390,9 +390,16 @@ namespace Intersect.Server.Entities.Events
                 var entities = mapInstance.GetEntities();
                 foreach (var en in entities)
                 {
-                    if (en.GetType() == typeof(Npc))
+                    if (en is Npc npc)
                     {
-                        return false;
+                        if (!condition.SpecificNpc)
+                        {
+                            return false;
+                        }
+                        else if (npc.Base?.Id == condition.NpcId)
+                        {
+                            return false;
+                        }
                     }
                 }
 

--- a/Intersect.Server/Entities/Events/Conditions.cs
+++ b/Intersect.Server/Entities/Events/Conditions.cs
@@ -390,16 +390,9 @@ namespace Intersect.Server.Entities.Events
                 var entities = mapInstance.GetEntities();
                 foreach (var en in entities)
                 {
-                    if (en is Npc npc)
+                    if (en is Npc npc && (!condition.SpecificNpc || npc.Base?.Id == condition.NpcId))
                     {
-                        if (!condition.SpecificNpc)
-                        {
-                            return false;
-                        }
-                        else if (npc.Base?.Id == condition.NpcId)
-                        {
-                            return false;
-                        }
+                        return false;
                     }
                 }
 

--- a/Intersect.Server/Entities/Events/Conditions.cs
+++ b/Intersect.Server/Entities/Events/Conditions.cs
@@ -390,9 +390,12 @@ namespace Intersect.Server.Entities.Events
                 var entities = mapInstance.GetEntities();
                 foreach (var en in entities)
                 {
-                    if (en is Npc npc && (!condition.SpecificNpc || npc.Base?.Id == condition.NpcId))
+                    if (en is Npc npc)
                     {
-                        return false;
+                        if (!condition.SpecificNpc || npc.Base?.Id == condition.NpcId)
+                        {
+                            return false;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Resolves #1240 

Extends the existing "No NPCs on Map" conditional by now allowing the user to check for if there are no NPCs of a _specific_ type, further expanding usability and event options.

This also fixes a small editor UI bug where the new `CheckEquippedSlot` condition didn't hide properly.

UI looks like this:
![image](https://user-images.githubusercontent.com/8580915/166123454-951d92e2-123b-4611-8d5a-4e0059c405d8.png)
*With a specified NPC enabled*

![image](https://user-images.githubusercontent.com/8580915/166123458-6c3ed285-a7bf-4757-8777-0c39286376a9.png)
*With a specified NPC disabled*

![image](https://user-images.githubusercontent.com/8580915/166123462-6f9ddf4a-6b33-4a6b-9b6e-f9177e6db4a0.png)
*Command printer text*

![image](https://user-images.githubusercontent.com/8580915/166123466-818112b4-3e69-4d64-8bdb-d000a7079937.png)
*Command printer text when no NPC specified*

https://user-images.githubusercontent.com/8580915/166123544-5603b2d4-5266-4720-93d7-f82082392b31.mp4
*In this video, you can see the "Nope" text when a "Some Scrub" appears on the map, followed by a "Nope!" When they leave the map (top-right).*
