### PR TITLE
fix: cast entityExperience to float for percentage calculation

### DIFF
--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -806,7 +806,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             if (entityExperienceToNextLevel > 0)
             {
                 var entityExperience = ((Player)MyEntity).Experience;
-                var entityExperienceRatio = entityExperience / entityExperienceToNextLevel;
+                var entityExperienceRatio = (float)entityExperience / entityExperienceToNextLevel;
                 var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
                     ? ExpBackground.Width
                     : ExpBackground.Height;


### PR DESCRIPTION

As reported in discord:
![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f7440343-30a6-4977-aa04-c38fab31f7bf)

Preview of this PR:

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/8dc6f4da-b9c9-4bf0-b0ca-3c6f357fef07) ![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/6ac094b4-ab02-42bf-9853-0c9dc1afeebf)
