### PR TITLE
Fix updating the event graphic resolving issue #1308

### DIFF
--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -62,6 +62,11 @@ namespace Intersect.Client.Entities.Events
             _drawCompletedWithoutTexture = Graphic.Type != EventGraphicType.Tileset;
 
             base.Load(packet);
+
+            if (!string.IsNullOrEmpty(Graphic?.Filename))
+            {
+                Sprite = Graphic.Filename;
+            }
         }
 
         public override bool Update()
@@ -77,11 +82,6 @@ namespace Intersect.Client.Entities.Events
 
         protected bool TryEnsureTexture(out GameTexture texture)
         {
-            if (Graphic != null && !string.IsNullOrEmpty(Graphic.Filename) && Sprite != Graphic.Filename)
-            {
-                Sprite = Graphic.Filename;
-            }
-
             if (_drawCompletedWithoutTexture)
             {
                 texture = Texture;

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -77,6 +77,11 @@ namespace Intersect.Client.Entities.Events
 
         protected bool TryEnsureTexture(out GameTexture texture)
         {
+            if (Graphic != null && !string.IsNullOrEmpty(Graphic.Filename) && Sprite != Graphic.Filename)
+            {
+                Sprite = Graphic.Filename;
+            }
+
             if (_drawCompletedWithoutTexture)
             {
                 texture = Texture;


### PR DESCRIPTION
Basically the EventGraphic object does not change the event sprite according to the Filename property.
Worked for both Sprite/Tileset.

This pull request fix the issue  #1308