### PR TITLE
fix: equipment color in character window

### DIFF
--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -259,11 +259,11 @@ namespace Intersect.Client.Interface.Game.Character
                                 .Inventory[equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])]]
                                 .ItemId;
 
-                            if (ItemBase.Get(itemNum) != null)
+                            if (ItemBase.TryGet(itemNum, out var itemDescriptor))
                             {
-                                var itemData = ItemBase.Get(itemNum);
-                                paperdoll = Globals.Me.Gender == 0 ? itemData.MalePaperdoll : itemData.FemalePaperdoll;
-                                PaperdollPanels[z].RenderColor = itemData.Color;
+                                paperdoll = Globals.Me.Gender == 0
+                                    ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                PaperdollPanels[z].RenderColor = itemDescriptor.Color;
                             }
                         }
                     }

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -261,15 +261,9 @@ namespace Intersect.Client.Interface.Game.Character
 
                             if (ItemBase.Get(itemNum) != null)
                             {
-                                var itemdata = ItemBase.Get(itemNum);
-                                if (Globals.Me.Gender == 0)
-                                {
-                                    paperdoll = itemdata.MalePaperdoll;
-                                }
-                                else
-                                {
-                                    paperdoll = itemdata.FemalePaperdoll;
-                                }
+                                var itemData = ItemBase.Get(itemNum);
+                                paperdoll = Globals.Me.Gender == 0 ? itemData.MalePaperdoll : itemData.FemalePaperdoll;
+                                PaperdollPanels[z].RenderColor = itemData.Color;
                             }
                         }
                     }

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -917,14 +917,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                             if (ItemBase.Get(itemId) != null)
                             {
                                 var itemdata = ItemBase.Get(itemId);
-                                if (MyEntity.Gender == 0)
-                                {
-                                    paperdoll = itemdata.MalePaperdoll;
-                                }
-                                else
-                                {
-                                    paperdoll = itemdata.FemalePaperdoll;
-                                }
+                                paperdoll = MyEntity.Gender == 0 ? itemdata.MalePaperdoll : itemdata.FemalePaperdoll;
                                 paperdollPanel.RenderColor = itemdata.Color;
                             }
                         }

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -914,11 +914,11 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                         if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] != Guid.Empty)
                         {
                             var itemId = equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])];
-                            if (ItemBase.Get(itemId) != null)
+                            if (ItemBase.TryGet(itemId, out var itemDescriptor))
                             {
-                                var itemdata = ItemBase.Get(itemId);
-                                paperdoll = MyEntity.Gender == 0 ? itemdata.MalePaperdoll : itemdata.FemalePaperdoll;
-                                paperdollPanel.RenderColor = itemdata.Color;
+                                paperdoll = MyEntity.Gender == 0
+                                    ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                paperdollPanel.RenderColor = itemDescriptor.Color;
                             }
                         }
                     }

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -889,14 +889,9 @@ namespace Intersect.Editor.Forms.Editors.Events
 
         private static string GetCommandText(ChangeGenderCommand command, MapInstance map)
         {
-            if (command.Gender == 0)
-            {
-                return Strings.EventCommandList.setgender.ToString(Strings.EventCommandList.male);
-            }
-            else
-            {
-                return Strings.EventCommandList.setgender.ToString(Strings.EventCommandList.female);
-            }
+            return Strings.EventCommandList.setgender.ToString(command.Gender == 0
+                ? Strings.EventCommandList.male
+                : Strings.EventCommandList.female);
         }
 
         private static string GetCommandText(SetAccessCommand command, MapInstance map)


### PR DESCRIPTION
* fixes an unwanted behavior within the character window where the player's equipped gear wasn't properly drawn with their corresponding color values.
* chore: simplified some gender checks by converting them into '?:' expressions.
* should resolve #1677 

### Before:
![imagen](https://user-images.githubusercontent.com/17498701/206876907-7ae5cce4-d3c3-4a56-85a1-d0bc290ae101.png)


### After:
![imagen](https://user-images.githubusercontent.com/17498701/206876887-8f6f2df8-9df7-4aa9-b94c-a07fbca2dbcd.png)



