### PR TITLE
fix: close context menu when closing window

### DIFF
--- a/Intersect.Client/Interface/Game/Bag/BagWindow.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagWindow.cs
@@ -95,6 +95,7 @@ namespace Intersect.Client.Interface.Game.Bag
 
         public void Close()
         {
+            mContextMenu.Close();
             mBagWindow.Close();
         }
 

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -125,8 +125,10 @@ namespace Intersect.Client.Interface.Game.Bank
 
         public void Update()
         {
-            if (mBankWindow.IsHidden == true)
+            if (mBankWindow.IsHidden)
             {
+                mContextMenu.Close();
+
                 if (mOpen)
                 {
                     Interface.GameUi.NotifyCloseBank();

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -126,7 +126,7 @@ namespace Intersect.Client.Interface.Game.Bank
 
         public void Update()
         {
-            if (mBankWindow.IsHidden == true)
+            if (mBankWindow.IsHidden)
             {
                 if (mOpen)
                 {

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -95,6 +95,7 @@ namespace Intersect.Client.Interface.Game.Bank
         {
             mBankWindow.IsHidden = true;
             mOpen = false;
+            mContextMenu.Close();
         }
 
         public void Open()
@@ -125,10 +126,8 @@ namespace Intersect.Client.Interface.Game.Bank
 
         public void Update()
         {
-            if (mBankWindow.IsHidden)
+            if (mBankWindow.IsHidden == true)
             {
-                mContextMenu.Close();
-
                 if (mOpen)
                 {
                     Interface.GameUi.NotifyCloseBank();

--- a/Intersect.Client/Interface/Game/GuildWindow.cs
+++ b/Intersect.Client/Interface/Game/GuildWindow.cs
@@ -146,6 +146,7 @@ namespace Intersect.Client.Interface.Game
 
         public void Hide()
         {
+            mContextMenu.Close();
             mGuildWindow.IsHidden = true;
         }
 

--- a/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
@@ -283,15 +283,15 @@ namespace Intersect.Client.Interface.Game.Inventory
             return !mInventoryWindow.IsHidden;
         }
 
-        public bool Hide()
+        public void Hide()
         {
             if (!Globals.CanCloseInventory)
             {
-                return false;
+                return;
             }
 
+            mContextMenu.Close();
             mInventoryWindow.IsHidden = true;
-            return true;
         }
 
         public FloatRect RenderBounds()

--- a/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
@@ -87,6 +87,7 @@ namespace Intersect.Client.Interface.Game.Shop
 
         public void Close()
         {
+            mContextMenu.Close();
             mShopWindow.Close();
         }
 

--- a/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
@@ -173,6 +173,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
         public void Hide()
         {
+            mContextMenu.Close();
             mSpellWindow.IsHidden = true;
         }
 

--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -121,6 +121,7 @@ namespace Intersect.Client.Interface.Game.Trades
 
         public void Close()
         {
+            mContextMenu.Close();
             mTradeWindow.Close();
         }
 


### PR DESCRIPTION
* Fixes an unwanted behavior (bug) where context menus would remain opened upon closing the window from where they were initially prompted (by closing them along with their parent window).
* Should resolve #1651 