### PR TITLE
feat: ability to show UI Bar values as percentage

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -2,18 +2,15 @@ using System;
 
 namespace Intersect.Client.Framework.Database
 {
-
+    /// <summary>
+    /// User preferences database for client settings.
+    /// </summary>
     public abstract partial class GameDatabase
     {
-        // Registry Database for Client Settings Preferences.
-
         public bool FullScreen { get; set; }
-
-        public bool HideOthersOnWindowOpen { get; set; }
 
         public bool TargetAccountDirection { get; set; }
 
-        //Preferences
         public int MusicVolume { get; set; }
 
         public int SoundVolume { get; set; }
@@ -26,17 +23,25 @@ namespace Intersect.Client.Framework.Database
 
         public bool StickyTarget { get; set; }
 
-        public bool FriendOverheadInfo;
+        public bool FriendOverheadInfo { get; set; }
 
-        public bool GuildMemberOverheadInfo;
+        public bool GuildMemberOverheadInfo { get; set; }
 
-        public bool MyOverheadInfo;
+        public bool MyOverheadInfo { get; set; }
 
-        public bool NpcOverheadInfo;
+        public bool NpcOverheadInfo { get; set; }
 
-        public bool PartyMemberOverheadInfo;
+        public bool PartyMemberOverheadInfo { get; set; }
 
-        public bool PlayerOverheadInfo;
+        public bool PlayerOverheadInfo { get; set; }
+
+        public bool HideOthersOnWindowOpen { get; set; }
+
+        public bool UiExpToPercentage { get; set; }
+
+        public bool UiHpToPercentage { get; set; }
+
+        public bool UiMpToPercentage { get; set; }
 
         public abstract void DeletePreference(string key);
 
@@ -76,6 +81,9 @@ namespace Intersect.Client.Framework.Database
             NpcOverheadInfo = LoadPreference("NpcOverheadInfo", true);
             PartyMemberOverheadInfo = LoadPreference("PartyMemberOverheadInfo", true);
             PlayerOverheadInfo = LoadPreference("PlayerOverheadInfo", true);
+            UiExpToPercentage = LoadPreference("UiExpToPercentage", true);
+            UiHpToPercentage = LoadPreference("UiHpToPercentage", false);
+            UiMpToPercentage = LoadPreference("UiMpToPercentage", false);
         }
 
         public virtual void SavePreferences()
@@ -95,6 +103,9 @@ namespace Intersect.Client.Framework.Database
             SavePreference("NpcOverheadInfo", NpcOverheadInfo.ToString());
             SavePreference("PartyMemberOverheadInfo", PartyMemberOverheadInfo.ToString());
             SavePreference("PlayerOverheadInfo", PlayerOverheadInfo.ToString());
+            SavePreference("UiExpToPercentage", UiExpToPercentage.ToString());
+            SavePreference("UiHpToPercentage", UiHpToPercentage.ToString());
+            SavePreference("UiMpToPercentage", UiMpToPercentage.ToString());
         }
 
         public abstract bool LoadConfig();

--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -9,6 +9,8 @@ namespace Intersect.Client.Framework.Database
     {
         public bool FullScreen { get; set; }
 
+        public bool HideOthersOnWindowOpen { get; set; }
+
         public bool TargetAccountDirection { get; set; }
 
         public int MusicVolume { get; set; }
@@ -35,13 +37,11 @@ namespace Intersect.Client.Framework.Database
 
         public bool PlayerOverheadInfo { get; set; }
 
-        public bool HideOthersOnWindowOpen { get; set; }
+        public bool ShowExperienceAsPercentage { get; set; }
 
-        public bool UiExpToPercentage { get; set; }
+        public bool ShowHealthAsPercentage { get; set; }
 
-        public bool UiHpToPercentage { get; set; }
-
-        public bool UiMpToPercentage { get; set; }
+        public bool ShowManaAsPercentage { get; set; }
 
         public abstract void DeletePreference(string key);
 
@@ -63,49 +63,54 @@ namespace Intersect.Client.Framework.Database
             return (T) Convert.ChangeType(value, typeof(T));
         }
 
-        //Load all preferences when the game starts
+        /// <summary>
+        /// Load all settings preferences when the game starts.
+        /// </summary>
         public virtual void LoadPreferences()
         {
-            MusicVolume = LoadPreference("MusicVolume", 25);
-            SoundVolume = LoadPreference("SoundVolume", 25);
-            TargetResolution = LoadPreference("Resolution", 0);
-            TargetFps = LoadPreference("Fps", 0);
-            FullScreen = LoadPreference("Fullscreen", false);
-            EnableLighting = LoadPreference("EnableLighting", true);
-            HideOthersOnWindowOpen = LoadPreference("HideOthersOnWindowOpen", true);
-            TargetAccountDirection = LoadPreference("TargetAccountDirection", false);
-            StickyTarget = LoadPreference("StickyTarget", true);
-            FriendOverheadInfo = LoadPreference("FriendOverheadInfo", true);
-            GuildMemberOverheadInfo = LoadPreference("GuildMemberOverheadInfo", true);
-            MyOverheadInfo = LoadPreference("MyOverheadInfo", true);
-            NpcOverheadInfo = LoadPreference("NpcOverheadInfo", true);
-            PartyMemberOverheadInfo = LoadPreference("PartyMemberOverheadInfo", true);
-            PlayerOverheadInfo = LoadPreference("PlayerOverheadInfo", true);
-            UiExpToPercentage = LoadPreference("UiExpToPercentage", true);
-            UiHpToPercentage = LoadPreference("UiHpToPercentage", false);
-            UiMpToPercentage = LoadPreference("UiMpToPercentage", false);
+            MusicVolume = LoadPreference(nameof(MusicVolume), 25);
+            SoundVolume = LoadPreference(nameof(SoundVolume), 25);
+            TargetResolution = LoadPreference(nameof(TargetResolution), 0);
+            TargetFps = LoadPreference(nameof(TargetFps), 0);
+            FullScreen = LoadPreference(nameof(FullScreen), false);
+            EnableLighting = LoadPreference(nameof(EnableLighting), true);
+            HideOthersOnWindowOpen = LoadPreference(nameof(HideOthersOnWindowOpen), true);
+            TargetAccountDirection = LoadPreference(nameof(TargetAccountDirection), false);
+            StickyTarget = LoadPreference(nameof(StickyTarget), true);
+            FriendOverheadInfo = LoadPreference(nameof(FriendOverheadInfo), true);
+            GuildMemberOverheadInfo = LoadPreference(nameof(GuildMemberOverheadInfo), true);
+            MyOverheadInfo = LoadPreference(nameof(MyOverheadInfo), true);
+            NpcOverheadInfo = LoadPreference(nameof(NpcOverheadInfo), true);
+            PartyMemberOverheadInfo = LoadPreference(nameof(PartyMemberOverheadInfo), true);
+            PlayerOverheadInfo = LoadPreference(nameof(PlayerOverheadInfo), true);
+            ShowExperienceAsPercentage = LoadPreference(nameof(ShowExperienceAsPercentage), true);
+            ShowHealthAsPercentage = LoadPreference(nameof(ShowHealthAsPercentage), false);
+            ShowManaAsPercentage = LoadPreference(nameof(ShowManaAsPercentage), false);
         }
 
+        /// <summary>
+        /// Saves all settings when applying preferences.
+        /// </summary>
         public virtual void SavePreferences()
         {
-            SavePreference("MusicVolume", MusicVolume.ToString());
-            SavePreference("SoundVolume", SoundVolume.ToString());
-            SavePreference("Fullscreen", FullScreen.ToString());
-            SavePreference("Resolution", TargetResolution.ToString());
-            SavePreference("Fps", TargetFps.ToString());
-            SavePreference("EnableLighting", EnableLighting.ToString());
-            SavePreference("HideOthersOnWindowOpen", HideOthersOnWindowOpen.ToString());
-            SavePreference("TargetAccountDirection", TargetAccountDirection.ToString());
-            SavePreference("StickyTarget", StickyTarget.ToString());
-            SavePreference("FriendOverheadInfo", FriendOverheadInfo.ToString());
-            SavePreference("GuildMemberOverheadInfo", GuildMemberOverheadInfo.ToString());
-            SavePreference("MyOverheadInfo", MyOverheadInfo.ToString());
-            SavePreference("NpcOverheadInfo", NpcOverheadInfo.ToString());
-            SavePreference("PartyMemberOverheadInfo", PartyMemberOverheadInfo.ToString());
-            SavePreference("PlayerOverheadInfo", PlayerOverheadInfo.ToString());
-            SavePreference("UiExpToPercentage", UiExpToPercentage.ToString());
-            SavePreference("UiHpToPercentage", UiHpToPercentage.ToString());
-            SavePreference("UiMpToPercentage", UiMpToPercentage.ToString());
+            SavePreference(nameof(MusicVolume), MusicVolume);
+            SavePreference(nameof(SoundVolume), SoundVolume);
+            SavePreference(nameof(TargetResolution), TargetResolution);
+            SavePreference(nameof(TargetFps), TargetFps);
+            SavePreference(nameof(FullScreen), FullScreen);
+            SavePreference(nameof(EnableLighting), EnableLighting);
+            SavePreference(nameof(HideOthersOnWindowOpen), HideOthersOnWindowOpen);
+            SavePreference(nameof(TargetAccountDirection), TargetAccountDirection);
+            SavePreference(nameof(StickyTarget), StickyTarget);
+            SavePreference(nameof(FriendOverheadInfo), FriendOverheadInfo);
+            SavePreference(nameof(GuildMemberOverheadInfo), GuildMemberOverheadInfo);
+            SavePreference(nameof(MyOverheadInfo), MyOverheadInfo);
+            SavePreference(nameof(NpcOverheadInfo), NpcOverheadInfo);
+            SavePreference(nameof(PartyMemberOverheadInfo), PartyMemberOverheadInfo);
+            SavePreference(nameof(PlayerOverheadInfo), PlayerOverheadInfo);
+            SavePreference(nameof(ShowExperienceAsPercentage), ShowExperienceAsPercentage);
+            SavePreference(nameof(ShowHealthAsPercentage), ShowHealthAsPercentage);
+            SavePreference(nameof(ShowManaAsPercentage), ShowManaAsPercentage);
         }
 
         public abstract bool LoadConfig();

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -585,10 +585,24 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 shieldfillRatio = Math.Min(1, Math.Max(0, shieldfillRatio));
                 targetShieldWidth = (float) Math.Floor(shieldfillRatio * width);
 
-                //Fix the Labels
-                HpLbl.Text = Strings.EntityBox.vital0val.ToString(
-                    MyEntity.Vital[(int) Vitals.Health], MyEntity.MaxVital[(int) Vitals.Health]
+                float hpPercentage = hpfillRatio * 100;
+                var hpPercentageText = hpPercentage == 0 ? $"{hpPercentage}%" : $"{hpPercentage:0.0}%";
+                var hpValueText = Strings.EntityBox.vital0val.ToString(
+                    MyEntity.Vital[(int)Vitals.Health], MyEntity.MaxVital[(int)Vitals.Health]
                 );
+
+                if (Globals.Database.UiHpToPercentage)
+                {
+                    HpLbl.Text = hpPercentageText;
+                    HpBackground.SetToolTipText(hpValueText);
+                    HpBar.SetToolTipText(hpValueText);
+                }
+                else
+                {
+                    HpLbl.Text = hpValueText;
+                    HpBackground.SetToolTipText(hpPercentageText);
+                    HpBar.SetToolTipText(hpPercentageText);
+                }
             }
             else
             {
@@ -684,13 +698,29 @@ namespace Intersect.Client.Interface.Game.EntityPanel
         private void UpdateMpBar(float elapsedTime, bool instant = false)
         {
             var targetMpWidth = 0f;
-            if (MyEntity.MaxVital[(int) Vitals.Mana] > 0)
+            
+            if (MyEntity.MaxVital[(int)Vitals.Mana] > 0)
             {
-                targetMpWidth = MyEntity.Vital[(int) Vitals.Mana] / (float) MyEntity.MaxVital[(int) Vitals.Mana];
+                targetMpWidth = MyEntity.Vital[(int)Vitals.Mana] / (float)MyEntity.MaxVital[(int)Vitals.Mana];
                 targetMpWidth = Math.Min(1, Math.Max(0, targetMpWidth));
-                MpLbl.Text = Strings.EntityBox.vital1val.ToString(
-                    MyEntity.Vital[(int) Vitals.Mana], MyEntity.MaxVital[(int) Vitals.Mana]
+                float mpPercentage = targetMpWidth * 100;
+                var mpPercentageText = mpPercentage == 0 ? $"{mpPercentage}%" : $"{mpPercentage:0.0}%";
+                var mpValueText = Strings.EntityBox.vital1val.ToString(
+                    MyEntity.Vital[(int)Vitals.Mana], MyEntity.MaxVital[(int)Vitals.Mana]
                 );
+
+                if (Globals.Database.UiMpToPercentage)
+                {
+                    MpLbl.Text = mpPercentageText;
+                    MpBackground.SetToolTipText(mpValueText);
+                    MpBar.SetToolTipText(mpValueText);
+                }
+                else
+                {
+                    MpLbl.Text = mpValueText;
+                    MpBackground.SetToolTipText(mpPercentageText);
+                    MpBar.SetToolTipText(mpPercentageText);
+                }
 
                 targetMpWidth *= MpBackground.Width;
             }
@@ -700,7 +730,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 targetMpWidth = MpBackground.Width;
             }
 
-            if ((int)targetMpWidth != CurMpWidth)
+            if (!targetMpWidth.Equals(CurMpWidth))
             {
                 if (!instant)
                 {
@@ -742,14 +772,29 @@ namespace Intersect.Client.Interface.Game.EntityPanel
         private void UpdateXpBar(float elapsedTime, bool instant = false)
         {
             float targetExpWidth = 1;
-            if (((Player) MyEntity).GetNextLevelExperience() > 0)
-            {
-                targetExpWidth = (float) ((Player) MyEntity).Experience /
-                                 (float) ((Player) MyEntity).GetNextLevelExperience();
 
-                ExpLbl.Text = Strings.EntityBox.expval.ToString(
-                    ((Player) MyEntity)?.Experience, ((Player) MyEntity)?.GetNextLevelExperience()
+            if (((Player)MyEntity).GetNextLevelExperience() > 0)
+            {
+                targetExpWidth = (float)((Player)MyEntity).Experience /
+                                 (float)((Player)MyEntity).GetNextLevelExperience();
+                float expPercentage = targetExpWidth * 100;
+                var expPercentageText = expPercentage == 0 ? $"{expPercentage}%" : $"{expPercentage:0.00}%";
+                var expValueText = Strings.EntityBox.expval.ToString(
+                    ((Player)MyEntity)?.Experience, ((Player)MyEntity)?.GetNextLevelExperience()
                 );
+
+                if (Globals.Database.UiExpToPercentage)
+                {
+                    ExpLbl.Text = expPercentageText;
+                    ExpBackground.SetToolTipText(expValueText);
+                    ExpBar.SetToolTipText(expValueText);
+                }
+                else
+                {
+                    ExpLbl.Text = expValueText;
+                    ExpBackground.SetToolTipText(expPercentageText);
+                    ExpBar.SetToolTipText(expPercentageText);
+                }
             }
             else
             {

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -586,22 +586,20 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 targetShieldWidth = (float) Math.Floor(shieldfillRatio * width);
 
                 float hpPercentage = hpfillRatio * 100;
-                var hpPercentageText = hpPercentage == 0 ? $"{hpPercentage}%" : $"{hpPercentage:0.0}%";
+                var hpPercentageText = $"{hpPercentage:0.##}%";
                 var hpValueText = Strings.EntityBox.vital0val.ToString(
                     MyEntity.Vital[(int)Vitals.Health], MyEntity.MaxVital[(int)Vitals.Health]
                 );
 
-                if (Globals.Database.UiHpToPercentage)
+                if (Globals.Database.ShowHealthAsPercentage)
                 {
                     HpLbl.Text = hpPercentageText;
                     HpBackground.SetToolTipText(hpValueText);
-                    HpBar.SetToolTipText(hpValueText);
                 }
                 else
                 {
                     HpLbl.Text = hpValueText;
                     HpBackground.SetToolTipText(hpPercentageText);
-                    HpBar.SetToolTipText(hpPercentageText);
                 }
             }
             else
@@ -704,22 +702,20 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 targetMpWidth = MyEntity.Vital[(int)Vitals.Mana] / (float)MyEntity.MaxVital[(int)Vitals.Mana];
                 targetMpWidth = Math.Min(1, Math.Max(0, targetMpWidth));
                 float mpPercentage = targetMpWidth * 100;
-                var mpPercentageText = mpPercentage == 0 ? $"{mpPercentage}%" : $"{mpPercentage:0.0}%";
+                var mpPercentageText = $"{mpPercentage:0.##}%";
                 var mpValueText = Strings.EntityBox.vital1val.ToString(
                     MyEntity.Vital[(int)Vitals.Mana], MyEntity.MaxVital[(int)Vitals.Mana]
                 );
 
-                if (Globals.Database.UiMpToPercentage)
+                if (Globals.Database.ShowManaAsPercentage)
                 {
                     MpLbl.Text = mpPercentageText;
                     MpBackground.SetToolTipText(mpValueText);
-                    MpBar.SetToolTipText(mpValueText);
                 }
                 else
                 {
                     MpLbl.Text = mpValueText;
                     MpBackground.SetToolTipText(mpPercentageText);
-                    MpBar.SetToolTipText(mpPercentageText);
                 }
 
                 targetMpWidth *= MpBackground.Width;
@@ -778,22 +774,20 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 targetExpWidth = (float)((Player)MyEntity).Experience /
                                  (float)((Player)MyEntity).GetNextLevelExperience();
                 float expPercentage = targetExpWidth * 100;
-                var expPercentageText = expPercentage == 0 ? $"{expPercentage}%" : $"{expPercentage:0.00}%";
+                var expPercentageText = $"{expPercentage:0.##}%";
                 var expValueText = Strings.EntityBox.expval.ToString(
                     ((Player)MyEntity)?.Experience, ((Player)MyEntity)?.GetNextLevelExperience()
                 );
 
-                if (Globals.Database.UiExpToPercentage)
+                if (Globals.Database.ShowExperienceAsPercentage)
                 {
                     ExpLbl.Text = expPercentageText;
                     ExpBackground.SetToolTipText(expValueText);
-                    ExpBar.SetToolTipText(expValueText);
                 }
                 else
                 {
                     ExpLbl.Text = expValueText;
                     ExpBackground.SetToolTipText(expPercentageText);
-                    ExpBar.SetToolTipText(expPercentageText);
                 }
             }
             else

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -77,6 +77,12 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
+        private readonly LabeledCheckBox mUiExpToPercentageCheckbox;
+        
+        private readonly LabeledCheckBox mUiHpToPercentageCheckbox;
+        
+        private readonly LabeledCheckBox mUiMpToPercentageCheckbox;
+
         // Video Settings.
         private readonly ImagePanel mResolutionBackground;
 
@@ -193,17 +199,25 @@ namespace Intersect.Client.Interface.Shared
             mPlayerOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PlayerOverheadInfoCheckbox");
             mPlayerOverheadInfoCheckbox.Text = Strings.Settings.PlayerOverheadInfo;
 
-            // Game Settings - Interface.
+            // Game Settings - User Interface.
             mInterfaceSettings = new Button(mGameSettingsContainer, "InterfaceSettings");
             mInterfaceSettings.Text = Strings.Settings.InterfaceSettings;
             mInterfaceSettingsHelper =
                 new Button(mGameSettingsContainer, "InterfaceSettingsHelper");
             mInterfaceSettingsHelper.SetToolTipText(Strings.Settings.InterfaceSettingsHelper);
 
-            // Game Settings - Toggle for: Interface Auto-close Windows.
+            // Game Settings - Toggle for: User Interface Auto-close Windows.
             mAutoCloseWindowsCheckbox = new LabeledCheckBox(mGameSettingsContainer, "AutoCloseWindowsCheckbox");
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
 
+            // Game Settings - Toggle for: User Interface EXP/HP/MP to Percentage.
+            mUiExpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiExpToPercentageCheckbox");
+            mUiExpToPercentageCheckbox.Text = Strings.Settings.UiExpToPercentage;
+            mUiHpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiHpToPercentageCheckbox");
+            mUiHpToPercentageCheckbox.Text = Strings.Settings.UiHpToPercentage;
+            mUiMpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiMpToPercentageCheckbox");
+            mUiMpToPercentageCheckbox.Text = Strings.Settings.UiMpToPercentage;
+            
             #endregion
 
             #region InitVideoSettings
@@ -546,7 +560,22 @@ namespace Intersect.Client.Interface.Shared
                 mSettingsPanel.MakeModal(true);
             }
 
-            mKeybindingEditControls = new Controls(Controls.ActiveControls);
+            // Game Settings.
+            mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
+            mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
+            mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
+            mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
+            mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
+            mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
+            mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
+            mUiExpToPercentageCheckbox.IsChecked = Globals.Database.UiExpToPercentage;
+            mUiHpToPercentageCheckbox.IsChecked = Globals.Database.UiHpToPercentage;
+            mUiMpToPercentageCheckbox.IsChecked = Globals.Database.UiMpToPercentage;
+
+            // Video Settings.
+            mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
+            mLightingEnabledCheckbox.IsChecked = Globals.Database.EnableLighting;
+
             if (Graphics.Renderer.GetValidVideoModes().Count > 0)
             {
                 string resolutionLabel;
@@ -601,19 +630,6 @@ namespace Intersect.Client.Interface.Shared
                     break;
             }
 
-            // Game Settings.
-            mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
-            mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
-            mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
-            mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
-            mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
-            mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
-
-            // Video Settings.
-            mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
-            mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
-            mLightingEnabledCheckbox.IsChecked = Globals.Database.EnableLighting;
-
             // Audio Settings.
             mPreviousMusicVolume = Globals.Database.MusicVolume;
             mPreviousSoundVolume = Globals.Database.SoundVolume;
@@ -621,6 +637,9 @@ namespace Intersect.Client.Interface.Shared
             mSoundSlider.Value = Globals.Database.SoundVolume;
             mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
             mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
+
+            // Control Settings.
+            mKeybindingEditControls = new Controls(Controls.ActiveControls);
 
             // Settings Window is not hidden anymore.
             mSettingsPanel.Show();
@@ -711,24 +730,42 @@ namespace Intersect.Client.Interface.Shared
         private void SettingsApplyBtn_Clicked(Base sender, ClickedEventArgs arguments)
         {
             var shouldReset = false;
+
+            // Game Settings.
+            Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
+            Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
+            Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
+            Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
+            Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
+            Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
+            Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
+            Globals.Database.UiExpToPercentage = mUiExpToPercentageCheckbox.IsChecked;
+            Globals.Database.UiHpToPercentage = mUiHpToPercentageCheckbox.IsChecked;
+            Globals.Database.UiMpToPercentage = mUiMpToPercentageCheckbox.IsChecked;
+
+
+            // Video Settings.
             var resolution = mResolutionList.SelectedItem;
             var validVideoModes = Graphics.Renderer.GetValidVideoModes();
-            var targetResolution = validVideoModes?.FindIndex(videoMode => string.Equals(videoMode, resolution.Text)) ?? -1;
+            var targetResolution = validVideoModes?.FindIndex(videoMode =>
+                string.Equals(videoMode, resolution.Text)) ?? -1;
+            var newFps = 0;
+
+            Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;
 
             if (targetResolution > -1)
             {
-                shouldReset = Globals.Database.TargetResolution != targetResolution || Graphics.Renderer.HasOverrideResolution;
+                shouldReset = Globals.Database.TargetResolution != targetResolution ||
+                              Graphics.Renderer.HasOverrideResolution;
                 Globals.Database.TargetResolution = targetResolution;
             }
 
-            Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
             if (Globals.Database.FullScreen != mFullscreenCheckbox.IsChecked)
             {
                 Globals.Database.FullScreen = mFullscreenCheckbox.IsChecked;
                 shouldReset = true;
             }
 
-            var newFps = 0;
             if (mFpsList.SelectedItem.Text == Strings.Settings.UnlimitedFps)
             {
                 newFps = -1;
@@ -756,44 +793,16 @@ namespace Intersect.Client.Interface.Shared
                 Globals.Database.TargetFps = newFps;
             }
 
-            Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;
-
-            if (Globals.Database.FriendOverheadInfo != mFriendOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
-            }
-
-            if (Globals.Database.GuildMemberOverheadInfo != mGuildMemberOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
-            }
-
-            if (Globals.Database.MyOverheadInfo != mMyOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
-            }
-
-            if (Globals.Database.NpcOverheadInfo != mNpcOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
-            }
-
-            if (Globals.Database.PartyMemberOverheadInfo != mPartyMemberOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
-            }
-
-            if (Globals.Database.PlayerOverheadInfo != mPlayerOverheadInfoCheckbox.IsChecked)
-            {
-                Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
-            }
-
-            // Save Settings.
+            // Audio Settings.
             Globals.Database.MusicVolume = (int)mMusicSlider.Value;
             Globals.Database.SoundVolume = (int)mSoundSlider.Value;
             Audio.UpdateGlobalVolume();
+
+            // Control Settings.
             Controls.ActiveControls = mKeybindingEditControls;
             Controls.ActiveControls.Save();
+
+            // Save Preferences.
             Globals.Database.SavePreferences();
 
             if (shouldReset)
@@ -803,7 +812,7 @@ namespace Intersect.Client.Interface.Shared
                 Graphics.Renderer.Init();
             }
 
-            // Hide our current window.
+            // Hide the currently opened window.
             Hide();
         }
 

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -77,11 +77,11 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
-        private readonly LabeledCheckBox mUiExpToPercentageCheckbox;
+        private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
         
-        private readonly LabeledCheckBox mUiHpToPercentageCheckbox;
+        private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
         
-        private readonly LabeledCheckBox mUiMpToPercentageCheckbox;
+        private readonly LabeledCheckBox mShowManaAsPercentageCheckbox;
 
         // Video Settings.
         private readonly ImagePanel mResolutionBackground;
@@ -211,12 +211,12 @@ namespace Intersect.Client.Interface.Shared
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
 
             // Game Settings - Toggle for: User Interface EXP/HP/MP to Percentage.
-            mUiExpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiExpToPercentageCheckbox");
-            mUiExpToPercentageCheckbox.Text = Strings.Settings.UiExpToPercentage;
-            mUiHpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiHpToPercentageCheckbox");
-            mUiHpToPercentageCheckbox.Text = Strings.Settings.UiHpToPercentage;
-            mUiMpToPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "UiMpToPercentageCheckbox");
-            mUiMpToPercentageCheckbox.Text = Strings.Settings.UiMpToPercentage;
+            mShowExperienceAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowExperienceAsPercentageCheckbox");
+            mShowExperienceAsPercentageCheckbox.Text = Strings.Settings.ShowExperienceAsPercentage;
+            mShowHealthAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowHealthAsPercentageCheckbox");
+            mShowHealthAsPercentageCheckbox.Text = Strings.Settings.ShowHealthAsPercentage;
+            mShowManaAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowManaAsPercentageCheckbox");
+            mShowManaAsPercentageCheckbox.Text = Strings.Settings.ShowManaAsPercentage;
             
             #endregion
 
@@ -568,9 +568,9 @@ namespace Intersect.Client.Interface.Shared
             mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
             mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
             mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
-            mUiExpToPercentageCheckbox.IsChecked = Globals.Database.UiExpToPercentage;
-            mUiHpToPercentageCheckbox.IsChecked = Globals.Database.UiHpToPercentage;
-            mUiMpToPercentageCheckbox.IsChecked = Globals.Database.UiMpToPercentage;
+            mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
+            mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
+            mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
 
             // Video Settings.
             mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
@@ -739,9 +739,9 @@ namespace Intersect.Client.Interface.Shared
             Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
             Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
             Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
-            Globals.Database.UiExpToPercentage = mUiExpToPercentageCheckbox.IsChecked;
-            Globals.Database.UiHpToPercentage = mUiHpToPercentageCheckbox.IsChecked;
-            Globals.Database.UiMpToPercentage = mUiMpToPercentageCheckbox.IsChecked;
+            Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
+            Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
+            Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;
 
 
             // Video Settings.

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1789,13 +1789,13 @@ namespace Intersect.Client.Localization
             public static LocalizedString Vsync = @"V-Sync";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UiExpToPercentage = @"EXP to Percentage";
+            public static LocalizedString ShowExperienceAsPercentage = @"Experience as percentage";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UiHpToPercentage = @"HP to Percentage";
+            public static LocalizedString ShowHealthAsPercentage = @"Health as percentage";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UiMpToPercentage = @"MP to Percentage";
+            public static LocalizedString ShowManaAsPercentage = @"Mana as percentage";
         }
 
         public partial struct Parties

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1789,13 +1789,13 @@ namespace Intersect.Client.Localization
             public static LocalizedString Vsync = @"V-Sync";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowExperienceAsPercentage = @"Experience as percentage";
+            public static LocalizedString ShowExperienceAsPercentage = @"Show Experience as percentage";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowHealthAsPercentage = @"Health as percentage";
+            public static LocalizedString ShowHealthAsPercentage = @"Show Health as percentage";
             
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowManaAsPercentage = @"Mana as percentage";
+            public static LocalizedString ShowManaAsPercentage = @"Show Mana as percentage";
         }
 
         public partial struct Parties

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1787,6 +1787,15 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Vsync = @"V-Sync";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UiExpToPercentage = @"EXP to Percentage";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UiHpToPercentage = @"HP to Percentage";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UiMpToPercentage = @"MP to Percentage";
         }
 
         public partial struct Parties


### PR DESCRIPTION
- chore: some things were reorganized around the modified code.
- new feat: ability to show UI Bar values as percentage.
- If enabled, will display the toggled bar's as percentage and it's tooltip will show the actual value instead.
- If disabled, will display the toggled bar's actual value and it's tooltip will show the percentage instead.
- should resolve #1431 

**Assets PR :** https://github.com/AscensionGameDev/Intersect-Assets/pull/22

### Preview

https://user-images.githubusercontent.com/17498701/189506575-57de6696-52cf-4656-be1c-4428e3d7e366.mp4



