### PR TITLE
Fix: hides character animations when entering hidden mode

### DIFF
--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -839,7 +839,7 @@ namespace Intersect.Client.Entities
                     continue;
                 }
 
-                if (IsStealthed)
+                if (IsStealthed || IsHidden)
                 {
                     animInstance.Hide();
                 }


### PR DESCRIPTION
This will correct the character's animations being hidden along with the rest of the entity when entering hidden mode, very useful for GMs who want to spy on players.