### PR TITLE
fix: entityExperienceToNextLevel as Long within EntityBox 

### DIFF
--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -801,7 +801,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             float targetExpSize;
             var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.VitalCount];
             var barPercentageSetting = Globals.Database.ShowExperienceAsPercentage;
-            var entityExperienceToNextLevel = (float)((Player)MyEntity).GetNextLevelExperience();
+            var entityExperienceToNextLevel = ((Player)MyEntity).GetNextLevelExperience();
 
             if (entityExperienceToNextLevel > 0)
             {


### PR DESCRIPTION
Should resolve #1898 

Preview:

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/5ca756e5-d637-42f2-b04e-45df8eb3b31c)

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/b815a87a-be5d-422d-9bb5-0cb3fe61c85e)

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/377764a7-b5b7-4b23-b594-79aa34c8bccb)

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/d6a3d14e-e1b4-4cf9-b2c3-cadefb5cc6a2)
