### PR TITLE
fix: correctly removes currency amount inShop

### DIFF
--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3520,13 +3520,13 @@ namespace Intersect.Server.Entities
         {
             if (InShop == default)
             {
-                PacketSender.SendChatMsg(this, Strings.Shops.error, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
                 return;
             }
 
             if (slot < 0 || slot >= InShop.SellingItems.Count)
             {
-                PacketSender.SendChatMsg(this, Strings.Shops.error, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
                 return;
             }
 
@@ -3534,14 +3534,14 @@ namespace Intersect.Server.Entities
             var boughtItemBase = ItemBase.Get(boughtItem.ItemId);
             if (boughtItemBase == default)
             {
-                PacketSender.SendChatMsg(this, Strings.Shops.error, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
                 return;
             }
 
             var currencyBase = ItemBase.Get(boughtItem.CostItemId);
             if (currencyBase == default)
             {
-                PacketSender.SendChatMsg(this, Strings.Shops.error, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
                 return;
             }
 
@@ -3602,7 +3602,7 @@ namespace Intersect.Server.Entities
                     TryGiveItem(removedItem.Key, removedItem.Value);
                 }
 
-                PacketSender.SendChatMsg(this, Strings.Shops.error, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+                PacketSender.SendChatMsg(this, Strings.Shops.TransactionFailed, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
                 return;
             }
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3565,7 +3565,7 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            bool sucess = true;
+            bool success = true;
             Dictionary<Guid, int> removedItems = new Dictionary<Guid, int>();
 
             if (itemCostTotal > 0)
@@ -3578,7 +3578,7 @@ namespace Intersect.Server.Entities
                     int quantityToRemove = Math.Min(remainingCost, itemSlot.Quantity);
                     if(!TryTakeItem(itemSlot, quantityToRemove))
                     {
-                        sucess = false;
+                        success = false;
                         Log.Warn(Strings.Shops.FailedRemovedItem.ToString(itemSlot, Id, quantityToRemove, "BuyItem(int slot, int amount)"));
                         break;
                     }
@@ -3594,7 +3594,7 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if(!sucess)
+            if(!success)
             {
                 //return all removed items because we failed to remove the rest
                 foreach (var removedItem in removedItems)

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -3559,36 +3559,34 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            if (CanGiveItem(boughtItemBase.Id, boughtItemAmount))
-            {
-                if (itemCostTotal > 0)
-                {
-                    var currencySlots = FindInventoryItemSlots(currencyBase.Id);
-                    int remainingCost = itemCostTotal;
-
-                    foreach (var itemSlot in currencySlots)
-                    {
-                        int quantityToRemove = Math.Min(remainingCost, itemSlot.Quantity);
-                        TryTakeItem(itemSlot.ItemId, quantityToRemove);
-                        remainingCost -= quantityToRemove;
-
-                        if (remainingCost <= 0)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                TryGiveItem(boughtItemBase.Id, boughtItemAmount);
-
-                if (!TextUtils.IsNone(InShop.BuySound))
-                {
-                    PacketSender.SendPlaySound(this, InShop.BuySound);
-                }
-            }
-            else
+            if (!CanGiveItem(boughtItemBase.Id, boughtItemAmount))
             {
                 PacketSender.SendChatMsg(this, Strings.Shops.inventoryfull, ChatMessageType.Inventory, CustomColors.Alerts.Error, Name);
+            }
+
+            if (itemCostTotal > 0)
+            {
+                var currencySlots = FindInventoryItemSlots(currencyBase.Id);
+                int remainingCost = itemCostTotal;
+
+                foreach (var itemSlot in currencySlots)
+                {
+                    int quantityToRemove = Math.Min(remainingCost, itemSlot.Quantity);
+                    TryTakeItem(itemSlot.ItemId, quantityToRemove);
+                    remainingCost -= quantityToRemove;
+
+                    if (remainingCost <= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            TryGiveItem(boughtItemBase.Id, boughtItemAmount);
+
+            if (!TextUtils.IsNone(InShop.BuySound))
+            {
+                PacketSender.SendPlaySound(this, InShop.BuySound);
             }
         }
 

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -1357,6 +1357,9 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString bound = @"This item is bound to you and cannot be sold!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString error = @"Transaction failed!";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString cantafford = @"Transaction failed due to insufficent funds.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -1368,6 +1368,12 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString inventoryfull = @"You do not have space to purchase that item!";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString SuccessfullyRemovedItem = @"Successfully took {00} items from slot {01} for player {02} at {03}";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString FailedRemovedItem = @"Failed to take items from slot {00} for player {01}. Quantity to remove: {02} at {03}";
+
         }
 
         public sealed partial class TradingNamespace : LocaleNamespace

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -1357,7 +1357,7 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString bound = @"This item is bound to you and cannot be sold!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public readonly LocalizedString error = @"Transaction failed!";
+            public readonly LocalizedString TransactionFailed = @"Transaction failed!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString cantafford = @"Transaction failed due to insufficent funds.";


### PR DESCRIPTION
resolves #1727 

Full refactoring of the server BuyItem method.

- Now the server says to client if there is no space in the inventory and won't let you buy (resolving the bug)
- Added bug checks if buy or sell item is null
- Correctly removes the amount of currency-item from the player
  - If the currency-item was not stockable (don't ask me why a currency-item would be non-stockable), the FindInventoryItemSlot methods only look for the first slot with the desired amount, I improved the search to remove the desired amount from all slots, regardless of whether it is stockable or not, in addition to using a better method to know the amount of items that the player has.

Note: Selling items is buggy the same way buying items was, when playing with inventory limits, my next pr will be to refactor the method of selling items, I'll keep the scope of this pr just about buying, so don't be alarmed when selling items and your items disappear and you don't receive the purchased item.