### PR TITLE
Fix #2155

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -962,29 +962,22 @@ namespace Intersect.Client.Entities
                 PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
                 return true;
             }
-            // Checking if the item is non-stackable
-            if (!itemDescriptor.IsStackable || skipPrompt)
-            {
-                PacketSender.SendWithdrawItem(bankSlotIndex, 1, inventorySlotIndex);  // Only 1 item
-                return true;
-            }
-            else
-            {
-                InputBox.Open(
-                    title: Strings.Bank.withdrawitem,
-                    prompt: Strings.Bank.withdrawitemprompt.ToString(itemDescriptor.Name),
-                    modal: true,
-                    inputType: InputBox.InputType.NumericSliderInput,
-                    onSuccess: WithdrawItemInputBoxOkay,
-                    onCancel: null,
-                    userData: new[] { bankSlotIndex, inventorySlotIndex },
-                    quantity: movableQuantity,
-                    maxQuantity: maximumQuantity
-                );
 
-                return true;
-            }
+            InputBox.Open(
+                title: Strings.Bank.withdrawitem,
+                prompt: Strings.Bank.withdrawitemprompt.ToString(itemDescriptor.Name),
+                modal: true,
+                inputType: InputBox.InputType.NumericSliderInput,
+                onSuccess: WithdrawItemInputBoxOkay,
+                onCancel: null,
+                userData: new[] { bankSlotIndex, inventorySlotIndex },
+                quantity: movableQuantity,
+                maxQuantity: maximumQuantity
+            );
+
+            return true;
         }
+
         private bool IsGuildBankWithdrawAllowed()
         {
             return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -835,22 +835,29 @@ namespace Intersect.Client.Entities
                 PacketSender.SendDepositItem(inventorySlotIndex, movableQuantity, bankSlotIndex);
                 return true;
             }
+            // Checking if the item is non-stackable
+            if (!itemDescriptor.IsStackable || skipPrompt)
+            {
+                PacketSender.SendDepositItem(inventorySlotIndex, 1, bankSlotIndex);  // Only 1 item
+                return true;
+            }
+            else
+            {
+                InputBox.Open(
+                    title: Strings.Bank.deposititem,
+                    prompt: Strings.Bank.deposititemprompt.ToString(itemDescriptor.Name),
+                    modal: true,
+                    inputType: InputBox.InputType.NumericSliderInput,
+                    onSuccess: DepositItemInputBoxOkay,
+                    onCancel: null,
+                    userData: new[] { inventorySlotIndex, bankSlotIndex },
+                    quantity: movableQuantity,
+                    maxQuantity: maximumQuantity
+                );
 
-            InputBox.Open(
-                title: Strings.Bank.deposititem,
-                prompt: Strings.Bank.deposititemprompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: DepositItemInputBoxOkay,
-                onCancel: null,
-                userData: new[] { inventorySlotIndex, bankSlotIndex },
-                quantity: movableQuantity,
-                maxQuantity: maximumQuantity
-            );
-
-            return true;
+                return true;
+            }
         }
-
         private bool IsGuildBankDepositAllowed()
         {
             return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&
@@ -955,22 +962,29 @@ namespace Intersect.Client.Entities
                 PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
                 return true;
             }
+            // Checking if the item is non-stackable
+            if (!itemDescriptor.IsStackable || skipPrompt)
+            {
+                PacketSender.SendWithdrawItem(bankSlotIndex, 1, inventorySlotIndex);  // Only 1 item
+                return true;
+            }
+            else
+            {
+                InputBox.Open(
+                    title: Strings.Bank.withdrawitem,
+                    prompt: Strings.Bank.withdrawitemprompt.ToString(itemDescriptor.Name),
+                    modal: true,
+                    inputType: InputBox.InputType.NumericSliderInput,
+                    onSuccess: WithdrawItemInputBoxOkay,
+                    onCancel: null,
+                    userData: new[] { bankSlotIndex, inventorySlotIndex },
+                    quantity: movableQuantity,
+                    maxQuantity: maximumQuantity
+                );
 
-            InputBox.Open(
-                title: Strings.Bank.withdrawitem,
-                prompt: Strings.Bank.withdrawitemprompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: WithdrawItemInputBoxOkay,
-                onCancel: null,
-                userData: new[] { bankSlotIndex, inventorySlotIndex },
-                quantity: movableQuantity,
-                maxQuantity: maximumQuantity
-            );
-
-            return true;
+                return true;
+            }
         }
-
         private bool IsGuildBankWithdrawAllowed()
         {
             return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -98,8 +98,11 @@ namespace Intersect.Client.Interface.Game.Inventory
             {
                 if (Globals.InputManager.KeyDown(Keys.Shift))
                 {
+                    var slot = Globals.Me.Inventory[mMySlot];
                     Globals.Me.TryDepositItem(
                         mMySlot,
+                        slot,
+                        quantityHint: slot.Quantity,
                         skipPrompt: true
                     );
                 }


### PR DESCRIPTION
A check has been added to the code to see if an item is non-stackable.
If it is non-stackable, as in the case of equipment, a window does not open asking how many items we want to put in the bank.

This solves the problem with transferring items from the inventory to the bank, because now an item equipped on a player will not be transferred with another identical item.

Individually transferred inventory items are removed correctly, so there is no possibility of an error/bug

Shift has also been changed because using the shift button and the mouse button will move all the same items that we have in the inventory.

Now it simply moves a given slot without displaying the window showing how much we want to put in the bank.

If we do not use shift, the window appears but not in the case of non-stackable items

EDIT: I changed the inputbox to be shown when withdrawing and it was possible to withdraw more than 1 item. Because in this case there is no way to make an error