### PR TITLE
fix(2053): don't reload relationships for last character

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -381,6 +381,13 @@ namespace Intersect.GameObjects
                 .ToArray();
         }
 
+        public string GetPaperdollForGender(Gender gender) =>
+            gender switch
+            {
+                Gender.Male => MalePaperdoll,
+                _ => FemalePaperdoll,
+            };
+
         private void Initialize()
         {
             Name = "New Item";

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -524,14 +524,7 @@ namespace Intersect.Server.Database
                 try
                 {
                     using var playerContext = CreatePlayerContext(readOnly: true, explicitLoad: false);
-                    var playerEntry = playerContext.Players.Attach(player);
-                    playerEntry.Collection(p => p.Items).Query().Load();
-                    playerEntry.Collection(player => player.Bank).Load();
-                    playerEntry.Collection(player => player.Hotbar).Load();
-                    playerEntry.Collection(player => player.Items).Load();
-                    playerEntry.Collection(player => player.Quests).Load();
-                    playerEntry.Collection(player => player.Spells).Load();
-                    playerEntry.Collection(player => player.Variables).Load();
+                    player.LoadRelationships(playerContext);
                     _ = Player.Validate(player);
                 }
                 catch (Exception exception)

--- a/Intersect.Server.Core/Database/IntersectDbContext.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.cs
@@ -199,7 +199,7 @@ public abstract partial class IntersectDbContext<TDbContext> : DbContext, IDbCon
             var rowsChanged = base.SaveChanges(acceptAllChangesOnSuccess);
 
 #if DEBUG
-            Log.Debug($"DBOP-B SaveChanges({{acceptAllChangesOnSuccess}}) #{{currentExecutionId}}");
+            Log.Debug($"DBOP-B SaveChanges({acceptAllChangesOnSuccess}) #{currentExecutionId}");
 #endif
 
             return rowsChanged;
@@ -240,7 +240,7 @@ public abstract partial class IntersectDbContext<TDbContext> : DbContext, IDbCon
             Log.Error(concurrencyErrors.ToString());
 
 #if DEBUG
-            Log.Debug($"DBOP-C SaveChanges({{acceptAllChangesOnSuccess}}) #{{currentExecutionId}}");
+            Log.Debug($"DBOP-C SaveChanges({acceptAllChangesOnSuccess}) #{currentExecutionId}");
 #endif
 
             ServerContext.DispatchUnhandledException(

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
@@ -407,6 +402,11 @@ namespace Intersect.Server.Entities
 
         private void Logout(bool softLogout = false)
         {
+            lock (_savingLock)
+            {
+                _saving = true;
+            }
+
             if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
             {
                 instance.RemoveEntity(this);
@@ -510,6 +510,11 @@ namespace Intersect.Server.Entities
 #endif
 
             User?.Save();
+
+            lock (_savingLock)
+            {
+                _saving = false;
+            }
 
             Dispose();
 

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -654,8 +654,9 @@ namespace Intersect.Server.Networking
                 (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
             {
                 client.Entity?.TryLogout(false, true);
-                client.Entity = null;
-                PacketSender.SendPlayerCharacters(client);
+                var lastPlayer = client.Entity;
+                client.Entity = default;
+                PacketSender.SendPlayerCharacters(client, lastPlayer);
             }
             else
             {

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -654,9 +654,8 @@ namespace Intersect.Server.Networking
                 (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
             {
                 client.Entity?.TryLogout(false, true);
-                var lastPlayer = client.Entity;
                 client.Entity = default;
-                PacketSender.SendPlayerCharacters(client, lastPlayer);
+                PacketSender.SendPlayerCharacters(client);
             }
             else
             {

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1251,7 +1251,7 @@ namespace Intersect.Server.Networking
         }
 
         //CharactersPacket
-        public static void SendPlayerCharacters(Client client)
+        public static void SendPlayerCharacters(Client client, Player? lastPlayer = default)
         {
             var characters = new List<CharacterPacket>();
             if (client.User == null)
@@ -1263,6 +1263,11 @@ namespace Intersect.Server.Networking
             {
                 foreach (var player in client.Characters.OrderByDescending(p => p.LastOnline))
                 {
+                    if (player.Id == lastPlayer?.Id)
+                    {
+                        continue;
+                    }
+
                     player.LoadRelationships(playerContext);
                 }
             }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1251,11 +1251,25 @@ namespace Intersect.Server.Networking
         }
 
         //CharactersPacket
-        public static void SendPlayerCharacters(Client client, Player? lastPlayer = default)
+        public static void SendPlayerCharacters(Client client)
         {
-            var characters = new List<CharacterPacket>();
-            if (client.User == null)
+            if (client == default)
             {
+                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to a null client?");
+                return;
+            }
+
+            var user = client.User;
+            if (user == default)
+            {
+                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no user? ({client.Id})");
+                return;
+            }
+
+            var clientCharacters = client.Characters;
+            if (clientCharacters == default)
+            {
+                Log.Warn($"Tried to {nameof(SendPlayerCharacters)}() to client with no characters? (client {client.Id}/user {user.Id})");
                 return;
             }
 
@@ -1263,82 +1277,96 @@ namespace Intersect.Server.Networking
             {
                 foreach (var player in client.Characters.OrderByDescending(p => p.LastOnline))
                 {
-                    if (player.Id == lastPlayer?.Id)
-                    {
-                        continue;
-                    }
-
                     player.LoadRelationships(playerContext);
                 }
             }
 
-            var clientCharacters = client?.Characters;
-            if (clientCharacters == default)
+            var characterPackets = new List<CharacterPacket>();
+
+            var equipmentSlotsOptions = Options.EquipmentSlots;
+            var paperdollOrderOptions = Options.PaperdollOrder;
+
+            if (clientCharacters.Count < 1)
             {
-                Log.Error($"PLEASE REPORT THIS WITH LOGS: About to crash because {(client == default ? nameof(client) : nameof(client.Characters))} is null.");
+                CharactersPacket emptyBulkCharactersPacket = new(
+                    Array.Empty<CharacterPacket>(),
+                    client.Characters.Count < Options.MaxCharacters
+                );
+
+                if (!client.Send(emptyBulkCharactersPacket))
+                {
+                    Log.Error($"Failed to send empty bulk characters packet to {client.Id}");
+                }
+
+                return;
             }
 
-            if (client.Characters.Count > 0) /* TODO: Fix NRE when logging out and back in */
+            foreach (var character in clientCharacters.OrderByDescending(p => p.LastOnline))
             {
-                foreach (var character in client.Characters.OrderByDescending(p => p.LastOnline))
+                var equipmentArray = character.Equipment;
+                var equipment = new EquipmentFragment[equipmentSlotsOptions.Count + 1];
+
+                // Draw the equipment/paperdolls
+                var paperdollOrderOptionLayer1 = paperdollOrderOptions[1];
+                for (var z = 0; z < paperdollOrderOptionLayer1.Count; z++)
                 {
-                    var equipmentArray = character.Equipment;
-                    var equipment = new EquipmentFragment[Options.EquipmentSlots.Count + 1];
-
-                    //Draw the equipment/paperdolls
-                    for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+                    var indexOfPaperdoll = equipmentSlotsOptions.IndexOf(Options.PaperdollOrder[1][z]);
+                    if (indexOfPaperdoll < 0)
                     {
-                        if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1)
+                        const string equipmentFragmentNamePlayer = "Player";
+                        if (Options.PaperdollOrder[1][z] == equipmentFragmentNamePlayer)
                         {
-                            if (equipmentArray[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
-                                equipmentArray[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
-                                Options.MaxInvItems)
-                            {
-                                var paperdollOrder = Options.PaperdollOrder[1][z];
-                                var equipmentSlot = Options.EquipmentSlots.IndexOf(paperdollOrder);
-                                var itemIndex = equipmentArray[equipmentSlot];
-
-                                var itemId = character
-                                    .Items[itemIndex]
-                                    .ItemId;
-
-                                if (ItemBase.Get(itemId) != null)
-                                {
-                                    var itemdata = ItemBase.Get(itemId);
-                                    equipment[z] = new EquipmentFragment
-                                    {
-                                        Name = character.Gender == 0 ? itemdata.MalePaperdoll : itemdata.FemalePaperdoll,
-                                        RenderColor = itemdata.Color,
-                                    };
-                                }
-                            }
+                            equipment[z] = new EquipmentFragment { Name = equipmentFragmentNamePlayer };
                         }
-                        else
-                        {
-                            if (Options.PaperdollOrder[1][z] == "Player")
-                            {
-                                equipment[z] = new EquipmentFragment { Name = "Player" };
-                            }
-                        }
+
+                        continue;
                     }
 
-                    characters.Add(
-                        new CharacterPacket(
-                            character.Id, character.Name, character.Sprite, character.Face, character.Level,
-                            ClassBase.GetName(character.ClassId), equipment
-                        )
-                    );
+                    var inventoryIndexOfEquip = equipmentArray[indexOfPaperdoll];
+                    if (inventoryIndexOfEquip <= -1 || inventoryIndexOfEquip >= Options.MaxInvItems)
+                    {
+                        continue;
+                    }
+
+                    var paperdollOrder = paperdollOrderOptionLayer1[z];
+                    var equipmentSlot = equipmentSlotsOptions.IndexOf(paperdollOrder);
+                    var itemIndex = equipmentArray[equipmentSlot];
+
+                    var itemId = character.Items[itemIndex].ItemId;
+
+                    if (!ItemBase.TryGet(itemId, out var itemDescriptor))
+                    {
+                        continue;
+                    }
+
+                    equipment[z] = new EquipmentFragment
+                    {
+                        Name = itemDescriptor.GetPaperdollForGender(character.Gender),
+                        RenderColor = itemDescriptor.Color,
+                    };
                 }
+
+                characterPackets.Add(
+                    new CharacterPacket(
+                        character.Id,
+                        character.Name,
+                        character.Sprite,
+                        character.Face,
+                        character.Level,
+                        ClassBase.GetName(character.ClassId),
+                        equipment
+                    )
+                );
             }
 
-            CharactersPacket packet = new(
-                characters.ToArray(),
+            CharactersPacket bulkCharactersPacket = new(
+                characterPackets.ToArray(),
                 client.Characters.Count < Options.MaxCharacters
             );
 
-            if (!client.Send(packet))
+            if (!client.Send(bulkCharactersPacket))
             {
-                Log.Error($"Failed to send {packet.Characters.Length} characters to {client.Id}");
+                Log.Error($"Failed to send {bulkCharactersPacket.Characters.Length} characters to {client.Id}");
             }
         }
 

--- a/Intersect.sln.DotSettings
+++ b/Intersect.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cipherdata/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Expiries/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migratable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paperdoll/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=plaindata/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=randomblob/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=singleplayer/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	


### PR DESCRIPTION
Resolves #2053 

Without this fix for both quests and variables I was able to crash by quickly getting the quest/variable (that did not previously exist in the DB) and then exiting to character selection _as fast as possible_.

My theory (verified I suppose by the fact that I was able to reproduce 100% of the time without the fix, and no longer able to reproduce this with the fix) is that when we loaded the relationships for the characters it populated the `Id` of the entity before it could save.

This put the new record into an invalid `Modified` state, which generates an `UPDATE` statement instead of `Added` which would have generated an `INSERT` statement. Of course `UPDATE` fails because the record does not yet exist.

The fix is to not load relationships if the player is in the middle of saving.

The first commit only targeted the last player but I think that the lock-model should be able to catch _multiple_ players being logged-in-and-out-of which is a theoretical more complicated version of this bug that would occur if a server is under extreme load and a user can manage to trigger the bug for multiple characters before even the first manages to save.