### PR TITLE
enhancements and fixes: attack, block and cast animations

### DIFF
--- a/Intersect (Core)/Config/SpriteOptions.cs
+++ b/Intersect (Core)/Config/SpriteOptions.cs
@@ -1,66 +1,76 @@
 ﻿using Newtonsoft.Json;
 
 namespace Intersect.Config
-{ 
+{
     /// <summary>
     /// Contains configurable options pertaining to the way sprites are rendered within the engine
     /// </summary>
     public partial class SpriteOptions
     {
         /// <summary>
-        /// Defines the number of frames there will be in idling sprite sheets
+        /// Defines the number of frames there will be in attacking sprite sheets.
         /// </summary>
-        public int IdleFrames = 4;
+        public int AttackFrames { get; set; } = 4;
 
         /// <summary>
-        /// Defines the number of frames there will be in normal (walking) sprite sheets
+        /// Defines the number of frames there will be in casting sprite sheets.
         /// </summary>
-        public int NormalFrames = 4;
+        public int CastFrames { get; set; } = 4;
 
         /// <summary>
-        /// Defines the number of frames there will be in casting sprite sheets
+        /// Defines the number of frames there will be in idling sprite sheets.
         /// </summary>
-        public int CastFrames = 4;
+        public int IdleFrames { get; set; } = 4;
 
         /// <summary>
-        /// Defines the number of frames there will be in attacking sprite sheets
+        /// Defines the duration (in milliseconds) for transitioning between consecutive idling frames.
         /// </summary>
-        public int AttackFrames = 4;
+        public int IdleFrameDuration { get; set; } = 200;
 
         /// <summary>
-        /// Defines the number of frames there will be in shooting sprite sheets
+        /// Defines how long (in milliseconds) a player must idle before the idling sprite starts to render.
         /// </summary>
-        public int ShootFrames = 4;
+        public int IdleStartDelay { get; set; } = 4000;
 
         /// <summary>
-        /// Defines the number of frames there will be in weapon attacking sprite sheets
+        /// Defines the number of frames there will be in normal (walking) sprite sheets.
         /// </summary>
-        public int WeaponFrames = 4;
+        public int NormalFrames { get; set; } = 4;
 
         /// <summary>
-        /// The frame on the normal sprite sheet to show when attacking when there is no designated sheet for attack.
+        /// Defines a single frame from the normal sprite sheet to show for attacking when there is no designated sheet for attack.
         /// </summary>
-        public int NormalSheetAttackFrame = 3;
+        public int NormalAttackFrame { get; set; } = 3;
 
         /// <summary>
-        /// The frame on the normal sprite sheet to show when dashing or sliding.
+        /// Defines a single frame from the normal sprite sheet to show when blocking.
         /// </summary>
-        public int NormalSheetDashFrame = 1;
+        public int NormalBlockFrame { get; set; } = 2;
 
         /// <summary>
-        /// Defines how long (in ms) between walking frames
+        /// Defines a single frame from the normal sprite sheet to show for casting when there is no designated sheet for cast.
         /// </summary>
-        public int MovingFrameDuration = 200;
+        public int NormalCastFrame { get; set; } = 2;
 
         /// <summary>
-        /// Defines how long (in ms) between idling frames
+        /// Defines a single frame from the normal sprite sheet to show when dashing or sliding.
         /// </summary>
-        public int IdleFrameDuration = 200;
+        public int NormalDashFrame { get; set; } = 1;
 
         /// <summary>
-        /// Defines how long (in ms) a player must idle before the idling sprite starts to render
+        /// Defines the duration (in milliseconds) for transitioning between consecutive walking frames.
         /// </summary>
-        public int TimeBeforeIdle = 4000;
+        public int MovingFrameDuration { get; set; } = 200;
+
+        /// <summary>
+        /// Defines the number of frames there will be in shooting sprite sheets.
+        /// </summary>
+        public int ShootFrames { get; set; } = 4;
+
+        /// <summary>
+        /// Defines the number of frames there will be in weapon attacking sprite sheets.
+        /// </summary>
+        public int WeaponFrames { get; set; } = 4;
 
         /// <summary>
         /// The number of rows in the sprite sheet that correspond to the number of directions supported in the game.

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -1,21 +1,17 @@
 using System;
-
 using Intersect.Admin.Actions;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.GenericClasses;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game;
 using Intersect.Client.Maps;
 using Intersect.Client.Networking;
-using Intersect.Logging;
 using Intersect.Utilities;
 
 namespace Intersect.Client.Core
 {
-
     public static partial class Input
     {
 
@@ -346,7 +342,7 @@ namespace Intersect.Client.Core
                     return;
                 }
 
-                if (Globals.Me.AttackTimer < Timing.Global.Milliseconds)
+                if (!Globals.Me.IsAttacking)
                 {
                     Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
                 }

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Logging;
@@ -393,23 +392,25 @@ namespace Intersect.Server.Entities
 
             //We were forcing at LEAST 1hp base damage.. but then you can't have guards that won't hurt the player.
             //https://www.ascensiongamedev.com/community/bug_tracker/intersect/npc-set-at-0-attack-damage-still-damages-player-by-1-initially-r915/
-            if (AttackTimer < Timing.Global.Milliseconds)
+            if (IsAttacking)
             {
-                if (Base.AttackAnimation != null)
-                {
-                    PacketSender.SendAnimationToProximity(
-                        Base.AttackAnimationId, -1, Guid.Empty, target.MapId, target.X, target.Y, Dir,
-                        target.MapInstanceId
-                    );
-                }
-
-                base.TryAttack(
-                    target, Base.Damage, (DamageType) Base.DamageType, (Stats) Base.ScalingStat, Base.Scaling,
-                    Base.CritChance, Base.CritMultiplier, deadAnimations, aliveAnimations
-                );
-
-                PacketSender.SendEntityAttack(this, CalculateAttackTime());
+                return;
             }
+
+            if (Base.AttackAnimation != null)
+            {
+                PacketSender.SendAnimationToProximity(
+                    Base.AttackAnimationId, -1, Guid.Empty, target.MapId, (byte)target.X, (byte)target.Y,
+                    Dir, target.MapInstanceId
+                );
+            }
+
+            base.TryAttack(
+                target, Base.Damage, (DamageType)Base.DamageType, (Stats)Base.ScalingStat, Base.Scaling,
+                Base.CritChance, Base.CritMultiplier, deadAnimations, aliveAnimations
+            );
+
+            PacketSender.SendEntityAttack(this, CalculateAttackTime());
         }
 
         public bool CanNpcCombat(Entity enemy, bool friendly = false)

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -24,7 +24,6 @@ using Intersect.Server.Maps;
 using Intersect.Server.Networking.Lidgren;
 using Intersect.Server.Notifications;
 using Intersect.Utilities;
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -1087,7 +1086,7 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            if (player.AttackTimer > Timing.Global.Milliseconds)
+            if (player.IsAttacking)
             {
                 return;
             }
@@ -1303,7 +1302,7 @@ namespace Intersect.Server.Networking
                 }
             }
 
-            if (player.AttackTimer > Timing.Global.Milliseconds)
+            if (player.IsAttacking)
             {
                 player.AttackTimer = Timing.Global.Milliseconds + latencyAdjustmentMs + player.CalculateAttackTime();
             }


### PR DESCRIPTION
* fix: normal sprite no longer overrides the attack sprites, it has it's own method now.
* fix: idle state wont mess around with casting nor blocking anymore.
* chore: less duplicated code at Entity.Draw and Entity.DrawEquipment, for which we now use the single int class "NormalSpriteAnimationFrame".
* The class "NormalSpriteAnimationFrame" handles the normal sheet attack, block and cast frames, which are now configurable by their own sprite option properties ! (NormalAttackFrame, NormalBlockFrame, NormalCastFrame).
* enhancement: prevents showing frames out of index, aka "invisible frames issue" for normal attack, block and cast frames in case of wrong config input (frame > amount of frames within the normal sheet). #1655
* shield improvements: no more frame randomness, blocking uses it's single configured frame without conflicts when standing and slowly moving now.
* Implements "IsAttacking" as an entity boolean on client and server.
* For NormalSpriteAnimationFrame, isAttacking behaves differently as it's own variable.
* Renames server entity boolean "Blocking" to "IsBlocking" for better name consistency.
* chore & fix (DrawEquipment method): added summary and code comments to improve readability, also fixes #1721
* chore (CalculateOrigin method): changed to virtual void, it shouldn't be a boolean.
* chore: removes ref variable 'entityRect' from DrawEquipment method (not used).