### PR TITLE
fix: show MapEditor upon starting the editor

### DIFF
--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -92,15 +92,14 @@ namespace Intersect.Editor.Forms
 
             dockLeft.Theme = new VS2015DarkTheme();
             Globals.MapListWindow = new FrmMapList();
-            Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
             Globals.MapLayersWindow = new FrmMapLayers();
-            Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
-
-            Globals.MapEditorWindow = new FrmMapEditor();
-            Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
-
             Globals.MapGridWindowNew = new FrmMapGrid();
+            Globals.MapEditorWindow = new FrmMapEditor();
+
+            Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
+            Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
             Globals.MapGridWindowNew.Show(dockLeft, DockState.Document);
+            Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
         }
 
         [System.Runtime.InteropServices.DllImport("user32.dll")]


### PR DESCRIPTION
Should fix #2196

After upgrading to .NET7, starting the editor shows up the MapGrid (world view) window tab as selected instead of the MapEditor. Seeing the code, this is what actually makes sense, no idea why it wasn't behaving like this before upgrading, but the expected behavior is to have the MapEditor to show up at the end of the form initialization. This commit sets it to be shown by the end, giving us back the expected behavior we originally had.