### PR TITLE
Manasteal

### DIFF
--- a/Intersect (Core)/Enums/EffectType.cs
+++ b/Intersect (Core)/Enums/EffectType.cs
@@ -1,4 +1,4 @@
-﻿namespace Intersect.Enums
+namespace Intersect.Enums
 {
 
     public enum EffectType : byte
@@ -14,7 +14,9 @@
 
         Luck = 4,
 
-        EXP = 5
+        EXP = 5,
+
+        Manasteal = 6,
 
     }
 

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -104,6 +104,10 @@ namespace Intersect.Client.Interface.Game.Character
 
         int CooldownAmount = 0;
 
+        Label mManaSteal;
+
+        int ManaStealAmount = 0;
+
         //Init
         public CharacterWindow(Canvas gameCanvas)
         {
@@ -176,6 +180,7 @@ namespace Intersect.Client.Interface.Game.Character
             mLuck = new Label(mCharacterWindow, "Luck");
             mTenacity = new Label(mCharacterWindow, "Tenacity");
             mCooldownReduction = new Label(mCharacterWindow, "CooldownReduction");
+            mManaSteal = new Label(mCharacterWindow, "Manasteal");
 
             mCharacterWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
@@ -411,12 +416,14 @@ namespace Intersect.Client.Interface.Game.Character
             TenacityAmount = 0;
             LuckAmount = 0;
             ExtraExpAmount = 0;
+            ManaStealAmount = 0;
 
             mLifeSteal.SetText(Strings.Character.Lifesteal.ToString(0));
             mExtraExp.SetText(Strings.Character.ExtraExp.ToString(0));
             mLuck.SetText(Strings.Character.Luck.ToString(0));
             mTenacity.SetText(Strings.Character.Tenacity.ToString(0));
             mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(0));
+            mManaSteal.SetText(Strings.Character.Manasteal.ToString(0));
 
             mAttackSpeed.SetText(Strings.Character.AttackSpeed.ToString(Globals.Me.CalculateAttackTime() / 1000f));
         }
@@ -475,6 +482,11 @@ namespace Intersect.Client.Interface.Game.Character
                     case EffectType.EXP:
                         ExtraExpAmount += item.Effect.Percentage;
                         mExtraExp?.SetText(Strings.Character.ExtraExp.ToString(ExtraExpAmount));
+
+                        break;
+                    case EffectType.Manasteal:
+                        ManaStealAmount += item.Effect.Percentage;
+                        mManaSteal?.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
 
                         break;
                 }

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -492,6 +492,8 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString CooldownReduction = @"Cooldown Reduction: {00}%";
 
+            public static LocalizedString Manasteal = @"Manasteal: {00}%";
+
         }
 
         public partial struct CharacterCreation
@@ -1313,6 +1315,7 @@ namespace Intersect.Client.Localization
                 {3, @"Tenacity:"},
                 {4, @"Luck:"},
                 {5, @"Bonus Experience:"},
+                {6, @"Manasteal:"},
             };
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3460,6 +3460,7 @@ Tick timer saved in server config.json.";
                 {3, @"Tenacity"},
                 {4, @"Luck"},
                 {5, @"EXP"},
+                {6, @"Mana Steal"},
             };
 
             public static LocalizedString bonuses = @"Stat Bonuses";

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1951,23 +1951,23 @@ namespace Intersect.Server.Entities
                     );
                 }
 
-                var manasteal = thisPlayer.GetEquipmentBonusEffect(EffectType.Manasteal) / 100f;
-                var manaRecovered = Math.Min(enemyVitals[(int) Vitals.Mana], manasteal * baseDamage);
+                var manasteal = (thisPlayer.GetEquipmentBonusEffect(EffectType.Manasteal) / 100f) * baseDamage;
+                var manaRecovered = Math.Min(enemyVitals[(int) Vitals.Mana], manasteal);
 
                 if (manaRecovered > 0) //Don't send any +0 msg's.
                 {
-                    AddVital(Vitals.Mana, (int) manaRecovered);
+                    AddVital(Vitals.Mana, (int) manasteal);
                     PacketSender.SendActionMsg(
-                        this, Strings.Combat.addsymbol + (int) manaRecovered, CustomColors.Combat.AddMana
+                        this, Strings.Combat.addsymbol + (int) manasteal, CustomColors.Combat.AddMana
                     );
 
-                    enemy.SubVital(Vitals.Mana, (int)manaRecovered);
+                    enemy.SubVital(Vitals.Mana, (int) manaRecovered);
 
                     //Whether the attacking player should recover more mana than the enemy has
                     //the rest will damage the enemy's health
-                    if (manasteal * baseDamage > enemyVitals[(int) Vitals.Mana])
+                    if (manasteal > enemyVitals[(int) Vitals.Mana])
                     {
-                        var amountToRemove = Math.Floor(manasteal * baseDamage - manaRecovered);
+                        var amountToRemove = Math.Floor(manasteal - manaRecovered);
                         if(amountToRemove > 0)
                         {
                             enemy.SubVital(Vitals.Health, (int) amountToRemove);
@@ -1980,12 +1980,16 @@ namespace Intersect.Server.Entities
                 else
                 {
                     //If enemy has 0 mana, all value will be dealt as damage
-                    var amountToRemove = Math.Floor(manasteal * baseDamage);
-                    if (amountToRemove > 0)
+                    if (manasteal > 0)
                     {
-                        enemy.SubVital(Vitals.Health, (int)amountToRemove);
+                        enemy.SubVital(Vitals.Health, (int) manasteal);
                         PacketSender.SendActionMsg(
-                            enemy, Strings.Combat.removesymbol + amountToRemove, CustomColors.Combat.TrueDamage
+                            enemy, Strings.Combat.removesymbol + manasteal, CustomColors.Combat.TrueDamage
+                        );
+
+                        AddVital(Vitals.Mana, (int)Math.Min(enemy.GetVital(Vitals.Health), manasteal));
+                        PacketSender.SendActionMsg(
+                            this, Strings.Combat.addsymbol + (int) manasteal, CustomColors.Combat.AddMana
                         );
                     }
                 }


### PR DESCRIPTION
resolves #1443

*Added a new (extra buff) equipment property - Manasteal
If the player has any percentage above 0 in any part of the equipment, mana will be stolen from the enemy in (percentage * damage).
**Enemy mana is decreased along with health**

If the percentage to be stolen is greater than the enemy's mana. Only the amount of mana will be regenerated and the rest will deal extra damage to the enemy.
For example: damage 20, 100% manasteal, enemy has 10 mana.
Will restore 10 mana to the attacker and deal +10 damage to the enemy

If the enemy has no mana then it will take everything as extra damage

The damage will be true, as it ignores defense, as it is damage caused directly by the server.