### PR TITLE
feat: add `--debugger` flag to wait for debugger

### DIFF
--- a/Intersect.Client/Program.cs
+++ b/Intersect.Client/Program.cs
@@ -27,6 +27,14 @@ namespace Intersect.Client
         [STAThread]
         internal static void Main(string[] args)
         {
+            var waitForDebugger = args.Contains("--debugger");
+
+            while (waitForDebugger && !Debugger.IsAttached)
+            {
+                System.Console.WriteLine("Waiting for debugger, sleeping 5000ms...");
+                Thread.Sleep(5000);
+            }
+
             CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 
             ExportDependencies();


### PR DESCRIPTION
  this makes debugging startup failures on remote
  devices (like steamdecks) easier to accomplish