### PR TITLE
fix: ability to set InstancingOptions properties

### DIFF
--- a/Intersect (Core)/Config/InstancingOptions.cs
+++ b/Intersect (Core)/Config/InstancingOptions.cs
@@ -12,32 +12,27 @@ namespace Intersect.Config
         /// <summary>
         /// Whether or not dieing in a shared instance "respawns" you at the instance entrance. Useful for dungeon implementations
         /// </summary>
-        public bool SharedInstanceRespawnInInstance { get; }  = true;
+        public bool SharedInstanceRespawnInInstance { get; set; } = true;
 
         /// <summary>
         /// Whether a player that leaves a shared instance can come back in to that instance after leaving.
         /// </summary>
-        public bool RejoinableSharedInstances { get; } = false;
+        public bool RejoinableSharedInstances { get; set; } = false;
 
         /// <summary>
         /// How many lives a party has in a shared instance, if enabled
         /// </summary>
-        public int MaxSharedInstanceLives { get; } = DefaultInstanceLives;
+        public int MaxSharedInstanceLives { get; set; } = DefaultInstanceLives;
 
         /// <summary>
         /// Whether or not all party members get booted out of an instance on lives reaching -1
         /// </summary>
-        public bool BootAllFromInstanceWhenOutOfLives { get; } = true;
+        public bool BootAllFromInstanceWhenOutOfLives { get; set; } = true;
 
         /// <summary>
         /// Whether or not you lose experience on death in a shared instance
         /// </summary>
-        public bool LoseExpOnInstanceDeath { get; } = false;
-
-        /// <summary>
-        /// Whether or not you regenerate mana on instance death
-        /// </summary>
-        public bool RegenManaOnInstanceDeath { get; } = false;
+        public bool LoseExpOnInstanceDeath { get; set; } = false;
 
         [OnDeserialized]
         internal void OnDeserializedMethod(StreamingContext context)
@@ -45,7 +40,7 @@ namespace Intersect.Config
             Validate();
         }
 
-        public void Validate()
+        private void Validate()
         {
         }
     }


### PR DESCRIPTION
* The server's InstancingOptions properties couldn't be set through their .json files, this commit fixes this behavior by allowing the user to input values other than the default ones. (resolves #1656 )
* chore: removes unused property "RegenManaOnInstanceDeath" since is not really implemented (yet?).