### PR TITLE
fix: remove log spam on control migration

### DIFF
--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -96,6 +96,8 @@ namespace Intersect.Client.Core.Controls
             {
                 Globals.Database.SavePreference($"{name}_binding0", Globals.Database.LoadPreference($"{name}_key1value"));
                 Globals.Database.SavePreference($"{name}_binding1", Globals.Database.LoadPreference($"{name}_key2value"));
+                Globals.Database.DeletePreference($"{name}_key1value");
+                Globals.Database.DeletePreference($"{name}_key2value");
             }
             else if (Globals.Database.HasPreference($"{name}_key1"))
             {
@@ -103,12 +105,9 @@ namespace Intersect.Client.Core.Controls
                 var key2 = JsonConvert.DeserializeObject<Keys>(Globals.Database.LoadPreference($"{name}_key2"));
                 Globals.Database.SavePreference($"{name}_binding0", JsonConvert.SerializeObject(new ControlValue(Keys.None, key1)));
                 Globals.Database.SavePreference($"{name}_binding1", JsonConvert.SerializeObject(new ControlValue(Keys.None, key2)));
+                Globals.Database.DeletePreference($"{name}_key1");
+                Globals.Database.DeletePreference($"{name}_key2");
             }
-
-            Globals.Database.DeletePreference($"{name}_key1");
-            Globals.Database.DeletePreference($"{name}_key2");
-            Globals.Database.DeletePreference($"{name}_key1value");
-            Globals.Database.DeletePreference($"{name}_key2value");
         }
 
         public void Save()


### PR DESCRIPTION
Fix is to not blindly delete preferences if they might not exist, there's already logic to check if they exist, move the deletion within those checks.