### PR TITLE
chore: CanMoveInDirection method

### DIFF
--- a/Intersect (Core)/Enums/MovementBlockerType.cs
+++ b/Intersect (Core)/Enums/MovementBlockerType.cs
@@ -1,0 +1,12 @@
+namespace Intersect.Enums
+{
+    public enum MovementBlockerType
+    {
+        NotBlocked = 0,
+        OutOfBounds,
+        MapAttribute,
+        Slide,
+        Entity,
+        ZDimension,
+    }
+}

--- a/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
@@ -243,7 +243,7 @@ namespace Intersect.GameObjects.Maps
 
         [EditorLabel("Attributes", "Direction")]
         [EditorDictionary(nameof(Direction), "WarpDirections")]
-        public byte Direction { get; set; }
+        public Direction Direction { get; set; }
 
         public override MapAttribute Clone()
         {

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -742,7 +742,7 @@ namespace Intersect.Editor.Forms.DockingElements
 
                 case MapAttribute.Slide:
                     var slideAttribute = attribute as MapSlideAttribute;
-                    slideAttribute.Direction = (byte)cmbSlideDir.SelectedIndex;
+                    slideAttribute.Direction = (Direction)cmbSlideDir.SelectedIndex;
                     break;
 
                 case MapAttribute.Critter:

--- a/Intersect.Server/Entities/Combat/Dash.cs
+++ b/Intersect.Server/Entities/Combat/Dash.cs
@@ -81,8 +81,14 @@ namespace Intersect.Server.Entities.Combat
                         case MovementBlockerType.Entity:
                             switch (entityType)
                             {
-                                case EntityType.Resource when activeResourcePass == false:
-                                case EntityType.Resource when deadResourcePass == false:
+                                case EntityType.Resource:
+                                    if (activeResourcePass || deadResourcePass)
+                                    {
+                                        break;
+                                    }
+
+                                    return;
+
                                 case EntityType.Event:
                                 case EntityType.Player:
                                 case EntityType.GlobalEntity:
@@ -90,8 +96,7 @@ namespace Intersect.Server.Entities.Combat
                                 case EntityType.Projectile:
                                     break;
                                 default:
-                                    throw new InvalidOperationException(
-                                        "Unreachable"); // TODO: Change to \UnreachableException` in .NET 7`
+                                    throw new InvalidOperationException("Unreachable"); // TODO: Change to UnreachableException in .NET 7
                             }
 
                             break;
@@ -101,9 +106,7 @@ namespace Intersect.Server.Entities.Combat
                             break;
 
                         default:
-                            throw
-                                new InvalidOperationException(
-                                    "Unreachable"); // TODO: Change to \UnreachableException` in .NET 7`
+                            throw new InvalidOperationException("Unreachable"); // TODO: Change to UnreachableException in .NET 7
                     }
                 }
 

--- a/Intersect.Server/Entities/Combat/Dash.cs
+++ b/Intersect.Server/Entities/Combat/Dash.cs
@@ -82,12 +82,12 @@ namespace Intersect.Server.Entities.Combat
                             switch (entityType)
                             {
                                 case EntityType.Resource:
-                                    if (activeResourcePass || deadResourcePass)
+                                    if (!activeResourcePass || !deadResourcePass)
                                     {
-                                        break;
+                                        return;
                                     }
 
-                                    return;
+                                    break;
 
                                 case EntityType.Event:
                                 case EntityType.Player:

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -477,15 +477,37 @@ namespace Intersect.Server.Entities
 
             switch (tileAttribute)
             {
-                case MapAnimationAttribute animAttr when animAttr.IsBlock:
-                case MapBlockedAttribute _:
-                case MapNpcAvoidAttribute _
-                    when (this is Npc || (this is EventPageInstance evtPage && !evtPage.MyPage.IgnoreNpcAvoids)):
+                case MapAnimationAttribute animAttr:
+                    if (!animAttr.IsBlock)
+                    {
+                        break;
+                    }
+
                     blockerType = MovementBlockerType.MapAttribute;
                     entityType = default;
                     return false;
 
-                case MapZDimensionAttribute zAttr when zAttr.BlockedLevel > 0 && zAttr.BlockedLevel - 1 == Z:
+                case MapBlockedAttribute _:
+                    blockerType = MovementBlockerType.MapAttribute;
+                    entityType = default;
+                    return false;
+                
+                case MapNpcAvoidAttribute _:
+                    if (!(this is Npc || (this is EventPageInstance evtPage && !evtPage.MyPage.IgnoreNpcAvoids)))
+                    {
+                        break;
+                    }
+                    
+                    blockerType = MovementBlockerType.MapAttribute;
+                    entityType = default;
+                    return false;
+
+                case MapZDimensionAttribute zAttr:
+                    if (!(zAttr.BlockedLevel > 0 && zAttr.BlockedLevel - 1 == Z))
+                    {
+                        break;
+                    }
+                    
                     blockerType = MovementBlockerType.ZDimension;
                     entityType = default;
                     return false;
@@ -519,13 +541,27 @@ namespace Intersect.Server.Entities
 
                     switch (en)
                     {
-                        case Player _ when blockableByPlayer:
+                        case Player _:
+                            if (!blockableByPlayer)
+                            {
+                                break;
+                            }
+
+                            blockerType = MovementBlockerType.Entity;
+                            entityType = EntityType.Player;
+                            return false;
+
                         case Npc _:
                             blockerType = MovementBlockerType.Entity;
                             entityType = EntityType.Player;
                             return false;
 
-                        case Resource resource when !resource.IsPassable():
+                        case Resource resource:
+                            if (resource.IsPassable())
+                            {
+                                break;
+                            }
+
                             blockerType = MovementBlockerType.Entity;
                             entityType = EntityType.Resource;
                             return false;

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -6519,7 +6519,7 @@ namespace Intersect.Server.Entities
 
                 if (instance.GlobalClone != null)
                 {
-                    instance = instance?.GlobalClone;
+                    instance = instance?.GlobalClone ?? instance;
                 }
 
                 if (instance.Map != mapController ||
@@ -6536,7 +6536,7 @@ namespace Intersect.Server.Entities
                 return false;
             }
 
-            blockerType = MovementBlockerType.NotBlocked;
+            blockerType = default;
             entityType = default;
             return true;
         }

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -701,8 +701,8 @@ namespace Intersect.Server.Networking
             if (player.ClientMoveTimer <= clientTime &&
                 (Options.Instance.PlayerOpts.AllowCombatMovement || player.ClientAttackTimer <= clientTime))
             {
-                var canMove = player.CanMove(packet.Dir);
-                if ((canMove == -1 || canMove == -4) && client.Entity.MoveRoute == null)
+                if ((player.CanMoveInDirection(packet.Dir, out var blockerType, out _) ||
+                     blockerType == MovementBlockerType.Slide) && client.Entity.MoveRoute == null)
                 {
                     player.Move(packet.Dir, player, false);
                     var utcDeltaMs = (Timing.Global.TicksUtc - packet.UTC) / TimeSpan.TicksPerMillisecond;


### PR DESCRIPTION
* Should resolve #1100

[chore: CanMoveInDirection method](https://github.com/AscensionGameDev/Intersect-Engine/pull/1775/commits/fd56dc2ca0be09747c48db41d95960c4c83a7abd)
* Renames "CanMove" to "CanMoveInDirection", which is now a boolean.
* Creates and uses enum type "MovementBlockerType".
* CanMoveInDirection takes in the direction and two out parameters of the MovementBlockerType and EntityType enum types. The method checks if the entity can move in the given direction by analyzing the MapController, MapAttributes, and nearby entities. If there is a blockage, the method sets the out parameters with the corresponding MovementBlockerType and EntityType, and returns false. Otherwise, it returns true.
* Updates Dash's CalculateRange with the new method and a simplified switch.

[review: 28.03.2023](https://github.com/AscensionGameDev/Intersect-Engine/pull/1775/commits/2acbb28862a64b156c627d38591ba35a291ae4b1)
- Renames "IsTileWalkable" -> "GetTileBlocker" which now returns Movement and Entity blocker types.
- (Editor) slideAttribute.Direction is a Direction value instead of byte now (tested and working).
- Restores equivalent checks commented in the review.
- Less code nesting.