### PR TITLE
feat: (Day) Add an instance controller for prep for future work

### DIFF
--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -176,7 +176,7 @@ namespace Intersect.Server.Core
                             }
 
                             // Allow our instance controllers to keep their instances up to date
-                            InstanceProcessor.UpdateInstanceControllers(ActiveMapInstances.Values.ToList());
+                            InstanceProcessor.UpdateInstanceControllers(ActiveMapInstances.Values.ToArray());
 
                             if (Options.Instance.Metrics.Enable)
                             {

--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -153,20 +153,26 @@ namespace Intersect.Server.Core
                             }
 
                             //Refresh list of active maps & their instances
-                            foreach (var instanceId in ActiveMapInstances.Keys.ToArray())
+                            foreach (var (instanceId, mapInstance) in ActiveMapInstances.ToArray())
                             {
-                                if (!processedMapInstances.Contains(instanceId))
+                                if (!processedMapInstances.Contains(instanceId) || mapInstance.ShouldBeActive())
                                 {
-                                    // Remove the map entirely from the update queue
-                                    if (ActiveMapInstances[instanceId] != null && ActiveMapInstances[instanceId].ShouldBeCleaned())
+                                    continue;
+                                }
+
+                                if (mapInstance != default)
+                                {
+                                    if (mapInstance.ShouldBeCleaned())
                                     {
-                                        ActiveMapInstances[instanceId].RemoveLayerFromController();
-                                        ActiveMapInstances.Remove(instanceId);
-                                    } else if (ActiveMapInstances[instanceId] == null || !ActiveMapInstances[instanceId].ShouldBeActive())
+                                        mapInstance.RemoveLayerFromController();
+                                    }
+                                    else if (!mapInstance.ShouldBeActive())
                                     {
-                                        ActiveMapInstances.Remove(instanceId);
+                                        mapInstance.ResetNpcSpawns();
                                     }
                                 }
+
+                                ActiveMapInstances.Remove(instanceId);
                             }
 
                             // Allow our instance controllers to keep their instances up to date

--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -155,7 +155,7 @@ namespace Intersect.Server.Core
                             //Refresh list of active maps & their instances
                             foreach (var (instanceId, mapInstance) in ActiveMapInstances.ToArray())
                             {
-                                if (!processedMapInstances.Contains(instanceId) || mapInstance.ShouldBeActive())
+                                if (processedMapInstances.Contains(instanceId) || mapInstance.ShouldBeActive())
                                 {
                                     continue;
                                 }

--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -11,6 +11,7 @@ using Intersect.Server.Networking;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Utilities;
 using Intersect.Server.Database.PlayerData.Api;
+using Intersect.Server.Core.MapInstancing;
 
 namespace Intersect.Server.Core
 {
@@ -152,21 +153,24 @@ namespace Intersect.Server.Core
                             }
 
                             //Refresh list of active maps & their instances
-                            foreach (var layerId in ActiveMapInstances.Keys.ToArray())
+                            foreach (var instanceId in ActiveMapInstances.Keys.ToArray())
                             {
-                                if (!processedMapInstances.Contains(layerId))
+                                if (!processedMapInstances.Contains(instanceId))
                                 {
                                     // Remove the map entirely from the update queue
-                                    if (ActiveMapInstances[layerId] != null && ActiveMapInstances[layerId].ShouldBeCleaned())
+                                    if (ActiveMapInstances[instanceId] != null && ActiveMapInstances[instanceId].ShouldBeCleaned())
                                     {
-                                        ActiveMapInstances[layerId].RemoveLayerFromController();
-                                        ActiveMapInstances.Remove(layerId);
-                                    } else if (ActiveMapInstances[layerId] == null || !ActiveMapInstances[layerId].ShouldBeActive())
+                                        ActiveMapInstances[instanceId].RemoveLayerFromController();
+                                        ActiveMapInstances.Remove(instanceId);
+                                    } else if (ActiveMapInstances[instanceId] == null || !ActiveMapInstances[instanceId].ShouldBeActive())
                                     {
-                                        ActiveMapInstances.Remove(layerId);
+                                        ActiveMapInstances.Remove(instanceId);
                                     }
                                 }
                             }
+
+                            // Allow our instance controllers to keep their instances up to date
+                            InstanceProcessor.UpdateInstanceControllers(ActiveMapInstances.Values.ToList());
 
                             if (Options.Instance.Metrics.Enable)
                             {

--- a/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
@@ -8,11 +8,9 @@ using Intersect.Server.Entities;
 namespace Intersect.Server.Core.MapInstancing.Controllers;
 public class InstanceController
 {
-    Guid InstanceId { get; set; }
+    public Guid InstanceId { get; set; }
 
-    public HashSet<Player> Players { get; set; } = new HashSet<Player>();
-
-    public int PlayerCount => Players.Count;
+    public HashSet<Player> Players { get; set; } = new();
 
     public InstanceController(Guid instanceId, Player creator)
     {

--- a/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
@@ -10,11 +10,9 @@ public class InstanceController
 {
     Guid InstanceId { get; set; }
 
-    public List<Player> Players { get; set; } = new List<Player>();
+    public HashSet<Player> Players { get; set; } = new HashSet<Player>();
 
     public int PlayerCount => Players.Count;
-
-    public List<Guid> PlayerIds => Players.Select(pl => pl.Id).ToList();
 
     public InstanceController(Guid instanceId, Player creator)
     {
@@ -28,19 +26,11 @@ public class InstanceController
         {
             return;
         }
-
-        if (PlayerIds.Contains(player.Id))
-        {
-            return;
-        }
-
-        Logging.Log.Debug($"{player.Name} has entered instance controller {InstanceId}!");
         Players.Add(player);
     }
 
     public void RemovePlayer(Guid playerId)
     {
-        Logging.Log.Debug($"{playerId} has left instance controller {InstanceId}...");
-        Players.RemoveAll(pl => pl.Id == playerId);
+        Players.RemoveWhere(pl => pl.Id == playerId);
     }
 }

--- a/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/Controllers/InstanceController.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.Core.MapInstancing.Controllers;
+public class InstanceController
+{
+    Guid InstanceId { get; set; }
+
+    public List<Player> Players { get; set; } = new List<Player>();
+
+    public int PlayerCount => Players.Count;
+
+    public List<Guid> PlayerIds => Players.Select(pl => pl.Id).ToList();
+
+    public InstanceController(Guid instanceId, Player creator)
+    {
+        InstanceId = instanceId;
+        AddPlayer(creator);
+    }
+
+    public void AddPlayer(Player player)
+    {
+        if (player == null || !player.Online)
+        {
+            return;
+        }
+
+        if (PlayerIds.Contains(player.Id))
+        {
+            return;
+        }
+
+        Logging.Log.Debug($"{player.Name} has entered instance controller {InstanceId}!");
+        Players.Add(player);
+    }
+
+    public void RemovePlayer(Guid playerId)
+    {
+        Logging.Log.Debug($"{playerId} has left instance controller {InstanceId}...");
+        Players.RemoveAll(pl => pl.Id == playerId);
+    }
+}

--- a/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Intersect.Server.Core.MapInstancing.Controllers;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+
+namespace Intersect.Server.Core.MapInstancing;
+public static class InstanceProcessor
+{
+    private static Dictionary<Guid, InstanceController> InstanceControllers = new Dictionary<Guid, InstanceController>();
+
+    public static Guid[] CurrentControllers => InstanceControllers.Keys.ToArray();
+
+    public static bool TryGetInstanceController(Guid instanceId, out InstanceController controller)
+    {
+        return InstanceControllers.TryGetValue(instanceId, out controller);
+    }
+
+    private static void CleanupOrphanedControllers(List<MapInstance> activeMaps)
+    {
+        var processingInstances = InstanceControllers.Keys;
+        var processingMaps = activeMaps.ToArray().Select(map => map.MapInstanceId);
+
+        foreach (var id in processingInstances.Except(processingMaps).ToArray())
+        {
+            // Never cleanup the overworld controller
+            if (id == Guid.Empty)
+            {
+                continue;
+            }
+            InstanceControllers.Remove(id);
+            Logging.Log.Debug($"Removing instance controller {id}");
+        }
+    }
+
+    public static void AddInstanceController(Guid mapInstanceId, Player creator)
+    {
+        if (!InstanceControllers.ContainsKey(mapInstanceId))
+        {
+            InstanceControllers[mapInstanceId] = new InstanceController(mapInstanceId, creator);
+        }
+    }
+
+    public static void UpdateInstanceControllers(List<MapInstance> activeMaps)
+    {
+        if (activeMaps == null || activeMaps.Count == 0)
+        {
+            return;
+        }
+
+        // Cleanup inactive instances
+        CleanupOrphanedControllers(activeMaps);
+
+        Dictionary<Guid, List<MapInstance>> mapsAndInstances = activeMaps
+            .GroupBy(m => m.MapInstanceId)
+            .ToDictionary(m => m.Key, m => m.ToList());
+
+        // For each instance...
+        foreach (var mapInstanceGroup in mapsAndInstances)
+        {
+            // Fetch our instance controller...
+            var instanceId = mapInstanceGroup.Key;
+            if (!InstanceControllers.TryGetValue(instanceId, out var instanceController))
+            {
+                continue;
+            }
+
+            // TODO do update-y things in here, i.e processing permadead NPCs. Keeping empty for initial code review
+        }
+    }
+}

--- a/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
@@ -35,10 +35,13 @@ public static class InstanceProcessor
 
     public static bool TryAddInstanceController(Guid mapInstanceId, Player creator)
     {
-        if (!InstanceControllers.ContainsKey(mapInstanceId))
+        if (InstanceControllers.ContainsKey(mapInstanceId))
         {
-            InstanceControllers[mapInstanceId] = new InstanceController(mapInstanceId, creator);
+            return false;
         }
+
+        InstanceControllers[mapInstanceId] = new InstanceController(mapInstanceId, creator);
+        return true;
     }
 
     public static void UpdateInstanceControllers(MapInstance[] activeMaps)

--- a/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
+++ b/Intersect.Server.Core/Core/MapInstancing/InstanceProcessor.cs
@@ -23,7 +23,7 @@ public static class InstanceProcessor
     {
         var processingInstances = InstanceControllers.Keys
             .Except(activeInstanceIds)
-            .Except(default) // Never cleanup the overworld controller
+            .Except(new Guid[1] { default }) // Never cleanup the overworld instance
             .ToArray();
 
         foreach (var id in processingInstances)
@@ -59,7 +59,7 @@ public static class InstanceProcessor
             .ToDictionary(m => m.Key, m => m.ToArray());
 
         // For each instance...
-        foreach (var (instanceId, mapInstance) in mapsAndInstances)
+        foreach (var (instanceId, mapsInInstance) in mapsAndInstances)
         {
             // Fetch our instance controller...
             if (!InstanceControllers.TryGetValue(instanceId, out var instanceController))

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -7,6 +7,7 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Switches_and_Variables;
+using Intersect.Server.Core.MapInstancing;
 using Intersect.Server.Database;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Database.PlayerData.Security;
@@ -330,9 +331,9 @@ namespace Intersect.Server.Entities.Events
                 return;
             }
 
-            if (command.AllInInstance)
+            if (command.AllInInstance && InstanceProcessor.TryGetInstanceController(player.MapInstanceId, out var instanceController))
             {
-                foreach (var instanceMember in Globals.OnlineList.ToArray())
+                foreach (var instanceMember in instanceController.Players.ToArray())
                 {
                     if (instanceMember.Id == player.Id || !instanceMember.Online)
                     {

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1806,7 +1806,11 @@ namespace Intersect.Server.Entities
                     // ...and its surroundings
                     foreach (var surrMap in newSurroundingMaps)
                     {
-                        MapController.Get(surrMap).TryCreateInstance(MapInstanceId, out _, this);
+                        if (!MapController.TryGet(surrMap, out var map))
+                        {
+                            continue;
+                        }
+                        map.TryCreateInstance(MapInstanceId, out _, this);
                     }
                 }
                 else
@@ -7191,9 +7195,9 @@ namespace Intersect.Server.Entities
 
         public bool TryAddToInstanceController()
         {
-            if (InstanceProcessor.TryGetInstanceController(MapInstanceId, out var newInstController))
+            if (InstanceProcessor.TryGetInstanceController(MapInstanceId, out var instanceController))
             {
-                newInstController.AddPlayer(this);
+                instanceController.AddPlayer(this);
                 return true;
             }
 

--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -422,11 +422,10 @@ namespace Intersect.Server.Maps
                 if (!mInstances.ContainsKey(instanceId))
                 {
                     Log.Debug($"Creating new instance with ID {instanceId} for map {Name}");
-                    var newMapInstance = new MapInstance(this, instanceId, creator);
-                    newMapInstance.Initialize();
-                    mInstances[instanceId] = newMapInstance;
+                    newLayer = new MapInstance(this, instanceId, creator);
+                    newLayer.Initialize();
+                    mInstances[instanceId] = newLayer;
 
-                    newLayer = mInstances[instanceId];
                     return true;
                 }
 

--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -422,8 +422,10 @@ namespace Intersect.Server.Maps
                 if (!mInstances.ContainsKey(instanceId))
                 {
                     Log.Debug($"Creating new instance with ID {instanceId} for map {Name}");
-                    mInstances[instanceId] = new MapInstance(this, instanceId, creator);
-                    mInstances[instanceId].Initialize();
+                    var newMapInstance = new MapInstance(this, instanceId, creator);
+                    newMapInstance.Initialize();
+                    mInstances[instanceId] = newMapInstance;
+
                     newLayer = mInstances[instanceId];
                     return true;
                 }
@@ -440,9 +442,7 @@ namespace Intersect.Server.Maps
         /// <returns>True if successful in finding the requested instance, false otherwise</returns>
         public bool TryGetInstance(Guid mapInstanceId, out MapInstance instance)
         {
-            mInstances.TryGetValue(mapInstanceId, out instance);
-
-            return instance != default;
+            return mInstances.TryGetValue(mapInstanceId, out instance) ? instance != default : false;
         }
 
         /// <summary>

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -15,6 +15,7 @@ using Intersect.Utilities;
 using Intersect.Server.Entities;
 using Intersect.Server.Classes.Maps;
 using MapAttribute = Intersect.Enums.MapAttribute;
+using Intersect.Server.Core.MapInstancing;
 
 namespace Intersect.Server.Maps
 {
@@ -144,11 +145,15 @@ namespace Intersect.Server.Maps
         private MapActionMessages mActionMessages = new MapActionMessages();
         private MapAnimations mMapAnimations = new MapAnimations();
 
-        public MapInstance(MapController map, Guid mapInstanceId)
+        public MapInstance(MapController map, Guid mapInstanceId, Player creator)
         {
             mMapController = map;
             MapInstanceId = mapInstanceId;
             Id = Guid.NewGuid();
+            if (!InstanceProcessor.CurrentControllers.Contains(MapInstanceId))
+            {
+                InstanceProcessor.AddInstanceController(MapInstanceId, creator);
+            }
         }
 
         public bool IsDisposed { get; protected set; }

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -150,10 +150,7 @@ namespace Intersect.Server.Maps
             mMapController = map;
             MapInstanceId = mapInstanceId;
             Id = Guid.NewGuid();
-            if (!InstanceProcessor.CurrentControllers.Contains(MapInstanceId))
-            {
-                InstanceProcessor.AddInstanceController(MapInstanceId, creator);
-            }
+            _ = InstanceProcessor.TryAddInstanceController(MapInstanceId, creator);
         }
 
         public bool IsDisposed { get; protected set; }


### PR DESCRIPTION
The idea of an "Instance Controller", and subsequent InstanceProcessor, is to have some entity out there (in-memory) that can manage instance state, outside the scope of a player. This will be required for...

- Instance Variables
- Fixing the bug where mob respawn timers aren't respected in an instance that has had a map cleaned up
- Perma-dead instance NPCs
- Etc