### PR TITLE
feat: toggle fullscreen key

### DIFF
--- a/Intersect.Client/Core/Controls/ControlEnum.cs
+++ b/Intersect.Client/Core/Controls/ControlEnum.cs
@@ -78,6 +78,8 @@
 
         HoldToZoomOut,
 
+        ToggleFullscreen,
+
     }
 
 }

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -92,13 +92,13 @@ namespace Intersect.Client.Core.Controls
             CreateControlMap(Control.OpenSettings, new ControlValue(Keys.None, Keys.O), ControlValue.Default);
             CreateControlMap(Control.OpenDebugger, new ControlValue(Keys.None, Keys.F2), ControlValue.Default);
             CreateControlMap(Control.OpenAdminPanel, new ControlValue(Keys.None, Keys.Insert), ControlValue.Default);
-            CreateControlMap(Control.ToggleGui, new ControlValue(Keys.Shift, Keys.F11), ControlValue.Default);
+            CreateControlMap(Control.ToggleGui, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
             CreateControlMap(Control.TurnAround, new ControlValue(Keys.None, Keys.Control), ControlValue.Default);
             CreateControlMap(Control.ToggleZoomIn, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.ToggleZoomOut, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.HoldToZoomIn, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.HoldToZoomOut, ControlValue.Default, ControlValue.Default);
-            CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
+            CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.Alt, Keys.Enter), ControlValue.Default);
         }
 
         private static void MigrateControlBindings(Control control)

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -92,12 +92,13 @@ namespace Intersect.Client.Core.Controls
             CreateControlMap(Control.OpenSettings, new ControlValue(Keys.None, Keys.O), ControlValue.Default);
             CreateControlMap(Control.OpenDebugger, new ControlValue(Keys.None, Keys.F2), ControlValue.Default);
             CreateControlMap(Control.OpenAdminPanel, new ControlValue(Keys.None, Keys.Insert), ControlValue.Default);
-            CreateControlMap(Control.ToggleGui, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
+            CreateControlMap(Control.ToggleGui, new ControlValue(Keys.Shift, Keys.F11), ControlValue.Default);
             CreateControlMap(Control.TurnAround, new ControlValue(Keys.None, Keys.Control), ControlValue.Default);
             CreateControlMap(Control.ToggleZoomIn, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.ToggleZoomOut, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.HoldToZoomIn, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.HoldToZoomOut, ControlValue.Default, ControlValue.Default);
+            CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
         }
 
         private static void MigrateControlBindings(Control control)

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -2,6 +2,7 @@ using System;
 using Intersect.Admin.Actions;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.GenericClasses;
+using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface;
@@ -173,6 +174,15 @@ namespace Intersect.Client.Core
                             case Control.ToggleZoomOut:
                             {
                                 HandleZoomOut();
+                                break;
+                            }
+
+                            case Control.ToggleFullscreen:
+                            {
+                                Globals.Database.FullScreen = !Globals.Database.FullScreen;
+                                Globals.Database.SavePreferences();
+                                Graphics.Renderer.OverrideResolution = Resolution.Empty;
+                                Graphics.Renderer.Init();
                                 break;
                             }
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -724,6 +724,7 @@ namespace Intersect.Client.Localization
                 {"holdtozoomin", "Hold to Zoom In:"},
                 {"togglezoomout", "Toggle Zoom Out:"},
                 {"holdtozoomout", "Hold to Zoom Out:"},
+                {"togglefullscreen", "Toggle Fullscreen:"},
             };
 
             public static LocalizedString listening = @"Listening";

--- a/Intersect.Client/MonoGame/Input/MonoInput.cs
+++ b/Intersect.Client/MonoGame/Input/MonoInput.cs
@@ -284,11 +284,10 @@ namespace Intersect.Client.MonoGame.Input
                 modifier = Keys.Shift;
             }
 
-            // TODO: Make Alt function? For some reason MonoGame / XNA seems to just not capture the alt key properly. GWEN manages to capture it but the game does not?
-            //if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightAlt))
-            //{
-            //    modifier = Keys.Alt;
-            //}
+            if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftAlt) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightAlt))
+            {
+                modifier = Keys.Alt;
+            }
 
             return modifier;
         }


### PR DESCRIPTION
Resolves #1868 
Assets: AscensionGameDev/Intersect-Assets#43

Re-enables Alt keybinds, not sure why it was ever disabled. It works on Linux at the very least :shrug: 

Default fullscreen keybind is Alt+Enter
- many browsers use F11, but we already have this for ToggleGui
- many games use Alt+Enter, so I went with this