### PR TITLE
enhancement: configurable map items size

### DIFF
--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -39,6 +39,16 @@ namespace Intersect.Config
         public LayerOptions Layers { get; set; } = new LayerOptions();
 
         /// <summary>
+        /// The width of map items.
+        /// </summary>
+        public int MapItemHeight { get; set; } = 32;
+
+        /// <summary>
+        /// The height of map items.
+        /// </summary>
+        public int MapItemWidth { get; set; } = 32;
+
+        /// <summary>
         /// The height of the map in tiles.
         /// </summary>
         public int MapHeight { get; set; } = 26;

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -41,12 +41,12 @@ namespace Intersect.Config
         /// <summary>
         /// The width of map items.
         /// </summary>
-        public int MapItemHeight { get; set; } = 32;
+        public uint MapItemHeight { get; set; }
 
         /// <summary>
         /// The height of map items.
         /// </summary>
-        public int MapItemWidth { get; set; } = 32;
+        public uint MapItemWidth { get; set; }
 
         /// <summary>
         /// The height of the map in tiles.

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -119,6 +119,9 @@ namespace Intersect.Config
             {
                 throw new Exception("Config Error: Map size out of bounds! (All values should be > 10 and < 64)");
             }
+
+            MapItemWidth = MapItemWidth < 1 ? (uint)TileWidth : MapItemWidth;
+            MapItemHeight = MapItemHeight < 1 ? (uint)TileHeight : MapItemHeight;
         }
     }
 }

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -160,6 +160,10 @@ namespace Intersect
 
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
+        public static int MapItemHeight => Instance?.MapOpts?.MapItemHeight ?? 32;
+
+        public static int MapItemWidth => Instance?.MapOpts?.MapItemWidth ?? 32;
+
         public static int MapWidth => Instance?.MapOpts?.MapWidth ?? 32;
 
         public static int MapHeight => Instance?.MapOpts?.MapHeight ?? 26;

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -160,10 +160,6 @@ namespace Intersect
 
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
-        public static int MapItemHeight => Instance?.MapOpts?.MapItemHeight ?? 32;
-
-        public static int MapItemWidth => Instance?.MapOpts?.MapItemWidth ?? 32;
-
         public static int MapWidth => Instance?.MapOpts?.MapWidth ?? 32;
 
         public static int MapHeight => Instance?.MapOpts?.MapHeight ?? 26;

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -719,12 +719,10 @@ namespace Intersect.Client.Maps
         public void DrawItemsAndLights()
         {
             // Calculate tile and map item dimensions.
-            var tileWidth = (uint)Options.TileWidth;
-            var tileHeight = (uint)Options.TileHeight;
-            var preferredMapItemWidth = Options.Instance.MapOpts.MapItemWidth;
-            var preferredMapItemHeight = Options.Instance.MapOpts.MapItemHeight;
-            var mapItemWidth = preferredMapItemWidth <= 0 ? tileWidth : preferredMapItemWidth;
-            var mapItemHeight = preferredMapItemHeight <= 0 ? tileHeight : preferredMapItemHeight;
+            var tileWidth = Options.TileWidth;
+            var tileHeight = Options.TileHeight;
+            var mapItemWidth = Options.Instance.MapOpts.MapItemWidth;
+            var mapItemHeight = Options.Instance.MapOpts.MapItemHeight;
 
             // Draw map items.
             foreach (var (key, tileItems) in MapItems)

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -718,9 +718,21 @@ namespace Intersect.Client.Maps
 
         public void DrawItemsAndLights()
         {
-            // Draw map item icons.
+            // Calculate tile and map item dimensions.
+            var tileWidth = (uint)Options.TileWidth;
+            var tileHeight = (uint)Options.TileHeight;
+            var preferredMapItemWidth = Options.Instance.MapOpts.MapItemWidth;
+            var preferredMapItemHeight = Options.Instance.MapOpts.MapItemHeight;
+            var mapItemWidth = preferredMapItemWidth <= 0 ? tileWidth : preferredMapItemWidth;
+            var mapItemHeight = preferredMapItemHeight <= 0 ? tileHeight : preferredMapItemHeight;
+
+            // Draw map items.
             foreach (var (key, tileItems) in MapItems)
             {
+                // Calculate tile coordinates.
+                var tileX = key % Options.MapWidth;
+                var tileY = (int)Math.Floor(key / (float)Options.MapWidth);
+
                 // Loop through this in reverse to match client/server display and pick-up order.
                 for (var index = tileItems.Count - 1; index >= 0; index--)
                 {
@@ -733,21 +745,18 @@ namespace Intersect.Client.Maps
                         continue;
                     }
 
-                    var tileX = key % Options.MapWidth;
-                    var tileY = (int)Math.Floor(key / (float)Options.MapWidth);
-                    var x = X + tileX * Options.TileWidth;
-                    var y = Y + tileY * Options.TileHeight;
-                    var centerX = x + (Options.TileWidth / 2);
-                    var centerY = y + (Options.TileHeight / 2);
-                    var textureWidth = Options.MapItemWidth;
-                    var textureHeight = Options.MapItemHeight;
-                    var textureXPosition = centerX - (textureWidth / 2);
-                    var textureYPosition = centerY - (textureHeight / 2);
+                    var x = X + tileX * tileWidth;
+                    var y = Y + tileY * tileHeight;
+                    var centerX = x + (tileWidth / 2);
+                    var centerY = y + (tileHeight / 2);
+                    var textureXPosition = centerX - (mapItemWidth / 2);
+                    var textureYPosition = centerY - (mapItemHeight / 2);
 
+                    // Draw the item texture.
                     Graphics.DrawGameTexture(
                         itemTex,
                         new FloatRect(0, 0, itemTex.Width, itemTex.Height),
-                        new FloatRect(textureXPosition, textureYPosition, textureWidth, textureHeight),
+                        new FloatRect(textureXPosition, textureYPosition, mapItemWidth, mapItemHeight),
                         itemBase.Color
                     );
                 }
@@ -757,8 +766,8 @@ namespace Intersect.Client.Maps
             foreach (var light in Lights)
             {
                 double w = light.Size;
-                var x = GetX() + (light.TileX * Options.TileWidth + light.OffsetX) + Options.TileWidth / 2f;
-                var y = GetY() + (light.TileY * Options.TileHeight + light.OffsetY) + Options.TileHeight / 2f;
+                var x = GetX() + (light.TileX * tileWidth + light.OffsetX) + tileWidth / 2f;
+                var y = GetY() + (light.TileY * tileHeight + light.OffsetY) + tileHeight / 2f;
                 Graphics.AddLight((int)x, (int)y, (int)w, light.Intensity, light.Expand, light.Color);
             }
         }

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -18,6 +18,7 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Compression;
 using Intersect.Enums;
+using Intersect.Extensions;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Maps;
 using Intersect.Network.Packets.Server;
@@ -718,32 +719,37 @@ namespace Intersect.Client.Maps
         public void DrawItemsAndLights()
         {
             // Draw map item icons.
-            foreach (var itemCollection in MapItems)
+            foreach (var (key, tileItems) in MapItems)
             {
-                var tileX = itemCollection.Key % Options.MapWidth;
-                var tileY = (int)Math.Floor(itemCollection.Key / (float)Options.MapWidth);
-                var tileItems = itemCollection.Value;
-
                 // Loop through this in reverse to match client/server display and pick-up order.
                 for (var index = tileItems.Count - 1; index >= 0; index--)
                 {
-                    var x = GetX() + tileX * Options.TileWidth;
-                    var y = GetY() + tileY * Options.TileHeight;
-
                     // Set up all information we need to draw this name.
                     var itemBase = ItemBase.Get(tileItems[index].ItemId);
-
                     var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, itemBase.Icon);
-                    if (itemTex != null)
+
+                    if (itemTex == null)
                     {
-                        Graphics.DrawGameTexture(
-                            itemTex, new FloatRect(0, 0, itemTex.GetWidth(), itemTex.GetHeight()),
-                            new FloatRect(
-                                x, y,
-                                Options.TileWidth, Options.TileHeight
-                            ), itemBase.Color
-                        );
+                        continue;
                     }
+
+                    var tileX = key % Options.MapWidth;
+                    var tileY = (int)Math.Floor(key / (float)Options.MapWidth);
+                    var x = X + tileX * Options.TileWidth;
+                    var y = Y + tileY * Options.TileHeight;
+                    var centerX = x + (Options.TileWidth / 2);
+                    var centerY = y + (Options.TileHeight / 2);
+                    var textureWidth = Options.MapItemWidth;
+                    var textureHeight = Options.MapItemHeight;
+                    var textureXPosition = centerX - (textureWidth / 2);
+                    var textureYPosition = centerY - (textureHeight / 2);
+
+                    Graphics.DrawGameTexture(
+                        itemTex,
+                        new FloatRect(0, 0, itemTex.Width, itemTex.Height),
+                        new FloatRect(textureXPosition, textureYPosition, textureWidth, textureHeight),
+                        itemBase.Color
+                    );
                 }
             }
 


### PR DESCRIPTION
enhances spawned/dropped items in maps by:
 - Adding configurable size for their sprites.
 - Centering their sprites in relation to the tiles they occupy.

_This doesn't requires additional texture loading, this simply allows the users to configure the size the icon textures.
The implementation also makes sure to always center the item's texture in relation with the tile they occupy while considering the configured item render size, this way we are not limited by the boundaries of the tile size of the grid anymore._

Preview:

![imagen](https://user-images.githubusercontent.com/17498701/232345490-0a0202bf-2232-4967-a720-ea7426c9fe0f.png)

![imagen](https://user-images.githubusercontent.com/17498701/232345804-141a7eb5-25f6-49ba-b100-befe5362ca00.png)

