### PR TITLE
fix: last direction for paperdoll order

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -625,10 +625,12 @@ namespace Intersect.Client.Entities
             else if (IsMoving)
             {
                 var displacementTime = ecTime * Options.TileHeight / GetMovementTime();
+
+                PickLastDirection(Dir);
+
                 switch (Dir)
                 {
                     case Direction.Up:
-                        mLastDirection = Direction.Up;
                         OffsetY -= displacementTime;
                         OffsetX = 0;
                         if (OffsetY < 0)
@@ -639,7 +641,6 @@ namespace Intersect.Client.Entities
                         break;
 
                     case Direction.Down:
-                        mLastDirection = Direction.Down;
                         OffsetY += displacementTime;
                         OffsetX = 0;
                         if (OffsetY > 0)
@@ -650,7 +651,6 @@ namespace Intersect.Client.Entities
                         break;
 
                     case Direction.Left:
-                        mLastDirection = Direction.Left;
                         OffsetX -= displacementTime;
                         OffsetY = 0;
                         if (OffsetX < 0)
@@ -661,7 +661,6 @@ namespace Intersect.Client.Entities
                         break;
 
                     case Direction.Right:
-                        mLastDirection = Direction.Right;
                         OffsetX += displacementTime;
                         OffsetY = 0;
                         if (OffsetX > 0)
@@ -1243,6 +1242,37 @@ namespace Intersect.Client.Entities
                 case Direction.DownRight when mLastDirection != Direction.Right:
                 default:
                     return 0;
+            }
+        }
+
+        public void PickLastDirection(Direction direction)
+        {
+            switch (direction)
+            {
+                case Direction.Left:
+                case Direction.DownLeft when mLastDirection == Direction.Left:
+                case Direction.UpLeft when mLastDirection == Direction.Left:
+                    mLastDirection = Direction.Left;
+                    break;
+
+                case Direction.Right:
+                case Direction.DownRight when mLastDirection == Direction.Right:
+                case Direction.UpRight when mLastDirection == Direction.Right:
+                    mLastDirection = Direction.Right;
+                    break;
+
+                case Direction.Up:
+                case Direction.UpLeft when mLastDirection != Direction.Left:
+                case Direction.UpRight when mLastDirection != Direction.Right:
+                    mLastDirection = Direction.Up;
+                    break;
+
+                case Direction.Down:
+                case Direction.DownLeft when mLastDirection != Direction.Left:
+                case Direction.DownRight when mLastDirection != Direction.Right:
+                default:
+                    mLastDirection = Direction.Down;
+                    break;
             }
         }
         

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2501,6 +2501,7 @@ namespace Intersect.Client.Entities
                     Dir = Globals.Me.MoveDir;
                     PacketSender.SendDirection(Dir);
                     Globals.Me.MoveDir = Direction.None;
+                    PickLastDirection(Dir);
                 }
 
                 // Hold the player in place if the requested direction is the same as the current one.


### PR DESCRIPTION
- improves the logic to pick the last direction with the PickLastDirection method.

- adds PickLastDirection into TurnAround function in order to make sure that the last direction is updated when turning around in place.

- this should also resolve an issue with wrong last direction value being used to set the paperdoll rendering under certain scenarios like:
  - (ie) walking from down-left to up-left (opposites).
  - hold key to turn around and walk to opposite direction.

- should resolve #1758 