### PR TITLE
fix: fully reset SpriteFrameTimer within ResetSpriteFrame

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -2046,7 +2046,7 @@ namespace Intersect.Client.Entities
         public void ResetSpriteFrame()
         {
             SpriteFrame = 0;
-            SpriteFrameTimer = Timing.Global.MillisecondsUtc;
+            SpriteFrameTimer = 0;
         }
 
         public virtual void LoadTextures(string textureName)


### PR DESCRIPTION
- I've previously changed this variable set from Timing.Global.Milliseconds to Timing.Global.MillisecondsUtc (https://github.com/AscensionGameDev/Intersect-Engine/pull/1792), right now this is doing some funky stuff to the idle animations, i was about to restore this change but after seeing the way that SpriteFrameTimer is used like and how it's it's already synchronized at L:2041, i've concluded that we simply need to "reset" it down to 0 (which is always going to be < timingMilliseconds) and that we don't really need to call the timer for it when resetting the sprite frame. After doing so, the animation flow for idle was restored to normal.
- should resolve #1808 