### PR TITLE
Item Vitals can now have negative values

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -1826,7 +1826,7 @@ namespace Intersect.Editor.Forms.Editors
             nudMPPercentage.Location = new System.Drawing.Point(155, 92);
             nudMPPercentage.Margin = new Padding(4, 3, 4, 3);
             nudMPPercentage.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
-            nudMPPercentage.Minimum = new decimal(new int[] { -1000, 0, 0, -2147483648 });
+            nudMPPercentage.Minimum = new decimal(new int[] { -100, 0, 0, int.MinValue });
             nudMPPercentage.Name = "nudMPPercentage";
             nudMPPercentage.Size = new Size(90, 23);
             nudMPPercentage.TabIndex = 68;
@@ -1840,7 +1840,7 @@ namespace Intersect.Editor.Forms.Editors
             nudHPPercentage.Location = new System.Drawing.Point(155, 43);
             nudHPPercentage.Margin = new Padding(4, 3, 4, 3);
             nudHPPercentage.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
-            nudHPPercentage.Minimum = new decimal(new int[] { -1000, 0, 0, -2147483648 });
+            nudHPPercentage.Minimum = new decimal(new int[] { -100, 0, 0, int.MinValue });
             nudHPPercentage.Name = "nudHPPercentage";
             nudHPPercentage.Size = new Size(90, 23);
             nudHPPercentage.TabIndex = 67;

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -1826,6 +1826,7 @@ namespace Intersect.Editor.Forms.Editors
             nudMPPercentage.Location = new System.Drawing.Point(155, 92);
             nudMPPercentage.Margin = new Padding(4, 3, 4, 3);
             nudMPPercentage.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudMPPercentage.Minimum = new decimal(new int[] { -1000, 0, 0, -2147483648 });
             nudMPPercentage.Name = "nudMPPercentage";
             nudMPPercentage.Size = new Size(90, 23);
             nudMPPercentage.TabIndex = 68;
@@ -1839,6 +1840,7 @@ namespace Intersect.Editor.Forms.Editors
             nudHPPercentage.Location = new System.Drawing.Point(155, 43);
             nudHPPercentage.Margin = new Padding(4, 3, 4, 3);
             nudHPPercentage.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudHPPercentage.Minimum = new decimal(new int[] { -1000, 0, 0, -2147483648 });
             nudHPPercentage.Name = "nudHPPercentage";
             nudHPPercentage.Size = new Size(90, 23);
             nudHPPercentage.TabIndex = 67;


### PR DESCRIPTION
Fixes https://github.com/AscensionGameDev/Intersect-Engine/issues/2182
![vitals](https://github.com/AscensionGameDev/Intersect-Engine/assets/6899464/f4105050-a9d8-4b44-975a-b1cb2c1a9eef)
[Intersect Client 2024-03-24 00-14-08.zip](https://github.com/AscensionGameDev/Intersect-Engine/files/14734354/Intersect.Client.2024-03-24.00-14-08.zip)

Works in client I tested it, zip has video.

If you set it to something like -200% the player will be left with one health. The game does that by design. 
