### PR TITLE
Use .AsSplitQuery() on anything with a lot of Includes for a huge performance boost

### DIFF
--- a/Intersect.Server/Database/PlayerData/User.cs
+++ b/Intersect.Server/Database/PlayerData/User.cs
@@ -969,6 +969,7 @@ namespace Intersect.Server.Database.PlayerData
                     .Include(p => p.Ban)
                     .Include(p => p.Mute)
                     .Include(p => p.Players)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -980,6 +981,7 @@ namespace Intersect.Server.Database.PlayerData
                     .Include(p => p.Ban)
                     .Include(p => p.Mute)
                     .Include(p => p.Players)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -992,6 +994,7 @@ namespace Intersect.Server.Database.PlayerData
                     .Include(p => p.Ban)
                     .Include(p => p.Mute)
                     .Include(p => p.Players)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -1001,6 +1004,7 @@ namespace Intersect.Server.Database.PlayerData
                     .Include(p => p.Ban)
                     .Include(p => p.Mute)
                     .Include(p => p.Players)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -1023,6 +1027,7 @@ namespace Intersect.Server.Database.PlayerData
                     .Include(p => p.Ban)
                     .Include(p => p.Mute)
                     .Include(p => p.Players)
+                    .AsSplitQuery()
                     .FirstOrDefault()
         ) ??
         throw new InvalidOperationException();

--- a/Intersect.Server/Entities/Player.Database.cs
+++ b/Intersect.Server/Entities/Player.Database.cs
@@ -406,6 +406,7 @@ namespace Intersect.Server.Entities
                     .Include(p => p.Variables)
                     .Include(p => p.Items)
                     .Include(p => p.Spells)
+                    .AsSplitQuery()
             ) ??
             throw new InvalidOperationException();
 
@@ -422,6 +423,7 @@ namespace Intersect.Server.Entities
                     .Include(p => p.Variables)
                     .Include(p => p.Items)
                     .Include(p => p.Spells)
+                    .AsSplitQuery()
             ) ??
             throw new InvalidOperationException();
 
@@ -434,6 +436,7 @@ namespace Intersect.Server.Entities
                     .Include(p => p.Variables)
                     .Include(p => p.Items)
                     .Include(p => p.Spells)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -448,6 +451,7 @@ namespace Intersect.Server.Entities
                     .Include(p => p.Variables)
                     .Include(p => p.Items)
                     .Include(p => p.Spells)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();
@@ -466,6 +470,7 @@ namespace Intersect.Server.Entities
                     .Include(c => c.Quests)
                     .Include(c => c.Spells)
                     .Include(c => c.Variables)
+                    .AsSplitQuery()
                     .FirstOrDefault()
             ) ??
             throw new InvalidOperationException();


### PR DESCRIPTION
This will allow some API calls which would time out, like player rankings to succeed.