### PR TITLE
Fix attack animation when allow combat movement is false

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -269,7 +269,7 @@ namespace Intersect.Client.Entities
                     }
                     else if (!Globals.Me.TryAttack())
                     {
-                        if (!Globals.Me.IsAttacking)
+                        if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.PlayerOpts.AllowCombatMovement))
                         {
                             Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
                         }

--- a/Intersect.Server.Core/Maps/MapGrid.cs
+++ b/Intersect.Server.Core/Maps/MapGrid.cs
@@ -105,6 +105,8 @@ public partial class MapGrid
             mapIds.Add(map.Id);
             map.MapGridX = x;
             map.MapGridY = y;
+            map.CachedMapClientPacket = default;
+
             if (x < _topLeft.X)
             {
                 _topLeft.X = x;

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -308,6 +308,7 @@ internal sealed partial class NetworkedPacketHandler
                                 tmpMap.MapGrid = MapController.Get(relativeMap).MapGrid;
                                 tmpMap.MapGridX = MapController.Get(relativeMap).MapGridX;
                                 tmpMap.MapGridY = MapController.Get(relativeMap).MapGridY - 1;
+                                tmpMap.CachedMapClientPacket = default;
                                 MapController.Get(relativeMap).Up = newMapId;
                                 DbInterface.SaveGameObject(MapController.Get(relativeMap));
                             }


### PR DESCRIPTION
Fixes https://github.com/AscensionGameDev/Intersect-Engine/issues/1760

The issue is that we set the attack timer if we failed an attack, but we didnt fail an attack, we didnt start the attack because we were moving and attacking. IsAttacking just checks if are attack timer is active. 