### PR TITLE
feat: client options for vitals and exp bar's direction

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 
 using Intersect.Enums;
+using Newtonsoft.Json;
 
 namespace Intersect.Configuration
 {
@@ -165,6 +166,13 @@ namespace Intersect.Configuration
         /// Configures the name of the skin or skin texture (must end in .png) to use.
         /// </summary>
         public string UiSkin { get; set; } = "Intersect2021";
+
+        /// <summary>
+        /// Configures the rendering direction of entity bars, vitals in their order, then experience
+        /// </summary>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public List<DisplayDirection> EntityBarDirections { get; set; } =
+            Enumerable.Range(0, 1 + (int)Vitals.VitalCount).Select(_ => DisplayDirection.StartToEnd).ToList();
 
         #endregion
 

--- a/Intersect (Core)/Enums/DisplayDirection.cs
+++ b/Intersect (Core)/Enums/DisplayDirection.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+namespace Intersect.Enums
+{
+    /// <summary>
+    /// Defines the way the bar will be rendered
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum DisplayDirection
+    {
+        /// <summary>
+        /// The bar will render from start (empty life) to end (full life)
+        /// </summary>
+        StartToEnd = 0,
+        /// <summary>
+        /// The bar will render from end (empty life) to start (full life)
+        /// </summary>
+        EndToStart,
+        /// <summary>
+        /// The bar will render from top (empty life) to bottom (full life)
+        /// </summary>
+        TopToBottom,
+        /// <summary>
+        /// The bar will render from bottom (empty life) to top (full life)
+        /// </summary>
+        BottomToTop,
+    }
+}

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -22,29 +22,24 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
     public partial class EntityBox
     {
+        public readonly Label EntityLevel;
 
-        private static int sStatusXPadding = 2;
+        public readonly Label EntityMap;
 
-        private static int sStatusYPadding = 2;
+        public readonly Label EntityName;
 
-        public readonly Framework.Gwen.Control.Label EntityLevel;
-
-        public readonly Framework.Gwen.Control.Label EntityMap;
-
-        public readonly Framework.Gwen.Control.Label EntityName;
-
-        public readonly Framework.Gwen.Control.Label EntityNameAndLevel;
+        public readonly Label EntityNameAndLevel;
 
         //Controls
         public readonly ImagePanel EntityWindow;
 
-        public float CurExpWidth = -1;
+        public float CurExpSize = -1;
 
-        public float CurHpWidth = -1;
+        public float CurHpSize = -1;
 
-        public float CurMpWidth = -1;
+        public float CurMpSize = -1;
 
-        public float CurShieldWidth = -1;
+        public float CurShieldSize = -1;
 
         public ImagePanel EntityFace;
 
@@ -62,9 +57,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public ImagePanel ExpBar;
 
-        public Framework.Gwen.Control.Label ExpLbl;
+        public Label ExpLbl;
 
-        public Framework.Gwen.Control.Label ExpTitle;
+        public Label ExpTitle;
 
         public Button FriendLabel;
 
@@ -72,9 +67,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public ImagePanel HpBar;
 
-        public Framework.Gwen.Control.Label HpLbl;
+        public Label HpLbl;
 
-        public Framework.Gwen.Control.Label HpTitle;
+        public Label HpTitle;
 
         private Dictionary<Guid, SpellStatus> mActiveStatuses = new Dictionary<Guid, SpellStatus>();
 
@@ -86,9 +81,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public ImagePanel MpBar;
 
-        public Framework.Gwen.Control.Label MpLbl;
+        public Label MpLbl;
 
-        public Framework.Gwen.Control.Label MpTitle;
+        public Label MpTitle;
 
         public Entity MyEntity;
 
@@ -123,12 +118,12 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
             EntityInfoPanel = new ImagePanel(EntityWindow, "EntityInfoPanel");
 
-            EntityName = new Framework.Gwen.Control.Label(EntityInfoPanel, "EntityNameLabel") {Text = myEntity?.Name};
-            EntityLevel = new Framework.Gwen.Control.Label(EntityInfoPanel, "EntityLevelLabel");
-            EntityNameAndLevel = new Framework.Gwen.Control.Label(EntityInfoPanel, "NameAndLevelLabel")
+            EntityName = new Label(EntityInfoPanel, "EntityNameLabel") {Text = myEntity?.Name};
+            EntityLevel = new Label(EntityInfoPanel, "EntityLevelLabel");
+            EntityNameAndLevel = new Label(EntityInfoPanel, "NameAndLevelLabel")
                 {IsHidden = true};
 
-            EntityMap = new Framework.Gwen.Control.Label(EntityInfoPanel, "EntityMapLabel");
+            EntityMap = new Label(EntityInfoPanel, "EntityMapLabel");
 
             PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count];
             PaperdollTextures = new string[Options.EquipmentSlots.Count];
@@ -157,21 +152,21 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             HpBackground = new ImagePanel(EntityInfoPanel, "HPBarBackground");
             HpBar = new ImagePanel(EntityInfoPanel, "HPBar");
             ShieldBar = new ImagePanel(EntityInfoPanel, "ShieldBar");
-            HpTitle = new Framework.Gwen.Control.Label(EntityInfoPanel, "HPTitle");
+            HpTitle = new Label(EntityInfoPanel, "HPTitle");
             HpTitle.SetText(Strings.EntityBox.vital0);
-            HpLbl = new Framework.Gwen.Control.Label(EntityInfoPanel, "HPLabel");
+            HpLbl = new Label(EntityInfoPanel, "HPLabel");
 
             MpBackground = new ImagePanel(EntityInfoPanel, "MPBackground");
             MpBar = new ImagePanel(EntityInfoPanel, "MPBar");
-            MpTitle = new Framework.Gwen.Control.Label(EntityInfoPanel, "MPTitle");
+            MpTitle = new Label(EntityInfoPanel, "MPTitle");
             MpTitle.SetText(Strings.EntityBox.vital1);
-            MpLbl = new Framework.Gwen.Control.Label(EntityInfoPanel, "MPLabel");
+            MpLbl = new Label(EntityInfoPanel, "MPLabel");
 
             ExpBackground = new ImagePanel(EntityInfoPanel, "EXPBackground");
             ExpBar = new ImagePanel(EntityInfoPanel, "EXPBar");
-            ExpTitle = new Framework.Gwen.Control.Label(EntityInfoPanel, "EXPTitle");
+            ExpTitle = new Label(EntityInfoPanel, "EXPTitle");
             ExpTitle.SetText(Strings.EntityBox.exp);
-            ExpLbl = new Framework.Gwen.Control.Label(EntityInfoPanel, "EXPLabel");
+            ExpLbl = new Label(EntityInfoPanel, "EXPLabel");
 
             TradeLabel = new Button(EntityInfoPanel, "TradeButton");
             TradeLabel.SetText(Strings.EntityBox.trade);
@@ -283,10 +278,10 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             ShowAllElements();
 
             //Update Bars
-            CurHpWidth = -1;
-            CurShieldWidth = -1;
-            CurMpWidth = -1;
-            CurExpWidth = -1;
+            CurHpSize = -1;
+            CurShieldSize = -1;
+            CurMpSize = -1;
+            CurExpSize = -1;
             ShieldBar.Hide();
             UpdateHpBar(0, true);
             UpdateMpBar(0, true);
@@ -563,8 +558,8 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         private void UpdateHpBar(float elapsedTime, bool instant = false)
         {
-            var targetHpWidth = 0f;
-            var targetShieldWidth = 0f;
+            var targetHpSize = 0f;
+            var targetShieldSize = 0f;
             if (MyEntity.MaxVital[(int) Vitals.Health] > 0)
             {
                 var maxVital = MyEntity.MaxVital[(int) Vitals.Health];
@@ -579,11 +574,11 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
                 var hpfillRatio = (float) MyEntity.Vital[(int) Vitals.Health] / maxVital;
                 hpfillRatio = Math.Min(1, Math.Max(0, hpfillRatio));
-                targetHpWidth = (float) Math.Ceiling(hpfillRatio * width);
+                targetHpSize = (float) Math.Ceiling(hpfillRatio * width);
 
                 var shieldfillRatio = (float) shieldSize / maxVital;
                 shieldfillRatio = Math.Min(1, Math.Max(0, shieldfillRatio));
-                targetShieldWidth = (float) Math.Floor(shieldfillRatio * width);
+                targetShieldSize = (float) Math.Floor(shieldfillRatio * width);
 
                 float hpPercentage = hpfillRatio * 100;
                 var hpPercentageText = $"{hpPercentage:0.##}%";
@@ -605,83 +600,83 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             else
             {
                 HpLbl.Text = Strings.EntityBox.vital0val.ToString(0, 0);
-                targetHpWidth = HpBackground.Width;
+                targetHpSize = HpBackground.Width;
             }
 
-            if ((int)targetHpWidth != CurHpWidth)
+            if ((int)targetHpSize != CurHpSize)
             {
                 if (!instant)
                 {
-                    if ((int)targetHpWidth > CurHpWidth)
+                    if ((int)targetHpSize > CurHpSize)
                     {
-                        CurHpWidth += 100f * elapsedTime;
-                        if (CurHpWidth > (int)targetHpWidth)
+                        CurHpSize += 100f * elapsedTime;
+                        if (CurHpSize > (int)targetHpSize)
                         {
-                            CurHpWidth = targetHpWidth;
+                            CurHpSize = targetHpSize;
                         }
                     }
                     else
                     {
-                        CurHpWidth -= 100f * elapsedTime;
-                        if (CurHpWidth < targetHpWidth)
+                        CurHpSize -= 100f * elapsedTime;
+                        if (CurHpSize < targetHpSize)
                         {
-                            CurHpWidth = targetHpWidth;
+                            CurHpSize = targetHpSize;
                         }
                     }
                 }
                 else
                 {
-                    CurHpWidth = (int)targetHpWidth;
+                    CurHpSize = (int)targetHpSize;
                 }
 
-                if (CurHpWidth == 0)
+                if (CurHpSize == 0)
                 {
                     HpBar.IsHidden = true;
                 }
                 else
                 {
-                    HpBar.Width = (int)CurHpWidth;
-                    HpBar.SetTextureRect(0, 0, (int)CurHpWidth, HpBar.Height);
+                    HpBar.Width = (int)CurHpSize;
+                    HpBar.SetTextureRect(0, 0, (int)CurHpSize, HpBar.Height);
                     HpBar.IsHidden = false;
                 }
             }
 
-            if ((int)targetShieldWidth != CurShieldWidth)
+            if ((int)targetShieldSize != CurShieldSize)
             {
                 if (!instant)
                 {
-                    if ((int)targetShieldWidth > CurShieldWidth)
+                    if ((int)targetShieldSize > CurShieldSize)
                     {
-                        CurShieldWidth += 100f * elapsedTime;
-                        if (CurShieldWidth > (int)targetShieldWidth)
+                        CurShieldSize += 100f * elapsedTime;
+                        if (CurShieldSize > (int)targetShieldSize)
                         {
-                            CurShieldWidth = targetShieldWidth;
+                            CurShieldSize = targetShieldSize;
                         }
                     }
                     else
                     {
-                        CurShieldWidth -= 100f * elapsedTime;
-                        if (CurShieldWidth < targetShieldWidth)
+                        CurShieldSize -= 100f * elapsedTime;
+                        if (CurShieldSize < targetShieldSize)
                         {
-                            CurShieldWidth = targetShieldWidth;
+                            CurShieldSize = targetShieldSize;
                         }
                     }
                 }
                 else
                 {
-                    CurShieldWidth = (int)targetShieldWidth;
+                    CurShieldSize = (int)targetShieldSize;
                 }
 
-                if (CurShieldWidth == 0)
+                if (CurShieldSize == 0)
                 {
                     ShieldBar.IsHidden = true;
                 }
                 else
                 {
-                    ShieldBar.Width = (int)CurShieldWidth;
-                    ShieldBar.SetBounds(CurHpWidth + HpBar.X, HpBar.Y, CurShieldWidth, ShieldBar.Height);
+                    ShieldBar.Width = (int)CurShieldSize;
+                    ShieldBar.SetBounds(CurHpSize + HpBar.X, HpBar.Y, CurShieldSize, ShieldBar.Height);
                     ShieldBar.SetTextureRect(
-                        (int)(HpBackground.Width - CurShieldWidth), 0, (int)CurShieldWidth, ShieldBar.Height
+                        (int)(HpBackground.Width - CurShieldSize), 0, (int)CurShieldSize, ShieldBar.Height
                     );
 
                     ShieldBar.IsHidden = false;
@@ -689,19 +684,18 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             }
             else
             {
-                ShieldBar.SetPosition(HpBar.X + CurHpWidth, HpBar.Y);
+                ShieldBar.SetPosition(HpBar.X + CurHpSize, HpBar.Y);
             }
         }
 
         private void UpdateMpBar(float elapsedTime, bool instant = false)
         {
-            var targetMpWidth = 0f;
-            
+            var targetMpSize = 0f;
             if (MyEntity.MaxVital[(int)Vitals.Mana] > 0)
             {
-                targetMpWidth = MyEntity.Vital[(int)Vitals.Mana] / (float)MyEntity.MaxVital[(int)Vitals.Mana];
-                targetMpWidth = Math.Min(1, Math.Max(0, targetMpWidth));
-                float mpPercentage = targetMpWidth * 100;
+                targetMpSize = MyEntity.Vital[(int) Vitals.Mana] / (float) MyEntity.MaxVital[(int) Vitals.Mana];
+                targetMpSize = Math.Min(1, Math.Max(0, targetMpSize));
+                float mpPercentage = targetMpSize * 100;
                 var mpPercentageText = $"{mpPercentage:0.##}%";
                 var mpValueText = Strings.EntityBox.vital1val.ToString(
                     MyEntity.Vital[(int)Vitals.Mana], MyEntity.MaxVital[(int)Vitals.Mana]
@@ -718,48 +712,48 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     MpBackground.SetToolTipText(mpPercentageText);
                 }
 
-                targetMpWidth *= MpBackground.Width;
+                targetMpSize *= MpBackground.Width;
             }
             else
             {
                 MpLbl.Text = Strings.EntityBox.vital1val.ToString(0, 0);
-                targetMpWidth = MpBackground.Width;
+                targetMpSize = MpBackground.Width;
             }
 
-            if (!targetMpWidth.Equals(CurMpWidth))
+            if (!targetMpSize.Equals(CurMpSize))
             {
                 if (!instant)
                 {
-                    if ((int)targetMpWidth > CurMpWidth)
+                    if ((int)targetMpSize > CurMpSize)
                     {
-                        CurMpWidth += 100f * elapsedTime;
-                        if (CurMpWidth > (int)targetMpWidth)
+                        CurMpSize += 100f * elapsedTime;
+                        if (CurMpSize > (int)targetMpSize)
                         {
-                            CurMpWidth = targetMpWidth;
+                            CurMpSize = targetMpSize;
                         }
                     }
                     else
                     {
-                        CurMpWidth -= 100f * elapsedTime;
-                        if (CurMpWidth < targetMpWidth)
+                        CurMpSize -= 100f * elapsedTime;
+                        if (CurMpSize < targetMpSize)
                         {
-                            CurMpWidth = targetMpWidth;
+                            CurMpSize = targetMpSize;
                         }
                     }
                 }
                 else
                 {
-                    CurMpWidth = (int)targetMpWidth;
+                    CurMpSize = (int)targetMpSize;
                 }
 
-                if (CurMpWidth == 0)
+                if (CurMpSize == 0)
                 {
                     MpBar.IsHidden = true;
                 }
                 else
                 {
-                    MpBar.Width = (int)CurMpWidth;
-                    MpBar.SetTextureRect(0, 0, (int)CurMpWidth, MpBar.Height);
+                    MpBar.Width = (int)CurMpSize;
+                    MpBar.SetTextureRect(0, 0, (int)CurMpSize, MpBar.Height);
                     MpBar.IsHidden = false;
                 }
             }
@@ -767,13 +761,12 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         private void UpdateXpBar(float elapsedTime, bool instant = false)
         {
-            float targetExpWidth = 1;
-
-            if (((Player)MyEntity).GetNextLevelExperience() > 0)
+            float targetExpSize = 1;
+            if (((Player) MyEntity).GetNextLevelExperience() > 0)
             {
-                targetExpWidth = (float)((Player)MyEntity).Experience /
+                targetExpSize = (float)((Player)MyEntity).Experience /
                                  (float)((Player)MyEntity).GetNextLevelExperience();
-                float expPercentage = targetExpWidth * 100;
+                float expPercentage = targetExpSize * 100;
                 var expPercentageText = $"{expPercentage:0.##}%";
                 var expValueText = Strings.EntityBox.expval.ToString(
                     ((Player)MyEntity)?.Experience, ((Player)MyEntity)?.GetNextLevelExperience()
@@ -792,48 +785,48 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             }
             else
             {
-                targetExpWidth = 1f;
+                targetExpSize = 1f;
                 ExpLbl.Text = Strings.EntityBox.maxlevel;
             }
 
-            targetExpWidth *= ExpBackground.Width;
-            if (Math.Abs((int) targetExpWidth - CurExpWidth) < 0.01)
+            targetExpSize *= ExpBackground.Width;
+            if (Math.Abs((int) targetExpSize - CurExpSize) < 0.01)
             {
                 return;
             }
 
             if (!instant)
             {
-                if ((int)targetExpWidth > CurExpWidth)
+                if ((int)targetExpSize > CurExpSize)
                 {
-                    CurExpWidth += 100f * elapsedTime;
-                    if (CurExpWidth > (int)targetExpWidth)
+                    CurExpSize += 100f * elapsedTime;
+                    if (CurExpSize > (int)targetExpSize)
                     {
-                        CurExpWidth = targetExpWidth;
+                        CurExpSize = targetExpSize;
                     }
                 }
                 else
                 {
-                    CurExpWidth -= 100f * elapsedTime;
-                    if (CurExpWidth < targetExpWidth)
+                    CurExpSize -= 100f * elapsedTime;
+                    if (CurExpSize < targetExpSize)
                     {
-                        CurExpWidth = targetExpWidth;
+                        CurExpSize = targetExpSize;
                     }
                 }
             }
             else
             {
-                CurExpWidth = (int)targetExpWidth;
+                CurExpSize = (int)targetExpSize;
             }
 
-            if (CurExpWidth == 0)
+            if (CurExpSize == 0)
             {
                 ExpBar.IsHidden = true;
             }
             else
             {
-                ExpBar.Width = (int) CurExpWidth;
-                ExpBar.SetTextureRect(0, 0, (int) CurExpWidth, ExpBar.Height);
+                ExpBar.Width = (int) CurExpSize;
+                ExpBar.SetTextureRect(0, 0, (int) CurExpSize, ExpBar.Height);
                 ExpBar.IsHidden = false;
             }
         }

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -694,25 +694,28 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
             if (MyEntity.MaxVital[(int) Vitals.Health] > 0)
             {
-                var maxVital = MyEntity.MaxVital[(int) Vitals.Health];
+                var entityVital = MyEntity.Vital[(int)Vitals.Health];
+                var entityMaxVital = MyEntity.MaxVital[(int) Vitals.Health];
+
                 var shieldSize = MyEntity.GetShieldSize();
                 var vitalSize = (int) clientSetting < (int) DisplayDirection.TopToBottom
                     ? HpBackground.Width
                     : HpBackground.Height;
 
-                if (shieldSize + MyEntity.Vital[(int) Vitals.Health] > maxVital)
+                //We have to get the maxVital value before being changed by the shield
+                //Shield changes vitalMax only on client, showing incorrect values
+                float hpPercentage = entityVital / (float)entityMaxVital * 100;
+
+                if (shieldSize + entityVital > entityMaxVital)
                 {
-                    maxVital = shieldSize + MyEntity.Vital[(int) Vitals.Health];
+                    entityMaxVital = shieldSize + entityVital;
                 }
 
-                targetHpSize = SetTargetBarSize(MyEntity.Vital[(int) Vitals.Health], maxVital, vitalSize);
-                targetShieldSize = SetTargetBarSize(shieldSize, maxVital, vitalSize);
+                targetHpSize = SetTargetBarSize(entityVital, entityMaxVital, vitalSize);
+                targetShieldSize = SetTargetBarSize(shieldSize, entityMaxVital, vitalSize);
 
-                float hpPercentage = (MyEntity.Vital[(int)Vitals.Health] / maxVital) * 100;
                 var hpPercentageText = $"{hpPercentage:0.##}%";
-                var hpValueText = Strings.EntityBox.vital0val.ToString(
-                    MyEntity.Vital[(int)Vitals.Health], MyEntity.MaxVital[(int)Vitals.Health]
-                );
+                var hpValueText = Strings.EntityBox.vital0val.ToString(entityVital, entityMaxVital);
 
                 if (Globals.Database.ShowHealthAsPercentage)
                 {
@@ -769,21 +772,19 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
             if (MyEntity.MaxVital[(int) Vitals.Mana] > 0)
             {
+
+                var entityVital = MyEntity.Vital[(int)Vitals.Mana];
+                var entityMaxVital = MyEntity.MaxVital[(int)Vitals.Mana];
+
                 var vitalSize = (int) clientSetting < (int) DisplayDirection.TopToBottom
                     ? MpBackground.Width
                     : MpBackground.Height;
 
-                targetMpSize = SetTargetBarSize(
-                    MyEntity.Vital[(int)Vitals.Mana],
-                    MyEntity.MaxVital[(int)Vitals.Mana],
-                    vitalSize
-                );
+                targetMpSize = SetTargetBarSize(entityVital, entityMaxVital, vitalSize);
 
-                float mpPercentage = targetMpSize * 100;
+                float mpPercentage = entityVital / (float)entityMaxVital * 100;
                 var mpPercentageText = $"{mpPercentage:0.##}%";
-                var mpValueText = Strings.EntityBox.vital1val.ToString(
-                    MyEntity.Vital[(int)Vitals.Mana], MyEntity.MaxVital[(int)Vitals.Mana]
-                );
+                var mpValueText = Strings.EntityBox.vital1val.ToString(entityVital, entityMaxVital);
 
                 if (Globals.Database.ShowManaAsPercentage)
                 {
@@ -795,8 +796,6 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     MpLbl.Text = mpValueText;
                     MpBackground.SetToolTipText(mpPercentageText);
                 }
-
-                targetMpSize *= MpBackground.Width;
             }
             else
             {
@@ -806,7 +805,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     : MpBackground.Height;
             }
 
-            if (!targetMpSize.Equals(CurMpSize))
+            if ((int)targetMpSize != CurMpSize)
             {
                 CurMpSize = SetCurrentBarSize(elapsedTime, instant, targetMpSize, CurMpSize);
 
@@ -825,19 +824,21 @@ namespace Intersect.Client.Interface.Game.EntityPanel
         {
             float targetExpSize = 1;
             var clientSetting = ClientConfiguration.Instance.EntityBarDirections[(int) Vitals.VitalCount];
-            var vitalSize = (int) clientSetting < (int) DisplayDirection.TopToBottom
-                    ? ExpBackground.Width
-                    : ExpBackground.Height;
 
             if (((Player)MyEntity).GetNextLevelExperience() > 0)
             {
+                var vitalSize = (int)clientSetting < (int)DisplayDirection.TopToBottom
+                    ? ExpBackground.Width
+                    : ExpBackground.Height;
+
                 targetExpSize = SetTargetBarSize(
                     ((Player)MyEntity).Experience,
                     ((Player)MyEntity).GetNextLevelExperience(),
                     vitalSize
                 );
 
-                float expPercentage = targetExpSize * 100;
+                float expPercentage =
+                    ((Player)MyEntity).Experience / (float)((Player)MyEntity).GetNextLevelExperience() * 100;
                 var expPercentageText = $"{expPercentage:0.##}%";
                 var expValueText = Strings.EntityBox.expval.ToString(
                     ((Player)MyEntity)?.Experience, ((Player)MyEntity)?.GetNextLevelExperience()

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -593,34 +593,93 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             }
         }
 
-        private void UpdateGauge(ImagePanel backgroundBar, ImagePanel foregroundBar, float CurrentBarSize, DisplayDirection direction)
+        private void UpdateGauge(
+            ImagePanel backgroundBar,
+            ImagePanel foregroundBar,
+            float CurrentBarSize,
+            DisplayDirection direction,
+            bool isShield = false
+        )
         {
-            switch(direction)
+            //If this method is called to update the shield, we need to invert the directions
+            if (isShield)
+            {
+                switch(direction)
+                {
+                    case DisplayDirection.StartToEnd:
+                        direction = DisplayDirection.EndToStart;
+                        foregroundBar.X = backgroundBar.X;
+                        break;
+                    case DisplayDirection.EndToStart:
+                        direction = DisplayDirection.StartToEnd;
+                        foregroundBar.X = backgroundBar.X;
+                        break;
+                    case DisplayDirection.TopToBottom:
+                        direction = DisplayDirection.BottomToTop;
+                        foregroundBar.X = backgroundBar.X;
+                        break;
+                    case DisplayDirection.BottomToTop:
+                        direction = DisplayDirection.TopToBottom;
+                        foregroundBar.X = backgroundBar.X;
+                        break;
+                }
+            }
+
+            var backgroundWidthFactor = backgroundBar.Width - (int)CurrentBarSize;
+            var backgroundHeightFactor = backgroundBar.Height - (int)CurrentBarSize;
+
+            switch (direction)
             {
                 case DisplayDirection.StartToEnd:
-                    foregroundBar.Width = (int) CurrentBarSize;
-                    foregroundBar.SetTextureRect(0, 0, (int) CurrentBarSize, foregroundBar.Height);
+                    foregroundBar.SetBounds(
+                        foregroundBar.X,
+                        foregroundBar.Y,
+                        (int) CurrentBarSize,
+                        foregroundBar.Height
+                    );
+
+                    foregroundBar.SetTextureRect(
+                        0, 0, (int) CurrentBarSize, foregroundBar.Height
+                    );
                     break;
 
                 case DisplayDirection.EndToStart:
-                    var backgroundWidthFactor = backgroundBar.Width - (int) CurrentBarSize;
+                    foregroundBar.SetBounds(
+                        backgroundBar.X + backgroundWidthFactor,
+                        foregroundBar.Y,
+                        (int) CurrentBarSize,
+                        foregroundBar.Height
+                    );
 
-                    foregroundBar.X = backgroundBar.X + backgroundWidthFactor;
-                    foregroundBar.Width = (int) CurrentBarSize;
-                    foregroundBar.SetTextureRect(backgroundWidthFactor, 0, (int) CurrentBarSize, foregroundBar.Height);
+                    foregroundBar.SetTextureRect(
+                        backgroundWidthFactor, 0, (int) CurrentBarSize, foregroundBar.Height
+                    );
                     break;
 
                 case DisplayDirection.TopToBottom:
-                    foregroundBar.Height = (int) CurrentBarSize;
-                    foregroundBar.SetTextureRect(0, 0, foregroundBar.Width, (int) CurrentBarSize);
+                    foregroundBar.SetBounds(
+                        foregroundBar.X,
+                        foregroundBar.Y,
+                        foregroundBar.Width,
+                        (int) CurrentBarSize
+                    );
+
+                    foregroundBar.SetTextureRect(
+                        0, 0, foregroundBar.Width, (int) CurrentBarSize
+                    );
                     break;
 
                 case DisplayDirection.BottomToTop:
-                    var backgroundHeightFactor = backgroundBar.Height - (int) CurrentBarSize;
+                    foregroundBar.SetBounds(
+                        foregroundBar.X,
+                        backgroundBar.Y + backgroundHeightFactor,
+                        foregroundBar.Width,
+                        (int) CurrentBarSize
+                    );
 
-                    foregroundBar.Y = backgroundBar.Y + backgroundHeightFactor;
-                    foregroundBar.Height = (int) CurrentBarSize;
-                    foregroundBar.SetTextureRect(0, backgroundHeightFactor, foregroundBar.Width, (int) CurrentBarSize);
+                    foregroundBar.SetTextureRect(
+                        0, backgroundHeightFactor, foregroundBar.Width, (int) CurrentBarSize
+                    );
                     break;
             }
 
@@ -669,7 +728,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             else
             {
                 HpLbl.Text = Strings.EntityBox.vital0val.ToString(0, 0);
-                targetHpSize = HpBackground.Width;
+                targetHpSize = (int) clientSetting < (int) DisplayDirection.TopToBottom
+                    ? HpBackground.Width
+                    : HpBackground.Height;
             }
 
             if ((int) targetHpSize != CurHpSize)
@@ -696,18 +757,8 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 }
                 else
                 {
-                    ShieldBar.Width = (int)CurShieldSize;
-                    ShieldBar.SetBounds(CurHpSize + HpBar.X, HpBar.Y, CurShieldSize, ShieldBar.Height);
-                    ShieldBar.SetTextureRect(
-                        (int)(HpBackground.Width - CurShieldSize), 0, (int)CurShieldSize, ShieldBar.Height
-                    );
-
-                    ShieldBar.IsHidden = false;
+                    UpdateGauge(HpBackground, ShieldBar, CurShieldSize, clientSetting, true);
                 }
-            }
-            else
-            {
-                ShieldBar.SetPosition(HpBar.X + CurHpSize, HpBar.Y);
             }
         }
 
@@ -750,7 +801,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             else
             {
                 MpLbl.Text = Strings.EntityBox.vital1val.ToString(0, 0);
-                targetMpSize = MpBackground.Width;
+                targetMpSize = (int) clientSetting < (int) DisplayDirection.TopToBottom
+                    ? MpBackground.Width
+                    : MpBackground.Height;
             }
 
             if (!targetMpSize.Equals(CurMpSize))


### PR DESCRIPTION
Resolves #1164

Adds two client options to choose the direction from which vitals and experience bars are filled and emptied.
This opens up a wide range of possibilities by allowing for a better customization of vitals/exp bars.

https://user-images.githubusercontent.com/63019821/185804094-155b3e0b-4198-4853-b602-3a9fbc3e97d6.mp4


