### PR TITLE
enhancement: bind description windows to cursor position

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -11,6 +11,8 @@ namespace Intersect.Client.Framework.Database
 
         public bool HideOthersOnWindowOpen { get; set; }
 
+        public bool BindDescriptionWindowToCursor { get; set; }
+
         public bool TargetAccountDirection { get; set; }
 
         public int MusicVolume { get; set; }
@@ -77,6 +79,7 @@ namespace Intersect.Client.Framework.Database
             FullScreen = LoadPreference(nameof(FullScreen), false);
             EnableLighting = LoadPreference(nameof(EnableLighting), true);
             HideOthersOnWindowOpen = LoadPreference(nameof(HideOthersOnWindowOpen), true);
+            BindDescriptionWindowToCursor = LoadPreference(nameof(BindDescriptionWindowToCursor), true);
             TargetAccountDirection = LoadPreference(nameof(TargetAccountDirection), false);
             StickyTarget = LoadPreference(nameof(StickyTarget), false);
             AutoTurnToTarget = LoadPreference(nameof(AutoTurnToTarget), false);
@@ -103,6 +106,7 @@ namespace Intersect.Client.Framework.Database
             SavePreference(nameof(FullScreen), FullScreen);
             SavePreference(nameof(EnableLighting), EnableLighting);
             SavePreference(nameof(HideOthersOnWindowOpen), HideOthersOnWindowOpen);
+            SavePreference(nameof(BindDescriptionWindowToCursor), BindDescriptionWindowToCursor);
             SavePreference(nameof(TargetAccountDirection), TargetAccountDirection);
             SavePreference(nameof(StickyTarget), StickyTarget);
             SavePreference(nameof(AutoTurnToTarget), AutoTurnToTarget);

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
-
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
 using Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows
@@ -137,32 +137,64 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
         /// <inheritdoc/>
         public override void SetPosition(int x, int y)
         {
-            var newX = x - mContainer.Width - mContainer.Padding.Right;
-            var newY = y + mContainer.Padding.Top;
+            int newX, newY;
 
-            // Center on the desired position if requested.
-            if (mCenterOnPosition)
+            if (!Globals.Database.BindDescriptionWindowToCursor)
             {
-                newX += (mContainer.Width - mContainer.Padding.Right) / 2;
-            }
-            
-            // Do not allow it to render outside of the screen canvas.
-            if (newX < 0)
-            {
-                newX = 0;
-            }
-            else if (newX > mContainer.Canvas.Width - mContainer.Width)
-            {
-                newX = mContainer.Canvas.Width - mContainer.Width;
-            }
+                // Legacy behavior: bind description window to it's item/spell container.
+                newX = x - mContainer.Width - mContainer.Padding.Right;
+                newY = y + mContainer.Padding.Top;
 
-            if (newY < 0)
-            {
-                newY = 0;
+                // Center position when prompted by hot-bars.
+                if (mCenterOnPosition)
+                {
+                    newX += (mContainer.Width - mContainer.Padding.Right) / 2;
+                }
+
+                // Do not allow it to render outside of the screen canvas.
+                if (newX < 0)
+                {
+                    newX = 0;
+                }
+                else if (newX > mContainer.Canvas.Width - mContainer.Width)
+                {
+                    newX = mContainer.Canvas.Width - mContainer.Width;
+                }
+
+                if (newY < 0)
+                {
+                    newY = 0;
+                }
+                else if (newY > mContainer.Canvas.Height - mContainer.Height)
+                {
+                    newY = mContainer.Canvas.Height - mContainer.Height;
+                }
             }
-            else if (newY > mContainer.Canvas.Height - mContainer.Height)
+            else
             {
-                newY = mContainer.Canvas.Height - mContainer.Height;
+                // Bind description window to cursor position (ish).
+                const int posAdjust = 16;
+                newX = (int)Globals.InputManager.GetMousePosition().X + posAdjust;
+                newY = (int)Globals.InputManager.GetMousePosition().Y + posAdjust;
+
+                // Center the description window based on the cursor position when prompted by hot-bars.
+                if (mCenterOnPosition)
+                {
+                    newX = (int)Globals.InputManager.GetMousePosition().X - (mContainer.Width / 2);
+                    newY = y + mContainer.Padding.Top;
+                }
+
+                // Do not allow it to render outside of the screen canvas while based on the cursor position.
+                // Note: we no longer need to check after   (newX < 0)   nor    (newY < 0)   in this case.
+                if (newX > mContainer.Canvas.Width - mContainer.Width)
+                {
+                    newX = (int)Globals.InputManager.GetMousePosition().X - mContainer.Width - posAdjust;
+                }
+
+                if (newY > mContainer.Canvas.Height - mContainer.Height)
+                {
+                    newY = (int)Globals.InputManager.GetMousePosition().Y - mContainer.Height - posAdjust;
+                }
             }
 
             mContainer.MoveTo(newX, newY);

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -57,6 +57,8 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
+        private readonly LabeledCheckBox mBindDescriptionWindowToCursor;
+
         private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
 
         private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
@@ -181,6 +183,10 @@ namespace Intersect.Client.Interface.Shared
             // Game Settings - Interface: Auto-close Windows.
             mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
+            
+            // Game Settings - Interface: Bind description windows to cursor.
+            mBindDescriptionWindowToCursor = new LabeledCheckBox(mInterfaceSettings, "BindDescriptionWindowToCursorCheckbox");
+            mBindDescriptionWindowToCursor.Text = Strings.Settings.BindDescriptionWindowToCursor;
 
             // Game Settings - Interface: Show EXP/HP/MP to Percentage.
             mShowExperienceAsPercentageCheckbox =
@@ -624,6 +630,7 @@ namespace Intersect.Client.Interface.Shared
 
             // Game Settings.
             mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
+            mBindDescriptionWindowToCursor.IsChecked = Globals.Database.BindDescriptionWindowToCursor;
             mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
             mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
             mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
@@ -797,6 +804,7 @@ namespace Intersect.Client.Interface.Shared
 
             // Game Settings.
             Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
+            Globals.Database.BindDescriptionWindowToCursor = mBindDescriptionWindowToCursor.IsChecked;
             Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
             Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
             Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1705,6 +1705,9 @@ namespace Intersect.Client.Localization
             public static LocalizedString AutoCloseWindows = @"Auto-close Windows";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString BindDescriptionWindowToCursor = @"Bind description windows to cursor";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Cancel = @"Cancel";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
* adds a client QoL interface setting (enabled by default) that allows to dynamically bind item/spell description windows to the current cursor position.
* this provides a more flexible and comfortable view in a way that description windows overlap their parent windows whenever we hover the cursor over items/spells.
* this also adjusts the description window without issues on the screen edges, while still based on the current cursor position.
* the legacy behavior is maintained untouched, which can be used back by disabling the enhancement checkbox.
* should resolve #1647 


[**Assets for this pull request**](https://github.com/AscensionGameDev/Intersect-Assets/pull/30)

### Preview

https://user-images.githubusercontent.com/17498701/199294300-db62adff-8a64-4015-9ebc-549616ad3963.mp4

