### PR TITLE
fix: rework bindings to be dynamic and independent

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Intersect.Client.Framework.Database
 {
@@ -37,6 +37,10 @@ namespace Intersect.Client.Framework.Database
         public bool PartyMemberOverheadInfo;
 
         public bool PlayerOverheadInfo;
+
+        public abstract void DeletePreference(string key);
+
+        public abstract bool HasPreference(string key);
 
         //Saving password, other stuff we don't want in the games directory
         public abstract void SavePreference(string key, object value);

--- a/Intersect.Client/Core/Controls/ControlMap.cs
+++ b/Intersect.Client/Core/Controls/ControlMap.cs
@@ -1,45 +1,40 @@
-﻿using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Input;
-using Intersect.Client.General;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Intersect.Client.Core.Controls
 {
-
     public partial class ControlMap
     {
-        public ControlValue Key1;
+        public List<ControlValue> Bindings { get; }
 
-        public ControlValue Key2;
-
-        public ControlMap(Control control, ControlValue key1, ControlValue key2)
+        public ControlMap(ControlValue binding, params ControlValue[] alternateBindings)
         {
-            this.Key1 = key1;
-            this.Key2 = key2;
+            Bindings = new List<ControlValue>(1 + (alternateBindings?.Length ?? 0)) { binding };
+            Bindings.AddRange(alternateBindings ?? Array.Empty<ControlValue>());
+
+            if (Bindings.Count < 2)
+            {
+                Bindings.Add(ControlValue.Default);
+            }
         }
 
-        public bool KeyDown()
+        public ControlMap(ControlMap controlMap)
         {
-            if (Key1.IsMouseKey || Key2.IsMouseKey)
+            if (controlMap == default)
             {
-                if (Interface.Interface.MouseHitGui())
-                {
-                    return false;
-                }
+                throw new ArgumentNullException(nameof(controlMap));
             }
 
-            if (Key1.IsDown())
+            var bindings = controlMap.Bindings.ToList();
+            if (bindings.Count < 1)
             {
-                return true;
+                throw new ArgumentException("The control map does not have at least one binding.", nameof(controlMap));
             }
 
-            if (Key2.IsDown())
-            {
-                return true;
-            }
-
-            return false;
+            Bindings = new List<ControlValue>(bindings);
         }
 
+        public bool KeyDown() => Bindings.Any(button => button.IsDown() && (!button.IsMouseKey || !Interface.Interface.MouseHitGui()));
     }
-
 }

--- a/Intersect.Client/Core/Controls/ControlValue.cs
+++ b/Intersect.Client/Core/Controls/ControlValue.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Client.General;
+using Intersect.Client.General;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Input;
 
@@ -6,6 +6,8 @@ namespace Intersect.Client.Core.Controls
 {
     public partial class ControlValue
     {
+        public static ControlValue Default => new ControlValue(Keys.None, Keys.None);
+
         public Keys Modifier { get; set; }
 
         public Keys Key { get; set; }

--- a/Intersect.Client/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client/Interface/Game/Chat/Chatbox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Intersect.Client.Core;
@@ -507,8 +507,8 @@ namespace Intersect.Client.Interface.Game.Chat
 
         string GetDefaultInputText()
         {
-            var key1 = Controls.ActiveControls.ControlMapping[Control.Enter].Key1;
-            var key2 = Controls.ActiveControls.ControlMapping[Control.Enter].Key2;
+            var key1 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[0];
+            var key2 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[1];
             if (key1.Key == Keys.None && key2.Key != Keys.None)
             {
                 return Strings.Chatbox.enterchat1.ToString(

--- a/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
@@ -221,7 +222,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
             }
 
             //See if Label Should be changed
-            var keybind = Controls.ActiveControls.ControlMapping[Control.Hotkey1 + mYindex].Key1;
+            var keybind = Controls.ActiveControls.ControlMapping[Control.Hotkey1 + mYindex].Bindings[0];
             if (mHotKey == null || mHotKey.Modifier != keybind.Modifier || mHotKey.Key != keybind.Key)
             {
                 if (keybind.Modifier != Keys.None)

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -135,7 +135,7 @@ namespace Intersect.Client.Interface.Shared
             mEscapeMenu = escapeMenu;
 
             // Main Menu Window.
-            mSettingsPanel = new ImagePanel(parent, "SettingsWindow") {IsHidden = true};
+            mSettingsPanel = new ImagePanel(parent, "SettingsWindow") { IsHidden = true };
             Interface.InputBlockingElements.Add(mSettingsPanel);
 
             // Menu Header.
@@ -299,12 +299,12 @@ namespace Intersect.Client.Interface.Shared
             #endregion
 
             #region InitKeybindingSettings
-            
+
             // Init KeybindingsSettings Tab.
             mKeybindingSettingsTab = new Button(mSettingsPanel, "KeybindingSettingsTab");
             mKeybindingSettingsTab.Text = Strings.Settings.KeyBindingSettingsTab;
             mKeybindingSettingsTab.Clicked += KeybindingSettingsTab_Clicked;
-            
+
             // KeybindingSettings Get Stored in the KeybindingSettings Scroll Control
             mKeybindingSettingsContainer = new ScrollControl(mSettingsPanel, "KeybindingSettingsContainer");
             mKeybindingSettingsContainer.EnableScroll(false, true);
@@ -321,18 +321,18 @@ namespace Intersect.Client.Interface.Shared
             {
                 var offset = row * 32;
                 var name = Enum.GetName(typeof(Control), control)?.ToLower();
-                
+
                 var label = new Label(mKeybindingSettingsContainer, $"Control{Enum.GetName(typeof(Control), control)}Label");
                 label.Text = Strings.Controls.controldict[name];
                 label.AutoSizeToContents = true;
                 label.Font = defaultFont;
                 label.SetBounds(8, 8 + offset, 0, 24);
                 label.SetTextColor(new Color(255, 255, 255, 255), Label.ControlState.Normal);
-                
+
                 var key1 = new Button(mKeybindingSettingsContainer, $"Control{Enum.GetName(typeof(Control), control)}Button1");
                 key1.Text = "";
                 key1.AutoSizeToContents = false;
-                key1.UserData = new KeyValuePair<Control, int>(control, 1);
+                key1.UserData = new KeyValuePair<Control, int>(control, 0);
                 key1.Font = defaultFont;
 
                 key1.Clicked += Key_Clicked;
@@ -341,13 +341,13 @@ namespace Intersect.Client.Interface.Shared
                 {
                     Text = "",
                     AutoSizeToContents = false,
-                    UserData = new KeyValuePair<Control, int>(control, 2),
+                    UserData = new KeyValuePair<Control, int>(control, 1),
                     Font = defaultFont
                 };
 
                 key2.Clicked += Key_Clicked;
 
-                mKeybindingBtns.Add(control, new[] {key1, key2});
+                mKeybindingBtns.Add(control, new[] { key1, key2 });
 
                 row++;
             }
@@ -376,7 +376,7 @@ namespace Intersect.Client.Interface.Shared
                 mVideoSettingsContainer.Hide();
                 mAudioSettingsContainer.Hide();
                 mKeybindingSettingsContainer.Hide();
-                
+
                 // Restore Default KeybindingSettings Button.
                 mKeybindingRestoreBtn.Hide();
             }
@@ -398,7 +398,7 @@ namespace Intersect.Client.Interface.Shared
                 mVideoSettingsContainer.Show();
                 mAudioSettingsContainer.Hide();
                 mKeybindingSettingsContainer.Hide();
-                
+
                 // Restore Default KeybindingSettings Button.
                 mKeybindingRestoreBtn.Hide();
             }
@@ -420,12 +420,12 @@ namespace Intersect.Client.Interface.Shared
                 mVideoSettingsContainer.Hide();
                 mAudioSettingsContainer.Show();
                 mKeybindingSettingsContainer.Hide();
-                
+
                 // Restore Default KeybindingSettings Button.
                 mKeybindingRestoreBtn.Hide();
             }
         }
-        
+
         private void KeybindingSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
         {
             // Determine if controls are currently being shown or not.
@@ -445,40 +445,15 @@ namespace Intersect.Client.Interface.Shared
 
                 // Restore Default KeybindingSettings Button.
                 mKeybindingRestoreBtn.Show();
-                
+
                 // KeybindingBtns.
                 foreach (Control control in Enum.GetValues(typeof(Control)))
                 {
-                    if (mKeybindingEditControls.ControlMapping[control].Key1.Modifier != Keys.None)
+                    var controlMapping = mKeybindingEditControls.ControlMapping[control];
+                    for (var bindingIndex = 0; bindingIndex < controlMapping.Bindings.Count; bindingIndex++)
                     {
-                        mKeybindingBtns[control][0].Text = String.Format("{00} + {01}",
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key1.Modifier).ToLower()],
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key1.Key).ToLower()]
-                        );
-                    }
-                    else
-                    {
-                        mKeybindingBtns[control][0].Text =
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key1.Key).ToLower()];
-                    }
-
-                    if (mKeybindingEditControls.ControlMapping[control].Key2.Modifier != Keys.None)
-                    {
-                        mKeybindingBtns[control][1].Text = String.Format("{00} + {01}",
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key2.Modifier).ToLower()],
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key2.Key).ToLower()]
-                        );
-                    }
-                    else
-                    {
-                        mKeybindingBtns[control][1].Text =
-                        Strings.Keys.keydict[
-                            Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key2.Key).ToLower()];
+                        var binding = controlMapping.Bindings[bindingIndex];
+                        mKeybindingBtns[control][bindingIndex].Text = Strings.Keys.FormatKeyName(binding.Modifier, binding.Key);
                     }
                 }
             }
@@ -518,59 +493,29 @@ namespace Intersect.Client.Interface.Shared
             if (mKeybindingEditBtn != null)
             {
                 mKeybindingEditControls.UpdateControl(mKeybindingEditControl, mKeyEdit, modifier, key);
-                if (mKeyEdit == 1)
-                {
-                    if (modifier != Keys.None)
-                    {
-                        mKeybindingEditBtn.Text = String.Format("{00} + {01}",
-                            Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key1.Modifier).ToLower()],
-                            Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key1.Key).ToLower()]
-                        );
-                    }
-                    else
-                    {
-                        mKeybindingEditBtn.Text =
-                        Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key1.Key).ToLower()];
-                    }
-                }
-                else
-                {
-                    if (modifier != Keys.None)
-                    {
-                        mKeybindingEditBtn.Text = String.Format("{00} + {01}",
-                            Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key2.Modifier).ToLower()],
-                            Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key2.Key).ToLower()]
-                        );
-                    }
-                    else
-                    {
-                        mKeybindingEditBtn.Text =
-                        Strings.Keys.keydict[Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[mKeybindingEditControl].Key2.Key).ToLower()];
-                    }
-                }
+                mKeybindingEditBtn.Text = Strings.Keys.FormatKeyName(modifier, key);
 
                 if (key != Keys.None)
                 {
                     foreach (var control in mKeybindingEditControls.ControlMapping)
                     {
-                        if (control.Key != mKeybindingEditControl)
+                        if (control.Key == mKeybindingEditControl)
                         {
-                            if (control.Value.Key1.Modifier == modifier && control.Value.Key1.Key == key)
+                            continue;
+                        }
+
+                        var bindings = control.Value.Bindings;
+                        for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
+                        {
+                            var binding = bindings[bindingIndex];
+
+                            if (binding.Modifier == modifier && binding.Key == key)
                             {
                                 // Remove this mapping.
-                                mKeybindingEditControls.UpdateControl(control.Key, 1, Keys.None, Keys.None);
+                                mKeybindingEditControls.UpdateControl(control.Key, bindingIndex, Keys.None, Keys.None);
 
                                 // Update UI.
-                                mKeybindingBtns[control.Key][0].Text = Strings.Keys.keydict[Enum.GetName(typeof(Keys), Keys.None).ToLower()];
-                            }
-
-                            if (control.Value.Key2.Modifier == modifier && control.Value.Key2.Key == key)
-                            {
-                                // Remove this mapping.
-                                mKeybindingEditControls.UpdateControl(control.Key, 2, Keys.None, Keys.None);
-
-                                // Update UI.
-                                mKeybindingBtns[control.Key][1].Text = Strings.Keys.keydict[Enum.GetName(typeof(Keys), Keys.None).ToLower()];
+                                mKeybindingBtns[control.Key][bindingIndex].Text = Strings.Keys.keydict[Enum.GetName(typeof(Keys), Keys.None).ToLower()];
                             }
                         }
                     }
@@ -674,12 +619,12 @@ namespace Intersect.Client.Interface.Shared
             mPreviousSoundVolume = Globals.Database.SoundVolume;
             mMusicSlider.Value = Globals.Database.MusicVolume;
             mSoundSlider.Value = Globals.Database.SoundVolume;
-            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int) mMusicSlider.Value);
-            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int) mSoundSlider.Value);
+            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
+            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
 
             // Settings Window is not hidden anymore.
             mSettingsPanel.Show();
-            
+
             // Load every GUI element to their default state when showing up the settings window (pressed tabs, containers, etc.)
             LoadSettingsWindow();
 
@@ -719,21 +664,21 @@ namespace Intersect.Client.Interface.Shared
         // Input Handlers
         private void MusicSlider_ValueChanged(Base sender, EventArgs arguments)
         {
-            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int) mMusicSlider.Value);
-            Globals.Database.MusicVolume = (int) mMusicSlider.Value;
+            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
+            Globals.Database.MusicVolume = (int)mMusicSlider.Value;
             Audio.UpdateGlobalVolume();
         }
 
         private void SoundSlider_ValueChanged(Base sender, EventArgs arguments)
         {
-            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int) mSoundSlider.Value);
-            Globals.Database.SoundVolume = (int) mSoundSlider.Value;
+            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
+            Globals.Database.SoundVolume = (int)mSoundSlider.Value;
             Audio.UpdateGlobalVolume();
         }
 
         private void Key_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            EditKeyPressed((Button) sender);
+            EditKeyPressed((Button)sender);
         }
 
         private void EditKeyPressed(Button sender)
@@ -741,8 +686,8 @@ namespace Intersect.Client.Interface.Shared
             if (mKeybindingEditBtn == null)
             {
                 sender.Text = Strings.Controls.listening;
-                mKeyEdit = ((KeyValuePair<Control, int>) sender.UserData).Value;
-                mKeybindingEditControl = ((KeyValuePair<Control, int>) sender.UserData).Key;
+                mKeyEdit = ((KeyValuePair<Control, int>)sender.UserData).Value;
+                mKeybindingEditControl = ((KeyValuePair<Control, int>)sender.UserData).Key;
                 mKeybindingEditBtn = sender;
                 Interface.GwenInput.HandleInput = false;
                 mKeybindingListeningTimer = Timing.Global.Milliseconds + 3000;
@@ -754,13 +699,12 @@ namespace Intersect.Client.Interface.Shared
             mKeybindingEditControls.ResetDefaults();
             foreach (Control control in Enum.GetValues(typeof(Control)))
             {
-                mKeybindingBtns[control][0].Text =
-                    Strings.Keys.keydict[
-                        Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key1.Key).ToLower()];
-
-                mKeybindingBtns[control][1].Text =
-                    Strings.Keys.keydict[
-                        Enum.GetName(typeof(Keys), mKeybindingEditControls.ControlMapping[control].Key2.Key).ToLower()];
+                var controlMapping = mKeybindingEditControls.ControlMapping[control];
+                for (var bindingIndex = 0; bindingIndex < controlMapping.Bindings.Count; bindingIndex++)
+                {
+                    var binding = controlMapping.Bindings[bindingIndex];
+                    mKeybindingBtns[control][bindingIndex].Text = Strings.Keys.FormatKeyName(binding.Modifier, binding.Key);
+                }
             }
         }
 
@@ -813,7 +757,7 @@ namespace Intersect.Client.Interface.Shared
             }
 
             Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;
-          
+
             if (Globals.Database.FriendOverheadInfo != mFriendOverheadInfoCheckbox.IsChecked)
             {
                 Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
@@ -845,8 +789,8 @@ namespace Intersect.Client.Interface.Shared
             }
 
             // Save Settings.
-            Globals.Database.MusicVolume = (int) mMusicSlider.Value;
-            Globals.Database.SoundVolume = (int) mSoundSlider.Value;
+            Globals.Database.MusicVolume = (int)mMusicSlider.Value;
+            Globals.Database.SoundVolume = (int)mSoundSlider.Value;
             Audio.UpdateGlobalVolume();
             Controls.ActiveControls = mKeybindingEditControls;
             Controls.ActiveControls.Save();

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1278,7 +1278,7 @@ namespace Intersect.Client.Localization
 
                 if (modifier == Framework.GenericClasses.Keys.None)
                 {
-                    var modifierName = Strings.Keys.keydict[Enum.GetName(typeof(Keys), modifier).ToLower()];
+                    var modifierName = keydict[Enum.GetName(typeof(Framework.GenericClasses.Keys), modifier).ToLower()];
                     formatted = KeyNameWithModifier.ToString(modifierName, formatted);
                 }
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1276,7 +1276,7 @@ namespace Intersect.Client.Localization
             {
                 var formatted = keydict[Enum.GetName(typeof(Framework.GenericClasses.Keys), key).ToLower()];
 
-                if (modifier == Framework.GenericClasses.Keys.None)
+                if (modifier != Framework.GenericClasses.Keys.None)
                 {
                     var modifierName = keydict[Enum.GetName(typeof(Framework.GenericClasses.Keys), modifier).ToLower()];
                     formatted = KeyNameWithModifier.ToString(modifierName, formatted);

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1272,6 +1272,21 @@ namespace Intersect.Client.Localization
 
         public partial struct Keys
         {
+            public static string FormatKeyName(Framework.GenericClasses.Keys modifier, Framework.GenericClasses.Keys key)
+            {
+                var formatted = keydict[Enum.GetName(typeof(Framework.GenericClasses.Keys), key).ToLower()];
+
+                if (modifier == Framework.GenericClasses.Keys.None)
+                {
+                    var modifierName = Strings.Keys.keydict[Enum.GetName(typeof(Keys), modifier).ToLower()];
+                    formatted = KeyNameWithModifier.ToString(modifierName, formatted);
+                }
+
+                return formatted;
+            }
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString KeyNameWithModifier = @"{00} + {01}";
 
             public static Dictionary<string, LocalizedString> keydict = new Dictionary<string, LocalizedString>()
             {

--- a/Intersect.Client/MonoGame/Database/MonoDatabase.cs
+++ b/Intersect.Client/MonoGame/Database/MonoDatabase.cs
@@ -1,46 +1,57 @@
-﻿using System;
+using System;
 
 using Intersect.Client.Framework.Database;
 using Intersect.Configuration;
+using Intersect.Logging;
 
 using Microsoft.Win32;
 
 namespace Intersect.Client.MonoGame.Database
 {
-
     public partial class MonoDatabase : GameDatabase
     {
-
-        public override void SavePreference(string key, object value)
-        {
-            var regkey = Registry.CurrentUser?.OpenSubKey("Software", true);
-
-            regkey?.CreateSubKey("IntersectClient");
-            regkey = regkey?.OpenSubKey("IntersectClient", true);
-            regkey?.CreateSubKey(ClientConfiguration.Instance.Host + ":" + ClientConfiguration.Instance.Port);
-            regkey = regkey?.OpenSubKey(
-                ClientConfiguration.Instance.Host + ":" + ClientConfiguration.Instance.Port, true
-            );
-
-            regkey?.SetValue(key, Convert.ToString(value));
-        }
-
-        public override string LoadPreference(string key)
+        private RegistryKey GetInstanceKey(bool writable = false)
         {
             var regkey = Registry.CurrentUser?.OpenSubKey("Software", false);
             regkey = regkey?.OpenSubKey("IntersectClient", false);
-            regkey = regkey?.OpenSubKey(ClientConfiguration.Instance.Host + ":" + ClientConfiguration.Instance.Port);
-
-            return regkey?.GetValue(key) as string ?? "";
+            regkey = regkey?.OpenSubKey(ClientConfiguration.Instance.Host + ":" + ClientConfiguration.Instance.Port, writable);
+            return regkey;
         }
 
-        public override bool LoadConfig()
+        public override void DeletePreference(string key)
         {
-            ClientConfiguration.LoadAndSave();
-
-            return true;
+            try
+            {
+                var instanceKey = GetInstanceKey(true);
+                if (instanceKey?.GetValue(key) != default)
+                {
+                    instanceKey.DeleteValue(key);
+                }
+            }
+            catch (Exception exception)
+            {
+#if DEBUG
+                Log.Error(exception);
+#endif
+            }
         }
 
-    }
+        public override bool HasPreference(string key) => GetInstanceKey()?.GetValue(key) != default;
 
+        public override void SavePreference(string key, object value)
+        {
+            try
+            {
+                GetInstanceKey(true)?.SetValue(key, Convert.ToString(value));
+            } catch (UnauthorizedAccessException)
+            {
+                Log.Error($"Unable to save preference {key} in the registry.");
+                throw;
+            }
+        }
+
+        public override string LoadPreference(string key) => GetInstanceKey()?.GetValue(key) as string ?? string.Empty;
+
+        public override bool LoadConfig() => ClientConfiguration.LoadAndSave() != default;
+    }
 }


### PR DESCRIPTION
Resolves #1266 

- bindings are now dynamically sized (in case we ever want to increase past 2 in the future)
  - this also allows for all of the code to be reused between keys
- bindings are checked independently to allow for mouse binds to not interfere with key binds (which caused #1266 )