### PR TITLE
enhancement: toggle turn around while casting

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -63,5 +63,10 @@
         /// If enabled this allows regenerate vitals in combat
         /// </summary>
         public bool RegenVitalsInCombat = false;
+
+        /// <summary>
+        /// If enabled, this allows entities to turn around while casting
+        /// </summary>
+        public bool EnableTurnAroundWhileCasting = false;
     }
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -49,6 +49,8 @@ namespace Intersect.Client.Entities
 
         public bool IsCasting => CastTime > Timing.Global.Milliseconds;
 
+        public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
+
         public bool IsDashing => Dashing != null;
 
         //Dashing instance

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1512,6 +1512,11 @@ namespace Intersect.Client.Entities
                 return;
             }
 
+            if (IsTurnAroundWhileCastingDisabled)
+            {
+                return;
+            }
+
             var directionToTarget = DirectionToTarget(en);
 
             if (IsMoving || Dir == MoveDir || Dir == directionToTarget)
@@ -2539,7 +2544,7 @@ namespace Intersect.Client.Entities
             // If players hold the 'TurnAround' Control Key and tap to any direction, they will turn on their own axis.
             for (var direction = 0; direction < Options.Instance.MapOpts.MovementDirections; direction++)
             {
-                if (!Controls.KeyDown(Control.TurnAround) || direction != (int)Globals.Me.MoveDir)
+                if (!Controls.KeyDown(Control.TurnAround) || direction != (int)Globals.Me.MoveDir || IsTurnAroundWhileCastingDisabled)
                 {
                     continue;
                 }

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -205,6 +205,9 @@ namespace Intersect.Server.Entities
         [NotMapped, JsonIgnore]
         public bool IsCasting => CastTime > Timing.Global.Milliseconds;
 
+        [NotMapped, JsonIgnore]
+        public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
+
         //Visuals
         [NotMapped, JsonIgnore]
         public bool HideName { get; set; }
@@ -2733,7 +2736,7 @@ namespace Intersect.Server.Entities
 
         protected Direction DirectionToTarget(Entity en)
         {
-            if (en == null)
+            if (en == null || IsTurnAroundWhileCastingDisabled)
             {
                 return Dir;
             }


### PR DESCRIPTION
This PR seeks to cover the following:

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/50042ceb-142a-46a9-9baf-62d81d22fdd5)

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/ebed9fe8-1525-4228-9286-c1d1ae7742d6

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/7a8377c9-36f6-4878-a199-4fb3d9b30d07)

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/3287b5c0-d649-4d73-8082-1302d42ed153)

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/87c11a92-9474-4af1-84a8-7b03c5a68589)


The PR adds a configurable combat option to the server settings which enables/disables the ability to turn around while casting.

![imagen](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/345fe7e6-a6a7-4a36-ac81-e5bd77cf25cb)
