### PR TITLE
fix: (Day) Fix so enemies can cast friendly spells on eachother

### DIFF
--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -1340,7 +1340,12 @@ namespace Intersect.Server.Entities
             switch (otherEntity)
             {
                 case Npc otherNpc:
-                    return Base == otherNpc.Base;
+                    if (!Base.NpcVsNpcEnabled && !otherNpc.Base.NpcVsNpcEnabled)
+                    {
+                        return true;
+                    }
+
+                    return !otherNpc.CanNpcCombat(this);
                 case Player otherPlayer:
                     var conditionLists = Base.PlayerFriendConditions;
                     if ((conditionLists?.Count ?? 0) == 0)


### PR DESCRIPTION
Fixes an issue where NPCs casting friendly AoE spells, such as to create a support NPC, do not consider other NPCs as friendly unless they are the exact same NPC as the caster.

NPCs should default to handling eachother as allies unless otherwise noted in the NPC's definition that they are hostile to certain NPCs