### PR TITLE
chore: none 1x1 tile if animations present

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -232,14 +232,9 @@ namespace Intersect.Client.Entities
 
         public Pointf Origin => LatestMap == default ? Pointf.Empty : mOrigin;
 
-        public Pointf Center
-        {
-            get
-            {
-                var sprite = Globals.ContentManager.GetTexture(TextureType.Entity, Sprite);
-                return Origin - ((sprite == default) ? Pointf.Empty : (Pointf.UnitY * sprite.Center.Y / Options.Instance.Sprites.Directions));
-            }
-        }
+        protected virtual Pointf CenterOffset => (Texture == default) ? Pointf.Empty : (Pointf.UnitY * Texture.Center.Y / Options.Instance.Sprites.Directions);
+
+        public Pointf Center => Origin - CenterOffset;
 
         public byte Dir
         {

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -40,6 +40,28 @@ namespace Intersect.Client.Entities.Events
 
         public bool WalkingAnim { get; set; } = true;
 
+        protected override Pointf CenterOffset
+        {
+            get
+            {
+                switch (Graphic.Type)
+                {
+                    case EventGraphicType.None:
+                        return Animations.Count == 0 ? Pointf.Empty : Pointf.UnitY * Options.TileHeight / 2f;
+
+                    case EventGraphicType.Sprite:
+                        return base.CenterOffset;
+
+                    case EventGraphicType.Tileset:
+                        return Pointf.UnitY * Options.TileHeight * (Graphic.Height + 1) / 2f;
+
+                    default:
+                        Log.Error($"Unimplemented graphic type: {Graphic.Type}");
+                        return Pointf.Empty;
+                }
+            }
+        }
+
         public Event(Guid id, EventEntityPacket packet) : base(id, packet, EntityTypes.Event)
         {
             mRenderPriority = 1;
@@ -261,7 +283,7 @@ namespace Intersect.Client.Entities.Events
                     break;
 
                 case EventGraphicType.None:
-                    heightScale = 0.5f;
+                    heightScale = Animations.Count > 0 ? 1 : 0.5f;
                     break;
 
                 default:


### PR DESCRIPTION
Resolves #1372

If the event does not have animations, the label is positioned in the middle of the event's tile like before

![image](https://user-images.githubusercontent.com/1476550/179368981-61b1fbc1-5efb-45e7-b81d-a049afe5f9a5.png)

To resolve the bug, if the event _does_ have animations, the label is positioned as though the event is a 1 tile tall tileset event, and the animation is centered accordingly:

![image](https://user-images.githubusercontent.com/1476550/179369008-0ee71c65-8539-4fb6-b064-8c98416eee59.png)
