### PR TITLE
Chore & Fix: some editor's comboboxes & 1299

### DIFF
--- a/Intersect.Editor/Content/ContentManager.cs
+++ b/Intersect.Editor/Content/ContentManager.cs
@@ -524,8 +524,7 @@ namespace Intersect.Editor.Content
 
         public static string[] GetSmartSortedTextureNames(TextureType type)
         {
-            var textureNames = GetTextureNames(type);
-            return textureNames.Length > 0 ? SmartSort(textureNames) : new[] {string.Empty};
+            return SmartSort(GetTextureNames(type));
         }
 
         //Getting Filenames

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
+using Intersect.Utilities;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 {
@@ -22,19 +23,12 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             InitializeComponent();
             mMyCommand = refCommand;
             mEventEditor = editor;
-            cmbFace.Items.Clear();
-            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            if (cmbFace.Items.IndexOf(mMyCommand.Face) > -1)
-            {
-                cmbFace.SelectedIndex = cmbFace.Items.IndexOf(mMyCommand.Face);
-            }
-            else
-            {
-                cmbFace.SelectedIndex = 0;
-            }
-
-            UpdatePreview();
             InitLocalization();
+            cmbFace.Items.Clear();
+            cmbFace.Items.Add(Strings.General.none);
+            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
+            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
+            UpdatePreview();
         }
 
         private void InitLocalization()

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
+using Intersect.Utilities;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 {
@@ -24,19 +25,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             mEventEditor = editor;
             InitLocalization();
             cmbSprite.Items.Clear();
+            cmbSprite.Items.Add(Strings.General.none);
             cmbSprite.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
-            );
-
-            if (cmbSprite.Items.IndexOf(mMyCommand.Sprite) > -1)
-            {
-                cmbSprite.SelectedIndex = cmbSprite.Items.IndexOf(mMyCommand.Sprite);
-            }
-            else
-            {
-                cmbSprite.SelectedIndex = 0;
-            }
-
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity));
+            cmbSprite.SelectedIndex = Math.Max(0, cmbSprite.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Sprite)));
             UpdatePreview();
         }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
@@ -36,15 +36,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             cmbFace.Items.Clear();
             cmbFace.Items.Add(Strings.General.none);
             cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            if (cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)) > -1)
-            {
-                cmbFace.SelectedIndex = cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face));
-            }
-            else
-            {
-                cmbFace.SelectedIndex = 0;
-            }
-
+            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
             UpdateFacePreview();
         }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
@@ -20,10 +20,19 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             InitializeComponent();
             mMyCommand = refCommand;
             mEventEditor = editor;
+            InitLocalization();
             cmbPicture.Items.Clear();
-            cmbPicture.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image)
-            );
+
+            var sortedTextures = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image);
+
+            if (sortedTextures.Length > 0)
+            {
+                cmbPicture.Items.AddRange(sortedTextures);
+            }
+            else
+            {
+                cmbPicture.Items.Add(Strings.General.none);
+            }
 
             cmbSize.Items.Clear();
             cmbSize.Items.Add(Strings.EventShowPicture.original);
@@ -39,8 +48,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 nudHideTime.Value = mMyCommand.HideTime;
                 chkWaitUntilClosed.Checked = mMyCommand.WaitUntilClosed;
             }
-
-            InitLocalization();
         }
 
         private void InitLocalization()

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
@@ -28,14 +28,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             cmbFace.Items.Clear();
             cmbFace.Items.Add(Strings.General.none);
             cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            if (cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)) > -1)
-            {
-                cmbFace.SelectedIndex = cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face));
-            }
-            else
-            {
-                cmbFace.SelectedIndex = 0;
-            }
+            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
 
             UpdateFacePreview();
         }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -93,14 +93,20 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 cmbGraphic.Show();
                 lblGraphic.Show();
                 cmbGraphic.Items.Clear();
-                cmbGraphic.Items.AddRange(
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
-                );
 
-                if (cmbGraphic.Items.Count > 0)
+                var sortedTextures =
+                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
+
+                if (sortedTextures.Length > 0)
                 {
-                    cmbGraphic.SelectedIndex = 0;
+                    cmbGraphic.Items.AddRange(sortedTextures);
                 }
+                else
+                {
+                    cmbGraphic.Items.Add(Strings.General.none);
+                }
+
+                cmbGraphic.SelectedIndex = 0;
             }
             else if (cmbGraphicType.SelectedIndex == 2) //Tileset
             {
@@ -110,21 +116,20 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 lblGraphic.Show();
                 cmbGraphic.Show();
                 cmbGraphic.Items.Clear();
-                foreach (var filename in TilesetBase.Names)
+
+                var sortedTextures =
+                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+
+                if (sortedTextures.Length > 0)
                 {
-                    if (File.Exists("resources/tilesets/" + filename))
-                    {
-                        cmbGraphic.Items.Add(filename);
-                    }
-                    else
-                    {
-                    }
+                    cmbGraphic.Items.AddRange(sortedTextures);
+                }
+                else
+                {
+                    cmbGraphic.Items.Add(Strings.General.none);
                 }
 
-                if (cmbGraphic.Items.Count > 0)
-                {
-                    cmbGraphic.SelectedIndex = 0;
-                }
+                cmbGraphic.SelectedIndex = 0;
             }
         }
 
@@ -140,34 +145,39 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 cmbGraphic.Show();
                 lblGraphic.Show();
-                cmbGraphic.Items.AddRange(
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
-                );
 
-                if (cmbGraphic.Items.Count > 0)
+                var sortedTextures =
+                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
+
+                if (sortedTextures.Length > 0)
                 {
-                    cmbGraphic.SelectedIndex = 0;
+                    cmbGraphic.Items.AddRange(sortedTextures);
                 }
+                else
+                {
+                    cmbGraphic.Items.Add(Strings.General.none);
+                }
+
+                cmbGraphic.SelectedIndex = 0;
             }
             else if (cmbGraphicType.SelectedIndex == 2) //Tileset
             {
                 lblGraphic.Show();
                 cmbGraphic.Show();
-                foreach (var filename in TilesetBase.Names)
+
+                var sortedTextures =
+                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+
+                if (sortedTextures.Length > 0)
                 {
-                    if (File.Exists("resources/tilesets/" + filename))
-                    {
-                        cmbGraphic.Items.Add(filename);
-                    }
-                    else
-                    {
-                    }
+                    cmbGraphic.Items.AddRange(sortedTextures);
+                }
+                else
+                {
+                    cmbGraphic.Items.Add(Strings.General.none);
                 }
 
-                if (cmbGraphic.Items.Count > 0)
-                {
-                    cmbGraphic.SelectedIndex = 0;
-                }
+                cmbGraphic.SelectedIndex = 0;
             }
         }
 
@@ -178,13 +188,21 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             Bitmap destBitmap = null;
             if (cmbGraphicType.SelectedIndex == 1) //Sprite
             {
-                sourceBitmap = new Bitmap("resources/entities/" + cmbGraphic.Text);
-                mSpriteWidth = sourceBitmap.Width / Options.Instance.Sprites.NormalFrames;
-                mSpriteHeight = sourceBitmap.Height / Options.Instance.Sprites.Directions;
+                var spriteFile = "resources/entities/" + cmbGraphic.Text;
+                if (File.Exists(spriteFile))
+                {
+                    sourceBitmap = new Bitmap(spriteFile);
+                    mSpriteWidth = sourceBitmap.Width / Options.Instance.Sprites.NormalFrames;
+                    mSpriteHeight = sourceBitmap.Height / Options.Instance.Sprites.Directions;
+                }
             }
             else if (cmbGraphicType.SelectedIndex == 2) //Tileset
             {
-                sourceBitmap = new Bitmap("resources/tilesets/" + cmbGraphic.Text);
+                var tileSetFile = "resources/tilesets/" + cmbGraphic.Text;
+                if (File.Exists(tileSetFile))
+                {
+                    sourceBitmap = new Bitmap(tileSetFile);
+                }
             }
 
             if (sourceBitmap != null)


### PR DESCRIPTION
* Undid unnecesary changes i commited to GetSmartSortedTextureNames (#1274), which triggered the issues reported in #1299
* Simplified some comboboxes selected indexes with Math.Max
* Allows to remove entities Face though EventCommand (added 'none'). Also prevents crash if the faces folder is empty.
* Allows to remove entities Sprite though EventCommand (added 'none'). Also prevents crash if the entities folder is empty.
* Prevents crash from ShowPicture EventCommand by adding 'none' to the combobox only if the images folder is empty.
* Prevents crash from event's sprite graphic selector by adding 'none' to the combobox only if the entities folder is empty.
* Prevents crash from event's tileset graphic selector by adding 'none' to the combobox only if the tilesets folder is empty.