### PR TITLE
Update shield info

### DIFF
--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -1270,6 +1270,14 @@ namespace Intersect.Server.Maps
 
                     en.Value.StatusesUpdated = false;
                 }
+
+                foreach (var status in en.Value.CachedStatuses)
+                {
+                    if (status.Type == StatusTypes.Shield)
+                    {
+                        statusUpdates.Add(en.Value);
+                    }
+                }
             }
 
             if (vitalUpdates.Count > 0)


### PR DESCRIPTION
The shield information is not updated constantly when the user uses the shield spell effect. It is necessary to keep recasting the spell constantly to know how much shield is left.

I don't know if this solution is the best (there must be other ways), but with this the problem is solved, I'm sending pr for better analysis by professionals