### PR TITLE
fix #1848 - map events not being deleted when the parent maps are removed

### DIFF
--- a/Intersect.Server/Database/DbInterface.cs
+++ b/Intersect.Server/Database/DbInterface.cs
@@ -1049,6 +1049,15 @@ namespace Intersect.Server.Database
 
                             break;
                         case GameObjectType.Map:
+                            //Delete all map events first
+                            foreach (var evtId in ((MapController)gameObject).EventIds)
+                            {
+                                var evt = EventBase.Get(evtId);
+                                if (evt != null)
+                                {
+                                    DeleteGameObject(evt);
+                                }
+                            }
                             context.Maps.Remove((MapController)gameObject);
                             MapController.Lookup.Delete(gameObject);
 

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -3347,11 +3347,12 @@ namespace Intersect.Server.Networking
 
                         lock (ServerContext.Instance.LogicService.LogicLock)
                         {
+                            var map = MapController.Get(mapId);
                             ServerContext.Instance.LogicService.LogicPool.WaitForIdle();
                             mapId = packet.TargetId;
-                            var players = MapController.Get(mapId).GetPlayersOnAllInstances();
+                            var players = map.GetPlayersOnAllInstances();
                             MapList.List.DeleteMap(mapId);
-                            DbInterface.DeleteGameObject(MapController.Get(mapId));
+                            DbInterface.DeleteGameObject(map);
                             DbInterface.GenerateMapGrids();
                             PacketSender.SendMapListToAll();
                             foreach (var plyr in players)


### PR DESCRIPTION
Minor cleanup and logic update to delete map events when maps are removed from the db

Untested. Someone should verify before we merge.