### PR TITLE
Fix: Re-allows to use Key actions while hovering the GUI

### DIFF
--- a/Intersect.Client/Core/Controls/ControlMap.cs
+++ b/Intersect.Client/Core/Controls/ControlMap.cs
@@ -1,5 +1,4 @@
-﻿using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Input;
+﻿using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 
 namespace Intersect.Client.Core.Controls
@@ -11,7 +10,7 @@ namespace Intersect.Client.Core.Controls
 
         public ControlValue Key2;
 
-        public ControlMap(Control control, ControlValue key1, ControlValue key2)
+        public ControlMap(ControlValue key1, ControlValue key2)
         {
             this.Key1 = key1;
             this.Key2 = key2;
@@ -19,25 +18,13 @@ namespace Intersect.Client.Core.Controls
 
         public bool KeyDown()
         {
-            if (Key1.IsMouseKey || Key2.IsMouseKey)
+            if (Interface.Interface.MouseHitGui() && (Globals.InputManager.MouseButtonDown(MouseButtons.Right) ||
+                                                      Globals.InputManager.MouseButtonDown(MouseButtons.Left)))
             {
-                if (Interface.Interface.MouseHitGui())
-                {
-                    return false;
-                }
+                return false;
             }
 
-            if (Key1.IsDown())
-            {
-                return true;
-            }
-
-            if (Key2.IsDown())
-            {
-                return true;
-            }
-
-            return false;
+            return Key1.IsDown() || Key2.IsDown();
         }
 
     }

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -163,11 +163,11 @@ namespace Intersect.Client.Core.Controls
         {
             if (ControlMapping.ContainsKey(control))
             {
-                ControlMapping[control] = new ControlMap(control, key1, key2);
+                ControlMapping[control] = new ControlMap(key1, key2);
             }
             else
             {
-                ControlMapping.Add(control, new ControlMap(control, key1, key2));
+                ControlMapping.Add(control, new ControlMap(key1, key2));
             }
         }
 


### PR DESCRIPTION
* Re-allows to use ControlMap **Keyboard Key actions** while hovering the GUI (ie: E key for attack/interact).
* Maintains behaviour: right and left **mouse buttons** don't trigger ControlMap actions (only GUI actions and menus) while hovering the GUI.
* Removed unused "control" parameter from ControlMap - Only "key1" and "key2" parameters are used.
* Resolves #1266 

**Video-Demo _( wear headphones / earphones to listen keys and mouse clicks ! )_**

https://user-images.githubusercontent.com/17498701/179371524-e9c90a76-5b0b-431e-8c8e-1defee624e92.mp4


