### PR TITLE
fix: item's quick cast

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5483,7 +5483,7 @@ namespace Intersect.Server.Entities
         public override void CastSpell(Guid spellId, int spellSlot = -1)
         {
             var spellBase = SpellBase.Get(spellId);
-            if (spellBase == null || spellSlot < 0 || spellSlot >= Options.MaxPlayerSkills)
+            if (spellBase == null)
             {
                 return;
             }


### PR DESCRIPTION
Fixes #2177

Restored quick casting functionality for spell items, resolving my mess from PR #2174. Also ensured last projectile removal for quick casted spells is working as expected.

Preview:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/8453d9c4-6ffc-4f1f-a949-695c77cd2ee3

