### PR TITLE
fix 1395: Strings#FormatQuantityAbbreviated on trade window

### DIFF
--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -150,28 +150,31 @@ namespace Intersect.Client.Interface.Game.Trades
                     if (Globals.Trade[n, i] != null && Globals.Trade[n, i].ItemId != Guid.Empty)
                     {
                         var item = ItemBase.Get(Globals.Trade[n, i].ItemId);
-                        if (item != null)
+                        if (item == null)
                         {
-                            g += item.Price * Globals.Trade[n, i].Quantity;
-                            TradeSegment[n].Items[i].Pnl.IsHidden = false;
-                            if (item.IsStackable)
-                            {
-                                TradeSegment[n].Values[i].IsHidden = Globals.Trade[n, i].Quantity <= 1;
-                                TradeSegment[n].Values[i].Text = Globals.Trade[n, i].Quantity.ToString();
-                            }
-                            else
-                            {
-                                TradeSegment[n].Values[i].IsHidden = true;
-                            }
-
-                            if (TradeSegment[n].Items[i].IsDragging)
-                            {
-                                TradeSegment[n].Items[i].Pnl.IsHidden = true;
-                                TradeSegment[n].Values[i].IsHidden = true;
-                            }
-
-                            TradeSegment[n].Items[i].Update();
+                            continue;
                         }
+
+                        g += item.Price * Globals.Trade[n, i].Quantity;
+                        TradeSegment[n].Items[i].Pnl.IsHidden = false;
+                        if (item.IsStackable)
+                        {
+                            TradeSegment[n].Values[i].IsHidden = Globals.Trade[n, i].Quantity <= 1;
+                            TradeSegment[n].Values[i].Text =
+                                Strings.FormatQuantityAbbreviated(Globals.Trade[n, i].Quantity);
+                        }
+                        else
+                        {
+                            TradeSegment[n].Values[i].IsHidden = true;
+                        }
+
+                        if (TradeSegment[n].Items[i].IsDragging)
+                        {
+                            TradeSegment[n].Items[i].Pnl.IsHidden = true;
+                            TradeSegment[n].Values[i].IsHidden = true;
+                        }
+
+                        TradeSegment[n].Items[i].Update();
                     }
                     else
                     {


### PR DESCRIPTION
* should resolve #1395 
* displays item quantities within the trade windows by using the client's Strings#FormatQuantityAbbreviated method
* inverted item != null and reformatted the changed lines of code

### Preview

![image](https://user-images.githubusercontent.com/17498701/187247778-24b2e024-b680-40c2-b78e-3134fc066c27.png)
