### PR TITLE
fix: prevent crash when going to character select from ingame

### DIFF
--- a/Intersect.Client/Core/Main.cs
+++ b/Intersect.Client/Core/Main.cs
@@ -330,10 +330,17 @@ namespace Intersect.Client.Core
             Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
         }
 
-        public static void Logout(bool characterSelect)
+        public static void Logout(bool characterSelect, bool skipFade = false)
         {
             Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-            Fade.FadeOut();
+            if (skipFade)
+            {
+                Fade.Cancel();
+            }
+            else
+            {
+                Fade.FadeOut();
+            }
 
             if (!ClientContext.IsSinglePlayer)
             {
@@ -387,7 +394,14 @@ namespace Intersect.Client.Core
                 PacketSender.SendLogout(characterSelect);
             }
 
-            Fade.FadeIn();
+            if (skipFade)
+            {
+                Fade.Cancel();
+            }
+            else
+            {
+                Fade.FadeIn();
+            }
         }
 
     }

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -344,6 +344,7 @@ namespace Intersect.Client.Interface.Menu
 
         private void mLogoutButton_Clicked(Base sender, ClickedEventArgs arguments)
         {
+            Main.Logout(false, skipFade: true);
             mMainMenu.Reset();
         }
 

--- a/Intersect.Network/LiteNetLib/LiteNetLibInterface.cs
+++ b/Intersect.Network/LiteNetLib/LiteNetLibInterface.cs
@@ -446,6 +446,13 @@ public sealed class LiteNetLibInterface : INetworkLayerInterface, INetEventListe
 
     public void OnNetworkLatencyUpdate(NetPeer peer, int latency)
     {
+#if !DIAGNOSTIC
+        if (latency < 1)
+        {
+            return;
+        }
+#endif
+
         Log.Verbose($"LTNC {peer.EndPoint} {latency}ms");
     }
 

--- a/Intersect.Server.Core/Core/ServerContext.cs
+++ b/Intersect.Server.Core/Core/ServerContext.cs
@@ -118,7 +118,7 @@ namespace Intersect.Server.Core
                 var savingTasks = new List<Task>();
                 foreach (var user in Database.PlayerData.User.OnlineList.ToArray())
                 {
-                    savingTasks.Add(Task.Run(() => user.Save()));
+                    savingTasks.Add(Task.Run(() => user.SaveWithDebounce()));
                 }
 
                 Task.WaitAll(savingTasks.ToArray());

--- a/Intersect.Server.Core/Database/IntersectDbContext.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.cs
@@ -9,6 +9,7 @@ using Intersect.Server.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Primitives;
 
 namespace Intersect.Server.Database;
 
@@ -204,15 +205,14 @@ public abstract partial class IntersectDbContext<TDbContext> : DbContext, IDbCon
 
             return rowsChanged;
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateConcurrencyException concurrencyException)
         {
             var concurrencyErrors = new StringBuilder();
-            foreach (var entry in ex.Entries)
+            foreach (var entry in concurrencyException.Entries)
             {
-                var type = entry.GetType().FullName;
-                concurrencyErrors.AppendLine($"Entry Type [{type} / {entry.State}]");
-                concurrencyErrors.AppendLine("--------------------");
-                concurrencyErrors.AppendLine($"Type: {entry.Entity.GetFullishName()}");
+                concurrencyErrors.AppendLine(
+                    $"[{entry.State}] {entry.Entity.GetFullishName()} ({entry.GetFullishName()})"
+                );
 
                 var proposedValues = entry.CurrentValues;
                 var databaseValues = entry.GetDatabaseValues();
@@ -220,23 +220,29 @@ public abstract partial class IntersectDbContext<TDbContext> : DbContext, IDbCon
                 foreach (var property in proposedValues.Properties)
                 {
                     concurrencyErrors.AppendLine(
-                        $"\t{property.Name:propertyNameColumnSize} (Token: {property.IsConcurrencyToken}): Proposed: {proposedValues[property]}  Original Value: {entry.OriginalValues[property]}  Database Value: {(databaseValues != null ? databaseValues[property] : "null")}"
+                        string.Join(
+                            ' ',
+                            $"\t{property.Name:propertyNameColumnSize} (Token: {property.IsConcurrencyToken}):",
+                            $"Proposed: {proposedValues[property]}",
+                            $"Original Value: {entry.OriginalValues[property]}",
+                            $"Database Value: {(databaseValues?[property] ?? "null")}"
+                        )
                     );
                 }
 
-                concurrencyErrors.AppendLine("");
-                concurrencyErrors.AppendLine("");
+                concurrencyErrors.AppendLine();
             }
 
-            var suffix = string.Empty;
 #if DEBUG
-            suffix = $"#{currentExecutionId}";
+            var suffix = $"#{currentExecutionId}";
+#else
+            var suffix = string.Empty;
 #endif
             var entityTypeNames = ChangeTracker.Entries()
                 .Select(entry => entry.Entity.GetType().Name)
                 .Distinct()
                 .ToArray();
-            Log.Error(ex, $"Jackpot! Concurrency Bug For {string.Join(", ", entityTypeNames)} {suffix}");
+            Log.Error(concurrencyException, $"Jackpot! Concurrency Bug For {string.Join(", ", entityTypeNames)} {suffix}");
             Log.Error(concurrencyErrors.ToString());
             Log.Error(Environment.StackTrace);
 

--- a/Intersect.Server.Core/Database/IntersectDbContext.cs
+++ b/Intersect.Server.Core/Database/IntersectDbContext.cs
@@ -238,6 +238,7 @@ public abstract partial class IntersectDbContext<TDbContext> : DbContext, IDbCon
                 .ToArray();
             Log.Error(ex, $"Jackpot! Concurrency Bug For {string.Join(", ", entityTypeNames)} {suffix}");
             Log.Error(concurrencyErrors.ToString());
+            Log.Error(Environment.StackTrace);
 
 #if DEBUG
             Log.Debug($"DBOP-C SaveChanges({acceptAllChangesOnSuccess}) #{currentExecutionId}");

--- a/Intersect.Server.Core/Database/PlayerData/Players/Variable.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Variable.cs
@@ -6,9 +6,19 @@ namespace Intersect.Server.Database.PlayerData.Players
 {
     public partial class Variable
     {
+        private Guid _id;
+
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         [JsonIgnore]
-        public Guid Id { get; protected set; }
+        public Guid Id
+        {
+            get => _id;
+            set
+            {
+                Console.WriteLine("HERE IS THE ISSUE?", Environment.StackTrace);
+                _id = value;
+            }
+        }
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public Guid VariableId { get; protected set; }

--- a/Intersect.Server.Core/Database/PlayerData/User.cs
+++ b/Intersect.Server.Core/Database/PlayerData/User.cs
@@ -32,6 +32,9 @@ namespace Intersect.Server.Database.PlayerData
     [ApiVisibility(ApiVisibility.Restricted | ApiVisibility.Private)]
     public partial class User
     {
+        private long _lastSave;
+        private readonly object _lastSaveLock = new();
+
         private static readonly ConcurrentDictionary<Guid, User> OnlineUsers = new();
 
         [JsonIgnore][NotMapped] private readonly object mSavingLock = new();
@@ -191,7 +194,11 @@ namespace Intersect.Server.Database.PlayerData
 
                     Players.Add(newCharacter);
 
+                    Console.WriteLine($"[AddCharacter Before Validate] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+
                     Player.Validate(newCharacter);
+
+                    Console.WriteLine($"[AddCharacter Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
                     context.ChangeTracker.DetectChanges();
 
@@ -200,7 +207,11 @@ namespace Intersect.Server.Database.PlayerData
                     //If we have a new character, intersect already generated the id.. which means the change tracker is gonna see them as modified and not added.. we need to manually set their state
                     context.Entry(newCharacter).State = EntityState.Added;
 
+                    Console.WriteLine($"[AddCharacter Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+
                     context.SaveChanges();
+
+                    Console.WriteLine($"[AddCharacter After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
                 }
             }
             catch (Exception ex)
@@ -225,20 +236,25 @@ namespace Intersect.Server.Database.PlayerData
             {
                 lock (mSavingLock)
                 {
-                    using (var context = DbInterface.CreatePlayerContext(false))
-                    {
-                        context.Users.Update(this);
+                    using var context = DbInterface.CreatePlayerContext(false);
 
-                        context.ChangeTracker.DetectChanges();
+                    context.Users.Update(this);
 
-                        context.StopTrackingUsersExcept(this);
+                    Players.Remove(deleteCharacter);
 
-                        context.Entry(deleteCharacter).State = EntityState.Deleted;
+                    Console.WriteLine($"[DeleteCharacter Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
-                        Players.Remove(deleteCharacter);
+                    context.ChangeTracker.DetectChanges();
 
-                        context.SaveChanges();
-                    }
+                    context.StopTrackingUsersExcept(this);
+
+                    context.Entry(deleteCharacter).State = EntityState.Deleted;
+
+                    Console.WriteLine($"[DeleteCharacter Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+
+                    context.SaveChanges();
+
+                    Console.WriteLine($"[DeleteCharacter After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
                 }
             }
             catch (Exception ex)
@@ -294,16 +310,35 @@ namespace Intersect.Server.Database.PlayerData
             CancellationToken cancellationToken = default
         ) => Save(playerContext, force);
 
-        public void Save(bool force) => Save(force: force, create: false);
+        public void SaveWithDebounce(long debounceMs = 5000)
+        {
+            lock (_lastSaveLock)
+            {
+                if (_lastSave < debounceMs + Timing.Global.MillisecondsUtc)
+                {
+                    Console.WriteLine("Skipping save due to debounce");
+                    return;
+                }
+            }
 
-        public void Save(bool force = false, bool create = false) => Save(default, force, create);
+            Save();
+        }
+
+        public UserSaveResult Save(bool force) => Save(force: force, create: false);
+
+        public UserSaveResult Save(bool force = false, bool create = false) => Save(default, force, create);
 
 #if DIAGNOSTIC
         private int _saveCounter = 0;
 #endif
 
-        private void Save(PlayerContext? playerContext, bool force = false, bool create = false)
+        private UserSaveResult Save(PlayerContext? playerContext, bool force = false, bool create = false)
         {
+            lock (_lastSaveLock)
+            {
+                _lastSave = Timing.Global.MillisecondsUtc;
+            }
+
 #if DIAGNOSTIC
             var currentExecutionId = _saveCounter++;
 #endif
@@ -316,17 +351,22 @@ namespace Intersect.Server.Database.PlayerData
             {
                 if (force)
                 {
+                    // Console.WriteLine($"Monitor.Enter [Before] {lockTaken} {Environment.StackTrace}");
                     Monitor.Enter(mSavingLock);
                     lockTaken = true;
+                    // Console.WriteLine($"Monitor.Enter [Before] {lockTaken} {Environment.StackTrace}");
                 }
                 else
                 {
+                    // Console.WriteLine($"Monitor.TryEnter [Before] {lockTaken} {Environment.StackTrace}");
                     Monitor.TryEnter(mSavingLock, 0, ref lockTaken);
+                    // Console.WriteLine($"Monitor.TryEnter [After] {lockTaken} {Environment.StackTrace}");
                 }
 
                 if (!lockTaken)
                 {
-                    return;
+                    Console.WriteLine($"Failed to take lock {Environment.StackTrace}");
+                    return UserSaveResult.SkippedCouldNotTakeLock;
                 }
 
 #if DIAGNOSTIC
@@ -339,16 +379,25 @@ namespace Intersect.Server.Database.PlayerData
                     playerContext = createdContext;
                 }
 
+                Console.WriteLine($"[User.Save Before Add/Update] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+                // Console.WriteLine($"[User.Save Before Add/Update] User PV States for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV States for {p.Id}: {string.Join(", ", p.Variables.Select(v => $"{v.Id} is {playerContext.Entry(v).State}"))}"))}");
+
                 if (create)
                 {
                     playerContext.Users.Add(this);
                 }
                 else
                 {
+                    // playerContext.Attach(this);
                     playerContext.Users.Update(this);
                 }
 
+                Console.WriteLine($"[User.Save Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+                // Console.WriteLine($"[User.Save Before DetectChanges] User PV States for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV States for {p.Id}: {string.Join(", ", p.Variables.Select(v => $"{v.Id} is {playerContext.Entry(v).State}"))}"))}");
+
                 playerContext.ChangeTracker.DetectChanges();
+
+                // Console.WriteLine($"[User.Save After DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
                 playerContext.StopTrackingUsersExcept(this);
 
@@ -362,11 +411,17 @@ namespace Intersect.Server.Database.PlayerData
                     playerContext.Entry(UserMute).State = EntityState.Detached;
                 }
 
+                // Console.WriteLine($"[User.Save Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
+
                 playerContext.SaveChanges();
+
+                // Console.WriteLine($"[User.Save After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
 #if DIAGNOSTIC
                 Log.Debug($"DBOP-B Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
 #endif
+
+                return UserSaveResult.Completed;
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -424,10 +479,17 @@ namespace Intersect.Server.Database.PlayerData
             {
                 if (lockTaken)
                 {
+                    Console.WriteLine($"Monitor.Exit [Locked] {Environment.StackTrace}");
                     createdContext?.Dispose();
                     Monitor.Exit(mSavingLock);
                 }
+                else
+                {
+                    Console.WriteLine($"Monitor.Exit [Skipping] {Environment.StackTrace}");
+                }
             }
+
+            return UserSaveResult.Failed;
         }
 
         [return: NotNullIfNotNull(nameof(user))]

--- a/Intersect.Server.Core/Database/PlayerData/User.cs
+++ b/Intersect.Server.Core/Database/PlayerData/User.cs
@@ -194,11 +194,7 @@ namespace Intersect.Server.Database.PlayerData
 
                     Players.Add(newCharacter);
 
-                    Console.WriteLine($"[AddCharacter Before Validate] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-
                     Player.Validate(newCharacter);
-
-                    Console.WriteLine($"[AddCharacter Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
                     context.ChangeTracker.DetectChanges();
 
@@ -207,11 +203,7 @@ namespace Intersect.Server.Database.PlayerData
                     //If we have a new character, intersect already generated the id.. which means the change tracker is gonna see them as modified and not added.. we need to manually set their state
                     context.Entry(newCharacter).State = EntityState.Added;
 
-                    Console.WriteLine($"[AddCharacter Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-
                     context.SaveChanges();
-
-                    Console.WriteLine($"[AddCharacter After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
                 }
             }
             catch (Exception ex)
@@ -242,19 +234,13 @@ namespace Intersect.Server.Database.PlayerData
 
                     Players.Remove(deleteCharacter);
 
-                    Console.WriteLine($"[DeleteCharacter Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-
                     context.ChangeTracker.DetectChanges();
 
                     context.StopTrackingUsersExcept(this);
 
                     context.Entry(deleteCharacter).State = EntityState.Deleted;
 
-                    Console.WriteLine($"[DeleteCharacter Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-
                     context.SaveChanges();
-
-                    Console.WriteLine($"[DeleteCharacter After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
                 }
             }
             catch (Exception ex)
@@ -316,7 +302,7 @@ namespace Intersect.Server.Database.PlayerData
             {
                 if (_lastSave < debounceMs + Timing.Global.MillisecondsUtc)
                 {
-                    Console.WriteLine("Skipping save due to debounce");
+                    Log.Debug("Skipping save due to debounce");
                     return;
                 }
             }
@@ -351,21 +337,19 @@ namespace Intersect.Server.Database.PlayerData
             {
                 if (force)
                 {
-                    // Console.WriteLine($"Monitor.Enter [Before] {lockTaken} {Environment.StackTrace}");
                     Monitor.Enter(mSavingLock);
                     lockTaken = true;
-                    // Console.WriteLine($"Monitor.Enter [Before] {lockTaken} {Environment.StackTrace}");
                 }
                 else
                 {
-                    // Console.WriteLine($"Monitor.TryEnter [Before] {lockTaken} {Environment.StackTrace}");
                     Monitor.TryEnter(mSavingLock, 0, ref lockTaken);
-                    // Console.WriteLine($"Monitor.TryEnter [After] {lockTaken} {Environment.StackTrace}");
                 }
 
                 if (!lockTaken)
                 {
-                    Console.WriteLine($"Failed to take lock {Environment.StackTrace}");
+#if DIAGNOSTIC
+                    Log.Debug($"Failed to take lock {Environment.StackTrace}");
+#endif
                     return UserSaveResult.SkippedCouldNotTakeLock;
                 }
 
@@ -379,9 +363,6 @@ namespace Intersect.Server.Database.PlayerData
                     playerContext = createdContext;
                 }
 
-                Console.WriteLine($"[User.Save Before Add/Update] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-                // Console.WriteLine($"[User.Save Before Add/Update] User PV States for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV States for {p.Id}: {string.Join(", ", p.Variables.Select(v => $"{v.Id} is {playerContext.Entry(v).State}"))}"))}");
-
                 if (create)
                 {
                     playerContext.Users.Add(this);
@@ -392,12 +373,7 @@ namespace Intersect.Server.Database.PlayerData
                     playerContext.Users.Update(this);
                 }
 
-                Console.WriteLine($"[User.Save Before DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-                // Console.WriteLine($"[User.Save Before DetectChanges] User PV States for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV States for {p.Id}: {string.Join(", ", p.Variables.Select(v => $"{v.Id} is {playerContext.Entry(v).State}"))}"))}");
-
                 playerContext.ChangeTracker.DetectChanges();
-
-                // Console.WriteLine($"[User.Save After DetectChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
                 playerContext.StopTrackingUsersExcept(this);
 
@@ -411,11 +387,7 @@ namespace Intersect.Server.Database.PlayerData
                     playerContext.Entry(UserMute).State = EntityState.Detached;
                 }
 
-                // Console.WriteLine($"[User.Save Before SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
-
                 playerContext.SaveChanges();
-
-                // Console.WriteLine($"[User.Save After SaveChanges] User PV IDs for {Id}:\n\t{string.Join("\n\t", Players.Select(p => $"Player PV IDs for {p.Id}: {string.Join(", ", p.Variables.Select(v => v.Id))}"))}");
 
 #if DIAGNOSTIC
                 Log.Debug($"DBOP-B Save({playerContext}, {force}, {create}) #{currentExecutionId} {Name} ({Id})");
@@ -479,13 +451,8 @@ namespace Intersect.Server.Database.PlayerData
             {
                 if (lockTaken)
                 {
-                    Console.WriteLine($"Monitor.Exit [Locked] {Environment.StackTrace}");
                     createdContext?.Dispose();
                     Monitor.Exit(mSavingLock);
-                }
-                else
-                {
-                    Console.WriteLine($"Monitor.Exit [Skipping] {Environment.StackTrace}");
                 }
             }
 

--- a/Intersect.Server.Core/Database/PlayerData/UserSaveResult.cs
+++ b/Intersect.Server.Core/Database/PlayerData/UserSaveResult.cs
@@ -1,0 +1,8 @@
+namespace Intersect.Server.Database.PlayerData;
+
+public enum UserSaveResult
+{
+    Completed,
+    SkippedCouldNotTakeLock,
+    Failed,
+}

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -467,7 +467,7 @@ namespace Intersect.Server.Entities
             BankInterface = default;
             InShop = default;
 
-            //Clear cooldowns that have expired
+            // Clear cooldowns that have expired
             RemoveStaleItemCooldowns();
             RemoveStaleSpellCooldowns();
 
@@ -478,10 +478,10 @@ namespace Intersect.Server.Entities
                 PacketSender.SendGlobalMsg(Strings.Player.left.ToString(Name, Options.Instance.GameName));
             }
 
-            //Remvoe this player from the online list
+            // Remove this player from the online list
             if (OnlinePlayers?.ContainsKey(Id) ?? false)
             {
-                OnlinePlayers.TryRemove(Id, out Player me);
+                OnlinePlayers.TryRemove(Id, out Player _);
                 OnlineList = OnlinePlayers.Values.ToArray();
             }
 
@@ -496,7 +496,7 @@ namespace Intersect.Server.Entities
                 User?.TryLogout(softLogout);
             }
 
-#if DEBUG
+#if DIAGNOSTIC
             var stackTrace = Environment.StackTrace;
 #else
             var stackTrace = default(string);
@@ -516,7 +516,7 @@ namespace Intersect.Server.Entities
                 Log.Debug($"Completing logout {logoutOperationId}");
             }
 
-            if (!string.IsNullOrWhiteSpace(stackTrace))
+            if (stackTrace != default)
             {
                 Log.Debug(stackTrace);
             }
@@ -526,24 +526,23 @@ namespace Intersect.Server.Entities
             Log.Debug($"Started {nameof(CompleteLogout)}() #{currentExecutionId} on {Name} ({User?.Name})");
 #endif
 
-            Console.WriteLine($"PVIDS for {Id}: {string.Join(", ", Variables.Select(v => v.Id))}");
             try
             {
-                Log.Debug($"Starting save for logout {logoutOperationId}");
+                Log.Diagnostic($"Starting save for logout {logoutOperationId}");
                 var saveResult = User?.Save();
                 switch (saveResult)
                 {
                     case UserSaveResult.Completed:
-                        Log.Debug($"Completed save for logout {logoutOperationId}");
+                        Log.Diagnostic($"Completed save for logout {logoutOperationId}");
                         break;
                     case UserSaveResult.SkippedCouldNotTakeLock:
                         Log.Debug($"Skipped save for logout {logoutOperationId}");
                         break;
                     case UserSaveResult.Failed:
-                        Log.Debug($"Save failed for logout {logoutOperationId}");
+                        Log.Warn($"Save failed for logout {logoutOperationId}");
                         break;
                     case null:
-                        Log.Debug($"Skipped save because {nameof(User)} is null.");
+                        Log.Warn($"Skipped save because {nameof(User)} is null.");
                         break;
                     default:
                         throw new UnreachableException();
@@ -551,7 +550,7 @@ namespace Intersect.Server.Entities
             }
             catch
             {
-                Log.Debug($"Crashed while saving for logout {logoutOperationId}");
+                Log.Warn($"Crashed while saving for logout {logoutOperationId}");
                 throw;
             }
 

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -653,9 +653,10 @@ namespace Intersect.Server.Networking
             if (packet.ReturningToCharSelect &&
                 (Options.MaxCharacters > 1 || !Options.Instance.PlayerOpts.SkipCharacterSelect))
             {
+                Log.Debug($"[{nameof(LogoutPacket)}] Returning to character select from player {client.Entity?.Id} ({client.User?.Id})");
                 client.Entity?.TryLogout(false, true);
                 client.Entity = default;
-                PacketSender.SendPlayerCharacters(client);
+                PacketSender.SendPlayerCharacters(client, skipLoadingRelationships: true);
             }
             else
             {
@@ -2479,7 +2480,9 @@ namespace Intersect.Server.Networking
         public void HandlePacket(Client client, DeleteCharacterPacket packet)
         {
             if (client.User == null)
+            {
                 return;
+            }
 
             if (Player.FindOnline(packet.CharacterId) != null)
             {

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1251,7 +1251,7 @@ namespace Intersect.Server.Networking
         }
 
         //CharactersPacket
-        public static void SendPlayerCharacters(Client client)
+        public static void SendPlayerCharacters(Client client, bool skipLoadingRelationships = false)
         {
             if (client == default)
             {
@@ -1273,8 +1273,9 @@ namespace Intersect.Server.Networking
                 return;
             }
 
-            using (var playerContext = DbInterface.CreatePlayerContext())
+            if (!skipLoadingRelationships)
             {
+                using var playerContext = DbInterface.CreatePlayerContext();
                 foreach (var player in client.Characters.OrderByDescending(p => p.LastOnline))
                 {
                     player.LoadRelationships(playerContext);

--- a/Intersect.Server/Intersect.Server.csproj
+++ b/Intersect.Server/Intersect.Server.csproj
@@ -22,10 +22,6 @@
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration.ToLower())' == 'nofody'">
-    <DisableFody>true</DisableFody>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Networking\IntersectNetworkServer.cs" />
     <Compile Remove="Networking\IntersectNetworkSocket.cs" />


### PR DESCRIPTION
can still cause it by logging in with no pv, setting the pv and quickly exiting to char select, logging out, deleting the pv instance from the player db, logging back in, setting the pv, and quickly exiting to char select (and maybe even just normal logout triggers it in this specific scenario?)