### PR TITLE
fix: (Day) Enforce TLS 1.2 when sending emails for recovery

### DIFF
--- a/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
+++ b/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
@@ -126,6 +126,7 @@ namespace Intersect.Client.Interface.Menu
         void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
         {
             Hide();
+            Globals.WaitingOnServer = false;
             Interface.MenuUi.MainMenu.NotifyOpenLogin();
         }
 

--- a/Intersect.Server/Notifications/Notification.cs
+++ b/Intersect.Server/Notifications/Notification.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Mail;
@@ -40,6 +40,14 @@ namespace Intersect.Server.Notifications
                         //Send the email
                         var fromAddress = new MailAddress(Options.Smtp.FromAddress, Options.Smtp.FromName);
                         var toAddress = new MailAddress(ToAddress);
+
+                        var securityProtocol = (int)System.Net.ServicePointManager.SecurityProtocol;
+
+                        // 0 = SystemDefault in .NET 4.7+
+                        if (securityProtocol != 0)
+                        {
+                            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                        }
 
                         var smtp = new SmtpClient
                         {


### PR DESCRIPTION
Fixes #1890 