### PR TITLE
fix: Correct the editor reconnect attempt timer in the most hideous of ways

### DIFF
--- a/Intersect.Editor/Forms/frmLogin.cs
+++ b/Intersect.Editor/Forms/frmLogin.cs
@@ -102,7 +102,7 @@ namespace Intersect.Editor.Forms
                 NetworkStatus.Unknown => Strings.Login.Denied,
                 NetworkStatus.Connecting => Strings.Login.connecting,
                 NetworkStatus.Online => Strings.Login.connected,
-                NetworkStatus.Offline => Strings.Login.failedtoconnect.ToString(((Globals.ReconnectTime - Timing.Global.MillisecondsUtc) / 1000).ToString("0")),
+                NetworkStatus.Offline => Strings.Login.failedtoconnect.ToString(((Globals.NextServerStatusPing - Timing.Global.MillisecondsUtc) / 1000).ToString("0")),
                 NetworkStatus.Failed => Strings.Login.Denied,
                 NetworkStatus.VersionMismatch => Strings.Login.Denied,
                 NetworkStatus.ServerFull => Strings.Login.Denied,

--- a/Intersect.Editor/General/Globals.cs
+++ b/Intersect.Editor/General/Globals.cs
@@ -131,6 +131,8 @@ namespace Intersect.Editor.General
         //Network Variables
         public static int ReconnectTime = 3000;
 
+        public static long NextServerStatusPing;
+
         //Game Object Editors
         public static FrmResource ResourceEditor;
 

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -222,6 +222,7 @@ namespace Intersect.Editor.Networking
                     }
 
                     _nextServerStatusPing = now + ServerStatusPingInterval;
+                    Globals.NextServerStatusPing = _nextServerStatusPing;
                 }
             }
 


### PR DESCRIPTION
Resolves #1942 

Yes, I'm aware there's likely a better and cleaner way.
Yes, I know this is stupid.

But since the entire editor is getting replaced anyway, I don't want to spend too long fixing a small UI countdown timer you won't even see most of the time.