### PR TITLE
[EDITOR] Updates Tile Preview On NPC Removal

### DIFF
--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -863,6 +863,8 @@ namespace Intersect.Editor.Forms.DockingElements
                 {
                     lstMapNpcs.SelectedIndex = 0;
                 }
+
+                Core.Graphics.TilePreviewUpdated = true;
             }
         }
 


### PR DESCRIPTION
* When editing NPCs with declared spawns, the editor's map preview will not update the spawn locations if one of those spawns is deleted, this commit should fix that behaviour by updating the editor's map preview whenever we delete an specific NPC from the map's spawn list.
* Should fix #1054

Preview:

https://user-images.githubusercontent.com/17498701/171522743-f0fe906a-e3b8-4fef-a212-ea6cef62a1c6.mp4


