### PR TITLE
fix: Potential IndexOutOfRangeException on Entity.DetermineRenderOrder

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1015,25 +1015,29 @@ namespace Intersect.Client.Entities
                                 priority += 3;
                             }
 
-                            HashSet<Entity> renderSet;
+                            HashSet<Entity> renderSet = default;
+                            int entY;
 
                             if (y == gridY - 1)
                             {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
+                                entY = Options.MapHeight + Y;
                             }
                             else if (y == gridY)
                             {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
+                                entY = Options.MapHeight * 2 + Y;
                             }
                             else
                             {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 3 + Y];
+                                entY = Options.MapHeight * 3 + Y;
                             }
 
-                            renderSet.Add(this);
-                            renderList = renderSet;
-
-                            return renderList;
+                            if (priority < Graphics.RenderingEntities.GetLength(0) && entY < Graphics.RenderingEntities.GetLength(1))
+                            {
+                                renderSet = Graphics.RenderingEntities[priority, entY];
+                                renderSet.Add(this);
+                            }
+                            
+                            return renderSet;
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #1920 

Have not been able to reproduce the issue Nazio reports, however this is the only place I can possibly see it crashing with an IndexOutOfRangeException. This way it should check if the value is valid before trying to pull the data from the two dimensional array.