### PR TITLE
fix: swap between "cast" and "learn" spell option

### DIFF
--- a/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
@@ -83,7 +83,9 @@ namespace Intersect.Client.Interface.Game.Inventory
             {
                 case Enums.ItemType.Spell:
                     mContextMenu.AddChild(mUseItemContextItem);
-                    mUseItemContextItem.SetText(Strings.ItemContextMenu.Learn.ToString(item.Name));
+                    mUseItemContextItem.SetText(item.QuickCast
+                        ? Strings.ItemContextMenu.Cast.ToString(item.Name)
+                        : Strings.ItemContextMenu.Learn.ToString(item.Name));
                     break;
 
                 case Enums.ItemType.Event:

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1186,6 +1186,9 @@ namespace Intersect.Client.Localization
             public static LocalizedString Learn = @"Learn {00}";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Cast = @"Cast {00}";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Drop = @"Drop {00}";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
Should resolve #1803 which reports an issue within InventoryWindow.cs and it's context menu: "learn x spell" was hardcoded as string for context menu options of spell items without making the distinction between cast-able spells and learnable spells. This commit changes the method so it makes the distinction in place in order to have the expected behavior.


### Issue (before):

![imagen](https://user-images.githubusercontent.com/17498701/236637559-5f0d4f28-4ad1-467f-8486-de2d364f4fbf.png) ![imagen](https://user-images.githubusercontent.com/17498701/236637742-56d67188-3c4d-487e-a1fd-551e28e4a602.png)


### After (this PR - Fix):

![imagen](https://user-images.githubusercontent.com/17498701/236637559-5f0d4f28-4ad1-467f-8486-de2d364f4fbf.png) ![imagen](https://user-images.githubusercontent.com/17498701/236637728-74745606-02b8-4508-bf85-5a92865edcf8.png)

![imagen](https://user-images.githubusercontent.com/17498701/236637526-05d82b89-2698-4f2c-b9e5-08fb018ea625.png) ![imagen](https://user-images.githubusercontent.com/17498701/236637716-59a7f788-e976-4d72-b7dd-55e2d0174a26.png)

