### PR TITLE
don't target dead NPCs

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1415,16 +1415,22 @@ namespace Intersect.Client.Entities
                 return;
             }
 
-            if (mlastTargetList.ContainsKey(currentEntity))
+            Globals.Entities.TryGetValue(currentEntity.Id, out var targetedEntity);
+            if(targetedEntity == default)
             {
-                mlastTargetList[currentEntity].LastTimeSelected = Timing.Global.Milliseconds;
+                return;
             }
-            mLastEntitySelected = currentEntity as Entity;
 
-            if (TargetIndex != currentEntity.Id)
+            if (mlastTargetList.ContainsKey(targetedEntity))
             {
-                SetTargetBox(currentEntity as Entity);
-                TargetIndex = currentEntity.Id;
+                mlastTargetList[targetedEntity].LastTimeSelected = Timing.Global.Milliseconds;
+            }
+            mLastEntitySelected = targetedEntity;
+
+            if (TargetIndex != targetedEntity.Id)
+            {
+                SetTargetBox(targetedEntity);
+                TargetIndex = targetedEntity.Id;
                 TargetType = 0;
             }
         }


### PR DESCRIPTION
Resolves #1730
Simple fix, after the entity was selected, there was no check if the selected entity existed within the list of entities, so the select happened, and the update cleared it. I put the same check as the update, before selecting the entity.