### PR TITLE
feature: minimap

### DIFF
--- a/Intersect (Core)/Config/MinimapOptions.cs
+++ b/Intersect (Core)/Config/MinimapOptions.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Intersect.Config
+{
+    /// <summary>
+    ///  Options for the game map.
+    /// </summary>
+    public partial class MinimapOptions
+    {
+        /// <summary>
+        /// Indicates whether or not the minimap window is enabled.
+        /// </summary>
+        public bool EnableMinimapWindow { get; set; } = false;
+
+        /// <summary>
+        /// Configures the size at which each minimap tile is rendered.
+        /// </summary>
+        public Point TileSize { get; set; } = new(8, 8);
+
+        /// <summary>
+        /// Configures the minimum zoom level (0 - 100)
+        /// </summary>
+        public byte MinimumZoom { get; set; } = 5;
+
+        /// <summary>
+        /// Configures the maximum zoom level (0 - 100)
+        /// </summary>
+        public byte MaximumZoom { get; set; } = 100;
+
+        /// <summary>
+        /// Configures the default zoom level (0 - 100)
+        /// </summary>
+        public byte DefaultZoom { get; set; } = 25;
+
+        /// <summary>
+        /// Configures the amount to zoom by each step.
+        /// </summary>
+        public byte ZoomStep { get; set; } = 5;
+
+        /// <summary>
+        /// Configures the images used within the minimap. If any are left blank the system will default to its color.
+        /// </summary>
+        public Images MinimapImages { get; set; } = new();
+
+        /// <summary>
+        /// Configures the colours used within the minimap.
+        /// </summary>
+        public Colors MinimapColors { get; set; } = new();
+
+        /// <summary>
+        /// Configures which map layers the minimap will render.
+        /// </summary>
+        public List<string> RenderLayers { get; set; } = new List<string>
+        {
+            "Ground",
+            "Mask 1",
+            "Mask 2",
+            "Fringe 1",
+            "Fringe 2",
+        };
+
+        [OnDeserializing]
+        internal void OnDeserializingMethod(StreamingContext context)
+        {
+            RenderLayers.Clear();
+        }
+
+        [OnDeserialized]
+        internal void OnDeserializedMethod(StreamingContext context)
+        {
+            Validate();
+        }
+
+        /// <summary>
+        /// Validates the properties of the map options object.
+        /// </summary>
+        public void Validate()
+        {
+            if (MinimumZoom is < 0 or > 100)
+            {
+                MinimumZoom = 0;
+            }
+
+            if (MaximumZoom is < 0 or > 100)
+            {
+                MaximumZoom = 100;
+            }
+
+            if (DefaultZoom is < 0 or > 100)
+            {
+                DefaultZoom = 0;
+            }
+        }
+        
+        public class Colors
+        {
+            public Color Player { get; set; } = Color.Cyan;
+
+            public Color PartyMember { get; set; } = Color.Blue;
+
+            public Color MyEntity { get; set; } = Color.Red;
+
+            public Color Npc { get; set; } = Color.Orange;
+
+            public Color Event { get; set; } = Color.Blue;
+
+            public Dictionary<string, Color> Resource { get; set; } = new() { { "None", Color.White } };
+
+            public Color Default { get; set; } = Color.Magenta;
+        }
+
+        public class Images
+        {
+            public string Player { get; set; } = "minimap_player.png";
+
+            public string PartyMember { get; set; } = "minimap_partymember.png";
+
+            public string MyEntity { get; set; } = "minimap_me.png";
+
+            public string Npc { get; set; } = "minimap_npc.png";
+
+            public string Event { get; set; } = "minimap_event.png";
+
+            public Dictionary<string, string> Resource { get; set; } = new() { { "None", "minimap_resource_none.png" } };
+
+            public string Default { get; set; } = "minimap_npc.png";
+        }
+    }
+}

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -62,6 +62,9 @@ namespace Intersect
 
         public DatabaseOptions PlayerDatabase = new DatabaseOptions();
 
+        [JsonProperty("Minimap")]
+        public MinimapOptions MinimapOpts = new();
+
         [JsonProperty("Player")]
         public PlayerOptions PlayerOpts = new PlayerOptions();
 

--- a/Intersect.Client/Core/Controls/ControlEnum.cs
+++ b/Intersect.Client/Core/Controls/ControlEnum.cs
@@ -59,6 +59,8 @@
         OpenGuild,
 
         OpenFriends,
+        
+        OpenMinimap,
 
         OpenSettings,
 

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -99,6 +99,7 @@ namespace Intersect.Client.Core.Controls
             CreateControlMap(Control.HoldToZoomIn, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.HoldToZoomOut, ControlValue.Default, ControlValue.Default);
             CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.Alt, Keys.Enter), ControlValue.Default);
+            CreateControlMap(Control.OpenMinimap, new ControlValue(Keys.None, Keys.M), ControlValue.Default);
             // CreateControlMap(Control.Submit, new ControlValue(Keys.None, Keys.Enter), ControlValue.Default);
             // CreateControlMap(Control.Cancel, new ControlValue(Keys.None, Keys.Back), ControlValue.Default);
             // CreateControlMap(Control.Next, new ControlValue(Keys.None, Keys.Tab), ControlValue.Default);

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -297,6 +297,11 @@ namespace Intersect.Client.Core
                                         Interface.Interface.GameUi?.GameMenu.ToggleGuildWindow();
 
                                         break;
+                                    
+                                    case Control.OpenMinimap:
+                                        Interface.Interface.GameUi?.GameMenu.ToggleMinimapWindow();
+
+                                        break;
                                 }
 
                                 break;

--- a/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
@@ -530,20 +530,22 @@ namespace Intersect.Client.Interface.Game.Map
             return entityInfo;
         }
 
-        private GameRenderTexture GenerateBaseRenderTexture()
+        private GameRenderTexture GenerateRenderTexture(int multiplier)
         {
-            var sizeX = (_minimapTileSize.X * Options.Instance.MapOpts.MapWidth) * 3;
-            var sizeY = (_minimapTileSize.Y * Options.Instance.MapOpts.MapHeight) * 3;
+            var sizeX = _minimapTileSize.X * Options.Instance.MapOpts.MapWidth * multiplier;
+            var sizeY = _minimapTileSize.Y * Options.Instance.MapOpts.MapHeight * multiplier;
 
             return Graphics.Renderer.CreateRenderTexture(sizeX, sizeY);
         }
 
+        private GameRenderTexture GenerateBaseRenderTexture()
+        {
+            return GenerateRenderTexture(3);
+        }
+
         private GameRenderTexture GenerateMapRenderTexture()
         {
-            var sizeX = _minimapTileSize.X * Options.Instance.MapOpts.MapWidth;
-            var sizeY = _minimapTileSize.Y * Options.Instance.MapOpts.MapHeight;
-
-            return Graphics.Renderer.CreateRenderTexture(sizeX, sizeY);
+            return GenerateRenderTexture(1);
         }
 
         private void MZoomOutButton_Clicked(Base sender, ClickedEventArgs arguments)

--- a/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
@@ -21,7 +21,7 @@ namespace Intersect.Client.Interface.Game.Map
 
         private bool _redrawMaps;
         private bool _redrawEntities;
-        private byte _zoomLevel;
+        private int _zoomLevel;
         private Point _minimapTileSize;
 
         private Dictionary<MapPosition, MapBase> _mapGrid = new();
@@ -548,30 +548,14 @@ namespace Intersect.Client.Interface.Game.Map
 
         private void MZoomOutButton_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            if (_zoomLevel >= Options.Instance.MinimapOpts.MaximumZoom)
-            {
-                return;
-            }
-
-            _zoomLevel += Options.Instance.MinimapOpts.ZoomStep;
-            if (_zoomLevel > Options.Instance.MinimapOpts.MaximumZoom)
-            {
-                _zoomLevel = Options.Instance.MinimapOpts.MaximumZoom;
-            }
+            _zoomLevel = Math.Min(_zoomLevel + Options.Instance.MinimapOpts.ZoomStep,
+                Options.Instance.MinimapOpts.MaximumZoom);
         }
 
         private void MZoomInButton_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            if (_zoomLevel <= Options.Instance.MinimapOpts.MinimumZoom)
-            {
-                return;
-            }
-
-            _zoomLevel -= Options.Instance.MinimapOpts.ZoomStep;
-            if (_zoomLevel < Options.Instance.MinimapOpts.MinimumZoom)
-            {
-                _zoomLevel = Options.Instance.MinimapOpts.MinimumZoom;
-            }
+            _zoomLevel = Math.Max(_zoomLevel - Options.Instance.MinimapOpts.ZoomStep,
+                Options.Instance.MinimapOpts.MinimumZoom);
         }
 
         private enum MapPosition

--- a/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
@@ -1,0 +1,571 @@
+using Intersect.Client.Core;
+using Intersect.Client.Entities;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.General;
+using Intersect.Client.Localization;
+using Intersect.Client.Maps;
+using Intersect.Enums;
+using Intersect.GameObjects;
+using Intersect.GameObjects.Maps;
+
+namespace Intersect.Client.Interface.Game.Map
+{
+    public sealed partial class MinimapWindow : Window
+    {
+        private GameRenderTexture _renderTexture;
+        private GameTexture _whiteTexture;
+
+        private bool _redrawMaps;
+        private bool _redrawEntities;
+        private byte _zoomLevel;
+        private Point _minimapTileSize;
+
+        private Dictionary<MapPosition, MapBase> _mapGrid = new();
+        private Dictionary<MapPosition, Dictionary<Point, EntityInfo>> _entityInfoCache = new();
+
+        private readonly Dictionary<MapPosition, GameRenderTexture> _minimapCache = new();
+        private readonly Dictionary<MapPosition, GameRenderTexture> _entityCache = new();
+        private readonly Dictionary<Guid, MapPosition> _mapPosition = new();
+        private readonly ImagePanel _minimap;
+        private readonly Button _zoomInButton;
+        private readonly Button _zoomOutButton;
+
+        private static readonly GameContentManager ContentManager = Globals.ContentManager;
+
+        // Constructors
+        public MinimapWindow(Base parent) : base(parent, Strings.Minimap.Title, false, "MinimapWindow")
+        {
+            DisableResizing();
+            IsHidden = true;
+
+            _minimap = new ImagePanel(this, "MinimapContainer");
+            _zoomInButton = new Button(_minimap, "ZoomInButton");
+            _zoomOutButton = new Button(_minimap, "ZoomOutButton");
+
+            LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            EnsureInitialized();
+        }
+
+        protected override void EnsureInitialized()
+        {
+            _zoomLevel = Options.Instance.MinimapOpts.DefaultZoom;
+            _minimapTileSize = Options.Instance.MinimapOpts.TileSize;
+
+            _zoomInButton.Clicked += MZoomInButton_Clicked;
+            _zoomInButton.SetToolTipText(Strings.Minimap.ZoomIn);
+            _zoomOutButton.Clicked += MZoomOutButton_Clicked;
+            _zoomOutButton.SetToolTipText(Strings.Minimap.ZoomOut);
+
+            _whiteTexture = Graphics.Renderer.GetWhiteTexture();
+            _renderTexture = GenerateBaseRenderTexture();
+            _minimap.Texture = _renderTexture;
+            _minimap.SetTextureRect(0, 0, _renderTexture.Width, _renderTexture.Height);
+        }
+
+        // Public Methods
+        public void Update()
+        {
+            if (!IsVisible())
+            {
+                return;
+            }
+
+            UpdateMinimap(Globals.Me, Globals.Entities);
+            DrawMinimap();
+        }
+
+        public void Show()
+        {
+            IsHidden = false;
+        }
+
+        public bool IsVisible()
+        {
+            return !IsHidden;
+        }
+
+        public void Hide()
+        {
+            IsHidden = true;
+        }
+
+        // Private Methods
+        private void UpdateMinimap(Player player, Dictionary<Guid, Entity> allEntities)
+        {
+            if (player == null)
+            {
+                return;
+            }
+
+            if (!MapInstance.TryGet(player.MapInstance.Id, out var mapBase))
+            {
+                return;
+            }
+
+            var newGrid = CreateMapGridFromMap(mapBase);
+
+            if (!newGrid.SequenceEqual(_mapGrid))
+            {
+                _mapGrid = newGrid;
+                _mapPosition.Clear();
+                foreach (var map in _mapGrid)
+                {
+                    if (map.Value != null)
+                    {
+                        _mapPosition.Add(map.Value.Id, map.Key);
+                    }
+                }
+
+                _redrawMaps = true;
+            }
+
+            var newLocations = GenerateEntityInfo(allEntities, player);
+            if (!newLocations.Equals(_entityInfoCache))
+            {
+                _entityInfoCache = newLocations;
+                _redrawEntities = true;
+            }
+
+            // Update our minimap display area
+            var centerX = (_renderTexture.Width / 3) + (player.X * _minimapTileSize.X);
+            var centerY = (_renderTexture.Height / 3) + (player.Y * _minimapTileSize.Y);
+            var displayWidth = (int)(_renderTexture.Width * (_zoomLevel / 100f));
+            var displayHeight = (int)(_renderTexture.Height * (_zoomLevel / 100f));
+
+            var x = centerX - (displayWidth / 2);
+            if (x + displayWidth > _renderTexture.Width)
+            {
+                x = _renderTexture.Width - displayWidth;
+            }
+
+            if (x < 0)
+            {
+                x = 0;
+            }
+
+            var y = centerY - (displayHeight / 2);
+            if (y + displayHeight > _renderTexture.Height)
+            {
+                y = _renderTexture.Height - displayHeight;
+            }
+
+            if (y < 0)
+            {
+                y = 0;
+            }
+
+            _minimap.SetTextureRect(x, y, displayWidth, displayHeight);
+        }
+
+        private void DrawMinimap()
+        {
+            if (!_redrawEntities && !_redrawMaps)
+            {
+                return;
+            }
+            
+            _renderTexture.Clear(Color.Transparent);
+
+            foreach (var pos in _mapGrid.Keys)
+            {
+                if (_redrawMaps)
+                {
+                    GenerateMinimapCacheFor(pos);
+                }
+
+                if (_redrawEntities)
+                {
+                    GenerateEntityCacheFor(pos);
+                }
+
+                DrawMinimapCacheToTexture(pos);
+            }
+
+            if (_redrawMaps)
+            {
+                _redrawMaps = false;
+            }
+
+            if (_redrawEntities)
+            {
+                _redrawEntities = false;
+            }
+        }
+
+        private void GenerateMinimapCacheFor(MapPosition position)
+        {
+            _minimapCache.TryAdd(position, null);
+            _minimapCache[position] ??= GenerateMapRenderTexture();
+            _minimapCache[position].Clear(Color.Transparent);
+
+            if (_mapGrid[position] == null)
+            {
+                return;
+            }
+
+            foreach (var layer in Options.Instance.MinimapOpts.RenderLayers)
+            {
+                for (var x = 0; x < Options.Instance.MapOpts.MapWidth; x++)
+                {
+                    for (var y = 0; y < Options.Instance.MapOpts.MapHeight; y++)
+                    {
+                        var curTile = _mapGrid[position].Layers[layer][x, y];
+
+                        if (curTile.TilesetId == Guid.Empty ||
+                            !TilesetBase.TryGet(curTile.TilesetId, out var tileSet))
+                        {
+                            continue;
+                        }
+
+                        var texture = ContentManager.GetTexture(Framework.Content.TextureType.Tileset, tileSet.Name);
+
+                        if (texture == null)
+                        {
+                            continue;
+                        }
+
+                        Graphics.Renderer.DrawTexture(
+                            texture,
+                            curTile.X * Options.Instance.MapOpts.TileWidth + (Options.Instance.MapOpts.TileWidth / 2),
+                            curTile.Y * Options.Instance.MapOpts.TileHeight + (Options.Instance.MapOpts.TileHeight / 2),
+                            1,
+                            1,
+                            x * _minimapTileSize.X,
+                            y * _minimapTileSize.Y,
+                            _minimapTileSize.X,
+                            _minimapTileSize.Y,
+                            Color.White,
+                            _minimapCache[position]);
+                    }
+                }
+            }
+        }
+
+        private void GenerateEntityCacheFor(MapPosition position)
+        {
+            _entityCache.TryAdd(position, null);
+            _entityCache[position] ??= GenerateMapRenderTexture();
+            _entityCache[position].Clear(Color.Transparent);
+
+            if (!_entityInfoCache.TryGetValue(position, out var value))
+            {
+                return;
+            }
+
+            foreach (var entity in value)
+            {
+                var texture = _whiteTexture;
+                var color = entity.Value.Color;
+
+                if (!string.IsNullOrWhiteSpace(entity.Value.Texture))
+                {
+                    var found = ContentManager.Find<GameTexture>(Framework.Content.ContentTypes.Miscellaneous, entity.Value.Texture);
+                    if (found != null)
+                    {
+                        texture = found;
+                        color = Color.White;
+                    }
+                }
+                
+                Graphics.Renderer.DrawTexture(
+                    texture,
+                    0,
+                    0,
+                    texture.Width,
+                    texture.Height,
+                    entity.Key.X * _minimapTileSize.X,
+                    entity.Key.Y * _minimapTileSize.Y,
+                    _minimapTileSize.X,
+                    _minimapTileSize.Y,
+                    color,
+                    _entityCache[position], GameBlendModes.Add);
+            }
+        }
+
+        private void DrawMinimapCacheToTexture(MapPosition position)
+        {
+            if (!_minimapCache.TryGetValue(position, out var value))
+            {
+                return;
+            }
+
+            var x = 0;
+            var y = 0;
+
+            switch (position)
+            {
+                case MapPosition.TopLeft:
+                    break;
+
+                case MapPosition.TopMiddle:
+                    x = value.Width;
+                    break;
+
+                case MapPosition.TopRight:
+                    x = value.Width * 2;
+                    break;
+
+                case MapPosition.MiddleLeft:
+                    y = value.Height;
+                    break;
+
+                case MapPosition.Middle:
+                    x = value.Width;
+                    y = value.Height;
+                    break;
+
+                case MapPosition.MiddleRight:
+                    x = value.Width * 2;
+                    y = value.Height;
+                    break;
+
+                case MapPosition.BottomLeft:
+                    y = value.Height * 2;
+                    break;
+
+                case MapPosition.BottomMiddle:
+                    x = value.Width;
+                    y = value.Height * 2;
+                    break;
+
+                case MapPosition.BottomRight:
+                    x = value.Width * 2;
+                    y = value.Height * 2;
+                    break;
+            }
+
+            if (_minimapCache.TryGetValue(position, out var cachedMinimap))
+            {
+                Graphics.Renderer.DrawTexture(cachedMinimap, 0, 0, cachedMinimap.Width,
+                    cachedMinimap.Height, x, y, cachedMinimap.Width, cachedMinimap.Height,
+                    Color.White, _renderTexture);
+            }
+
+            if (_entityCache.TryGetValue(position, out var cachedEntity))
+            {
+                Graphics.Renderer.DrawTexture(cachedEntity, 0, 0, cachedEntity.Width,
+                    cachedEntity.Height, x, y, cachedEntity.Width, cachedEntity.Height,
+                    Color.White, _renderTexture);
+            }
+        }
+
+        private static Dictionary<MapPosition, MapBase> CreateMapGridFromMap(MapInstance map)
+        {
+            var grid = new Dictionary<MapPosition, MapBase>();
+            for (var x = map.GridX - 1; x <= map.GridX + 1; x++)
+            {
+                for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
+                {
+                    if (x < 0 || x >= Globals.MapGridWidth ||
+                        y < 0 || y >= Globals.MapGridHeight ||
+                        Globals.MapGrid[x, y] == Guid.Empty)
+                    {
+                        continue;
+                    }
+
+                    int minimapX = x - (map.GridX - 1);
+                    int minimapY = y - (map.GridY - 1);
+
+                    grid.Add((MapPosition)(minimapX + (minimapY * 3)), MapBase.Get(Globals.MapGrid[x, y]));
+                }
+            }
+            
+            return grid;
+        }
+
+        private Dictionary<MapPosition, Dictionary<Point, EntityInfo>> GenerateEntityInfo(Dictionary<Guid, Entity> entities, Player player)
+        {
+            var dict = new Dictionary<MapPosition, Dictionary<Point, EntityInfo>>();
+
+            foreach (var entity in entities.Values)
+            {
+                if (!_mapPosition.TryGetValue(entity.MapInstance.Id, out var map))
+                {
+                    continue;
+                }
+
+                if (entity.IsHidden)
+                {
+                    continue;
+                }
+
+                var color = Color.Transparent;
+                var texture = string.Empty;
+                
+                if (entity.Id == player.Id)
+                {
+                    color = Options.Instance.MinimapOpts.MinimapColors.MyEntity;
+                    texture = Options.Instance.MinimapOpts.MinimapImages.MyEntity;
+                }
+                else
+                {
+                    switch (entity.Type)
+                    {
+                        case EntityType.Player:
+                            if (player.IsInMyParty(entity.Id))
+                            {
+                                color = Options.Instance.MinimapOpts.MinimapColors.PartyMember;
+                                texture = Options.Instance.MinimapOpts.MinimapImages.PartyMember;
+                            }
+                            else
+                            {
+                                color = Options.Instance.MinimapOpts.MinimapColors.Player;
+                                texture = Options.Instance.MinimapOpts.MinimapImages.Player;
+                            }
+
+                            break;
+
+                        case EntityType.Event:
+                            color = Options.Instance.MinimapOpts.MinimapColors.Event;
+                            texture = Options.Instance.MinimapOpts.MinimapImages.Event;
+                            break;
+
+                        case EntityType.GlobalEntity:
+                            color = Options.Instance.MinimapOpts.MinimapColors.Npc;
+                            texture = Options.Instance.MinimapOpts.MinimapImages.Npc;
+                            break;
+
+                        case EntityType.Resource:
+                            // This relies on users configuring it PROPERLY.
+                            var tool = ((Resource)entity).BaseResource.Tool;
+                            var texSet = false;
+                            var colSet = false;
+
+                            // Is the tool a valid one to get the string version for?
+                            if (tool >= 0 && tool < Options.Instance.EquipmentOpts.ToolTypes.Count)
+                            {
+                                // Get the actual tool type from the server configuration.
+                                var toolType = Options.Instance.EquipmentOpts.ToolTypes[tool];
+
+                                // Attempt to get our color from the plugin configuration.
+                                if (Options.Instance.MinimapOpts.MinimapColors.Resource.TryGetValue(toolType, out color))
+                                {
+                                    colSet = true;
+                                }
+
+                                // Attempt to get our texture from the plugin configuration.
+                                if (Options.Instance.MinimapOpts.MinimapImages.Resource.TryGetValue(toolType, out texture))
+                                {
+                                    texSet = true;
+                                }
+                            }
+                            // Is it a None tool?
+                            else if (tool == -1)
+                            {
+                                color = Options.Instance.MinimapOpts.MinimapColors.Resource["None"];
+                                colSet = true;
+                                texture = Options.Instance.MinimapOpts.MinimapImages.Resource["None"];
+                                texSet = true;
+                            }
+
+                            // Have we managed to set our color? If not, set to default.
+                            if (!colSet)
+                            {
+                                color = Options.Instance.MinimapOpts.MinimapColors.Default;
+                            }
+
+                            // Have we managed to set our texture? If not, set to blank.
+                            if (!texSet)
+                            {
+                                texture = string.Empty;
+                            }
+
+                            break;
+
+                        case EntityType.Projectile:
+                            continue;
+
+                        default:
+                            color = Options.Instance.MinimapOpts.MinimapColors.Default;
+                            texture = Options.Instance.MinimapOpts.MinimapImages.Default;
+                            break;
+                    }
+                }
+
+                // Add this to our location dictionary!
+                if (!dict.TryGetValue(map, out var locationDictionary))
+                {
+                    locationDictionary = new Dictionary<Point, EntityInfo>();
+                    dict.Add(map, locationDictionary);
+                }
+
+                if (color == null || texture == null)
+                {
+                    continue;
+                }
+
+                locationDictionary.TryAdd(new Point(entity.X, entity.Y),
+                    new EntityInfo { Color = color, Texture = texture });
+            }
+
+            return dict;
+        }
+
+        private GameRenderTexture GenerateBaseRenderTexture()
+        {
+            var sizeX = (_minimapTileSize.X * Options.Instance.MapOpts.MapWidth) * 3;
+            var sizeY = (_minimapTileSize.Y * Options.Instance.MapOpts.MapHeight) * 3;
+
+            return Graphics.Renderer.CreateRenderTexture(sizeX, sizeY);
+        }
+
+        private GameRenderTexture GenerateMapRenderTexture()
+        {
+            var sizeX = _minimapTileSize.X * Options.Instance.MapOpts.MapWidth;
+            var sizeY = _minimapTileSize.Y * Options.Instance.MapOpts.MapHeight;
+
+            return Graphics.Renderer.CreateRenderTexture(sizeX, sizeY);
+        }
+
+        private void MZoomOutButton_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            if (_zoomLevel >= Options.Instance.MinimapOpts.MaximumZoom)
+            {
+                return;
+            }
+
+            _zoomLevel += Options.Instance.MinimapOpts.ZoomStep;
+            if (_zoomLevel > Options.Instance.MinimapOpts.MaximumZoom)
+            {
+                _zoomLevel = Options.Instance.MinimapOpts.MaximumZoom;
+            }
+        }
+
+        private void MZoomInButton_Clicked(Base sender, ClickedEventArgs arguments)
+        {
+            if (_zoomLevel <= Options.Instance.MinimapOpts.MinimumZoom)
+            {
+                return;
+            }
+
+            _zoomLevel -= Options.Instance.MinimapOpts.ZoomStep;
+            if (_zoomLevel < Options.Instance.MinimapOpts.MinimumZoom)
+            {
+                _zoomLevel = Options.Instance.MinimapOpts.MinimumZoom;
+            }
+        }
+
+        private enum MapPosition
+        {
+            TopLeft,
+            TopMiddle,
+            TopRight,
+            MiddleLeft,
+            Middle,
+            MiddleRight,
+            BottomLeft,
+            BottomMiddle,
+            BottomRight,
+        }
+        
+        private sealed class EntityInfo
+        {
+            public Color Color { get; set; }
+
+            public string Texture { get; set; }
+        }
+    }
+}

--- a/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client/Interface/Game/Map/MinimapWindow.cs
@@ -376,8 +376,14 @@ namespace Intersect.Client.Interface.Game.Map
                 for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
                 {
                     if (x < 0 || x >= Globals.MapGridWidth ||
-                        y < 0 || y >= Globals.MapGridHeight ||
-                        Globals.MapGrid[x, y] == Guid.Empty)
+                        y < 0 || y >= Globals.MapGridHeight)
+                    {
+                        continue;
+                    }
+
+                    var currentGridValue = Globals.MapGrid[x, y];
+
+                    if (currentGridValue == Guid.Empty)
                     {
                         continue;
                     }
@@ -385,7 +391,11 @@ namespace Intersect.Client.Interface.Game.Map
                     int minimapX = x - (map.GridX - 1);
                     int minimapY = y - (map.GridY - 1);
 
-                    grid.Add((MapPosition)(minimapX + (minimapY * 3)), MapBase.Get(Globals.MapGrid[x, y]));
+                    var mapBase = MapBase.Get(currentGridValue);
+                    if (mapBase != null)
+                    {
+                        grid.Add((MapPosition)(minimapX + (minimapY * 3)), mapBase);
+                    }
                 }
             }
             

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -1,17 +1,16 @@
 ﻿using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
-using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Character;
 using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Interface.Game.Inventory;
+using Intersect.Client.Interface.Game.Map;
 using Intersect.Client.Interface.Game.Spells;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Enums;
-using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game
 {
@@ -24,6 +23,8 @@ namespace Intersect.Client.Interface.Game
         private readonly Button mCharacterButton;
 
         private readonly CharacterWindow mCharacterWindow;
+
+        private readonly MinimapWindow mMinimapWindow;
 
         private readonly ImagePanel mFriendsBackground;
 
@@ -139,6 +140,7 @@ namespace Intersect.Client.Interface.Game
             mInventoryWindow = new InventoryWindow(gameCanvas);
             mSpellsWindow = new SpellsWindow(gameCanvas);
             mCharacterWindow = new CharacterWindow(gameCanvas);
+            mMinimapWindow = new MinimapWindow(gameCanvas);
             mQuestsWindow = new QuestsWindow(gameCanvas);
             mMapItemWindow = new MapItemWindow(gameCanvas);
             mGuildWindow = new GuildWindow(gameCanvas);
@@ -150,6 +152,7 @@ namespace Intersect.Client.Interface.Game
             mInventoryWindow.Update();
             mSpellsWindow.Update();
             mCharacterWindow.Update();
+            mMinimapWindow.Update();
             mPartyWindow.Update();
             mFriendsWindow.Update();
             mQuestsWindow.Update(updateQuestLog);
@@ -175,6 +178,7 @@ namespace Intersect.Client.Interface.Game
             }
 
             mCharacterWindow.Hide();
+            mMinimapWindow.Hide();
             mFriendsWindow.Hide();
             mInventoryWindow.Hide();
             mPartyWindow.Hide();
@@ -193,6 +197,24 @@ namespace Intersect.Client.Interface.Game
             {
                 HideWindows();
                 mCharacterWindow.Show();
+            }
+        }
+
+        public void ToggleMinimapWindow()
+        {
+            if (!Options.Instance.MinimapOpts.EnableMinimapWindow)
+            {
+                return;
+            }
+
+            if (mMinimapWindow.IsVisible())
+            {
+                mMinimapWindow.Hide();
+            }
+            else
+            {
+                HideWindows();
+                mMinimapWindow.Show();
             }
         }
 

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -724,6 +724,7 @@ namespace Intersect.Client.Localization
                 {"togglezoomout", "Toggle Zoom Out:"},
                 {"holdtozoomout", "Hold to Zoom Out:"},
                 {"togglefullscreen", "Toggle Fullscreen:"},
+                {"openminimap", @"Open Minimap:"},
                 // {"submit", "Submit"},
                 // {"cancel", "Cancel"},
                 // {"next", "Next"},
@@ -2309,6 +2310,18 @@ namespace Intersect.Client.Localization
 
             public static LocalizedString youroffer = @"Your Offer:";
 
+        }
+
+        public partial struct Minimap
+        {
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Title = @"Minimap";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ZoomIn = @"Zoom In";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ZoomOut = @"Zoom Out";
         }
 
         public partial struct EscapeMenu


### PR DESCRIPTION
Based on @Cheshire92 's work:
- https://github.com/Cheshire92/Intersect-Plugins/tree/main/Cheshire.Plugins.Client.Minimap
- https://www.ascensiongamedev.com/topic/6171-client-development-branch-minimap-plugin/
- **Assets PR** (Required for this): https://github.com/AscensionGameDev/Intersect-Assets/pull/48

What is this about:
- Adds a configurable minimap to Intersect !
- Renders the lowest layers of your map by colour approximation to the minimap.
- Renders entities such as players, events, npcs and resources to the minimap with configurable colours and textures.
- A configurable GUI element with its own json file and graphics files.
- Configuration options to decide which map layers get drawn to the minimap.
- Zooming in and out as well as configurable zoom levels.

Changes from Cheshire's work:
- Refactored a bit for less nested code.
- Using TryGet(s) for less nesting and null checking.
- Fixed an issue when zooming in too much.
- Configurable though server options.
- Includes a close button.
- Includes a localized title.
- Includes a new game control for opening and closing the minimap (Default: M).
- Added localized text tooltips for zooming buttons.
- Added custom textures for zooming buttons.


Preview:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/cdce7d41-4c0c-4681-aa1a-801596674e84


https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/8cf9b858-0056-4694-a229-49add98f18a9


https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/677ebd66-d401-4475-b1f9-be12e9dfeb8d




