### PR TITLE
fix: transformed casting sprite behavior

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -172,7 +172,7 @@ namespace Intersect.Client.Entities
                 }
 
                 _spellCast = value;
-                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Cast);
+                LoadAnimationTexture(TransformedSprite ?? Sprite, SpriteAnimations.Cast);
             }
         }
 


### PR DESCRIPTION
should resolve #1649

### Preview

![imagen](https://user-images.githubusercontent.com/17498701/205513235-67a9166f-7cb3-4b80-8c6b-e6c43cf0d11f.png)

Spell has a duration of 36 seconds and transforms into Male_003, previously and as reported, the base cast sprite would incorrectly show up when casting while transformed, but as you may see in the following video, this has been corrected to show the transformed casting sprite when casting while transformed:

https://user-images.githubusercontent.com/17498701/205513203-9fa947f9-5bc9-4e62-88a7-01e96bfc3c96.mp4

