### PR TITLE
Fixed issue where attacker time was updated even though the player ne…

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -269,7 +269,7 @@ namespace Intersect.Client.Entities
                     }
                     else if (!Globals.Me.TryAttack())
                     {
-                        if (!Globals.Me.IsAttacking)
+                        if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.PlayerOpts.AllowCombatMovement))
                         {
                             Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
                         }


### PR DESCRIPTION
…ver attacked when AllowCombatMovement setting was set to false. This caused the client to think it was attacking because IsAttacking only checks the attack timer. 

Fixes: https://github.com/AscensionGameDev/Intersect-Engine/issues/1760

