### PR TITLE
Animation camera shake feature

### DIFF
--- a/Intersect (Core)/GameObjects/AnimationBase.cs
+++ b/Intersect (Core)/GameObjects/AnimationBase.cs
@@ -82,6 +82,8 @@ namespace Intersect.GameObjects
 
         public bool CompleteSound { get; set; }
 
+        public int CameraShakeInterval { get; set; }
+
         /// <inheritdoc />
         public string Folder { get; set; } = "";
 

--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Intersect.Client.Framework.Database
 {
@@ -38,6 +38,8 @@ namespace Intersect.Client.Framework.Database
 
         public bool PlayerOverheadInfo;
 
+        public int CameraShakeIntensity;
+
         //Saving password, other stuff we don't want in the games directory
         public abstract void SavePreference(string key, object value);
 
@@ -72,6 +74,7 @@ namespace Intersect.Client.Framework.Database
             NpcOverheadInfo = LoadPreference("NpcOverheadInfo", true);
             PartyMemberOverheadInfo = LoadPreference("PartyMemberOverheadInfo", true);
             PlayerOverheadInfo = LoadPreference("PlayerOverheadInfo", true);
+            CameraShakeIntensity = LoadPreference("CameraShakeIntensity", 2);
         }
 
         public virtual void SavePreferences()
@@ -91,6 +94,7 @@ namespace Intersect.Client.Framework.Database
             SavePreference("NpcOverheadInfo", NpcOverheadInfo.ToString());
             SavePreference("PartyMemberOverheadInfo", PartyMemberOverheadInfo.ToString());
             SavePreference("PlayerOverheadInfo", PlayerOverheadInfo.ToString());
+            SavePreference("CameraShakeIntensity", CameraShakeIntensity.ToString());
         }
 
         public abstract bool LoadConfig();

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -98,6 +98,9 @@ namespace Intersect.Client.Core
 
         public static GameFont UIFont;
 
+        //Camera Shake
+        public static Point CameraShakePoint = new Point();
+
         //Init Functions
         public static void InitGraphics()
         {
@@ -1012,6 +1015,12 @@ namespace Intersect.Client.Core
             else
             {
                 CurrentView = new FloatRect(0, 0, Renderer.GetScreenWidth(), Renderer.GetScreenHeight());
+            }
+
+            if (Globals.Database.CameraShakeIntensity > 0 && Globals.CameraShake > Timing.Global.Milliseconds)
+            {
+                CurrentView.X += CameraShakePoint.X;
+                CurrentView.Y += CameraShakePoint.Y;
             }
 
             Renderer.SetView(CurrentView);

--- a/Intersect.Client/Core/Main.cs
+++ b/Intersect.Client/Core/Main.cs
@@ -23,6 +23,8 @@ namespace Intersect.Client.Core
 
         private static long _animTimer;
 
+        private static long _cameraShakeTimer;
+
         private static bool _createdMapTextures;
 
         private static bool _loadedTilesets;
@@ -326,6 +328,21 @@ namespace Intersect.Client.Core
                 }
 
                 _animTimer = Timing.Global.Milliseconds + 500;
+            }
+
+            //Update Game Animations
+            if (_cameraShakeTimer < Timing.Global.Milliseconds)
+            {
+                var intensity = Globals.Database.CameraShakeIntensity;
+
+                if (Globals.CameraShake > Timing.Global.Milliseconds)
+                {
+                    var rnd = new Random();
+                    Graphics.CameraShakePoint.X = rnd.Next(-intensity, intensity);
+                    Graphics.CameraShakePoint.Y = rnd.Next(-intensity, intensity);
+                }
+
+                _cameraShakeTimer = Timing.Global.Milliseconds + 50;
             }
 
             //Remove Event Holds If Invalid

--- a/Intersect.Client/Entities/Animation.cs
+++ b/Intersect.Client/Entities/Animation.cs
@@ -83,6 +83,16 @@ namespace Intersect.Client.Entities
                 {
                     Graphics.LiveAnimations.Add(this);
                 }
+
+                if (MyBase.CameraShakeInterval > 0)
+                {
+                    var cameraShakeInterval = Timing.Global.Milliseconds + MyBase.CameraShakeInterval;
+
+                    if (cameraShakeInterval > Globals.CameraShake)
+                    {
+                        Globals.CameraShake = cameraShakeInterval;
+                    }
+                }
             }
             else
             {

--- a/Intersect.Client/General/Globals.cs
+++ b/Intersect.Client/General/Globals.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Intersect.Client.Entities;
@@ -211,6 +211,9 @@ namespace Intersect.Client.General
 
         //Scene management
         public static bool WaitingOnServer = false;
+
+        //Camera effects
+        public static long CameraShake;
 
         public static Entity GetEntity(Guid id, EntityTypes type)
         {

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -96,6 +96,12 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mLightingEnabledCheckbox;
 
+        private readonly ImagePanel mCameraShakeBackground;
+
+        private readonly Label mCameraShakeLabel;
+
+        private readonly ComboBox mCameraShakeList;
+
         // Audio Settings.
         private readonly HorizontalSlider mMusicSlider;
 
@@ -250,6 +256,21 @@ namespace Intersect.Client.Interface.Shared
             mFpsList.AddItem(Strings.Settings.Fps90);
             mFpsList.AddItem(Strings.Settings.Fps120);
             mFpsList.AddItem(Strings.Settings.UnlimitedFps);
+
+            // Video Settings - Camera Shake Background.
+            mCameraShakeBackground = new ImagePanel(mVideoSettingsContainer, "CameraShakePanel");
+
+            // Video Settings - Camera Shake Label.
+            mCameraShakeLabel = new Label(mCameraShakeBackground, "CameraShakeLabel");
+            mCameraShakeLabel.SetText(Strings.Settings.CameraShakeIntensity);
+
+            // Video Settings - Camera Shake List.
+            mCameraShakeList = new ComboBox(mCameraShakeBackground, "CameraShakeCombobox");
+            mCameraShakeList.AddItem(Strings.Settings.CameraShakeIntensityNone);
+            mCameraShakeList.AddItem(Strings.Settings.CameraShakeIntensityLight);
+            mCameraShakeList.AddItem(Strings.Settings.CameraShakeIntensityNormal);
+            mCameraShakeList.AddItem(Strings.Settings.CameraShakeIntensityStrong);
+            mCameraShakeList.AddItem(Strings.Settings.CameraShakeIntensityVeryStrong);
 
             // Video Settings - Fullscreen Checkbox.
             mFullscreenCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "FullscreenCheckbox")
@@ -656,6 +677,34 @@ namespace Intersect.Client.Interface.Shared
                     break;
             }
 
+            switch (Globals.Database.CameraShakeIntensity)
+            {
+                case 0: // No shake
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityNone);
+
+                    break;
+                case 1: // Light intensity
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityLight);
+
+                    break;
+                case 2: // Normal intensity (default)
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityNormal);
+
+                    break;
+                case 3: // Strong intensity
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityStrong);
+
+                    break;
+                case 4: // Very strong intensity
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityVeryStrong);
+
+                    break;
+                default:
+                    mCameraShakeList.SelectByText(Strings.Settings.CameraShakeIntensityNormal);
+
+                    break;
+            }
+
             // Game Settings.
             mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
             mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
@@ -810,6 +859,33 @@ namespace Intersect.Client.Interface.Shared
             {
                 shouldReset = true;
                 Globals.Database.TargetFps = newFps;
+            }
+
+            var newCameraShakeIntensity = 0;
+            if (mCameraShakeList.SelectedItem.Text == Strings.Settings.CameraShakeIntensityNone)
+            {
+                newCameraShakeIntensity = 0;
+            }
+            else if (mCameraShakeList.SelectedItem.Text == Strings.Settings.CameraShakeIntensityLight)
+            {
+                newCameraShakeIntensity = 1;
+            }
+            else if (mCameraShakeList.SelectedItem.Text == Strings.Settings.CameraShakeIntensityNormal)
+            {
+                newCameraShakeIntensity = 2;
+            }
+            else if (mCameraShakeList.SelectedItem.Text == Strings.Settings.CameraShakeIntensityStrong)
+            {
+                newCameraShakeIntensity = 3;
+            }
+            else if (mCameraShakeList.SelectedItem.Text == Strings.Settings.CameraShakeIntensityVeryStrong)
+            {
+                newCameraShakeIntensity = 4;
+            }
+
+            if (newCameraShakeIntensity != Globals.Database.CameraShakeIntensity)
+            {
+                Globals.Database.CameraShakeIntensity = newCameraShakeIntensity;
             }
 
             Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1621,6 +1621,24 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Vsync = @"V-Sync";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensity = @"Camera Shake Intensity:";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensityNone = @"None";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensityLight = @"Light";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensityNormal = @"Normal";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensityStrong = @"Strong";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString CameraShakeIntensityVeryStrong = @"Very Strong";
         }
 
         public partial struct Parties

--- a/Intersect.Editor/Forms/Editors/frmAnimation.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmAnimation.Designer.cs
@@ -1,4 +1,4 @@
-﻿using DarkUI.Controls;
+using DarkUI.Controls;
 
 namespace Intersect.Editor.Forms.Editors
 {
@@ -37,6 +37,8 @@ namespace Intersect.Editor.Forms.Editors
             this.txtSearch = new DarkUI.Controls.DarkTextBox();
             this.lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
             this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
+            this.scrlCameraShakeInterval = new DarkUI.Controls.DarkScrollBar();
+            this.lblCameraShakeInterval = new System.Windows.Forms.Label();
             this.chkCompleteSoundPlayback = new DarkUI.Controls.DarkCheckBox();
             this.btnAddFolder = new DarkUI.Controls.DarkButton();
             this.lblFolder = new System.Windows.Forms.Label();
@@ -194,6 +196,8 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.scrlCameraShakeInterval);
+            this.grpGeneral.Controls.Add(this.lblCameraShakeInterval);
             this.grpGeneral.Controls.Add(this.chkCompleteSoundPlayback);
             this.grpGeneral.Controls.Add(this.btnAddFolder);
             this.grpGeneral.Controls.Add(this.lblFolder);
@@ -212,6 +216,25 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.TabIndex = 18;
             this.grpGeneral.TabStop = false;
             this.grpGeneral.Text = "General";
+            // 
+            // scrlCameraShakeInterval
+            // 
+            this.scrlCameraShakeInterval.Location = new System.Drawing.Point(599, 45);
+            this.scrlCameraShakeInterval.Maximum = 5000;
+            this.scrlCameraShakeInterval.Name = "scrlCameraShakeInterval";
+            this.scrlCameraShakeInterval.ScrollOrientation = DarkUI.Controls.DarkScrollOrientation.Horizontal;
+            this.scrlCameraShakeInterval.Size = new System.Drawing.Size(218, 17);
+            this.scrlCameraShakeInterval.TabIndex = 31;
+            this.scrlCameraShakeInterval.ValueChanged += new System.EventHandler<DarkUI.Controls.ScrollValueEventArgs>(this.scrlCameraShakeInterval_Scroll);
+            // 
+            // lblCameraShakeInterval
+            // 
+            this.lblCameraShakeInterval.AutoSize = true;
+            this.lblCameraShakeInterval.Location = new System.Drawing.Point(470, 46);
+            this.lblCameraShakeInterval.Name = "lblCameraShakeInterval";
+            this.lblCameraShakeInterval.Size = new System.Drawing.Size(111, 13);
+            this.lblCameraShakeInterval.TabIndex = 30;
+            this.lblCameraShakeInterval.Text = "Camera Shake (ms): 0";
             // 
             // chkCompleteSoundPlayback
             // 
@@ -264,7 +287,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnSwap
             // 
-            this.btnSwap.Location = new System.Drawing.Point(473, 43);
+            this.btnSwap.Location = new System.Drawing.Point(823, 41);
             this.btnSwap.Name = "btnSwap";
             this.btnSwap.Padding = new System.Windows.Forms.Padding(5);
             this.btnSwap.Size = new System.Drawing.Size(158, 23);
@@ -274,7 +297,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // scrlDarkness
             // 
-            this.scrlDarkness.Location = new System.Drawing.Point(584, 19);
+            this.scrlDarkness.Location = new System.Drawing.Point(599, 19);
             this.scrlDarkness.Name = "scrlDarkness";
             this.scrlDarkness.ScrollOrientation = DarkUI.Controls.DarkScrollOrientation.Horizontal;
             this.scrlDarkness.Size = new System.Drawing.Size(218, 17);
@@ -1311,5 +1334,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkTextBox txtSearch;
         private DarkCheckBox chkCompleteSoundPlayback;
         private Controls.GameObjectList lstGameObjects;
+        private DarkScrollBar scrlCameraShakeInterval;
+        private System.Windows.Forms.Label lblCameraShakeInterval;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/frmAnimation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -161,6 +161,7 @@ namespace Intersect.Editor.Forms.Editors
             lblSound.Text = Strings.AnimationEditor.sound;
             chkCompleteSoundPlayback.Text = Strings.AnimationEditor.soundcomplete;
             labelDarkness.Text = Strings.AnimationEditor.simulatedarkness.ToString(scrlDarkness.Value);
+            lblCameraShakeInterval.Text = Strings.AnimationEditor.camerashake.ToString(scrlCameraShakeInterval.Value);
             btnSwap.Text = Strings.AnimationEditor.swap;
 
             grpLower.Text = Strings.AnimationEditor.lowergroup;
@@ -213,6 +214,7 @@ namespace Intersect.Editor.Forms.Editors
                 txtName.Text = mEditorItem.Name;
                 cmbSound.SelectedIndex = cmbSound.FindString(TextUtils.NullToNone(mEditorItem.Sound));
                 chkCompleteSoundPlayback.Checked = mEditorItem.CompleteSound;
+                scrlCameraShakeInterval.Value = mEditorItem.CameraShakeInterval;
 
                 cmbLowerGraphic.SelectedIndex =
                     cmbLowerGraphic.FindString(TextUtils.NullToNone(mEditorItem.Lower.Sprite));
@@ -874,6 +876,11 @@ namespace Intersect.Editor.Forms.Editors
 
         #endregion
 
+        private void scrlCameraShakeInterval_Scroll(object sender, ScrollValueEventArgs e)
+        {
+            lblCameraShakeInterval.Text = Strings.AnimationEditor.camerashake.ToString(scrlCameraShakeInterval.Value);
+            mEditorItem.CameraShakeInterval = scrlCameraShakeInterval.Value;
+        }
     }
 
 }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -642,6 +642,8 @@ namespace Intersect.Editor.Localization
 
             public static LocalizedString simulatedarkness = @"Simulate Darkness: {00}";
 
+            public static LocalizedString camerashake = @"Camera Shake (ms): {00}";
+
             public static LocalizedString sound = @"Sound:";
 
             public static LocalizedString soundcomplete = @"Complete Sound Playback After Anim Dies";

--- a/Intersect.Server/Migrations/Game/20220628180051_AddedCameraShakeInterval.Designer.cs
+++ b/Intersect.Server/Migrations/Game/20220628180051_AddedCameraShakeInterval.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations.Game
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20220628180051_AddedCameraShakeInterval")]
+    partial class AddedCameraShakeInterval
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/Game/20220628180051_AddedCameraShakeInterval.cs
+++ b/Intersect.Server/Migrations/Game/20220628180051_AddedCameraShakeInterval.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Game
+{
+    public partial class AddedCameraShakeInterval : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CameraShakeInterval",
+                table: "Animations",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CameraShakeInterval",
+                table: "Animations");
+        }
+    }
+}


### PR DESCRIPTION
Solving the feature request of #1281

Created a new animation feature for camera shaking. 
- Animations now have a new Integer property "CameraShakeInterval" that represents how many ms the camera will shake.
- If there is two animations shaking the camera, only the longer one will prevail.
- Camera shake intensity can be configured at client options. (Also can be disabled).

Long time i promised this feature, sorry, but now there is.