### PR TITLE
[EDITOR] Fix for Empty Directory with ShowPicture events

### DIFF
--- a/Intersect.Editor/Content/ContentManager.cs
+++ b/Intersect.Editor/Content/ContentManager.cs
@@ -524,7 +524,8 @@ namespace Intersect.Editor.Content
 
         public static string[] GetSmartSortedTextureNames(TextureType type)
         {
-            return SmartSort(GetTextureNames(type));
+            var textureNames = GetTextureNames(type);
+            return textureNames.Length > 0 ? SmartSort(textureNames) : new[] {string.Empty};
         }
 
         //Getting Filenames

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
@@ -25,35 +25,20 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image)
             );
 
-            if (cmbPicture.Items.IndexOf(mMyCommand.File) > -1)
-            {
-                cmbPicture.SelectedIndex = cmbPicture.Items.IndexOf(mMyCommand.File);
-            }
-            else
-            {
-                if (cmbPicture.Items.Count > 0)
-                {
-                    cmbPicture.SelectedIndex = 0;
-                }
-            }
-
             cmbSize.Items.Clear();
             cmbSize.Items.Add(Strings.EventShowPicture.original);
             cmbSize.Items.Add(Strings.EventShowPicture.fullscreen);
             cmbSize.Items.Add(Strings.EventShowPicture.halfscreen);
             cmbSize.Items.Add(Strings.EventShowPicture.stretchtofit);
-            if (mMyCommand.Size > -1)
-            {
-                cmbSize.SelectedIndex = mMyCommand.Size;
-            }
-            else
-            {
-                cmbSize.SelectedIndex = 0;
-            }
 
-            chkClick.Checked = mMyCommand.Clickable;
-            nudHideTime.Value = mMyCommand.HideTime;
-            chkWaitUntilClosed.Checked = mMyCommand.WaitUntilClosed;
+            if (mMyCommand != null)
+            {
+                cmbPicture.SelectedIndex = Math.Max(0, cmbPicture.Items.IndexOf(mMyCommand.File));
+                cmbSize.SelectedIndex = Math.Max(0, mMyCommand.Size);
+                chkClick.Checked = mMyCommand.Clickable;
+                nudHideTime.Value = mMyCommand.HideTime;
+                chkWaitUntilClosed.Checked = mMyCommand.WaitUntilClosed;
+            }
 
             InitLocalization();
         }


### PR DESCRIPTION
[ShowPicture EventCommand] Fix for Empty Directory
* Avoids reaching a run-time exception within the ShowPicture event Command window when the image directory is empty by filling up the combo box list with an empty string instead of null.
* Made sure to properly check for null mMyCommand variable before making use of it.
* cmbPicture.SelectedIndex & cmbSize.SelectedIndex have been properly checked and converted to '?:' operators.
* Should Resolve #1261

[ Panda's Review I ]
* Saved the result of GetTextureNames(type) to a local variable to prevent calling it twice.

[ Panda's Review II ]
* Changed the SelectedIndex of cmbPicture and cmbSize for Math.Max that returns the 
parameter val1 or val2 (whichever is larger). 
* This will maintain consistency and will not corrupt the state of the outcome.