### PR TITLE
fix: correct keys on slot packets

### DIFF
--- a/Intersect (Core)/Network/Packets/Client/BuyItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/BuyItemPacket.cs
@@ -1,19 +1,16 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class BuyItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class BuyItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public BuyItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public BuyItemPacket() : base(0, 0)
-        {
-        }
-
-        public BuyItemPacket(int slot, int quantity) : base(slot, quantity)
-        {
-        }
-
     }
 
+    public BuyItemPacket(int slot, int quantity) : base(slot, quantity)
+    {
+    }
 }

--- a/Intersect (Core)/Network/Packets/Client/DepositItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/DepositItemPacket.cs
@@ -1,23 +1,19 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class DepositItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class DepositItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public DepositItemPacket() : base(0, 0)
     {
-
-        //Parameterless Constructor for MessagePack
-        public DepositItemPacket() : base(0, 0)
-        {
-        }
-
-        public DepositItemPacket(int slot, int quantity, int bankSlot = -1) : base(slot, quantity)
-        {
-            BankSlot = bankSlot;
-        }
-
-        [Key(0)]
-        public int BankSlot { get; set; }
     }
 
+    public DepositItemPacket(int slot, int quantity, int bankSlot = -1) : base(slot, quantity)
+    {
+        BankSlot = bankSlot;
+    }
+
+    [Key(3)] public int BankSlot { get; set; }
 }

--- a/Intersect (Core)/Network/Packets/Client/DropItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/DropItemPacket.cs
@@ -1,19 +1,16 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class DropItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class DropItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public DropItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public DropItemPacket() : base(0, 0)
-        {
-        }
-
-        public DropItemPacket(int slot, int quantity) : base(slot, quantity)
-        {
-        }
-
     }
 
+    public DropItemPacket(int slot, int quantity) : base(slot, quantity)
+    {
+    }
 }

--- a/Intersect (Core)/Network/Packets/Client/OfferTradeItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/OfferTradeItemPacket.cs
@@ -1,19 +1,16 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class OfferTradeItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class OfferTradeItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public OfferTradeItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public OfferTradeItemPacket() : base(0, 0)
-        {
-        }
-
-        public OfferTradeItemPacket(int slot, int quantity) : base(slot, quantity)
-        {
-        }
-
     }
 
+    public OfferTradeItemPacket(int slot, int quantity) : base(slot, quantity)
+    {
+    }
 }

--- a/Intersect (Core)/Network/Packets/Client/RetrieveBagItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/RetrieveBagItemPacket.cs
@@ -1,23 +1,19 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class RetrieveBagItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class RetrieveBagItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public RetrieveBagItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public RetrieveBagItemPacket() : base(0, 0)
-        {
-        }
-
-        public RetrieveBagItemPacket(int bagSlot, int quantity, int invSlot) : base(bagSlot, quantity)
-        {
-            InventorySlot = invSlot;
-        }
-
-        [Key(4)]
-        public int InventorySlot { get; set; }
-
     }
 
+    public RetrieveBagItemPacket(int bagSlot, int quantity, int invSlot) : base(bagSlot, quantity)
+    {
+        InventorySlot = invSlot;
+    }
+
+    [Key(3)] public int InventorySlot { get; set; }
 }

--- a/Intersect (Core)/Network/Packets/Client/RevokeTradeItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/RevokeTradeItemPacket.cs
@@ -1,19 +1,16 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class RevokeTradeItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class RevokeTradeItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public RevokeTradeItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public RevokeTradeItemPacket() : base(0,0)
-        {
-        }
-
-        public RevokeTradeItemPacket(int slot, int quantity) : base(slot, quantity)
-        {
-        }
-
     }
 
+    public RevokeTradeItemPacket(int slot, int quantity) : base(slot, quantity)
+    {
+    }
 }

--- a/Intersect (Core)/Network/Packets/Client/SellItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/SellItemPacket.cs
@@ -1,19 +1,16 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class SellItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class SellItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public SellItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public SellItemPacket() : base(0, 0)
-        {
-        }
-
-        public SellItemPacket(int slot, int quantity) : base(slot, quantity)
-        {
-        }
-
     }
 
+    public SellItemPacket(int slot, int quantity) : base(slot, quantity)
+    {
+    }
 }

--- a/Intersect (Core)/Network/Packets/Client/StoreBagItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/StoreBagItemPacket.cs
@@ -1,23 +1,19 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class StoreBagItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class StoreBagItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public StoreBagItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public StoreBagItemPacket() : base(0, 0)
-        {
-        }
-        public StoreBagItemPacket(int invSlot, int quantity, int bagSlot) : base(invSlot, quantity)
-        {
-            BagSlot = bagSlot;
-        }
-
-        [Key(0)]
-        public int BagSlot { get; set; }
-
-
     }
 
+    public StoreBagItemPacket(int invSlot, int quantity, int bagSlot) : base(invSlot, quantity)
+    {
+        BagSlot = bagSlot;
+    }
+
+    [Key(3)] public int BagSlot { get; set; }
 }

--- a/Intersect (Core)/Network/Packets/Client/WithdrawItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/WithdrawItemPacket.cs
@@ -1,23 +1,19 @@
 ﻿using MessagePack;
 
-namespace Intersect.Network.Packets.Client
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class WithdrawItemPacket : SlotQuantityPacket
 {
-    [MessagePackObject]
-    public partial class WithdrawItemPacket : SlotQuantityPacket
+    //Parameterless Constructor for MessagePack
+    public WithdrawItemPacket() : base(0, 0)
     {
-        //Parameterless Constructor for MessagePack
-        public WithdrawItemPacket() : base(0, 0)
-        {
-        }
-
-        public WithdrawItemPacket(int slot, int quantity, int invSlot = -1) : base(slot, quantity)
-        {
-            InvSlot = invSlot;
-        }
-
-        [Key(0)]
-        public int InvSlot { get; set; }
-
     }
 
+    public WithdrawItemPacket(int slot, int quantity, int invSlot = -1) : base(slot, quantity)
+    {
+        InvSlot = invSlot;
+    }
+
+    [Key(3)] public int InvSlot { get; set; }
 }

--- a/Intersect (Core)/Network/Packets/SlotQuantityPacket.cs
+++ b/Intersect (Core)/Network/Packets/SlotQuantityPacket.cs
@@ -36,7 +36,7 @@ namespace Intersect.Network.Packets
         [Key(2)]
         public int Quantity { get; set; }
 
-        [Key(3)]
+        [IgnoreMember]
         public override bool IsValid => Slot >= 0 && Quantity >= 0;
 
         public override Dictionary<string, SanitizedValue<object>> Sanitize()


### PR DESCRIPTION
Fixes #1953 by correcting the `[Key(#)]` attributes on the different slot packets

For some reason the base slot packet had `[Key(3)]` on a `bool` property with only an expression-body getter (so quite literally cannot be set even with reflection hacks), and the deposit bank slot was `[Key(0)]`.

It appears that there isn't actually a `[Key(0)]` on anything? Which is weird, but whatever. The problem is that the weird key situation was causing deserialization to totally break, and I am guessing since our .NET 7 upgrade MessagePack actually expects the code to be correct instead of correcting for developer mistakes.