### PR TITLE
enhancement: Display stats and stat ranges on crafting tables

### DIFF
--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -324,11 +324,17 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             }
 
             // Stats
-            if (mItemProperties?.StatModifiers != default)
+            for (var i = 0; i < (int)Stat.StatCount; i++)
             {
-                for (var i = 0; i < (int)Stat.StatCount; i++)
+                // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
+                if (mItemProperties != default || mItem.StatGrowth == 0)
                 {
-                    var flatStat = mItem.StatsGiven[i] + mItemProperties.StatModifiers[i];
+                    var flatStat = mItem.StatsGiven[i];
+                    if (mItemProperties != default)
+                    {
+                        flatStat += mItemProperties.StatModifiers[i];
+                    }
+
                     if (flatStat != 0 && mItem.PercentageStatsGiven[i] != 0)
                     {
                         rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.RegularAndPercentage.ToString(flatStat, mItem.PercentageStatsGiven[i]));
@@ -342,6 +348,22 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
                         rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageStatsGiven[i]));
                     }
                 }
+                // We do not have item properties and have growing stats! So don't display a finished stat but a range instead.
+                else
+                {
+                    var statLow = mItem.StatsGiven[i] - mItem.StatGrowth;
+                    var statHigh = mItem.StatsGiven[i] + mItem.StatGrowth;
+
+                    if (mItem.PercentageStatsGiven[i] != 0)
+                    {
+                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.RegularAndPercentage.ToString(Strings.ItemDescription.StatGrowthRange.ToString(statLow, statHigh), mItem.PercentageStatsGiven[i]));
+                    }
+                    else
+                    {
+                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.StatGrowthRange.ToString(statLow, statHigh));
+                    }
+                }
+                
             }
 
             // Bonus Effect

--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -324,15 +324,16 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             }
 
             // Stats
+            var statModifiers = mItemProperties?.StatModifiers;
             for (var i = 0; i < (int)Stat.StatCount; i++)
             {
                 // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
-                if (mItemProperties != default || mItem.StatGrowth == 0)
+                if (statModifiers != default || mItem.StatGrowth == 0)
                 {
                     var flatStat = mItem.StatsGiven[i];
-                    if (mItemProperties != default)
+                    if (statModifiers != default)
                     {
-                        flatStat += mItemProperties.StatModifiers[i];
+                        flatStat += statModifiers[i];
                     }
 
                     if (flatStat != 0 && mItem.PercentageStatsGiven[i] != 0)

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -1301,6 +1301,9 @@ namespace Intersect.Client.Localization
             public static LocalizedString RegularAndPercentage = @"{00} + {01}%";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString StatGrowthRange = @"{00} to {01}";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static Dictionary<int, LocalizedString> Stats = new Dictionary<int, LocalizedString>
             {
                 {0, @"Attack"},


### PR DESCRIPTION
Resolves #1987 

Fixes the lack of a display for items we're crafting and adds a visible stat range if applicable.
Now stop bugging me about this.


https://github.com/AscensionGameDev/Intersect-Engine/assets/13875600/fb2f46e5-d706-4feb-b282-8e46bec05bb0

