### PR TITLE
fix: last projectile spell casting

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2477,24 +2477,10 @@ namespace Intersect.Server.Entities
                         break;
                 }
 
-                if (spellSlot >= 0 && spellSlot < Options.MaxPlayerSkills)
+                if (this is not Player && spellSlot >= 0 && spellSlot < Options.MaxPlayerSkills)
                 {
-                    // Player cooldown handling is done elsewhere!
-                    if (this is Player player)
-                    {
-                        player.UpdateCooldown(spellBase);
-
-                        // Trigger the global cooldown, if we're allowed to.
-                        if (!spellBase.IgnoreGlobalCooldown)
-                        {
-                            player.UpdateGlobalCooldown();
-                        }
-                    }
-                    else
-                    {
-                        SpellCooldowns[Spells[spellSlot].SpellId] =
-                            Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
-                    }
+                    SpellCooldowns[Spells[spellSlot].SpellId] =
+                        Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
                 }
             }
             finally

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -378,6 +378,20 @@ namespace Intersect.Server.Entities
         }
 
         /// <summary>
+        ///     Updates the entity's spell cooldown for the specified <paramref name="spellBase"/>.
+        ///     <para> This method is called when a spell is casted by an entity. </para>
+        /// </summary>
+        public virtual void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
+        {
+            if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+            {
+                return;
+            }
+
+            SpellCooldowns[Spells[spellSlot].SpellId] = Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
+        }
+
+        /// <summary>
         ///     Determines if this entity can move in the specified <paramref name="direction"/>.
         /// </summary>
         /// <param name="direction">The <see cref="Direction"/> the entity is attempting to move in.</param>
@@ -2477,11 +2491,7 @@ namespace Intersect.Server.Entities
                         break;
                 }
 
-                if (this is not Player && spellSlot >= 0 && spellSlot < Options.MaxPlayerSkills)
-                {
-                    SpellCooldowns[Spells[spellSlot].SpellId] =
-                        Timing.Global.MillisecondsUtc + spellBase.CooldownDuration;
-                }
+                UpdateSpellCooldown(spellBase, spellSlot);
             }
             finally
             {

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5507,6 +5507,18 @@ namespace Intersect.Server.Entities
 
             UpdateSpellCooldown(spellBase, spellSlot);
 
+            ConsumeSpellProjectile(spellBase);
+        }
+
+        /// <summary>
+        /// Checks if the caster has the required projectile(s) for the spell and tries to take them.
+        /// This method is used when a spell that requires projectile is casted.
+        /// If the spell has a valid ProjectileId, it retrieves the projectile and checks if it has a valid AmmoItemId.
+        /// If it does, it attempts to take the required amount of ammo from the player's inventory.
+        /// </summary>
+        /// <param name="spellBase">The spell that is being cast.</param>
+        private void ConsumeSpellProjectile(SpellBase spellBase)
+        {
             // Check if the caster has the required projectile(s) for the spell and try to take it/them.
             if (spellBase.SpellType == SpellType.CombatSpell &&
                 spellBase.Combat.TargetType == SpellTargetType.Projectile &&

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -891,6 +891,26 @@ namespace Intersect.Server.Entities
             }
         }
 
+        /// <summary>
+        ///     Updates the player's spell cooldown for the specified <paramref name="spellBase"/>.
+        ///     <para> This method is called when a spell is casted by a player. </para>
+        /// </summary>
+        public override void UpdateSpellCooldown(SpellBase spellBase, int spellSlot)
+        {
+            if (spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+            {
+                return;
+            }
+
+            this.UpdateCooldown(spellBase);
+
+            // Trigger the global cooldown, if we're allowed to.
+            if (!spellBase.IgnoreGlobalCooldown)
+            {
+                this.UpdateGlobalCooldown();
+            }
+        }
+        
         public void RemoveEvent(Guid id, bool sendLeave = true)
         {
             Event outInstance;
@@ -5485,14 +5505,7 @@ namespace Intersect.Server.Entities
                     break;
             }
 
-            // Player cooldown handling!
-            UpdateCooldown(spellBase);
-
-            // Trigger the global cooldown, if we're allowed to.
-            if (!spellBase.IgnoreGlobalCooldown)
-            {
-                UpdateGlobalCooldown();
-            }
+            UpdateSpellCooldown(spellBase, spellSlot);
 
             // Check if the caster has the required projectile(s) for the spell and try to take it/them.
             if (spellBase.SpellType == SpellType.CombatSpell &&


### PR DESCRIPTION
Fixes #1683 
Which reported a bug where a spell with ammunition requirements would consume the last projectile without actually casting it out. It is also intended to provide additional chore changes and move player related code out to it's corresponding overrides.

Files changed:
1. Entity.cs - Moved projectile removal to player's CastSpell override method. Also moved the player's specific handlers for spell's cooldown to player's CastSpell override method.
2. Player.cs - Removed redundant and repeated code within the UseSpell method (ie. CastSpell(..) is already called within Entity's Update method when required) and added projectile removal and cooldown handlers within the CastSpell override method.

Bug:

https://user-images.githubusercontent.com/17498701/206912343-1b49c1e3-e80f-4e66-96b6-376a60164f68.mp4

After the fix:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/ca7e1663-867d-4424-8a3a-e227f8a2982b