### PR TITLE
fix: don't auto-turn when self targeting

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1454,8 +1454,22 @@ namespace Intersect.Client.Entities
 
         private void AutoTurnToTarget(Entity en)
         {
-            if (!Globals.Database.AutoTurnToTarget || !Options.Instance.PlayerOpts.EnableAutoTurnToTarget ||
-                Controls.KeyDown(Control.TurnAround))
+            if (!Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
+            {
+                return;
+            }
+
+            if (!Globals.Database.AutoTurnToTarget)
+            {
+                return;
+            }
+
+            if (Controls.KeyDown(Control.TurnAround))
+            {
+                return;
+            }
+
+            if (en == this)
             {
                 return;
             }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1454,7 +1454,7 @@ namespace Intersect.Client.Entities
 
         private void AutoTurnToTarget(Entity en)
         {
-            if (!Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
+            if (en == this)
             {
                 return;
             }
@@ -1464,12 +1464,12 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            if (Controls.KeyDown(Control.TurnAround))
+            if (!Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
             {
                 return;
             }
 
-            if (en == this)
+            if (Controls.KeyDown(Control.TurnAround))
             {
                 return;
             }


### PR DESCRIPTION
- fixes an issue where auto-turn to target made the player turn over to the right whenever they target themselves.
- should resolve #1754 

### Preview:

https://user-images.githubusercontent.com/17498701/223774184-0aa71dde-174e-4478-adaf-486c11096eb9.mp4


