### PR TITLE
chore: configurable listbox even rows

### DIFF
--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -165,7 +165,7 @@ namespace Intersect.Configuration
         /// <summary>
         /// Configures whether the highlighted even rows of list elements should be marked differently or not.
         /// </summary>
-        public bool MarkListEvenRows { get; set; } = true;
+        public bool EnableZebraStripedRows { get; set; } = true;
 
         /// <summary>
         /// Configures the name of the skin or skin texture (must end in .png) to use.

--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -165,7 +165,7 @@ namespace Intersect.Configuration
         /// <summary>
         /// Configures whether the highlighted even rows of list elements should be marked differently or not.
         /// </summary>
-        public bool MarkListEvenRows { get; set; } = false;
+        public bool MarkListEvenRows { get; set; } = true;
 
         /// <summary>
         /// Configures the name of the skin or skin texture (must end in .png) to use.

--- a/Intersect (Core)/Configuration/ClientConfiguration.cs
+++ b/Intersect (Core)/Configuration/ClientConfiguration.cs
@@ -163,6 +163,11 @@ namespace Intersect.Configuration
         public bool EnableContextMenus { get; set; } = true;
 
         /// <summary>
+        /// Configures whether the highlighted even rows of list elements should be marked differently or not.
+        /// </summary>
+        public bool MarkListEvenRows { get; set; } = false;
+
+        /// <summary>
         /// Configures the name of the skin or skin texture (must end in .png) to use.
         /// </summary>
         public string UiSkin { get; set; } = "Intersect2021";

--- a/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
@@ -394,7 +394,7 @@ namespace Intersect.Client.Framework.Gwen.Control.Layout
             foreach (TableRow row in Children)
             {
                 row.EvenRow = even;
-                even = ClientConfiguration.Instance.MarkListEvenRows && !even;
+                even = ClientConfiguration.Instance.EnableZebraStripedRows && !even;
 
                 row.SetColumnWidths(mColumnWidths);
             }

--- a/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
@@ -393,15 +393,8 @@ namespace Intersect.Client.Framework.Gwen.Control.Layout
             var even = false;
             foreach (TableRow row in Children)
             {
-                if (ClientConfiguration.Instance.MarkListEvenRows)
-                {
-                    row.EvenRow = even;
-                    even = !even;
-                }
-                else
-                {
-                    row.EvenRow = false;
-                }
+                row.EvenRow = even;
+                even = ClientConfiguration.Instance.MarkListEvenRows && !even;
 
                 row.SetColumnWidths(mColumnWidths);
             }

--- a/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Layout/Table.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control.Data;
-
+using Intersect.Configuration;
 using Newtonsoft.Json.Linq;
 
 namespace Intersect.Client.Framework.Gwen.Control.Layout
@@ -393,8 +393,16 @@ namespace Intersect.Client.Framework.Gwen.Control.Layout
             var even = false;
             foreach (TableRow row in Children)
             {
-                row.EvenRow = even;
-                even = !even;
+                if (ClientConfiguration.Instance.MarkListEvenRows)
+                {
+                    row.EvenRow = even;
+                    even = !even;
+                }
+                else
+                {
+                    row.EvenRow = false;
+                }
+
                 row.SetColumnWidths(mColumnWidths);
             }
         }


### PR DESCRIPTION
Adds a client config to set whether the highlighted even rows of list elements should be marked differently or not.

### _Preview_:

### When false (default):

![image](https://user-images.githubusercontent.com/17498701/198794584-b9345eba-1c06-4622-8ec8-055a21ba07d0.png)
![image](https://user-images.githubusercontent.com/17498701/198791576-2f4e55dc-af70-49b6-ae72-ea10c9e733f2.png)
![image](https://user-images.githubusercontent.com/17498701/198793681-9ab7e83f-37fe-4aa4-95aa-a502230f89b0.png)


### When true (previously hard-coded to be the default behavior):

![image](https://user-images.githubusercontent.com/17498701/198794692-6e4ba80c-439d-49fd-bab2-c9d5926caa00.png)
![image](https://user-images.githubusercontent.com/17498701/198792536-d154bd32-eb54-4eb4-8768-1d8508a3145f.png)
![image](https://user-images.githubusercontent.com/17498701/198793308-ecff8a1a-72e6-4413-8c1b-9945c2249621.png)



