### PR TITLE
bug fix #1716

### DIFF
--- a/Intersect (Core)/GameObjects/LightBase.cs
+++ b/Intersect (Core)/GameObjects/LightBase.cs
@@ -68,7 +68,7 @@ namespace Intersect.GameObjects
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return Intensity ^ (int)Expand ^ (Color?.GetHashCode() ?? 0) ^ TileX.GetHashCode() ^ TileY.GetHashCode();
+            return HashCode.Combine(Intensity, (int)Expand, Color, TileX, TileY);
         }
 
         /// <summary>

--- a/Intersect (Core)/GameObjects/LightBase.cs
+++ b/Intersect (Core)/GameObjects/LightBase.cs
@@ -68,7 +68,7 @@ namespace Intersect.GameObjects
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return Intensity ^ (int)Expand ^ (Color?.GetHashCode() ?? 0);
+            return Intensity ^ (int)Expand ^ (Color?.GetHashCode() ?? 0) ^ TileX.GetHashCode() ^ TileY.GetHashCode();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Intersect.GameObjects
         {
             if (obj is LightBase light)
             {
-                return Intensity == light.Intensity && Color == light.Color&& Expand == light.Expand;
+                return Intensity == light.Intensity && Color == light.Color && Expand == light.Expand && TileX == light.TileX && TileY == light.TileY;
             }
 
             return false;

--- a/Intersect (Core)/GameObjects/LightBase.cs
+++ b/Intersect (Core)/GameObjects/LightBase.cs
@@ -68,7 +68,7 @@ namespace Intersect.GameObjects
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return HashCode.Combine(Intensity, (int)Expand, Color, TileX, TileY);
+            return HashCode.Combine(Intensity, Expand, Color, TileX, TileY);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1716

I've added TileX and TileY to both methods GetHashCode() & Equals() in LightBase.cs

This change ensure that the hash code and equality comparison take into account the TileX and TileY properties, necessary for drag / copy / undo ...