### PR TITLE
fix: unequip equipment when depositing into the bank

### DIFF
--- a/Intersect.Server.Core/Entities/BankInterface.cs
+++ b/Intersect.Server.Core/Entities/BankInterface.cs
@@ -236,6 +236,13 @@ namespace Intersect.Server.Entities
                     Debug.Assert(slotToRemoveFrom != default);
                     var quantityToRemoveFromSlot = Math.Min(remainingQuantityToRemove, slotToRemoveFrom.Quantity);
                     slotToRemoveFrom.Quantity -= quantityToRemoveFromSlot;
+
+                    // If the item is equipped equipment, we need to unequip it before taking it out of the inventory.
+                    if (itemDescriptor.ItemType == ItemType.Equipment && slotIndexToRemoveFrom > -1)
+                    {
+                        mPlayer.EquipmentProcessItemLoss(slotIndexToRemoveFrom);
+                    }
+
                     if (slotToRemoveFrom.Quantity < 1)
                     {
                         slotToRemoveFrom.Set(Item.None);
@@ -262,14 +269,6 @@ namespace Intersect.Server.Entities
                 else if (remainingQuantityToRemove > 0)
                 {
                     Log.Error($"{mPlayer.Id} did not have {remainingQuantity}x {itemDescriptor.Id} taken");
-                }
-
-                if (itemDescriptor.ItemType == ItemType.Equipment)
-                {
-                    if (inventorySlotIndex > -1)
-                    {
-                        mPlayer.EquipmentProcessItemLoss(inventorySlotIndex);
-                    }
                 }
 
                 if (sendUpdate)


### PR DESCRIPTION
### Fixes #2155 

Issue is basically about equipped items not being unequipped before we take them out of the inventory into the bank, which triggers the funky behavior reported at #2155 

### The bug: keep an eye on the equipped bow and Attack stat:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/ffdd43a3-7ee5-4dfa-8447-e92d902b59c0


### After the fix:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/d7fb766c-1ab3-4a08-92db-ca8b51078235

