### PR TITLE
enh: Add timer to remove stale cooldowns during playtime

### DIFF
--- a/Intersect (Core)/Config/ProcessingOptions.cs
+++ b/Intersect (Core)/Config/ProcessingOptions.cs
@@ -103,6 +103,11 @@ namespace Intersect.Config
         /// </summary>
         public int CommonEventAutorunStartInterval { get; set; } = 500;
 
+        /// <summary>
+        /// How often should the server check for stale cooldowns on players to remove them from their respective collections.
+        /// </summary>
+        public int StaleCooldownRemovalTimer { get; set; } = 60000;
+
         [OnDeserialized]
         internal void OnDeserializedMethod(StreamingContext context)
         {

--- a/Intersect (Core)/Config/ProcessingOptions.cs
+++ b/Intersect (Core)/Config/ProcessingOptions.cs
@@ -175,6 +175,11 @@ namespace Intersect.Config
             {
                 throw new InvalidOperationException("Player save interval is too low and would cause performance issues, consider raising.");
             }
+
+            if (StaleCooldownRemovalTimer < 100) 
+            {
+                throw new InvalidOperationException("StaleCooldownRemovalTimer is too low, value should be at least 100ms to avoid running this check every server tick.");
+            }
         }
     }
 }

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -253,6 +253,8 @@ namespace Intersect.Server.Entities
         [NotMapped, JsonIgnore]
         public int InstanceLives { get; set; }
 
+        private long mStaleCooldownTimer;
+
         public static Player FindOnline(Guid id)
         {
             return OnlinePlayers.ContainsKey(id) ? OnlinePlayers[id] : null;
@@ -461,23 +463,8 @@ namespace Intersect.Server.Entities
             InShop = default;
 
             //Clear cooldowns that have expired
-            var keys = SpellCooldowns.Keys.ToArray();
-            foreach (var key in keys)
-            {
-                if (SpellCooldowns.TryGetValue(key, out var time) && time < Timing.Global.MillisecondsUtc)
-                {
-                    SpellCooldowns.TryRemove(key, out _);
-                }
-            }
-
-            keys = ItemCooldowns.Keys.ToArray();
-            foreach (var key in keys)
-            {
-                if (ItemCooldowns.TryGetValue(key, out var time) && time < Timing.Global.MillisecondsUtc)
-                {
-                    ItemCooldowns.TryRemove(key, out _);
-                }
-            }
+            RemoveStaleItemCooldowns();
+            RemoveStaleSpellCooldowns();
 
             PacketSender.SendEntityLeave(this);
 
@@ -575,6 +562,17 @@ namespace Intersect.Server.Entities
                             CraftingState = default;
                         }
                     }
+
+                    // Check for stale cooldown values and remove them
+                    if (mStaleCooldownTimer <= Timing.Global.Milliseconds)
+                    {
+                        RemoveStaleItemCooldowns();
+                        RemoveStaleSpellCooldowns();
+
+                        // Increment our timer for the next check.
+                        mStaleCooldownTimer = Timing.Global.Milliseconds + Options.Instance.Processing.StaleCooldownRemovalTimer;
+                    }
+
 
                     base.Update(timeMs);
 
@@ -6865,6 +6863,54 @@ namespace Intersect.Server.Entities
             else
             {
                 SpellCooldowns.TryAdd(spellId, cooldownTime);
+            }
+        }
+
+        /// <summary>
+        /// Remove the cooldown time entry for a specified Item.
+        /// </summary>
+        /// <param name="itemId">The <see cref="ItemBase"/> id to remove the cooldown entry for.</param>
+        private void RemoveItemCooldown(Guid itemId)
+        {
+            ItemCooldowns.TryRemove(itemId, out _);
+        }
+
+        /// <summary>
+        /// Remove the cooldown time entry for a specified Spell.
+        /// </summary>
+        /// <param name="itemId">The <see cref="SpellBase"/> id to remove the cooldown entry for.</param>
+        private void RemoveSpellCooldown(Guid itemId)
+        {
+            SpellCooldowns.TryRemove(itemId, out _);
+        }
+
+        /// <summary>
+        /// Remove all stale spell cooldowns.
+        /// </summary>
+        private void RemoveStaleSpellCooldowns()
+        {
+            var spellcds = SpellCooldowns.ToArray();
+            foreach (var cd in spellcds)
+            {
+                if (cd.Value <= Timing.Global.Milliseconds)
+                {
+                    RemoveSpellCooldown(cd.Key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove all stale item cooldowns.
+        /// </summary>
+        private void RemoveStaleItemCooldowns()
+        {
+            var itemcds = ItemCooldowns.ToArray();
+            foreach (var cd in itemcds)
+            {
+                if (cd.Value <= Timing.Global.Milliseconds)
+                {
+                    RemoveItemCooldown(cd.Key);
+                }
             }
         }
 


### PR DESCRIPTION
Resolves #1904 

Adds a timer to remove stale cooldowns while a player is logged in.
Instead of duplicating the removal code between logout and runtime removal, I turned removal of spell and item cooldowns into a re-usable method.

Won't solve major issues at the moment, but will at least stop sending endless stale records around constantly for the time being.