### PR TITLE
feat: (Day) Add ability to enable self-cast when casting friendly spe…

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -72,6 +72,6 @@
         /// <summary>
         /// If enabled, this makes it so a player casting a friendly spell on a hostile target instead casts the spell upon themselves
         /// </summary>
-        public bool EnableAutoSelfCastOnFriendlyHostile = false;
+        public bool EnableAutoSelfCastOnFriendlyHostile { get; set; } = false;
     }
 }

--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -72,6 +72,6 @@
         /// <summary>
         /// If enabled, this makes it so a player casting a friendly spell on a hostile target instead casts the spell upon themselves
         /// </summary>
-        public bool EnableAutoSelfCastOnFriendlyHostile { get; set; } = false;
+        public bool EnableAutoSelfCastFriendlySpellsWhenTargetingHostile { get; set; } = false;
     }
 }

--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -68,5 +68,10 @@
         /// If enabled, this allows entities to turn around while casting
         /// </summary>
         public bool EnableTurnAroundWhileCasting = false;
+
+        /// <summary>
+        /// If enabled, this makes it so a player casting a friendly spell on a hostile target instead casts the spell upon themselves
+        /// </summary>
+        public bool EnableAutoSelfCastOnFriendlyHostile = false;
     }
 }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2277,6 +2277,12 @@ namespace Intersect.Server.Entities
             {
                 if ((spell.Combat.Friendly != IsAllyOf(target)) || !CanAttack(target, spell))
                 {
+                    if (spell.Combat.Friendly && Options.Instance.CombatOpts.EnableAutoSelfCastOnFriendlyHostile)
+                    {
+                        // Set the target to self and try again
+                        return CanCastSpell(spell, this, checkVitalReqs, out reason);
+                    }
+
                     reason = SpellCastFailureReason.InvalidTarget;
                     return false;
                 }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2277,7 +2277,7 @@ namespace Intersect.Server.Entities
             {
                 if ((spell.Combat.Friendly != IsAllyOf(target)) || !CanAttack(target, spell))
                 {
-                    if (spell.Combat.Friendly && Options.Instance.CombatOpts.EnableAutoSelfCastOnFriendlyHostile)
+                    if (spell.Combat.Friendly && Options.Instance.CombatOpts.EnableAutoSelfCastFriendlySpellsWhenTargetingHostile)
                     {
                         // Set the target to self and try again
                         return CanCastSpell(spell, this, checkVitalReqs, out reason);


### PR DESCRIPTION
…lls on hostile

Basically, if you are targeting a hostile with this option enabled, and you cast a friendly spell, the engine will try to cast the spell on your self instead. This makes combat more fluid and makes it easier to panic heal/buff yourself, or maintain buffs