### PR TITLE
fix 1207: properly sets MouseInput on CellText

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Layout/TableRow.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Layout/TableRow.cs
@@ -352,7 +352,8 @@ namespace Intersect.Client.Framework.Gwen.Control.Layout
         /// </summary>
         /// <param name="column">Column number.</param>
         /// <param name="text">Text to set.</param>
-        public void SetCellText(int column, string text)
+        /// <param name="enableMouseInput">Determines whether mouse input should be enabled for the cell.</param>
+        public void SetCellText(int column, string text, bool enableMouseInput = false)
         {
             if (null == mColumns[column])
             {
@@ -360,6 +361,7 @@ namespace Intersect.Client.Framework.Gwen.Control.Layout
             }
 
             mColumns[column].Text = text;
+            mColumns[column].MouseInputEnabled = enableMouseInput;
         }
 
         /// <summary>


### PR DESCRIPTION
Should resolve #1207 by adding the boolean parameter 'enableMouseInput' as false by default into the SetCellText method in order to disable the MouseInput within cell's text, which now allows to properly hover/click their parent buttons/elements.

### Preview:

https://user-images.githubusercontent.com/17498701/186951416-a377a016-40e2-4c4d-b58d-a8beb58d4c2c.mp4

![image](https://user-images.githubusercontent.com/17498701/186951462-6375585f-e4ca-4a01-bc41-8dc94fc83290.png)

