### PR TITLE
Correct rendering of event names and images.

### DIFF
--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -289,13 +289,13 @@ namespace Intersect.Client.Entities.Events
                 Graphics.DrawGameTexture(
                     Graphics.Renderer.GetWhiteTexture(),
                     new FloatRect(0, 0, 1, 1),
-                    new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y),
+                    new FloatRect(x - textSize.X / 2f - 4, y - 10, textSize.X + 8, textSize.Y),
                     CustomColors.Names.Events.Background
                 );
             }
 
             Graphics.Renderer.DrawString(
-                Name, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y, 1,
+                Name, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y - 10, 1,
                 Color.FromArgb(CustomColors.Names.Events.Name.ToArgb()), true, null,
                 Color.FromArgb(CustomColors.Names.Events.Outline.ToArgb())
             );

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -267,19 +267,13 @@ namespace Intersect.Client.Entities.Events
                 return;
             }
 
-            if (!WorldPos.IntersectsWith(Graphics.Renderer.GetView()))
+            if (!WorldPos.IntersectsWith(Graphics.Renderer.GetView()) && Graphic.Type != EventGraphicType.None)
             {
-                return;
+                return; 
             }
 
             if (LatestMap == default || !Globals.GridMaps.Contains(MapId))
             {
-                return;
-            }
-
-            if (Graphic.Type == EventGraphicType.Sprite)
-            {
-                base.DrawName(textColor, borderColor, backgroundColor);
                 return;
             }
 


### PR DESCRIPTION
Will correct the rendering of event color when selecting an image directly from a sprite.
It will fix the error of not appearing the event name when selecting NONE as image.

Fix for #1267  and #1259 

Screen of the bug fixed
[https://ascensiongamedev.com/resources/filehost/7e65ff74818edf92609e35396ee0f234.png](https://www.ascensiongamedev.com/resources/filehost/7e65ff74818edf92609e35396ee0f234.png)