### PR TITLE
enhancement: configurable character select skip

### DIFF
--- a/Intersect (Core)/Config/PlayerOptions.cs
+++ b/Intersect (Core)/Config/PlayerOptions.cs
@@ -91,6 +91,12 @@
         public bool ShowLevelByName { get; set; } = false;
 
         /// <summary>
+        /// Configures whether or not the game client skips the character select window upon login or going back
+        /// to characters when the max number of characters allowed per account is one.
+        /// </summary>
+        public bool SkipCharacterSelect { get; set; } = false;
+
+        /// <summary>
         /// Distance (in tiles) between players in which a trade offer can be sent and accepted.
         /// </summary>
         public int TradeRange { get; set; } = 6;

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -605,16 +605,20 @@ namespace Intersect.Server.Networking
             }
 
             //Otherwise proceed with login normally...
-            if (Options.MaxCharacters > 1)
+            if (client.Characters?.Count > 0)
             {
-                PacketSender.SendPlayerCharacters(client);
-            }
-            else if (client.Characters?.Count > 0)
-            {
-                client.LoadCharacter(client.Characters.First());
-                client.Entity.SetOnline();
+                if (Options.MaxCharacters > 1 ||
+                    !(Options.MaxCharacters == 1 && Options.Instance.PlayerOpts.SkipCharacterSelect))
+                {
+                    PacketSender.SendPlayerCharacters(client);
+                }
+                else
+                {
+                    client.LoadCharacter(client.Characters.First());
+                    client.Entity.SetOnline();
 
-                PacketSender.SendJoinGame(client);
+                    PacketSender.SendJoinGame(client);
+                }
             }
             else
             {
@@ -626,20 +630,28 @@ namespace Intersect.Server.Networking
         //LogoutPacket
         public void HandlePacket(Client client, LogoutPacket packet)
         {
-            if (client != null)
+            if (client == null)
             {
-                UserActivityHistory.LogActivity(client?.User?.Id ?? Guid.Empty, Guid.Empty, client?.GetIp(), UserActivityHistory.PeerType.Client, packet.ReturningToCharSelect ? UserActivityHistory.UserAction.SwitchPlayer : UserActivityHistory.UserAction.DisconnectLogout, $"{client?.Name},{client?.Entity?.Name}");
+                return;
+            }
 
-                if (Options.MaxCharacters > 1 && packet.ReturningToCharSelect)
-                {
-                    client.Entity?.TryLogout(false, true);
-                    client.Entity = null;
-                    PacketSender.SendPlayerCharacters(client);
-                }
-                else
-                {
-                    client?.Logout();
-                }
+            UserActivityHistory.LogActivity(client.User?.Id ?? Guid.Empty, Guid.Empty, client.GetIp(),
+                UserActivityHistory.PeerType.Client,
+                packet.ReturningToCharSelect
+                    ? UserActivityHistory.UserAction.SwitchPlayer
+                    : UserActivityHistory.UserAction.DisconnectLogout, $"{client.Name},{client.Entity?.Name}");
+
+            if (packet.ReturningToCharSelect && (Options.MaxCharacters > 1 ||
+                                                 !(Options.MaxCharacters == 1 &&
+                                                   Options.Instance.PlayerOpts.SkipCharacterSelect)))
+            {
+                client.Entity?.TryLogout(false, true);
+                client.Entity = null;
+                PacketSender.SendPlayerCharacters(client);
+            }
+            else
+            {
+                client.Logout();
             }
         }
 
@@ -1424,16 +1436,9 @@ namespace Intersect.Server.Networking
                         }
                     }
 
-                    //Character selection if more than one.
-                    if (Options.MaxCharacters > 1)
-                    {
-                        PacketSender.SendPlayerCharacters(client);
-                    }
-                    else
-                    {
-                        PacketSender.SendGameObjects(client, GameObjectType.Class);
-                        PacketSender.SendCreateCharacter(client);
-                    }
+                    //Start the character creation process for the newly created account.
+                    PacketSender.SendGameObjects(client, GameObjectType.Class);
+                    PacketSender.SendCreateCharacter(client);
                 }
             }
         }


### PR DESCRIPTION
* A configurable alternative to resolve #1666 
* Adds the ability to configure whether or not the game client skips the character select window upon login or going back to characters when the max number of characters allowed per account is one.
* QoL change: By logic, newly created accounts have 0 characters on them, so the code logic behind this has been changed to skip the character select window upon creating a new account by directly going thru the character creation window instead.
* QoL change: Already created accounts with 0 characters will directly go thru the character creation window now.