### PR TITLE
enhancement: don't drop items in arena map.

### DIFF
--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -21,6 +21,10 @@ namespace Intersect.Config
                 MovementDirections = mEnableDiagonalMovement ? 8 : 4;
             }
         }
+        /// <summary>
+        /// option to drop items on arena type maps
+        /// </summary>
+        public bool DisablePlayerDropsInArenaMaps { get; set; } = false;
 
         /// <summary>
         /// The style of the game's border.

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2946,6 +2946,7 @@ namespace Intersect.Server.Entities
 
         protected virtual void DropItems(Entity killer, bool sendUpdate = true)
         {
+            if (Map.ZoneType == MapZone.Arena && this is Player) return; // Don't Drop Items in Arena
             // Drop items
             foreach (var slot in Items)
             {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2946,13 +2946,11 @@ namespace Intersect.Server.Entities
 
         protected virtual void DropItems(Entity killer, bool sendUpdate = true)
         {
-            if (Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps = true)
+            if (this is Player && Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps && Map.ZoneType == MapZone.Arena)
             {
-                if (Map.ZoneType == MapZone.Arena && this is Player) // Don't Drop Items in Arena
-                {
-                    return;
-                }  
+                return;
             }
+
             // Drop items
             foreach (var slot in Items)
             {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2946,7 +2946,13 @@ namespace Intersect.Server.Entities
 
         protected virtual void DropItems(Entity killer, bool sendUpdate = true)
         {
-            if (Map.ZoneType == MapZone.Arena && this is Player) return; // Don't Drop Items in Arena
+            if (Options.Instance.MapOpts.DisablePlayerDropsInArenaMaps = true)
+            {
+                if (Map.ZoneType == MapZone.Arena && this is Player) // Don't Drop Items in Arena
+                {
+                    return;
+                }  
+            }
             // Drop items
             foreach (var slot in Items)
             {


### PR DESCRIPTION
I think many project owners use this type of map for some pvp system or battle in general, I'm sending this suggestion that will protect the player's item drops when dying on this type of map.