### PR TITLE
feat: overhead hp bar settings

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -29,15 +29,27 @@ namespace Intersect.Client.Framework.Database
 
         public bool FriendOverheadInfo { get; set; }
 
+        public bool FriendOverheadHpBar { get; set; }
+
         public bool GuildMemberOverheadInfo { get; set; }
+
+        public bool GuildMemberOverheadHpBar { get; set; }
 
         public bool MyOverheadInfo { get; set; }
 
+        public bool MyOverheadHpBar { get; set; }
+
         public bool NpcOverheadInfo { get; set; }
+
+        public bool NpcOverheadHpBar { get; set; }
 
         public bool PartyMemberOverheadInfo { get; set; }
 
+        public bool PartyMemberOverheadHpBar { get; set; }
+
         public bool PlayerOverheadInfo { get; set; }
+
+        public bool PlayerOverheadHpBar { get; set; }
 
         public bool ShowExperienceAsPercentage { get; set; }
 
@@ -81,11 +93,17 @@ namespace Intersect.Client.Framework.Database
             StickyTarget = LoadPreference(nameof(StickyTarget), false);
             AutoTurnToTarget = LoadPreference(nameof(AutoTurnToTarget), false);
             FriendOverheadInfo = LoadPreference(nameof(FriendOverheadInfo), true);
+            FriendOverheadHpBar = LoadPreference(nameof(FriendOverheadHpBar), false);
             GuildMemberOverheadInfo = LoadPreference(nameof(GuildMemberOverheadInfo), true);
+            GuildMemberOverheadHpBar = LoadPreference(nameof(GuildMemberOverheadHpBar), false);
             MyOverheadInfo = LoadPreference(nameof(MyOverheadInfo), true);
+            MyOverheadHpBar = LoadPreference(nameof(MyOverheadHpBar), false);
             NpcOverheadInfo = LoadPreference(nameof(NpcOverheadInfo), true);
+            NpcOverheadHpBar = LoadPreference(nameof(NpcOverheadHpBar), false);
             PartyMemberOverheadInfo = LoadPreference(nameof(PartyMemberOverheadInfo), true);
+            PartyMemberOverheadHpBar = LoadPreference(nameof(PartyMemberOverheadHpBar), false);
             PlayerOverheadInfo = LoadPreference(nameof(PlayerOverheadInfo), true);
+            PlayerOverheadHpBar = LoadPreference(nameof(PlayerOverheadHpBar), false);
             ShowExperienceAsPercentage = LoadPreference(nameof(ShowExperienceAsPercentage), true);
             ShowHealthAsPercentage = LoadPreference(nameof(ShowHealthAsPercentage), false);
             ShowManaAsPercentage = LoadPreference(nameof(ShowManaAsPercentage), false);
@@ -107,11 +125,17 @@ namespace Intersect.Client.Framework.Database
             SavePreference(nameof(StickyTarget), StickyTarget);
             SavePreference(nameof(AutoTurnToTarget), AutoTurnToTarget);
             SavePreference(nameof(FriendOverheadInfo), FriendOverheadInfo);
+            SavePreference(nameof(FriendOverheadHpBar), FriendOverheadHpBar);
             SavePreference(nameof(GuildMemberOverheadInfo), GuildMemberOverheadInfo);
+            SavePreference(nameof(GuildMemberOverheadHpBar), GuildMemberOverheadHpBar);
             SavePreference(nameof(MyOverheadInfo), MyOverheadInfo);
+            SavePreference(nameof(MyOverheadHpBar), MyOverheadHpBar);
             SavePreference(nameof(NpcOverheadInfo), NpcOverheadInfo);
+            SavePreference(nameof(NpcOverheadHpBar), NpcOverheadHpBar);
             SavePreference(nameof(PartyMemberOverheadInfo), PartyMemberOverheadInfo);
+            SavePreference(nameof(PartyMemberOverheadHpBar), PartyMemberOverheadHpBar);
             SavePreference(nameof(PlayerOverheadInfo), PlayerOverheadInfo);
+            SavePreference(nameof(PlayerOverheadHpBar), PlayerOverheadHpBar);
             SavePreference(nameof(ShowExperienceAsPercentage), ShowExperienceAsPercentage);
             SavePreference(nameof(ShowHealthAsPercentage), ShowHealthAsPercentage);
             SavePreference(nameof(ShowManaAsPercentage), ShowManaAsPercentage);

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1413,7 +1413,7 @@ namespace Intersect.Client.Entities
                     return true;
                 }
 
-                return GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar);
+                return GetType() == typeof(Entity) && Globals.Database.NpcOverheadHpBar;
             }
         }
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1404,7 +1404,7 @@ namespace Intersect.Client.Entities
             return shieldSize;
         }
 
-        public virtual bool ShouldDrawHpBar
+        protected virtual bool ShouldDrawHpBar
         {
             get
             {
@@ -1417,7 +1417,7 @@ namespace Intersect.Client.Entities
             }
         }
 
-        public bool ShouldDrawEntityHpBar
+        protected bool ShouldDrawEntityHpBar
         {
             get
             {

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1408,16 +1408,16 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (ShouldNotDrawHpBar)
+                if (ShouldDrawEntityHpBar)
                 {
                     return true;
                 }
 
-                return (GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar || IsHovered));
+                return (GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar));
             }
         }
 
-        public bool ShouldNotDrawHpBar
+        public bool ShouldDrawEntityHpBar
         {
             get
             {
@@ -1430,7 +1430,12 @@ namespace Intersect.Client.Entities
                     maxHealth = MaxVital[(int)Vitals.Health],
                     shieldSize = GetShieldSize();
 
-                return shieldSize > 0 || health != maxHealth;
+                if (health < 1)
+                {
+                    return false;
+                }
+
+                return IsHovered || health != maxHealth || shieldSize > 0;
             }
         }
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -214,6 +214,8 @@ namespace Intersect.Client.Entities
         public int WalkFrame { get; set; }
 
         public FloatRect WorldPos { get; set; } = new FloatRect();
+        
+        public bool IsHovered { get; set; }
 
         //Location Info
         public byte X { get; set; }
@@ -1402,7 +1404,7 @@ namespace Intersect.Client.Entities
             return shieldSize;
         }
 
-        public bool ShouldDrawHpBar
+        public virtual bool ShouldDrawHpBar
         {
             get
             {
@@ -1416,8 +1418,6 @@ namespace Intersect.Client.Entities
                     return false;
                 }
 
-                //return true;
-
                 var health = Vital[(int)Vitals.Health];
                 if (health < 1)
                 {
@@ -1426,7 +1426,10 @@ namespace Intersect.Client.Entities
 
                 var maxHealth = MaxVital[(int)Vitals.Health];
                 var shieldSize = GetShieldSize();
-                return shieldSize > 0 || health != maxHealth;
+
+                return (shieldSize > 0 || health != maxHealth) ||
+                       (!(this is Player || this is Projectile || this is Resource || this is Event) &&
+                        (Globals.Database.NpcOverheadHpBar || IsHovered));
             }
         }
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1408,28 +1408,29 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (LatestMap == default)
+                if (ShouldNotDrawHpBar)
+                {
+                    return true;
+                }
+
+                return (GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar || IsHovered));
+            }
+        }
+
+        public bool ShouldNotDrawHpBar
+        {
+            get
+            {
+                if (LatestMap == default || !ShouldDraw)
                 {
                     return false;
                 }
 
-                if (!ShouldDraw)
-                {
-                    return false;
-                }
+                int health = Vital[(int)Vitals.Health],
+                    maxHealth = MaxVital[(int)Vitals.Health],
+                    shieldSize = GetShieldSize();
 
-                var health = Vital[(int)Vitals.Health];
-                if (health < 1)
-                {
-                    return false;
-                }
-
-                var maxHealth = MaxVital[(int)Vitals.Health];
-                var shieldSize = GetShieldSize();
-
-                return (shieldSize > 0 || health != maxHealth) ||
-                       (!(this is Player || this is Projectile || this is Resource || this is Event) &&
-                        (Globals.Database.NpcOverheadHpBar || IsHovered));
+                return shieldSize > 0 || health != maxHealth;
             }
         }
 

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1408,34 +1408,29 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (ShouldDrawEntityHpBar)
+                if (!ShouldNotDrawHpBar || IsHovered)
                 {
                     return true;
                 }
 
-                return (GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar));
+                return GetType() == typeof(Entity) && (Globals.Database.NpcOverheadHpBar);
             }
         }
 
-        protected bool ShouldDrawEntityHpBar
+        protected bool ShouldNotDrawHpBar
         {
             get
             {
                 if (LatestMap == default || !ShouldDraw)
                 {
-                    return false;
+                    return true;
                 }
 
                 int health = Vital[(int)Vitals.Health],
                     maxHealth = MaxVital[(int)Vitals.Health],
                     shieldSize = GetShieldSize();
 
-                if (health < 1)
-                {
-                    return false;
-                }
-
-                return IsHovered || health != maxHealth || shieldSize > 0;
+                return health < 1 || health == maxHealth || shieldSize > 0;
             }
         }
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2380,12 +2380,17 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (!ShouldNotDrawHpBar || IsHovered)
+                if (ShouldNotDrawHpBar)
+                {
+                    return false;
+                }
+
+                if (IsHovered)
                 {
                     return true;
                 }
 
-                if (this.Id == Globals.Me.Id)
+                if (Id == Globals.Me.Id)
                 {
                     return Globals.Database.MyOverheadHpBar;
                 }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2380,41 +2380,37 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (LatestMap == default)
+                if (base.ShouldDrawHpBar)
                 {
-                    return false;
+                    return true;
                 }
 
-                if (!ShouldDraw)
+                if (IsHovered)
                 {
-                    return false;
+                    return true;
                 }
 
-                var health = Vital[(int)Vitals.Health];
-                if (health < 1)
+                if (this.Id == Globals.Me.Id)
                 {
-                    return false;
+                    return Globals.Database.MyOverheadHpBar;
                 }
 
-                var maxHealth = MaxVital[(int)Vitals.Health];
-                var shieldSize = GetShieldSize();
+                if (Globals.Database.PartyMemberOverheadHpBar && Globals.Me.IsInMyParty(this))
+                {
+                    return true;
+                }
 
-                var player = this;
-                bool isMe = player.Id == Globals.Me.Id,
-                    isFriend = !isMe && Globals.Me.IsFriend(player),
-                    isPartyMate = !isMe && Globals.Me.IsInMyParty(player),
-                    isGuildMate = !isMe && Globals.Me.IsGuildMate(player),
-                    friendSettingMatch = isFriend && Globals.Database.FriendOverheadHpBar,
-                    guildSettingMatch = isGuildMate && Globals.Database.GuildMemberOverheadHpBar;
+                if (Globals.Database.FriendOverheadHpBar && Globals.Me.IsFriend(this))
+                {
+                    return true;
+                }
 
-                return (shieldSize > 0 || health != maxHealth) ||
-                       (isMe && Globals.Database.MyOverheadHpBar) ||
-                       (!isMe && !isFriend && !isGuildMate && !isPartyMate && Globals.Database.PlayerOverheadHpBar) ||
-                       (isPartyMate && Globals.Database.PartyMemberOverheadHpBar) ||
-                       (friendSettingMatch && guildSettingMatch && !isPartyMate) ||
-                       (friendSettingMatch && !guildSettingMatch && !isPartyMate) ||
-                       (guildSettingMatch && !friendSettingMatch && !isPartyMate) ||
-                       IsHovered;
+                if (Globals.Database.GuildMemberOverheadHpBar && Globals.Me.IsGuildMate(this))
+                {
+                    return true;
+                }
+
+                return Globals.Database.PlayerOverheadHpBar;
             }
         }
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2380,12 +2380,7 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (base.ShouldDrawHpBar)
-                {
-                    return true;
-                }
-
-                if (IsHovered)
+                if (base.ShouldDrawEntityHpBar)
                 {
                     return true;
                 }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2376,7 +2376,7 @@ namespace Intersect.Client.Entities
             }
         }
 
-        public override bool ShouldDrawHpBar
+        protected override bool ShouldDrawHpBar
         {
             get
             {

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2380,7 +2380,7 @@ namespace Intersect.Client.Entities
         {
             get
             {
-                if (base.ShouldDrawEntityHpBar)
+                if (!ShouldNotDrawHpBar || IsHovered)
                 {
                     return true;
                 }

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -240,7 +240,7 @@ namespace Intersect.Client.Interface.Shared
                 new LabeledCheckBox(mInformationSettings, "FriendOverheadHpBarCheckbox");
             mFriendOverheadHpBarCheckbox.Text = Strings.Settings.ShowFriendOverheadHpBar;
 
-            // Game Settings - Information: guild overhead members hp bar.
+            // Game Settings - Information: guild members overhead hp bar.
             mGuildMemberOverheadHpBarCheckbox =
                 new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadHpBarCheckbox");
             mGuildMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowGuildOverheadHpBar;
@@ -255,9 +255,9 @@ namespace Intersect.Client.Interface.Shared
                 new LabeledCheckBox(mInformationSettings, "NpcOverheadHpBarCheckbox");
             mNpcOverheadHpBarCheckbox.Text = Strings.Settings.ShowNpcOverheadHpBar;
 
-            // Game Settings - Information: party overhead members hp bar.
+            // Game Settings - Information: party members overhead hp bar.
             mPartyMemberOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "PartyOverheadHpBarCheckbox");
+                new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadHpBarCheckbox");
             mPartyMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowPartyOverheadHpBar;
 
             // Game Settings - Information: players overhead hp bar.

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -78,6 +78,18 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
 
+        private readonly LabeledCheckBox mFriendOverheadHpBarCheckbox;
+
+        private readonly LabeledCheckBox mGuildMemberOverheadHpBarCheckbox;
+
+        private readonly LabeledCheckBox mMyOverheadHpBarCheckbox;
+
+        private readonly LabeledCheckBox mNpcOverheadHpBarCheckbox;
+
+        private readonly LabeledCheckBox mPartyMemberOverheadHpBarCheckbox;
+
+        private readonly LabeledCheckBox mPlayerOverheadHpBarCheckbox;
+
         // Game Settings - Targeting.
         private readonly ScrollControl mTargetingSettings;
 
@@ -182,7 +194,7 @@ namespace Intersect.Client.Interface.Shared
             mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
 
-            // Game Settings - Interface: Show EXP/HP/MP to Percentage.
+            // Game Settings - Interface: Show EXP/HP/MP as Percentage.
             mShowExperienceAsPercentageCheckbox =
                 new LabeledCheckBox(mInterfaceSettings, "ShowExperienceAsPercentageCheckbox");
             mShowExperienceAsPercentageCheckbox.Text = Strings.Settings.ShowExperienceAsPercentage;
@@ -222,6 +234,36 @@ namespace Intersect.Client.Interface.Shared
             mPlayerOverheadInfoCheckbox =
                 new LabeledCheckBox(mInformationSettings, "PlayerOverheadInfoCheckbox");
             mPlayerOverheadInfoCheckbox.Text = Strings.Settings.ShowPlayerOverheadInformation;
+
+            // Game Settings - Information: friends overhead hp bar.
+            mFriendOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "FriendOverheadHpBarCheckbox");
+            mFriendOverheadHpBarCheckbox.Text = Strings.Settings.ShowFriendOverheadHpBar;
+
+            // Game Settings - Information: guild overhead members hp bar.
+            mGuildMemberOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadHpBarCheckbox");
+            mGuildMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowGuildOverheadHpBar;
+
+            // Game Settings - Information: my overhead hp bar.
+            mMyOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "MyOverheadHpBarCheckbox");
+            mMyOverheadHpBarCheckbox.Text = Strings.Settings.ShowMyOverheadHpBar;
+
+            // Game Settings - Information: NPC overhead hp bar.
+            mNpcOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "NpcOverheadHpBarCheckbox");
+            mNpcOverheadHpBarCheckbox.Text = Strings.Settings.ShowNpcOverheadHpBar;
+
+            // Game Settings - Information: party overhead members hp bar.
+            mPartyMemberOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "PartyOverheadHpBarCheckbox");
+            mPartyMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowPartyOverheadHpBar;
+
+            // Game Settings - Information: players overhead hp bar.
+            mPlayerOverheadHpBarCheckbox =
+                new LabeledCheckBox(mInformationSettings, "PlayerOverheadHpBarCheckbox");
+            mPlayerOverheadHpBarCheckbox.Text = Strings.Settings.ShowPlayerOverheadHpBar;
 
             // Game Settings - Targeting.
             mTargetingSettings = new ScrollControl(mGameSettingsContainer, "TargetingSettings");
@@ -633,6 +675,12 @@ namespace Intersect.Client.Interface.Shared
             mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
             mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
             mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
+            mFriendOverheadHpBarCheckbox.IsChecked = Globals.Database.FriendOverheadHpBar;
+            mGuildMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.GuildMemberOverheadHpBar;
+            mMyOverheadHpBarCheckbox.IsChecked = Globals.Database.MyOverheadHpBar;
+            mNpcOverheadHpBarCheckbox.IsChecked = Globals.Database.NpcOverheadHpBar;
+            mPartyMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.PartyMemberOverheadHpBar;
+            mPlayerOverheadHpBarCheckbox.IsChecked = Globals.Database.PlayerOverheadHpBar;
             mStickyTarget.IsChecked = Globals.Database.StickyTarget;
             mAutoTurnToTarget.IsChecked = Globals.Database.AutoTurnToTarget;
 
@@ -806,6 +854,12 @@ namespace Intersect.Client.Interface.Shared
             Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
             Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
             Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
+            Globals.Database.FriendOverheadHpBar = mFriendOverheadHpBarCheckbox.IsChecked;
+            Globals.Database.GuildMemberOverheadHpBar = mGuildMemberOverheadHpBarCheckbox.IsChecked;
+            Globals.Database.MyOverheadHpBar= mMyOverheadHpBarCheckbox.IsChecked;
+            Globals.Database.NpcOverheadHpBar= mNpcOverheadHpBarCheckbox.IsChecked;
+            Globals.Database.PartyMemberOverheadHpBar = mPartyMemberOverheadHpBarCheckbox.IsChecked;
+            Globals.Database.PlayerOverheadHpBar = mPlayerOverheadHpBarCheckbox.IsChecked;
             Globals.Database.StickyTarget = mStickyTarget.IsChecked;
             Globals.Database.AutoTurnToTarget = mAutoTurnToTarget.IsChecked;
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1753,31 +1753,49 @@ namespace Intersect.Client.Localization
             public static LocalizedString SoundVolume = @"Sound Volume: {00}%";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowExperienceAsPercentage = @"Show Experience as percentage";
+            public static LocalizedString ShowExperienceAsPercentage = @"Show experience as percentage";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowFriendOverheadInformation = @"Show Friend Overhead Information";
+            public static LocalizedString ShowFriendOverheadHpBar = @"Show friends overhead HP bar";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowGuildOverheadInformation = @"Show Guild Overhead Information";
+            public static LocalizedString ShowFriendOverheadInformation = @"Show friends overhead information";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowHealthAsPercentage = @"Show Health as percentage";
+            public static LocalizedString ShowGuildOverheadHpBar = @"Show guild overhead HP bar";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowNpcOverheadInformation = @"Show Npc Overhead Information";
+            public static LocalizedString ShowGuildOverheadInformation = @"Show guild overhead information";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowManaAsPercentage = @"Show Mana as percentage";
+            public static LocalizedString ShowHealthAsPercentage = @"Show health as percentage";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowMyOverheadInformation = @"Show My Overhead Information";
+            public static LocalizedString ShowNpcOverheadHpBar = @"Show NPC overhead HP bar";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPartyOverheadInformation = @"Show Party Overhead Information";
+            public static LocalizedString ShowNpcOverheadInformation = @"Show NPC overhead information";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPlayerOverheadInformation = @"Show Players Overhead Information";
+            public static LocalizedString ShowManaAsPercentage = @"Show mana as percentage";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowMyOverheadHpBar = @"Show my overhead HP bar";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowMyOverheadInformation = @"Show my overhead information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPartyOverheadHpBar = @"Show party overhead HP bar";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPartyOverheadInformation = @"Show party overhead information";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPlayerOverheadHpBar = @"Show players overhead HP bar";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ShowPlayerOverheadInformation = @"Show players overhead information";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString StickyTarget = @"Sticky Target";


### PR DESCRIPTION
* Adds feature: visibility settings for entity overhead hp bars.
* When toggled off (default) : 
original behaviour (damaged entity) will show up hp bars on entities ;
along with the ability to see their hp bars by hovering the cursor on them.
* When toggled on, the selected type of entity will always show up their hp bars in the game view.
* Adds player-exclusive override for the boolean ShouldDrawHpBar.
* Fixes a crash due to null player being parsed over to the player boolean IsInMyParty.
* Fixed a couple of localized string and comment typos.
* Should resolve #969

[**Assets for this pull request**](https://github.com/AscensionGameDev/Intersect-Assets/pull/28)

### Preview:

![image](https://user-images.githubusercontent.com/17498701/198728683-328cbb13-4430-4b48-8ec8-a4b70f81e3f4.png)

![image](https://user-images.githubusercontent.com/17498701/198730263-5137c242-238e-472d-89c9-c0b6eb2e068b.png) ![image](https://user-images.githubusercontent.com/17498701/198730365-37e3f608-1983-4bf7-8e32-1d10fe3d7b95.png) ![image](https://user-images.githubusercontent.com/17498701/198730152-593eb1f7-2157-45fd-ba7f-336952f5f53e.png)

![image](https://user-images.githubusercontent.com/17498701/198730189-7b20a9e7-78b3-47fe-9cb3-35942591b320.png) ![image](https://user-images.githubusercontent.com/17498701/198730213-e9bb9dda-9294-4ef6-8e7c-7359246b7676.png)







