### PR TITLE
chore: tweaks game settings and exposes `stickytarget`

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -76,7 +76,7 @@ namespace Intersect.Client.Framework.Database
             EnableLighting = LoadPreference(nameof(EnableLighting), true);
             HideOthersOnWindowOpen = LoadPreference(nameof(HideOthersOnWindowOpen), true);
             TargetAccountDirection = LoadPreference(nameof(TargetAccountDirection), false);
-            StickyTarget = LoadPreference(nameof(StickyTarget), true);
+            StickyTarget = LoadPreference(nameof(StickyTarget), false);
             FriendOverheadInfo = LoadPreference(nameof(FriendOverheadInfo), true);
             GuildMemberOverheadInfo = LoadPreference(nameof(GuildMemberOverheadInfo), true);
             MyOverheadInfo = LoadPreference(nameof(MyOverheadInfo), true);

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.File_Management;
@@ -14,7 +13,6 @@ using Intersect.Client.Interface.Game;
 using Intersect.Client.Interface.Menu;
 using Intersect.Client.Localization;
 using Intersect.Utilities;
-
 using static Intersect.Client.Framework.File_Management.GameContentManager;
 
 namespace Intersect.Client.Interface.Shared
@@ -53,10 +51,19 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly Button mKeybindingSettingsTab;
 
-        // Game Settings - Overhead Information.
-        private readonly Button mOverheadInformationSettings;
+        // Game Settings - Interface.
+        private readonly ScrollControl mInterfaceSettings;
 
-        private readonly Button mOverheadInfoSettingsHelper;
+        private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
+
+        private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
+
+        private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
+
+        private readonly LabeledCheckBox mShowManaAsPercentageCheckbox;
+
+        // Game Settings - Information.
+        private readonly ScrollControl mInformationSettings;
 
         private readonly LabeledCheckBox mFriendOverheadInfoCheckbox;
 
@@ -70,31 +77,15 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
 
-        // Game Settings - Interface.
-        private readonly Button mInterfaceSettings;
+        // Game Settings - Targeting.
+        private readonly ScrollControl mTargetingSettings;
 
-        private readonly Button mInterfaceSettingsHelper;
-
-        private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
-
-        private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
-        
-        private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
-        
-        private readonly LabeledCheckBox mShowManaAsPercentageCheckbox;
+        private readonly LabeledCheckBox mStickyTarget;
 
         // Video Settings.
-        private readonly ImagePanel mResolutionBackground;
-
-        private readonly Label mResolutionLabel;
-
         private readonly ComboBox mResolutionList;
 
         private MenuItem mCustomResolutionMenuItem;
-
-        private readonly ImagePanel mFpsBackground;
-
-        private readonly Label mFpsLabel;
 
         private readonly ComboBox mFpsList;
 
@@ -165,59 +156,78 @@ namespace Intersect.Client.Interface.Shared
             mGameSettingsTab.Text = Strings.Settings.GameSettingsTab;
             mGameSettingsTab.Clicked += GameSettingsTab_Clicked;
 
-            // Game Settings Get Stored in the GameSettings Scroll Control.
+            // Game Settings are stored in the GameSettings Scroll Control.
             mGameSettingsContainer = new ScrollControl(mSettingsPanel, "GameSettingsContainer");
-            mGameSettingsContainer.EnableScroll(false, true);
+            mGameSettingsContainer.EnableScroll(false, false);
 
-            // Game Settings - Overhead Information.
-            mOverheadInformationSettings = new Button(mGameSettingsContainer, "OverheadInformationSettings");
-            mOverheadInformationSettings.Text = Strings.Settings.OverheadInformationSettings;
-            mOverheadInfoSettingsHelper = new Button(mGameSettingsContainer, "OverheadInfoSettingsHelper");
-            mOverheadInfoSettingsHelper.SetToolTipText(Strings.Settings.OverheadInfoSettingsHelper);
+            // Game Settings subcategories are stored in the GameSettings List.
+            var gameSettingsList = new ListBox(mGameSettingsContainer, "GameSettingsList");
+            gameSettingsList.AddRow(Strings.Settings.InterfaceSettings);
+            gameSettingsList.AddRow(Strings.Settings.InformationSettings);
+            gameSettingsList.AddRow(Strings.Settings.TargetingSettings);
+            gameSettingsList.EnableScroll(false, true);
+            gameSettingsList.SelectedRowIndex = 0;
+            gameSettingsList[0].Clicked += InterfaceSettings_Clicked;
+            gameSettingsList[1].Clicked += InformationSettings_Clicked;
+            gameSettingsList[2].Clicked += TargetingSettings_Clicked;
 
-            // Game Settings - Toggle for: Friends Overhead Information.
-            mFriendOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "FriendOverheadInfoCheckbox");
-            mFriendOverheadInfoCheckbox.Text = Strings.Settings.FriendOverheadInfo;
+            // Game Settings - Interface.
+            mInterfaceSettings = new ScrollControl(mGameSettingsContainer, "InterfaceSettings");
+            mInterfaceSettings.EnableScroll(false, true);
 
-            // Game Settings - Toggle for: Guild Members Overhead Information.
-            mGuildMemberOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "GuildMemberOverheadInfoCheckbox");
-            mGuildMemberOverheadInfoCheckbox.Text = Strings.Settings.GuildMemberOverheadInfo;
-
-            // Game Settings - Toggle for: My Overhead Information (Local Player).
-            mMyOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "MyOverheadInfoCheckbox");
-            mMyOverheadInfoCheckbox.Text = Strings.Settings.MyOverheadInfo;
-
-            // Game Settings - Toggle for: NPCs Overhead Information.
-            mNpcOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "NpcOverheadInfoCheckbox");
-            mNpcOverheadInfoCheckbox.Text = Strings.Settings.NpcOverheadInfo;
-
-            // Game Settings - Toggle for: Party Members Overhead Information.
-            mPartyMemberOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PartyMemberOverheadInfoCheckbox");
-            mPartyMemberOverheadInfoCheckbox.Text = Strings.Settings.PartyMemberOverheadInfo;
-
-            // Game Settings - Toggle for: Players Overhead Information.
-            mPlayerOverheadInfoCheckbox = new LabeledCheckBox(mGameSettingsContainer, "PlayerOverheadInfoCheckbox");
-            mPlayerOverheadInfoCheckbox.Text = Strings.Settings.PlayerOverheadInfo;
-
-            // Game Settings - User Interface.
-            mInterfaceSettings = new Button(mGameSettingsContainer, "InterfaceSettings");
-            mInterfaceSettings.Text = Strings.Settings.InterfaceSettings;
-            mInterfaceSettingsHelper =
-                new Button(mGameSettingsContainer, "InterfaceSettingsHelper");
-            mInterfaceSettingsHelper.SetToolTipText(Strings.Settings.InterfaceSettingsHelper);
-
-            // Game Settings - Toggle for: User Interface Auto-close Windows.
-            mAutoCloseWindowsCheckbox = new LabeledCheckBox(mGameSettingsContainer, "AutoCloseWindowsCheckbox");
+            // Game Settings - Interface: Auto-close Windows.
+            mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
 
-            // Game Settings - Toggle for: User Interface EXP/HP/MP to Percentage.
-            mShowExperienceAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowExperienceAsPercentageCheckbox");
+            // Game Settings - Interface: Show EXP/HP/MP to Percentage.
+            mShowExperienceAsPercentageCheckbox =
+                new LabeledCheckBox(mInterfaceSettings, "ShowExperienceAsPercentageCheckbox");
             mShowExperienceAsPercentageCheckbox.Text = Strings.Settings.ShowExperienceAsPercentage;
-            mShowHealthAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowHealthAsPercentageCheckbox");
+            mShowHealthAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowHealthAsPercentageCheckbox");
             mShowHealthAsPercentageCheckbox.Text = Strings.Settings.ShowHealthAsPercentage;
-            mShowManaAsPercentageCheckbox = new LabeledCheckBox(mGameSettingsContainer, "ShowManaAsPercentageCheckbox");
+            mShowManaAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowManaAsPercentageCheckbox");
             mShowManaAsPercentageCheckbox.Text = Strings.Settings.ShowManaAsPercentage;
-            
+
+            // Game Settings - Information.
+            mInformationSettings = new ScrollControl(mGameSettingsContainer, "InformationSettings");
+            mInformationSettings.EnableScroll(false, true);
+
+            // Game Settings - Information: Friends.
+            mFriendOverheadInfoCheckbox =
+                new LabeledCheckBox(mInformationSettings, "FriendOverheadInfoCheckbox");
+            mFriendOverheadInfoCheckbox.Text = Strings.Settings.ShowFriendOverheadInformation;
+
+            // Game Settings - Information: Guild Members.
+            mGuildMemberOverheadInfoCheckbox =
+                new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadInfoCheckbox");
+            mGuildMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowGuildOverheadInformation;
+
+            // Game Settings - Information: Myself.
+            mMyOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "MyOverheadInfoCheckbox");
+            mMyOverheadInfoCheckbox.Text = Strings.Settings.ShowMyOverheadInformation;
+
+            // Game Settings - Information: NPCs.
+            mNpcOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "NpcOverheadInfoCheckbox");
+            mNpcOverheadInfoCheckbox.Text = Strings.Settings.ShowNpcOverheadInformation;
+
+            // Game Settings - Information: Party Members.
+            mPartyMemberOverheadInfoCheckbox =
+                new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadInfoCheckbox");
+            mPartyMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowPartyOverheadInformation;
+
+            // Game Settings - Information: Players.
+            mPlayerOverheadInfoCheckbox =
+                new LabeledCheckBox(mInformationSettings, "PlayerOverheadInfoCheckbox");
+            mPlayerOverheadInfoCheckbox.Text = Strings.Settings.ShowPlayerOverheadInformation;
+
+            // Game Settings - Targeting.
+            mTargetingSettings = new ScrollControl(mGameSettingsContainer, "TargetingSettings");
+            mTargetingSettings.EnableScroll(false, false);
+
+            // Game Settings - Targeting: Sticky Target.
+            mStickyTarget = new LabeledCheckBox(mTargetingSettings, "StickyTargetCheckbox");
+            mStickyTarget.Text = Strings.Settings.StickyTarget;
+
             #endregion
 
             #region InitVideoSettings
@@ -232,14 +242,14 @@ namespace Intersect.Client.Interface.Shared
             mVideoSettingsContainer.EnableScroll(false, false);
 
             // Video Settings - Resolution Background.
-            mResolutionBackground = new ImagePanel(mVideoSettingsContainer, "ResolutionPanel");
+            var resolutionBackground = new ImagePanel(mVideoSettingsContainer, "ResolutionPanel");
 
             // Video Settings - Resolution Label.
-            mResolutionLabel = new Label(mResolutionBackground, "ResolutionLabel");
-            mResolutionLabel.SetText(Strings.Settings.Resolution);
+            var resolutionLabel = new Label(resolutionBackground, "ResolutionLabel");
+            resolutionLabel.SetText(Strings.Settings.Resolution);
 
             // Video Settings - Resolution List.
-            mResolutionList = new ComboBox(mResolutionBackground, "ResolutionCombobox");
+            mResolutionList = new ComboBox(resolutionBackground, "ResolutionCombobox");
             var myModes = Graphics.Renderer.GetValidVideoModes();
             myModes?.ForEach(
                 t =>
@@ -250,14 +260,14 @@ namespace Intersect.Client.Interface.Shared
             );
 
             // Video Settings - FPS Background.
-            mFpsBackground = new ImagePanel(mVideoSettingsContainer, "FPSPanel");
+            var fpsBackground = new ImagePanel(mVideoSettingsContainer, "FPSPanel");
 
             // Video Settings - FPS Label.
-            mFpsLabel = new Label(mFpsBackground, "FPSLabel");
-            mFpsLabel.SetText(Strings.Settings.TargetFps);
+            var fpsLabel = new Label(fpsBackground, "FPSLabel");
+            fpsLabel.SetText(Strings.Settings.TargetFps);
 
             // Video Settings - FPS List.
-            mFpsList = new ComboBox(mFpsBackground, "FPSCombobox");
+            mFpsList = new ComboBox(fpsBackground, "FPSCombobox");
             mFpsList.AddItem(Strings.Settings.Vsync);
             mFpsList.AddItem(Strings.Settings.Fps30);
             mFpsList.AddItem(Strings.Settings.Fps60);
@@ -394,6 +404,27 @@ namespace Intersect.Client.Interface.Shared
                 // Restore Default KeybindingSettings Button.
                 mKeybindingRestoreBtn.Hide();
             }
+        }
+
+        void InterfaceSettings_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            mInterfaceSettings.Show();
+            mInformationSettings.Hide();
+            mTargetingSettings.Hide();
+        }
+        
+        void InformationSettings_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            mInterfaceSettings.Hide();
+            mInformationSettings.Show();
+            mTargetingSettings.Hide();
+        }
+        
+        void TargetingSettings_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            mInterfaceSettings.Hide();
+            mInformationSettings.Hide();
+            mTargetingSettings.Show();
         }
 
         private void VideoSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
@@ -561,16 +592,17 @@ namespace Intersect.Client.Interface.Shared
             }
 
             // Game Settings.
+            mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
+            mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
+            mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
+            mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
             mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
             mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
             mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
             mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
             mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
             mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
-            mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
-            mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
-            mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
-            mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
+            mStickyTarget.IsChecked = Globals.Database.StickyTarget;
 
             // Video Settings.
             mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
@@ -732,17 +764,17 @@ namespace Intersect.Client.Interface.Shared
             var shouldReset = false;
 
             // Game Settings.
+            Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
+            Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
+            Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
+            Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;
             Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
             Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
             Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
             Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
             Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
             Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
-            Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
-            Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
-            Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
-            Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;
-
+            Globals.Database.StickyTarget = mStickyTarget.IsChecked;
 
             // Video Settings.
             var resolution = mResolutionList.SelectedItem;

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1719,47 +1719,22 @@ namespace Intersect.Client.Localization
             public static LocalizedString Fps90 = @"90";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FriendOverheadInfo = @"Friends";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Fullscreen = @"Fullscreen";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString GameSettingsTab = @"Game";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildMemberOverheadInfo = @"Guild";
+            public static LocalizedString InformationSettings = @"Information";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString InterfaceSettings = @"Interface";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InterfaceSettingsHelper = @"Game Interface related settings.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString KeyBindingSettingsTab = @"Controls";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString MusicVolume = @"Music Volume: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MyOverheadInfo = @"Myself";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NpcOverheadInfo = @"NPCs";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OverheadInformationSettings = @"Overhead Information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OverheadInfoSettingsHelper =
-                @"Overhead information may still be viewed by positioning the cursor over the hidden cases.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PartyMemberOverheadInfo = @"Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PlayerOverheadInfo = @"Players";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Resolution = @"Resolution:";
@@ -1774,7 +1749,40 @@ namespace Intersect.Client.Localization
             public static LocalizedString SoundVolume = @"Sound Volume: {00}%";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowExperienceAsPercentage = @"Show Experience as percentage";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowFriendOverheadInformation = @"Show Friend Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowGuildOverheadInformation = @"Show Guild Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowHealthAsPercentage = @"Show Health as percentage";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowNpcOverheadInformation = @"Show Npc Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowManaAsPercentage = @"Show Mana as percentage";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowMyOverheadInformation = @"Show My Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPartyOverheadInformation = @"Show Party Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPlayerOverheadInformation = @"Show Players Overhead Information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString StickyTarget = @"Sticky Target";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString TargetFps = @"Target FPS:";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString TargetingSettings = @"Targeting";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Title = @"Settings";
@@ -1787,15 +1795,6 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Vsync = @"V-Sync";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowExperienceAsPercentage = @"Show Experience as percentage";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowHealthAsPercentage = @"Show Health as percentage";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowManaAsPercentage = @"Show Mana as percentage";
         }
 
         public partial struct Parties


### PR DESCRIPTION
* tweaks game settings, allowing for a modular and easier to organize sub-categories within a listbox.
* exposes `stickytarget` and restores it's default value back to false, which allows to un-target by clicking anywhere and/or the target. [this feat was reported to be working prior b7.](https://www.ascensiongamedev.com/topic/6533-cant-un-select-a-target-self-or-other-player/)

[assets pull request](https://github.com/AscensionGameDev/Intersect-Assets/pull/23)

**Preview:**

https://user-images.githubusercontent.com/17498701/190838566-374c4872-6d1c-4a63-bf3a-55abdbb8044b.mp4

