### PR TITLE
chore: MovesTo method with map attributes

### DIFF
--- a/Intersect (Core)/Enums/MapAttribute.cs
+++ b/Intersect (Core)/Enums/MapAttribute.cs
@@ -1,29 +1,38 @@
 namespace Intersect.Enums
 {
-    public enum MapAttribute : byte
+    /// <summary>
+    /// This enumeration type represents the attributes and/or entities within in-game tiles.
+    /// </summary>
+    public enum MapAttribute
     {
-        Walkable = 0,
+        Animation,
 
         Blocked,
 
-        Item,
+        Critter,
 
-        ZDimension,
-
-        NpcAvoid,
-
-        Warp,
-
-        Sound,
-
-        Resource,
-
-        Animation,
+        Event,
 
         GrappleStone,
 
+        Item,
+
+        NpcAvoid,
+
+        OutOfBounds,
+
+        Player,
+
+        Resource,
+
         Slide,
 
-        Critter
+        Sound,
+
+        Walkable,
+
+        Warp,
+
+        ZDimension
     }
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -571,56 +571,6 @@ namespace Intersect.Editor.Forms.DockingElements
             return 0;
         }
 
-        public int GetAttributeFromEditor()
-        {
-            if (rbBlocked.Checked == true)
-            {
-                return (int) MapAttribute.Blocked;
-            }
-            else if (rbItem.Checked == true)
-            {
-                return (int) MapAttribute.Item;
-            }
-            else if (rbZDimension.Checked == true)
-            {
-                return (int) MapAttribute.ZDimension;
-            }
-            else if (rbNPCAvoid.Checked == true)
-            {
-                return (int) MapAttribute.NpcAvoid;
-            }
-            else if (rbWarp.Checked == true)
-            {
-                return (int) MapAttribute.Warp;
-            }
-            else if (rbSound.Checked == true)
-            {
-                return (int) MapAttribute.Sound;
-            }
-            else if (rbResource.Checked == true)
-            {
-                return (int) MapAttribute.Resource;
-            }
-            else if (rbAnimation.Checked == true)
-            {
-                return (int) MapAttribute.Animation;
-            }
-            else if (rbGrappleStone.Checked == true)
-            {
-                return (int) MapAttribute.GrappleStone;
-            }
-            else if (rbSlide.Checked == true)
-            {
-                return (int) MapAttribute.Slide;
-            }
-            else if (rbCritter.Checked == true)
-            {
-                return (int) MapAttribute.Critter;
-            }
-
-            return (int) MapAttribute.Walkable;
-        }
-
         private MapAttribute SelectedMapAttributeType
         {
             get

--- a/Intersect.Server/Entities/Combat/Dash.cs
+++ b/Intersect.Server/Entities/Combat/Dash.cs
@@ -50,40 +50,20 @@ namespace Intersect.Server.Entities.Combat
             bool zdimensionPass = false
         )
         {
-            var n = 0;
             en.MoveTimer = 0;
             Range = 0;
             for (var i = 1; i <= range; i++)
             {
-                n = en.CanMove(Direction);
-                if (n == -5) //Check for out of bounds
+                switch (en.MovesTo(Direction))
                 {
-                    return;
-                } //Check for blocks
-
-                if (n == -2 && blockPass == false)
-                {
-                    return;
-                } //Check for ZDimensionTiles
-
-                if (n == -3 && zdimensionPass == false)
-                {
-                    return;
-                } //Check for active resources
-
-                if (n == (int) EntityType.Resource && activeResourcePass == false)
-                {
-                    return;
-                } //Check for dead resources
-
-                if (n == (int) EntityType.Resource && deadResourcePass == false)
-                {
-                    return;
-                } //Check for players and solid events
-
-                if (n == (int) EntityType.Player || n == (int) EntityType.Event)
-                {
-                    return;
+                    case MapAttribute.OutOfBounds:
+                    case MapAttribute.Blocked when blockPass == false:
+                    case MapAttribute.ZDimension when zdimensionPass == false:
+                    case MapAttribute.Resource when activeResourcePass == false:
+                    case MapAttribute.Resource when deadResourcePass == false:
+                    case MapAttribute.Player:
+                    case MapAttribute.Event:
+                        return;
                 }
 
                 en.Move(Direction, null, true);

--- a/Intersect.Server/Entities/Events/EventPageInstance.cs
+++ b/Intersect.Server/Entities/Events/EventPageInstance.cs
@@ -337,7 +337,7 @@ namespace Intersect.Server.Entities.Events
                     }
 
                     var dir = Randomization.NextDirection();
-                    if (CanMove(dir) == -1)
+                    if (MovesTo(dir) == MapAttribute.Walkable)
                     {
                         Move(dir, Player);
                     }
@@ -397,7 +397,7 @@ namespace Intersect.Server.Entities.Events
                                     var pathDir = mPathFinder.GetMove();
                                     if (pathDir > Direction.None)
                                     {
-                                        if (CanMove(pathDir) == -1)
+                                        if (MovesTo(pathDir) == MapAttribute.Walkable)
                                         {
                                             Move(pathDir, forPlayer);
                                             moved = true;
@@ -438,7 +438,7 @@ namespace Intersect.Server.Entities.Events
                                             break;
                                     }
 
-                                    if (CanMove(moveDir) == -1)
+                                    if (MovesTo(moveDir) == MapAttribute.Walkable)
                                     {
                                         Move(moveDir, forPlayer);
                                         moved = true;
@@ -447,7 +447,7 @@ namespace Intersect.Server.Entities.Events
                                     {
                                         //Move Randomly
                                         moveDir = Randomization.NextDirection();
-                                        if (CanMove(moveDir) == -1)
+                                        if (MovesTo(moveDir) == MapAttribute.Walkable)
                                         {
                                             Move(moveDir, forPlayer);
                                             moved = true;
@@ -458,7 +458,7 @@ namespace Intersect.Server.Entities.Events
                                 {
                                     //Move Randomly
                                     moveDir = Randomization.NextDirection();
-                                    if (CanMove(moveDir) == -1)
+                                    if (MovesTo(moveDir) == MapAttribute.Walkable)
                                     {
                                         Move(moveDir, forPlayer);
                                         moved = true;
@@ -730,11 +730,11 @@ namespace Intersect.Server.Entities.Events
             }
         }
 
-        public override int CanMove(Direction moveDir)
+        public override MapAttribute MovesTo(Direction moveDir)
         {
             if (Player == null && mPageNum != 0)
             {
-                return -5;
+                return MapAttribute.OutOfBounds;
             }
 
             switch (moveDir)
@@ -742,34 +742,34 @@ namespace Intersect.Server.Entities.Events
                 case Direction.Up:
                     if (Y == 0)
                     {
-                        return -5;
+                        return MapAttribute.OutOfBounds;
                     }
 
                     break;
                 case Direction.Down:
                     if (Y == Options.MapHeight - 1)
                     {
-                        return -5;
+                        return MapAttribute.OutOfBounds;
                     }
 
                     break;
                 case Direction.Left:
                     if (X == 0)
                     {
-                        return -5;
+                        return MapAttribute.OutOfBounds;
                     }
 
                     break;
                 case Direction.Right:
                     if (X == Options.MapWidth - 1)
                     {
-                        return -5;
+                        return MapAttribute.OutOfBounds;
                     }
 
                     break;
             }
 
-            return base.CanMove(moveDir);
+            return base.MovesTo(moveDir);
         }
 
         public void TurnTowardsPlayer()

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -6470,52 +6470,56 @@ namespace Intersect.Server.Entities
             }
         }
 
-        public override int CanMove(Direction moveDir)
+        public override MapAttribute MovesTo(Direction moveDir)
         {
             //If crafting or locked by event return blocked
             if (OpenCraftingTableId != default && CraftingState != default)
             {
-                return -5;
+                return MapAttribute.OutOfBounds;
             }
 
             foreach (var evt in EventLookup)
             {
                 if (evt.Value.HoldingPlayer)
                 {
-                    return -5;
+                    return MapAttribute.OutOfBounds;
                 }
             }
 
-            return base.CanMove(moveDir);
+            return base.MovesTo(moveDir);
         }
 
-        protected override int IsTileWalkable(MapController map, int x, int y, int z)
+        protected override MapAttribute IsTileWalkable(MapController map, int x, int y, int z)
         {
-            if (base.IsTileWalkable(map, x, y, z) == -1)
+            if (base.IsTileWalkable(map, x, y, z) != MapAttribute.Walkable)
             {
-                foreach (var evt in EventLookup)
-                {
-                    if (evt.Value.PageInstance != null)
-                    {
-                        var instance = evt.Value.PageInstance;
-                        if (instance.GlobalClone != null)
-                        {
-                            instance = instance.GlobalClone;
-                        }
+                return MapAttribute.Walkable;
+            }
 
-                        if (instance.Map == map &&
-                            instance.X == x &&
-                            instance.Y == y &&
-                            instance.Z == z &&
-                            !instance.Passable)
-                        {
-                            return (int) EntityType.Event;
-                        }
-                    }
+            foreach (var evt in EventLookup)
+            {
+                if (evt.Value.PageInstance == null)
+                {
+                    continue;
+                }
+
+                var instance = evt.Value.PageInstance;
+                if (instance.GlobalClone != null)
+                {
+                    instance = instance.GlobalClone;
+                }
+
+                if (instance.Map == map &&
+                    instance.X == x &&
+                    instance.Y == y &&
+                    instance.Z == z &&
+                    !instance.Passable)
+                {
+                    return MapAttribute.Event;
                 }
             }
 
-            return -1;
+            return MapAttribute.Walkable;
         }
 
         public override void Move(Direction moveDir, Player forPlayer, bool dontUpdate = false,

--- a/Intersect.Server/Maps/MapInstance.cs
+++ b/Intersect.Server/Maps/MapInstance.cs
@@ -466,7 +466,7 @@ namespace Intersect.Server.Maps
                 {
                     x = (byte)Randomization.Next(0, Options.MapWidth);
                     y = (byte)Randomization.Next(0, Options.MapHeight);
-                    if (mMapController.Attributes[x, y] == null || mMapController.Attributes[x, y].Type == (int)MapAttribute.Walkable)
+                    if (mMapController.Attributes[x, y] == null || mMapController.Attributes[x, y].Type == MapAttribute.Walkable)
                     {
                         break;
                     }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using MapAttribute = Intersect.Enums.MapAttribute;
 
 namespace Intersect.Server.Networking
 {
@@ -697,8 +698,8 @@ namespace Intersect.Server.Networking
             if (player.ClientMoveTimer <= clientTime &&
                 (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
             {
-                var canMove = player.CanMove(packet.Dir);
-                if ((canMove == -1 || canMove == -4) && client.Entity.MoveRoute == null)
+                var movesTo = player.MovesTo(packet.Dir);
+                if ((movesTo == MapAttribute.Walkable || movesTo == MapAttribute.Slide) && client.Entity.MoveRoute == null)
                 {
                     player.Move(packet.Dir, player, false);
                     var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;


### PR DESCRIPTION
- Renames "CanMove" to "MovesTo" in order to make more sense (the method wasn't a boolean).
- Adds additional values to MapAttribute (OutOfBounds, Player, Event) and sorts them all alphabetically.
- MovesTo now returns updated MapAttribute values from the core instead of confusing integers, which allows us to have more readable and simplified code.
- frmMapLayers.cs: removes Method 'GetAttributeFromEditor' which contained unnecessary int casts to map attributes plus, is never used.
- Updates Dash's CalculateRange with the new values and a simplified switch.
- Should resolve #1100