### PR TITLE
fix: Cache player party in Entity.Die to avoid Collection Modified Exceptions

### DIFF
--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -2834,11 +2834,15 @@ namespace Intersect.Server.Entities
                         var player = Player.FindOnline(entityEntry);
                         if (player != null)
                         {
+
+                            // Cache our value for further processing.
+                            var party = player.Party.ToArray();
+
                             // is this player in a party?
-                            if (player.Party.Count > 0 && Options.Instance.LootOpts.IndividualizedLootAutoIncludePartyMembers)
+                            if (party.Length > 0 && Options.Instance.LootOpts.IndividualizedLootAutoIncludePartyMembers)
                             {
                                 // They are, so check for all party members and drop if still eligible!
-                                foreach (var partyMember in player.Party)
+                                foreach (var partyMember in party)
                                 {
                                     if (!lootGenerated.Contains(partyMember))
                                     {


### PR DESCRIPTION
Resolves #1913 

Cache Player.Party as a copied array so that we can avoid the collection being modified as we iterate over it whenever an Entity dies with IndividualizedLootAutoIncludePartyMembers enabled in the server config.