### PR TITLE
fix: pick last direction when auto-turning to target

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1498,6 +1498,7 @@ namespace Intersect.Client.Entities
             MoveDir = Direction.None;
             Dir = directionToTarget;
             PacketSender.SendDirection(Dir);
+            PickLastDirection(Dir);
         }
 
         public bool TryBlock()


### PR DESCRIPTION
- Adds PickLastDirection into AutoTurnToTarget function in order to ensure that the last direction is updated when players are auto-turning towards targets.
- Should resolve #1770 

### Preview:

https://user-images.githubusercontent.com/17498701/226206541-8458906b-2dbd-46ae-8947-9e5d9b758815.mp4