### PR TITLE
bug fix #2132

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -833,6 +833,8 @@ namespace Intersect.Server.Entities
                         }
                     }
 
+                    map = MapController.Get(MapId);
+
                     //Check to see if we can spawn events, if already spawned.. update them.
                     lock (mEventLock)
                     {


### PR DESCRIPTION
The player's MapId references a new map, but the 'map' variable in the event loop is referring to the original/old map.

Adding after loop "map = MapController.Get(MapId);" fixes the #2132 issue.

