### PR TITLE
feat: auto-turn to selected target

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -102,6 +102,8 @@ namespace Intersect
         /// </summary>
         public static int MaxLoggedinUsers => Instance._maxUsers;
 
+        public static bool EnableAutoTurnToTarget => Instance.PlayerOpts.EnableAutoTurnToTarget;
+
         public static int MaxStatValue => Instance.PlayerOpts.MaxStat;
 
         public static int MaxLevel => Instance.PlayerOpts.MaxLevel;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -102,8 +102,6 @@ namespace Intersect
         /// </summary>
         public static int MaxLoggedinUsers => Instance._maxUsers;
 
-        public static bool EnableAutoTurnToTarget => Instance.PlayerOpts.EnableAutoTurnToTarget;
-
         public static int MaxStatValue => Instance.PlayerOpts.MaxStat;
 
         public static int MaxLevel => Instance.PlayerOpts.MaxLevel;

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -16,6 +16,11 @@
         public bool AllowCombatMovement { get; set; } = true;
 
         /// <summary>
+        /// Enables de client setting 'Auto-turn to target'.
+        /// </summary>
+        public bool EnableAutoTurnToTarget { get; set; } = true;
+
+        /// <summary>
         /// Enables or disables friend login notifications when a user joins the game.
         /// </summary>
         public bool EnableFriendLoginNotifications { get; set; } = true;

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -16,9 +16,14 @@
         public bool AllowCombatMovement { get; set; } = true;
 
         /// <summary>
-        /// Enables de client setting 'Auto-turn to target'.
+        /// Enables the client feature 'Auto-turn to target'.
         /// </summary>
         public bool EnableAutoTurnToTarget { get; set; } = true;
+
+        /// <summary>
+        /// Sets the delay (milliseconds) for the feature 'Auto-turn to target'.
+        /// </summary>
+        public long AutoTurnToTargetDelay { get; set; } = 50;
 
         /// <summary>
         /// Enables or disables friend login notifications when a user joins the game.

--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -23,7 +23,7 @@
         /// <summary>
         /// Sets the delay (milliseconds) for the feature 'Auto-turn to target'.
         /// </summary>
-        public long AutoTurnToTargetDelay { get; set; } = 50;
+        public ushort AutoTurnToTargetDelay { get; set; } = 500;
 
         /// <summary>
         /// Enables or disables friend login notifications when a user joins the game.

--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -25,6 +25,8 @@ namespace Intersect.Client.Framework.Database
 
         public bool StickyTarget { get; set; }
 
+        public bool AutoTurnToTarget { get; set; }
+
         public bool FriendOverheadInfo { get; set; }
 
         public bool GuildMemberOverheadInfo { get; set; }
@@ -77,6 +79,7 @@ namespace Intersect.Client.Framework.Database
             HideOthersOnWindowOpen = LoadPreference(nameof(HideOthersOnWindowOpen), true);
             TargetAccountDirection = LoadPreference(nameof(TargetAccountDirection), false);
             StickyTarget = LoadPreference(nameof(StickyTarget), false);
+            AutoTurnToTarget = LoadPreference(nameof(AutoTurnToTarget), false);
             FriendOverheadInfo = LoadPreference(nameof(FriendOverheadInfo), true);
             GuildMemberOverheadInfo = LoadPreference(nameof(GuildMemberOverheadInfo), true);
             MyOverheadInfo = LoadPreference(nameof(MyOverheadInfo), true);
@@ -102,6 +105,7 @@ namespace Intersect.Client.Framework.Database
             SavePreference(nameof(HideOthersOnWindowOpen), HideOthersOnWindowOpen);
             SavePreference(nameof(TargetAccountDirection), TargetAccountDirection);
             SavePreference(nameof(StickyTarget), StickyTarget);
+            SavePreference(nameof(AutoTurnToTarget), AutoTurnToTarget);
             SavePreference(nameof(FriendOverheadInfo), FriendOverheadInfo);
             SavePreference(nameof(GuildMemberOverheadInfo), GuildMemberOverheadInfo);
             SavePreference(nameof(MyOverheadInfo), MyOverheadInfo);

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1921,35 +1921,16 @@ namespace Intersect.Client.Entities
 
             var yOffset = originY - targetY;
             var xOffset = originX - targetX;
-            var preferY = (Math.Abs(yOffset) - Math.Abs(xOffset)) > 0;
 
-            switch (preferY)
+            if ((Math.Abs(yOffset) - Math.Abs(xOffset)) > 0)
             {
-                case true when yOffset > 0:
-                    newDir = (byte)Directions.Up;
-                    break;
-                case true when yOffset < 0:
-                    newDir = (byte)Directions.Down;
-                    break;
-                case true when xOffset > 0:
-                    newDir = (byte)Directions.Left;
-                    break;
-                case true when xOffset < 0:
-                    newDir = (byte)Directions.Right;
-                    break;
-
-                case false when xOffset > 0:
-                    newDir = (byte)Directions.Left;
-                    break;
-                case false when xOffset < 0:
-                    newDir = (byte)Directions.Right;
-                    break;
-                case false when yOffset > 0:
-                    newDir = (byte)Directions.Up;
-                    break;
-                case false when yOffset < 0:
-                    newDir = (byte)Directions.Down;
-                    break;
+                newDir = (Math.Abs(yOffset) != 0) ? (yOffset > 0) ? (byte)Directions.Up : (byte)Directions.Down :
+                    (xOffset > 0) ? (byte)Directions.Left : (byte)Directions.Right;
+            }
+            else
+            {
+                newDir = (Math.Abs(xOffset) != 0) ? (xOffset > 0) ? (byte)Directions.Left : (byte)Directions.Right :
+                    (yOffset > 0) ? (byte)Directions.Up : (byte)Directions.Down;
             }
 
             return newDir;

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -198,6 +198,9 @@ namespace Intersect.Client.Entities
         public long SpriteFrameTimer { get; set; } = -1;
 
         public long LastActionTime { get; set; } = -1;
+
+        public long AutoTargetingTime { get; set; } = -1;
+
         #endregion
 
         public EntityTypes Type { get; }
@@ -1921,17 +1924,10 @@ namespace Intersect.Client.Entities
 
             var yOffset = originY - targetY;
             var xOffset = originX - targetX;
+            var xDir = xOffset == 0 ? newDir : (xOffset < 0 ? (byte)Directions.Right : (byte)Directions.Left);
+            var yDir = yOffset == 0 ? newDir : (yOffset < 0 ? (byte)Directions.Down : (byte)Directions.Up);
 
-            if ((Math.Abs(yOffset) - Math.Abs(xOffset)) > 0)
-            {
-                newDir = (Math.Abs(yOffset) != 0) ? (yOffset > 0) ? (byte)Directions.Up : (byte)Directions.Down :
-                    (xOffset > 0) ? (byte)Directions.Left : (byte)Directions.Right;
-            }
-            else
-            {
-                newDir = (Math.Abs(xOffset) != 0) ? (xOffset > 0) ? (byte)Directions.Left : (byte)Directions.Right :
-                    (yOffset > 0) ? (byte)Directions.Up : (byte)Directions.Down;
-            }
+            newDir = Math.Abs(yOffset) > Math.Abs(xOffset) ? yDir : xDir;
 
             return newDir;
         }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1878,6 +1878,83 @@ namespace Intersect.Client.Entities
             return texture != default;
         }
 
+        /// <summary>
+        /// <para>Returns the direction to a player's selected target.
+        /// Thanks to Daywalkr (Middle Ages: Online) for this !</para>
+        /// </summary>
+        /// <param name="en">entity's target</param>
+        /// <returns>direction to player's selected target</returns>
+        protected byte DirectionToTarget(Entity en)
+        {
+            byte newDir = Dir;
+
+            if (en == null)
+            {
+                return newDir;
+            }
+
+            int originY = Y;
+            int originX = X;
+            int targetY = en.Y;
+            int targetX = en.X;
+
+            if (en.MapInstance.Id != MapInstance.Id)
+            {
+                if (en.MapInstance.GridY < MapInstance.GridY)
+                {
+                    originY += Options.MapHeight - 1;
+                }
+                else if (en.MapInstance.GridY > MapInstance.GridY)
+                {
+                    targetY += Options.MapHeight - 1;
+                }
+
+                if (en.MapInstance.GridX < MapInstance.GridX)
+                {
+                    originX += Options.MapWidth - 1;
+                }
+                else if (en.MapInstance.GridX > MapInstance.GridX)
+                {
+                    targetX += (Options.MapWidth - 1);
+                }
+            }
+
+            var yOffset = originY - targetY;
+            var xOffset = originX - targetX;
+            var preferY = (Math.Abs(yOffset) - Math.Abs(xOffset)) > 0;
+
+            switch (preferY)
+            {
+                case true when yOffset > 0:
+                    newDir = (byte)Directions.Up;
+                    break;
+                case true when yOffset < 0:
+                    newDir = (byte)Directions.Down;
+                    break;
+                case true when xOffset > 0:
+                    newDir = (byte)Directions.Left;
+                    break;
+                case true when xOffset < 0:
+                    newDir = (byte)Directions.Right;
+                    break;
+
+                case false when xOffset > 0:
+                    newDir = (byte)Directions.Left;
+                    break;
+                case false when xOffset < 0:
+                    newDir = (byte)Directions.Right;
+                    break;
+                case false when yOffset > 0:
+                    newDir = (byte)Directions.Up;
+                    break;
+                case false when yOffset < 0:
+                    newDir = (byte)Directions.Down;
+                    break;
+            }
+
+            return newDir;
+        }
+
         //Movement
         /// <summary>
         ///     Returns -6 if the tile is blocked by a global (non-event) entity

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -199,7 +199,7 @@ namespace Intersect.Client.Entities
 
         public long LastActionTime { get; set; } = -1;
 
-        public long AutoTargetingTime { get; set; } = -1;
+        public long AutoTurnToTargetTimer { get; set; } = -1;
 
         #endregion
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1405,16 +1405,27 @@ namespace Intersect.Client.Entities
 
         private void AutoTurnToTarget(Entity en)
         {
-            if (!Globals.Database.AutoTurnToTarget || !Options.Instance.PlayerOpts.EnableAutoTurnToTarget || IsMoving ||
-                Dir == MoveDir)
+            if (!Globals.Database.AutoTurnToTarget || !Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
+            {
+                return;
+            }
+
+            if (IsMoving || Dir == MoveDir)
+            {
+                AutoTargetingTime = Timing.Global.Milliseconds + 120;
+                return;
+            }
+
+            byte directionToTarget = DirectionToTarget(en);
+
+            if (AutoTargetingTime + 120 > Timing.Global.Milliseconds || Dir == directionToTarget)
             {
                 return;
             }
 
             MoveDir = -1;
-            byte directionToTarget = DirectionToTarget(en);
             Dir = directionToTarget;
-            PacketSender.SendDirection(directionToTarget);
+            PacketSender.SendDirection(Dir);
         }
 
         public bool TryBlock()
@@ -2327,7 +2338,7 @@ namespace Intersect.Client.Entities
                         continue;
                     }
 
-                    if (((Event)en.Value).DisablePreview)
+                    if (en.Value is Event eventEntity && eventEntity.DisablePreview)
                     {
                         continue;
                     }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1410,15 +1410,15 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            if (IsMoving || Dir == MoveDir)
+            byte directionToTarget = DirectionToTarget(en);
+
+            if (IsMoving || Dir == MoveDir || Dir == directionToTarget)
             {
-                AutoTargetingTime = Timing.Global.Milliseconds + 120;
+                AutoTurnToTargetTimer = Timing.Global.Milliseconds + Options.Instance.PlayerOpts.AutoTurnToTargetDelay;
                 return;
             }
 
-            byte directionToTarget = DirectionToTarget(en);
-
-            if (AutoTargetingTime + 120 > Timing.Global.Milliseconds || Dir == directionToTarget)
+            if (AutoTurnToTargetTimer > Timing.Global.Milliseconds)
             {
                 return;
             }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1405,7 +1405,7 @@ namespace Intersect.Client.Entities
 
         private void AutoTurnToTarget(Entity en)
         {
-            if (!Globals.Database.AutoTurnToTarget || !Options.EnableAutoTurnToTarget || IsMoving ||
+            if (!Globals.Database.AutoTurnToTarget || !Options.Instance.PlayerOpts.EnableAutoTurnToTarget || IsMoving ||
                 Dir == MoveDir)
             {
                 return;
@@ -2282,12 +2282,29 @@ namespace Intersect.Client.Entities
 
         public void DrawTargets()
         {
-            foreach (var en in Globals.Entities.Where(en => en.Value != null))
+            foreach (var en in Globals.Entities)
             {
-                if (en.Value.IsHidden ||
-                    (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player))) ||
-                    (en.Value is Projectile || en.Value is Resource) || TargetType != 0 ||
-                    TargetIndex != en.Value.Id)
+                if (en.Value == null)
+                {
+                    continue;
+                }
+
+                if (en.Value.IsHidden)
+                {
+                    continue;
+                }
+
+                if (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player)))
+                {
+                    continue;
+                }
+
+                if (en.Value is Projectile || en.Value is Resource)
+                {
+                    continue;
+                }
+
+                if (TargetType != 0 || TargetIndex != en.Value.Id)
                 {
                     continue;
                 }
@@ -2298,13 +2315,34 @@ namespace Intersect.Client.Entities
 
             foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
             {
-                foreach (var en in eventMap.LocalEntities.Where(en => en.Value != null))
+                foreach (var en in eventMap.LocalEntities)
                 {
-                    if (en.Value.MapId != eventMap.Id ||
-                        ((Event)en.Value).DisablePreview ||
-                        en.Value.IsHidden ||
-                        (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player))) ||
-                        TargetType != 1 || TargetIndex != en.Value.Id)
+                    if (en.Value == null)
+                    {
+                        continue;
+                    }
+
+                    if (en.Value.MapId != eventMap.Id)
+                    {
+                        continue;
+                    }
+
+                    if (((Event)en.Value).DisablePreview)
+                    {
+                        continue;
+                    }
+
+                    if (en.Value.IsHidden)
+                    {
+                        continue;
+                    }
+
+                    if (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player)))
+                    {
+                        continue;
+                    }
+
+                    if (TargetType != 1 || TargetIndex != en.Value.Id)
                     {
                         continue;
                     }

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -82,6 +82,8 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mStickyTarget;
 
+        private readonly LabeledCheckBox mAutoTurnToTarget;
+
         // Video Settings.
         private readonly ComboBox mResolutionList;
 
@@ -227,6 +229,10 @@ namespace Intersect.Client.Interface.Shared
             // Game Settings - Targeting: Sticky Target.
             mStickyTarget = new LabeledCheckBox(mTargetingSettings, "StickyTargetCheckbox");
             mStickyTarget.Text = Strings.Settings.StickyTarget;
+
+            // Game Settings - Targeting: Auto-turn to Target.
+            mAutoTurnToTarget = new LabeledCheckBox(mTargetingSettings, "AutoTurnToTargetCheckbox");
+            mAutoTurnToTarget.Text = Strings.Settings.AutoTurnToTarget;
 
             #endregion
 
@@ -425,6 +431,11 @@ namespace Intersect.Client.Interface.Shared
             mInterfaceSettings.Hide();
             mInformationSettings.Hide();
             mTargetingSettings.Show();
+            if (!Options.EnableAutoTurnToTarget)
+            {
+                mAutoTurnToTarget.IsChecked = false;
+                mAutoTurnToTarget.IsDisabled = true;
+            }
         }
 
         private void VideoSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
@@ -603,6 +614,7 @@ namespace Intersect.Client.Interface.Shared
             mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
             mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
             mStickyTarget.IsChecked = Globals.Database.StickyTarget;
+            mAutoTurnToTarget.IsChecked = Globals.Database.AutoTurnToTarget;
 
             // Video Settings.
             mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
@@ -775,6 +787,7 @@ namespace Intersect.Client.Interface.Shared
             Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
             Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
             Globals.Database.StickyTarget = mStickyTarget.IsChecked;
+            Globals.Database.AutoTurnToTarget = mAutoTurnToTarget.IsChecked;
 
             // Video Settings.
             var resolution = mResolutionList.SelectedItem;

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -418,24 +418,20 @@ namespace Intersect.Client.Interface.Shared
             mInformationSettings.Hide();
             mTargetingSettings.Hide();
         }
-        
+
         void InformationSettings_Clicked(Base sender, ClickedEventArgs arguments)
         {
             mInterfaceSettings.Hide();
             mInformationSettings.Show();
             mTargetingSettings.Hide();
         }
-        
+
         void TargetingSettings_Clicked(Base sender, ClickedEventArgs arguments)
         {
             mInterfaceSettings.Hide();
             mInformationSettings.Hide();
             mTargetingSettings.Show();
-            if (!Options.EnableAutoTurnToTarget)
-            {
-                mAutoTurnToTarget.IsChecked = false;
-                mAutoTurnToTarget.IsDisabled = true;
-            }
+            mAutoTurnToTarget.IsDisabled = !Options.Instance.PlayerOpts.EnableAutoTurnToTarget;
         }
 
         private void VideoSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1785,6 +1785,9 @@ namespace Intersect.Client.Localization
             public static LocalizedString TargetingSettings = @"Targeting";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString AutoTurnToTarget = @"Auto-turn to target";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Title = @"Settings";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
* Implements a new targeting game setting that allows players to auto-turn to the selected target when enabled.

* Player will auto-turn to their currently selected target (by clicking on them or switching targets) only when not moving and if the direction needs to be changed from the current one.

* The feature can be toggled by the server config as well. When disabled, it will make it so the feature no longer works for the client and the checkbox within the game settings is disabled and unchecked.

* Minor chore at DrawTargets() : reduced nesting by merging and inverting if(s) and used conditional en.Value != null within the foreach loops required for this feature.

* Special thanks to Daywalkr (Middle Ages: Online), took (and changed a bit) the implementation from his repository.

* Should resolve #993 
( #1530 )

[Assets pull request](https://github.com/AscensionGameDev/Intersect-Assets/pull/25)

Video Preview:

https://user-images.githubusercontent.com/17498701/193482524-49ae44a0-d41c-40a8-abbc-15d0e77facc1.mp4

![image](https://user-images.githubusercontent.com/17498701/193482764-bca680d8-195c-4784-8b28-9b226ba6018c.png)



