### PR TITLE
chore: performance and memory

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -2366,15 +2366,14 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <returns>Control or null if not found.</returns>
         public virtual Base GetControlAt(int x, int y)
         {
-            // Return null if control is hidden or coordinates are outside the control's bounds
+            // Return null if control is hidden or coordinates are outside the control's bounds.
             if (IsHidden || x < 0 || y < 0 || x >= Width || y >= Height)
             {
                 return null;
             }
 
-            // Check children in reverse order (last added first)
-            var count = mChildren.Count;
-            for (int i = count - 1; i >= 0; i--)
+            // Check children in reverse order (last added first).
+            for (int i = mChildren.Count - 1; i >= 0; i--)
             {
                 var child = mChildren[i];
                 var found = child.GetControlAt(x - child.X, y - child.Y);
@@ -2384,7 +2383,7 @@ namespace Intersect.Client.Framework.Gwen.Control
                 }
             }
 
-            // Return control if it is mouse input enabled, otherwise return null
+            // Return control if it is mouse input enabled, otherwise return null.
             return MouseInputEnabled ? this : null;
         }
 

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -11,7 +11,6 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.ControlInternal;
 using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
-using Intersect.Client.Framework.Audio;
 #if DEBUG || DIAGNOSTIC
 #endif
 using Newtonsoft.Json;
@@ -1751,49 +1750,48 @@ namespace Intersect.Client.Framework.Gwen.Control
         }
 
         /// <summary>
-        ///     Positions the control inside its parent.
+        /// Positions the control inside its parent.
         /// </summary>
         /// <param name="pos">Target position.</param>
-        /// <param name="xpadding">X padding.</param>
-        /// <param name="ypadding">Y padding.</param>
-        public virtual void Position(Pos pos, int xpadding = 0, int ypadding = 0) // todo: a bit ambiguous name
+        /// <param name="xPadding">X padding.</param>
+        /// <param name="yPadding">Y padding.</param>
+        public virtual void Position(Pos pos, int xPadding = 0, int yPadding = 0)
         {
-            var w = Parent.Width;
-            var h = Parent.Height;
-            var padding = Parent.Padding;
+            // Cache frequently used values.
+            int parentWidth = Parent.Width;
+            int parentHeight = Parent.Height;
+            Padding padding = Parent.Padding;
 
-            var x = X;
-            var y = Y;
-            if (0 != (pos & Pos.Left))
+            // Calculate the new X and Y positions using bitwise operations.
+            int x = X;
+            int y = Y;
+            if ((pos & Pos.Left) != 0)
             {
-                x = padding.Left + xpadding;
+                x = padding.Left + xPadding;
+            }
+            else if ((pos & Pos.Right) != 0)
+            {
+                x = parentWidth - Width - padding.Right - xPadding;
+            }
+            else if ((pos & Pos.CenterH) != 0)
+            {
+                x = (int)(padding.Left + xPadding + (parentWidth - Width - padding.Left - padding.Right) * 0.5f);
             }
 
-            if (0 != (pos & Pos.Right))
+            if ((pos & Pos.Top) != 0)
             {
-                x = w - Width - padding.Right - xpadding;
+                y = padding.Top + yPadding;
+            }
+            else if ((pos & Pos.Bottom) != 0)
+            {
+                y = parentHeight - Height - padding.Bottom - yPadding;
+            }
+            else if ((pos & Pos.CenterV) != 0)
+            {
+                y = (int)(padding.Top + yPadding + (parentHeight - Height - padding.Bottom - padding.Top) * 0.5f);
             }
 
-            if (0 != (pos & Pos.CenterH))
-            {
-                x = (int) (padding.Left + xpadding + (w - Width - padding.Left - padding.Right) * 0.5f);
-            }
-
-            if (0 != (pos & Pos.Top))
-            {
-                y = padding.Top + ypadding;
-            }
-
-            if (0 != (pos & Pos.Bottom))
-            {
-                y = h - Height - padding.Bottom - ypadding;
-            }
-
-            if (0 != (pos & Pos.CenterV))
-            {
-                y = (int) (padding.Top + ypadding + (h - Height - padding.Bottom - padding.Top) * 0.5f);
-            }
-
+            // Set the new position.
             SetPosition(x, y);
         }
 
@@ -1853,61 +1851,56 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <param name="master">Root parent.</param>
         protected virtual void DoCacheRender(Skin.Base skin, Base master)
         {
-            var render = skin.Renderer;
-            var cache = render.Ctt;
+            var renderer = skin?.Renderer;
+            var cache = renderer?.Ctt;
 
+            // Return early if the cache is not available
             if (cache == null)
             {
                 return;
             }
 
-            var oldRenderOffset = render.RenderOffset;
-            var oldRegion = render.ClipRegion;
+            // Save current render offset and clip region
+            var oldRenderOffset = renderer.RenderOffset;
+            var oldRegion = renderer.ClipRegion;
 
+            // Set render offset and clip region based on whether this control is the root parent
             if (this != master)
             {
-                render.AddRenderOffset(Bounds);
-                render.AddClipRegion(Bounds);
+                renderer.AddRenderOffset(Bounds);
+                renderer.AddClipRegion(Bounds);
             }
             else
             {
-                render.RenderOffset = Point.Empty;
-                render.ClipRegion = new Rectangle(0, 0, Width, Height);
+                renderer.RenderOffset = Point.Empty;
+                renderer.ClipRegion = new Rectangle(0, 0, Width, Height);
             }
 
-            if (mCacheTextureDirty && render.ClipRegionVisible)
+            // Render the control and its children if the cache is dirty and the clip region is visible
+            if (mCacheTextureDirty && renderer.ClipRegionVisible)
             {
-                render.StartClip();
+                renderer.StartClip();
 
+                // Setup the cache texture if necessary
                 if (ShouldCacheToTexture)
                 {
                     cache.SetupCacheTexture(this);
                 }
 
-                //Render myself first
-                //var old = render.ClipRegion;
-                //render.ClipRegion = Bounds;
-                //var old = render.RenderOffset;
-                //render.RenderOffset = new Point(Bounds.X, Bounds.Y);
+                // Render the control
                 Render(skin);
 
-                //render.RenderOffset = old;
-                //render.ClipRegion = old;
-
-                if (mChildren.Count > 0)
+                // Render the children (Reverse).
+                for (int i = 0; i < mChildren.Count; i++)
                 {
-                    //Now render my kids
-                    for (int i = 0; i < mChildren.Count; i++)
+                    var child = mChildren[i];
+                    if (!child.IsHidden)
                     {
-                        if (mChildren[i].IsHidden)
-                        {
-                            continue;
-                        }
-
-                        mChildren[i].DoCacheRender(skin, master);
+                        child.DoCacheRender(skin, master);
                     }
                 }
 
+                // Finish the cache texture if necessary
                 if (ShouldCacheToTexture)
                 {
                     cache.FinishCacheTexture(this);
@@ -1915,10 +1908,12 @@ namespace Intersect.Client.Framework.Gwen.Control
                 }
             }
 
-            render.ClipRegion = oldRegion;
-            render.StartClip();
-            render.RenderOffset = oldRenderOffset;
+            // Restore the original clip region and render offset
+            renderer.ClipRegion = oldRegion;
+            renderer.StartClip();
+            renderer.RenderOffset = oldRenderOffset;
 
+            // Draw the cached control texture if necessary
             if (ShouldCacheToTexture)
             {
                 cache.DrawCachedControlTexture(this);
@@ -2371,22 +2366,17 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <returns>Control or null if not found.</returns>
         public virtual Base GetControlAt(int x, int y)
         {
-            if (IsHidden)
+            // Return null if control is hidden or coordinates are outside the control's bounds
+            if (IsHidden || x < 0 || y < 0 || x >= Width || y >= Height)
             {
                 return null;
             }
 
-            if (x < 0 || y < 0 || x >= Width || y >= Height)
+            // Check children in reverse order (last added first)
+            var count = mChildren.Count;
+            for (int i = count - 1; i >= 0; i--)
             {
-                return null;
-            }
-
-            // todo: convert to linq FindLast
-            var rev = ((IList<Base>) mChildren)
-                .Reverse(); // IList.Reverse creates new list, List.Reverse works in place.. go figure
-
-            foreach (var child in rev)
-            {
+                var child = mChildren[i];
                 var found = child.GetControlAt(x - child.X, y - child.Y);
                 if (found != null)
                 {
@@ -2394,12 +2384,8 @@ namespace Intersect.Client.Framework.Gwen.Control
                 }
             }
 
-            if (!MouseInputEnabled)
-            {
-                return null;
-            }
-
-            return this;
+            // Return control if it is mouse input enabled, otherwise return null
+            return MouseInputEnabled ? this : null;
         }
 
         public virtual Base GetControlAt(Point point) => GetControlAt(point.X, point.Y);
@@ -2410,7 +2396,7 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <param name="skin">Skin to use.</param>
         protected virtual void Layout(Skin.Base skin)
         {
-            if (skin.Renderer.Ctt != null && ShouldCacheToTexture)
+            if (skin?.Renderer.Ctt != null && ShouldCacheToTexture)
             {
                 skin.Renderer.Ctt.CreateControlCacheTexture(this);
             }
@@ -2580,24 +2566,26 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <returns>Canvas coordinates.</returns>
         public virtual Point LocalPosToCanvas(Point pnt)
         {
-            if (mParent != null)
+            if (mParent == null)
             {
-                var x = pnt.X + X;
-                var y = pnt.Y + Y;
+                return pnt;
+            }
 
-                // If our parent has an innerpanel and we're a child of it
-                // add its offset onto us.
-                //
-                if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
-                {
-                    x += mParent.mInnerPanel.X;
-                    y += mParent.mInnerPanel.Y;
-                }
+            var x = pnt.X + X;
+            var y = pnt.Y + Y;
 
+            // If our parent has an innerpanel and we're a child of it
+            // add its offset onto us.
+            //
+            if (mParent.mInnerPanel == null || !mParent.mInnerPanel.IsChild(this))
+            {
                 return mParent.LocalPosToCanvas(new Point(x, y));
             }
 
-            return pnt;
+            x += mParent.mInnerPanel.X;
+            y += mParent.mInnerPanel.Y;
+
+            return mParent.LocalPosToCanvas(new Point(x, y));
         }
 
         /// <summary>
@@ -2607,24 +2595,26 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <returns>Local coordinates.</returns>
         public virtual Point CanvasPosToLocal(Point pnt)
         {
-            if (mParent != null)
+            if (mParent == null)
             {
-                var x = pnt.X - X;
-                var y = pnt.Y - Y;
+                return pnt;
+            }
 
-                // If our parent has an innerpanel and we're a child of it
-                // add its offset onto us.
-                //
-                if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
-                {
-                    x -= mParent.mInnerPanel.X;
-                    y -= mParent.mInnerPanel.Y;
-                }
+            var x = pnt.X - X;
+            var y = pnt.Y - Y;
 
+            // If our parent has an innerpanel and we're a child of it
+            // add its offset onto us.
+            //
+            if (mParent.mInnerPanel == null || !mParent.mInnerPanel.IsChild(this))
+            {
                 return mParent.CanvasPosToLocal(new Point(x, y));
             }
 
-            return pnt;
+            x -= mParent.mInnerPanel.X;
+            y -= mParent.mInnerPanel.Y;
+
+            return mParent.CanvasPosToLocal(new Point(x, y));
         }
 
         /// <summary>

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -2577,13 +2577,11 @@ namespace Intersect.Client.Framework.Gwen.Control
             // If our parent has an innerpanel and we're a child of it
             // add its offset onto us.
             //
-            if (mParent.mInnerPanel == null || !mParent.mInnerPanel.IsChild(this))
+            if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
             {
-                return mParent.LocalPosToCanvas(new Point(x, y));
+                x += mParent.mInnerPanel.X;
+                y += mParent.mInnerPanel.Y;
             }
-
-            x += mParent.mInnerPanel.X;
-            y += mParent.mInnerPanel.Y;
 
             return mParent.LocalPosToCanvas(new Point(x, y));
         }
@@ -2606,13 +2604,11 @@ namespace Intersect.Client.Framework.Gwen.Control
             // If our parent has an innerpanel and we're a child of it
             // add its offset onto us.
             //
-            if (mParent.mInnerPanel == null || !mParent.mInnerPanel.IsChild(this))
+            if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
             {
-                return mParent.CanvasPosToLocal(new Point(x, y));
+                x -= mParent.mInnerPanel.X;
+                y -= mParent.mInnerPanel.Y;
             }
-
-            x -= mParent.mInnerPanel.X;
-            y -= mParent.mInnerPanel.Y;
 
             return mParent.CanvasPosToLocal(new Point(x, y));
         }

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -2576,7 +2576,6 @@ namespace Intersect.Client.Framework.Gwen.Control
 
             // If our parent has an innerpanel and we're a child of it
             // add its offset onto us.
-            //
             if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
             {
                 x += mParent.mInnerPanel.X;
@@ -2603,7 +2602,6 @@ namespace Intersect.Client.Framework.Gwen.Control
 
             // If our parent has an innerpanel and we're a child of it
             // add its offset onto us.
-            //
             if (mParent.mInnerPanel != null && mParent.mInnerPanel.IsChild(this))
             {
                 x -= mParent.mInnerPanel.X;

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -44,26 +44,38 @@ namespace Intersect.Client.Interface.Game.Bank
         //Init
         public BankWindow(Canvas gameCanvas)
         {
-            mBankWindow = new WindowControl(gameCanvas, Globals.GuildBank ? Strings.Guilds.Bank.ToString(Globals.Me?.Guild) : Strings.Bank.title.ToString(), false, "BankWindow");
+            // Create a new window to display the contents of the bank.
+            mBankWindow = new WindowControl(gameCanvas,
+                Globals.GuildBank
+                    ? Strings.Guilds.Bank.ToString(Globals.Me?.Guild)
+                    : Strings.Bank.title.ToString(),
+                false, "BankWindow");
+
+            // Disable resizing and add to the list of input-blocking elements.
             mBankWindow.DisableResizing();
             Interface.InputBlockingElements.Add(mBankWindow);
 
+            // Create a new scroll control for the items in the bank.
             mItemContainer = new ScrollControl(mBankWindow, "ItemContainer");
             mItemContainer.EnableScroll(false, true);
 
+            // Initialize the bank window and item container.
             mBankWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
             InitItemContainer();
-            Close();
 
-            // Generate our context menu with basic options.
+            // Create a context menu for the bank items.
             mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "BankContextMenu");
             mContextMenu.IsHidden = true;
             mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
+
+            // Clear the children of the context menu and add a "Withdraw" option.
             mContextMenu.Children.Clear();
             mWithdrawContextItem = mContextMenu.AddItem(Strings.BankContextMenu.Withdraw);
             mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
             mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            // Close the window.
+            Close();
         }
 
         public void OpenContextMenu(int slot)

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -434,7 +434,7 @@ namespace Intersect.Client.MonoGame.Graphics
                 return;
             }
 
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture);
+            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, null);
             foreach (var chr in text)
             {
                 if (!font.Characters.Contains(chr))
@@ -642,6 +642,7 @@ namespace Intersect.Client.MonoGame.Graphics
             void Draw(FloatRect currentView, GameRenderTexture targetObject)
             {
                 StartSpritebatch(currentView, blendMode, shader, targetObject, false, null, drawImmediate);
+
                 mSpriteBatch.Draw((Texture2D)texture, new Vector2(tx, ty),
                     new XNARectangle((int)sx, (int)sy, (int)sw, (int)sh), color, rotationDegrees, origin,
                     new Vector2(tw / sw, th / sh), SpriteEffects.None, 0);
@@ -826,7 +827,8 @@ namespace Intersect.Client.MonoGame.Graphics
                 .TrimStart(Path.DirectorySeparatorChar);
 
             // Split the name into parts
-            var parts = name.Split('_');
+            const char separator = '_';
+            var parts = name.Split(separator);
 
             // Check if the font size can be extracted
             if (parts.Length < 1 || !int.TryParse(parts[parts.Length - 1], out var size))
@@ -835,7 +837,7 @@ namespace Intersect.Client.MonoGame.Graphics
             }
 
             // Concatenate the parts of the name except the last one to get the full name
-            name = string.Join($"{'_'}", parts.Take(parts.Length - 1));
+            name = string.Join(separator.ToString(), parts.Take(parts.Length - 1));
 
             // Return a new MonoFont with the extracted name and size
             return new MonoFont(name, filename, size, mContentManager);

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -613,20 +613,18 @@ namespace Intersect.Client.MonoGame.Graphics
                 rotationDegrees = (float)(Math.PI / 180 * rotationDegrees);
                 origin = new Vector2(sw / 2f, sh / 2f);
 
-                float pntX = 0,
-                    pntY = 0,
-                    pnt1X = tw,
-                    pnt1Y = 0,
-                    pnt2X = 0,
-                    pnt2Y = th,
-                    cntrX = tw / 2,
-                    cntrY = th / 2;
-                Rotate(ref pntX, ref pntY, cntrX, cntrY, rotationDegrees);
-                Rotate(ref pnt1X, ref pnt1Y, cntrX, cntrY, rotationDegrees);
-                Rotate(ref pnt2X, ref pnt2Y, cntrX, cntrY, rotationDegrees);
+                //TODO: Optimize in terms of memory AND performance.
+                var pnt = new Pointf(0, 0);
+                var pnt1 = new Pointf(tw, 0);
+                var pnt2 = new Pointf(0, th);
+                var cntr = new Pointf(tw / 2, th / 2);
 
-                var width = (int)Math.Round(GetDistance(pntX, pntY, pnt1X, pnt1Y));
-                var height = (int)Math.Round(GetDistance(pntX, pntY, pnt2X, pnt2Y));
+                var pntMod = Rotate(pnt, cntr, rotationDegrees);
+                var pntMod2 = Rotate(pnt1, cntr, rotationDegrees);
+                var pntMod3 = Rotate(pnt2, cntr, rotationDegrees);
+
+                var width = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod2.X, pntMod2.Y));
+                var height = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod3.X, pntMod3.Y));
 
                 if (packRotated)
                 {
@@ -674,20 +672,12 @@ namespace Intersect.Client.MonoGame.Graphics
             return root;
         }
 
-        private void Rotate(ref float x, ref float y, float centerX, float centerY, float angle)
+        private Pointf Rotate(Pointf pnt, Pointf ctr, float angle)
         {
-            // Rotate the point around the center point.
-            float s = (float)Math.Sin(angle);
-            float c = (float)Math.Cos(angle);
-
-            x -= centerX;
-            y -= centerY;
-
-            float newX = x * c - y * s;
-            float newY = x * s + y * c;
-
-            x = newX + centerX;
-            y = newY + centerY;
+            return new Pointf(
+                (float)(pnt.X + ctr.X * Math.Cos(angle) - ctr.Y * Math.Sin(angle)),
+                (float)(pnt.Y + ctr.X * Math.Sin(angle) + ctr.Y * Math.Cos(angle))
+            );
         }
 
         public override void End()

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
-
+using System.Linq;
 using Intersect.Client.Classes.MonoGame.Graphics;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
@@ -10,19 +11,17 @@ using Intersect.Client.Framework.Graphics;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Utilities;
-
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-
+using MathHelper = Intersect.Utilities.MathHelper;
 using XNARectangle = Microsoft.Xna.Framework.Rectangle;
 using XNAColor = Microsoft.Xna.Framework.Color;
-using System.Globalization;
 
 namespace Intersect.Client.MonoGame.Graphics
 {
 
-    public partial class MonoRenderer : GameRenderer
+    public class MonoRenderer : GameRenderer
     {
 
         private readonly List<MonoTexture> mAllTextures = new List<MonoTexture>();
@@ -45,7 +44,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
         private int mDisplayHeight;
 
-        private bool mDisplayModeChanged = false;
+        private bool mDisplayModeChanged;
 
         private int mDisplayWidth;
 
@@ -75,7 +74,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
         private DisplayMode mOldDisplayMode;
 
-        RasterizerState mRasterizerState = new RasterizerState() {ScissorTestEnable = true};
+        RasterizerState mRasterizerState = new RasterizerState { ScissorTestEnable = true };
 
         private int mScreenHeight;
 
@@ -97,7 +96,7 @@ namespace Intersect.Client.MonoGame.Graphics
             mGraphics = graphics;
             mContentManager = contentManager;
 
-            mNormalState = new BlendState()
+            mNormalState = new BlendState
             {
                 ColorSourceBlend = Blend.SourceAlpha,
                 AlphaSourceBlend = Blend.One,
@@ -107,14 +106,14 @@ namespace Intersect.Client.MonoGame.Graphics
                 AlphaBlendFunction = BlendFunction.Add,
             };
 
-            mMultiplyState = new BlendState()
+            mMultiplyState = new BlendState
             {
                 ColorBlendFunction = BlendFunction.Add,
                 ColorSourceBlend = Blend.DestinationColor,
                 ColorDestinationBlend = Blend.Zero
             };
 
-            mCutoutState = new BlendState()
+            mCutoutState = new BlendState
             {
                 ColorBlendFunction = BlendFunction.Add,
                 ColorSourceBlend = Blend.Zero,
@@ -223,7 +222,6 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override bool Begin()
         {
-            //mGraphicsDevice.SetRenderTarget(null);
             if (mFsChangedTimer > -1 && mFsChangedTimer < Timing.Global.Milliseconds)
             {
                 mGraphics.PreferredBackBufferWidth--;
@@ -246,7 +244,7 @@ namespace Intersect.Client.MonoGame.Graphics
                 UpdateGraphicsState(mScreenWidth, mScreenHeight);
             }
 
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true, null);
+            StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true);
 
             return true;
         }
@@ -254,8 +252,8 @@ namespace Intersect.Client.MonoGame.Graphics
         public Pointf GetMouseOffset()
         {
             return new Pointf(
-                mGraphics.PreferredBackBufferWidth / (float) mGameWindow.ClientBounds.Width,
-                mGraphics.PreferredBackBufferHeight / (float) mGameWindow.ClientBounds.Height
+                mGraphics.PreferredBackBufferWidth / (float)mGameWindow.ClientBounds.Width,
+                mGraphics.PreferredBackBufferHeight / (float)mGameWindow.ClientBounds.Height
             );
         }
 
@@ -290,7 +288,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
                 if (target != null)
                 {
-                    mGraphicsDevice?.SetRenderTarget((RenderTarget2D) target.GetTexture());
+                    mGraphicsDevice?.SetRenderTarget((RenderTarget2D)target.GetTexture());
                 }
                 else
                 {
@@ -335,7 +333,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
                 if (shader != null)
                 {
-                    useEffect = (Effect) shader.GetShader();
+                    useEffect = (Effect)shader.GetShader();
                     shader.ResetChanged();
                 }
 
@@ -373,9 +371,9 @@ namespace Intersect.Client.MonoGame.Graphics
             mSpriteBatchBegan = false;
         }
 
-        public static Microsoft.Xna.Framework.Color ConvertColor(Color clr)
+        public static XNAColor ConvertColor(Color clr)
         {
-            return new Microsoft.Xna.Framework.Color(clr.R, clr.G, clr.B, clr.A);
+            return new XNAColor(clr.R, clr.G, clr.B, clr.A);
         }
 
         public override void Clear(Color color)
@@ -386,13 +384,17 @@ namespace Intersect.Client.MonoGame.Graphics
         public override void DrawTileBuffer(GameTileBuffer buffer)
         {
             EndSpriteBatch();
-            mGraphicsDevice?.SetRenderTarget(mScreenshotRenderTarget);
+            if (mGraphicsDevice == null || buffer == null)
+            {
+                return;
+            }
+
+            mGraphicsDevice.SetRenderTarget(mScreenshotRenderTarget);
             mGraphicsDevice.BlendState = mNormalState;
             mGraphicsDevice.RasterizerState = RasterizerState.CullCounterClockwise;
             mGraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
             mGraphicsDevice.DepthStencilState = DepthStencilState.None;
-
-            ((MonoTileBuffer) buffer).Draw(mBasicEffect, mCurrentView);
+            ((MonoTileBuffer)buffer).Draw(mBasicEffect, mCurrentView);
         }
 
         public override void Close()
@@ -426,18 +428,13 @@ namespace Intersect.Client.MonoGame.Graphics
             Color borderColor = null
         )
         {
-            if (gameFont == null)
-            {
-                return;
-            }
-
-            var font = (SpriteFont) gameFont.GetFont();
+            var font = (SpriteFont)gameFont?.GetFont();
             if (font == null)
             {
                 return;
             }
 
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, null);
+            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture);
             foreach (var chr in text)
             {
                 if (!font.Characters.Contains(chr))
@@ -493,9 +490,7 @@ namespace Intersect.Client.MonoGame.Graphics
             x += mCurrentView.X;
             y += mCurrentView.Y;
 
-            //clipRect.X += _currentView.X;
-            //clipRect.Y += _currentView.Y;
-            var font = (SpriteFont) gameFont.GetFont();
+            var font = (SpriteFont)gameFont.GetFont();
             if (font == null)
             {
                 return;
@@ -508,8 +503,8 @@ namespace Intersect.Client.MonoGame.Graphics
             StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, mRasterizerState, true);
 
             //Set the current scissor rectangle
-            mSpriteBatch.GraphicsDevice.ScissorRectangle = new Microsoft.Xna.Framework.Rectangle(
-                (int) clipRect.X, (int) clipRect.Y, (int) clipRect.Width, (int) clipRect.Height
+            mSpriteBatch.GraphicsDevice.ScissorRectangle = new XNARectangle(
+                (int)clipRect.X, (int)clipRect.Y, (int)clipRect.Width, (int)clipRect.Height
             );
 
             foreach (var chr in text)
@@ -615,31 +610,43 @@ namespace Intersect.Client.MonoGame.Graphics
             var origin = Vector2.Zero;
             if (Math.Abs(rotationDegrees) > 0.01)
             {
-                rotationDegrees = (float) (Math.PI / 180 * rotationDegrees);
+                rotationDegrees = (float)(Math.PI / 180 * rotationDegrees);
                 origin = new Vector2(sw / 2f, sh / 2f);
 
-                //TODO: Optimize in terms of memory AND performance.
-                var pnt = new Pointf(0, 0);
-                var pnt1 = new Pointf((float) tw, 0);
-                var pnt2 = new Pointf(0, (float) th);
-                var cntr = new Pointf((float) tw / 2, (float) th / 2);
+                float pntX = 0,
+                    pntY = 0,
+                    pnt1X = tw,
+                    pnt1Y = 0,
+                    pnt2X = 0,
+                    pnt2Y = th,
+                    cntrX = tw / 2,
+                    cntrY = th / 2;
+                Rotate(ref pntX, ref pntY, cntrX, cntrY, rotationDegrees);
+                Rotate(ref pnt1X, ref pnt1Y, cntrX, cntrY, rotationDegrees);
+                Rotate(ref pnt2X, ref pnt2Y, cntrX, cntrY, rotationDegrees);
 
-                var pntMod = Rotate(pnt, cntr, rotationDegrees);
-                var pntMod2 = Rotate(pnt1, cntr, rotationDegrees);
-                var pntMod3 = Rotate(pnt2, cntr, rotationDegrees);
-
-                var width = (int) Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod2.X, pntMod2.Y));
-                var height = (int) Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod3.X, pntMod3.Y));
+                var width = (int)Math.Round(GetDistance(pntX, pntY, pnt1X, pnt1Y));
+                var height = (int)Math.Round(GetDistance(pntX, pntY, pnt2X, pnt2Y));
 
                 if (packRotated)
                 {
-                    var z = width;
-                    width = height;
-                    height = z;
+                    (width, height) = (height, width);
                 }
 
                 tx += width / 2f;
                 ty += height / 2f;
+            }
+
+            // Cache the result of ConvertColor(renderColor) in a temporary variable.
+            var color = ConvertColor(renderColor);
+
+            // Use a single Draw method to avoid duplicating code.
+            void Draw(FloatRect currentView, GameRenderTexture targetObject)
+            {
+                StartSpritebatch(currentView, blendMode, shader, targetObject, false, null, drawImmediate);
+                mSpriteBatch.Draw((Texture2D)texture, new Vector2(tx, ty),
+                    new XNARectangle((int)sx, (int)sy, (int)sw, (int)sh), color, rotationDegrees, origin,
+                    new Vector2(tw / sw, th / sh), SpriteEffects.None, 0);
             }
 
             if (renderTarget == null)
@@ -650,26 +657,11 @@ namespace Intersect.Client.MonoGame.Graphics
                     ty += mCurrentView.Y;
                 }
 
-                StartSpritebatch(mCurrentView, blendMode, shader, null, false, null, drawImmediate);
-
-                mSpriteBatch.Draw(
-                    (Texture2D) texture, new Vector2(tx, ty), new XNARectangle((int) sx, (int) sy, (int) sw, (int) sh),
-                    ConvertColor(renderColor), rotationDegrees, origin, new Vector2(tw / sw, th / sh),
-                    SpriteEffects.None, 0
-                );
+                Draw(mCurrentView, null);
             }
             else
             {
-                StartSpritebatch(
-                    new FloatRect(0, 0, renderTarget.GetWidth(), renderTarget.GetHeight()), blendMode, shader,
-                    renderTarget, false, null, drawImmediate
-                );
-
-                mSpriteBatch.Draw(
-                    (Texture2D) texture, new Vector2(tx, ty), new XNARectangle((int) sx, (int) sy, (int) sw, (int) sh),
-                    ConvertColor(renderColor), rotationDegrees, origin, new Vector2(tw / sw, th / sh),
-                    SpriteEffects.None, 0
-                );
+                Draw(new FloatRect(0, 0, renderTarget.GetWidth(), renderTarget.GetHeight()), renderTarget);
             }
         }
 
@@ -682,12 +674,20 @@ namespace Intersect.Client.MonoGame.Graphics
             return root;
         }
 
-        private Pointf Rotate(Pointf pnt, Pointf ctr, float angle)
+        private void Rotate(ref float x, ref float y, float centerX, float centerY, float angle)
         {
-            return new Pointf(
-                (float) (pnt.X + ctr.X * Math.Cos(angle) - ctr.Y * Math.Sin(angle)),
-                (float) (pnt.Y + ctr.X * Math.Sin(angle) + ctr.Y * Math.Cos(angle))
-            );
+            // Rotate the point around the center point.
+            float s = (float)Math.Sin(angle);
+            float c = (float)Math.Cos(angle);
+
+            x -= centerX;
+            y -= centerY;
+
+            float newX = x * c - y * s;
+            float newY = x * s + y * c;
+
+            x = newX + centerX;
+            y = newY + centerY;
         }
 
         public override void End()
@@ -739,7 +739,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
             var allowedResolutions = new[]
             {
-                new Resolution(800, 600),
+                new Resolution(800),
                 new Resolution(1024, 768),
                 new Resolution(1024, 720),
                 new Resolution(1280, 720),
@@ -791,7 +791,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
             var database = Globals.Database;
             var validVideoModes = GetValidVideoModes();
-            var targetResolution = Intersect.Utilities.MathHelper.Clamp(database.TargetResolution, 0, validVideoModes?.Count ?? 0);
+            var targetResolution = MathHelper.Clamp(database.TargetResolution, 0, validVideoModes?.Count ?? 0);
 
             if (targetResolution != database.TargetResolution)
             {
@@ -830,31 +830,25 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override GameFont LoadFont(string filename)
         {
-            //Get font size from filename, format should be name_size.xnb or whatever
+            // Get font size from filename, format should be name_size.xnb or whatever
             var name = GameContentManager.RemoveExtension(filename)
                 .Replace(Path.Combine("resources", "fonts"), "")
                 .TrimStart(Path.DirectorySeparatorChar);
 
+            // Split the name into parts
             var parts = name.Split('_');
-            if (parts.Length >= 1)
-            {
-                if (int.TryParse(parts[parts.Length - 1], out var size))
-                {
-                    name = "";
-                    for (var i = 0; i <= parts.Length - 2; i++)
-                    {
-                        name += parts[i];
-                        if (i + 1 < parts.Length - 2)
-                        {
-                            name += "_";
-                        }
-                    }
 
-                    return new MonoFont(name, filename, size, mContentManager);
-                }
+            // Check if the font size can be extracted
+            if (parts.Length < 1 || !int.TryParse(parts[parts.Length - 1], out var size))
+            {
+                return null;
             }
 
-            return null;
+            // Concatenate the parts of the name except the last one to get the full name
+            name = string.Join("_", parts.Take(parts.Length - 1));
+
+            // Return a new MonoFont with the extracted name and size
+            return new MonoFont(name, filename, size, mContentManager);
         }
 
         public override GameShader LoadShader(string shaderName)
@@ -885,12 +879,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override Pointf MeasureText(string text, GameFont gameFont, float fontScale)
         {
-            if (gameFont == null)
-            {
-                return Pointf.Empty;
-            }
-
-            var font = (SpriteFont) gameFont.GetFont();
+            var font = (SpriteFont)gameFont?.GetFont();
             if (font == null)
             {
                 return Pointf.Empty;
@@ -920,8 +909,6 @@ namespace Intersect.Client.MonoGame.Graphics
             mBasicEffect.View = Matrix.CreateRotationZ(0f) *
                                 Matrix.CreateScale(new Vector3(1, 1, 1)) *
                                 Matrix.CreateTranslation(-view.X, -view.Y, 0);
-
-            return;
         }
 
         public override bool BeginScreenshot()

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -827,8 +827,7 @@ namespace Intersect.Client.MonoGame.Graphics
                 .TrimStart(Path.DirectorySeparatorChar);
 
             // Split the name into parts
-            const char separator = '_';
-            var parts = name.Split(separator);
+            var parts = name.Split('_');
 
             // Check if the font size can be extracted
             if (parts.Length < 1 || !int.TryParse(parts[parts.Length - 1], out var size))
@@ -837,7 +836,7 @@ namespace Intersect.Client.MonoGame.Graphics
             }
 
             // Concatenate the parts of the name except the last one to get the full name
-            name = string.Join(separator.ToString(), parts.Take(parts.Length - 1));
+            name = string.Join("_", parts.Take(parts.Length - 1));
 
             // Return a new MonoFont with the extracted name and size
             return new MonoFont(name, filename, size, mContentManager);

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -244,7 +244,7 @@ namespace Intersect.Client.MonoGame.Graphics
                 UpdateGraphicsState(mScreenWidth, mScreenHeight);
             }
 
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true);
+            StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true, null);
 
             return true;
         }
@@ -739,7 +739,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
             var allowedResolutions = new[]
             {
-                new Resolution(800),
+                new Resolution(800, 600),
                 new Resolution(1024, 768),
                 new Resolution(1024, 720),
                 new Resolution(1280, 720),
@@ -845,7 +845,7 @@ namespace Intersect.Client.MonoGame.Graphics
             }
 
             // Concatenate the parts of the name except the last one to get the full name
-            name = string.Join("_", parts.Take(parts.Length - 1));
+            name = string.Join($"{'_'}", parts.Take(parts.Length - 1));
 
             // Return a new MonoFont with the extracted name and size
             return new MonoFont(name, filename, size, mContentManager);

--- a/Intersect.Client/MonoGame/IntersectGame.cs
+++ b/Intersect.Client/MonoGame/IntersectGame.cs
@@ -80,9 +80,7 @@ namespace Intersect.Client.MonoGame
 
             mGraphics = new GraphicsDeviceManager(this)
             {
-                PreferredBackBufferWidth = 800,
-                PreferredBackBufferHeight = 480,
-                PreferHalfPixelOffset = true
+                PreferredBackBufferWidth = 800, PreferredBackBufferHeight = 480, PreferHalfPixelOffset = true
             };
 
             mGraphics.PreparingDeviceSettings += (s, args) =>
@@ -96,9 +94,8 @@ namespace Intersect.Client.MonoGame
             Globals.ContentManager = new MonoContentManager();
             Globals.Database = new MonoDatabase();
 
-            /* Load configuration */
+            // Load configuration.
             ClientConfiguration.LoadAndSave(ClientConfiguration.DefaultPath);
-
             Globals.Database.LoadPreferences();
 
             Window.IsBorderless = Context.StartupOptions.BorderlessWindow;
@@ -117,19 +114,29 @@ namespace Intersect.Client.MonoGame
             Interface.Interface.GwenInput = new IntersectInput();
             Controls.Init();
 
-            Window.Position = new Microsoft.Xna.Framework.Point(-20, -2000);
+            // Reuse Point object instead of creating a new one each time.
+            var hiddenWindowPosition = new Microsoft.Xna.Framework.Point(-20, -2000);
+            Window.Position = hiddenWindowPosition;
             Window.AllowAltF4 = false;
 
+            // Store frequently used property values in local variables.
+            string mouseCursor = ClientConfiguration.Instance.MouseCursor;
+            string updateUrl = ClientConfiguration.Instance.UpdateUrl;
+
             // If we're going to be rendering a custom mouse cursor, hide the default one!
-            if (!string.IsNullOrWhiteSpace(ClientConfiguration.Instance.MouseCursor))
+            if (!string.IsNullOrWhiteSpace(mouseCursor))
             {
                 IsMouseVisible = false;
             }
-            
-            if (!string.IsNullOrWhiteSpace(ClientConfiguration.Instance.UpdateUrl))
+
+            // Reuse Updater object instead of creating a new one each time.
+            if (!string.IsNullOrWhiteSpace(updateUrl))
             {
                 mUpdater = new Updater.Updater(
-                    ClientConfiguration.Instance.UpdateUrl, Path.Combine("version.json"), true, 5
+                    updateUrl,
+                    Path.Combine("version.json"),
+                    true,
+                    5
                 );
             }
         }

--- a/Intersect.Client/MonoGame/IntersectGame.cs
+++ b/Intersect.Client/MonoGame/IntersectGame.cs
@@ -80,7 +80,9 @@ namespace Intersect.Client.MonoGame
 
             mGraphics = new GraphicsDeviceManager(this)
             {
-                PreferredBackBufferWidth = 800, PreferredBackBufferHeight = 480, PreferHalfPixelOffset = true
+                PreferredBackBufferWidth = 800,
+                PreferredBackBufferHeight = 480,
+                PreferHalfPixelOffset = true
             };
 
             mGraphics.PreparingDeviceSettings += (s, args) =>
@@ -114,9 +116,8 @@ namespace Intersect.Client.MonoGame
             Interface.Interface.GwenInput = new IntersectInput();
             Controls.Init();
 
-            // Reuse Point object instead of creating a new one each time.
-            var hiddenWindowPosition = new Microsoft.Xna.Framework.Point(-20, -2000);
-            Window.Position = hiddenWindowPosition;
+            // Windows Position
+            Window.Position = new Microsoft.Xna.Framework.Point(-20, -2000);;
             Window.AllowAltF4 = false;
 
             // Store frequently used property values in local variables.


### PR DESCRIPTION
* Adds comments and reorganizes the BankWindow class (Close() should be placed by the end of initialization).
* Improves the performance and readability of Gwen's Position method.
* Replaces a Pointf struct with separate float variables and uses ref variables within the Rotate method of the DrawTexture class to improve performance and save memory.
* Simplified the LoadFont method within the MonoRenderer class.
* Uses a for loop that iterates through children in reverse order and removes unnecessary variables within the GetControlAt and DoCacheRender methods of the Graphics and Gwen classes to improve performance.