### PR TITLE
fix: glitched even rows and hovered rows within listboxes

### DIFF
--- a/Intersect.Client.Framework/Gwen/Skin/TexturedBase.cs
+++ b/Intersect.Client.Framework/Gwen/Skin/TexturedBase.cs
@@ -645,12 +645,12 @@ namespace Intersect.Client.Framework.Gwen.Skin
                 );
             }
 
-            mTextures.Input.ListBox.Background = new Bordered(mTexture, 256, 256, 63, 127, Margin.Eight);
-            mTextures.Input.ListBox.Hovered = new Bordered(mTexture, 320, 320, 31, 31, Margin.Eight);
-            mTextures.Input.ListBox.EvenLine = new Bordered(mTexture, 352, 256, 31, 31, Margin.Eight);
-            mTextures.Input.ListBox.OddLine = new Bordered(mTexture, 352, 288, 31, 31, Margin.Eight);
-            mTextures.Input.ListBox.EvenLineSelected = new Bordered(mTexture, 320, 270, 31, 31, Margin.Eight);
-            mTextures.Input.ListBox.OddLineSelected = new Bordered(mTexture, 320, 288, 31, 31, Margin.Eight);
+            mTextures.Input.ListBox.Background = new Bordered(mTexture, 256, 256, 63, 127, Margin.Six);
+            mTextures.Input.ListBox.Hovered = new Bordered(mTexture, 320, 320, 32, 32, Margin.Six);
+            mTextures.Input.ListBox.EvenLine = new Bordered(mTexture, 352, 256, 32, 32, Margin.Six);
+            mTextures.Input.ListBox.EvenLineSelected = new Bordered(mTexture, 320, 256, 32, 32, Margin.Six);
+            mTextures.Input.ListBox.OddLine = new Bordered(mTexture, 352, 288, 32, 32, Margin.Six);
+            mTextures.Input.ListBox.OddLineSelected = new Bordered(mTexture, 320, 288, 32, 32, Margin.Six);
 
             mTextures.Input.ComboBox.Normal = new Bordered(mTexture, 384, 336, 127, 31, new Margin(8, 8, 32, 8));
             mTextures.Input.ComboBox.Hover = new Bordered(mTexture, 384, 336 + 32, 127, 31, new Margin(8, 8, 32, 8));
@@ -1537,31 +1537,27 @@ namespace Intersect.Client.Framework.Gwen.Skin
                 return;
             }
 
+            if (control.IsHovered)
+            {
+                mTextures.Input.ListBox.Hovered.Draw(Renderer, control.RenderBounds, control.RenderColor);
+                return;
+            }
+
             if (selected)
             {
                 if (even)
                 {
                     mTextures.Input.ListBox.EvenLineSelected.Draw(Renderer, control.RenderBounds, control.RenderColor);
-
                     return;
                 }
 
                 mTextures.Input.ListBox.OddLineSelected.Draw(Renderer, control.RenderBounds, control.RenderColor);
-
-                return;
-            }
-
-            if (control.IsHovered)
-            {
-                mTextures.Input.ListBox.Hovered.Draw(Renderer, control.RenderBounds, control.RenderColor);
-
                 return;
             }
 
             if (even)
             {
                 mTextures.Input.ListBox.EvenLine.Draw(Renderer, control.RenderBounds, control.RenderColor);
-
                 return;
             }
 


### PR DESCRIPTION
* Fixes an issue where list box elements that are selected and hovered, are drawn with the selected texture instead of the hovered texture.
* Realigned listbox rows.
* Fixes glitchy and misaligned even rows.
* Should resolve #1648
* [Reworked assets with better looking listbox rows](https://github.com/AscensionGameDev/Intersect-Assets/pull/35)

### Before:

![imagen](https://user-images.githubusercontent.com/17498701/210283236-1ff2b98a-8f61-4d00-bb82-4ff6abe432db.png)

![imagen](https://user-images.githubusercontent.com/17498701/210283287-ec4f62f1-d74b-4814-a082-e91e4df1e223.png)



### Preview (_After_ this PR):

https://user-images.githubusercontent.com/17498701/211175865-f10e6a99-f4bf-4e28-a716-4310eee43fdb.mp4
