### PR TITLE
enhancement: negative bonus effects

### DIFF
--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -449,14 +449,10 @@ namespace Intersect.Client.Interface.Game.Character
             }
 
             //Getting extra buffs
-            if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.Percentage > 0) != default)
+            if (item.Effects.Find(effect => effect.Type != ItemEffect.None) != default)
             {
                 foreach(var effect in item.Effects)
                 {
-                    if (effect.Percentage <= 0)
-                    {
-                        continue;
-                    }
 
                     switch (effect.Type)
                     {

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -463,8 +463,15 @@ namespace Intersect.Client.Interface.Game.Character
                             break;
                         case ItemEffect.Lifesteal:
                             LifeStealAmount += effect.Percentage;
-                            mLifeSteal?.SetText(Strings.Character.Lifesteal.ToString(LifeStealAmount));
-
+                            // Checks if LifeStealAmount is less than 0, if so, sets the text to "0"
+                            if (LifeStealAmount < 0)
+                            {
+                                mLifeSteal?.SetText(Strings.Character.Lifesteal.ToString(0));
+                            }
+                            else
+                            {
+                                mLifeSteal?.SetText(Strings.Character.Lifesteal.ToString(LifeStealAmount));
+                            }
                             break;
                         case ItemEffect.Tenacity:
                             TenacityAmount += effect.Percentage;
@@ -483,6 +490,16 @@ namespace Intersect.Client.Interface.Game.Character
                             break;
                         case ItemEffect.Manasteal:
                             ManaStealAmount += effect.Percentage;
+                            // Checks if ManaStealAmount is less than 0, if so, sets the text to "0"
+                            if (ManaStealAmount < 0)
+                            {
+                                mManaSteal?.SetText(Strings.Character.Manasteal.ToString(0));
+                            }
+                            else
+                            {
+                                mManaSteal?.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
+                            }
+                            break;
                             mManaSteal?.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
 
                             break;

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -1697,6 +1697,8 @@ namespace Intersect.Editor.Forms.Editors
             nudEffectPercent.ForeColor = System.Drawing.Color.Gainsboro;
             nudEffectPercent.Location = new System.Drawing.Point(15, 190);
             nudEffectPercent.Margin = new Padding(4, 3, 4, 3);
+            nudEffectPercent.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudEffectPercent.Minimum = new decimal(new int[] { -100, 0, 0, int.MinValue });
             nudEffectPercent.Name = "nudEffectPercent";
             nudEffectPercent.Size = new Size(282, 23);
             nudEffectPercent.TabIndex = 55;

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2084,6 +2084,10 @@ namespace Intersect.Server.Entities
             if (this is Player && !(enemy is Resource))
             {
                 var lifestealRate = thisPlayer.GetEquipmentBonusEffect(ItemEffect.Lifesteal) / 100f;
+                    if (lifestealRate < 0)
+                {
+                    lifestealRate = 0; // If lifestealRate is negative, set to zero
+                }
                 var idealHealthRecovered = lifestealRate * baseDamage;
                 var actualHealthRecovered = Math.Min(enemyVitals[(int)Vital.Health], idealHealthRecovered);
 
@@ -2099,6 +2103,10 @@ namespace Intersect.Server.Entities
                 }
 
                 var manastealRate = (thisPlayer.GetEquipmentBonusEffect(ItemEffect.Manasteal) / 100f);
+                   if (manastealRate < 0)
+                {
+                    manastealRate = 0; // If manastealRate is negative, set to zero
+                }
                 var idealManaRecovered = manastealRate * baseDamage;
                 var actualManaRecovered = Math.Min(enemyVitals[(int)Vital.Mana], idealManaRecovered);
 


### PR DESCRIPTION
Added the ability to set negative bonus effect values.
Negative CDR increases spell cooldown.
Negative Tenacity increases the duration of effect, e.g. stun, but does not cause the damage to be duplicated over time.
A negative exp and luck bonus results in lower chances of drops and lower exp for the player.
Lifesteal and manasteal are negative, it works like 0, but if other equipment adds lifesteal or manasteal, it is known that the minus value takes it into account. PS: Works as 0 because healing spells have minus values, which causes a minus lifesteal to double the healing
The characterwindow has also been changed so that negative values ​​can be shown