### PR TITLE
fix: LoadAnimationTexture, Sprite and TransformedSprite

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -75,7 +75,7 @@ namespace Intersect.Client.Entities
                 }
 
                 _equipment = value;
-                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Weapon);
+                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Weapon);
             }
         }
 
@@ -171,7 +171,7 @@ namespace Intersect.Client.Entities
                 }
 
                 _spellCast = value;
-                LoadAnimationTexture(TransformedSprite ?? Sprite, SpriteAnimations.Cast);
+                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Cast);
             }
         }
 

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -45,7 +45,7 @@ namespace Intersect.Client.Entities
                 }
 
                 _class = value;
-                LoadAnimationTexture(Sprite ?? TransformedSprite, SpriteAnimations.Attack);
+                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Attack);
             }
         }
 


### PR DESCRIPTION
- Previous attempt to fix #1649 by swapping `Sprite ?? TransformedSprite` for `TransformedSprite ?? Sprite` at SpellCast specifically was a total mess as it broke Weylon's custom animation override for casting. So, after some testing and code reading, i've concluded that replacing these with `string.IsNullOrEmpty(TransformedSprite) ? Sprite : TransformedSprite` is instead, the good way to go, this fixes the originally reported issues at #1649 while maintaining the original behavior for non-transformed entities.
- Should resolve #1806 