### PR TITLE
Disallows spell swap while casting

### DIFF
--- a/Intersect.Client/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellItem.cs
@@ -301,7 +301,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
                         if (bestIntersectIndex > -1)
                         {
-                            if (mYindex != bestIntersectIndex)
+                            if (mYindex != bestIntersectIndex && !Globals.Me.IsCasting)
                             {
                                 //Try to swap....
                                 PacketSender.SendSwapSpells(bestIntersectIndex, mYindex);

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1705,7 +1705,7 @@ namespace Intersect.Server.Networking
         public void HandlePacket(Client client, SwapSpellsPacket packet)
         {
             var player = client?.Entity;
-            if (player == null)
+            if (player == null || player.IsCasting)
             {
                 return;
             }


### PR DESCRIPTION
* This workaround prevents taking advantage of the cast timing exploit when swapping spells within the spell window by disallowing the ability to swap them while casting. -> Should fix #1069
* A client-side and server-side check has been added (even if the client is modified with malicious intents, the server will still prevent the exploit from happening).

A note to Developers, Collaboratos and Maintainers: This should be considered a workaround for now, despite the fact that it *does prevents the exploit from happening thus, resolves the issue for now*, the root of the problem lies in the way the spells are currently implemented, so eventually it will be necessary to open another issue report and PR that aims to re-engineer the implementation from the ground up.

Preview:

https://user-images.githubusercontent.com/17498701/174462942-bf5f6179-cba8-4fea-90ab-4be6520ca8bd.mp4


