### PR TITLE
fix: smtp emails not sending using tls 1.2 in mono runtime environments

### DIFF
--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -83,6 +83,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MailKit" Version="4.2.0" />
     <PackageReference Include="Markdown" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNet.Cors" Version="5.2.9" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />


### PR DESCRIPTION
Fixes #1890 