### PR TITLE
fix: NullReferenceException when closing context menus

### DIFF
--- a/Intersect.Client/Interface/Game/Bag/BagWindow.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagWindow.cs
@@ -95,7 +95,7 @@ namespace Intersect.Client.Interface.Game.Bag
 
         public void Close()
         {
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mBagWindow.Close();
         }
 

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -95,7 +95,7 @@ namespace Intersect.Client.Interface.Game.Bank
         {
             mBankWindow.IsHidden = true;
             mOpen = false;
-            mContextMenu.Close();
+            mContextMenu?.Close();
         }
 
         public void Open()

--- a/Intersect.Client/Interface/Game/GuildWindow.cs
+++ b/Intersect.Client/Interface/Game/GuildWindow.cs
@@ -146,7 +146,7 @@ namespace Intersect.Client.Interface.Game
 
         public void Hide()
         {
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mGuildWindow.IsHidden = true;
         }
 

--- a/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
@@ -290,7 +290,7 @@ namespace Intersect.Client.Interface.Game.Inventory
                 return;
             }
 
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mInventoryWindow.IsHidden = true;
         }
 

--- a/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
@@ -87,7 +87,7 @@ namespace Intersect.Client.Interface.Game.Shop
 
         public void Close()
         {
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mShopWindow.Close();
         }
 

--- a/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
@@ -173,7 +173,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
         public void Hide()
         {
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mSpellWindow.IsHidden = true;
         }
 

--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -121,7 +121,7 @@ namespace Intersect.Client.Interface.Game.Trades
 
         public void Close()
         {
-            mContextMenu.Close();
+            mContextMenu?.Close();
             mTradeWindow.Close();
         }
 


### PR DESCRIPTION
* Also checks for other use cases after null context menus before continuing.
* Should resolve #1664 