### PR TITLE
fix: client-side timing synchronization

### DIFF
--- a/Intersect.Client/Core/Audio.cs
+++ b/Intersect.Client/Core/Audio.cs
@@ -7,7 +7,6 @@ using Intersect.Client.Framework.Core.Sounds;
 using Intersect.Client.Framework.Entities;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.General;
-using Intersect.Configuration;
 using Intersect.Logging;
 using Intersect.Utilities;
 
@@ -73,7 +72,7 @@ namespace Intersect.Client.Core
         {
             if (sMyMusic != null)
             {
-                var currentTime = Timing.Global.Milliseconds;
+                var currentTime = Timing.Global.MillisecondsUtc;
                 if (sFadeTimer != 0 && sFadeTimer < currentTime)
                 {
                     if (sFadingOut)
@@ -207,7 +206,7 @@ namespace Intersect.Client.Core
             sMyMusic.SetVolume(0, true);
             sMyMusic.IsLooping = loop;
             sFadeRate = fadein / 100;
-            sFadeTimer = Timing.Global.Milliseconds + sFadeRate;
+            sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
             sFadingOut = false;
         }
 
@@ -237,7 +236,7 @@ namespace Intersect.Client.Core
             {
                 //Start fadeout
                 sFadeRate = fadeout / sMyMusic.GetVolume();
-                sFadeTimer = Timing.Global.Milliseconds + sFadeRate;
+                sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
                 sFadingOut = true;
             }
         }

--- a/Intersect.Client/Core/Fade.cs
+++ b/Intersect.Client/Core/Fade.cs
@@ -29,14 +29,14 @@ namespace Intersect.Client.Core
         {
             sCurrentAction = FadeType.In;
             sFadeAmt = 255f;
-            sLastUpdate = Timing.Global.Milliseconds;
+            sLastUpdate = Timing.Global.MillisecondsUtc;
         }
 
         public static void FadeOut()
         {
             sCurrentAction = FadeType.Out;
             sFadeAmt = 0f;
-            sLastUpdate = Timing.Global.Milliseconds;
+            sLastUpdate = Timing.Global.MillisecondsUtc;
         }
 
         public static bool DoneFading()
@@ -53,7 +53,7 @@ namespace Intersect.Client.Core
         {
             if (sCurrentAction == FadeType.In)
             {
-                sFadeAmt -= (Timing.Global.Milliseconds - sLastUpdate) / sFadeRate * 255f;
+                sFadeAmt -= (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeRate * 255f;
                 if (sFadeAmt <= 0f)
                 {
                     sCurrentAction = FadeType.None;
@@ -62,7 +62,7 @@ namespace Intersect.Client.Core
             }
             else if (sCurrentAction == FadeType.Out)
             {
-                sFadeAmt += (Timing.Global.Milliseconds - sLastUpdate) / sFadeRate * 255f;
+                sFadeAmt += (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeRate * 255f;
                 if (sFadeAmt >= 255f)
                 {
                     sCurrentAction = FadeType.None;
@@ -70,7 +70,7 @@ namespace Intersect.Client.Core
                 }
             }
 
-            sLastUpdate = Timing.Global.Milliseconds;
+            sLastUpdate = Timing.Global.MillisecondsUtc;
         }
 
     }

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -169,7 +169,7 @@ namespace Intersect.Client.Core
                     return;
                 }
 
-                var currentTimeMs = Timing.Global.Milliseconds;
+                var currentTimeMs = Timing.Global.MillisecondsUtc;
 
                 if (sMenuBackgroundInterval < currentTimeMs)
                 {
@@ -638,7 +638,7 @@ namespace Intersect.Client.Core
             var map = MapInstance.Get(Globals.Me.MapId);
             if (map != null)
             {
-                float ecTime = Timing.Global.Milliseconds - sOverlayUpdate;
+                float ecTime = Timing.Global.MillisecondsUtc - sOverlayUpdate;
 
                 if (OverlayColor.A != map.AHue ||
                     OverlayColor.R != map.RHue ||
@@ -744,7 +744,7 @@ namespace Intersect.Client.Core
             }
 
             DrawGameTexture(Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1), CurrentView, OverlayColor, null);
-            sOverlayUpdate = Timing.Global.Milliseconds;
+            sOverlayUpdate = Timing.Global.MillisecondsUtc;
         }
 
         public static FloatRect GetSourceRect(GameTexture gameTexture)
@@ -1092,7 +1092,7 @@ namespace Intersect.Client.Core
             var map = MapInstance.Get(Globals.Me.MapId);
             if (map != null)
             {
-                float ecTime = Timing.Global.Milliseconds - sLightUpdate;
+                float ecTime = Timing.Global.MillisecondsUtc - sLightUpdate;
                 var valChange = 255 * ecTime / 2000f;
                 var brightnessTarget = (byte) (map.Brightness / 100f * 255);
                 if (BrightnessLevel < brightnessTarget)
@@ -1273,7 +1273,7 @@ namespace Intersect.Client.Core
 
                 // Cap instensity between 0 and 255 so as not to overflow (as it is an alpha value)
                 sPlayerLightIntensity = (float) MathHelper.Clamp(sPlayerLightIntensity, 0f, 255f);
-                sLightUpdate = Timing.Global.Milliseconds;
+                sLightUpdate = Timing.Global.MillisecondsUtc;
             }
         }
 

--- a/Intersect.Client/Core/Main.cs
+++ b/Intersect.Client/Core/Main.cs
@@ -126,7 +126,7 @@ namespace Intersect.Client.Core
                         {
                             if (Globals.IntroComing)
                             {
-                                Globals.IntroStartTime = Timing.Global.Milliseconds;
+                                Globals.IntroStartTime = Timing.Global.MillisecondsUtc;
                             }
                             else
                             {
@@ -138,7 +138,7 @@ namespace Intersect.Client.Core
                     }
                     else
                     {
-                        if (Timing.Global.Milliseconds > Globals.IntroStartTime + Globals.IntroDelay)
+                        if (Timing.Global.MillisecondsUtc > Globals.IntroStartTime + Globals.IntroDelay)
                         {
                             //If we have shown an image long enough, fade to black -- keep track that the image is going
                             Fade.FadeOut();
@@ -311,7 +311,7 @@ namespace Intersect.Client.Core
             }
 
             //Update Game Animations
-            if (_animTimer < Timing.Global.Milliseconds)
+            if (_animTimer < Timing.Global.MillisecondsUtc)
             {
                 Globals.AnimFrame++;
                 if (Globals.AnimFrame == 3)
@@ -319,7 +319,7 @@ namespace Intersect.Client.Core
                     Globals.AnimFrame = 0;
                 }
 
-                _animTimer = Timing.Global.Milliseconds + 500;
+                _animTimer = Timing.Global.MillisecondsUtc + 500;
             }
 
             //Remove Event Holds If Invalid

--- a/Intersect.Client/Core/Sounds/Sound.cs
+++ b/Intersect.Client/Core/Sounds/Sound.cs
@@ -72,11 +72,11 @@ namespace Intersect.Client.Core.Sounds
             {
                 if (mStoppedTime == -1)
                 {
-                    mStoppedTime = Timing.Global.Milliseconds;
+                    mStoppedTime = Timing.Global.MillisecondsUtc;
                 }
                 else
                 {
-                    if (mStoppedTime + mLoopInterval < Timing.Global.Milliseconds)
+                    if (mStoppedTime + mLoopInterval < Timing.Global.MillisecondsUtc)
                     {
                         mSound.Play();
                         mStoppedTime = -1;

--- a/Intersect.Client/Entities/Animation.cs
+++ b/Intersect.Client/Entities/Animation.cs
@@ -46,7 +46,7 @@ namespace Intersect.Client.Entities
 
         private MapSound mSound;
 
-        private long mStartTime = Timing.Global.Milliseconds;
+        private long mStartTime = Timing.Global.MillisecondsUtc;
 
         private int mUpperFrame;
 
@@ -74,8 +74,8 @@ namespace Intersect.Client.Entities
             {
                 mLowerLoop = animBase.Lower.LoopCount;
                 mUpperLoop = animBase.Upper.LoopCount;
-                mLowerTimer = Timing.Global.Milliseconds + animBase.Lower.FrameSpeed;
-                mUpperTimer = Timing.Global.Milliseconds + animBase.Upper.FrameSpeed;
+                mLowerTimer = Timing.Global.MillisecondsUtc + animBase.Lower.FrameSpeed;
+                mUpperTimer = Timing.Global.MillisecondsUtc + animBase.Upper.FrameSpeed;
                 InfiniteLoop = loopForever;
                 AutoRotate = autoRotate;
                 mZDimension = zDimension;
@@ -342,7 +342,7 @@ namespace Intersect.Client.Entities
                 }
 
                 //Calculate Frames
-                var elapsedTime = Timing.Global.Milliseconds - mStartTime;
+                var elapsedTime = Timing.Global.MillisecondsUtc - mStartTime;
 
                 //Lower
                 if (MyBase.Lower.FrameCount > 0 && MyBase.Lower.FrameSpeed > 0)

--- a/Intersect.Client/Entities/ChatBubble.cs
+++ b/Intersect.Client/Entities/ChatBubble.cs
@@ -40,13 +40,13 @@ namespace Intersect.Client.Entities
 
             mOwner = owner;
             mSourceText = text;
-            mRenderTimer = Timing.Global.Milliseconds + 5000;
+            mRenderTimer = Timing.Global.MillisecondsUtc + 5000;
             mBubbleTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "chatbubble.png");
         }
 
         public bool Update()
         {
-            if (mRenderTimer < Timing.Global.Milliseconds)
+            if (mRenderTimer < Timing.Global.MillisecondsUtc)
             {
                 return false;
             }

--- a/Intersect.Client/Entities/Critter.cs
+++ b/Intersect.Client/Entities/Critter.cs
@@ -53,7 +53,7 @@ namespace Intersect.Client.Entities
         {
             if (base.Update())
             {
-                if (mLastMove < Timing.Global.Milliseconds)
+                if (mLastMove < Timing.Global.MillisecondsUtc)
                 {
                     switch (mAttribute.Movement)
                     {
@@ -66,7 +66,7 @@ namespace Intersect.Client.Entities
 
                     }
 
-                    mLastMove = Timing.Global.Milliseconds + mAttribute.Frequency + Globals.Random.Next((int)(mAttribute.Frequency * .5f));
+                    mLastMove = Timing.Global.MillisecondsUtc + mAttribute.Frequency + Globals.Random.Next((int)(mAttribute.Frequency * .5f));
                 }
                 return true;
             }
@@ -80,7 +80,7 @@ namespace Intersect.Client.Entities
             var tmpY = (sbyte)Y;
             IEntity blockedBy = null;
 
-            if (IsMoving || MoveTimer >= Timing.Global.Milliseconds)
+            if (IsMoving || MoveTimer >= Timing.Global.MillisecondsUtc)
             {
                 return;
             }
@@ -171,7 +171,7 @@ namespace Intersect.Client.Entities
             {
                 X = (byte)tmpX;
                 Y = (byte)tmpY;
-                MoveTimer = Timing.Global.Milliseconds + (long)GetMovementTime();
+                MoveTimer = Timing.Global.MillisecondsUtc + (long)GetMovementTime();
             }
             else if (MoveDir != Dir)
             {

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -248,7 +248,7 @@ namespace Intersect.Client.Entities
                 }
             }
 
-            AnimationTimer = Timing.Global.Milliseconds + Globals.Random.Next(0, 500);
+            AnimationTimer = Timing.Global.MillisecondsUtc + Globals.Random.Next(0, 500);
 
             //TODO Remove because fixed orrrrr change the exception text
             if (Options.EquipmentSlots.Count == 0)
@@ -809,9 +809,9 @@ namespace Intersect.Client.Entities
                 }
             }
 
-            if (AnimationTimer < Timing.Global.Milliseconds)
+            if (AnimationTimer < Timing.Global.MillisecondsUtc)
             {
-                AnimationTimer = Timing.Global.Milliseconds + 200;
+                AnimationTimer = Timing.Global.MillisecondsUtc + 200;
                 AnimationFrame++;
                 if (AnimationFrame >= SpriteFrames)
                 {
@@ -2046,7 +2046,7 @@ namespace Intersect.Client.Entities
         public void ResetSpriteFrame()
         {
             SpriteFrame = 0;
-            SpriteFrameTimer = Timing.Global.Milliseconds;
+            SpriteFrameTimer = Timing.Global.MillisecondsUtc;
         }
 
         public virtual void LoadTextures(string textureName)

--- a/Intersect.Client/General/Time.cs
+++ b/Intersect.Client/General/Time.cs
@@ -37,14 +37,14 @@ namespace Intersect.Client.General
                 sUpdateTime = Timing.Global.Milliseconds + 1000;
             }
 
-            float ecTime = Timing.Global.Milliseconds - sColorUpdate;
+            float ecTime = Timing.Global.MillisecondsUtc - sColorUpdate;
             var valChange = 255 * ecTime / 10000f;
             sCurrentColor.A = LerpVal(sCurrentColor.A, sTargetColor.A, valChange);
             sCurrentColor.R = LerpVal(sCurrentColor.R, sTargetColor.R, valChange);
             sCurrentColor.G = LerpVal(sCurrentColor.G, sTargetColor.G, valChange);
             sCurrentColor.B = LerpVal(sCurrentColor.B, sTargetColor.B, valChange);
 
-            sColorUpdate = Timing.Global.Milliseconds;
+            sColorUpdate = Timing.Global.MillisecondsUtc;
         }
 
         private static float LerpVal(float val, float target, float amt)

--- a/Intersect.Client/Interface/Game/AnnouncementWindow.cs
+++ b/Intersect.Client/Interface/Game/AnnouncementWindow.cs
@@ -1,6 +1,5 @@
 ﻿using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 
 using Intersect.Utilities;
@@ -57,7 +56,7 @@ namespace Intersect.Client.Interface.Game
                 mLabel.Text = mLabelText;
 
                 // Are we still supposed to be visible?
-                if (Timing.Global.Milliseconds > mDisplayUntil)
+                if (Timing.Global.MillisecondsUtc > mDisplayUntil)
                 {
                     Hide();
                 }
@@ -72,7 +71,7 @@ namespace Intersect.Client.Interface.Game
         public void ShowAnnouncement(string announcementText, long displayTime)
         {
             mLabelText = announcementText;
-            mDisplayUntil = Timing.Global.Milliseconds + displayTime;
+            mDisplayUntil = Timing.Global.MillisecondsUtc + displayTime;
             Show();
         }
 

--- a/Intersect.Client/Interface/Game/AnnouncementWindow.cs
+++ b/Intersect.Client/Interface/Game/AnnouncementWindow.cs
@@ -56,7 +56,7 @@ namespace Intersect.Client.Interface.Game
                 mLabel.Text = mLabelText;
 
                 // Are we still supposed to be visible?
-                if (Timing.Global.MillisecondsUtc > mDisplayUntil)
+                if (Timing.Global.Milliseconds > mDisplayUntil)
                 {
                     Hide();
                 }
@@ -71,7 +71,7 @@ namespace Intersect.Client.Interface.Game
         public void ShowAnnouncement(string announcementText, long displayTime)
         {
             mLabelText = announcementText;
-            mDisplayUntil = Timing.Global.MillisecondsUtc + displayTime;
+            mDisplayUntil = Timing.Global.Milliseconds + displayTime;
             Show();
         }
 

--- a/Intersect.Client/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagItem.cs
@@ -90,7 +90,7 @@ namespace Intersect.Client.Interface.Game.Bag
 
         void pnl_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_HoverLeave(Base sender, EventArgs arguments)
@@ -189,7 +189,7 @@ namespace Intersect.Client.Interface.Game.Bag
                         mCanDrag = true;
                         mMouseX = -1;
                         mMouseY = -1;
-                        if (Timing.Global.Milliseconds < mClickTime)
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
                         {
                             mClickTime = 0;
                         }

--- a/Intersect.Client/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankItem.cs
@@ -93,7 +93,7 @@ namespace Intersect.Client.Interface.Game.Bank
 
         void pnl_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_HoverLeave(Base sender, EventArgs arguments)
@@ -192,7 +192,7 @@ namespace Intersect.Client.Interface.Game.Bank
                         mCanDrag = true;
                         mMouseX = -1;
                         mMouseY = -1;
-                        if (Timing.Global.Milliseconds < mClickTime)
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
                         {
                             //Globals.Me.TryUseItem(_mySlot);
                             mClickTime = 0;

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -215,7 +215,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
             EntityWindow.Hide();
 
-            mLastUpdateTime = Timing.Global.Milliseconds;
+            mLastUpdateTime = Timing.Global.MillisecondsUtc;
         }
 
         public void SetEntity(Entity entity)
@@ -398,7 +398,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             UpdateSpellStatus();
 
             //Time since this window was last updated (for bar animations)
-            var elapsedTime = (Timing.Global.Milliseconds - mLastUpdateTime) / 1000.0f;
+            var elapsedTime = (Timing.Global.MillisecondsUtc - mLastUpdateTime) / 1000.0f;
 
             //Update the event/entity face.
             UpdateImage();
@@ -456,7 +456,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 itm.Value.Update();
             }
 
-            mLastUpdateTime = Timing.Global.Milliseconds;
+            mLastUpdateTime = Timing.Global.MillisecondsUtc;
         }
 
         public void UpdateSpellStatus()

--- a/Intersect.Client/Interface/Game/EventWindow.cs
+++ b/Intersect.Client/Interface/Game/EventWindow.cs
@@ -1,10 +1,7 @@
-using System.Collections.Generic;
 using System.Linq;
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.File_Management;
-using Intersect.Client.Framework.Graphics;
-using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
@@ -284,7 +281,7 @@ namespace Intersect.Client.Interface.Game
                     _writer.Write(ClientConfiguration.Instance.TypewriterSounds.ElementAtOrDefault(voiceIdx));
                     if (_writer.IsDone)
                     {
-                        var disableResponse = Timing.Global.Milliseconds - _writer.DoneAtMilliseconds < _typewriterResponseDelay;
+                        var disableResponse = Timing.Global.MillisecondsUtc - _writer.DoneAtMilliseconds < _typewriterResponseDelay;
                         mEventResponse1.IsDisabled = disableResponse;
                         mEventResponse2.IsDisabled = disableResponse;
                         mEventResponse3.IsDisabled = disableResponse;

--- a/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.GenericClasses;
@@ -137,7 +135,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
 
         void pnl_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_HoverLeave(Base sender, EventArgs arguments)
@@ -473,7 +471,7 @@ namespace Intersect.Client.Interface.Game.Hotbar
                             mCanDrag = true;
                             mMouseX = -1;
                             mMouseY = -1;
-                            if (Timing.Global.Milliseconds < mClickTime)
+                            if (Timing.Global.MillisecondsUtc < mClickTime)
                             {
                                 Activate();
                                 mClickTime = 0;

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -9,7 +9,6 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Localization;
-using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Utilities;
@@ -115,7 +114,7 @@ namespace Intersect.Client.Interface.Game.Inventory
 
         void pnl_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
@@ -355,7 +354,7 @@ namespace Intersect.Client.Interface.Game.Inventory
                         mCanDrag = true;
                         mMouseX = -1;
                         mMouseY = -1;
-                        if (Timing.Global.Milliseconds < mClickTime)
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
                         {
                             mClickTime = 0;
                         }

--- a/Intersect.Client/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellItem.cs
@@ -8,7 +8,6 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Localization;
-using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Utilities;
@@ -78,7 +77,7 @@ namespace Intersect.Client.Interface.Game.Spells
 
         void pnl_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
@@ -224,7 +223,7 @@ namespace Intersect.Client.Interface.Game.Spells
                         mCanDrag = true;
                         mMouseX = -1;
                         mMouseY = -1;
-                        if (Timing.Global.Milliseconds < mClickTime)
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
                         {
                             mClickTime = 0;
                         }

--- a/Intersect.Client/Interface/Game/Trades/TradeItem.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradeItem.cs
@@ -110,7 +110,7 @@ namespace Intersect.Client.Interface.Game.Trades
                 return;
             }
 
-            mClickTime = Timing.Global.Milliseconds + 500;
+            mClickTime = Timing.Global.MillisecondsUtc + 500;
         }
 
         void pnl_HoverLeave(Base sender, EventArgs arguments)
@@ -214,7 +214,7 @@ namespace Intersect.Client.Interface.Game.Trades
 
                         mMouseX = -1;
                         mMouseY = -1;
-                        if (Timing.Global.Milliseconds < mClickTime)
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
                         {
                             mClickTime = 0;
                         }

--- a/Intersect.Client/Interface/Game/Typewriting/Typewriter.cs
+++ b/Intersect.Client/Interface/Game/Typewriting/Typewriter.cs
@@ -28,7 +28,7 @@ namespace Intersect.Client.Interface.Game.Typewriting
 
         public void Initialize(List<Label> labels)
         {
-            _nextUpdateTime = Timing.Global.Milliseconds;
+            _nextUpdateTime = Timing.Global.MillisecondsUtc;
             _labels = labels;
             _lines = _labels.Select(l => l.Text).ToArray();
             _labels.ForEach(l =>
@@ -66,7 +66,7 @@ namespace Intersect.Client.Interface.Game.Typewriting
                 return;
             }
 
-            if (Timing.Global.Milliseconds < _nextUpdateTime)
+            if (Timing.Global.MillisecondsUtc < _nextUpdateTime)
             {
                 return;
             }
@@ -91,7 +91,7 @@ namespace Intersect.Client.Interface.Game.Typewriting
             var written = currentLine.Substring(0, _charIndex);
             _labels[_lineIndex].SetText(written);
 
-            _nextUpdateTime = Timing.Global.Milliseconds + GetTypingDelayFor(currentLine[_charIndex], _lastChar);
+            _nextUpdateTime = Timing.Global.MillisecondsUtc + GetTypingDelayFor(currentLine[_charIndex], _lastChar);
         }
 
         private static long GetTypingDelayFor(char currentChar, char? lastChar)
@@ -139,7 +139,7 @@ namespace Intersect.Client.Interface.Game.Typewriting
             }
 
             IsDone = true;
-            DoneAtMilliseconds = Timing.Global.Milliseconds;
+            DoneAtMilliseconds = Timing.Global.MillisecondsUtc;
         }
     }
 }

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -12,7 +12,6 @@ using Intersect.Client.General;
 using Intersect.Client.Interface.Game;
 using Intersect.Client.Interface.Menu;
 using Intersect.Client.Localization;
-using Intersect.Logging;
 using Intersect.Utilities;
 using static Intersect.Client.Framework.File_Management.GameContentManager;
 
@@ -656,7 +655,7 @@ namespace Intersect.Client.Interface.Shared
         {
             if (mSettingsPanel.IsVisible &&
                 mKeybindingEditBtn != null &&
-                mKeybindingListeningTimer < Timing.Global.Milliseconds)
+                mKeybindingListeningTimer < Timing.Global.MillisecondsUtc)
             {
                 OnKeyUp(Keys.None, Keys.None);
             }
@@ -828,7 +827,7 @@ namespace Intersect.Client.Interface.Shared
                 mKeybindingEditControl = ((KeyValuePair<Control, int>)sender.UserData).Key;
                 mKeybindingEditBtn = sender;
                 Interface.GwenInput.HandleInput = false;
-                mKeybindingListeningTimer = Timing.Global.Milliseconds + 3000;
+                mKeybindingListeningTimer = Timing.Global.MillisecondsUtc + 3000;
             }
         }
 

--- a/Intersect.Client/Maps/ActionMessage.cs
+++ b/Intersect.Client/Maps/ActionMessage.cs
@@ -30,12 +30,12 @@ namespace Intersect.Client.Maps
             Msg = message;
             Color = color;
             XOffset = Globals.Random.Next(-30, 30); //+- 16 pixels so action msg's don't overlap!
-            TransmissionTimer = Timing.Global.Milliseconds + 1000;
+            TransmissionTimer = Timing.Global.MillisecondsUtc + 1000;
         }
 
         public void TryRemove()
         {
-            if (TransmissionTimer <= Timing.Global.Milliseconds)
+            if (TransmissionTimer <= Timing.Global.MillisecondsUtc)
             {
                 (Map as MapInstance).ActionMessages.Remove(this);
             }

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -1024,8 +1024,8 @@ namespace Intersect.Client.Maps
 
             // Calculate elapsed time since the last update and set maximum value for elapsedTime to
             // prevent large jumps in fog intensity (1 second maximum).
-            float elapsedTime = Math.Min(Timing.Global.Milliseconds - mFogUpdateTime, 1000);
-            mFogUpdateTime = Timing.Global.Milliseconds;
+            float elapsedTime = Math.Min(Timing.Global.MillisecondsUtc - mFogUpdateTime, 1000);
+            mFogUpdateTime = Timing.Global.MillisecondsUtc;
 
             // Update fog intensity based on whether the player is on the current map or not.
             mCurFogIntensity = Id == Globals.Me.MapId
@@ -1083,7 +1083,7 @@ namespace Intersect.Client.Maps
 
             if ((WeatherXSpeed != 0 || WeatherYSpeed != 0) && Globals.Me.MapInstance == this)
             {
-                if (Timing.Global.Milliseconds > _weatherParticleSpawnTime)
+                if (Timing.Global.MillisecondsUtc > _weatherParticleSpawnTime)
                 {
                     _weatherParticles.Add(new WeatherParticle(_removeParticles, WeatherXSpeed, WeatherYSpeed, anim));
                     var spawnTime = 25 + (int)(475 * (1f - WeatherIntensity / 100f));
@@ -1091,7 +1091,7 @@ namespace Intersect.Client.Maps
                                        (480000f /
                                         (Graphics.Renderer.GetScreenWidth() * Graphics.Renderer.GetScreenHeight())));
 
-                    _weatherParticleSpawnTime = Timing.Global.Milliseconds + spawnTime;
+                    _weatherParticleSpawnTime = Timing.Global.MillisecondsUtc + spawnTime;
                 }
             }
 
@@ -1127,8 +1127,8 @@ namespace Intersect.Client.Maps
 
         public void DrawPanorama()
         {
-            float ecTime = Timing.Global.Milliseconds - mPanoramaUpdateTime;
-            mPanoramaUpdateTime = Timing.Global.Milliseconds;
+            float ecTime = Timing.Global.MillisecondsUtc - mPanoramaUpdateTime;
+            mPanoramaUpdateTime = Timing.Global.MillisecondsUtc;
             if (Id == Globals.Me.MapId)
             {
                 if (mPanoramaIntensity != 1)
@@ -1161,8 +1161,8 @@ namespace Intersect.Client.Maps
 
         public void DrawOverlayGraphic()
         {
-            float ecTime = Timing.Global.Milliseconds - mOverlayUpdateTime;
-            mOverlayUpdateTime = Timing.Global.Milliseconds;
+            float ecTime = Timing.Global.MillisecondsUtc - mOverlayUpdateTime;
+            mOverlayUpdateTime = Timing.Global.MillisecondsUtc;
             if (Id == Globals.Me.MapId)
             {
                 if (mOverlayIntensity != 1)
@@ -1260,7 +1260,7 @@ namespace Intersect.Client.Maps
                     ActionMessages[n].Y * Options.TileHeight -
                     Options.TileHeight *
                     2 *
-                    (1000 - (ActionMessages[n].TransmissionTimer - Timing.Global.Milliseconds)) /
+                    (1000 - (ActionMessages[n].TransmissionTimer - Timing.Global.MillisecondsUtc)) /
                     1000
                 );
 

--- a/Intersect.Client/Maps/WeatherParticle.cs
+++ b/Intersect.Client/Maps/WeatherParticle.cs
@@ -43,7 +43,7 @@ namespace Intersect.Client.Maps
 
         public WeatherParticle(List<IWeatherParticle> RemoveParticle, int xvelocity, int yvelocity, AnimationBase anim)
         {
-            TransmittionTimer = Timing.Global.Milliseconds;
+            TransmittionTimer = Timing.Global.MillisecondsUtc;
             bounds = new Rectangle(0, 0, Graphics.Renderer.GetScreenWidth(), Graphics.Renderer.GetScreenHeight());
 
             xVelocity = xvelocity;
@@ -140,7 +140,7 @@ namespace Intersect.Client.Maps
             }
             else
             {
-                var timeScale = (Timing.Global.Milliseconds - TransmittionTimer) / 10f;
+                var timeScale = (Timing.Global.MillisecondsUtc - TransmittionTimer) / 10f;
                 X = originalX + xVelocity * timeScale;
                 Y = originalY + yVelocity * timeScale;
                 animInstance.SetPosition(cameraSpawnX + X, cameraSpawnY + Y, -1, -1, Guid.Empty, Direction.None, 0);

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -203,7 +203,7 @@ namespace Intersect.Client.MonoGame.Graphics
             mOldDisplayMode = currentDisplayMode;
             if (fsChanged)
             {
-                mFsChangedTimer = Timing.Global.Milliseconds + 1000;
+                mFsChangedTimer = Timing.Global.MillisecondsUtc + 1000;
             }
 
             if (fsChanged)
@@ -222,7 +222,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public override bool Begin()
         {
-            if (mFsChangedTimer > -1 && mFsChangedTimer < Timing.Global.Milliseconds)
+            if (mFsChangedTimer > -1 && mFsChangedTimer < Timing.Global.MillisecondsUtc)
             {
                 mGraphics.PreferredBackBufferWidth--;
                 mGraphics.ApplyChanges();
@@ -685,11 +685,11 @@ namespace Intersect.Client.MonoGame.Graphics
         {
             EndSpriteBatch();
             mFpsCount++;
-            if (mFpsTimer < Timing.Global.Milliseconds)
+            if (mFpsTimer < Timing.Global.MillisecondsUtc)
             {
                 mFps = mFpsCount;
                 mFpsCount = 0;
-                mFpsTimer = Timing.Global.Milliseconds + 1000;
+                mFpsTimer = Timing.Global.MillisecondsUtc + 1000;
                 mGameWindow.Title = Strings.Main.gamename;
             }
 

--- a/Intersect.Client/MonoGame/Graphics/MonoTexture.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoTexture.cs
@@ -152,7 +152,7 @@ namespace Intersect.Client.MonoGame.Graphics
 
         public void ResetAccessTime()
         {
-            mLastAccessTime = Timing.Global.Milliseconds + 15000;
+            mLastAccessTime = Timing.Global.MillisecondsUtc + 15000;
         }
 
         public override string GetName()
@@ -268,7 +268,7 @@ namespace Intersect.Client.MonoGame.Graphics
                 return;
             }
 
-            if (mLastAccessTime >= Timing.Global.Milliseconds)
+            if (mLastAccessTime >= Timing.Global.MillisecondsUtc)
             {
                 return;
             }


### PR DESCRIPTION
### Potentially fixes the following:
- If the server is started while the client is already open while in the main menu, the animated background (if there's any) abruptly stops as the client detects the server's status changing from offline to online due to time synchronization issues, this can rely on MillisecondsUtc, which avoid this unintended behavior.
- Similar issue happens with the day/time/hue color cycles in game, we don't need to sync the clients to Milliseconds (sColorUpdate), MillisecondsUtc is the way.
- Hopefully fixes a reported issue where weather suddenly "stops" falling in some maps [(?) (need more testing - unable to reproduce yet).](https://github.com/AscensionGameDev/Intersect-Engine/issues/1725)

### As overall, the following can rely on MillisecondsUtc (client's local timing)
Without having to worry about server timing synchronization (+ potentially avoids issues): 
- Animations (intro/world/auto.tiles/entities)
- Audio
- Critters
- Basic interface elements such as click timers, context menus, typewriter, inventory, settings, chat box, etc.
- Graphic effects such as fading, fog, weather and rendering in general.

### Timing.Global.Milliseconds is still used for things that require timing synchronization:
- ServerTime timing update.
- Player input.
- Mobility.
- Attack, cast, shield and projectile handlers.
- Networking handlers.


From discord:

![imagen](https://user-images.githubusercontent.com/17498701/234091779-22d41732-7d7d-40fb-a7f1-c0cf3f5a338d.png)


To consider (not part of this PR but is quite do-able - to be discussed (?) ):

![imagen](https://user-images.githubusercontent.com/17498701/234091922-214b28b2-d3a0-4945-b960-b6860fe319ed.png)
