### PR TITLE
fix: adds missing update for paperdoll direction order

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -2150,6 +2150,7 @@ namespace Intersect.Client.Entities
                 {
                     Dir = MoveDir;
                     PacketSender.SendDirection(Dir);
+                    PickLastDirection(Dir);
                 }
 
                 if (blockedBy != null && mLastBumpedEvent != blockedBy && blockedBy is Event)


### PR DESCRIPTION
- Adds a missing update for paperdoll direction order by calling PickLastDirection when players attempt to move but they are unable to and/or collide into blocked paths.
- Should resolve #1799


https://user-images.githubusercontent.com/17498701/235956869-8c395e6c-50a7-4434-8b18-6d6640ca6b2a.mp4

