### PR TITLE
Account variables

### DIFF
--- a/Intersect (Core)/Enums/CommonEventTrigger.cs
+++ b/Intersect (Core)/Enums/CommonEventTrigger.cs
@@ -1,4 +1,4 @@
-﻿namespace Intersect.Enums
+namespace Intersect.Enums
 {
 
     public enum CommonEventTrigger
@@ -39,6 +39,8 @@
         InventoryChanged,
 
         MapChanged,
+
+        UserVariableChanged,
 
     }
 

--- a/Intersect (Core)/Enums/CommonEventTrigger.cs
+++ b/Intersect (Core)/Enums/CommonEventTrigger.cs
@@ -40,7 +40,7 @@ namespace Intersect.Enums
 
         MapChanged,
 
-        UserVariableChanged,
+        UserVariableChange,
 
     }
 

--- a/Intersect (Core)/Enums/GameObjectType.cs
+++ b/Intersect (Core)/Enums/GameObjectType.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Extensions;
+using Intersect.Extensions;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
 using Intersect.GameObjects.Events;
@@ -62,6 +62,9 @@ namespace Intersect.Enums
 
         [GameObjectInfo(typeof(GuildVariableBase), "guild_variables")]
         GuildVariable,
+
+        [GameObjectInfo(typeof(UserVariableBase), "user_variables")]
+        UserVariable,
 
     }
 

--- a/Intersect (Core)/Enums/SwitchVariableTypes.cs
+++ b/Intersect (Core)/Enums/SwitchVariableTypes.cs
@@ -94,6 +94,20 @@ namespace Intersect.Enums
         LeftShiftGuildVar, 
         
         RightShiftGuildVar,
+
+        DupUserVar,
+
+        AddUserVar,
+
+        SubtractUserVar,
+
+        MultiplyUserVar,
+
+        DivideUserVar,
+
+        LeftShiftUserVar,
+
+        RightShiftUserVar,
     }
 
     public enum VariableComparators

--- a/Intersect (Core)/Enums/SwitchVariableTypes.cs
+++ b/Intersect (Core)/Enums/SwitchVariableTypes.cs
@@ -21,7 +21,9 @@ namespace Intersect.Enums
 
         ServerVariable,
 
-        GuildVariable
+        GuildVariable,
+
+        UserVariable,
 
     }
 

--- a/Intersect (Core)/Enums/SwitchVariableTypes.cs
+++ b/Intersect (Core)/Enums/SwitchVariableTypes.cs
@@ -95,19 +95,19 @@ namespace Intersect.Enums
         
         RightShiftGuildVar,
 
-        DupUserVar,
+        DuplicateUserVariable,
 
-        AddUserVar,
+        AddUserVariable,
 
-        SubtractUserVar,
+        SubtractUserVariable,
 
-        MultiplyUserVar,
+        MultiplyUserVariable,
 
-        DivideUserVar,
+        DivideUserVariable,
 
-        LeftShiftUserVar,
+        LeftShiftUserVariable,
 
-        RightShiftUserVar,
+        RightShiftUserVariable,
     }
 
     public enum VariableComparators

--- a/Intersect (Core)/GameObjects/UserVariableBase.cs
+++ b/Intersect (Core)/GameObjects/UserVariableBase.cs
@@ -35,10 +35,12 @@ namespace Intersect.GameObjects
         /// </summary>
         /// <param name="dataType">The data type to retrieve names of.</param>
         /// <returns>Returns an array of names.</returns>
-        public static string[] GetNamesByType(VariableDataTypes dataType)
-        {
-            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Name).ToArray();
-        }
+        public static string[] GetNamesByType(VariableDataTypes dataType) =>
+            Lookup
+                .Where(pair => pair.Value is UserVariableBase descriptor && descriptor.DataType == dataType)
+                .OrderBy(pair => pair.Value.TimeCreated)
+                .Select(pair => pair.Value.Name)
+                .ToArray();
 
         /// <summary>
         /// Retrieve the list index of an Id within a specific data type list.
@@ -46,10 +48,12 @@ namespace Intersect.GameObjects
         /// <param name="id">The Id to look up.</param>
         /// <param name="dataType">The data type to search up.</param>
         /// <returns>Returns the list Index of the provided Id.</returns>
-        public static int ListIndex(Guid id, VariableDataTypes dataType)
-        {
-            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Id).ToList().IndexOf(id);
-        }
+        public static int ListIndex(Guid id, VariableDataTypes dataType) =>
+            Lookup
+                .Where(pair => pair.Value is UserVariableBase descriptor && descriptor.DataType == dataType)
+                .OrderBy(pair => pair.Value.TimeCreated)
+                .ToList()
+                .FindIndex(pair => pair.Value.Id == id);
 
         /// <summary>
         /// Retrieve the Id associated with a list index of a specific data type.
@@ -64,7 +68,11 @@ namespace Intersect.GameObjects
                 return Guid.Empty;
             }
 
-            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Id).ToArray()[listIndex];
+            return Lookup
+                .Where(pair => pair.Value is UserVariableBase descriptor && descriptor.DataType == dataType)
+                .OrderBy(pair => pair.Value.TimeCreated)
+                .Skip(listIndex)
+                .First().Value.Id;
         }
     }
 }

--- a/Intersect (Core)/GameObjects/UserVariableBase.cs
+++ b/Intersect (Core)/GameObjects/UserVariableBase.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using Intersect.Enums;
+using Intersect.Models;
+
+using Newtonsoft.Json;
+
+namespace Intersect.GameObjects
+{
+    public partial class UserVariableBase : DatabaseObject<UserVariableBase>, IFolderable
+    {
+
+        [JsonConstructor]
+        public UserVariableBase(Guid id) : base(id)
+        {
+            Name = "New User Variable";
+        }
+
+        public UserVariableBase()
+        {
+            Name = "New User Variable";
+        }
+
+        //Identifier used for event chat variables to display the value of this variable/switch.
+        //See https://www.ascensiongamedev.com/topic/749-event-text-variables/ for usage info.
+        public string TextId { get; set; }
+
+        public VariableDataTypes DataType { get; set; } = VariableDataTypes.Boolean;
+
+        /// <inheritdoc />
+        public string Folder { get; set; } = "";
+
+        /// <summary>
+        /// Retrieve an array of variable names of the supplied data type.
+        /// </summary>
+        /// <param name="dataType">The data type to retrieve names of.</param>
+        /// <returns>Returns an array of names.</returns>
+        public static string[] GetNamesByType(VariableDataTypes dataType)
+        {
+            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Name).ToArray();
+        }
+
+        /// <summary>
+        /// Retrieve the list index of an Id within a specific data type list.
+        /// </summary>
+        /// <param name="id">The Id to look up.</param>
+        /// <param name="dataType">The data type to search up.</param>
+        /// <returns>Returns the list Index of the provided Id.</returns>
+        public static int ListIndex(Guid id, VariableDataTypes dataType)
+        {
+            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Id).ToList().IndexOf(id);
+        }
+
+        /// <summary>
+        /// Retrieve the Id associated with a list index of a specific data type.
+        /// </summary>
+        /// <param name="listIndex">The list index to retrieve.</param>
+        /// <param name="dataType">The data type to search up.</param>
+        /// <returns>Returns the Id of the provided index.</returns>
+        public static Guid IdFromList(int listIndex, VariableDataTypes dataType)
+        {
+            if (listIndex < 0 || listIndex > GetNamesByType(dataType).Length)
+            {
+                return Guid.Empty;
+            }
+
+            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.TimeCreated).Where(pairs => ((UserVariableBase)Lookup[pairs]).DataType == dataType).Select(pairs => ((UserVariableBase)Lookup[pairs]).Id).ToArray()[listIndex];
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1319,6 +1319,7 @@ namespace Intersect.Editor.Forms.Editors.Events
                 else if (mod.DupVariableType == VariableTypes.UserVariable)
                 {
                     varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
                 }
@@ -1359,7 +1360,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             if (command.VariableType == VariableTypes.UserVariable)
             {
                 return Strings.EventCommandList.UserVariable.ToString(
-                    UserVariableBase.GetName(command.VariableId), varvalue
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(command.VariableId),
+                    varvalue
                 );
             }
 
@@ -1545,44 +1548,51 @@ namespace Intersect.Editor.Forms.Editors.Events
 
 
                 //User Variable
-                case Enums.VariableMods.DupUserVar:
+                case Enums.VariableMods.DuplicateUserVariable:
                     varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.AddUserVar:
+                case Enums.VariableMods.AddUserVariable:
                     varvalue = Strings.EventCommandList.AddUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.SubtractUserVar:
+                case Enums.VariableMods.SubtractUserVariable:
                     varvalue = Strings.EventCommandList.SubtractUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.MultiplyUserVar:
+                case Enums.VariableMods.MultiplyUserVariable:
                     varvalue = Strings.EventCommandList.MultiplyUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.DivideUserVar:
+                case Enums.VariableMods.DivideUserVariable:
                     varvalue = Strings.EventCommandList.DivideUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.LeftShiftUserVar:
+                case Enums.VariableMods.LeftShiftUserVariable:
                     varvalue = Strings.EventCommandList.LeftShiftUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.RightShiftUserVar:
+                case Enums.VariableMods.RightShiftUserVariable:
                     varvalue = Strings.EventCommandList.RightShiftUserVariable.ToString(
+                        Strings.GameObjectStrings.UserVariable,
                         UserVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
@@ -1613,7 +1623,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             if (command.VariableType == VariableTypes.UserVariable)
             {
                 return Strings.EventCommandList.UserVariable.ToString(
-                    UserVariableBase.GetName(command.VariableId), varvalue
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(command.VariableId),
+                    varvalue
                 );
             }
 
@@ -1659,7 +1671,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             if (command.VariableType == VariableTypes.UserVariable)
             {
                 return Strings.EventCommandList.UserVariable.ToString(
-                    UserVariableBase.GetName(command.VariableId), varvalue
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(command.VariableId),
+                    varvalue
                 );
             }
 

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1316,6 +1316,12 @@ namespace Intersect.Editor.Forms.Editors.Events
                         GuildVariableBase.GetName(mod.DuplicateVariableId)
                     );
                 }
+                else if (mod.DupVariableType == VariableTypes.UserVariable)
+                {
+                    varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+                }
             }
             else
             {
@@ -1347,6 +1353,13 @@ namespace Intersect.Editor.Forms.Editors.Events
             {
                 return Strings.EventCommandList.guildvariable.ToString(
                     GuildVariableBase.GetName(command.VariableId), varvalue
+                );
+            }
+
+            if (command.VariableType == VariableTypes.UserVariable)
+            {
+                return Strings.EventCommandList.UserVariable.ToString(
+                    UserVariableBase.GetName(command.VariableId), varvalue
                 );
             }
 
@@ -1394,15 +1407,12 @@ namespace Intersect.Editor.Forms.Editors.Events
                     varvalue = Strings.EventCommandList.systemtimevariable;
 
                     break;
+
+
+                //Player Variable
                 case Enums.VariableMods.DupPlayerVar:
                     varvalue = Strings.EventCommandList.dupplayervariable.ToString(
                         PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMods.DupGlobalVar:
-                    varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
@@ -1412,21 +1422,9 @@ namespace Intersect.Editor.Forms.Editors.Events
                     );
 
                     break;
-                case Enums.VariableMods.AddGlobalVar:
-                    varvalue = Strings.EventCommandList.addglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
                 case Enums.VariableMods.SubtractPlayerVar:
                     varvalue = Strings.EventCommandList.subtractplayervariable.ToString(
                         PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMods.SubtractGlobalVar:
-                    varvalue = Strings.EventCommandList.subtractglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
@@ -1436,21 +1434,9 @@ namespace Intersect.Editor.Forms.Editors.Events
                     );
 
                     break;
-                case Enums.VariableMods.MultiplyGlobalVar:
-                    varvalue = Strings.EventCommandList.multiplyglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
                 case Enums.VariableMods.DividePlayerVar:
                     varvalue = Strings.EventCommandList.divideplayervariable.ToString(
                         PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMods.DivideGlobalVar:
-                    varvalue = Strings.EventCommandList.divideglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
@@ -1460,15 +1446,48 @@ namespace Intersect.Editor.Forms.Editors.Events
                     );
 
                     break;
-                case Enums.VariableMods.LeftShiftGlobalVar:
-                    varvalue = Strings.EventCommandList.leftshiftglobalvariable.ToString(
+                case Enums.VariableMods.RightShiftPlayerVar:
+                    varvalue = Strings.EventCommandList.rightshiftplayervariable.ToString(
+                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+
+
+                //Global Variable
+                case Enums.VariableMods.DupGlobalVar:
+                    varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
                         ServerVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
-                case Enums.VariableMods.RightShiftPlayerVar:
-                    varvalue = Strings.EventCommandList.rightshiftplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                case Enums.VariableMods.AddGlobalVar:
+                    varvalue = Strings.EventCommandList.addglobalvariable.ToString(
+                        ServerVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.SubtractGlobalVar:
+                    varvalue = Strings.EventCommandList.subtractglobalvariable.ToString(
+                        ServerVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.MultiplyGlobalVar:
+                    varvalue = Strings.EventCommandList.multiplyglobalvariable.ToString(
+                        ServerVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.DivideGlobalVar:
+                    varvalue = Strings.EventCommandList.divideglobalvariable.ToString(
+                        ServerVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.LeftShiftGlobalVar:
+                    varvalue = Strings.EventCommandList.leftshiftglobalvariable.ToString(
+                        ServerVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
                     break;
@@ -1480,7 +1499,7 @@ namespace Intersect.Editor.Forms.Editors.Events
                     break;
 
 
-                //Guilds
+                //Guilds Variable
                 case Enums.VariableMods.DupGuildVar:
                     varvalue = Strings.EventCommandList.dupguildvariable.ToString(
                         GuildVariableBase.GetName(mod.DuplicateVariableId)
@@ -1494,7 +1513,7 @@ namespace Intersect.Editor.Forms.Editors.Events
 
                     break;
                 case Enums.VariableMods.SubtractGuildVar:
-                    varvalue = Strings.EventCommandList.subtractglobalvariable.ToString(
+                    varvalue = Strings.EventCommandList.subtractguildvariable.ToString(
                         GuildVariableBase.GetName(mod.DuplicateVariableId)
                     );
 
@@ -1523,6 +1542,51 @@ namespace Intersect.Editor.Forms.Editors.Events
                     );
 
                     break;
+
+
+                //User Variable
+                case Enums.VariableMods.DupUserVar:
+                    varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.AddUserVar:
+                    varvalue = Strings.EventCommandList.AddUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.SubtractUserVar:
+                    varvalue = Strings.EventCommandList.SubtractUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.MultiplyUserVar:
+                    varvalue = Strings.EventCommandList.MultiplyUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.DivideUserVar:
+                    varvalue = Strings.EventCommandList.DivideUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.LeftShiftUserVar:
+                    varvalue = Strings.EventCommandList.LeftShiftUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
+                case Enums.VariableMods.RightShiftUserVar:
+                    varvalue = Strings.EventCommandList.RightShiftUserVariable.ToString(
+                        UserVariableBase.GetName(mod.DuplicateVariableId)
+                    );
+
+                    break;
             }
 
             if (command.VariableType == VariableTypes.PlayerVariable)
@@ -1543,6 +1607,13 @@ namespace Intersect.Editor.Forms.Editors.Events
             {
                 return Strings.EventCommandList.guildvariable.ToString(
                     GuildVariableBase.GetName(command.VariableId), varvalue
+                );
+            }
+
+            if (command.VariableType == VariableTypes.UserVariable)
+            {
+                return Strings.EventCommandList.UserVariable.ToString(
+                    UserVariableBase.GetName(command.VariableId), varvalue
                 );
             }
 
@@ -1582,6 +1653,13 @@ namespace Intersect.Editor.Forms.Editors.Events
             {
                 return Strings.EventCommandList.guildvariable.ToString(
                     GuildVariableBase.GetName(command.VariableId), varvalue
+                );
+            }
+
+            if (command.VariableType == VariableTypes.UserVariable)
+            {
+                return Strings.EventCommandList.UserVariable.ToString(
+                    UserVariableBase.GetName(command.VariableId), varvalue
                 );
             }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.Designer.cs
@@ -31,6 +31,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private void InitializeComponent()
         {
             this.grpConditional = new DarkUI.Controls.DarkGroupBox();
+            this.grpNpc = new DarkUI.Controls.DarkGroupBox();
+            this.chkNpc = new DarkUI.Controls.DarkCheckBox();
+            this.cmbNpcs = new DarkUI.Controls.DarkComboBox();
+            this.lblNpc = new System.Windows.Forms.Label();
             this.grpInventoryConditions = new DarkUI.Controls.DarkGroupBox();
             this.chkBank = new DarkUI.Controls.DarkCheckBox();
             this.grpVariableAmount = new DarkUI.Controls.DarkGroupBox();
@@ -145,11 +149,13 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpCheckEquippedSlot = new DarkUI.Controls.DarkGroupBox();
             this.cmbCheckEquippedSlot = new DarkUI.Controls.DarkComboBox();
             this.lblCheckEquippedSlot = new System.Windows.Forms.Label();
-            this.grpNpc = new DarkUI.Controls.DarkGroupBox();
-            this.cmbNpcs = new DarkUI.Controls.DarkComboBox();
-            this.lblNpc = new System.Windows.Forms.Label();
-            this.chkNpc = new DarkUI.Controls.DarkCheckBox();
+            this.rdoUserVariable = new DarkUI.Controls.DarkRadioButton();
+            this.cmbCompareUserVar = new DarkUI.Controls.DarkComboBox();
+            this.rdoVarCompareUserVar = new DarkUI.Controls.DarkRadioButton();
+            this.cmbBooleanUserVariable = new DarkUI.Controls.DarkComboBox();
+            this.optBooleanUserVariable = new DarkUI.Controls.DarkRadioButton();
             this.grpConditional.SuspendLayout();
+            this.grpNpc.SuspendLayout();
             this.grpInventoryConditions.SuspendLayout();
             this.grpVariableAmount.SuspendLayout();
             this.grpManualAmount.SuspendLayout();
@@ -177,15 +183,12 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpGender.SuspendLayout();
             this.grpEquippedItem.SuspendLayout();
             this.grpCheckEquippedSlot.SuspendLayout();
-            this.grpNpc.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpConditional
             // 
             this.grpConditional.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpConditional.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpConditional.Controls.Add(this.grpNpc);
-            this.grpConditional.Controls.Add(this.grpInventoryConditions);
             this.grpConditional.Controls.Add(this.grpVariable);
             this.grpConditional.Controls.Add(this.grpMapZoneType);
             this.grpConditional.Controls.Add(this.grpInGuild);
@@ -208,6 +211,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpConditional.Controls.Add(this.grpGender);
             this.grpConditional.Controls.Add(this.grpEquippedItem);
             this.grpConditional.Controls.Add(this.grpCheckEquippedSlot);
+            this.grpConditional.Controls.Add(this.grpNpc);
+            this.grpConditional.Controls.Add(this.grpInventoryConditions);
             this.grpConditional.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpConditional.Location = new System.Drawing.Point(3, 3);
             this.grpConditional.Name = "grpConditional";
@@ -215,6 +220,60 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpConditional.TabIndex = 17;
             this.grpConditional.TabStop = false;
             this.grpConditional.Text = "Conditional";
+            // 
+            // grpNpc
+            // 
+            this.grpNpc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpNpc.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpNpc.Controls.Add(this.chkNpc);
+            this.grpNpc.Controls.Add(this.cmbNpcs);
+            this.grpNpc.Controls.Add(this.lblNpc);
+            this.grpNpc.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpNpc.Location = new System.Drawing.Point(10, 48);
+            this.grpNpc.Name = "grpNpc";
+            this.grpNpc.Size = new System.Drawing.Size(260, 74);
+            this.grpNpc.TabIndex = 40;
+            this.grpNpc.TabStop = false;
+            this.grpNpc.Text = "NPCs";
+            this.grpNpc.Visible = false;
+            // 
+            // chkNpc
+            // 
+            this.chkNpc.Location = new System.Drawing.Point(7, 22);
+            this.chkNpc.Name = "chkNpc";
+            this.chkNpc.Size = new System.Drawing.Size(98, 17);
+            this.chkNpc.TabIndex = 60;
+            this.chkNpc.Text = "Specify NPC?";
+            this.chkNpc.CheckedChanged += new System.EventHandler(this.chkNpc_CheckedChanged);
+            // 
+            // cmbNpcs
+            // 
+            this.cmbNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbNpcs.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbNpcs.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbNpcs.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbNpcs.DrawDropdownHoverOutline = false;
+            this.cmbNpcs.DrawFocusRectangle = false;
+            this.cmbNpcs.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbNpcs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbNpcs.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbNpcs.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbNpcs.FormattingEnabled = true;
+            this.cmbNpcs.Location = new System.Drawing.Point(67, 45);
+            this.cmbNpcs.Name = "cmbNpcs";
+            this.cmbNpcs.Size = new System.Drawing.Size(177, 21);
+            this.cmbNpcs.TabIndex = 39;
+            this.cmbNpcs.Text = null;
+            this.cmbNpcs.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // lblNpc
+            // 
+            this.lblNpc.AutoSize = true;
+            this.lblNpc.Location = new System.Drawing.Point(6, 49);
+            this.lblNpc.Name = "lblNpc";
+            this.lblNpc.Size = new System.Drawing.Size(32, 13);
+            this.lblNpc.TabIndex = 38;
+            this.lblNpc.Text = "NPC:";
             // 
             // grpInventoryConditions
             // 
@@ -449,6 +508,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpSelectVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpSelectVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpSelectVariable.Controls.Add(this.rdoUserVariable);
             this.grpSelectVariable.Controls.Add(this.rdoPlayerVariable);
             this.grpSelectVariable.Controls.Add(this.cmbVariable);
             this.grpSelectVariable.Controls.Add(this.rdoGlobalVariable);
@@ -518,6 +578,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpNumericVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpNumericVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpNumericVariable.Controls.Add(this.cmbCompareUserVar);
+            this.grpNumericVariable.Controls.Add(this.rdoVarCompareUserVar);
             this.grpNumericVariable.Controls.Add(this.cmbNumericComparitor);
             this.grpNumericVariable.Controls.Add(this.nudVariableValue);
             this.grpNumericVariable.Controls.Add(this.lblNumericComparator);
@@ -529,9 +591,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpNumericVariable.Controls.Add(this.cmbCompareGlobalVar);
             this.grpNumericVariable.Controls.Add(this.rdoVarCompareGlobalVar);
             this.grpNumericVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNumericVariable.Location = new System.Drawing.Point(8, 144);
+            this.grpNumericVariable.Location = new System.Drawing.Point(8, 139);
             this.grpNumericVariable.Name = "grpNumericVariable";
-            this.grpNumericVariable.Size = new System.Drawing.Size(247, 171);
+            this.grpNumericVariable.Size = new System.Drawing.Size(247, 182);
             this.grpNumericVariable.TabIndex = 51;
             this.grpNumericVariable.TabStop = false;
             this.grpNumericVariable.Text = "Numeric Variable:";
@@ -780,6 +842,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpBooleanVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpBooleanVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpBooleanVariable.Controls.Add(this.cmbBooleanUserVariable);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanUserVariable);
             this.grpBooleanVariable.Controls.Add(this.optBooleanTrue);
             this.grpBooleanVariable.Controls.Add(this.optBooleanFalse);
             this.grpBooleanVariable.Controls.Add(this.cmbBooleanComparator);
@@ -791,9 +855,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpBooleanVariable.Controls.Add(this.cmbBooleanGlobalVariable);
             this.grpBooleanVariable.Controls.Add(this.optBooleanGlobalVariable);
             this.grpBooleanVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpBooleanVariable.Location = new System.Drawing.Point(8, 145);
+            this.grpBooleanVariable.Location = new System.Drawing.Point(8, 139);
             this.grpBooleanVariable.Name = "grpBooleanVariable";
-            this.grpBooleanVariable.Size = new System.Drawing.Size(247, 170);
+            this.grpBooleanVariable.Size = new System.Drawing.Size(247, 182);
             this.grpBooleanVariable.TabIndex = 52;
             this.grpBooleanVariable.TabStop = false;
             this.grpBooleanVariable.Text = "Boolean Variable:";
@@ -861,7 +925,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbBooleanGuildVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbBooleanGuildVariable.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbBooleanGuildVariable.FormattingEnabled = true;
-            this.cmbBooleanGuildVariable.Location = new System.Drawing.Point(146, 129);
+            this.cmbBooleanGuildVariable.Location = new System.Drawing.Point(146, 124);
             this.cmbBooleanGuildVariable.Name = "cmbBooleanGuildVariable";
             this.cmbBooleanGuildVariable.Size = new System.Drawing.Size(94, 21);
             this.cmbBooleanGuildVariable.TabIndex = 48;
@@ -881,7 +945,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbBooleanPlayerVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbBooleanPlayerVariable.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbBooleanPlayerVariable.FormattingEnabled = true;
-            this.cmbBooleanPlayerVariable.Location = new System.Drawing.Point(146, 75);
+            this.cmbBooleanPlayerVariable.Location = new System.Drawing.Point(146, 70);
             this.cmbBooleanPlayerVariable.Name = "cmbBooleanPlayerVariable";
             this.cmbBooleanPlayerVariable.Size = new System.Drawing.Size(94, 21);
             this.cmbBooleanPlayerVariable.TabIndex = 47;
@@ -891,7 +955,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // optBooleanPlayerVariable
             // 
             this.optBooleanPlayerVariable.AutoSize = true;
-            this.optBooleanPlayerVariable.Location = new System.Drawing.Point(10, 76);
+            this.optBooleanPlayerVariable.Location = new System.Drawing.Point(10, 71);
             this.optBooleanPlayerVariable.Name = "optBooleanPlayerVariable";
             this.optBooleanPlayerVariable.Size = new System.Drawing.Size(128, 17);
             this.optBooleanPlayerVariable.TabIndex = 45;
@@ -900,7 +964,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // optBooleanGuildVariable
             // 
             this.optBooleanGuildVariable.AutoSize = true;
-            this.optBooleanGuildVariable.Location = new System.Drawing.Point(10, 130);
+            this.optBooleanGuildVariable.Location = new System.Drawing.Point(10, 125);
             this.optBooleanGuildVariable.Name = "optBooleanGuildVariable";
             this.optBooleanGuildVariable.Size = new System.Drawing.Size(123, 17);
             this.optBooleanGuildVariable.TabIndex = 46;
@@ -919,7 +983,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbBooleanGlobalVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbBooleanGlobalVariable.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbBooleanGlobalVariable.FormattingEnabled = true;
-            this.cmbBooleanGlobalVariable.Location = new System.Drawing.Point(146, 102);
+            this.cmbBooleanGlobalVariable.Location = new System.Drawing.Point(146, 97);
             this.cmbBooleanGlobalVariable.Name = "cmbBooleanGlobalVariable";
             this.cmbBooleanGlobalVariable.Size = new System.Drawing.Size(94, 21);
             this.cmbBooleanGlobalVariable.TabIndex = 48;
@@ -929,7 +993,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // optBooleanGlobalVariable
             // 
             this.optBooleanGlobalVariable.AutoSize = true;
-            this.optBooleanGlobalVariable.Location = new System.Drawing.Point(10, 103);
+            this.optBooleanGlobalVariable.Location = new System.Drawing.Point(10, 98);
             this.optBooleanGlobalVariable.Name = "optBooleanGlobalVariable";
             this.optBooleanGlobalVariable.Size = new System.Drawing.Size(129, 17);
             this.optBooleanGlobalVariable.TabIndex = 46;
@@ -1865,59 +1929,74 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.lblCheckEquippedSlot.TabIndex = 2;
             this.lblCheckEquippedSlot.Text = "Slot:";
             // 
-            // grpNpc
+            // rdoUserVariable
             // 
-            this.grpNpc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.grpNpc.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpNpc.Controls.Add(this.chkNpc);
-            this.grpNpc.Controls.Add(this.cmbNpcs);
-            this.grpNpc.Controls.Add(this.lblNpc);
-            this.grpNpc.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNpc.Location = new System.Drawing.Point(10, 48);
-            this.grpNpc.Name = "grpNpc";
-            this.grpNpc.Size = new System.Drawing.Size(260, 74);
-            this.grpNpc.TabIndex = 40;
-            this.grpNpc.TabStop = false;
-            this.grpNpc.Text = "NPCs";
-            this.grpNpc.Visible = false;
+            this.rdoUserVariable.AutoSize = true;
+            this.rdoUserVariable.Location = new System.Drawing.Point(116, 41);
+            this.rdoUserVariable.Name = "rdoUserVariable";
+            this.rdoUserVariable.Size = new System.Drawing.Size(106, 17);
+            this.rdoUserVariable.TabIndex = 36;
+            this.rdoUserVariable.Text = "Account Variable";
+            this.rdoUserVariable.CheckedChanged += new System.EventHandler(this.rdoUserVariable_CheckedChanged);
             // 
-            // cmbNpcs
+            // cmbCompareUserVar
             // 
-            this.cmbNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbNpcs.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbNpcs.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbNpcs.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbNpcs.DrawDropdownHoverOutline = false;
-            this.cmbNpcs.DrawFocusRectangle = false;
-            this.cmbNpcs.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbNpcs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbNpcs.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbNpcs.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbNpcs.FormattingEnabled = true;
-            this.cmbNpcs.Location = new System.Drawing.Point(67, 45);
-            this.cmbNpcs.Name = "cmbNpcs";
-            this.cmbNpcs.Size = new System.Drawing.Size(177, 21);
-            this.cmbNpcs.TabIndex = 39;
-            this.cmbNpcs.Text = null;
-            this.cmbNpcs.TextPadding = new System.Windows.Forms.Padding(2);
+            this.cmbCompareUserVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbCompareUserVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbCompareUserVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbCompareUserVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbCompareUserVar.DrawDropdownHoverOutline = false;
+            this.cmbCompareUserVar.DrawFocusRectangle = false;
+            this.cmbCompareUserVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbCompareUserVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbCompareUserVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbCompareUserVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbCompareUserVar.FormattingEnabled = true;
+            this.cmbCompareUserVar.Location = new System.Drawing.Point(146, 156);
+            this.cmbCompareUserVar.Name = "cmbCompareUserVar";
+            this.cmbCompareUserVar.Size = new System.Drawing.Size(94, 21);
+            this.cmbCompareUserVar.TabIndex = 51;
+            this.cmbCompareUserVar.Text = null;
+            this.cmbCompareUserVar.TextPadding = new System.Windows.Forms.Padding(2);
             // 
-            // lblNpc
+            // rdoVarCompareUserVar
             // 
-            this.lblNpc.AutoSize = true;
-            this.lblNpc.Location = new System.Drawing.Point(6, 49);
-            this.lblNpc.Name = "lblNpc";
-            this.lblNpc.Size = new System.Drawing.Size(32, 13);
-            this.lblNpc.TabIndex = 38;
-            this.lblNpc.Text = "NPC:";
+            this.rdoVarCompareUserVar.AutoSize = true;
+            this.rdoVarCompareUserVar.Location = new System.Drawing.Point(10, 157);
+            this.rdoVarCompareUserVar.Name = "rdoVarCompareUserVar";
+            this.rdoVarCompareUserVar.Size = new System.Drawing.Size(139, 17);
+            this.rdoVarCompareUserVar.TabIndex = 50;
+            this.rdoVarCompareUserVar.Text = "Account Variable Value:";
+            this.rdoVarCompareUserVar.CheckedChanged += new System.EventHandler(this.rdoVarCompareUserVar_CheckedChanged);
             // 
-            // chkNpc
+            // cmbBooleanUserVariable
             // 
-            this.chkNpc.Location = new System.Drawing.Point(7, 22);
-            this.chkNpc.Name = "chkNpc";
-            this.chkNpc.Size = new System.Drawing.Size(98, 17);
-            this.chkNpc.TabIndex = 60;
-            this.chkNpc.Text = "Specify NPC?";
-            this.chkNpc.CheckedChanged += new System.EventHandler(this.chkNpc_CheckedChanged);
+            this.cmbBooleanUserVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbBooleanUserVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbBooleanUserVariable.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbBooleanUserVariable.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbBooleanUserVariable.DrawDropdownHoverOutline = false;
+            this.cmbBooleanUserVariable.DrawFocusRectangle = false;
+            this.cmbBooleanUserVariable.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbBooleanUserVariable.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbBooleanUserVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbBooleanUserVariable.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbBooleanUserVariable.FormattingEnabled = true;
+            this.cmbBooleanUserVariable.Location = new System.Drawing.Point(146, 151);
+            this.cmbBooleanUserVariable.Name = "cmbBooleanUserVariable";
+            this.cmbBooleanUserVariable.Size = new System.Drawing.Size(94, 21);
+            this.cmbBooleanUserVariable.TabIndex = 52;
+            this.cmbBooleanUserVariable.Text = null;
+            this.cmbBooleanUserVariable.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // optBooleanUserVariable
+            // 
+            this.optBooleanUserVariable.AutoSize = true;
+            this.optBooleanUserVariable.Location = new System.Drawing.Point(10, 152);
+            this.optBooleanUserVariable.Name = "optBooleanUserVariable";
+            this.optBooleanUserVariable.Size = new System.Drawing.Size(139, 17);
+            this.optBooleanUserVariable.TabIndex = 51;
+            this.optBooleanUserVariable.Text = "Account Variable Value:";
             // 
             // EventCommandConditionalBranch
             // 
@@ -1930,6 +2009,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.Size = new System.Drawing.Size(285, 440);
             this.grpConditional.ResumeLayout(false);
             this.grpConditional.PerformLayout();
+            this.grpNpc.ResumeLayout(false);
+            this.grpNpc.PerformLayout();
             this.grpInventoryConditions.ResumeLayout(false);
             this.grpInventoryConditions.PerformLayout();
             this.grpVariableAmount.ResumeLayout(false);
@@ -1979,8 +2060,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpEquippedItem.PerformLayout();
             this.grpCheckEquippedSlot.ResumeLayout(false);
             this.grpCheckEquippedSlot.PerformLayout();
-            this.grpNpc.ResumeLayout(false);
-            this.grpNpc.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -2106,5 +2185,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private DarkCheckBox chkNpc;
         private DarkComboBox cmbNpcs;
         private System.Windows.Forms.Label lblNpc;
+        private DarkRadioButton rdoUserVariable;
+        internal DarkComboBox cmbCompareUserVar;
+        internal DarkRadioButton rdoVarCompareUserVar;
+        internal DarkComboBox cmbBooleanUserVariable;
+        internal DarkRadioButton optBooleanUserVariable;
     }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -87,7 +87,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoPlayerVariable.Text = Strings.EventConditional.playervariable;
             rdoGlobalVariable.Text = Strings.EventConditional.globalvariable;
             rdoGuildVariable.Text = Strings.EventConditional.guildvariable;
-            rdoUserVariable.Text = Strings.EventConditional.UserVariable;
+            rdoUserVariable.Text = Strings.GameObjectStrings.UserVariable;
 
             //Numeric Variable
             grpNumericVariable.Text = Strings.EventConditional.numericvariable;
@@ -749,7 +749,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
                     if (userVar != null)
                     {
-                        varType = (byte)userVar.Type;
+                        varType = (byte)userVar.DataType;
                     }
                 }
             }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -87,6 +87,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoPlayerVariable.Text = Strings.EventConditional.playervariable;
             rdoGlobalVariable.Text = Strings.EventConditional.globalvariable;
             rdoGuildVariable.Text = Strings.EventConditional.guildvariable;
+            rdoUserVariable.Text = Strings.EventConditional.UserVariable;
 
             //Numeric Variable
             grpNumericVariable.Text = Strings.EventConditional.numericvariable;
@@ -95,6 +96,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoVarComparePlayerVar.Text = Strings.EventConditional.playervariablevalue;
             rdoVarCompareGlobalVar.Text = Strings.EventConditional.globalvariablevalue;
             rdoVarCompareGuildVar.Text = Strings.EventConditional.guildvariablevalue;
+            rdoVarCompareUserVar.Text = Strings.EventConditional.UserVariableValue;
             cmbNumericComparitor.Items.Clear();
             for (var i = 0; i < Strings.EventConditional.comparators.Count; i++)
             {
@@ -114,6 +116,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             optBooleanGlobalVariable.Text = Strings.EventConditional.globalvariablevalue;
             optBooleanPlayerVariable.Text = Strings.EventConditional.playervariablevalue;
             optBooleanGuildVariable.Text = Strings.EventConditional.guildvariablevalue;
+            optBooleanUserVariable.Text = Strings.EventConditional.UserVariableValue;
 
             //String Variable
             grpStringVariable.Text = Strings.EventConditional.stringvariable;
@@ -441,6 +444,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     cmbComparePlayerVar.Items.AddRange(PlayerVariableBase.Names);
                     cmbCompareGuildVar.Items.Clear();
                     cmbCompareGuildVar.Items.AddRange(GuildVariableBase.Names);
+                    cmbCompareUserVar.Items.Clear();
+                    cmbCompareUserVar.Items.AddRange(UserVariableBase.Names);
 
                     cmbBooleanGlobalVariable.Items.Clear();
                     cmbBooleanGlobalVariable.Items.AddRange(ServerVariableBase.Names);
@@ -448,6 +453,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     cmbBooleanPlayerVariable.Items.AddRange(PlayerVariableBase.Names);
                     cmbBooleanGuildVariable.Items.Clear();
                     cmbBooleanGuildVariable.Items.AddRange(GuildVariableBase.Names);
+                    cmbBooleanUserVariable.Items.Clear();
+                    cmbBooleanUserVariable.Items.AddRange(UserVariableBase.Names);
 
                     break;
                 case ConditionTypes.HasItem:
@@ -688,12 +695,18 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             UpdateNumericVariableElements();
         }
 
+        private void rdoVarCompareUserVar_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateNumericVariableElements();
+        }
+
         private void UpdateNumericVariableElements()
         {
             nudVariableValue.Enabled = rdoVarCompareStaticValue.Checked;
             cmbComparePlayerVar.Enabled = rdoVarComparePlayerVar.Checked;
             cmbCompareGlobalVar.Enabled = rdoVarCompareGlobalVar.Checked;
             cmbCompareGuildVar.Enabled = rdoVarCompareGuildVar.Checked;
+            cmbCompareUserVar.Enabled = rdoVarCompareUserVar.Checked;
         }
 
         private void UpdateVariableElements()
@@ -729,6 +742,14 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     if (guildVar != null)
                     {
                         varType = (byte)guildVar.Type;
+                    }
+                }
+                else if (rdoUserVariable.Checked)
+                {
+                    var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
+                    if (userVar != null)
+                    {
+                        varType = (byte)userVar.Type;
                     }
                 }
             }
@@ -800,6 +821,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     optBooleanGuildVariable.Checked = true;
                     cmbBooleanGuildVariable.SelectedIndex = GuildVariableBase.ListIndex(booleanComparison.CompareVariableId);
                 }
+                else if (booleanComparison.CompareVariableType == VariableTypes.UserVariable)
+                {
+                    optBooleanUserVariable.Checked = true;
+                    cmbBooleanUserVariable.SelectedIndex = UserVariableBase.ListIndex(booleanComparison.CompareVariableId);
+                }
             }
         }
 
@@ -833,6 +859,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 {
                     rdoVarCompareGuildVar.Checked = true;
                     cmbCompareGuildVar.SelectedIndex = GuildVariableBase.ListIndex(integerComparison.CompareVariableId);
+                }
+                else if (integerComparison.CompareVariableType == VariableTypes.UserVariable)
+                {
+                    rdoVarCompareUserVar.Checked = true;
+                    cmbCompareUserVar.SelectedIndex = UserVariableBase.ListIndex(integerComparison.CompareVariableId);
                 }
             }
             else
@@ -880,6 +911,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 cmbVariable.Items.AddRange(GuildVariableBase.Names);
                 cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(variableId);
             }
+            else if (rdoUserVariable.Checked)
+            {
+                cmbVariable.Items.AddRange(UserVariableBase.Names);
+                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(variableId);
+            }
 
             mLoading = false;
         }
@@ -911,6 +947,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 comparison.CompareVariableType = VariableTypes.GuildVariable;
                 comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbBooleanGuildVariable.SelectedIndex);
+            }
+            else if (optBooleanUserVariable.Checked)
+            {
+                comparison.CompareVariableType = VariableTypes.UserVariable;
+                comparison.CompareVariableId = UserVariableBase.IdFromList(cmbBooleanUserVariable.SelectedIndex);
             }
 
             return comparison;
@@ -949,6 +990,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 comparison.CompareVariableType = VariableTypes.GuildVariable;
                 comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbCompareGuildVar.SelectedIndex);
             }
+            else if (rdoVarCompareUserVar.Checked)
+            {
+                comparison.CompareVariableType = VariableTypes.UserVariable;
+                comparison.CompareVariableId = UserVariableBase.IdFromList(cmbCompareUserVar.SelectedIndex);
+            }
 
             return comparison;
         }
@@ -980,14 +1026,20 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
         {
-            InitVariableElements(Guid.Empty);
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
+            VariableRadioChanged();
         }
 
         private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void rdoUserVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void VariableRadioChanged()
         {
             InitVariableElements(Guid.Empty);
             if (!mLoading && cmbVariable.Items.Count > 0)
@@ -1014,6 +1066,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             else if (rdoGuildVariable.Checked)
             {
                 InitVariableElements(GuildVariableBase.IdFromList(cmbVariable.SelectedIndex));
+            }
+            else if (rdoUserVariable.Checked)
+            {
+                InitVariableElements(UserVariableBase.IdFromList(cmbVariable.SelectedIndex));
             }
 
             UpdateVariableElements();
@@ -1180,6 +1236,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             else if (condition.VariableType == VariableTypes.GuildVariable)
             {
                 rdoGuildVariable.Checked = true;
+            }
+            else if (condition.VariableType == VariableTypes.UserVariable)
+            {
+                rdoUserVariable.Checked = true;
             }
 
             InitVariableElements(condition.VariableId);
@@ -1348,6 +1408,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 condition.VariableType = VariableTypes.GuildVariable;
                 condition.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
+            }
+            else if (rdoUserVariable.Checked)
+            {
+                condition.VariableType = VariableTypes.UserVariable;
+                condition.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
             }
 
             if (grpBooleanVariable.Visible)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.Designer.cs
@@ -38,7 +38,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.nudMinVal = new DarkUI.Controls.DarkNumericUpDown();
             this.lblMinVal = new System.Windows.Forms.Label();
             this.cmbVariable = new DarkUI.Controls.DarkComboBox();
-            this.rdoGlobalVariables = new DarkUI.Controls.DarkRadioButton();
             this.rdoGuildVariables = new DarkUI.Controls.DarkRadioButton();
             this.rdoPlayerVariables = new DarkUI.Controls.DarkRadioButton();
             this.lblCommands = new System.Windows.Forms.Label();
@@ -46,6 +45,8 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.lblText = new System.Windows.Forms.Label();
             this.btnCancel = new DarkUI.Controls.DarkButton();
             this.btnSave = new DarkUI.Controls.DarkButton();
+            this.rdoGlobalVariables = new DarkUI.Controls.DarkRadioButton();
+            this.rdoUserVariables = new DarkUI.Controls.DarkRadioButton();
             this.grpInput.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMaxVal)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMinVal)).BeginInit();
@@ -55,6 +56,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpInput.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpInput.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpInput.Controls.Add(this.rdoUserVariables);
             this.grpInput.Controls.Add(this.lblTitle);
             this.grpInput.Controls.Add(this.txtTitle);
             this.grpInput.Controls.Add(this.nudMaxVal);
@@ -174,16 +176,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbVariable.TextPadding = new System.Windows.Forms.Padding(2);
             this.cmbVariable.SelectedIndexChanged += new System.EventHandler(this.cmbVariable_SelectedIndexChanged);
             // 
-            // rdoGlobalVariables
-            // 
-            this.rdoGlobalVariables.AutoSize = true;
-            this.rdoGlobalVariables.Location = new System.Drawing.Point(131, 144);
-            this.rdoGlobalVariables.Name = "rdoGlobalVariables";
-            this.rdoGlobalVariables.Size = new System.Drawing.Size(101, 17);
-            this.rdoGlobalVariables.TabIndex = 28;
-            this.rdoGlobalVariables.Text = "Global Variables";
-            this.rdoGlobalVariables.CheckedChanged += new System.EventHandler(this.rdoGlobalVariables_CheckedChanged);
-            // 
             // rdoGuildVariables
             // 
             this.rdoGuildVariables.AutoSize = true;
@@ -260,6 +252,26 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.btnSave.Text = "Ok";
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
+            // rdoGlobalVariables
+            // 
+            this.rdoGlobalVariables.AutoSize = true;
+            this.rdoGlobalVariables.Location = new System.Drawing.Point(131, 144);
+            this.rdoGlobalVariables.Name = "rdoGlobalVariables";
+            this.rdoGlobalVariables.Size = new System.Drawing.Size(101, 17);
+            this.rdoGlobalVariables.TabIndex = 28;
+            this.rdoGlobalVariables.Text = "Global Variables";
+            this.rdoGlobalVariables.CheckedChanged += new System.EventHandler(this.rdoGlobalVariables_CheckedChanged);
+            // 
+            // rdoUserVariables
+            // 
+            this.rdoUserVariables.AutoSize = true;
+            this.rdoUserVariables.Location = new System.Drawing.Point(131, 165);
+            this.rdoUserVariables.Name = "rdoUserVariables";
+            this.rdoUserVariables.Size = new System.Drawing.Size(111, 17);
+            this.rdoUserVariables.TabIndex = 64;
+            this.rdoUserVariables.Text = "Account Variables";
+            this.rdoUserVariables.CheckedChanged += new System.EventHandler(this.rdoUserVariables_CheckedChanged);
+            // 
             // EventCommandInput
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -295,5 +307,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private System.Windows.Forms.Label lblMinVal;
         private System.Windows.Forms.Label lblTitle;
         private DarkTextBox txtTitle;
+        private DarkRadioButton rdoUserVariables;
     }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Forms;
 
 using Intersect.Editor.Localization;
+using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
@@ -29,17 +30,21 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             nudMaxVal.Value = mMyCommand.Maximum;
             nudMinVal.Value = mMyCommand.Minimum;
 
-            if (mMyCommand.VariableType == Enums.VariableTypes.PlayerVariable)
+            if (mMyCommand.VariableType == VariableTypes.PlayerVariable)
             {
                 rdoPlayerVariables.Checked = true;
             }
-            else if (mMyCommand.VariableType == Enums.VariableTypes.ServerVariable)
+            else if (mMyCommand.VariableType == VariableTypes.ServerVariable)
             {
                 rdoGlobalVariables.Checked = true;
             }
-            else if (mMyCommand.VariableType == Enums.VariableTypes.GuildVariable)
+            else if (mMyCommand.VariableType == VariableTypes.GuildVariable)
             {
                 rdoGuildVariables.Checked = true;
+            }
+            else if (mMyCommand.VariableType == VariableTypes.UserVariable)
+            {
+                rdoUserVariables.Checked = true;
             }
 
             LoadVariableList();
@@ -58,6 +63,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoPlayerVariables.Text = Strings.EventInput.playervariable;
             rdoGlobalVariables.Text = Strings.EventInput.globalvariable;
             rdoGuildVariables.Text = Strings.EventInput.guildvariable;
+            rdoUserVariables.Text = Strings.EventInput.UserVariable;
         }
 
         private void LoadVariableList()
@@ -98,9 +104,20 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     );
                 }
             }
+            else if (rdoUserVariables.Checked)
+            {
+                cmbVariable.Items.AddRange(UserVariableBase.Names);
+                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(mMyCommand.VariableId);
+                if (cmbVariable.SelectedIndex != -1)
+                {
+                    UpdateMinMaxValues(
+                        UserVariableBase.Get(UserVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
+                    );
+                }
+            }
         }
 
-        private void UpdateMinMaxValues(Enums.VariableDataTypes type)
+        private void UpdateMinMaxValues(VariableDataTypes type)
         {
             lblMaxVal.Show();
             lblMinVal.Show();
@@ -109,18 +126,18 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
             switch (type)
             {
-                case Enums.VariableDataTypes.Integer:
-                case Enums.VariableDataTypes.Number:
+                case VariableDataTypes.Integer:
+                case VariableDataTypes.Number:
                     lblMinVal.Text = Strings.EventInput.minval;
                     lblMaxVal.Text = Strings.EventInput.maxval;
 
                     break;
-                case Enums.VariableDataTypes.String:
+                case VariableDataTypes.String:
                     lblMinVal.Text = Strings.EventInput.minlength;
                     lblMaxVal.Text = Strings.EventInput.maxlength;
 
                     break;
-                case Enums.VariableDataTypes.Boolean:
+                case VariableDataTypes.Boolean:
                     lblMaxVal.Hide();
                     lblMinVal.Hide();
                     nudMaxVal.Hide();
@@ -139,18 +156,23 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
             if (rdoPlayerVariables.Checked)
             {
-                mMyCommand.VariableType = Enums.VariableTypes.PlayerVariable;
+                mMyCommand.VariableType = VariableTypes.PlayerVariable;
                 mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
             }
             else if (rdoGlobalVariables.Checked)
             {
-                mMyCommand.VariableType = Enums.VariableTypes.ServerVariable;
+                mMyCommand.VariableType = VariableTypes.ServerVariable;
                 mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex);
             }
             else if (rdoGuildVariables.Checked)
             {
-                mMyCommand.VariableType = Enums.VariableTypes.GuildVariable;
+                mMyCommand.VariableType = VariableTypes.GuildVariable;
                 mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                mMyCommand.VariableType = VariableTypes.UserVariable;
+                mMyCommand.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
             }
 
             mEventEditor.FinishCommandEdit();
@@ -170,23 +192,25 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
         {
-            LoadVariableList();
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
+            VariableRadioChanged();
         }
 
         private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
         {
-            LoadVariableList();
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
+            VariableRadioChanged();
         }
 
         private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void VariableRadioChanged()
         {
             LoadVariableList();
             if (!mLoading && cmbVariable.Items.Count > 0)
@@ -212,6 +236,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 variableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
                 UpdateMinMaxValues(GuildVariableBase.Get(variableId).Type);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                variableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
+                UpdateMinMaxValues(UserVariableBase.Get(variableId).Type);
             }
         }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
@@ -63,7 +63,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoPlayerVariables.Text = Strings.EventInput.playervariable;
             rdoGlobalVariables.Text = Strings.EventInput.globalvariable;
             rdoGuildVariables.Text = Strings.EventInput.guildvariable;
-            rdoUserVariables.Text = Strings.EventInput.UserVariable;
+            rdoUserVariables.Text = Strings.GameObjectStrings.UserVariable;
         }
 
         private void LoadVariableList()
@@ -111,7 +111,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 if (cmbVariable.SelectedIndex != -1)
                 {
                     UpdateMinMaxValues(
-                        UserVariableBase.Get(UserVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
+                        UserVariableBase.Get(UserVariableBase.IdFromList(cmbVariable.SelectedIndex)).DataType
                     );
                 }
             }
@@ -240,7 +240,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             else if (rdoUserVariables.Checked)
             {
                 variableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
-                UpdateMinMaxValues(UserVariableBase.Get(variableId).Type);
+                UpdateMinMaxValues(UserVariableBase.Get(variableId).DataType);
             }
         }
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.Designer.cs
@@ -146,7 +146,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.rdoUserVariable.Name = "rdoUserVariable";
             this.rdoUserVariable.Size = new System.Drawing.Size(106, 17);
             this.rdoUserVariable.TabIndex = 41;
-            this.rdoUserVariable.Text = "Account Variable";
+            this.rdoUserVariable.Text = "User Variable";
             this.rdoUserVariable.CheckedChanged += new System.EventHandler(this.rdoUserVariable_CheckedChanged);
             // 
             // chkSyncParty
@@ -548,7 +548,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.optNumericCloneUserVar.Name = "optNumericCloneUserVar";
             this.optNumericCloneUserVar.Size = new System.Drawing.Size(139, 17);
             this.optNumericCloneUserVar.TabIndex = 48;
-            this.optNumericCloneUserVar.Text = "Account Variable Value:";
+            this.optNumericCloneUserVar.Text = "User Variable Value:";
             // 
             // nudNumericValue
             // 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.Designer.cs
@@ -1,4 +1,4 @@
-﻿using DarkUI.Controls;
+using DarkUI.Controls;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 {
@@ -32,13 +32,25 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         {
             this.grpSetVariable = new DarkUI.Controls.DarkGroupBox();
             this.grpSelectVariable = new DarkUI.Controls.DarkGroupBox();
+            this.rdoUserVariable = new DarkUI.Controls.DarkRadioButton();
             this.chkSyncParty = new DarkUI.Controls.DarkCheckBox();
             this.rdoPlayerVariable = new DarkUI.Controls.DarkRadioButton();
             this.cmbVariable = new DarkUI.Controls.DarkComboBox();
-            this.rdoGlobalVariable = new DarkUI.Controls.DarkRadioButton();
             this.rdoGuildVariable = new DarkUI.Controls.DarkRadioButton();
+            this.rdoGlobalVariable = new DarkUI.Controls.DarkRadioButton();
             this.btnCancel = new DarkUI.Controls.DarkButton();
             this.btnSave = new DarkUI.Controls.DarkButton();
+            this.grpBooleanVariable = new DarkUI.Controls.DarkGroupBox();
+            this.cmbBooleanCloneUserVar = new DarkUI.Controls.DarkComboBox();
+            this.optBooleanCloneUserVar = new DarkUI.Controls.DarkRadioButton();
+            this.cmbBooleanCloneGlobalVar = new DarkUI.Controls.DarkComboBox();
+            this.cmbBooleanCloneGuildVar = new DarkUI.Controls.DarkComboBox();
+            this.cmbBooleanClonePlayerVar = new DarkUI.Controls.DarkComboBox();
+            this.optBooleanCloneGlobalVar = new DarkUI.Controls.DarkRadioButton();
+            this.optBooleanCloneGuildVar = new DarkUI.Controls.DarkRadioButton();
+            this.optBooleanClonePlayerVar = new DarkUI.Controls.DarkRadioButton();
+            this.optBooleanTrue = new DarkUI.Controls.DarkRadioButton();
+            this.optBooleanFalse = new DarkUI.Controls.DarkRadioButton();
             this.grpNumericVariable = new DarkUI.Controls.DarkGroupBox();
             this.optNumericRightShift = new DarkUI.Controls.DarkRadioButton();
             this.optNumericLeftShift = new DarkUI.Controls.DarkRadioButton();
@@ -50,14 +62,16 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.optNumericSubtract = new DarkUI.Controls.DarkRadioButton();
             this.optNumericSystemTime = new DarkUI.Controls.DarkRadioButton();
             this.grpNumericValues = new DarkUI.Controls.DarkGroupBox();
+            this.cmbNumericCloneUserVar = new DarkUI.Controls.DarkComboBox();
+            this.optNumericCloneUserVar = new DarkUI.Controls.DarkRadioButton();
             this.nudNumericValue = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbNumericCloneGlobalVar = new DarkUI.Controls.DarkComboBox();
             this.cmbNumericCloneGuildVar = new DarkUI.Controls.DarkComboBox();
             this.cmbNumericClonePlayerVar = new DarkUI.Controls.DarkComboBox();
-            this.optNumericCloneGlobalVar = new DarkUI.Controls.DarkRadioButton();
             this.optNumericCloneGuildVar = new DarkUI.Controls.DarkRadioButton();
             this.optNumericClonePlayerVar = new DarkUI.Controls.DarkRadioButton();
             this.optNumericStaticVal = new DarkUI.Controls.DarkRadioButton();
+            this.cmbNumericCloneGlobalVar = new DarkUI.Controls.DarkComboBox();
+            this.optNumericCloneGlobalVar = new DarkUI.Controls.DarkRadioButton();
             this.grpNumericRandom = new DarkUI.Controls.DarkGroupBox();
             this.nudHigh = new DarkUI.Controls.DarkNumericUpDown();
             this.nudLow = new DarkUI.Controls.DarkNumericUpDown();
@@ -75,17 +89,9 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpStringSet = new DarkUI.Controls.DarkGroupBox();
             this.lblStringValue = new System.Windows.Forms.Label();
             this.txtStringValue = new DarkUI.Controls.DarkTextBox();
-            this.grpBooleanVariable = new DarkUI.Controls.DarkGroupBox();
-            this.cmbBooleanCloneGlobalVar = new DarkUI.Controls.DarkComboBox();
-            this.cmbBooleanCloneGuildVar = new DarkUI.Controls.DarkComboBox();
-            this.cmbBooleanClonePlayerVar = new DarkUI.Controls.DarkComboBox();
-            this.optBooleanCloneGlobalVar = new DarkUI.Controls.DarkRadioButton();
-            this.optBooleanCloneGuildVar = new DarkUI.Controls.DarkRadioButton();
-            this.optBooleanClonePlayerVar = new DarkUI.Controls.DarkRadioButton();
-            this.optBooleanTrue = new DarkUI.Controls.DarkRadioButton();
-            this.optBooleanFalse = new DarkUI.Controls.DarkRadioButton();
             this.grpSetVariable.SuspendLayout();
             this.grpSelectVariable.SuspendLayout();
+            this.grpBooleanVariable.SuspendLayout();
             this.grpNumericVariable.SuspendLayout();
             this.grpNumericValues.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNumericValue)).BeginInit();
@@ -95,7 +101,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpStringVariable.SuspendLayout();
             this.grpStringReplace.SuspendLayout();
             this.grpStringSet.SuspendLayout();
-            this.grpBooleanVariable.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpSetVariable
@@ -105,13 +110,13 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpSetVariable.Controls.Add(this.grpSelectVariable);
             this.grpSetVariable.Controls.Add(this.btnCancel);
             this.grpSetVariable.Controls.Add(this.btnSave);
+            this.grpSetVariable.Controls.Add(this.grpBooleanVariable);
             this.grpSetVariable.Controls.Add(this.grpNumericVariable);
             this.grpSetVariable.Controls.Add(this.grpStringVariable);
-            this.grpSetVariable.Controls.Add(this.grpBooleanVariable);
             this.grpSetVariable.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpSetVariable.Location = new System.Drawing.Point(3, 3);
             this.grpSetVariable.Name = "grpSetVariable";
-            this.grpSetVariable.Size = new System.Drawing.Size(308, 376);
+            this.grpSetVariable.Size = new System.Drawing.Size(311, 394);
             this.grpSetVariable.TabIndex = 17;
             this.grpSetVariable.TabStop = false;
             this.grpSetVariable.Text = "Set Variable";
@@ -120,18 +125,29 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpSelectVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpSelectVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpSelectVariable.Controls.Add(this.rdoUserVariable);
             this.grpSelectVariable.Controls.Add(this.chkSyncParty);
             this.grpSelectVariable.Controls.Add(this.rdoPlayerVariable);
             this.grpSelectVariable.Controls.Add(this.cmbVariable);
             this.grpSelectVariable.Controls.Add(this.rdoGuildVariable);
             this.grpSelectVariable.Controls.Add(this.rdoGlobalVariable);
             this.grpSelectVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSelectVariable.Location = new System.Drawing.Point(6, 19);
+            this.grpSelectVariable.Location = new System.Drawing.Point(6, 20);
             this.grpSelectVariable.Name = "grpSelectVariable";
             this.grpSelectVariable.Size = new System.Drawing.Size(296, 107);
-            this.grpSelectVariable.TabIndex = 40;
+            this.grpSelectVariable.TabIndex = 0;
             this.grpSelectVariable.TabStop = false;
             this.grpSelectVariable.Text = "Select Variable";
+            // 
+            // rdoUserVariable
+            // 
+            this.rdoUserVariable.AutoSize = true;
+            this.rdoUserVariable.Location = new System.Drawing.Point(105, 42);
+            this.rdoUserVariable.Name = "rdoUserVariable";
+            this.rdoUserVariable.Size = new System.Drawing.Size(106, 17);
+            this.rdoUserVariable.TabIndex = 41;
+            this.rdoUserVariable.Text = "Account Variable";
+            this.rdoUserVariable.CheckedChanged += new System.EventHandler(this.rdoUserVariable_CheckedChanged);
             // 
             // chkSyncParty
             // 
@@ -176,16 +192,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbVariable.TextPadding = new System.Windows.Forms.Padding(2);
             this.cmbVariable.SelectedIndexChanged += new System.EventHandler(this.cmbVariable_SelectedIndexChanged);
             // 
-            // rdoGlobalVariable
-            // 
-            this.rdoGlobalVariable.AutoSize = true;
-            this.rdoGlobalVariable.Location = new System.Drawing.Point(105, 19);
-            this.rdoGlobalVariable.Name = "rdoGlobalVariable";
-            this.rdoGlobalVariable.Size = new System.Drawing.Size(96, 17);
-            this.rdoGlobalVariable.TabIndex = 35;
-            this.rdoGlobalVariable.Text = "Global Variable";
-            this.rdoGlobalVariable.CheckedChanged += new System.EventHandler(this.rdoGlobalVariable_CheckedChanged);
-            // 
             // rdoGuildVariable
             // 
             this.rdoGuildVariable.AutoSize = true;
@@ -196,9 +202,19 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.rdoGuildVariable.Text = "Guild Variable";
             this.rdoGuildVariable.CheckedChanged += new System.EventHandler(this.rdoGuildVariable_CheckedChanged);
             // 
+            // rdoGlobalVariable
+            // 
+            this.rdoGlobalVariable.AutoSize = true;
+            this.rdoGlobalVariable.Location = new System.Drawing.Point(105, 19);
+            this.rdoGlobalVariable.Name = "rdoGlobalVariable";
+            this.rdoGlobalVariable.Size = new System.Drawing.Size(96, 17);
+            this.rdoGlobalVariable.TabIndex = 35;
+            this.rdoGlobalVariable.Text = "Global Variable";
+            this.rdoGlobalVariable.CheckedChanged += new System.EventHandler(this.rdoGlobalVariable_CheckedChanged);
+            // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(221, 347);
+            this.btnCancel.Location = new System.Drawing.Point(221, 363);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
@@ -208,13 +224,169 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(12, 347);
+            this.btnSave.Location = new System.Drawing.Point(12, 363);
             this.btnSave.Name = "btnSave";
             this.btnSave.Padding = new System.Windows.Forms.Padding(5);
             this.btnSave.Size = new System.Drawing.Size(75, 23);
             this.btnSave.TabIndex = 19;
             this.btnSave.Text = "Ok";
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // grpBooleanVariable
+            // 
+            this.grpBooleanVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpBooleanVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpBooleanVariable.Controls.Add(this.cmbBooleanCloneUserVar);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanCloneUserVar);
+            this.grpBooleanVariable.Controls.Add(this.cmbBooleanCloneGlobalVar);
+            this.grpBooleanVariable.Controls.Add(this.cmbBooleanCloneGuildVar);
+            this.grpBooleanVariable.Controls.Add(this.cmbBooleanClonePlayerVar);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanCloneGlobalVar);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanCloneGuildVar);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanClonePlayerVar);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanTrue);
+            this.grpBooleanVariable.Controls.Add(this.optBooleanFalse);
+            this.grpBooleanVariable.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpBooleanVariable.Location = new System.Drawing.Point(6, 135);
+            this.grpBooleanVariable.Name = "grpBooleanVariable";
+            this.grpBooleanVariable.Size = new System.Drawing.Size(296, 183);
+            this.grpBooleanVariable.TabIndex = 1;
+            this.grpBooleanVariable.TabStop = false;
+            this.grpBooleanVariable.Text = "Boolean Variable:";
+            // 
+            // cmbBooleanCloneUserVar
+            // 
+            this.cmbBooleanCloneUserVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbBooleanCloneUserVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbBooleanCloneUserVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbBooleanCloneUserVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbBooleanCloneUserVar.DrawDropdownHoverOutline = false;
+            this.cmbBooleanCloneUserVar.DrawFocusRectangle = false;
+            this.cmbBooleanCloneUserVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbBooleanCloneUserVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbBooleanCloneUserVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbBooleanCloneUserVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbBooleanCloneUserVar.FormattingEnabled = true;
+            this.cmbBooleanCloneUserVar.Location = new System.Drawing.Point(146, 152);
+            this.cmbBooleanCloneUserVar.Name = "cmbBooleanCloneUserVar";
+            this.cmbBooleanCloneUserVar.Size = new System.Drawing.Size(138, 21);
+            this.cmbBooleanCloneUserVar.TabIndex = 51;
+            this.cmbBooleanCloneUserVar.Text = null;
+            this.cmbBooleanCloneUserVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // optBooleanCloneUserVar
+            // 
+            this.optBooleanCloneUserVar.AutoSize = true;
+            this.optBooleanCloneUserVar.Location = new System.Drawing.Point(9, 152);
+            this.optBooleanCloneUserVar.Name = "optBooleanCloneUserVar";
+            this.optBooleanCloneUserVar.Size = new System.Drawing.Size(121, 17);
+            this.optBooleanCloneUserVar.TabIndex = 50;
+            this.optBooleanCloneUserVar.Text = "User Variable Value:";
+            // 
+            // cmbBooleanCloneGlobalVar
+            // 
+            this.cmbBooleanCloneGlobalVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbBooleanCloneGlobalVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbBooleanCloneGlobalVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbBooleanCloneGlobalVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbBooleanCloneGlobalVar.DrawDropdownHoverOutline = false;
+            this.cmbBooleanCloneGlobalVar.DrawFocusRectangle = false;
+            this.cmbBooleanCloneGlobalVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbBooleanCloneGlobalVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbBooleanCloneGlobalVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbBooleanCloneGlobalVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbBooleanCloneGlobalVar.FormattingEnabled = true;
+            this.cmbBooleanCloneGlobalVar.Location = new System.Drawing.Point(146, 98);
+            this.cmbBooleanCloneGlobalVar.Name = "cmbBooleanCloneGlobalVar";
+            this.cmbBooleanCloneGlobalVar.Size = new System.Drawing.Size(138, 21);
+            this.cmbBooleanCloneGlobalVar.TabIndex = 49;
+            this.cmbBooleanCloneGlobalVar.Text = null;
+            this.cmbBooleanCloneGlobalVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // cmbBooleanCloneGuildVar
+            // 
+            this.cmbBooleanCloneGuildVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbBooleanCloneGuildVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbBooleanCloneGuildVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbBooleanCloneGuildVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbBooleanCloneGuildVar.DrawDropdownHoverOutline = false;
+            this.cmbBooleanCloneGuildVar.DrawFocusRectangle = false;
+            this.cmbBooleanCloneGuildVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbBooleanCloneGuildVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbBooleanCloneGuildVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbBooleanCloneGuildVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbBooleanCloneGuildVar.FormattingEnabled = true;
+            this.cmbBooleanCloneGuildVar.Location = new System.Drawing.Point(146, 125);
+            this.cmbBooleanCloneGuildVar.Name = "cmbBooleanCloneGuildVar";
+            this.cmbBooleanCloneGuildVar.Size = new System.Drawing.Size(138, 21);
+            this.cmbBooleanCloneGuildVar.TabIndex = 49;
+            this.cmbBooleanCloneGuildVar.Text = null;
+            this.cmbBooleanCloneGuildVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // cmbBooleanClonePlayerVar
+            // 
+            this.cmbBooleanClonePlayerVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbBooleanClonePlayerVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbBooleanClonePlayerVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbBooleanClonePlayerVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbBooleanClonePlayerVar.DrawDropdownHoverOutline = false;
+            this.cmbBooleanClonePlayerVar.DrawFocusRectangle = false;
+            this.cmbBooleanClonePlayerVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbBooleanClonePlayerVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbBooleanClonePlayerVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbBooleanClonePlayerVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbBooleanClonePlayerVar.FormattingEnabled = true;
+            this.cmbBooleanClonePlayerVar.Location = new System.Drawing.Point(146, 71);
+            this.cmbBooleanClonePlayerVar.Name = "cmbBooleanClonePlayerVar";
+            this.cmbBooleanClonePlayerVar.Size = new System.Drawing.Size(138, 21);
+            this.cmbBooleanClonePlayerVar.TabIndex = 48;
+            this.cmbBooleanClonePlayerVar.Text = null;
+            this.cmbBooleanClonePlayerVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // optBooleanCloneGlobalVar
+            // 
+            this.optBooleanCloneGlobalVar.AutoSize = true;
+            this.optBooleanCloneGlobalVar.Location = new System.Drawing.Point(9, 98);
+            this.optBooleanCloneGlobalVar.Name = "optBooleanCloneGlobalVar";
+            this.optBooleanCloneGlobalVar.Size = new System.Drawing.Size(129, 17);
+            this.optBooleanCloneGlobalVar.TabIndex = 47;
+            this.optBooleanCloneGlobalVar.Text = "Global Variable Value:";
+            // 
+            // optBooleanCloneGuildVar
+            // 
+            this.optBooleanCloneGuildVar.AutoSize = true;
+            this.optBooleanCloneGuildVar.Location = new System.Drawing.Point(9, 125);
+            this.optBooleanCloneGuildVar.Name = "optBooleanCloneGuildVar";
+            this.optBooleanCloneGuildVar.Size = new System.Drawing.Size(123, 17);
+            this.optBooleanCloneGuildVar.TabIndex = 47;
+            this.optBooleanCloneGuildVar.Text = "Guild Variable Value:";
+            // 
+            // optBooleanClonePlayerVar
+            // 
+            this.optBooleanClonePlayerVar.AutoSize = true;
+            this.optBooleanClonePlayerVar.Location = new System.Drawing.Point(9, 71);
+            this.optBooleanClonePlayerVar.Name = "optBooleanClonePlayerVar";
+            this.optBooleanClonePlayerVar.Size = new System.Drawing.Size(128, 17);
+            this.optBooleanClonePlayerVar.TabIndex = 46;
+            this.optBooleanClonePlayerVar.Text = "Player Variable Value:";
+            // 
+            // optBooleanTrue
+            // 
+            this.optBooleanTrue.AutoSize = true;
+            this.optBooleanTrue.Location = new System.Drawing.Point(9, 19);
+            this.optBooleanTrue.Name = "optBooleanTrue";
+            this.optBooleanTrue.Size = new System.Drawing.Size(47, 17);
+            this.optBooleanTrue.TabIndex = 26;
+            this.optBooleanTrue.Text = "True";
+            // 
+            // optBooleanFalse
+            // 
+            this.optBooleanFalse.AutoSize = true;
+            this.optBooleanFalse.Location = new System.Drawing.Point(9, 44);
+            this.optBooleanFalse.Name = "optBooleanFalse";
+            this.optBooleanFalse.Size = new System.Drawing.Size(50, 17);
+            this.optBooleanFalse.TabIndex = 25;
+            this.optBooleanFalse.Text = "False";
             // 
             // grpNumericVariable
             // 
@@ -232,10 +404,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpNumericVariable.Controls.Add(this.grpNumericValues);
             this.grpNumericVariable.Controls.Add(this.grpNumericRandom);
             this.grpNumericVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNumericVariable.Location = new System.Drawing.Point(6, 144);
+            this.grpNumericVariable.Location = new System.Drawing.Point(6, 135);
             this.grpNumericVariable.Name = "grpNumericVariable";
-            this.grpNumericVariable.Size = new System.Drawing.Size(296, 183);
-            this.grpNumericVariable.TabIndex = 36;
+            this.grpNumericVariable.Size = new System.Drawing.Size(296, 222);
+            this.grpNumericVariable.TabIndex = 3;
             this.grpNumericVariable.TabStop = false;
             this.grpNumericVariable.Text = "Numeric Variable:";
             // 
@@ -332,20 +504,51 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // 
             this.grpNumericValues.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.grpNumericValues.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpNumericValues.Controls.Add(this.cmbNumericCloneUserVar);
+            this.grpNumericValues.Controls.Add(this.optNumericCloneUserVar);
             this.grpNumericValues.Controls.Add(this.nudNumericValue);
-            this.grpNumericValues.Controls.Add(this.cmbNumericCloneGlobalVar);
             this.grpNumericValues.Controls.Add(this.cmbNumericCloneGuildVar);
             this.grpNumericValues.Controls.Add(this.cmbNumericClonePlayerVar);
-            this.grpNumericValues.Controls.Add(this.optNumericCloneGlobalVar);
             this.grpNumericValues.Controls.Add(this.optNumericCloneGuildVar);
             this.grpNumericValues.Controls.Add(this.optNumericClonePlayerVar);
             this.grpNumericValues.Controls.Add(this.optNumericStaticVal);
+            this.grpNumericValues.Controls.Add(this.cmbNumericCloneGlobalVar);
+            this.grpNumericValues.Controls.Add(this.optNumericCloneGlobalVar);
             this.grpNumericValues.ForeColor = System.Drawing.Color.Gainsboro;
             this.grpNumericValues.Location = new System.Drawing.Point(6, 71);
             this.grpNumericValues.Name = "grpNumericValues";
-            this.grpNumericValues.Size = new System.Drawing.Size(284, 100);
+            this.grpNumericValues.Size = new System.Drawing.Size(284, 146);
             this.grpNumericValues.TabIndex = 37;
             this.grpNumericValues.TabStop = false;
+            // 
+            // cmbNumericCloneUserVar
+            // 
+            this.cmbNumericCloneUserVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbNumericCloneUserVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbNumericCloneUserVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbNumericCloneUserVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbNumericCloneUserVar.DrawDropdownHoverOutline = false;
+            this.cmbNumericCloneUserVar.DrawFocusRectangle = false;
+            this.cmbNumericCloneUserVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbNumericCloneUserVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbNumericCloneUserVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbNumericCloneUserVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbNumericCloneUserVar.FormattingEnabled = true;
+            this.cmbNumericCloneUserVar.Location = new System.Drawing.Point(143, 116);
+            this.cmbNumericCloneUserVar.Name = "cmbNumericCloneUserVar";
+            this.cmbNumericCloneUserVar.Size = new System.Drawing.Size(125, 21);
+            this.cmbNumericCloneUserVar.TabIndex = 49;
+            this.cmbNumericCloneUserVar.Text = null;
+            this.cmbNumericCloneUserVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // optNumericCloneUserVar
+            // 
+            this.optNumericCloneUserVar.AutoSize = true;
+            this.optNumericCloneUserVar.Location = new System.Drawing.Point(6, 116);
+            this.optNumericCloneUserVar.Name = "optNumericCloneUserVar";
+            this.optNumericCloneUserVar.Size = new System.Drawing.Size(139, 17);
+            this.optNumericCloneUserVar.TabIndex = 48;
+            this.optNumericCloneUserVar.Text = "Account Variable Value:";
             // 
             // nudNumericValue
             // 
@@ -371,26 +574,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             0,
             0});
             // 
-            // cmbNumericCloneGlobalVar
-            // 
-            this.cmbNumericCloneGlobalVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbNumericCloneGlobalVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbNumericCloneGlobalVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbNumericCloneGlobalVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbNumericCloneGlobalVar.DrawDropdownHoverOutline = false;
-            this.cmbNumericCloneGlobalVar.DrawFocusRectangle = false;
-            this.cmbNumericCloneGlobalVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbNumericCloneGlobalVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbNumericCloneGlobalVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbNumericCloneGlobalVar.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbNumericCloneGlobalVar.FormattingEnabled = true;
-            this.cmbNumericCloneGlobalVar.Location = new System.Drawing.Point(143, 70);
-            this.cmbNumericCloneGlobalVar.Name = "cmbNumericCloneGlobalVar";
-            this.cmbNumericCloneGlobalVar.Size = new System.Drawing.Size(125, 21);
-            this.cmbNumericCloneGlobalVar.TabIndex = 45;
-            this.cmbNumericCloneGlobalVar.Text = null;
-            this.cmbNumericCloneGlobalVar.TextPadding = new System.Windows.Forms.Padding(2);
-            // 
             // cmbNumericCloneGuildVar
             // 
             this.cmbNumericCloneGuildVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
@@ -404,7 +587,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbNumericCloneGuildVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbNumericCloneGuildVar.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbNumericCloneGuildVar.FormattingEnabled = true;
-            this.cmbNumericCloneGuildVar.Location = new System.Drawing.Point(143, 70);
+            this.cmbNumericCloneGuildVar.Location = new System.Drawing.Point(143, 89);
             this.cmbNumericCloneGuildVar.Name = "cmbNumericCloneGuildVar";
             this.cmbNumericCloneGuildVar.Size = new System.Drawing.Size(125, 21);
             this.cmbNumericCloneGuildVar.TabIndex = 45;
@@ -424,27 +607,17 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.cmbNumericClonePlayerVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbNumericClonePlayerVar.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbNumericClonePlayerVar.FormattingEnabled = true;
-            this.cmbNumericClonePlayerVar.Location = new System.Drawing.Point(143, 38);
+            this.cmbNumericClonePlayerVar.Location = new System.Drawing.Point(143, 35);
             this.cmbNumericClonePlayerVar.Name = "cmbNumericClonePlayerVar";
             this.cmbNumericClonePlayerVar.Size = new System.Drawing.Size(125, 21);
             this.cmbNumericClonePlayerVar.TabIndex = 44;
             this.cmbNumericClonePlayerVar.Text = null;
             this.cmbNumericClonePlayerVar.TextPadding = new System.Windows.Forms.Padding(2);
             // 
-            // optNumericCloneGlobalVar
-            // 
-            this.optNumericCloneGlobalVar.AutoSize = true;
-            this.optNumericCloneGlobalVar.Location = new System.Drawing.Point(6, 70);
-            this.optNumericCloneGlobalVar.Name = "optNumericCloneGlobalVar";
-            this.optNumericCloneGlobalVar.Size = new System.Drawing.Size(129, 17);
-            this.optNumericCloneGlobalVar.TabIndex = 43;
-            this.optNumericCloneGlobalVar.Text = "Global Variable Value:";
-            this.optNumericCloneGlobalVar.CheckedChanged += new System.EventHandler(this.optNumericCloneGlobalVar_CheckedChanged);
-            // 
             // optNumericCloneGuildVar
             // 
             this.optNumericCloneGuildVar.AutoSize = true;
-            this.optNumericCloneGuildVar.Location = new System.Drawing.Point(6, 70);
+            this.optNumericCloneGuildVar.Location = new System.Drawing.Point(6, 89);
             this.optNumericCloneGuildVar.Name = "optNumericCloneGuildVar";
             this.optNumericCloneGuildVar.Size = new System.Drawing.Size(123, 17);
             this.optNumericCloneGuildVar.TabIndex = 43;
@@ -454,7 +627,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             // optNumericClonePlayerVar
             // 
             this.optNumericClonePlayerVar.AutoSize = true;
-            this.optNumericClonePlayerVar.Location = new System.Drawing.Point(6, 38);
+            this.optNumericClonePlayerVar.Location = new System.Drawing.Point(6, 35);
             this.optNumericClonePlayerVar.Name = "optNumericClonePlayerVar";
             this.optNumericClonePlayerVar.Size = new System.Drawing.Size(128, 17);
             this.optNumericClonePlayerVar.TabIndex = 42;
@@ -471,6 +644,36 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.optNumericStaticVal.TabIndex = 46;
             this.optNumericStaticVal.TabStop = true;
             this.optNumericStaticVal.Text = "Static Value:";
+            // 
+            // cmbNumericCloneGlobalVar
+            // 
+            this.cmbNumericCloneGlobalVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbNumericCloneGlobalVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbNumericCloneGlobalVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbNumericCloneGlobalVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbNumericCloneGlobalVar.DrawDropdownHoverOutline = false;
+            this.cmbNumericCloneGlobalVar.DrawFocusRectangle = false;
+            this.cmbNumericCloneGlobalVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbNumericCloneGlobalVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbNumericCloneGlobalVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbNumericCloneGlobalVar.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbNumericCloneGlobalVar.FormattingEnabled = true;
+            this.cmbNumericCloneGlobalVar.Location = new System.Drawing.Point(143, 62);
+            this.cmbNumericCloneGlobalVar.Name = "cmbNumericCloneGlobalVar";
+            this.cmbNumericCloneGlobalVar.Size = new System.Drawing.Size(125, 21);
+            this.cmbNumericCloneGlobalVar.TabIndex = 45;
+            this.cmbNumericCloneGlobalVar.Text = null;
+            this.cmbNumericCloneGlobalVar.TextPadding = new System.Windows.Forms.Padding(2);
+            // 
+            // optNumericCloneGlobalVar
+            // 
+            this.optNumericCloneGlobalVar.AutoSize = true;
+            this.optNumericCloneGlobalVar.Location = new System.Drawing.Point(6, 62);
+            this.optNumericCloneGlobalVar.Name = "optNumericCloneGlobalVar";
+            this.optNumericCloneGlobalVar.Size = new System.Drawing.Size(129, 17);
+            this.optNumericCloneGlobalVar.TabIndex = 43;
+            this.optNumericCloneGlobalVar.Text = "Global Variable Value:";
+            this.optNumericCloneGlobalVar.CheckedChanged += new System.EventHandler(this.optNumericCloneGlobalVar_CheckedChanged);
             // 
             // grpNumericRandom
             // 
@@ -564,10 +767,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpStringVariable.Controls.Add(this.optStaticString);
             this.grpStringVariable.Controls.Add(this.grpStringSet);
             this.grpStringVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpStringVariable.Location = new System.Drawing.Point(6, 145);
+            this.grpStringVariable.Location = new System.Drawing.Point(6, 135);
             this.grpStringVariable.Name = "grpStringVariable";
             this.grpStringVariable.Size = new System.Drawing.Size(296, 183);
-            this.grpStringVariable.TabIndex = 51;
+            this.grpStringVariable.TabIndex = 2;
             this.grpStringVariable.TabStop = false;
             this.grpStringVariable.Text = "String Variable:";
             this.grpStringVariable.Visible = false;
@@ -692,131 +895,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.txtStringValue.Size = new System.Drawing.Size(207, 20);
             this.txtStringValue.TabIndex = 62;
             // 
-            // grpBooleanVariable
-            // 
-            this.grpBooleanVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.grpBooleanVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpBooleanVariable.Controls.Add(this.cmbBooleanCloneGlobalVar);
-            this.grpBooleanVariable.Controls.Add(this.cmbBooleanCloneGuildVar);
-            this.grpBooleanVariable.Controls.Add(this.cmbBooleanClonePlayerVar);
-            this.grpBooleanVariable.Controls.Add(this.optBooleanCloneGlobalVar);
-            this.grpBooleanVariable.Controls.Add(this.optBooleanCloneGuildVar);
-            this.grpBooleanVariable.Controls.Add(this.optBooleanClonePlayerVar);
-            this.grpBooleanVariable.Controls.Add(this.optBooleanTrue);
-            this.grpBooleanVariable.Controls.Add(this.optBooleanFalse);
-            this.grpBooleanVariable.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpBooleanVariable.Location = new System.Drawing.Point(6, 148);
-            this.grpBooleanVariable.Name = "grpBooleanVariable";
-            this.grpBooleanVariable.Size = new System.Drawing.Size(296, 183);
-            this.grpBooleanVariable.TabIndex = 40;
-            this.grpBooleanVariable.TabStop = false;
-            this.grpBooleanVariable.Text = "Boolean Variable:";
-            // 
-            // cmbBooleanCloneGlobalVar
-            // 
-            this.cmbBooleanCloneGlobalVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbBooleanCloneGlobalVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbBooleanCloneGlobalVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbBooleanCloneGlobalVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbBooleanCloneGlobalVar.DrawDropdownHoverOutline = false;
-            this.cmbBooleanCloneGlobalVar.DrawFocusRectangle = false;
-            this.cmbBooleanCloneGlobalVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbBooleanCloneGlobalVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbBooleanCloneGlobalVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbBooleanCloneGlobalVar.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbBooleanCloneGlobalVar.FormattingEnabled = true;
-            this.cmbBooleanCloneGlobalVar.Location = new System.Drawing.Point(146, 103);
-            this.cmbBooleanCloneGlobalVar.Name = "cmbBooleanCloneGlobalVar";
-            this.cmbBooleanCloneGlobalVar.Size = new System.Drawing.Size(138, 21);
-            this.cmbBooleanCloneGlobalVar.TabIndex = 49;
-            this.cmbBooleanCloneGlobalVar.Text = null;
-            this.cmbBooleanCloneGlobalVar.TextPadding = new System.Windows.Forms.Padding(2);
-            // 
-            // cmbBooleanCloneGuildVar
-            // 
-            this.cmbBooleanCloneGuildVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbBooleanCloneGuildVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbBooleanCloneGuildVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbBooleanCloneGuildVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbBooleanCloneGuildVar.DrawDropdownHoverOutline = false;
-            this.cmbBooleanCloneGuildVar.DrawFocusRectangle = false;
-            this.cmbBooleanCloneGuildVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbBooleanCloneGuildVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbBooleanCloneGuildVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbBooleanCloneGuildVar.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbBooleanCloneGuildVar.FormattingEnabled = true;
-            this.cmbBooleanCloneGuildVar.Location = new System.Drawing.Point(146, 103);
-            this.cmbBooleanCloneGuildVar.Name = "cmbBooleanCloneGuildVar";
-            this.cmbBooleanCloneGuildVar.Size = new System.Drawing.Size(138, 21);
-            this.cmbBooleanCloneGuildVar.TabIndex = 49;
-            this.cmbBooleanCloneGuildVar.Text = null;
-            this.cmbBooleanCloneGuildVar.TextPadding = new System.Windows.Forms.Padding(2);
-            // 
-            // cmbBooleanClonePlayerVar
-            // 
-            this.cmbBooleanClonePlayerVar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbBooleanClonePlayerVar.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbBooleanClonePlayerVar.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbBooleanClonePlayerVar.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbBooleanClonePlayerVar.DrawDropdownHoverOutline = false;
-            this.cmbBooleanClonePlayerVar.DrawFocusRectangle = false;
-            this.cmbBooleanClonePlayerVar.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbBooleanClonePlayerVar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbBooleanClonePlayerVar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbBooleanClonePlayerVar.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbBooleanClonePlayerVar.FormattingEnabled = true;
-            this.cmbBooleanClonePlayerVar.Location = new System.Drawing.Point(146, 71);
-            this.cmbBooleanClonePlayerVar.Name = "cmbBooleanClonePlayerVar";
-            this.cmbBooleanClonePlayerVar.Size = new System.Drawing.Size(138, 21);
-            this.cmbBooleanClonePlayerVar.TabIndex = 48;
-            this.cmbBooleanClonePlayerVar.Text = null;
-            this.cmbBooleanClonePlayerVar.TextPadding = new System.Windows.Forms.Padding(2);
-            // 
-            // optBooleanCloneGlobalVar
-            // 
-            this.optBooleanCloneGlobalVar.AutoSize = true;
-            this.optBooleanCloneGlobalVar.Location = new System.Drawing.Point(9, 103);
-            this.optBooleanCloneGlobalVar.Name = "optBooleanCloneGlobalVar";
-            this.optBooleanCloneGlobalVar.Size = new System.Drawing.Size(129, 17);
-            this.optBooleanCloneGlobalVar.TabIndex = 47;
-            this.optBooleanCloneGlobalVar.Text = "Global Variable Value:";
-            // 
-            // optBooleanCloneGuildVar
-            // 
-            this.optBooleanCloneGuildVar.AutoSize = true;
-            this.optBooleanCloneGuildVar.Location = new System.Drawing.Point(9, 103);
-            this.optBooleanCloneGuildVar.Name = "optBooleanCloneGuildVar";
-            this.optBooleanCloneGuildVar.Size = new System.Drawing.Size(123, 17);
-            this.optBooleanCloneGuildVar.TabIndex = 47;
-            this.optBooleanCloneGuildVar.Text = "Guild Variable Value:";
-            // 
-            // optBooleanClonePlayerVar
-            // 
-            this.optBooleanClonePlayerVar.AutoSize = true;
-            this.optBooleanClonePlayerVar.Location = new System.Drawing.Point(9, 71);
-            this.optBooleanClonePlayerVar.Name = "optBooleanClonePlayerVar";
-            this.optBooleanClonePlayerVar.Size = new System.Drawing.Size(128, 17);
-            this.optBooleanClonePlayerVar.TabIndex = 46;
-            this.optBooleanClonePlayerVar.Text = "Player Variable Value:";
-            // 
-            // optBooleanTrue
-            // 
-            this.optBooleanTrue.AutoSize = true;
-            this.optBooleanTrue.Location = new System.Drawing.Point(9, 19);
-            this.optBooleanTrue.Name = "optBooleanTrue";
-            this.optBooleanTrue.Size = new System.Drawing.Size(47, 17);
-            this.optBooleanTrue.TabIndex = 26;
-            this.optBooleanTrue.Text = "True";
-            // 
-            // optBooleanFalse
-            // 
-            this.optBooleanFalse.AutoSize = true;
-            this.optBooleanFalse.Location = new System.Drawing.Point(9, 44);
-            this.optBooleanFalse.Name = "optBooleanFalse";
-            this.optBooleanFalse.Size = new System.Drawing.Size(50, 17);
-            this.optBooleanFalse.TabIndex = 25;
-            this.optBooleanFalse.Text = "False";
-            // 
             // EventCommandVariable
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -825,10 +903,12 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.Controls.Add(this.grpSetVariable);
             this.Name = "EventCommandVariable";
-            this.Size = new System.Drawing.Size(315, 387);
+            this.Size = new System.Drawing.Size(320, 403);
             this.grpSetVariable.ResumeLayout(false);
             this.grpSelectVariable.ResumeLayout(false);
             this.grpSelectVariable.PerformLayout();
+            this.grpBooleanVariable.ResumeLayout(false);
+            this.grpBooleanVariable.PerformLayout();
             this.grpNumericVariable.ResumeLayout(false);
             this.grpNumericVariable.PerformLayout();
             this.grpNumericValues.ResumeLayout(false);
@@ -844,8 +924,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             this.grpStringReplace.PerformLayout();
             this.grpStringSet.ResumeLayout(false);
             this.grpStringSet.PerformLayout();
-            this.grpBooleanVariable.ResumeLayout(false);
-            this.grpBooleanVariable.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -906,5 +984,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         internal DarkRadioButton optNumericLeftShift;
         internal DarkRadioButton optNumericDivide;
         internal DarkRadioButton optNumericMultiply;
+        private DarkRadioButton rdoUserVariable;
+        internal DarkComboBox cmbBooleanCloneUserVar;
+        internal DarkRadioButton optBooleanCloneUserVar;
+        internal DarkComboBox cmbNumericCloneUserVar;
+        internal DarkRadioButton optNumericCloneUserVar;
     }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
@@ -28,20 +28,24 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             InitLocalization();
 
             //Numerics
-            cmbNumericCloneGlobalVar.Items.Clear();
-            cmbNumericCloneGlobalVar.Items.AddRange(ServerVariableBase.Names);
             cmbNumericClonePlayerVar.Items.Clear();
             cmbNumericClonePlayerVar.Items.AddRange(PlayerVariableBase.Names);
+            cmbNumericCloneGlobalVar.Items.Clear();
+            cmbNumericCloneGlobalVar.Items.AddRange(ServerVariableBase.Names);
             cmbNumericCloneGuildVar.Items.Clear();
-            cmbNumericCloneGuildVar.Items.AddRange(PlayerVariableBase.Names);
+            cmbNumericCloneGuildVar.Items.AddRange(GuildVariableBase.Names);
+            cmbNumericCloneUserVar.Items.Clear();
+            cmbNumericCloneUserVar.Items.AddRange(UserVariableBase.Names);
 
             //Booleans
-            cmbBooleanCloneGlobalVar.Items.Clear();
-            cmbBooleanCloneGlobalVar.Items.AddRange(ServerVariableBase.Names);
             cmbBooleanClonePlayerVar.Items.Clear();
             cmbBooleanClonePlayerVar.Items.AddRange(PlayerVariableBase.Names);
+            cmbBooleanCloneGlobalVar.Items.Clear();
+            cmbBooleanCloneGlobalVar.Items.AddRange(ServerVariableBase.Names);
             cmbBooleanCloneGuildVar.Items.Clear();
-            cmbBooleanCloneGuildVar.Items.AddRange(PlayerVariableBase.Names);
+            cmbBooleanCloneGuildVar.Items.AddRange(GuildVariableBase.Names);
+            cmbBooleanCloneUserVar.Items.Clear();
+            cmbBooleanCloneUserVar.Items.AddRange(UserVariableBase.Names);
 
             if (mMyCommand.VariableType == VariableTypes.ServerVariable)
             {
@@ -54,6 +58,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             else if (mMyCommand.VariableType == VariableTypes.GuildVariable)
             {
                 rdoGuildVariable.Checked = true;
+            }
+            else if (mMyCommand.VariableType == VariableTypes.UserVariable)
+            {
+                rdoUserVariable.Checked = true;
             }
 
             mLoading = false;
@@ -68,6 +76,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoGlobalVariable.Text = Strings.EventSetVariable.global;
             rdoPlayerVariable.Text = Strings.EventSetVariable.player;
             rdoGuildVariable.Text = Strings.EventSetVariable.guild;
+            rdoUserVariable.Text = Strings.EventSetVariable.UserVariable;
             btnSave.Text = Strings.EventSetVariable.okay;
             btnCancel.Text = Strings.EventSetVariable.cancel;
             chkSyncParty.Text = Strings.EventSetVariable.syncparty;
@@ -87,6 +96,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             optNumericClonePlayerVar.Text = Strings.EventSetVariable.numericcloneplayervariablevalue;
             optNumericCloneGuildVar.Text = Strings.EventSetVariable.numericcloneguildvariablevalue;
             optNumericCloneGlobalVar.Text = Strings.EventSetVariable.numericcloneglobalvariablevalue;
+            optNumericCloneUserVar.Text = Strings.EventSetVariable.NumericCloneUserVariableValue;
             lblNumericRandomLow.Text = Strings.EventSetVariable.numericrandomlow;
             lblNumericRandomHigh.Text = Strings.EventSetVariable.numericrandomhigh;
 
@@ -97,6 +107,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             optBooleanCloneGlobalVar.Text = Strings.EventSetVariable.booleanccloneglobalvariablevalue;
             optBooleanClonePlayerVar.Text = Strings.EventSetVariable.booleancloneplayervariablevalue;
             optBooleanCloneGuildVar.Text = Strings.EventSetVariable.booleanccloneguildvariablevalue;
+            optBooleanCloneUserVar.Text = Strings.EventSetVariable.BooleanCloneUserVariableValue;
 
             //String
             grpStringVariable.Text = Strings.EventSetVariable.stringlabel;
@@ -113,7 +124,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         private void InitEditor()
         {
             cmbVariable.Items.Clear();
-            var varCount = 0;
+
             if (rdoPlayerVariable.Checked)
             {
                 cmbVariable.Items.AddRange(PlayerVariableBase.Names);
@@ -128,6 +139,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 cmbVariable.Items.AddRange(GuildVariableBase.Names);
                 cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(mMyCommand.VariableId);
+            }
+            else if (rdoUserVariable.Checked)
+            {
+                cmbVariable.Items.AddRange(UserVariableBase.Names);
+                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(mMyCommand.VariableId);
             }
 
             chkSyncParty.Checked = mMyCommand.SyncParty;
@@ -168,6 +184,14 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     if (guildVar != null)
                     {
                         varType = (byte)guildVar.Type;
+                    }
+                }
+                else if (rdoUserVariable.Checked)
+                {
+                    var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
+                    if (userVar != null)
+                    {
+                        varType = (byte)userVar.Type;
                     }
                 }
             }
@@ -226,6 +250,12 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
             }
 
+            if (rdoUserVariable.Checked)
+            {
+                mMyCommand.VariableType = VariableTypes.UserVariable;
+                mMyCommand.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
+            }
+
             if (grpNumericVariable.Visible)
             {
                 mMyCommand.Modification = GetNumericVariableMod();
@@ -268,43 +298,25 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
         private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
         {
-            InitEditor();
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-
-            if (!mLoading)
-            {
-                optNumericSet.Checked = true;
-            }
-
-            if (!mLoading)
-            {
-                nudNumericValue.Value = 0;
-            }
+            VariableRadioChanged();
         }
 
         private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
         {
-            InitEditor();
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-
-            if (!mLoading)
-            {
-                optNumericSet.Checked = true;
-            }
-
-            if (!mLoading)
-            {
-                nudNumericValue.Value = 0;
-            }
+            VariableRadioChanged();
         }
 
         private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void rdoUserVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void VariableRadioChanged()
         {
             InitEditor();
             if (!mLoading && cmbVariable.Items.Count > 0)
@@ -365,6 +377,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 optBooleanCloneGuildVar.Checked = true;
                 cmbBooleanCloneGuildVar.SelectedIndex = GuildVariableBase.ListIndex(booleanMod.DuplicateVariableId);
             }
+            else if (booleanMod.DupVariableType == VariableTypes.UserVariable)
+            {
+                optBooleanCloneUserVar.Checked = true;
+                cmbBooleanCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(booleanMod.DuplicateVariableId);
+            }
         }
 
         private BooleanVariableMod GetBooleanVariableMod()
@@ -388,6 +405,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 mod.DupVariableType = VariableTypes.GuildVariable;
                 mod.DuplicateVariableId = GuildVariableBase.IdFromList(cmbBooleanCloneGuildVar.SelectedIndex);
+            }
+            else if (optBooleanCloneUserVar.Checked)
+            {
+                mod.DupVariableType = VariableTypes.UserVariable;
+                mod.DuplicateVariableId = UserVariableBase.IdFromList(cmbBooleanCloneUserVar.SelectedIndex);
             }
 
             return mod;
@@ -474,17 +496,11 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
 
+                //Player variable modifications
                 case VariableMods.DupPlayerVar:
                     optNumericSet.Checked = true;
                     optNumericClonePlayerVar.Checked = true;
                     cmbNumericClonePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerMod.DuplicateVariableId);
-
-                    break;
-
-                case VariableMods.DupGlobalVar:
-                    optNumericSet.Checked = true;
-                    optNumericCloneGlobalVar.Checked = true;
-                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
@@ -495,24 +511,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
 
-                case VariableMods.AddGlobalVar:
-                    optNumericAdd.Checked = true;
-                    optNumericCloneGlobalVar.Checked = true;
-                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
-
-                    break;
-
                 case VariableMods.SubtractPlayerVar:
                     optNumericSubtract.Checked = true;
                     optNumericClonePlayerVar.Checked = true;
                     cmbNumericClonePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerMod.DuplicateVariableId);
-
-                    break;
-
-                case VariableMods.SubtractGlobalVar:
-                    optNumericSubtract.Checked = true;
-                    optNumericCloneGlobalVar.Checked = true;
-                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
@@ -523,24 +525,10 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
 
-                case VariableMods.MultiplyGlobalVar:
-                    optNumericMultiply.Checked = true;
-                    optNumericCloneGlobalVar.Checked = true;
-                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
-
-                    break;
-
                 case VariableMods.DividePlayerVar:
                     optNumericDivide.Checked = true;
                     optNumericClonePlayerVar.Checked = true;
                     cmbNumericClonePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerMod.DuplicateVariableId);
-
-                    break;
-
-                case VariableMods.DivideGlobalVar:
-                    optNumericDivide.Checked = true;
-                    optNumericCloneGlobalVar.Checked = true;
-                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
@@ -551,17 +539,53 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
 
-                case VariableMods.LeftShiftGlobalVar:
-                    optNumericLeftShift.Checked = true;
+                case VariableMods.RightShiftPlayerVar:
+                    optNumericRightShift.Checked = true;
+                    optNumericClonePlayerVar.Checked = true;
+                    cmbNumericClonePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                //Global variable modifications
+                case VariableMods.DupGlobalVar:
+                    optNumericSet.Checked = true;
                     optNumericCloneGlobalVar.Checked = true;
                     cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.RightShiftPlayerVar:
-                    optNumericRightShift.Checked = true;
-                    optNumericClonePlayerVar.Checked = true;
-                    cmbNumericClonePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+                case VariableMods.AddGlobalVar:
+                    optNumericAdd.Checked = true;
+                    optNumericCloneGlobalVar.Checked = true;
+                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.SubtractGlobalVar:
+                    optNumericSubtract.Checked = true;
+                    optNumericCloneGlobalVar.Checked = true;
+                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.MultiplyGlobalVar:
+                    optNumericMultiply.Checked = true;
+                    optNumericCloneGlobalVar.Checked = true;
+                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.DivideGlobalVar:
+                    optNumericDivide.Checked = true;
+                    optNumericCloneGlobalVar.Checked = true;
+                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.LeftShiftGlobalVar:
+                    optNumericLeftShift.Checked = true;
+                    optNumericCloneGlobalVar.Checked = true;
+                    cmbNumericCloneGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
@@ -572,6 +596,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
 
                     break;
 
+                //Guild variable modifications
                 case VariableMods.DupGuildVar:
                     optNumericSet.Checked = true;
                     optNumericCloneGuildVar.Checked = true;
@@ -618,6 +643,56 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     optNumericRightShift.Checked = true;
                     optNumericCloneGuildVar.Checked = true;
                     cmbNumericCloneGuildVar.SelectedIndex = GuildVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                //User variable modifications
+                case VariableMods.DupUserVar:
+                    optNumericSet.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.AddUserVar:
+                    optNumericAdd.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.SubtractUserVar:
+                    optNumericSubtract.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.MultiplyUserVar:
+                    optNumericMultiply.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.DivideUserVar:
+                    optNumericDivide.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.LeftShiftUserVar:
+                    optNumericLeftShift.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
+
+                    break;
+
+                case VariableMods.RightShiftUserVar:
+                    optNumericRightShift.Checked = true;
+                    optNumericCloneUserVar.Checked = true;
+                    cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
             }
@@ -842,6 +917,39 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                 }
 
                 mod.DuplicateVariableId = GuildVariableBase.IdFromList(cmbNumericCloneGuildVar.SelectedIndex);
+            }
+            else if (optNumericCloneUserVar.Checked)
+            {
+                if (optNumericSet.Checked)
+                {
+                    mod.ModType = VariableMods.DupUserVar;
+                }
+                else if (optNumericAdd.Checked)
+                {
+                    mod.ModType = VariableMods.AddUserVar;
+                }
+                else if (optNumericSubtract.Checked)
+                {
+                    mod.ModType = VariableMods.SubtractUserVar;
+                }
+                else if (optNumericMultiply.Checked)
+                {
+                    mod.ModType = VariableMods.MultiplyUserVar;
+                }
+                else if (optNumericDivide.Checked)
+                {
+                    mod.ModType = VariableMods.DivideUserVar;
+                }
+                else if (optNumericLeftShift.Checked)
+                {
+                    mod.ModType = VariableMods.LeftShiftUserVar;
+                }
+                else
+                {
+                    mod.ModType = VariableMods.RightShiftUserVar;
+                }
+
+                mod.DuplicateVariableId = UserVariableBase.IdFromList(cmbNumericCloneUserVar.SelectedIndex);
             }
 
             return mod;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
@@ -76,7 +76,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             rdoGlobalVariable.Text = Strings.EventSetVariable.global;
             rdoPlayerVariable.Text = Strings.EventSetVariable.player;
             rdoGuildVariable.Text = Strings.EventSetVariable.guild;
-            rdoUserVariable.Text = Strings.EventSetVariable.UserVariable;
+            rdoUserVariable.Text = Strings.GameObjectStrings.UserVariable;
             btnSave.Text = Strings.EventSetVariable.okay;
             btnCancel.Text = Strings.EventSetVariable.cancel;
             chkSyncParty.Text = Strings.EventSetVariable.syncparty;
@@ -191,7 +191,7 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
                     if (userVar != null)
                     {
-                        varType = (byte)userVar.Type;
+                        varType = (byte)userVar.DataType;
                     }
                 }
             }
@@ -647,49 +647,49 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
                     break;
 
                 //User variable modifications
-                case VariableMods.DupUserVar:
+                case VariableMods.DuplicateUserVariable:
                     optNumericSet.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.AddUserVar:
+                case VariableMods.AddUserVariable:
                     optNumericAdd.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.SubtractUserVar:
+                case VariableMods.SubtractUserVariable:
                     optNumericSubtract.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.MultiplyUserVar:
+                case VariableMods.MultiplyUserVariable:
                     optNumericMultiply.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.DivideUserVar:
+                case VariableMods.DivideUserVariable:
                     optNumericDivide.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.LeftShiftUserVar:
+                case VariableMods.LeftShiftUserVariable:
                     optNumericLeftShift.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
 
                     break;
 
-                case VariableMods.RightShiftUserVar:
+                case VariableMods.RightShiftUserVariable:
                     optNumericRightShift.Checked = true;
                     optNumericCloneUserVar.Checked = true;
                     cmbNumericCloneUserVar.SelectedIndex = UserVariableBase.ListIndex(integerMod.DuplicateVariableId);
@@ -922,31 +922,31 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             {
                 if (optNumericSet.Checked)
                 {
-                    mod.ModType = VariableMods.DupUserVar;
+                    mod.ModType = VariableMods.DuplicateUserVariable;
                 }
                 else if (optNumericAdd.Checked)
                 {
-                    mod.ModType = VariableMods.AddUserVar;
+                    mod.ModType = VariableMods.AddUserVariable;
                 }
                 else if (optNumericSubtract.Checked)
                 {
-                    mod.ModType = VariableMods.SubtractUserVar;
+                    mod.ModType = VariableMods.SubtractUserVariable;
                 }
                 else if (optNumericMultiply.Checked)
                 {
-                    mod.ModType = VariableMods.MultiplyUserVar;
+                    mod.ModType = VariableMods.MultiplyUserVariable;
                 }
                 else if (optNumericDivide.Checked)
                 {
-                    mod.ModType = VariableMods.DivideUserVar;
+                    mod.ModType = VariableMods.DivideUserVariable;
                 }
                 else if (optNumericLeftShift.Checked)
                 {
-                    mod.ModType = VariableMods.LeftShiftUserVar;
+                    mod.ModType = VariableMods.LeftShiftUserVariable;
                 }
                 else
                 {
-                    mod.ModType = VariableMods.RightShiftUserVar;
+                    mod.ModType = VariableMods.RightShiftUserVariable;
                 }
 
                 mod.DuplicateVariableId = UserVariableBase.IdFromList(cmbNumericCloneUserVar.SelectedIndex);

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -1825,6 +1825,15 @@ namespace Intersect.Editor.Forms.Editors.Events
                     lblVariableTrigger.Show();
                     lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
                 }
+                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
+                {
+                    cmbVariable.Show();
+                    cmbVariable.Items.Add(Strings.General.None);
+                    cmbVariable.Items.AddRange(UserVariableBase.Names);
+                    cmbVariable.SelectedIndex = UserVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
+                    lblVariableTrigger.Show();
+                    lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
+                }
             }
         }
 
@@ -1843,6 +1852,10 @@ namespace Intersect.Editor.Forms.Editors.Events
                 else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.GuildVariableChange)
                 {
                     CurrentPage.TriggerId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
+                }
+                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
+                {
+                    CurrentPage.TriggerId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
                 }
             }
         }

--- a/Intersect.Editor/Forms/Editors/frmVariable.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.Designer.cs
@@ -1,4 +1,4 @@
-﻿using DarkUI.Controls;
+using DarkUI.Controls;
 
 namespace Intersect.Editor.Forms.Editors
 {
@@ -33,6 +33,8 @@ namespace Intersect.Editor.Forms.Editors
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmSwitchVariable));
             this.grpTypes = new DarkUI.Controls.DarkGroupBox();
+            this.rdoUserVariables = new DarkUI.Controls.DarkRadioButton();
+            this.rdoGuildVariables = new DarkUI.Controls.DarkRadioButton();
             this.rdoGlobalVariables = new DarkUI.Controls.DarkRadioButton();
             this.rdoPlayerVariables = new DarkUI.Controls.DarkRadioButton();
             this.grpList = new DarkUI.Controls.DarkGroupBox();
@@ -65,7 +67,6 @@ namespace Intersect.Editor.Forms.Editors
             this.btnAlphabetical = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
-            this.rdoGuildVariables = new DarkUI.Controls.DarkRadioButton();
             this.grpTypes.SuspendLayout();
             this.grpList.SuspendLayout();
             this.grpEditor.SuspendLayout();
@@ -79,6 +80,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             this.grpTypes.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpTypes.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpTypes.Controls.Add(this.rdoUserVariables);
             this.grpTypes.Controls.Add(this.rdoGuildVariables);
             this.grpTypes.Controls.Add(this.rdoGlobalVariables);
             this.grpTypes.Controls.Add(this.rdoPlayerVariables);
@@ -89,6 +91,26 @@ namespace Intersect.Editor.Forms.Editors
             this.grpTypes.TabIndex = 0;
             this.grpTypes.TabStop = false;
             this.grpTypes.Text = "Variable Type";
+            // 
+            // rdoUserVariables
+            // 
+            this.rdoUserVariables.AutoSize = true;
+            this.rdoUserVariables.Location = new System.Drawing.Point(352, 20);
+            this.rdoUserVariables.Name = "rdoUserVariables";
+            this.rdoUserVariables.Size = new System.Drawing.Size(111, 17);
+            this.rdoUserVariables.TabIndex = 5;
+            this.rdoUserVariables.Text = "Account Variables";
+            this.rdoUserVariables.CheckedChanged += new System.EventHandler(this.rdoUserVariables_CheckedChanged);
+            // 
+            // rdoGuildVariables
+            // 
+            this.rdoGuildVariables.AutoSize = true;
+            this.rdoGuildVariables.Location = new System.Drawing.Point(242, 20);
+            this.rdoGuildVariables.Name = "rdoGuildVariables";
+            this.rdoGuildVariables.Size = new System.Drawing.Size(95, 17);
+            this.rdoGuildVariables.TabIndex = 4;
+            this.rdoGuildVariables.Text = "Guild Variables";
+            this.rdoGuildVariables.CheckedChanged += new System.EventHandler(this.rdoGuildVariables_CheckedChanged);
             // 
             // rdoGlobalVariables
             // 
@@ -507,16 +529,6 @@ namespace Intersect.Editor.Forms.Editors
             this.toolStripItemUndo.Text = "Undo";
             this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
             // 
-            // rdoGuildVariables
-            // 
-            this.rdoGuildVariables.AutoSize = true;
-            this.rdoGuildVariables.Location = new System.Drawing.Point(242, 20);
-            this.rdoGuildVariables.Name = "rdoGuildVariables";
-            this.rdoGuildVariables.Size = new System.Drawing.Size(95, 17);
-            this.rdoGuildVariables.TabIndex = 4;
-            this.rdoGuildVariables.Text = "Guild Variables";
-            this.rdoGuildVariables.CheckedChanged += new System.EventHandler(this.rdoGuildVariables_CheckedChanged);
-            // 
             // FrmSwitchVariable
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -586,5 +598,6 @@ namespace Intersect.Editor.Forms.Editors
         private DarkTextBox txtStringValue;
         private Controls.GameObjectList lstGameObjects;
         private DarkRadioButton rdoGuildVariables;
+        private DarkRadioButton rdoUserVariables;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmVariable.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.Designer.cs
@@ -99,7 +99,7 @@ namespace Intersect.Editor.Forms.Editors
             this.rdoUserVariables.Name = "rdoUserVariables";
             this.rdoUserVariables.Size = new System.Drawing.Size(111, 17);
             this.rdoUserVariables.TabIndex = 5;
-            this.rdoUserVariables.Text = "Account Variables";
+            this.rdoUserVariables.Text = "User Variables";
             this.rdoUserVariables.CheckedChanged += new System.EventHandler(this.rdoUserVariables_CheckedChanged);
             // 
             // rdoGuildVariables

--- a/Intersect.Editor/Forms/Editors/frmVariable.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.cs
@@ -95,7 +95,7 @@ namespace Intersect.Editor.Forms.Editors
             rdoPlayerVariables.Text = Strings.VariableEditor.playervariables;
             rdoGlobalVariables.Text = Strings.VariableEditor.globalvariables;
             rdoGuildVariables.Text = Strings.VariableEditor.guildvariables;
-            rdoUserVariables.Text = Strings.VariableEditor.UserVariables;
+            rdoUserVariables.Text = Strings.GameObjectStrings.UserVariables;
             grpEditor.Text = Strings.VariableEditor.editor;
             lblName.Text = Strings.VariableEditor.name;
             grpValue.Text = Strings.VariableEditor.value;
@@ -299,7 +299,7 @@ namespace Intersect.Editor.Forms.Editors
                 }
                 else if (rdoUserVariables.Checked)
                 {
-                    lblObject.Text = Strings.VariableEditor.UserVariable;
+                    lblObject.Text = Strings.GameObjectStrings.UserVariable;
                     txtObjectName.Text = ((UserVariableBase)mEditorItem).Name;
                     txtId.Text = ((UserVariableBase)mEditorItem).TextId;
                     cmbFolder.Text = ((UserVariableBase)mEditorItem).Folder;
@@ -642,7 +642,7 @@ namespace Intersect.Editor.Forms.Editors
 
                 mUserKnownFolders.Sort();
                 cmbFolder.Items.AddRange(mUserKnownFolders.ToArray());
-                lblId.Text = Strings.VariableEditor.TextIdUserVar;
+                lblId.Text = Strings.VariableEditor.UserVariableId;
             }
 
             mFolders.Sort();

--- a/Intersect.Editor/Forms/Editors/frmVariable.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -34,6 +34,10 @@ namespace Intersect.Editor.Forms.Editors
 
         private List<string> mGuildExpandedFolders = new List<string>();
 
+        private List<string> mUserKnownFolders = new List<string>();
+
+        private List<string> mUserExpandedFolders = new List<string>();
+
         public FrmSwitchVariable()
         {
             ApplyHooks();
@@ -46,6 +50,7 @@ namespace Intersect.Editor.Forms.Editors
 
             lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, null, toolStripItemUndo_Click, null, toolStripItemDelete_Click);
         }
+
         private void AssignEditorItem(Guid id)
         {
             if (id != Guid.Empty)
@@ -63,6 +68,10 @@ namespace Intersect.Editor.Forms.Editors
                 {
                     obj = GuildVariableBase.Get(id);
                 }
+                else if (rdoUserVariables.Checked)
+                {
+                    obj = UserVariableBase.Get(id);
+                }
 
                 if (obj != null)
                 {
@@ -74,6 +83,7 @@ namespace Intersect.Editor.Forms.Editors
                     }
                 }
             }
+
             UpdateEditor();
         }
 
@@ -85,6 +95,7 @@ namespace Intersect.Editor.Forms.Editors
             rdoPlayerVariables.Text = Strings.VariableEditor.playervariables;
             rdoGlobalVariables.Text = Strings.VariableEditor.globalvariables;
             rdoGuildVariables.Text = Strings.VariableEditor.guildvariables;
+            rdoUserVariables.Text = Strings.VariableEditor.UserVariables;
             grpEditor.Text = Strings.VariableEditor.editor;
             lblName.Text = Strings.VariableEditor.name;
             grpValue.Text = Strings.VariableEditor.value;
@@ -139,6 +150,15 @@ namespace Intersect.Editor.Forms.Editors
                     UpdateEditor();
                 }
             }
+            else if (type == GameObjectType.UserVariable)
+            {
+                InitEditor();
+                if (mEditorItem != null && !UserVariableBase.Lookup.Values.Contains(mEditorItem))
+                {
+                    mEditorItem = null;
+                    UpdateEditor();
+                }
+            }
         }
 
         private void toolStripItemNew_Click(object sender, EventArgs e)
@@ -154,6 +174,10 @@ namespace Intersect.Editor.Forms.Editors
             else if (rdoGuildVariables.Checked)
             {
                 PacketSender.SendCreateObject(GameObjectType.GuildVariable);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                PacketSender.SendCreateObject(GameObjectType.UserVariable);
             }
         }
 
@@ -210,25 +234,30 @@ namespace Intersect.Editor.Forms.Editors
 
         private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
         {
-            mEditorItem = null;
-            lstGameObjects.ClearExpandedFolders();
-            InitEditor();
+            VariableRadioChanged();
         }
 
         private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
         {
-            mEditorItem = null;
-            lstGameObjects.ClearExpandedFolders();
-            InitEditor();
+            VariableRadioChanged();
 
         }
 
         private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
         {
+            VariableRadioChanged();
+
+        }
+        private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
+        {
+            VariableRadioChanged();
+        }
+
+        private void VariableRadioChanged()
+        {
             mEditorItem = null;
             lstGameObjects.ClearExpandedFolders();
             InitEditor();
-
         }
 
         private void UpdateToolStripItems()
@@ -268,6 +297,14 @@ namespace Intersect.Editor.Forms.Editors
                     cmbFolder.Text = ((GuildVariableBase)mEditorItem).Folder;
                     cmbVariableType.SelectedIndex = (int)(((GuildVariableBase)mEditorItem).Type - 1);
                 }
+                else if (rdoUserVariables.Checked)
+                {
+                    lblObject.Text = Strings.VariableEditor.UserVariable;
+                    txtObjectName.Text = ((UserVariableBase)mEditorItem).Name;
+                    txtId.Text = ((UserVariableBase)mEditorItem).TextId;
+                    cmbFolder.Text = ((UserVariableBase)mEditorItem).Folder;
+                    cmbVariableType.SelectedIndex = (int)(((UserVariableBase)mEditorItem).DataType - 1);
+                }
 
                 InitValueGroup();
             }
@@ -301,6 +338,12 @@ namespace Intersect.Editor.Forms.Editors
                     lstGameObjects.SelectedNode.Text = obj.Name;
                     grpValue.Hide();
                 }
+                else if (rdoUserVariables.Checked)
+                {
+                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    lstGameObjects.SelectedNode.Text = obj.Name;
+                    grpValue.Hide();
+                }
             }
         }
 
@@ -325,6 +368,12 @@ namespace Intersect.Editor.Forms.Editors
                 else if (rdoGuildVariables.Checked)
                 {
                     var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    obj.Name = txtObjectName.Text;
+                    lstGameObjects.UpdateText(obj.Name);
+                }
+                else if (rdoUserVariables.Checked)
+                {
+                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
                     obj.Name = txtObjectName.Text;
                     lstGameObjects.UpdateText(obj.Name);
                 }
@@ -355,21 +404,10 @@ namespace Intersect.Editor.Forms.Editors
                     var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
                     obj.TextId = txtId.Text;
                 }
-            }
-        }
-
-        private void nudVariableValue_ValueChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoGlobalVariables.Checked)
+                else if (rdoUserVariables.Checked)
                 {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    if (obj != null)
-                    {
-                        obj.Value.Integer = (long) nudVariableValue.Value;
-                        UpdateSelection();
-                    }
+                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    obj.TextId = txtId.Text;
                 }
             }
         }
@@ -393,6 +431,11 @@ namespace Intersect.Editor.Forms.Editors
                     var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
                     obj.Type = (VariableDataTypes)(cmbVariableType.SelectedIndex + 1);
                 }
+                else if (rdoUserVariables.Checked)
+                {
+                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    obj.DataType = (VariableDataTypes)(cmbVariableType.SelectedIndex + 1);
+                }
 
                 InitValueGroup();
                 UpdateSelection();
@@ -401,7 +444,7 @@ namespace Intersect.Editor.Forms.Editors
 
         private void InitValueGroup()
         {
-            if (rdoPlayerVariables.Checked || rdoGuildVariables.Checked)
+            if (rdoPlayerVariables.Checked || rdoGuildVariables.Checked || rdoUserVariables.Checked)
             {
                 grpValue.Hide();
             }
@@ -438,6 +481,22 @@ namespace Intersect.Editor.Forms.Editors
 
                         default:
                             throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+        }
+
+        private void nudVariableValue_ValueChanged(object sender, EventArgs e)
+        {
+            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+            {
+                if (rdoGlobalVariables.Checked)
+                {
+                    var obj = ServerVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    if (obj != null)
+                    {
+                        obj.Value.Integer = (long)nudVariableValue.Value;
+                        UpdateSelection();
                     }
                 }
             }
@@ -493,6 +552,10 @@ namespace Intersect.Editor.Forms.Editors
             else if (rdoGuildVariables.Checked)
             {
                 grpVariables.Text = rdoGuildVariables.Text;
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                grpVariables.Text = rdoUserVariables.Text;
             }
 
             grpEditor.Hide();
@@ -562,6 +625,25 @@ namespace Intersect.Editor.Forms.Editors
                 cmbFolder.Items.AddRange(mGuildKnownFolders.ToArray());
                 lblId.Text = Strings.VariableEditor.textidguildvar;
             }
+            else if (rdoUserVariables.Checked)
+            {
+                foreach (var itm in UserVariableBase.Lookup)
+                {
+                    if (!string.IsNullOrEmpty(((UserVariableBase)itm.Value).Folder) &&
+                        !mFolders.Contains(((UserVariableBase)itm.Value).Folder))
+                    {
+                        mFolders.Add(((UserVariableBase)itm.Value).Folder);
+                        if (!mUserKnownFolders.Contains(((UserVariableBase)itm.Value).Folder))
+                        {
+                            mUserKnownFolders.Add(((UserVariableBase)itm.Value).Folder);
+                        }
+                    }
+                }
+
+                mUserKnownFolders.Sort();
+                cmbFolder.Items.AddRange(mUserKnownFolders.ToArray());
+                lblId.Text = Strings.VariableEditor.TextIdUserVar;
+            }
 
             mFolders.Sort();
 
@@ -570,17 +652,22 @@ namespace Intersect.Editor.Forms.Editors
             if (rdoPlayerVariables.Checked)
             {
                 items = PlayerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((PlayerVariableBase)pair.Value)?.Name ?? Models.DatabaseObject<PlayerVariableBase>.Deleted, ((PlayerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+                    new KeyValuePair<string, string>(((PlayerVariableBase)pair.Value)?.Name ?? DatabaseObject<PlayerVariableBase>.Deleted, ((PlayerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
             }
             else if (rdoGlobalVariables.Checked)
             {
                 items = ServerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((ServerVariableBase)pair.Value)?.Name ?? Models.DatabaseObject<ServerVariableBase>.Deleted + " = " + ((ServerVariableBase)pair.Value)?.Value.ToString(((ServerVariableBase)pair.Value).Type) ?? "", ((ServerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+                    new KeyValuePair<string, string>(((ServerVariableBase)pair.Value)?.Name ?? DatabaseObject<ServerVariableBase>.Deleted + " = " + ((ServerVariableBase)pair.Value)?.Value.ToString(((ServerVariableBase)pair.Value).Type) ?? "", ((ServerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
             }
             else if (rdoGuildVariables.Checked)
             {
                 items = GuildVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((GuildVariableBase)pair.Value)?.Name ?? Models.DatabaseObject<GuildVariableBase>.Deleted, ((GuildVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+                    new KeyValuePair<string, string>(((GuildVariableBase)pair.Value)?.Name ?? DatabaseObject<GuildVariableBase>.Deleted, ((GuildVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                items = UserVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                    new KeyValuePair<string, string>(((UserVariableBase)pair.Value)?.Name ?? DatabaseObject<UserVariableBase>.Deleted, ((UserVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
             }
 
             lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
@@ -620,6 +707,12 @@ namespace Intersect.Editor.Forms.Editors
                             obj.Folder = folderName;
                             mGuildExpandedFolders.Add(folderName);
                         }
+                        else if (rdoUserVariables.Checked)
+                        {
+                            var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                            obj.Folder = folderName;
+                            mUserExpandedFolders.Add(folderName);
+                        }
 
                         InitEditor();
                         cmbFolder.Text = folderName;
@@ -645,6 +738,11 @@ namespace Intersect.Editor.Forms.Editors
                 else if (rdoGuildVariables.Checked)
                 {
                     var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                    obj.Folder = cmbFolder.Text;
+                }
+                else if (rdoUserVariables.Checked)
+                {
+                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
                     obj.Folder = cmbFolder.Text;
                 }
 
@@ -697,6 +795,7 @@ namespace Intersect.Editor.Forms.Editors
         }
 
         #endregion
+
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/frmVariable.resx
+++ b/Intersect.Editor/Forms/Editors/frmVariable.resx
@@ -120,9 +120,6 @@
   <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="toolStripItemNew.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -86,6 +86,12 @@ namespace Intersect.Editor.Localization
                     GuildVariableBase.GetName(condition.VariableId), pVar
                 );
             }
+            else if (condition.VariableType == VariableTypes.UserVariable)
+            {
+                return EventConditionDesc.UserVariable.ToString(
+                    UserVariableBase.GetName(condition.VariableId), pVar
+                );
+            }
 
             return "";
         }
@@ -2537,6 +2543,12 @@ Tick timer saved in server config.json.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString CheckBank = @"Check Bank?";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UserVariable = @"Account Variable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UserVariableValue = @"Account Variable Value:";
         }
 
         public partial struct EventConditionDesc
@@ -2647,6 +2659,8 @@ Tick timer saved in server config.json.";
             public static LocalizedString timeinvalid = @"invalid";
 
             public static LocalizedString True = @"True";
+
+            public static LocalizedString UserVariable = @"Account Variable: {00} {01}";
 
         }
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -89,7 +89,9 @@ namespace Intersect.Editor.Localization
             else if (condition.VariableType == VariableTypes.UserVariable)
             {
                 return EventConditionDesc.UserVariable.ToString(
-                    UserVariableBase.GetName(condition.VariableId), pVar
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(condition.VariableId),
+                    pVar
                 );
             }
 
@@ -1905,7 +1907,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dupguildvariable = @"Guild Variable: {00}'s Value";
 
-            public static LocalizedString DupUserVariable = @"Account Variable: {00}'s Value";
+            public static LocalizedString DupUserVariable = @"{00}: {01}'s Value";
 
             public static LocalizedString addglobalvariable = @"Add Global Variable: {00}'s Value";
 
@@ -1913,7 +1915,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString addguildvariable = @"Add Guild Variable: {00}'s Value";
 
-            public static LocalizedString AddUserVariable = @"Add Account Variable: {00}'s Value";
+            public static LocalizedString AddUserVariable = @"Add {00}: {01}'s Value";
 
             public static LocalizedString subtractglobalvariable = @"Subtract Global Variable: {00}'s Value";
 
@@ -1921,7 +1923,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString subtractguildvariable = @"Subtract Guild Variable: {00}'s Value";
 
-            public static LocalizedString SubtractUserVariable = @"Subtract Account Variable: {00}'s Value";
+            public static LocalizedString SubtractUserVariable = @"Subtract {00}: {01}'s Value";
 
             public static LocalizedString multiplyglobalvariable = @"Multiply Global Variable: {00}'s Value";
 
@@ -1929,7 +1931,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString multiplyguildvariable = @"Multiply Guild Variable: {00}'s Value";
 
-            public static LocalizedString MultiplyUserVariable = @"Multiply Account Variable: {00}'s Value";
+            public static LocalizedString MultiplyUserVariable = @"Multiply {00}: {01}'s Value";
 
             public static LocalizedString divideglobalvariable = @"Divide Global Variable: {00}'s Value";
 
@@ -1937,7 +1939,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString divideguildvariable = @"Divide Guild Variable: {00}'s Value";
 
-            public static LocalizedString DivideUserVariable = @"Divide Account Variable: {00}'s Value";
+            public static LocalizedString DivideUserVariable = @"Divide {00}: {01}'s Value";
 
             public static LocalizedString leftshiftglobalvariable = @"Left Bit Shift Global Variable: {00}'s Value";
 
@@ -1945,7 +1947,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString leftshiftguildvariable = @"Left Bit Shift Guild Variable: {00}'s Value";
 
-            public static LocalizedString LeftShiftUserVariable = @"Left Bit Shift Account Variable: {00}'s Value";
+            public static LocalizedString LeftShiftUserVariable = @"Left Bit Shift {00}: {01}'s Value";
 
             public static LocalizedString rightshiftglobalvariable = @"Right Bit Shift Global Variable: {00}'s Value";
 
@@ -1953,7 +1955,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString rightshiftguildvariable = @"Right Bit Shift Guild Variable: {00}'s Value";
 
-            public static LocalizedString RightShiftUserVariable = @"Right Bit Shift Account Variable: {00}'s Value";
+            public static LocalizedString RightShiftUserVariable = @"Right Bit Shift {00}: {01}'s Value";
 
             public static LocalizedString enditemchange = @"End Item Change";
 
@@ -1989,7 +1991,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString guildvariable = @"Set Guild Variable {00} ({01})";
 
-            public static LocalizedString UserVariable = @"Set Account Variable {00} ({01})";
+            public static LocalizedString UserVariable = @"Set {00} {01} ({02})";
 
             public static LocalizedString gotolabel = @"Go to Label {00}";
 
@@ -2545,10 +2547,7 @@ Tick timer saved in server config.json.";
             public static LocalizedString CheckBank = @"Check Bank?";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UserVariable = @"Account Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UserVariableValue = @"Account Variable Value:";
+            public static LocalizedString UserVariableValue = @"User Variable Value:";
         }
 
         public partial struct EventConditionDesc
@@ -2660,7 +2659,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString True = @"True";
 
-            public static LocalizedString UserVariable = @"Account Variable: {00} {01}";
+            public static LocalizedString UserVariable = @"{00}: {01} {02}";
 
         }
 
@@ -2741,7 +2740,7 @@ Tick timer saved in server config.json.";
                 {15, @"Guild Variable Changed"},
                 {16, @"Inventory Changed"},
                 {17, @"Map Changed"},
-                {18, @"Account Variable Changed"},
+                {18, @"User Variable Changed"},
             };
 
             public static LocalizedString conditions = @"Conditions";
@@ -3225,7 +3224,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString booleancloneplayervariablevalue = @"Player Variable Value: ";
 
-            public static LocalizedString BooleanCloneUserVariableValue = @"Account Variable Value: ";
+            public static LocalizedString BooleanCloneUserVariableValue = @"User Variable Value: ";
 
             public static LocalizedString numericlabel = @"Integer Variable:";
 
@@ -3241,7 +3240,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString numericcloneplayervariablevalue = @"Player Variable Value: ";
 
-            public static LocalizedString NumericCloneUserVariableValue = @"Account Variable Value: ";
+            public static LocalizedString NumericCloneUserVariableValue = @"User Variable Value: ";
 
             public static LocalizedString numericmultiply = @"Multiply";
 
@@ -3274,8 +3273,6 @@ Tick timer saved in server config.json.";
             public static LocalizedString stringreplacereplace = @"Replace:";
 
             public static LocalizedString stringtip = @"Text variables work with strings. Click here for a list!";
-
-            public static LocalizedString UserVariable = @"Account Variable";
 
         }
 
@@ -3349,8 +3346,6 @@ Tick timer saved in server config.json.";
             public static LocalizedString minlength = @"Minimum Length";
 
             public static LocalizedString maxlength = @"Maximum Length";
-
-            public static LocalizedString UserVariable = @"Account Variable";
 
         }
 
@@ -3472,6 +3467,18 @@ Tick timer saved in server config.json.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Yes = @"Yes";
+        }
+
+        public partial struct GameObjectStrings
+        {
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString New = @"New {00}";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UserVariable = @"User Variable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString UserVariables = @"User Variables";
         }
 
         public partial struct Time
@@ -5239,11 +5246,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString textidguildvar = @"Text Id: \guildvar ";
 
-            public static LocalizedString UserVariable = @"Account Variable";
-
-            public static LocalizedString UserVariables = @"Account Variables";
-
-            public static LocalizedString TextIdUserVar = @"Text Id: \accountvar ";
+            public static LocalizedString UserVariableId = @"Text Id: \uservar ";
 
         }
 

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3313,6 +3313,8 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString maxlength = @"Maximum Length";
 
+            public static LocalizedString UserVariable = @"Account Variable";
+
         }
 
         public partial struct EventSpawnNpc

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2711,6 +2711,7 @@ Tick timer saved in server config.json.";
                 {15, @"Guild Variable Changed"},
                 {16, @"Inventory Changed"},
                 {17, @"Map Changed"},
+                {18, @"Account Variable Changed"},
             };
 
             public static LocalizedString conditions = @"Conditions";

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5200,6 +5200,12 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString textidguildvar = @"Text Id: \guildvar ";
 
+            public static LocalizedString UserVariable = @"Account Variable";
+
+            public static LocalizedString UserVariables = @"Account Variables";
+
+            public static LocalizedString TextIdUserVar = @"Text Id: \accountvar ";
+
         }
 
         public partial struct TaskEditor

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -1899,11 +1899,15 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dupguildvariable = @"Guild Variable: {00}'s Value";
 
+            public static LocalizedString DupUserVariable = @"Account Variable: {00}'s Value";
+
             public static LocalizedString addglobalvariable = @"Add Global Variable: {00}'s Value";
 
             public static LocalizedString addplayervariable = @"Add Player Variable: {00}'s Value";
 
             public static LocalizedString addguildvariable = @"Add Guild Variable: {00}'s Value";
+
+            public static LocalizedString AddUserVariable = @"Add Account Variable: {00}'s Value";
 
             public static LocalizedString subtractglobalvariable = @"Subtract Global Variable: {00}'s Value";
 
@@ -1911,11 +1915,15 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString subtractguildvariable = @"Subtract Guild Variable: {00}'s Value";
 
+            public static LocalizedString SubtractUserVariable = @"Subtract Account Variable: {00}'s Value";
+
             public static LocalizedString multiplyglobalvariable = @"Multiply Global Variable: {00}'s Value";
 
             public static LocalizedString multiplyplayervariable = @"Multiply Player Variable: {00}'s Value";
 
             public static LocalizedString multiplyguildvariable = @"Multiply Guild Variable: {00}'s Value";
+
+            public static LocalizedString MultiplyUserVariable = @"Multiply Account Variable: {00}'s Value";
 
             public static LocalizedString divideglobalvariable = @"Divide Global Variable: {00}'s Value";
 
@@ -1923,17 +1931,23 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString divideguildvariable = @"Divide Guild Variable: {00}'s Value";
 
+            public static LocalizedString DivideUserVariable = @"Divide Account Variable: {00}'s Value";
+
             public static LocalizedString leftshiftglobalvariable = @"Left Bit Shift Global Variable: {00}'s Value";
 
             public static LocalizedString leftshiftplayervariable = @"Left Bit Shift Player Variable: {00}'s Value";
 
             public static LocalizedString leftshiftguildvariable = @"Left Bit Shift Guild Variable: {00}'s Value";
 
+            public static LocalizedString LeftShiftUserVariable = @"Left Bit Shift Account Variable: {00}'s Value";
+
             public static LocalizedString rightshiftglobalvariable = @"Right Bit Shift Global Variable: {00}'s Value";
 
             public static LocalizedString rightshiftplayervariable = @"Right Bit Shift Player Variable: {00}'s Value";
 
             public static LocalizedString rightshiftguildvariable = @"Right Bit Shift Guild Variable: {00}'s Value";
+
+            public static LocalizedString RightShiftUserVariable = @"Right Bit Shift Account Variable: {00}'s Value";
 
             public static LocalizedString enditemchange = @"End Item Change";
 
@@ -1968,6 +1982,8 @@ Tick timer saved in server config.json.";
             public static LocalizedString globalvariable = @"Set Global Variable {00} ({01})";
 
             public static LocalizedString guildvariable = @"Set Guild Variable {00} ({01})";
+
+            public static LocalizedString UserVariable = @"Set Account Variable {00} ({01})";
 
             public static LocalizedString gotolabel = @"Go to Label {00}";
 
@@ -3195,6 +3211,8 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString booleancloneplayervariablevalue = @"Player Variable Value: ";
 
+            public static LocalizedString BooleanCloneUserVariableValue = @"Account Variable Value: ";
+
             public static LocalizedString numericlabel = @"Integer Variable:";
 
             public static LocalizedString numericadd = @"Add";
@@ -3205,9 +3223,11 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString numericcloneglobalvariablevalue = @"Global Variable Value: ";
 
-            public static LocalizedString numericcloneguildvariablevalue = @"Global Variable Value: ";
+            public static LocalizedString numericcloneguildvariablevalue = @"Guild Variable Value: ";
 
             public static LocalizedString numericcloneplayervariablevalue = @"Player Variable Value: ";
+
+            public static LocalizedString NumericCloneUserVariableValue = @"Account Variable Value: ";
 
             public static LocalizedString numericmultiply = @"Multiply";
 
@@ -3240,6 +3260,8 @@ Tick timer saved in server config.json.";
             public static LocalizedString stringreplacereplace = @"Replace:";
 
             public static LocalizedString stringtip = @"Text variables work with strings. Click here for a list!";
+
+            public static LocalizedString UserVariable = @"Account Variable";
 
         }
 

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -665,6 +665,21 @@ namespace Intersect.Editor.Networking
                     }
 
                     break;
+
+                case GameObjectType.UserVariable:
+                    if (deleted)
+                    {
+                        var pvar = UserVariableBase.Get(id);
+                        pvar.Delete();
+                    }
+                    else
+                    {
+                        var pvar = new UserVariableBase(id);
+                        pvar.Load(json);
+                        UserVariableBase.Lookup.Set(id, pvar);
+                    }
+
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Intersect.Server/Database/DbInterface.cs
+++ b/Intersect.Server/Database/DbInterface.cs
@@ -1324,7 +1324,7 @@ namespace Intersect.Server.Database
             {
                 if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
                 {
-                    lookup.Add(Strings.Events.AccountVar + "{" + variable.TextId + "}", variable);
+                    lookup.Add(Strings.Events.UserVariable + "{" + variable.TextId + "}", variable);
                     addedIds.Add(variable.TextId);
                 }
             }

--- a/Intersect.Server/Database/DbInterface.cs
+++ b/Intersect.Server/Database/DbInterface.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -71,6 +71,8 @@ namespace Intersect.Server.Database
         public static Dictionary<string, PlayerVariableBase> PlayerVariableEventTextLookup = new Dictionary<string, PlayerVariableBase>();
 
         public static Dictionary<string, GuildVariableBase> GuildVariableEventTextLookup = new Dictionary<string, GuildVariableBase>();
+
+        public static Dictionary<string, UserVariableBase> UserVariableEventTextLookup = new Dictionary<string, UserVariableBase>();
 
         public static ConcurrentDictionary<Guid, ServerVariableBase> UpdatedServerVariables = new ConcurrentDictionary<Guid, ServerVariableBase>();
 
@@ -323,6 +325,7 @@ namespace Intersect.Server.Database
                     CacheServerVariableEventTextLookups();
                     CachePlayerVariableEventTextLookups();
                     CacheGuildVariableEventTextLookups();
+                    CacheUserVariableEventTextLookups();
                 }
             }
 
@@ -566,6 +569,10 @@ namespace Intersect.Server.Database
                     GuildVariableBase.Lookup.Clear();
 
                     break;
+                case GameObjectType.UserVariable:
+                    UserVariableBase.Lookup.Clear();
+
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
@@ -705,6 +712,13 @@ namespace Intersect.Server.Database
                             }
 
                             break;
+                        case GameObjectType.UserVariable:
+                            foreach (var psw in context.UserVariables)
+                            {
+                                UserVariableBase.Lookup.Set(psw.Id, psw);
+                            }
+
+                            break;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(gameObjectType), gameObjectType, null);
                     }
@@ -806,6 +820,11 @@ namespace Intersect.Server.Database
 
                 case GameObjectType.GuildVariable:
                     dbObj = new GuildVariableBase(predefinedid);
+
+                    break;
+
+                case GameObjectType.UserVariable:
+                    dbObj = new UserVariableBase(predefinedid);
 
                     break;
                 default:
@@ -925,6 +944,12 @@ namespace Intersect.Server.Database
                         case GameObjectType.GuildVariable:
                             context.GuildVariables.Add((GuildVariableBase)dbObj);
                             GuildVariableBase.Lookup.Set(dbObj.Id, dbObj);
+
+                            break;
+
+                        case GameObjectType.UserVariable:
+                            context.UserVariables.Add((UserVariableBase)dbObj);
+                            UserVariableBase.Lookup.Set(dbObj.Id, dbObj);
 
                             break;
 
@@ -1050,6 +1075,10 @@ namespace Intersect.Server.Database
                             context.GuildVariables.Remove((GuildVariableBase)gameObject);
 
                             break;
+                        case GameObjectType.UserVariable:
+                            context.UserVariables.Remove((UserVariableBase)gameObject);
+
+                            break;
                     }
 
                     if (gameObject.Type.GetLookup().Values.Contains(gameObject))
@@ -1170,6 +1199,10 @@ namespace Intersect.Server.Database
                             context.GuildVariables.Update((GuildVariableBase)gameObject);
 
                             break;
+                        case GameObjectType.UserVariable:
+                            context.UserVariables.Update((UserVariableBase)gameObject);
+
+                            break;
                     }
 
                     context.ChangeTracker.DetectChanges();
@@ -1281,6 +1314,21 @@ namespace Intersect.Server.Database
                 }
             }
             GuildVariableEventTextLookup = lookup;
+        }
+
+        public static void CacheUserVariableEventTextLookups()
+        {
+            var lookup = new Dictionary<string, UserVariableBase>();
+            var addedIds = new HashSet<string>();
+            foreach (UserVariableBase variable in UserVariableBase.Lookup.Values)
+            {
+                if (!string.IsNullOrWhiteSpace(variable.TextId) && !addedIds.Contains(variable.TextId))
+                {
+                    lookup.Add(Strings.Events.AccountVar + "{" + variable.TextId + "}", variable);
+                    addedIds.Add(variable.TextId);
+                }
+            }
+            UserVariableEventTextLookup = lookup;
         }
 
         //Extra Map Helper Functions

--- a/Intersect.Server/Database/GameData/GameContext.cs
+++ b/Intersect.Server/Database/GameData/GameContext.cs
@@ -87,6 +87,8 @@ namespace Intersect.Server.Database.GameData
 
         public DbSet<GuildVariableBase> GuildVariables { get; set; }
 
+        public DbSet<UserVariableBase> UserVariables { get; set; }
+
         //Tilesets
         public DbSet<TilesetBase> Tilesets { get; set; }
 

--- a/Intersect.Server/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server/Database/PlayerData/PlayerContext.cs
@@ -136,7 +136,7 @@ namespace Intersect.Server.Database.PlayerData
             modelBuilder.Entity<GuildVariable>().HasIndex(p => new { p.VariableId, GuildId = p.GuildId }).IsUnique();
 
             modelBuilder.Entity<User>().HasMany(b => b.Variables).WithOne(p => p.User);
-            modelBuilder.Entity<UserVariable>().HasKey();
+            modelBuilder.Entity<UserVariable>().HasKey(p => new { p.VariableId, UserId = p.UserId });
             modelBuilder.Entity<UserVariable>().Ignore(v => v.Id);
         }
 

--- a/Intersect.Server/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server/Database/PlayerData/PlayerContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -71,6 +71,8 @@ namespace Intersect.Server.Database.PlayerData
 
         public DbSet<GuildVariable> Guild_Variables { get; set; }
 
+        public DbSet<UserVariable> User_Variables { get; set; }
+
         internal async ValueTask Commit(
             bool commit = false,
             CancellationToken cancellationToken = default(CancellationToken)
@@ -132,6 +134,10 @@ namespace Intersect.Server.Database.PlayerData
 
             modelBuilder.Entity<Guild>().HasMany(b => b.Variables).WithOne(p => p.Guild);
             modelBuilder.Entity<GuildVariable>().HasIndex(p => new { p.VariableId, GuildId = p.GuildId }).IsUnique();
+
+            modelBuilder.Entity<User>().HasMany(b => b.Variables).WithOne(p => p.User);
+            modelBuilder.Entity<UserVariable>().HasKey();
+            modelBuilder.Entity<UserVariable>().Ignore(v => v.Id);
         }
 
         public void Seed()

--- a/Intersect.Server/Database/PlayerData/Players/UserVariable.cs
+++ b/Intersect.Server/Database/PlayerData/Players/UserVariable.cs
@@ -1,0 +1,26 @@
+using Intersect.GameObjects;
+using Newtonsoft.Json;
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Intersect.Server.Database.PlayerData.Players
+{
+    public partial class UserVariable : Variable
+    {
+        public UserVariable() : this(Guid.Empty) { }
+
+        public UserVariable(Guid userVariableBaseId)
+        {
+            VariableId = userVariableBaseId;
+        }
+
+        [NotMapped]
+        public string VariableName => UserVariableBase.GetName(VariableId);
+
+        [JsonIgnore]
+        public Guid UserId { get; protected set; }
+
+        [JsonIgnore]
+        public virtual User User { get; protected set; }
+    }
+}

--- a/Intersect.Server/Database/PlayerData/User.cs
+++ b/Intersect.Server/Database/PlayerData/User.cs
@@ -134,7 +134,7 @@ namespace Intersect.Server.Database.PlayerData
         }
 
         /// <summary>
-        /// Account Variable Values
+        /// User Variable Values
         /// </summary>
         [JsonIgnore]
         public virtual List<UserVariable> Variables { get; set; } = new List<UserVariable>();
@@ -637,10 +637,10 @@ namespace Intersect.Server.Database.PlayerData
         }
 
         /// <summary>
-        /// Returns a variable object given a account variable id
+        /// Returns a variable object given a user variable id
         /// </summary>
         /// <param name="id">Variable id</param>
-        /// <param name="createIfNull">Creates this variable for the account if it hasn't been set yet</param>
+        /// <param name="createIfNull">Creates this variable for the user if it hasn't been set yet</param>
         /// <returns></returns>
         public Variable GetVariable(Guid id, bool createIfNull = false)
         {
@@ -661,7 +661,7 @@ namespace Intersect.Server.Database.PlayerData
         }
 
         /// <summary>
-        /// Creates a variable for this account with a given id if it doesn't already exist
+        /// Creates a variable for this user with a given id if it doesn't already exist
         /// </summary>
         /// <param name="id">Variablke id</param>
         /// <returns></returns>

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -110,7 +110,7 @@ namespace Intersect.Server.Entities.Events
             else if (command.VariableType == VariableTypes.UserVariable)
             {
                 var variable = UserVariableBase.Get(command.VariableId);
-                type = (int)variable.Type;
+                type = (int)variable.DataType;
             }
             else if (type == -1)
             {

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -10,6 +10,7 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Switches_and_Variables;
 using Intersect.Server.Database;
+using Intersect.Server.Database.PlayerData;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Database.PlayerData.Security;
 using Intersect.Server.General;
@@ -1718,6 +1719,7 @@ namespace Intersect.Server.Entities.Events
         {
             VariableValue value = null;
             Guild guild = null;
+
             if (command.VariableType == VariableTypes.PlayerVariable)
             {
                 value = player.GetVariableValue(command.VariableId);
@@ -1734,6 +1736,10 @@ namespace Intersect.Server.Entities.Events
                     return;
                 }
                 value = guild.GetVariableValue(command.VariableId) ?? new VariableValue();
+            }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                value = player.User.GetVariableValue(command.VariableId);
             }
 
             if (value == null)
@@ -1762,6 +1768,14 @@ namespace Intersect.Server.Entities.Events
                     if (player.Guild != null)
                     {
                         value.Boolean = player.Guild.GetVariableValue(mod.DuplicateVariableId).Boolean;
+                    }
+                }
+                else if (mod.DupVariableType == VariableTypes.UserVariable)
+                {
+                    var variable = UserVariableBase.Get(mod.DuplicateVariableId);
+                    if (variable != null)
+                    {
+                        value.Boolean = player.User.GetVariableValue(mod.DuplicateVariableId).Value.Boolean;
                     }
                 }
             }
@@ -1800,7 +1814,7 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    Player.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
                     DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
                 }
             }
@@ -1808,8 +1822,16 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
                     guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+                }
+            }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                if (changed)
+                {
+                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
                 }
             }
         }
@@ -1823,6 +1845,7 @@ namespace Intersect.Server.Entities.Events
         {
             VariableValue value = null;
             Guild guild = null;
+
             if (command.VariableType == VariableTypes.PlayerVariable)
             {
                 value = player.GetVariableValue(command.VariableId);
@@ -1840,6 +1863,10 @@ namespace Intersect.Server.Entities.Events
                 }
                 value = guild.GetVariableValue(command.VariableId);
             }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                value = player.User.GetVariableValue(command.VariableId);
+            }
 
             if (value == null)
             {
@@ -1850,54 +1877,54 @@ namespace Intersect.Server.Entities.Events
 
             switch (mod.ModType)
             {
-                case Enums.VariableMods.Set:
+                case VariableMods.Set:
                     value.Integer = mod.Value;
 
                     break;
-                case Enums.VariableMods.Add:
+                case VariableMods.Add:
                     value.Integer += mod.Value;
 
                     break;
-                case Enums.VariableMods.Subtract:
+                case VariableMods.Subtract:
                     value.Integer -= mod.Value;
 
                     break;
-                case Enums.VariableMods.Multiply:
+                case VariableMods.Multiply:
                     value.Integer *= mod.Value;
 
                     break;
-                case Enums.VariableMods.Divide:
+                case VariableMods.Divide:
                     if (mod.Value != 0)  //Idiot proofing divide by 0 LOL
                     {
                         value.Integer /= mod.Value;
                     }
 
                     break;
-                case Enums.VariableMods.LeftShift:
+                case VariableMods.LeftShift:
                     value.Integer = value.Integer << (int)mod.Value;
 
                     break;
-                case Enums.VariableMods.RightShift:
+                case VariableMods.RightShift:
                     value.Integer = value.Integer >> (int)mod.Value;
 
                     break;
-                case Enums.VariableMods.Random:
+                case VariableMods.Random:
                     //TODO: Fix - Random doesnt work with longs lolz
                     value.Integer = Randomization.Next((int) mod.Value, (int) mod.HighValue + 1);
 
                     break;
-                case Enums.VariableMods.SystemTime:
+                case VariableMods.SystemTime:
                     var ms = (long) (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc))
                         .TotalMilliseconds;
 
                     value.Integer = ms;
 
                     break;
-                case Enums.VariableMods.DupPlayerVar:
+                case VariableMods.DupPlayerVar:
                     value.Integer = player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.DupGlobalVar:
+                case VariableMods.DupGlobalVar:
                     var dupServerVariable = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (dupServerVariable != null)
                     {
@@ -1905,11 +1932,11 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.AddPlayerVar:
+                case VariableMods.AddPlayerVar:
                     value.Integer += player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.AddGlobalVar:
+                case VariableMods.AddGlobalVar:
                     var asv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (asv != null)
                     {
@@ -1917,11 +1944,11 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.SubtractPlayerVar:
+                case VariableMods.SubtractPlayerVar:
                     value.Integer -= player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.SubtractGlobalVar:
+                case VariableMods.SubtractGlobalVar:
                     var ssv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (ssv != null)
                     {
@@ -1929,11 +1956,11 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.MultiplyPlayerVar:
+                case VariableMods.MultiplyPlayerVar:
                     value.Integer *= player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.MultiplyGlobalVar:
+                case VariableMods.MultiplyGlobalVar:
                     var msv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (msv != null)
                     {
@@ -1941,14 +1968,14 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.DividePlayerVar:
+                case VariableMods.DividePlayerVar:
                     if (player.GetVariableValue(mod.DuplicateVariableId).Integer != 0) //Idiot proofing divide by 0 LOL
                     {
                         value.Integer /= player.GetVariableValue(mod.DuplicateVariableId).Integer;
                     }
 
                     break;
-                case Enums.VariableMods.DivideGlobalVar:
+                case VariableMods.DivideGlobalVar:
                     var dsv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (dsv != null)
                     {
@@ -1959,11 +1986,11 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.LeftShiftPlayerVar:
+                case VariableMods.LeftShiftPlayerVar:
                     value.Integer = value.Integer << (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.LeftShiftGlobalVar:
+                case VariableMods.LeftShiftGlobalVar:
                     var lhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (lhsv != null)
                     {
@@ -1971,11 +1998,11 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     break;
-                case Enums.VariableMods.RightShiftPlayerVar:
+                case VariableMods.RightShiftPlayerVar:
                     value.Integer = value.Integer >> (int)player.GetVariableValue(mod.DuplicateVariableId).Integer;
 
                     break;
-                case Enums.VariableMods.RightShiftGlobalVar:
+                case VariableMods.RightShiftGlobalVar:
                     var rhsv = ServerVariableBase.Get(mod.DuplicateVariableId);
                     if (rhsv != null)
                     {
@@ -2011,7 +2038,7 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    Player.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
                     DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
                 }
             }
@@ -2019,8 +2046,16 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
                     guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+                }
+            }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                if (changed)
+                {
+                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
                 }
             }
         }
@@ -2034,6 +2069,7 @@ namespace Intersect.Server.Entities.Events
         {
             VariableValue value = null;
             Guild guild = null;
+
             if (command.VariableType == VariableTypes.PlayerVariable)
             {
                 value = player.GetVariableValue(command.VariableId);
@@ -2051,6 +2087,10 @@ namespace Intersect.Server.Entities.Events
                 }
                 value = guild.GetVariableValue(command.VariableId);
             }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                value = player.User.GetVariableValue(command.VariableId);
+            }
 
             if (value == null)
             {
@@ -2061,11 +2101,11 @@ namespace Intersect.Server.Entities.Events
 
             switch (mod.ModType)
             {
-                case Enums.VariableMods.Set:
+                case VariableMods.Set:
                     value.String = ParseEventText(mod.Value, player, instance);
 
                     break;
-                case Enums.VariableMods.Replace:
+                case VariableMods.Replace:
                     var find = ParseEventText(mod.Value, player, instance);
                     var replace = ParseEventText(mod.Replace, player, instance);
                     value.String = value.String.Replace(find, replace);
@@ -2098,7 +2138,7 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    Player.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
+                    Player.StartCommonEventsWithTriggerForAll(CommonEventTrigger.ServerVariableChange, "", command.VariableId.ToString());
                     DbInterface.UpdatedServerVariables.AddOrUpdate(command.VariableId, ServerVariableBase.Get(command.VariableId), (key, oldValue) => ServerVariableBase.Get(command.VariableId));
                 }
             }
@@ -2106,8 +2146,16 @@ namespace Intersect.Server.Entities.Events
             {
                 if (changed)
                 {
-                    guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
+                    guild.StartCommonEventsWithTriggerForAll(CommonEventTrigger.GuildVariableChange, "", command.VariableId.ToString());
                     guild.UpdatedVariables.AddOrUpdate(command.VariableId, GuildVariableBase.Get(command.VariableId), (key, oldValue) => GuildVariableBase.Get(command.VariableId));
+                }
+            }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                if (changed)
+                {
+                    player.User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", command.VariableId.ToString());
+                    player.User.UpdatedVariables.AddOrUpdate(command.VariableId, UserVariableBase.Get(command.VariableId), (key, oldValue) => UserVariableBase.Get(command.VariableId));
                 }
             }
         }

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -1675,6 +1675,12 @@ namespace Intersect.Server.Entities.Events
                         sb.Replace(val.Key, (player.Guild?.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).Type));
                 }
 
+                foreach (var val in DbInterface.UserVariableEventTextLookup)
+                {
+                    if (input.Contains(val.Key))
+                        sb.Replace(val.Key, (player.User.GetVariableValue(val.Value.Id) ?? new VariableValue()).ToString((val.Value).DataType));
+                }
+
                 if (instance != null)
                 {
                     var parms = instance.GetParams(player);

--- a/Intersect.Server/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server/Entities/Events/CommandProcessing.cs
@@ -101,17 +101,21 @@ namespace Intersect.Server.Entities.Events
                     type = (int)variable.Type;
                 }
             }
-
-            if (type == -1)
-            {
-                var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1]);
-                callStack.Push(tmpStack);
-                return;
-            }
             else if (command.VariableType == VariableTypes.GuildVariable)
             {
                 var variable = GuildVariableBase.Get(command.VariableId);
                 type = (int)variable.Type;
+            }
+            else if (command.VariableType == VariableTypes.UserVariable)
+            {
+                var variable = UserVariableBase.Get(command.VariableId);
+                type = (int)variable.Type;
+            }
+            else if (type == -1)
+            {
+                var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1]);
+                callStack.Push(tmpStack);
+                return;
             }
 
             PacketSender.SendInputVariableDialog(player, title, txt, (VariableDataTypes)type, instance.PageInstance.Id);

--- a/Intersect.Server/Entities/Events/Conditions.cs
+++ b/Intersect.Server/Entities/Events/Conditions.cs
@@ -123,6 +123,10 @@ namespace Intersect.Server.Entities.Events
             {
                 value = player.Guild?.GetVariableValue(condition.VariableId);
             }
+            else if (condition.VariableType == VariableTypes.UserVariable)
+            {
+                value = player.User.GetVariableValue(condition.VariableId);
+            }
 
             if (value == null)
             {
@@ -544,6 +548,10 @@ namespace Intersect.Server.Entities.Events
                 {
                     compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
                 }
+                else if (comparison.CompareVariableType == VariableTypes.UserVariable)
+                {
+                    compValue = player.User.GetVariableValue(comparison.CompareVariableId);
+                }
             }
             else
             {
@@ -599,6 +607,10 @@ namespace Intersect.Server.Entities.Events
                 else if (comparison.CompareVariableType == VariableTypes.GuildVariable)
                 {
                     compValue = player.Guild?.GetVariableValue(comparison.CompareVariableId);
+                }
+                else if (comparison.CompareVariableType == VariableTypes.UserVariable)
+                {
+                    compValue = player.User.GetVariableValue(comparison.CompareVariableId);
                 }
             }
             else

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -6172,6 +6172,16 @@ namespace Intersect.Server.Entities
 
                                 value = Guild?.GetVariableValue(cmd.VariableId) ?? new VariableValue();
                             }
+                            else if (cmd.VariableType == VariableTypes.UserVariable)
+                            {
+                                var variable = UserVariableBase.Get(cmd.VariableId);
+                                if (variable != null)
+                                {
+                                    type = variable.Type;
+                                }
+
+                                value = User.GetVariableValue(cmd.VariableId) ?? new VariableValue();
+                            }
 
                             if (value == null)
                             {
@@ -6265,6 +6275,16 @@ namespace Intersect.Server.Entities
                                         Guild.StartCommonEventsWithTriggerForAll(Enums.CommonEventTrigger.GuildVariableChange, "", cmd.VariableId.ToString());
                                         Guild.UpdatedVariables.AddOrUpdate(cmd.VariableId, GuildVariableBase.Get(cmd.VariableId), (key, oldValue) => GuildVariableBase.Get(cmd.VariableId));
                                     }
+                                }
+                            }
+                            else if (cmd.VariableType == VariableTypes.UserVariable)
+                            {
+                                var variable = User.GetVariable(cmd.VariableId);
+                                if (changed)
+                                {
+                                    variable.Value = value;
+                                    User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChanged, "", cmd.VariableId.ToString());
+                                    User.UpdatedVariables.AddOrUpdate(cmd.VariableId, UserVariableBase.Get(cmd.VariableId), (key, oldValue) => UserVariableBase.Get(cmd.VariableId));
                                 }
                             }
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -6283,7 +6283,7 @@ namespace Intersect.Server.Entities
                                 if (changed)
                                 {
                                     variable.Value = value;
-                                    User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChanged, "", cmd.VariableId.ToString());
+                                    User.StartCommonEventsWithTriggerForAll(CommonEventTrigger.UserVariableChange, "", cmd.VariableId.ToString());
                                     User.UpdatedVariables.AddOrUpdate(cmd.VariableId, UserVariableBase.Get(cmd.VariableId), (key, oldValue) => UserVariableBase.Get(cmd.VariableId));
                                 }
                             }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -6177,7 +6177,7 @@ namespace Intersect.Server.Entities
                                 var variable = UserVariableBase.Get(cmd.VariableId);
                                 if (variable != null)
                                 {
-                                    type = variable.Type;
+                                    type = variable.DataType;
                                 }
 
                                 value = User.GetVariableValue(cmd.VariableId) ?? new VariableValue();

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -668,6 +668,9 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString guildvar = @"\guildvar";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString AccountVar = @"\accountvar";
+
         }
 
         public sealed partial class FormulasNamespace : LocaleNamespace

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -669,7 +669,7 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString guildvar = @"\guildvar";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString AccountVar = @"\accountvar";
+            public readonly LocalizedString UserVariable = @"\uservar";
 
         }
 

--- a/Intersect.Server/Migrations/20221016173603_AddUserVariables.Designer.cs
+++ b/Intersect.Server/Migrations/20221016173603_AddUserVariables.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.PlayerData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations
 {
     [DbContext(typeof(PlayerContext))]
-    partial class PlayerContextModelSnapshot : ModelSnapshot
+    [Migration("20221016173603_AddUserVariables")]
+    partial class AddUserVariables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/20221016173603_AddUserVariables.cs
+++ b/Intersect.Server/Migrations/20221016173603_AddUserVariables.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations
+{
+    public partial class AddUserVariables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "User_Variables",
+                columns: table => new
+                {
+                    VariableId = table.Column<Guid>(nullable: false),
+                    Value = table.Column<string>(nullable: true),
+                    UserId = table.Column<Guid>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_User_Variables", x => new { x.VariableId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_User_Variables_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_User_Variables_UserId",
+                table: "User_Variables",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "User_Variables");
+        }
+    }
+}

--- a/Intersect.Server/Migrations/Game/20221016173617_AddUserVariables.Designer.cs
+++ b/Intersect.Server/Migrations/Game/20221016173617_AddUserVariables.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Intersect.Server.Migrations.Game
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20221016173617_AddUserVariables")]
+    partial class AddUserVariables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/Game/20221016173617_AddUserVariables.cs
+++ b/Intersect.Server/Migrations/Game/20221016173617_AddUserVariables.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Game
+{
+    public partial class AddUserVariables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserVariables",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    TimeCreated = table.Column<long>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    TextId = table.Column<string>(nullable: true),
+                    DataType = table.Column<byte>(nullable: false),
+                    Folder = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserVariables", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserVariables");
+        }
+    }
+}

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -3722,6 +3722,11 @@ namespace Intersect.Server.Networking
 
                     break;
 
+                case GameObjectType.UserVariable:
+                    obj = UserVariableBase.Get(id);
+
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -3846,6 +3851,11 @@ namespace Intersect.Server.Networking
 
                     break;
 
+                case GameObjectType.UserVariable:
+                    obj = UserVariableBase.Get(id);
+
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -3914,6 +3924,10 @@ namespace Intersect.Server.Networking
                     else if (type == GameObjectType.GuildVariable)
                     {
                         DbInterface.CacheGuildVariableEventTextLookups();
+                    }
+                    else if (type == GameObjectType.UserVariable)
+                    {
+                        DbInterface.CacheUserVariableEventTextLookups();
                     }
 
                     DbInterface.SaveGameObject(obj);

--- a/Intersect.Server/Networking/PacketSender.cs
+++ b/Intersect.Server/Networking/PacketSender.cs
@@ -658,11 +658,12 @@ namespace Intersect.Server.Networking
                         continue;
                     }
 
-                    if (((GameObjectType)val == GameObjectType.Shop ||
+                    if ((GameObjectType)val == GameObjectType.Shop ||
                          (GameObjectType)val == GameObjectType.Event ||
                          (GameObjectType)val == GameObjectType.PlayerVariable ||
                          (GameObjectType)val == GameObjectType.ServerVariable ||
-                         (GameObjectType)val == GameObjectType.GuildVariable))
+                         (GameObjectType)val == GameObjectType.GuildVariable ||
+                         (GameObjectType)val == GameObjectType.UserVariable)
                     {
                         SendGameObjects(client, (GameObjectType)val, null);
                     }
@@ -690,7 +691,8 @@ namespace Intersect.Server.Networking
                     (GameObjectType) val == GameObjectType.Event ||
                     (GameObjectType) val == GameObjectType.PlayerVariable ||
                     (GameObjectType) val == GameObjectType.ServerVariable ||
-                    (GameObjectType)val == GameObjectType.GuildVariable)
+                    (GameObjectType) val == GameObjectType.GuildVariable ||
+                    (GameObjectType) val == GameObjectType.UserVariable)
                 {
                     continue;
                 }
@@ -1689,6 +1691,13 @@ namespace Intersect.Server.Networking
                     break;
                 case GameObjectType.GuildVariable:
                     foreach (var obj in GuildVariableBase.Lookup)
+                    {
+                        SendGameObject(client, obj.Value, false, false, packetList);
+                    }
+
+                    break;
+                case GameObjectType.UserVariable:
+                    foreach (var obj in UserVariableBase.Lookup)
                     {
                         SendGameObject(client, obj.Value, false, false, packetList);
                     }


### PR DESCRIPTION
This commit consists of creating variables that have the scope of the account. Same value for all characters on the same account

Features:
-- basic features in the variable editor(create, delete...)
-- Input variable event command
-- Set variable event command
-- When account variable value changes trigger common event
-- Added in "Variable is..." condition

to check the value of the variable use the text param \accountvar{<_varName>}, configurable in server strings.

It was not part of the scope of the pr but

-- Fixed issues regarding define any variable for the value of some guild variable. (there was no way to choose the guild variable)
-- An infinitesimal rearranged in some places

Resolves #1543