### PR TITLE
enhancement: chat log tools

### DIFF
--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -12,6 +12,8 @@ namespace Intersect.Client.Framework.Database
 
         public bool HideOthersOnWindowOpen { get; set; }
 
+        public bool AutoToggleChatLog { get; set; }
+
         public bool TargetAccountDirection { get; set; }
 
         public int MusicVolume { get; set; }
@@ -106,6 +108,7 @@ namespace Intersect.Client.Framework.Database
             FullScreen = LoadPreference(nameof(FullScreen), false);
             EnableLighting = LoadPreference(nameof(EnableLighting), true);
             HideOthersOnWindowOpen = LoadPreference(nameof(HideOthersOnWindowOpen), true);
+            AutoToggleChatLog = LoadPreference(nameof(AutoToggleChatLog), false);
             TargetAccountDirection = LoadPreference(nameof(TargetAccountDirection), false);
             StickyTarget = LoadPreference(nameof(StickyTarget), false);
             AutoTurnToTarget = LoadPreference(nameof(AutoTurnToTarget), false);
@@ -139,6 +142,7 @@ namespace Intersect.Client.Framework.Database
             SavePreference(nameof(FullScreen), FullScreen);
             SavePreference(nameof(EnableLighting), EnableLighting);
             SavePreference(nameof(HideOthersOnWindowOpen), HideOthersOnWindowOpen);
+            SavePreference(nameof(AutoToggleChatLog), AutoToggleChatLog);
             SavePreference(nameof(TargetAccountDirection), TargetAccountDirection);
             SavePreference(nameof(StickyTarget), StickyTarget);
             SavePreference(nameof(AutoTurnToTarget), AutoTurnToTarget);

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -56,6 +56,8 @@ namespace Intersect.Client.Interface.Shared
 
         private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
 
+        private readonly LabeledCheckBox mAutoToggleChatLogCheckbox;
+
         private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
 
         private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
@@ -194,6 +196,10 @@ namespace Intersect.Client.Interface.Shared
             // Game Settings - Interface: Auto-close Windows.
             mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
             mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
+
+            // Game Settings - Interface: Auto-toggle chat log visibility.
+            mAutoToggleChatLogCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoToggleChatLogCheckbox");
+            mAutoToggleChatLogCheckbox.Text = Strings.Settings.AutoToggleChatLog;
 
             // Game Settings - Interface: Show EXP/HP/MP as Percentage.
             mShowExperienceAsPercentageCheckbox =
@@ -671,6 +677,7 @@ namespace Intersect.Client.Interface.Shared
 
             // Game Settings.
             mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
+            mAutoToggleChatLogCheckbox.IsChecked = Globals.Database.AutoToggleChatLog;
             mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
             mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
             mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
@@ -851,6 +858,7 @@ namespace Intersect.Client.Interface.Shared
 
             // Game Settings.
             Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
+            Globals.Database.AutoToggleChatLog = mAutoToggleChatLogCheckbox.IsChecked;
             Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
             Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
             Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -605,6 +605,10 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString toofast = @"You are chatting too fast!";
 
+            public static LocalizedString ToggleLogButtonToolTip = @"Toggle chat log visibility";
+            
+            public static LocalizedString ClearLogButtonToolTip = @"Clear chat log messages";
+
             public static Dictionary<ChatboxTab, LocalizedString> ChatTabButtons = new Dictionary<Enums.ChatboxTab, LocalizedString>() {
                 { ChatboxTab.All, @"All" },
                 { ChatboxTab.Local, @"Local" },
@@ -1706,6 +1710,9 @@ namespace Intersect.Client.Localization
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString AutoCloseWindows = @"Auto-close Windows";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString AutoToggleChatLog = @"Auto-toggle chat log visibility";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Cancel = @"Cancel";


### PR DESCRIPTION
### Chat log tools  :wrench: ! 

- This QoL update adds a handy way to show/hide the chat log by pressing a button. :see_no_evil:
- You may also optionally allow it (via game settings) to auto-show the chat log when pressing enter to chat or auto-hide it when pressing esc to un-focus the chat box.
- This QoL update also adds the ability to clear the entire chat log by pressing a button.
- Chore: fixed some code typos in Chatbox.cs
- Chore (GetDefaultInputText): removed unnecessary "else" keywords, these conditions already *return* by their own.
- Fix (GetDefaultInputText): properly uses the previously unused localized string "Chatbox.enterchat2" - this is used for whenever the user has two configured keys for chatting.
- Should address _at some degree_ the reported issues of #1684

### [Assets Pull Request with the required resources](https://github.com/AscensionGameDev/Intersect-Assets/pull/41)

### Preview:

https://user-images.githubusercontent.com/17498701/235386660-be68b1b8-5e32-4e47-a599-8100abdf6fc9.mp4

![imagen](https://user-images.githubusercontent.com/17498701/235388589-5b25489f-e498-483f-ae8f-f37d5a88ad01.png) ![imagen](https://user-images.githubusercontent.com/17498701/235388598-7c145116-241e-4825-beb1-acb8662e3ba2.png)

![imagen](https://user-images.githubusercontent.com/17498701/235388612-b435be0a-27d0-454d-bcaf-7851ca487353.png)

![imagen](https://user-images.githubusercontent.com/17498701/235388660-ad4f7682-c3ea-403f-8137-103f42ab444c.png)




