### PR TITLE
feat: configurable key to hold and turn around

### DIFF
--- a/Intersect.Client/Core/Controls/ControlEnum.cs
+++ b/Intersect.Client/Core/Controls/ControlEnum.cs
@@ -68,7 +68,7 @@
 
         ToggleGui,
         
-        TurnAround
+        TurnAround,
 
     }
 

--- a/Intersect.Client/Core/Controls/ControlEnum.cs
+++ b/Intersect.Client/Core/Controls/ControlEnum.cs
@@ -66,7 +66,9 @@
 
         OpenAdminPanel,
 
-        ToggleGui
+        ToggleGui,
+        
+        TurnAround
 
     }
 

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -87,6 +87,7 @@ namespace Intersect.Client.Core.Controls
             CreateControlMap(Control.OpenDebugger, new ControlValue(Keys.None, Keys.F2), ControlValue.Default);
             CreateControlMap(Control.OpenAdminPanel, new ControlValue(Keys.None, Keys.Insert), ControlValue.Default);
             CreateControlMap(Control.ToggleGui, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
+            CreateControlMap(Control.TurnAround, new ControlValue(Keys.None, Keys.Control), ControlValue.Default);
         }
 
         private static void MigrateControlBindings(Control control)

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2545,9 +2545,9 @@ namespace Intersect.Client.Entities
         private void TurnAround()
         {
             // If players hold the 'TurnAround' Control Key and tap to any direction, they will turn on their own axis.
-            for (var i = 0; i < Options.Instance.Sprites.Directions; i++)
+            for (var direction = 0; direction < Options.Instance.Sprites.Directions; direction++)
             {
-                if (!Controls.KeyDown(Control.TurnAround) || i != Globals.Me.MoveDir)
+                if (!Controls.KeyDown(Control.TurnAround) || direction != Globals.Me.MoveDir)
                 {
                     continue;
                 }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1238,6 +1238,8 @@ namespace Intersect.Client.Entities
                     Globals.Me.MoveDir = 3;
                 }
             }
+            
+            TurnAround();
 
             var castInput = -1;
             for (var barSlot = 0; barSlot < Options.Instance.PlayerOpts.HotbarSlotCount; barSlot++)
@@ -2540,6 +2542,31 @@ namespace Intersect.Client.Entities
             public int DistanceTo;
         }
 
+        private void TurnAround()
+        {
+            // If players hold the 'TurnAround' Control Key and tap to any direction, they will turn on their own axis.
+            for (var i = 0; i < Options.Instance.Sprites.Directions; i++)
+            {
+                if (!Controls.KeyDown(Control.TurnAround) || i != Globals.Me.MoveDir)
+                {
+                    continue;
+                }
+
+                // Turn around and hold the player in place if the requested direction is different from the current one.
+                if (!Globals.Me.IsMoving && Dir != Globals.Me.MoveDir)
+                {
+                    Dir = (byte)Globals.Me.MoveDir;
+                    PacketSender.SendDirection(Dir);
+                    Globals.Me.MoveDir = -1;
+                }
+
+                // Hold the player in place if the requested direction is the same as the current one.
+                if (!Globals.Me.IsMoving && Dir == Globals.Me.MoveDir)
+                {
+                    Globals.Me.MoveDir = -1;
+                }
+            }
+        }
     }
 
 }

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -713,7 +713,7 @@ namespace Intersect.Client.Localization
                 {"opendebugger", @"Open Debugger:"},
                 {"openadminpanel", @"Open Admin Panel:"},
                 {"togglegui", @"Toggle Interface:"},
-                {"turnaround", @"Hold to turn around:"}
+                {"turnaround", @"Hold to turn around:"},
             };
 
             public static LocalizedString listening = @"Listening";

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -712,7 +712,8 @@ namespace Intersect.Client.Localization
                 {"opensettings", @"Open Settings:"},
                 {"opendebugger", @"Open Debugger:"},
                 {"openadminpanel", @"Open Admin Panel:"},
-                {"togglegui", @"Toggle Interface:"}
+                {"togglegui", @"Toggle Interface:"},
+                {"turnaround", @"Hold to turn around:"}
             };
 
             public static LocalizedString listening = @"Listening";


### PR DESCRIPTION
* If players holds the 'TurnAround' Control Key and **tap to any direction**, they will turn on their own axis.
* Added configurable control key (default: Keys.Control)
* This feature doesn't messes with the normal processing nor timing of walking.
* Should resolve #987
* Should resolve #1529
* For testing, [Assets PR Here.](https://github.com/AscensionGameDev/Intersect-Assets/pull/26)

![image](https://user-images.githubusercontent.com/17498701/194784334-1804e9e2-801d-4e45-886a-077f3ced66fe.png)

https://user-images.githubusercontent.com/17498701/194784430-93e24eab-d4c0-45c0-9be6-b078e534d93e.mp4


