### PR TITLE
enhancement: bank withdraw behavior

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -847,11 +847,11 @@ namespace Intersect.Client.Entities
             for (int i = 0; i < Inventory.Length; i++)
             {
                 var inventorySlot = Inventory[i];
-                if (inventorySlot?.ItemId == itemId)
+                if (inventorySlot != null && inventorySlot.ItemId == itemId)
                 {
                     spaceLeft += maxInventoryStack - inventorySlot.Quantity;
                 }
-                else if (inventorySlot?.ItemId == Guid.Empty)
+                else if (inventorySlot == null || inventorySlot.ItemId == Guid.Empty)
                 {
                     spaceLeft += maxInventoryStack;
                 }

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -438,6 +438,8 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString withdrawitemprompt = @"How many/much {00} would you like to withdraw?";
 
+            public static LocalizedString WithdrawItemNoSpace = @"There is no space left in your inventory for that item!";
+
         }
 
         public partial struct BanMute


### PR DESCRIPTION
- Implements the 'FindAvailableInventorySpaceForItem' method to ensure sliders display the correct values for available inventory space.
- Instead of blindly opening the item withdraw slider with a max quantity of 0 when there's no space left in the inventory (pointless), we now inform the player: "There is no space left in your inventory for that item!"

Before:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/6646df47-a3f5-4ae0-b3bb-e8841f249918


After:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/a00f6826-54ae-4d86-970c-82ff492c7668

