### PR TITLE
fix: fog timing, intensity and consistency

### DIFF
--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -1036,7 +1036,7 @@ namespace Intersect.Client.Maps
             var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.GetHeight();
 
             // Update the fog texture's position based on its speed and elapsed time.
-            mFogCurrentX -= elapsedTime / 1000f * FogXSpeed * -6;
+            mFogCurrentX += elapsedTime / 1000f * FogXSpeed * 2;
             mFogCurrentY += elapsedTime / 1000f * FogYSpeed * 2;
 
             // Handle cases where the fog texture's position goes out of bounds.

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -1008,13 +1008,13 @@ namespace Intersect.Client.Maps
         /// </summary>
         public void DrawFog()
         {
-            // Exit early if the player or map data is not available, or if there is no fog texture
+            // Exit early if the player or map data is not available, or if there is no fog texture.
             if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || Fog == null || Fog.Length <= 0)
             {
                 return;
             }
 
-            // Get fog texture and exit early if it is not available
+            // Get fog texture and exit early if it is not available.
             var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
             if (fogTex == null)
             {
@@ -1195,52 +1195,60 @@ namespace Intersect.Client.Maps
 
         public void CompareEffects(IMapInstance oldMap)
         {
-            var tempMap = oldMap as MapInstance;
-            //Check if fogs the same
-            if (tempMap.Fog == Fog)
+            // Return if the old map is not a MapInstance.
+            if (!(oldMap is MapInstance tempMap))
             {
-                var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
-                if (fogTex != null)
-                {
-                    //Copy over fog values
-                    mFogUpdateTime = tempMap.mFogUpdateTime;
-                    var ratio = (float)tempMap.FogTransparency / FogTransparency;
-                    mCurFogIntensity = ratio * tempMap.mCurFogIntensity;
-                    mFogCurrentX = tempMap.mFogCurrentX;
-                    mFogCurrentY = tempMap.mFogCurrentY;
-                    if (GetX() > tempMap.GetX())
-                    {
-                        mFogCurrentX -= Options.TileWidth * Options.MapWidth % fogTex.GetWidth();
-                    }
-                    else if (GetX() < oldMap.X)
-                    {
-                        mFogCurrentX += Options.TileWidth * Options.MapWidth % fogTex.GetWidth();
-                    }
-
-                    if (GetY() > oldMap.Y)
-                    {
-                        mFogCurrentY -= Options.TileHeight * Options.MapHeight % fogTex.GetHeight();
-                    }
-                    else if (GetY() < oldMap.Y)
-                    {
-                        mFogCurrentY += Options.TileHeight * Options.MapHeight % fogTex.GetHeight();
-                    }
-
-                    tempMap.mCurFogIntensity = 0;
-                }
+                return;
             }
 
+            // Check if fog is the same.
+            if (tempMap.Fog == Fog)
+            {
+                // Get fog texture.
+                var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
+                if (fogTex == null)
+                {
+                    return;
+                }
+
+                // Copy over fog values.
+                mFogUpdateTime = tempMap.mFogUpdateTime;
+                var ratio = (float)tempMap.FogTransparency / FogTransparency;
+                mCurFogIntensity = ratio * tempMap.mCurFogIntensity;
+                mFogCurrentX = tempMap.mFogCurrentX;
+                mFogCurrentY = tempMap.mFogCurrentY;
+
+                // Calculate displacement of current map compared to old map.
+                float dx = GetX() - oldMap.X;
+                float dy = GetY() - oldMap.Y;
+
+                // Update fog position based on displacement.
+                float fogWidth = fogTex.GetWidth();
+                float fogHeight = fogTex.GetHeight();
+                mFogCurrentX -= dx * Options.TileWidth * Options.MapWidth % fogWidth;
+                mFogCurrentY -= dy * Options.TileHeight * Options.MapHeight % fogHeight;
+
+                // Reset fog intensity of old map.
+                tempMap.mCurFogIntensity = 0;
+            }
+
+            // Check if panorama is the same.
             if (tempMap.Panorama == Panorama)
             {
+                // Copy over panorama values.
                 mPanoramaIntensity = tempMap.mPanoramaIntensity;
                 mPanoramaUpdateTime = tempMap.mPanoramaUpdateTime;
+                // Reset panorama intensity of old map.
                 tempMap.mPanoramaIntensity = 0;
             }
 
+            // Check if overlay graphic is the same.
             if (tempMap.OverlayGraphic == OverlayGraphic)
             {
+                // Copy over overlay graphic values.
                 mOverlayIntensity = tempMap.mOverlayIntensity;
                 mOverlayUpdateTime = tempMap.mOverlayUpdateTime;
+                // Reset overlay graphic intensity of old map.
                 tempMap.mOverlayIntensity = 0;
             }
         }

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -1003,104 +1003,63 @@ namespace Intersect.Client.Maps
             return outputBuffers;
         }
 
-        //Fogs/Panorama/Overlay
+        /// <summary>
+        /// Draws the fog over the game view.
+        /// </summary>
         public void DrawFog()
         {
-            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null)
+            // Exit early if the player or map data is not available, or if there is no fog texture
+            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || Fog == null || Fog.Length <= 0)
             {
                 return;
             }
 
-            float ecTime = Timing.Global.Milliseconds - mFogUpdateTime;
+            // Get fog texture and exit early if it is not available
+            var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
+            if (fogTex == null)
+            {
+                return;
+            }
+
+            // Calculate elapsed time since the last update and set maximum value for elapsedTime to
+            // prevent large jumps in fog intensity (1 second maximum).
+            float elapsedTime = Math.Min(Timing.Global.Milliseconds - mFogUpdateTime, 1000);
             mFogUpdateTime = Timing.Global.Milliseconds;
-            if (Id == Globals.Me.MapId)
+
+            // Update fog intensity based on whether the player is on the current map or not.
+            mCurFogIntensity = Id == Globals.Me.MapId
+                ? Math.Min(1, mCurFogIntensity + elapsedTime / 2000f)
+                : Math.Max(0, mCurFogIntensity - elapsedTime / 2000f);
+
+            // Calculate the number of times the fog texture needs to be drawn to cover the map area.
+            var xCount = Options.MapWidth * Options.TileWidth * 3 / fogTex.GetWidth();
+            var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.GetHeight();
+
+            // Update the fog texture's position based on its speed and elapsed time.
+            mFogCurrentX -= elapsedTime / 1000f * FogXSpeed * -6;
+            mFogCurrentY += elapsedTime / 1000f * FogYSpeed * 2;
+
+            // Handle cases where the fog texture's position goes out of bounds.
+            mFogCurrentX %= fogTex.GetWidth();
+            mFogCurrentY %= fogTex.GetHeight();
+
+            // Round the fog texture's position to the nearest integer value.
+            var drawX = (float)Math.Round(mFogCurrentX);
+            var drawY = (float)Math.Round(mFogCurrentY);
+
+            for (var x = -1; x < xCount; x++)
             {
-                if (mCurFogIntensity != 1)
+                for (var y = -1; y < yCount; y++)
                 {
-                    if (mCurFogIntensity < 1)
-                    {
-                        mCurFogIntensity += ecTime / 2000f;
-                        if (mCurFogIntensity > 1)
-                        {
-                            mCurFogIntensity = 1;
-                        }
-                    }
-                    else
-                    {
-                        mCurFogIntensity -= ecTime / 2000f;
-                        if (mCurFogIntensity < 1)
-                        {
-                            mCurFogIntensity = 1;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (mCurFogIntensity != 0)
-                {
-                    mCurFogIntensity -= ecTime / 2000f;
-                    if (mCurFogIntensity < 0)
-                    {
-                        mCurFogIntensity = 0;
-                    }
-                }
-            }
-
-            if (Fog != null && Fog.Length > 0)
-            {
-                var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
-                if (fogTex != null)
-                {
-                    var xCount = (int)(Options.MapWidth * Options.TileWidth * 3 / fogTex.GetWidth());
-                    var yCount = (int)(Options.MapHeight * Options.TileHeight * 3 / fogTex.GetHeight());
-
-                    mFogCurrentX -= ecTime / 1000f * FogXSpeed * -6;
-                    mFogCurrentY += ecTime / 1000f * FogYSpeed * 2;
-                    float deltaX = 0;
-                    mFogCurrentX -= deltaX;
-                    float deltaY = 0;
-                    mFogCurrentY -= deltaY;
-
-                    if (mFogCurrentX < fogTex.GetWidth())
-                    {
-                        mFogCurrentX += fogTex.GetWidth();
-                    }
-
-                    if (mFogCurrentX > fogTex.GetWidth())
-                    {
-                        mFogCurrentX -= fogTex.GetWidth();
-                    }
-
-                    if (mFogCurrentY < fogTex.GetHeight())
-                    {
-                        mFogCurrentY += fogTex.GetHeight();
-                    }
-
-                    if (mFogCurrentY > fogTex.GetHeight())
-                    {
-                        mFogCurrentY -= fogTex.GetHeight();
-                    }
-
-                    var drawX = (float)Math.Round(mFogCurrentX);
-                    var drawY = (float)Math.Round(mFogCurrentY);
-
-                    for (var x = -1; x < xCount; x++)
-                    {
-                        for (var y = -1; y < yCount; y++)
-                        {
-                            var fogW = fogTex.GetWidth();
-                            var fogH = fogTex.GetHeight();
-                            Graphics.DrawGameTexture(
-                                fogTex, new FloatRect(0, 0, fogW, fogH),
-                                new FloatRect(
-                                    GetX() - Options.MapWidth * Options.TileWidth * 1f + x * fogW + drawX,
-                                    GetY() - Options.MapHeight * Options.TileHeight * 1f + y * fogH + drawY, fogW, fogH
-                                ), new Intersect.Color((byte)(FogTransparency * mCurFogIntensity), 255, 255, 255),
-                                null, GameBlendModes.None
-                            );
-                        }
-                    }
+                    var fogW = fogTex.GetWidth();
+                    var fogH = fogTex.GetHeight();
+                    Graphics.DrawGameTexture(
+                        fogTex, new FloatRect(0, 0, fogW, fogH),
+                        new FloatRect(
+                            GetX() - Options.MapWidth * Options.TileWidth * 1f + x * fogW + drawX,
+                            GetY() - Options.MapHeight * Options.TileHeight * 1f + y * fogH + drawY, fogW, fogH
+                        ), new Color((byte)(FogTransparency * mCurFogIntensity), 255, 255, 255)
+                    );
                 }
             }
         }

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -1009,7 +1009,7 @@ namespace Intersect.Client.Maps
         public void DrawFog()
         {
             // Exit early if the player or map data is not available, or if there is no fog texture.
-            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || Fog == null || Fog.Length <= 0)
+            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || string.IsNullOrWhiteSpace(Fog))
             {
                 return;
             }
@@ -1032,32 +1032,31 @@ namespace Intersect.Client.Maps
                 : Math.Max(0, mCurFogIntensity - elapsedTime / 2000f);
 
             // Calculate the number of times the fog texture needs to be drawn to cover the map area.
-            var xCount = Options.MapWidth * Options.TileWidth * 3 / fogTex.GetWidth();
-            var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.GetHeight();
+            var xCount = Options.MapWidth * Options.TileWidth * 3 / fogTex.Width;
+            var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.Height;
 
             // Update the fog texture's position based on its speed and elapsed time.
             mFogCurrentX += elapsedTime / 1000f * FogXSpeed * 2;
             mFogCurrentY += elapsedTime / 1000f * FogYSpeed * 2;
 
             // Handle cases where the fog texture's position goes out of bounds.
-            mFogCurrentX %= fogTex.GetWidth();
-            mFogCurrentY %= fogTex.GetHeight();
+            mFogCurrentX %= fogTex.Width;
+            mFogCurrentY %= fogTex.Height;
 
             // Round the fog texture's position to the nearest integer value.
             var drawX = (float)Math.Round(mFogCurrentX);
             var drawY = (float)Math.Round(mFogCurrentY);
 
-            for (var x = -1; x < xCount; x++)
+            for (var x = 0; x <= xCount; x++)
             {
-                for (var y = -1; y < yCount; y++)
+                for (var y = 0; y <= yCount; y++)
                 {
-                    var fogW = fogTex.GetWidth();
-                    var fogH = fogTex.GetHeight();
                     Graphics.DrawGameTexture(
-                        fogTex, new FloatRect(0, 0, fogW, fogH),
+                        fogTex, new FloatRect(0, 0, fogTex.Width, fogTex.Height),
                         new FloatRect(
-                            GetX() - Options.MapWidth * Options.TileWidth * 1f + x * fogW + drawX,
-                            GetY() - Options.MapHeight * Options.TileHeight * 1f + y * fogH + drawY, fogW, fogH
+                            X - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
+                            Y - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY,
+                            fogTex.Width, fogTex.Height
                         ), new Color((byte)(FogTransparency * mCurFogIntensity), 255, 255, 255)
                     );
                 }
@@ -1219,14 +1218,12 @@ namespace Intersect.Client.Maps
                 mFogCurrentY = tempMap.mFogCurrentY;
 
                 // Calculate displacement of current map compared to old map.
-                float dx = GetX() - oldMap.X;
-                float dy = GetY() - oldMap.Y;
+                float dx = X - oldMap.X;
+                float dy = Y - oldMap.Y;
 
                 // Update fog position based on displacement.
-                float fogWidth = fogTex.GetWidth();
-                float fogHeight = fogTex.GetHeight();
-                mFogCurrentX -= dx * Options.TileWidth * Options.MapWidth % fogWidth;
-                mFogCurrentY -= dy * Options.TileHeight * Options.MapHeight % fogHeight;
+                mFogCurrentX -= dx * Options.TileWidth * Options.MapWidth % fogTex.Width;
+                mFogCurrentY -= dy * Options.TileHeight * Options.MapHeight % fogTex.Height;
 
                 // Reset fog intensity of old map.
                 tempMap.mCurFogIntensity = 0;

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1834,38 +1834,31 @@ namespace Intersect.Editor.Core
             sFogUpdateTime = Timing.Global.Milliseconds;
 
             // Calculate the number of times the fog texture needs to be drawn to cover the map area.
-            var xCount = Globals.MapEditorWindow.picMap.Width / fogTex.Width + 1;
-            var yCount = Globals.MapEditorWindow.picMap.Height / fogTex.Height + 1;
+            var xCount = Globals.MapEditorWindow.picMap.Width * Options.TileWidth / fogTex.Width;
+            var yCount = Globals.MapEditorWindow.picMap.Height * Options.TileHeight / fogTex.Height;
 
             // Update the fog texture's position based on its speed and elapsed time.
             sFogCurrentX += elapsedTime / 1000f * currentMap.FogXSpeed * 2;
             sFogCurrentY += elapsedTime / 1000f * currentMap.FogYSpeed * 2;
 
             // Handle cases where the fog texture's position goes out of bounds.
-            if (sFogCurrentX < 0 || sFogCurrentX > fogTex.Width)
-            {
-                sFogCurrentX %= fogTex.Width;
-            }
-
-            if (sFogCurrentY < 0 || sFogCurrentY > fogTex.Height)
-            {
-                sFogCurrentY %= fogTex.Height;
-            }
+            sFogCurrentX %= fogTex.Width;
+            sFogCurrentY %= fogTex.Height;
 
             // Round the fog texture's position to the nearest integer value.
             var drawX = (float)Math.Round(sFogCurrentX);
             var drawY = (float)Math.Round(sFogCurrentY);
 
-            for (var x = -1; x < xCount; x++)
+            for (var x = 0; x <= xCount; x++)
             {
-                for (var y = -1; y < yCount; y++)
+                for (var y = 0; y <= yCount; y++)
                 {
-                    var fogW = fogTex.Width;
-                    var fogH = fogTex.Height;
                     DrawTexture(
-                        fogTex, new RectangleF(0, 0, fogW, fogH),
+                        fogTex, new RectangleF(0, 0, fogTex.Width, fogTex.Height),
                         new RectangleF(
-                            x * fogW + drawX, y * fogH + drawY, fogW, fogH
+                            0 - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
+                            0 - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY, fogTex.Width,
+                            fogTex.Height
                         ), System.Drawing.Color.FromArgb(currentMap.FogTransparency, 255, 255, 255), target
                     );
                 }


### PR DESCRIPTION
* Should resolve #1652 
* Chore: refactors client's `DrawFog` method in order to improve: performance, readability and stability.
* Fix: Solves an issue where the value of `elapsedTime` could potentially be very large if there is a significant delay between calls to the `DrawFog` method. This could cause the `mCurFogIntensity` to increase or decrease at an unexpectedly fast rate, which could cause the fog to appear and disappear abruptly or delayed.
* Removed the unnecessary check for `mCurFogIntensity` being less than 1 in the first conditional block.
* Used Math.Min and Math.Max instead of the if statements to clamp the values of `mCurFogIntensity`
* In order to handle cases where the fog texture's position goes out of bounds: converted `mFogCurrentX`/`mFogCurrentY` to compound assignments.

(30-12-22)
* refactor: client's `CompareEffects`
* refactor: editor's `DrawFog` method in order to improve: performance, readability and stability.
* fixed [inconsistent / mismatching / out of sync] fog texture's position based on its speed and elapsed time on both ends: client and editor.

### Preview (Before this PR)

https://user-images.githubusercontent.com/17498701/201734643-eea23e00-dbf6-4e86-9e0e-9c8080e6f309.mp4

### Preview (After this PR)

https://user-images.githubusercontent.com/17498701/201734675-1ab4947a-8df0-49a6-9dfc-c23540ee6433.mp4

https://user-images.githubusercontent.com/17498701/199637035-850de0cd-d586-4135-9fdd-6a33b56fb949.mp4