### PR TITLE
fix: use separate workflow for PRs, limit build workflow file triggers

### DIFF
--- a/.github/workflows/build.0.7.2-beta.yml
+++ b/.github/workflows/build.0.7.2-beta.yml
@@ -3,15 +3,15 @@ name: v0.7.2-beta
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
 
 permissions:
   contents: write
 
 env:
   VERSION_PREFIX: 0.7.2
-  VERSION_SUFFIX: -beta.
+  VERSION_SUFFIX: -beta
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Cache binaries
-      uses: actions/cache@v3.2.6
+      uses: actions/cache@v3
       id: cache-binaries
       with:
         path: |
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build solution
       if: steps.cache-binaries.outputs.cache-hit == 'false' || steps.cache-nuget.outputs.cache-hit == 'false'
-      run: msbuild Intersect.sln /p:Configuration=Release /p:PackageVersion=${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}${{ github.run_number }}+build.${{ github.sha }} /p:Version=0.7.2.${{ github.run_number }}
+      run: msbuild Intersect.sln /p:Configuration=Release /p:PackageVersion=${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}+build.${{ github.sha }} /p:Version=0.7.2.${{ github.run_number }}
 
     - name: Checkout assets main_upgrade branch
       uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
       uses: AscensionGameDev/actions@4c9073d0721da476ac9337fbbfe46a9ca1ae4389
       with:
         bundle: .github/bundles/*.json
-        version: ${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}${{ github.run_number }}+build.${{ github.sha }}
+        version: ${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}+build.${{ github.sha }}
 
     - name: Publish GitHub Release
       uses: softprops/action-gh-release@v0.1.15
@@ -95,8 +95,8 @@ jobs:
         files: "dist/*.zip"
         generate_release_notes: true
         prerelease: true
-        name: ${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}${{ github.run_number }}
-        tag_name: v${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}${{ github.run_number }}
+        name: ${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}
+        tag_name: v${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}
         target_commitish: ${{ github.sha }}
 
   # publish:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,56 @@
+name: v0.7.2-beta
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  VERSION_PREFIX: 0.7.2
+  VERSION_SUFFIX: -beta
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Cache NuGet dependencies
+      uses: actions/cache@v3.2.6
+      id: cache-nuget-pr
+      with:
+        path: |
+          ~/.nuget/packages
+          Intersect*/obj/project.assets.json
+        key: ${{ runner.os }}-nuget-${{ hashFiles('Intersect.*/*.csproj') }}
+
+    - name: Add msbuild to PATH
+      if: steps.cache-nuget-pr.outputs.cache-hit == 'false'
+      uses: microsoft/setup-msbuild@v1.3.1
+      with:
+        msbuild-architecture: x64
+
+    - name: Setup NuGet.exe for use with actions
+      if: steps.cache-nuget-pr.outputs.cache-hit == 'false'
+      # You may pin to the exact commit or the version.
+      # uses: NuGet/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37
+      uses: NuGet/setup-nuget@v1.1.1
+      with:
+        # NuGet version to install. Can be `latest`, `preview`, a concrete version like `5.3.1`, or a semver range specifier like `5.x`.
+        nuget-version: latest # optional, default is latest
+        # NuGet API Key to configure.
+        # nuget-api-key: # optional
+        # Source to scope the NuGet API Key to.
+        # nuget-api-key-source: # optional
+
+    - name: Restore NuGet Packages
+      if: steps.cache-nuget-pr.outputs.cache-hit == 'false'
+      run: nuget restore Intersect.sln
+
+    - name: Build solution (Debug)
+      if: steps.cache-nuget-pr.outputs.cache-hit == 'false'
+      run: msbuild Intersect.sln /p:Configuration=Debug /p:PackageVersion=${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}+build.${{ github.sha }} /p:Version=0.7.2.${{ github.run_number }}
+
+    - name: Build solution (Release)
+      if: steps.cache-nuget-pr.outputs.cache-hit == 'false'
+      run: msbuild Intersect.sln /p:Configuration=Release /p:PackageVersion=${{ env.VERSION_PREFIX }}${{ env.VERSION_SUFFIX }}.${{ github.run_number }}+build.${{ github.sha }} /p:Version=0.7.2.${{ github.run_number }}


### PR DESCRIPTION
- split PRs into separate workflow file so that PRs do not accidentally trigger releases
- limit push workflow to look for changes that are outside of the .github directory