### PR TITLE
Custom Animations

### DIFF
--- a/Intersect (Core)/GameObjects/ClassBase.cs
+++ b/Intersect (Core)/GameObjects/ClassBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -90,6 +90,8 @@ namespace Intersect.GameObjects
         public int AttackSpeedModifier { get; set; }
 
         public int AttackSpeedValue { get; set; }
+
+        public string AttackSpriteOverride { get; set; }
 
         public long BaseExp
         {

--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -132,6 +132,8 @@ namespace Intersect.GameObjects
 
         public int AttackSpeedValue { get; set; }
 
+        public string WeaponSpriteOverride { get; set; }
+
         public ConsumableData Consumable { get; set; }
 
         public int EquipmentSlot { get; set; }

--- a/Intersect (Core)/GameObjects/SpellBase.cs
+++ b/Intersect (Core)/GameObjects/SpellBase.cs
@@ -108,6 +108,8 @@ namespace Intersect.GameObjects
 
         public string CannotCastMessage { get; set; } = "";
 
+        public string CastSpriteOverride { get; set; }
+
         //Combat Info
         public SpellCombatData Combat { get; set; } = new SpellCombatData();
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1710,7 +1710,9 @@ namespace Intersect.Client.Entities
                                 SpriteAnimation = SpriteAnimations.Weapon;
                             }
 
-                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _) && item.ProjectileId != Guid.Empty)
+                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _) &&
+                                item.ProjectileId != Guid.Empty &&
+                                item.WeaponSpriteOverride == null)
                             {
                                 SpriteAnimation = SpriteAnimations.Shoot;
                             }
@@ -1736,7 +1738,9 @@ namespace Intersect.Client.Entities
                         SpriteAnimation = SpriteAnimations.Cast;
                     }
 
-                    if (spell.SpellType == SpellTypes.CombatSpell && spell.Combat.TargetType == SpellTargetTypes.Projectile)
+                    if (spell.SpellType == SpellTypes.CombatSpell &&
+                        spell.Combat.TargetType == SpellTargetTypes.Projectile &&
+                        spell.CastSpriteOverride == null)
                     {
                         if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _))
                         {

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -61,7 +61,22 @@ namespace Intersect.Client.Entities
 
         public float elapsedtime { get; set; } //to be removed
 
-        public Guid[] Equipment { get; set; } = new Guid[Options.EquipmentSlots.Count];
+        private Guid[] _equipment = new Guid[Options.EquipmentSlots.Count];
+
+        public Guid[] Equipment
+        {
+            get => _equipment;
+            set
+            {
+                if (_equipment == value)
+                {
+                    return;
+                }
+
+                _equipment = value;
+                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Weapon);
+            }
+        }
 
         IReadOnlyList<int> IEntity.EquipmentSlots => MyEquipment.ToList();
 
@@ -144,7 +159,22 @@ namespace Intersect.Client.Entities
         //Rendering Variables
         public HashSet<Entity> RenderList { get; set; }
 
-        public Guid SpellCast { get; set; }
+        private Guid _spellCast;
+
+        public Guid SpellCast
+        {
+            get => _spellCast;
+            set
+            {
+                if (value == SpellCast)
+                {
+                    return;
+                }
+
+                _spellCast = value;
+                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Cast);
+            }
+        }
 
         public Spell[] Spells { get; set; } = new Spell[Options.MaxPlayerSkills];
 
@@ -938,8 +968,12 @@ namespace Intersect.Client.Entities
                 Sprite = sprite;
             }
 
-            var texture = AnimatedTextures[SpriteAnimation] ?? Texture;
-            if (texture == null)
+            if (!AnimatedTextures.TryGetValue(SpriteAnimation, out var texture))
+            {
+                texture = Texture;
+            }
+
+            if (texture == default)
             {
                 // We don't have a texture to render, but we still want this to be targetable.
                 WorldPos = new FloatRect(
@@ -1011,9 +1045,10 @@ namespace Intersect.Client.Entities
                             }
 
                             var item = ItemBase.Get(itemId);
-                            if (item != null)
+                            if (ItemBase.TryGet(itemId, out var itemDescriptor))
                             {
-                                DrawEquipment(Gender == 0 ? item.MalePaperdoll : item.FemalePaperdoll, item.Color * renderColor, destRectangle);
+                                var itemPaperdoll = Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                DrawEquipment(itemPaperdoll, item.Color * renderColor, destRectangle);
                             }
                         }
                     }
@@ -1052,8 +1087,19 @@ namespace Intersect.Client.Entities
             }
 
             var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
+            string filenameSuffix = SpriteAnimation.ToString();
+
+            if (SpriteAnimation == SpriteAnimations.Attack ||
+                SpriteAnimation == SpriteAnimations.Cast ||
+                SpriteAnimation == SpriteAnimations.Weapon)
+            {
+                var animationName = Path.GetFileNameWithoutExtension(AnimatedTextures[SpriteAnimation].Name);
+                int separatorIndex = animationName.IndexOf('_') + 1;
+                filenameSuffix = animationName.Substring(separatorIndex);
+            }
+
             var paperdollTex = Globals.ContentManager.GetTexture(
-                TextureType.Paperdoll, $"{filenameNoExt}_{SpriteAnimation}.png"
+                TextureType.Paperdoll, $"{filenameNoExt}_{filenameSuffix}.png"
             );
 
             var spriteFrames = SpriteFrames;
@@ -1610,15 +1656,18 @@ namespace Intersect.Client.Entities
 
         public void UpdateSpriteAnimation()
         {
-            var oldAnim = SpriteAnimation;
-
             //Exit if textures haven't been loaded yet
             if (AnimatedTextures.Count == 0)
             {
                 return;
             }
 
-            SpriteAnimation = AnimatedTextures[SpriteAnimations.Idle] != null && LastActionTime + Options.Instance.Sprites.TimeBeforeIdle < Timing.Global.Milliseconds ? SpriteAnimations.Idle : SpriteAnimations.Normal;
+            SpriteAnimation = SpriteAnimations.Normal;
+            if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _) && LastActionTime + Options.Instance.Sprites.TimeBeforeIdle < Timing.Global.Milliseconds)
+            {
+                SpriteAnimation = SpriteAnimations.Idle;
+            }
+
             if (IsMoving)
             {
                 SpriteAnimation = SpriteAnimations.Normal;
@@ -1629,7 +1678,7 @@ namespace Intersect.Client.Entities
                 var timeIn = CalculateAttackTime() - (AttackTimer - Timing.Global.Ticks / TimeSpan.TicksPerMillisecond);
                 LastActionTime = Timing.Global.Milliseconds;
 
-                if (AnimatedTextures[SpriteAnimations.Attack] != null)
+                if (AnimatedTextures.TryGetValue(SpriteAnimations.Attack, out _))
                 {
                     SpriteAnimation = SpriteAnimations.Attack;
                 }
@@ -1656,12 +1705,12 @@ namespace Intersect.Client.Entities
                         var item = ItemBase.Get(itemId);
                         if (item != null)
                         {
-                            if (AnimatedTextures[SpriteAnimations.Weapon] != null)
+                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
                             {
                                 SpriteAnimation = SpriteAnimations.Weapon;
                             }
 
-                            if (AnimatedTextures[SpriteAnimations.Shoot] != null && item.ProjectileId != Guid.Empty)
+                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _) && item.ProjectileId != Guid.Empty)
                             {
                                 SpriteAnimation = SpriteAnimations.Shoot;
                             }
@@ -1682,15 +1731,17 @@ namespace Intersect.Client.Entities
                     var duration = spell.CastDuration;
                     var timeIn = duration - (CastTime - Timing.Global.Milliseconds);
 
-                    if (AnimatedTextures[SpriteAnimations.Cast] != null)
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Cast, out _))
                     {
                         SpriteAnimation = SpriteAnimations.Cast;
                     }
 
-                    if (spell.SpellType == SpellTypes.CombatSpell &&
-                        spell.Combat.TargetType == SpellTargetTypes.Projectile && AnimatedTextures[SpriteAnimations.Shoot] != null)
+                    if (spell.SpellType == SpellTypes.CombatSpell && spell.Combat.TargetType == SpellTargetTypes.Projectile)
                     {
-                        SpriteAnimation = SpriteAnimations.Shoot;
+                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _))
+                        {
+                            SpriteAnimation = SpriteAnimations.Shoot;
+                        }
                     }
 
                     SpriteFrame = (int)Math.Floor((timeIn / (duration / (float)SpriteFrames)));
@@ -1724,26 +1775,103 @@ namespace Intersect.Client.Entities
 
         public virtual void LoadTextures(string textureName)
         {
-            Texture = Globals.ContentManager.GetTexture(TextureType.Entity, textureName);
-            LoadAnimationTextures(textureName);
+            AnimatedTextures.Clear();
+            foreach (SpriteAnimations spriteAnimation in Enum.GetValues(typeof(SpriteAnimations)))
+            {
+                if (spriteAnimation == SpriteAnimations.Normal)
+                {
+                    Texture = Globals.ContentManager.GetTexture(TextureType.Entity, textureName);
+                }
+                else
+                {
+                    LoadAnimationTexture(textureName, spriteAnimation);
+                }
+            }
         }
 
-        public virtual void LoadAnimationTextures(string textureName)
+        protected virtual void LoadAnimationTexture(string textureName, SpriteAnimations spriteAnimation)
+        {
+            SpriteAnimations spriteAnimationOveride = spriteAnimation;
+            string textureOverride = default;
+
+            switch (spriteAnimation)
+            {
+                // No override for this
+                case SpriteAnimations.Normal: break;
+
+                case SpriteAnimations.Idle: break;
+                case SpriteAnimations.Attack:
+                    if (this is Player player && ClassBase.TryGet(player.Class, out var classDescriptor))
+                    {
+                        textureOverride = classDescriptor.AttackSpriteOverride;
+                    }
+                    break;
+
+                case SpriteAnimations.Shoot:
+                    {
+                        if (Equipment.Length <= Options.WeaponIndex)
+                        {
+                            break;
+                        }
+
+                        var weaponId = Equipment[Options.WeaponIndex];
+                        if (ItemBase.TryGet(weaponId, out var itemDescriptor))
+                        {
+                            textureOverride = itemDescriptor.WeaponSpriteOverride;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(textureOverride))
+                        {
+                            spriteAnimationOveride = SpriteAnimations.Weapon;
+                        }
+                    }
+                    break;
+
+                case SpriteAnimations.Cast:
+                    if (SpellBase.TryGet(SpellCast, out var spellDescriptor))
+                    {
+                        textureOverride = spellDescriptor.CastSpriteOverride;
+                    }
+                    break;
+
+                case SpriteAnimations.Weapon:
+                    {
+                        if (Equipment.Length <= Options.WeaponIndex)
+                        {
+                            break;
+                        }
+
+                        var weaponId = Equipment[Options.WeaponIndex];
+                        if (ItemBase.TryGet(weaponId, out var itemDescriptor))
+                        {
+                            textureOverride = itemDescriptor.WeaponSpriteOverride;
+                        }
+                    }
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(spriteAnimation));
+            }
+
+            if (TryGetAnimationTexture(textureName, spriteAnimationOveride, textureOverride, out var texture))
+            {
+                AnimatedTextures[spriteAnimation] = texture;
+            }
+        }
+
+        protected virtual bool TryGetAnimationTexture(string textureName, SpriteAnimations spriteAnimation, string textureOverride, out GameTexture texture)
         {
             var baseFilename = Path.GetFileNameWithoutExtension(textureName);
             var extension = Path.GetExtension(textureName);
+            var animationTextureName = $"{baseFilename}_{spriteAnimation.ToString()?.ToLowerInvariant() ?? string.Empty}";
 
-            AnimatedTextures.Clear();
-            foreach (var animationName in Enum.GetValues(typeof(SpriteAnimations)))
+            if (!string.IsNullOrWhiteSpace(textureOverride))
             {
-                AnimatedTextures.Add(
-                    (SpriteAnimations)animationName,
-                    Globals.ContentManager.GetTexture(
-                        TextureType.Entity,
-                        $@"{baseFilename}_{animationName}{extension}"
-                    )
-                );
+                animationTextureName = $"{animationTextureName}_{textureOverride}";
             }
+
+            texture = Globals.ContentManager.GetTexture(TextureType.Entity, $"{animationTextureName}{extension}");
+            return texture != default;
         }
 
         //Movement

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -31,7 +31,22 @@ namespace Intersect.Client.Entities
 
         public delegate void InventoryUpdated();
 
-        public Guid Class { get; set; }
+        private Guid _class;
+
+        public Guid Class
+        {
+            get => _class;
+            set
+            {
+                if (_class == value)
+                {
+                    return;
+                }
+
+                _class = value;
+                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Attack);
+            }
+        }
 
         public long Experience { get; set; } = 0;
 
@@ -113,7 +128,7 @@ namespace Intersect.Client.Entities
         /// <summary>
         /// Obtains our rank and permissions from the game config
         /// </summary>
-        public GuildRank GuildRank => IsInGuild ? Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(this.Rank, Options.Instance.Guild.Ranks.Length - 1))] : null;
+        public GuildRank GuildRank => IsInGuild ? Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Rank, Options.Instance.Guild.Ranks.Length - 1))] : null;
 
         /// <summary>
         /// Contains a record of all members of this player's guild.
@@ -300,11 +315,11 @@ namespace Intersect.Client.Entities
             {
                 if (this == Globals.Me && playerPacket.Equipment.InventorySlots != null)
                 {
-                    this.MyEquipment = playerPacket.Equipment.InventorySlots;
+                    MyEquipment = playerPacket.Equipment.InventorySlots;
                 }
                 else if (playerPacket.Equipment.ItemIds != null)
                 {
-                    this.Equipment = playerPacket.Equipment.ItemIds;
+                    Equipment = playerPacket.Equipment.ItemIds;
                 }
             }
 

--- a/Intersect.Editor/Forms/Editors/frmClass.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.Designer.cs
@@ -1,4 +1,4 @@
-﻿using DarkUI.Controls;
+using DarkUI.Controls;
 
 namespace Intersect.Editor.Forms.Editors
 {
@@ -31,9 +31,9 @@ namespace Intersect.Editor.Forms.Editors
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmClass));
             this.grpClasses = new DarkUI.Controls.DarkGroupBox();
             this.btnClearSearch = new DarkUI.Controls.DarkButton();
@@ -99,6 +99,7 @@ namespace Intersect.Editor.Forms.Editors
             this.lblSpawnItemAmount = new System.Windows.Forms.Label();
             this.lblSpawnItem = new System.Windows.Forms.Label();
             this.grpCombat = new DarkUI.Controls.DarkGroupBox();
+            this.lblSpriteAttack = new System.Windows.Forms.Label();
             this.grpAttackSpeed = new DarkUI.Controls.DarkGroupBox();
             this.nudAttackSpeedValue = new DarkUI.Controls.DarkNumericUpDown();
             this.lblAttackSpeedValue = new System.Windows.Forms.Label();
@@ -174,6 +175,7 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
             this.mnuExpGrid = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.btnExpPaste = new System.Windows.Forms.ToolStripMenuItem();
+            this.cmbAttackSprite = new DarkUI.Controls.DarkComboBox();
             this.grpClasses.SuspendLayout();
             this.grpBaseStats.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudBaseMana)).BeginInit();
@@ -1151,6 +1153,8 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpCombat.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpCombat.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpCombat.Controls.Add(this.cmbAttackSprite);
+            this.grpCombat.Controls.Add(this.lblSpriteAttack);
             this.grpCombat.Controls.Add(this.grpAttackSpeed);
             this.grpCombat.Controls.Add(this.nudCritMultiplier);
             this.grpCombat.Controls.Add(this.lblCritMultiplier);
@@ -1169,10 +1173,19 @@ namespace Intersect.Editor.Forms.Editors
             this.grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpCombat.Location = new System.Drawing.Point(537, 169);
             this.grpCombat.Name = "grpCombat";
-            this.grpCombat.Size = new System.Drawing.Size(226, 405);
+            this.grpCombat.Size = new System.Drawing.Size(226, 446);
             this.grpCombat.TabIndex = 30;
             this.grpCombat.TabStop = false;
             this.grpCombat.Text = "Combat (Unarmed)";
+            // 
+            // lblSpriteAttack
+            // 
+            this.lblSpriteAttack.AutoSize = true;
+            this.lblSpriteAttack.Location = new System.Drawing.Point(10, 267);
+            this.lblSpriteAttack.Name = "lblSpriteAttack";
+            this.lblSpriteAttack.Size = new System.Drawing.Size(120, 13);
+            this.lblSpriteAttack.TabIndex = 67;
+            this.lblSpriteAttack.Text = "Sprite Attack Animation:";
             // 
             // grpAttackSpeed
             // 
@@ -1183,7 +1196,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpAttackSpeed.Controls.Add(this.cmbAttackSpeedModifier);
             this.grpAttackSpeed.Controls.Add(this.lblAttackSpeedModifier);
             this.grpAttackSpeed.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpAttackSpeed.Location = new System.Drawing.Point(13, 309);
+            this.grpAttackSpeed.Location = new System.Drawing.Point(13, 351);
             this.grpAttackSpeed.Name = "grpAttackSpeed";
             this.grpAttackSpeed.Size = new System.Drawing.Size(192, 86);
             this.grpAttackSpeed.TabIndex = 66;
@@ -1429,7 +1442,7 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbAttackAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbAttackAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbAttackAnimation.FormattingEnabled = true;
-            this.cmbAttackAnimation.Location = new System.Drawing.Point(12, 277);
+            this.cmbAttackAnimation.Location = new System.Drawing.Point(12, 325);
             this.cmbAttackAnimation.Name = "cmbAttackAnimation";
             this.cmbAttackAnimation.Size = new System.Drawing.Size(192, 21);
             this.cmbAttackAnimation.TabIndex = 50;
@@ -1440,11 +1453,11 @@ namespace Intersect.Editor.Forms.Editors
             // lblAttackAnimation
             // 
             this.lblAttackAnimation.AutoSize = true;
-            this.lblAttackAnimation.Location = new System.Drawing.Point(9, 262);
+            this.lblAttackAnimation.Location = new System.Drawing.Point(9, 310);
             this.lblAttackAnimation.Name = "lblAttackAnimation";
-            this.lblAttackAnimation.Size = new System.Drawing.Size(90, 13);
+            this.lblAttackAnimation.Size = new System.Drawing.Size(117, 13);
             this.lblAttackAnimation.TabIndex = 49;
-            this.lblAttackAnimation.Text = "Attack Animation:";
+            this.lblAttackAnimation.Text = "Extra Attack Animation:";
             // 
             // lblDamage
             // 
@@ -1667,21 +1680,21 @@ namespace Intersect.Editor.Forms.Editors
             this.expGrid.AllowUserToDeleteRows = false;
             this.expGrid.AllowUserToResizeColumns = false;
             this.expGrid.AllowUserToResizeRows = false;
-            dataGridViewCellStyle1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(50)))), ((int)(((byte)(53)))), ((int)(((byte)(55)))));
-            this.expGrid.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(50)))), ((int)(((byte)(53)))), ((int)(((byte)(55)))));
+            this.expGrid.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle4;
             this.expGrid.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.expGrid.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.expGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.expGrid.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
             this.expGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Gainsboro;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.expGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.Color.Gainsboro;
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.expGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle5;
             this.expGrid.ColumnHeadersHeight = 24;
             this.expGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.expGrid.EnableHeadersVisualStyles = false;
@@ -1689,8 +1702,8 @@ namespace Intersect.Editor.Forms.Editors
             this.expGrid.MultiSelect = false;
             this.expGrid.Name = "expGrid";
             this.expGrid.RowHeadersVisible = false;
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.expGrid.RowsDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.expGrid.RowsDefaultCellStyle = dataGridViewCellStyle6;
             this.expGrid.Size = new System.Drawing.Size(515, 125);
             this.expGrid.TabIndex = 0;
             this.expGrid.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.expGrid_CellEndEdit);
@@ -2243,6 +2256,27 @@ namespace Intersect.Editor.Forms.Editors
             this.btnExpPaste.Text = "Paste";
             this.btnExpPaste.Click += new System.EventHandler(this.btnPaste_Click);
             // 
+            // cmbAttackSprite
+            // 
+            this.cmbAttackSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbAttackSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbAttackSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbAttackSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbAttackSprite.DrawDropdownHoverOutline = false;
+            this.cmbAttackSprite.DrawFocusRectangle = false;
+            this.cmbAttackSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbAttackSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbAttackSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbAttackSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbAttackSprite.FormattingEnabled = true;
+            this.cmbAttackSprite.Location = new System.Drawing.Point(12, 283);
+            this.cmbAttackSprite.Name = "cmbAttackSprite";
+            this.cmbAttackSprite.Size = new System.Drawing.Size(192, 21);
+            this.cmbAttackSprite.TabIndex = 68;
+            this.cmbAttackSprite.Text = null;
+            this.cmbAttackSprite.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbAttackSprite.SelectedIndexChanged += new System.EventHandler(this.cmbAttackSprite_SelectedIndexChanged);
+            // 
             // FrmClass
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2473,5 +2507,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkComboBox cmbAttackSpeedModifier;
         private System.Windows.Forms.Label lblAttackSpeedModifier;
         private Controls.GameObjectList lstGameObjects;
+        private System.Windows.Forms.Label lblSpriteAttack;
+        private DarkComboBox cmbAttackSprite;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -174,6 +174,9 @@ namespace Intersect.Editor.Forms.Editors
                 nudScaling.Value = mEditorItem.Scaling;
                 cmbDamageType.SelectedIndex = mEditorItem.DamageType;
                 cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
+                cmbAttackSprite.SelectedIndex = cmbAttackSprite.FindString(
+                        TextUtils.NullToNone(mEditorItem.AttackSpriteOverride)
+                );
                 cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
                 cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
                 nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
@@ -299,6 +302,11 @@ namespace Intersect.Editor.Forms.Editors
             cmbAttackAnimation.Items.Clear();
             cmbAttackAnimation.Items.Add(Strings.General.None);
             cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
+            cmbAttackSprite.Items.Clear();
+            cmbAttackSprite.Items.Add(Strings.General.None);
+            cmbAttackSprite.Items.AddRange(
+                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "attack").ToArray()
+            );
             cmbScalingStat.Items.Clear();
             for (var x = 0; x < ((int)Stats.Speed) + 1; x++)
             {
@@ -394,6 +402,7 @@ namespace Intersect.Editor.Forms.Editors
             lblScalingStat.Text = Strings.ClassEditor.scalingstat;
             lblScalingAmount.Text = Strings.ClassEditor.scalingamount;
             lblAttackAnimation.Text = Strings.ClassEditor.attackanimation;
+            lblSpriteAttack.Text = Strings.ClassEditor.AttackSpriteOverride;
 
             grpAttackSpeed.Text = Strings.NpcEditor.attackspeed;
             lblAttackSpeedModifier.Text = Strings.NpcEditor.attackspeedmodifier;
@@ -909,6 +918,11 @@ namespace Intersect.Editor.Forms.Editors
         {
             mEditorItem.AttackAnimation =
                 AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+        }
+
+        private void cmbAttackSprite_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mEditorItem.AttackSpriteOverride = TextUtils.SanitizeNone(cmbAttackSprite?.Text);
         }
 
         private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
@@ -1525,7 +1539,6 @@ namespace Intersect.Editor.Forms.Editors
         }
 
         #endregion
-
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -159,6 +159,7 @@ namespace Intersect.Editor.Forms.Editors
             this.nudBlockChance = new DarkUI.Controls.DarkNumericUpDown();
             this.lblBlockChance = new System.Windows.Forms.Label();
             this.grpWeaponProperties = new DarkUI.Controls.DarkGroupBox();
+            this.lblSpriteAttack = new System.Windows.Forms.Label();
             this.nudCritMultiplier = new DarkUI.Controls.DarkNumericUpDown();
             this.lblCritMultiplier = new System.Windows.Forms.Label();
             this.grpAttackSpeed = new DarkUI.Controls.DarkGroupBox();
@@ -214,6 +215,7 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
+            this.cmbWeaponSprite = new DarkUI.Controls.DarkComboBox();
             this.grpItems.SuspendLayout();
             this.grpGeneral.SuspendLayout();
             this.grpRequirements.SuspendLayout();
@@ -1094,7 +1096,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEquipment.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpEquipment.Location = new System.Drawing.Point(2, 435);
             this.grpEquipment.Name = "grpEquipment";
-            this.grpEquipment.Size = new System.Drawing.Size(439, 742);
+            this.grpEquipment.Size = new System.Drawing.Size(439, 794);
             this.grpEquipment.TabIndex = 12;
             this.grpEquipment.TabStop = false;
             this.grpEquipment.Text = "Equipment";
@@ -1364,7 +1366,7 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbEquipmentAnimation.FormattingEnabled = true;
             this.cmbEquipmentAnimation.Items.AddRange(new object[] {
             "None"});
-            this.cmbEquipmentAnimation.Location = new System.Drawing.Point(221, 509);
+            this.cmbEquipmentAnimation.Location = new System.Drawing.Point(221, 557);
             this.cmbEquipmentAnimation.Name = "cmbEquipmentAnimation";
             this.cmbEquipmentAnimation.Size = new System.Drawing.Size(207, 21);
             this.cmbEquipmentAnimation.TabIndex = 57;
@@ -1375,7 +1377,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblEquipmentAnimation
             // 
             this.lblEquipmentAnimation.AutoSize = true;
-            this.lblEquipmentAnimation.Location = new System.Drawing.Point(218, 493);
+            this.lblEquipmentAnimation.Location = new System.Drawing.Point(218, 541);
             this.lblEquipmentAnimation.Name = "lblEquipmentAnimation";
             this.lblEquipmentAnimation.Size = new System.Drawing.Size(109, 13);
             this.lblEquipmentAnimation.TabIndex = 56;
@@ -1385,9 +1387,9 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.nudEffectPercent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
             this.nudEffectPercent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudEffectPercent.Location = new System.Drawing.Point(103, 510);
+            this.nudEffectPercent.Location = new System.Drawing.Point(14, 558);
             this.nudEffectPercent.Name = "nudEffectPercent";
-            this.nudEffectPercent.Size = new System.Drawing.Size(114, 20);
+            this.nudEffectPercent.Size = new System.Drawing.Size(203, 20);
             this.nudEffectPercent.TabIndex = 55;
             this.nudEffectPercent.Value = new decimal(new int[] {
             0,
@@ -1824,9 +1826,9 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbFemalePaperdoll.FormattingEnabled = true;
             this.cmbFemalePaperdoll.Items.AddRange(new object[] {
             "None"});
-            this.cmbFemalePaperdoll.Location = new System.Drawing.Point(221, 550);
+            this.cmbFemalePaperdoll.Location = new System.Drawing.Point(221, 598);
             this.cmbFemalePaperdoll.Name = "cmbFemalePaperdoll";
-            this.cmbFemalePaperdoll.Size = new System.Drawing.Size(168, 21);
+            this.cmbFemalePaperdoll.Size = new System.Drawing.Size(207, 21);
             this.cmbFemalePaperdoll.TabIndex = 36;
             this.cmbFemalePaperdoll.Text = "None";
             this.cmbFemalePaperdoll.TextPadding = new System.Windows.Forms.Padding(2);
@@ -1835,7 +1837,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblFemalePaperdoll
             // 
             this.lblFemalePaperdoll.AutoSize = true;
-            this.lblFemalePaperdoll.Location = new System.Drawing.Point(218, 533);
+            this.lblFemalePaperdoll.Location = new System.Drawing.Point(218, 581);
             this.lblFemalePaperdoll.Name = "lblFemalePaperdoll";
             this.lblFemalePaperdoll.Size = new System.Drawing.Size(91, 13);
             this.lblFemalePaperdoll.TabIndex = 35;
@@ -1844,7 +1846,7 @@ namespace Intersect.Editor.Forms.Editors
             // picFemalePaperdoll
             // 
             this.picFemalePaperdoll.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
-            this.picFemalePaperdoll.Location = new System.Drawing.Point(221, 577);
+            this.picFemalePaperdoll.Location = new System.Drawing.Point(221, 625);
             this.picFemalePaperdoll.Name = "picFemalePaperdoll";
             this.picFemalePaperdoll.Size = new System.Drawing.Size(200, 156);
             this.picFemalePaperdoll.TabIndex = 34;
@@ -1853,7 +1855,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblEffectPercent
             // 
             this.lblEffectPercent.AutoSize = true;
-            this.lblEffectPercent.Location = new System.Drawing.Point(10, 512);
+            this.lblEffectPercent.Location = new System.Drawing.Point(10, 542);
             this.lblEffectPercent.Name = "lblEffectPercent";
             this.lblEffectPercent.Size = new System.Drawing.Size(94, 13);
             this.lblEffectPercent.TabIndex = 31;
@@ -1872,7 +1874,7 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbEquipmentBonus.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbEquipmentBonus.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbEquipmentBonus.FormattingEnabled = true;
-            this.cmbEquipmentBonus.Location = new System.Drawing.Point(103, 483);
+            this.cmbEquipmentBonus.Location = new System.Drawing.Point(103, 504);
             this.cmbEquipmentBonus.Name = "cmbEquipmentBonus";
             this.cmbEquipmentBonus.Size = new System.Drawing.Size(114, 21);
             this.cmbEquipmentBonus.TabIndex = 29;
@@ -1883,7 +1885,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblBonusEffect
             // 
             this.lblBonusEffect.AutoSize = true;
-            this.lblBonusEffect.Location = new System.Drawing.Point(10, 486);
+            this.lblBonusEffect.Location = new System.Drawing.Point(10, 507);
             this.lblBonusEffect.Name = "lblBonusEffect";
             this.lblBonusEffect.Size = new System.Drawing.Size(71, 13);
             this.lblBonusEffect.TabIndex = 28;
@@ -1934,9 +1936,9 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbMalePaperdoll.FormattingEnabled = true;
             this.cmbMalePaperdoll.Items.AddRange(new object[] {
             "None"});
-            this.cmbMalePaperdoll.Location = new System.Drawing.Point(11, 550);
+            this.cmbMalePaperdoll.Location = new System.Drawing.Point(11, 598);
             this.cmbMalePaperdoll.Name = "cmbMalePaperdoll";
-            this.cmbMalePaperdoll.Size = new System.Drawing.Size(168, 21);
+            this.cmbMalePaperdoll.Size = new System.Drawing.Size(206, 21);
             this.cmbMalePaperdoll.TabIndex = 22;
             this.cmbMalePaperdoll.Text = "None";
             this.cmbMalePaperdoll.TextPadding = new System.Windows.Forms.Padding(2);
@@ -1945,7 +1947,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblMalePaperdoll
             // 
             this.lblMalePaperdoll.AutoSize = true;
-            this.lblMalePaperdoll.Location = new System.Drawing.Point(8, 533);
+            this.lblMalePaperdoll.Location = new System.Drawing.Point(8, 581);
             this.lblMalePaperdoll.Name = "lblMalePaperdoll";
             this.lblMalePaperdoll.Size = new System.Drawing.Size(80, 13);
             this.lblMalePaperdoll.TabIndex = 21;
@@ -1954,7 +1956,7 @@ namespace Intersect.Editor.Forms.Editors
             // picMalePaperdoll
             // 
             this.picMalePaperdoll.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
-            this.picMalePaperdoll.Location = new System.Drawing.Point(11, 577);
+            this.picMalePaperdoll.Location = new System.Drawing.Point(11, 625);
             this.picMalePaperdoll.Name = "picMalePaperdoll";
             this.picMalePaperdoll.Size = new System.Drawing.Size(200, 156);
             this.picMalePaperdoll.TabIndex = 16;
@@ -2059,6 +2061,8 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpWeaponProperties.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpWeaponProperties.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpWeaponProperties.Controls.Add(this.cmbWeaponSprite);
+            this.grpWeaponProperties.Controls.Add(this.lblSpriteAttack);
             this.grpWeaponProperties.Controls.Add(this.nudCritMultiplier);
             this.grpWeaponProperties.Controls.Add(this.lblCritMultiplier);
             this.grpWeaponProperties.Controls.Add(this.grpAttackSpeed);
@@ -2082,11 +2086,20 @@ namespace Intersect.Editor.Forms.Editors
             this.grpWeaponProperties.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpWeaponProperties.Location = new System.Drawing.Point(221, 14);
             this.grpWeaponProperties.Name = "grpWeaponProperties";
-            this.grpWeaponProperties.Size = new System.Drawing.Size(207, 463);
+            this.grpWeaponProperties.Size = new System.Drawing.Size(207, 519);
             this.grpWeaponProperties.TabIndex = 39;
             this.grpWeaponProperties.TabStop = false;
             this.grpWeaponProperties.Text = "Weapon Properties";
             this.grpWeaponProperties.Visible = false;
+            // 
+            // lblSpriteAttack
+            // 
+            this.lblSpriteAttack.AutoSize = true;
+            this.lblSpriteAttack.Location = new System.Drawing.Point(12, 296);
+            this.lblSpriteAttack.Name = "lblSpriteAttack";
+            this.lblSpriteAttack.Size = new System.Drawing.Size(120, 13);
+            this.lblSpriteAttack.TabIndex = 59;
+            this.lblSpriteAttack.Text = "Sprite Attack Animation:";
             // 
             // nudCritMultiplier
             // 
@@ -2132,7 +2145,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpAttackSpeed.Controls.Add(this.cmbAttackSpeedModifier);
             this.grpAttackSpeed.Controls.Add(this.lblAttackSpeedModifier);
             this.grpAttackSpeed.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpAttackSpeed.Location = new System.Drawing.Point(15, 371);
+            this.grpAttackSpeed.Location = new System.Drawing.Point(15, 423);
             this.grpAttackSpeed.Name = "grpAttackSpeed";
             this.grpAttackSpeed.Size = new System.Drawing.Size(180, 86);
             this.grpAttackSpeed.TabIndex = 56;
@@ -2369,7 +2382,7 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbAttackAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbAttackAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbAttackAnimation.FormattingEnabled = true;
-            this.cmbAttackAnimation.Location = new System.Drawing.Point(15, 308);
+            this.cmbAttackAnimation.Location = new System.Drawing.Point(15, 350);
             this.cmbAttackAnimation.Name = "cmbAttackAnimation";
             this.cmbAttackAnimation.Size = new System.Drawing.Size(180, 21);
             this.cmbAttackAnimation.TabIndex = 38;
@@ -2380,11 +2393,11 @@ namespace Intersect.Editor.Forms.Editors
             // lblAttackAnimation
             // 
             this.lblAttackAnimation.AutoSize = true;
-            this.lblAttackAnimation.Location = new System.Drawing.Point(12, 293);
+            this.lblAttackAnimation.Location = new System.Drawing.Point(12, 335);
             this.lblAttackAnimation.Name = "lblAttackAnimation";
-            this.lblAttackAnimation.Size = new System.Drawing.Size(90, 13);
+            this.lblAttackAnimation.Size = new System.Drawing.Size(117, 13);
             this.lblAttackAnimation.TabIndex = 37;
-            this.lblAttackAnimation.Text = "Attack Animation:";
+            this.lblAttackAnimation.Text = "Extra Attack Animation:";
             // 
             // chk2Hand
             // 
@@ -2399,7 +2412,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblToolType
             // 
             this.lblToolType.AutoSize = true;
-            this.lblToolType.Location = new System.Drawing.Point(13, 335);
+            this.lblToolType.Location = new System.Drawing.Point(13, 377);
             this.lblToolType.Name = "lblToolType";
             this.lblToolType.Size = new System.Drawing.Size(58, 13);
             this.lblToolType.TabIndex = 26;
@@ -2418,7 +2431,7 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbToolType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbToolType.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbToolType.FormattingEnabled = true;
-            this.cmbToolType.Location = new System.Drawing.Point(16, 349);
+            this.cmbToolType.Location = new System.Drawing.Point(16, 391);
             this.cmbToolType.Name = "cmbToolType";
             this.cmbToolType.Size = new System.Drawing.Size(180, 21);
             this.cmbToolType.TabIndex = 27;
@@ -2869,6 +2882,27 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemUndo.Text = "Undo";
             this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
             // 
+            // cmbWeaponSprite
+            // 
+            this.cmbWeaponSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbWeaponSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbWeaponSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbWeaponSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbWeaponSprite.DrawDropdownHoverOutline = false;
+            this.cmbWeaponSprite.DrawFocusRectangle = false;
+            this.cmbWeaponSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbWeaponSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbWeaponSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbWeaponSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbWeaponSprite.FormattingEnabled = true;
+            this.cmbWeaponSprite.Location = new System.Drawing.Point(15, 312);
+            this.cmbWeaponSprite.Name = "cmbWeaponSprite";
+            this.cmbWeaponSprite.Size = new System.Drawing.Size(180, 21);
+            this.cmbWeaponSprite.TabIndex = 60;
+            this.cmbWeaponSprite.Text = null;
+            this.cmbWeaponSprite.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbWeaponSprite.SelectedIndexChanged += new System.EventHandler(this.cmbWeaponSprite_SelectedIndexChanged);
+            // 
             // FrmItem
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -3147,5 +3181,7 @@ namespace Intersect.Editor.Forms.Editors
         private Label lblBlockAmount;
         private DarkNumericUpDown nudBlockChance;
         private Label lblBlockChance;
+        private Label lblSpriteAttack;
+        private DarkComboBox cmbWeaponSprite;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -116,6 +116,11 @@ namespace Intersect.Editor.Forms.Editors
             var itemnames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Item);
             cmbPic.Items.AddRange(itemnames);
 
+            cmbWeaponSprite.Items.Clear();
+            cmbWeaponSprite.Items.Add(Strings.General.None);
+            cmbWeaponSprite.Items.AddRange(
+                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "weapon").ToArray()
+            );
             cmbAttackAnimation.Items.Clear();
             cmbAttackAnimation.Items.Add(Strings.General.None);
             cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
@@ -243,6 +248,7 @@ namespace Intersect.Editor.Forms.Editors
             lblScalingStat.Text = Strings.ItemEditor.scalingstat;
             lblScalingAmount.Text = Strings.ItemEditor.scalingamount;
             lblAttackAnimation.Text = Strings.ItemEditor.attackanimation;
+            lblSpriteAttack.Text = Strings.ItemEditor.AttackSpriteOverride;
             lblProjectile.Text = Strings.ItemEditor.projectile;
             lblToolType.Text = Strings.ItemEditor.tooltype;
 
@@ -369,6 +375,9 @@ namespace Intersect.Editor.Forms.Editors
                 nudDeathDropChance.Value = mEditorItem.DropChanceOnDeath;
                 cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
                 cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
+                cmbWeaponSprite.SelectedIndex = cmbWeaponSprite.FindString(
+                        TextUtils.NullToNone(mEditorItem.WeaponSpriteOverride)
+                );
                 nudBlockChance.Value = mEditorItem.BlockChance;
                 nudBlockAmount.Value = mEditorItem.BlockAmount;
                 nudBlockDmgAbs.Value = mEditorItem.BlockAbsorption;
@@ -696,6 +705,11 @@ namespace Intersect.Editor.Forms.Editors
                     toolStripItemNew_Click(null, null);
                 }
             }
+        }
+
+        private void cmbWeaponSprite_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mEditorItem.WeaponSpriteOverride = TextUtils.SanitizeNone(cmbWeaponSprite?.Text);
         }
 
         private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
@@ -34,6 +34,7 @@ namespace Intersect.Editor.Forms.Editors
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmSpell));
             this.pnlContainer = new System.Windows.Forms.Panel();
             this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
+            this.lblSpriteCastAnimation = new System.Windows.Forms.Label();
             this.btnAddFolder = new DarkUI.Controls.DarkButton();
             this.lblFolder = new System.Windows.Forms.Label();
             this.cmbFolder = new DarkUI.Controls.DarkComboBox();
@@ -175,6 +176,7 @@ namespace Intersect.Editor.Forms.Editors
             this.btnClearSearch = new DarkUI.Controls.DarkButton();
             this.txtSearch = new DarkUI.Controls.DarkTextBox();
             this.lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
+            this.cmbCastSprite = new DarkUI.Controls.DarkComboBox();
             this.pnlContainer.SuspendLayout();
             this.grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picSpell)).BeginInit();
@@ -243,6 +245,8 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpGeneral.Controls.Add(this.cmbCastSprite);
+            this.grpGeneral.Controls.Add(this.lblSpriteCastAnimation);
             this.grpGeneral.Controls.Add(this.btnAddFolder);
             this.grpGeneral.Controls.Add(this.lblFolder);
             this.grpGeneral.Controls.Add(this.cmbFolder);
@@ -263,10 +267,19 @@ namespace Intersect.Editor.Forms.Editors
             this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpGeneral.Location = new System.Drawing.Point(2, 0);
             this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(207, 299);
+            this.grpGeneral.Size = new System.Drawing.Size(207, 327);
             this.grpGeneral.TabIndex = 17;
             this.grpGeneral.TabStop = false;
             this.grpGeneral.Text = "General";
+            // 
+            // lblSpriteCastAnimation
+            // 
+            this.lblSpriteCastAnimation.AutoSize = true;
+            this.lblSpriteCastAnimation.Location = new System.Drawing.Point(6, 222);
+            this.lblSpriteCastAnimation.Name = "lblSpriteCastAnimation";
+            this.lblSpriteCastAnimation.Size = new System.Drawing.Size(90, 13);
+            this.lblSpriteCastAnimation.TabIndex = 60;
+            this.lblSpriteCastAnimation.Text = "Sprite Cast Anim.:";
             // 
             // btnAddFolder
             // 
@@ -312,7 +325,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.chkBound.AutoSize = true;
             this.chkBound.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkBound.Location = new System.Drawing.Point(9, 270);
+            this.chkBound.Location = new System.Drawing.Point(9, 301);
             this.chkBound.Name = "chkBound";
             this.chkBound.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.chkBound.Size = new System.Drawing.Size(63, 17);
@@ -333,9 +346,9 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbHitAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbHitAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbHitAnimation.FormattingEnabled = true;
-            this.cmbHitAnimation.Location = new System.Drawing.Point(90, 241);
+            this.cmbHitAnimation.Location = new System.Drawing.Point(96, 273);
             this.cmbHitAnimation.Name = "cmbHitAnimation";
-            this.cmbHitAnimation.Size = new System.Drawing.Size(111, 21);
+            this.cmbHitAnimation.Size = new System.Drawing.Size(105, 21);
             this.cmbHitAnimation.TabIndex = 21;
             this.cmbHitAnimation.Text = null;
             this.cmbHitAnimation.TextPadding = new System.Windows.Forms.Padding(2);
@@ -354,9 +367,9 @@ namespace Intersect.Editor.Forms.Editors
             this.cmbCastAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbCastAnimation.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbCastAnimation.FormattingEnabled = true;
-            this.cmbCastAnimation.Location = new System.Drawing.Point(90, 214);
+            this.cmbCastAnimation.Location = new System.Drawing.Point(96, 246);
             this.cmbCastAnimation.Name = "cmbCastAnimation";
-            this.cmbCastAnimation.Size = new System.Drawing.Size(111, 21);
+            this.cmbCastAnimation.Size = new System.Drawing.Size(105, 21);
             this.cmbCastAnimation.TabIndex = 20;
             this.cmbCastAnimation.Text = null;
             this.cmbCastAnimation.TextPadding = new System.Windows.Forms.Padding(2);
@@ -386,7 +399,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblHitAnimation
             // 
             this.lblHitAnimation.AutoSize = true;
-            this.lblHitAnimation.Location = new System.Drawing.Point(6, 244);
+            this.lblHitAnimation.Location = new System.Drawing.Point(6, 276);
             this.lblHitAnimation.Name = "lblHitAnimation";
             this.lblHitAnimation.Size = new System.Drawing.Size(72, 13);
             this.lblHitAnimation.TabIndex = 16;
@@ -395,11 +408,11 @@ namespace Intersect.Editor.Forms.Editors
             // lblCastAnimation
             // 
             this.lblCastAnimation.AutoSize = true;
-            this.lblCastAnimation.Location = new System.Drawing.Point(6, 217);
+            this.lblCastAnimation.Location = new System.Drawing.Point(6, 249);
             this.lblCastAnimation.Name = "lblCastAnimation";
-            this.lblCastAnimation.Size = new System.Drawing.Size(80, 13);
+            this.lblCastAnimation.Size = new System.Drawing.Size(87, 13);
             this.lblCastAnimation.TabIndex = 14;
-            this.lblCastAnimation.Text = "Cast Animation:";
+            this.lblCastAnimation.Text = "Extra Cast Anim.:";
             // 
             // cmbSprite
             // 
@@ -516,7 +529,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpSpellCost.Controls.Add(this.lblCastDuration);
             this.grpSpellCost.Controls.Add(this.lblCooldownDuration);
             this.grpSpellCost.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpellCost.Location = new System.Drawing.Point(3, 301);
+            this.grpSpellCost.Location = new System.Drawing.Point(3, 335);
             this.grpSpellCost.Name = "grpSpellCost";
             this.grpSpellCost.Size = new System.Drawing.Size(438, 143);
             this.grpSpellCost.TabIndex = 36;
@@ -771,7 +784,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpTargetInfo.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpTargetInfo.Location = new System.Drawing.Point(215, 105);
             this.grpTargetInfo.Name = "grpTargetInfo";
-            this.grpTargetInfo.Size = new System.Drawing.Size(225, 192);
+            this.grpTargetInfo.Size = new System.Drawing.Size(225, 222);
             this.grpTargetInfo.TabIndex = 19;
             this.grpTargetInfo.TabStop = false;
             this.grpTargetInfo.Text = "Targetting Info";
@@ -937,7 +950,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpCombat.Controls.Add(this.grpEffectDuration);
             this.grpCombat.Controls.Add(this.grpDamage);
             this.grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpCombat.Location = new System.Drawing.Point(3, 448);
+            this.grpCombat.Location = new System.Drawing.Point(3, 485);
             this.grpCombat.Name = "grpCombat";
             this.grpCombat.Size = new System.Drawing.Size(440, 500);
             this.grpCombat.TabIndex = 39;
@@ -1877,7 +1890,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
             this.grpEvent.Controls.Add(this.cmbEvent);
             this.grpEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpEvent.Location = new System.Drawing.Point(3, 448);
+            this.grpEvent.Location = new System.Drawing.Point(3, 485);
             this.grpEvent.Name = "grpEvent";
             this.grpEvent.Size = new System.Drawing.Size(438, 48);
             this.grpEvent.TabIndex = 40;
@@ -1914,7 +1927,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpDash.Controls.Add(this.lblRange);
             this.grpDash.Controls.Add(this.scrlRange);
             this.grpDash.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpDash.Location = new System.Drawing.Point(3, 448);
+            this.grpDash.Location = new System.Drawing.Point(3, 485);
             this.grpDash.Name = "grpDash";
             this.grpDash.Size = new System.Drawing.Size(200, 181);
             this.grpDash.TabIndex = 38;
@@ -2011,7 +2024,7 @@ namespace Intersect.Editor.Forms.Editors
             this.grpWarp.Controls.Add(this.lblX);
             this.grpWarp.Controls.Add(this.lblMap);
             this.grpWarp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpWarp.Location = new System.Drawing.Point(3, 448);
+            this.grpWarp.Location = new System.Drawing.Point(3, 485);
             this.grpWarp.Name = "grpWarp";
             this.grpWarp.Size = new System.Drawing.Size(247, 182);
             this.grpWarp.TabIndex = 35;
@@ -2340,6 +2353,27 @@ namespace Intersect.Editor.Forms.Editors
             this.lstGameObjects.Size = new System.Drawing.Size(191, 422);
             this.lstGameObjects.TabIndex = 32;
             // 
+            // cmbCastSprite
+            // 
+            this.cmbCastSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbCastSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbCastSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbCastSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbCastSprite.DrawDropdownHoverOutline = false;
+            this.cmbCastSprite.DrawFocusRectangle = false;
+            this.cmbCastSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbCastSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbCastSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbCastSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbCastSprite.FormattingEnabled = true;
+            this.cmbCastSprite.Location = new System.Drawing.Point(96, 219);
+            this.cmbCastSprite.Name = "cmbCastSprite";
+            this.cmbCastSprite.Size = new System.Drawing.Size(105, 21);
+            this.cmbCastSprite.TabIndex = 61;
+            this.cmbCastSprite.Text = null;
+            this.cmbCastSprite.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbCastSprite.SelectedIndexChanged += new System.EventHandler(this.cmbCastSprite_SelectedIndexChanged);
+            // 
             // FrmSpell
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2570,5 +2604,7 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblManaDamage;
         private System.Windows.Forms.Label lblTickAnimation;
         private DarkComboBox cmbTickAnimation;
+        private System.Windows.Forms.Label lblSpriteCastAnimation;
+        private DarkComboBox cmbCastSprite;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -120,6 +120,12 @@ namespace Intersect.Editor.Forms.Editors
             var spriteNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
             cmbTransform.Items.AddRange(spriteNames);
 
+            cmbCastSprite.Items.Clear();
+            cmbCastSprite.Items.Add(Strings.General.None);
+            cmbCastSprite.Items.AddRange(
+                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "cast").ToArray()
+            );
+
             nudWarpX.Maximum = (int) Options.MapWidth;
             nudWarpY.Maximum = (int) Options.MapHeight;
 
@@ -168,6 +174,7 @@ namespace Intersect.Editor.Forms.Editors
             lblIcon.Text = Strings.SpellEditor.icon;
             lblDesc.Text = Strings.SpellEditor.description;
             lblCastAnimation.Text = Strings.SpellEditor.castanimation;
+            lblSpriteCastAnimation.Text = Strings.SpellEditor.CastSpriteOverride;
             lblHitAnimation.Text = Strings.SpellEditor.hitanimation;
             chkBound.Text = Strings.SpellEditor.bound;
 
@@ -290,6 +297,9 @@ namespace Intersect.Editor.Forms.Editors
                 cmbCastAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.CastAnimationId) + 1;
                 cmbHitAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.HitAnimationId) + 1;
                 cmbTickAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.TickAnimationId) + 1;
+                cmbCastSprite.SelectedIndex = cmbCastSprite.FindString(
+                        TextUtils.NullToNone(mEditorItem.CastSpriteOverride)
+                );
 
                 chkBound.Checked = mEditorItem.Bound;
 
@@ -707,6 +717,11 @@ namespace Intersect.Editor.Forms.Editors
         {
             var frm = new FrmDynamicRequirements(mEditorItem.CastingRequirements, RequirementType.Spell);
             frm.ShowDialog();
+        }
+
+        private void cmbCastSprite_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mEditorItem.CastSpriteOverride = TextUtils.SanitizeNone(cmbCastSprite?.Text);
         }
 
         private void cmbCastAnimation_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -888,7 +888,9 @@ namespace Intersect.Editor.Localization
 
             public static LocalizedString armorboost = @"Armor (+{00}):";
 
-            public static LocalizedString attackanimation = @"Attack Animation:";
+            public static LocalizedString attackanimation = @"Extra Attack Animation:";
+
+            public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
 
             public static LocalizedString attackboost = @"Attack (+{00}):";
 
@@ -3327,7 +3329,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString animation = @"Animation:";
 
-            public static LocalizedString attackanimation = @"Attack Animation:";
+            public static LocalizedString attackanimation = @"Extra Attack Animation:";
 
             public static LocalizedString attackbonus = @"Attack:";
 
@@ -3548,6 +3550,8 @@ Tick timer saved in server config.json.";
             public static LocalizedString title = @"Item Editor";
 
             public static LocalizedString tooltype = @"Tool Type:";
+
+            public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
 
             public static LocalizedString twohanded = @"2 Hand";
 
@@ -4774,7 +4778,9 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString castanimation = @"Cast Animation:";
+            public static LocalizedString castanimation = @"Extra Cast Anim.:";
+
+            public static LocalizedString CastSpriteOverride = @"Sprite Cast Anim.:";
 
             public static LocalizedString castrange = @"Cast Range (tiles):";
 

--- a/Intersect.Server/Migrations/Game/20220828125719_CustomAnimations.Designer.cs
+++ b/Intersect.Server/Migrations/Game/20220828125719_CustomAnimations.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations.Game
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20220828125719_CustomAnimations")]
+    partial class CustomAnimations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/Game/20220828125719_CustomAnimations.cs
+++ b/Intersect.Server/Migrations/Game/20220828125719_CustomAnimations.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Game
+{
+    public partial class CustomAnimations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CastSpriteOverride",
+                table: "Spells",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "WeaponSpriteOverride",
+                table: "Items",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AttackSpriteOverride",
+                table: "Classes",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CastSpriteOverride",
+                table: "Spells");
+
+            migrationBuilder.DropColumn(
+                name: "WeaponSpriteOverride",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "AttackSpriteOverride",
+                table: "Classes");
+        }
+    }
+}


### PR DESCRIPTION
resolves #1198 and
resolves #1199

Added to the Class Editor, Item Editor and Spell Editor, a new combobox, allowing users to select their own custom "_animations", for attack(unarmed and armed) and cast.

In the case of items, if the weapon has a custom animation
the _shoot will be ignored and the custom animation will be prioritized.
_shoot will only be used if the weapon is projectile and does not have custom animation.

Priority will always be given to custom animation, if not set, the engine will look for the default "_animation" (attack, cast, weapon and shoot), if none then uses default 3rd frame for attacks and nothing for cast.

Paperdolls support the new animations defined in the editor.

CAUTION: The files from this pr must follow the format "<base-name>_<animation>_<custom-animation>.png"
Examples:
base-male.png
base-male_attack.png ==> Default sprite attack animation
base-male_attack_sword.png ==> Custom animation
base-male_cast.png ==> Default sprite cast animation
base-male_cast_kamehameha.png ==> Custom animation
and so on...

The "_" is used as a separator between the base filename, animation and custom animation
"base_male_attack.png" will not work for custom animation.

Modifications to Entity.cs and Player.cs are authored by: @lodicolo
