### PR TITLE
PVP Team Node (Need testing)

### DIFF
--- a/Intersect (Core)/GameObjects/Events/Commands/EventCommands.cs
+++ b/Intersect (Core)/GameObjects/Events/Commands/EventCommands.cs
@@ -539,6 +539,18 @@ namespace Intersect.GameObjects.Events.Commands
 
         public Access Access { get; set; }
     }
+    public partial class SetPVPTeamCommand : EventCommand
+    {
+        public override EventCommandType Type { get; } = EventCommandType.SetPVPTeam;
+
+        public bool UseVariable { get; set; } = false;
+
+        public VariableType VariableType { get; set; } = VariableType.PlayerVariable;
+
+        public Guid VariableId { get; set; }
+
+        public int PVPTeamID { get; set; } = -1;
+    }
 
     public partial class WarpCommand : EventCommand
     {

--- a/Intersect (Core)/GameObjects/Events/Enums.cs
+++ b/Intersect (Core)/GameObjects/Events/Enums.cs
@@ -238,6 +238,8 @@ namespace Intersect.GameObjects.Events
         CastSpellOn,
 
         Fade,
+
+        SetPVPTeam,
     }
 
     public enum FadeType

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -829,6 +829,32 @@ namespace Intersect.Editor.Forms.Editors.Events
             }
         }
 
+        private static string GetCommandText(SetPVPTeamCommand command, MapInstance map)
+        {
+            if (command.UseVariable)
+            {
+                var exp = string.Empty;
+                switch (command.VariableType)
+                {
+                    case VariableType.PlayerVariable:
+                        exp = string.Format(@"({0}: {1})", Strings.EventSetPVPTeam.PlayerVariable, PlayerVariableBase.GetName(command.VariableId));
+                        break;
+                    case VariableType.ServerVariable:
+                        exp = string.Format(@"({0}: {1})", Strings.EventSetPVPTeam.ServerVariable, ServerVariableBase.GetName(command.VariableId));
+                        break;
+                    case VariableType.GuildVariable:
+                        exp = string.Format(@"({0}: {1})", Strings.EventSetPVPTeam.GuildVariable, GuildVariableBase.GetName(command.VariableId));
+                        break;
+                }
+
+                return Strings.EventCommandList.pvpteam.ToString(exp);
+            }
+            else
+            {
+                return Strings.EventCommandList.setpvpteam.ToString(command.PVPTeamID);
+            }
+        }
+
         private static string GetCommandText(ChangeLevelCommand command, MapInstance map)
         {
             return Strings.EventCommandList.setlevel.ToString(command.Level);

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.Designer.cs
@@ -1,0 +1,282 @@
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+partial class EventCommandChangePVPTeam
+{
+    /// <summary> 
+    /// Обязательная переменная конструктора.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary> 
+    /// Освободить все используемые ресурсы.
+    /// </summary>
+    /// <param name="disposing">истинно, если управляемый ресурс должен быть удален; иначе ложно.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Код, автоматически созданный конструктором компонентов
+
+    /// <summary> 
+    /// Требуемый метод для поддержки конструктора — не изменяйте 
+    /// содержимое этого метода с помощью редактора кода.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.grpSetPVPTeam = new DarkUI.Controls.DarkGroupBox();
+        this.grpManualAmount = new DarkUI.Controls.DarkGroupBox();
+        this.nudTeamID = new DarkUI.Controls.DarkNumericUpDown();
+        this.lblPVPTeam = new System.Windows.Forms.Label();
+        this.grpVariableAmount = new DarkUI.Controls.DarkGroupBox();
+        this.cmbVariable = new DarkUI.Controls.DarkComboBox();
+        this.lblVariable = new System.Windows.Forms.Label();
+        this.rdoGlobalVariable = new DarkUI.Controls.DarkRadioButton();
+        this.rdoGuildVariable = new DarkUI.Controls.DarkRadioButton();
+        this.rdoPlayerVariable = new DarkUI.Controls.DarkRadioButton();
+        this.grpAmountType = new DarkUI.Controls.DarkGroupBox();
+        this.rdoVariable = new DarkUI.Controls.DarkRadioButton();
+        this.rdoManual = new DarkUI.Controls.DarkRadioButton();
+        this.btnCancel = new DarkUI.Controls.DarkButton();
+        this.btnSave = new DarkUI.Controls.DarkButton();
+        this.grpSetPVPTeam.SuspendLayout();
+        this.grpManualAmount.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.nudTeamID)).BeginInit();
+        this.grpVariableAmount.SuspendLayout();
+        this.grpAmountType.SuspendLayout();
+        this.SuspendLayout();
+        // 
+        // grpSetPVPTeam
+        // 
+        this.grpSetPVPTeam.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+        this.grpSetPVPTeam.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+        this.grpSetPVPTeam.Controls.Add(this.grpVariableAmount);
+        this.grpSetPVPTeam.Controls.Add(this.grpAmountType);
+        this.grpSetPVPTeam.Controls.Add(this.btnCancel);
+        this.grpSetPVPTeam.Controls.Add(this.btnSave);
+        this.grpSetPVPTeam.Controls.Add(this.grpManualAmount);
+        this.grpSetPVPTeam.ForeColor = System.Drawing.Color.Gainsboro;
+        this.grpSetPVPTeam.Location = new System.Drawing.Point(3, 3);
+        this.grpSetPVPTeam.Name = "grpSetPVPTeam";
+        this.grpSetPVPTeam.Size = new System.Drawing.Size(427, 157);
+        this.grpSetPVPTeam.TabIndex = 17;
+        this.grpSetPVPTeam.TabStop = false;
+        this.grpSetPVPTeam.Text = "Set PVP Team:";
+        // 
+        // grpManualAmount
+        // 
+        this.grpManualAmount.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+        this.grpManualAmount.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+        this.grpManualAmount.Controls.Add(this.nudTeamID);
+        this.grpManualAmount.Controls.Add(this.lblPVPTeam);
+        this.grpManualAmount.ForeColor = System.Drawing.Color.Gainsboro;
+        this.grpManualAmount.Location = new System.Drawing.Point(6, 19);
+        this.grpManualAmount.Name = "grpManualAmount";
+        this.grpManualAmount.Size = new System.Drawing.Size(292, 71);
+        this.grpManualAmount.TabIndex = 40;
+        this.grpManualAmount.TabStop = false;
+        this.grpManualAmount.Text = "Manual";
+        this.grpManualAmount.Visible = false;
+        // 
+        // nudTeamID
+        // 
+        this.nudTeamID.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+        this.nudTeamID.ForeColor = System.Drawing.Color.Gainsboro;
+        this.nudTeamID.Location = new System.Drawing.Point(130, 25);
+        this.nudTeamID.Minimum = -1;
+        this.nudTeamID.Maximum = 1000;
+        this.nudTeamID.Name = "nudTeamID";
+        this.nudTeamID.Size = new System.Drawing.Size(141, 20);
+        this.nudTeamID.TabIndex = 24;
+        this.nudTeamID.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+        // 
+        // lblPVPTeam
+        // 
+        this.lblPVPTeam.AutoSize = true;
+        this.lblPVPTeam.Location = new System.Drawing.Point(22, 27);
+        this.lblPVPTeam.Name = "lblPVPTeam";
+        this.lblPVPTeam.Size = new System.Drawing.Size(91, 13);
+        this.lblPVPTeam.TabIndex = 23;
+        this.lblPVPTeam.Text = "Set PVP Team: ";
+        // 
+        // grpVariableAmount
+        // 
+        this.grpVariableAmount.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+        this.grpVariableAmount.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+        this.grpVariableAmount.Controls.Add(this.cmbVariable);
+        this.grpVariableAmount.Controls.Add(this.lblVariable);
+        this.grpVariableAmount.Controls.Add(this.rdoGlobalVariable);
+        this.grpVariableAmount.Controls.Add(this.rdoGuildVariable);
+        this.grpVariableAmount.Controls.Add(this.rdoPlayerVariable);
+        this.grpVariableAmount.ForeColor = System.Drawing.Color.Gainsboro;
+        this.grpVariableAmount.Location = new System.Drawing.Point(6, 19);
+        this.grpVariableAmount.Name = "grpVariableAmount";
+        this.grpVariableAmount.Size = new System.Drawing.Size(292, 103);
+        this.grpVariableAmount.TabIndex = 39;
+        this.grpVariableAmount.TabStop = false;
+        this.grpVariableAmount.Text = "Variable";
+        this.grpVariableAmount.Visible = false;
+        // 
+        // cmbVariable
+        // 
+        this.cmbVariable.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+        this.cmbVariable.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+        this.cmbVariable.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+        this.cmbVariable.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+        this.cmbVariable.DrawDropdownHoverOutline = false;
+        this.cmbVariable.DrawFocusRectangle = false;
+        this.cmbVariable.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+        this.cmbVariable.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+        this.cmbVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+        this.cmbVariable.ForeColor = System.Drawing.Color.Gainsboro;
+        this.cmbVariable.FormattingEnabled = true;
+        this.cmbVariable.Location = new System.Drawing.Point(67, 72);
+        this.cmbVariable.Name = "cmbVariable";
+        this.cmbVariable.Size = new System.Drawing.Size(219, 21);
+        this.cmbVariable.TabIndex = 39;
+        this.cmbVariable.Text = null;
+        this.cmbVariable.TextPadding = new System.Windows.Forms.Padding(2);
+        // 
+        // lblVariable
+        // 
+        this.lblVariable.AutoSize = true;
+        this.lblVariable.Location = new System.Drawing.Point(8, 74);
+        this.lblVariable.Name = "lblVariable";
+        this.lblVariable.Size = new System.Drawing.Size(45, 13);
+        this.lblVariable.TabIndex = 38;
+        this.lblVariable.Text = "Variable";
+        // 
+        // rdoGlobalVariable
+        // 
+        this.rdoGlobalVariable.AutoSize = true;
+        this.rdoGlobalVariable.Location = new System.Drawing.Point(165, 19);
+        this.rdoGlobalVariable.Name = "rdoGlobalVariable";
+        this.rdoGlobalVariable.Size = new System.Drawing.Size(96, 17);
+        this.rdoGlobalVariable.TabIndex = 37;
+        this.rdoGlobalVariable.Text = "Global Variable";
+        this.rdoGlobalVariable.CheckedChanged += new System.EventHandler(this.rdoGlobalVariable_CheckedChanged);
+        // 
+        // rdoGuildVariable
+        // 
+        this.rdoGuildVariable.AutoSize = true;
+        this.rdoGuildVariable.Location = new System.Drawing.Point(6, 42);
+        this.rdoGuildVariable.Name = "rdoGuildVariable";
+        this.rdoGuildVariable.Size = new System.Drawing.Size(90, 17);
+        this.rdoGuildVariable.TabIndex = 37;
+        this.rdoGuildVariable.Text = "Guild Variable";
+        this.rdoGuildVariable.CheckedChanged += new System.EventHandler(this.rdoGuildVariable_CheckedChanged);
+        // 
+        // rdoPlayerVariable
+        // 
+        this.rdoPlayerVariable.AutoSize = true;
+        this.rdoPlayerVariable.Checked = true;
+        this.rdoPlayerVariable.Location = new System.Drawing.Point(6, 19);
+        this.rdoPlayerVariable.Name = "rdoPlayerVariable";
+        this.rdoPlayerVariable.Size = new System.Drawing.Size(95, 17);
+        this.rdoPlayerVariable.TabIndex = 36;
+        this.rdoPlayerVariable.TabStop = true;
+        this.rdoPlayerVariable.Text = "Player Variable";
+        this.rdoPlayerVariable.CheckedChanged += new System.EventHandler(this.rdoPlayerVariable_CheckedChanged);
+        // 
+        // grpAmountType
+        // 
+        this.grpAmountType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+        this.grpAmountType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+        this.grpAmountType.Controls.Add(this.rdoVariable);
+        this.grpAmountType.Controls.Add(this.rdoManual);
+        this.grpAmountType.ForeColor = System.Drawing.Color.Gainsboro;
+        this.grpAmountType.Location = new System.Drawing.Point(305, 19);
+        this.grpAmountType.Name = "grpAmountType";
+        this.grpAmountType.Size = new System.Drawing.Size(115, 71);
+        this.grpAmountType.TabIndex = 37;
+        this.grpAmountType.TabStop = false;
+        this.grpAmountType.Text = "Amount Type:";
+        // 
+        // rdoVariable
+        // 
+        this.rdoVariable.AutoSize = true;
+        this.rdoVariable.Location = new System.Drawing.Point(9, 42);
+        this.rdoVariable.Name = "rdoVariable";
+        this.rdoVariable.Size = new System.Drawing.Size(63, 17);
+        this.rdoVariable.TabIndex = 36;
+        this.rdoVariable.Text = "Variable";
+        this.rdoVariable.CheckedChanged += new System.EventHandler(this.rdoVariable_CheckedChanged);
+        // 
+        // rdoManual
+        // 
+        this.rdoManual.AutoSize = true;
+        this.rdoManual.Checked = true;
+        this.rdoManual.Location = new System.Drawing.Point(9, 19);
+        this.rdoManual.Name = "rdoManual";
+        this.rdoManual.Size = new System.Drawing.Size(60, 17);
+        this.rdoManual.TabIndex = 35;
+        this.rdoManual.TabStop = true;
+        this.rdoManual.Text = "Manual";
+        this.rdoManual.CheckedChanged += new System.EventHandler(this.rdoManual_CheckedChanged);
+        // 
+        // btnCancel
+        // 
+        this.btnCancel.Location = new System.Drawing.Point(223, 128);
+        this.btnCancel.Name = "btnCancel";
+        this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
+        this.btnCancel.Size = new System.Drawing.Size(75, 23);
+        this.btnCancel.TabIndex = 20;
+        this.btnCancel.Text = "Cancel";
+        this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+        // 
+        // btnSave
+        // 
+        this.btnSave.Location = new System.Drawing.Point(6, 128);
+        this.btnSave.Name = "btnSave";
+        this.btnSave.Padding = new System.Windows.Forms.Padding(5);
+        this.btnSave.Size = new System.Drawing.Size(75, 23);
+        this.btnSave.TabIndex = 19;
+        this.btnSave.Text = "Ok";
+        this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+        // 
+        // EventCommandSetPVPTeam
+        // 
+        this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.AutoSize = true;
+        this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+        this.Controls.Add(this.grpSetPVPTeam);
+        this.Name = "EventCommandSetPVPTeam";
+        this.Size = new System.Drawing.Size(436, 163);
+        this.grpSetPVPTeam.ResumeLayout(false);
+        this.grpManualAmount.ResumeLayout(false);
+        this.grpManualAmount.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.nudTeamID)).EndInit();
+        this.grpVariableAmount.ResumeLayout(false);
+        this.grpVariableAmount.PerformLayout();
+        this.grpAmountType.ResumeLayout(false);
+        this.grpAmountType.PerformLayout();
+        this.ResumeLayout(false);
+
+    }
+    #endregion
+
+    private DarkUI.Controls.DarkGroupBox grpSetPVPTeam;
+    private DarkUI.Controls.DarkGroupBox grpVariableAmount;
+    private DarkUI.Controls.DarkComboBox cmbVariable;
+    private Label lblVariable;
+    private DarkUI.Controls.DarkRadioButton rdoGlobalVariable;
+    private DarkUI.Controls.DarkRadioButton rdoGuildVariable;
+    private DarkUI.Controls.DarkRadioButton rdoPlayerVariable;
+    private DarkUI.Controls.DarkGroupBox grpAmountType;
+    private DarkUI.Controls.DarkRadioButton rdoVariable;
+    private DarkUI.Controls.DarkRadioButton rdoManual;
+    private DarkUI.Controls.DarkButton btnCancel;
+    private DarkUI.Controls.DarkButton btnSave;
+    private DarkUI.Controls.DarkGroupBox grpManualAmount;
+    private DarkUI.Controls.DarkNumericUpDown nudTeamID;
+    private Label lblPVPTeam;
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Windows.Forms;
+
+using Intersect.Editor.Localization;
+using Intersect.Enums;
+using Intersect.GameObjects;
+using Intersect.GameObjects.Events.Commands;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    public partial class EventCommandChangePVPTeam : UserControl
+    {
+
+        private readonly FrmEvent mEventEditor;
+
+        private SetPVPTeamCommand mMyCommand;
+
+
+        public EventCommandChangePVPTeam(SetPVPTeamCommand refCommand, FrmEvent editor)
+        {
+            InitializeComponent();
+            mMyCommand = refCommand;
+            mEventEditor = editor;
+            InitLocalization();
+
+            rdoVariable.Checked = mMyCommand.UseVariable;
+            rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
+            rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
+
+            SetupAmountInput();
+        }
+
+        private void InitLocalization()
+        {
+            grpSetPVPTeam.Text = Strings.EventSetPVPTeam.title;
+            lblPVPTeam.Text = Strings.EventSetPVPTeam.label;
+
+            lblVariable.Text = Strings.EventSetPVPTeam.Variable;
+
+            grpAmountType.Text = Strings.EventSetPVPTeam.AmountType;
+            rdoManual.Text = Strings.EventSetPVPTeam.Manual;
+            rdoVariable.Text = Strings.EventSetPVPTeam.Variable;
+
+            grpManualAmount.Text = Strings.EventSetPVPTeam.Manual;
+            grpVariableAmount.Text = Strings.EventSetPVPTeam.Variable;
+
+            rdoPlayerVariable.Text = Strings.EventSetPVPTeam.PlayerVariable;
+            rdoGlobalVariable.Text = Strings.EventSetPVPTeam.ServerVariable;
+            rdoGuildVariable.Text = Strings.EventSetPVPTeam.GuildVariable;
+
+            btnSave.Text = Strings.EventSetPVPTeam.okay;
+            btnCancel.Text = Strings.EventSetPVPTeam.cancel;
+        }
+
+        private void GrpSetPvpTeamEnter(object sender, EventArgs e)
+        {
+
+        }
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            mMyCommand.PVPTeamID = (int)nudTeamID.Value;
+            if (rdoPlayerVariable.Checked)
+            {
+                mMyCommand.VariableType = VariableType.PlayerVariable;
+                mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+            }
+            else if (rdoGlobalVariable.Checked)
+            {
+                mMyCommand.VariableType = VariableType.ServerVariable;
+                mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+            }
+            else if (rdoGuildVariable.Checked)
+            {
+                mMyCommand.VariableType = VariableType.GuildVariable;
+                mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+            }
+            mMyCommand.UseVariable = !rdoManual.Checked;
+            mEventEditor.FinishCommandEdit();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            mEventEditor.CancelCommandEdit();
+        }
+
+        private void rdoManual_CheckedChanged(object sender, EventArgs e)
+        {
+            SetupAmountInput();
+        }
+
+        private void rdoVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            SetupAmountInput();
+        }
+
+        private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            SetupAmountInput();
+        }
+
+        private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            SetupAmountInput();
+        }
+
+        private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+        {
+            SetupAmountInput();
+        }
+        private void SetupAmountInput()
+        {
+            grpManualAmount.Visible = rdoManual.Checked;
+            grpVariableAmount.Visible = !rdoManual.Checked;
+
+            cmbVariable.Items.Clear();
+            if (rdoPlayerVariable.Checked)
+            {
+                cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
+                // Do not update if the wrong type of variable is saved
+                if (mMyCommand.VariableType == VariableType.PlayerVariable)
+                {
+                    var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                    if (index > -1)
+                    {
+                        cmbVariable.SelectedIndex = index;
+                    }
+                    else
+                    {
+                        VariableBlank();
+                    }
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else if (rdoGlobalVariable.Checked)
+            {
+                cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
+                // Do not update if the wrong type of variable is saved
+                if (mMyCommand.VariableType == VariableType.ServerVariable)
+                {
+                    var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                    if (index > -1)
+                    {
+                        cmbVariable.SelectedIndex = index;
+                    }
+                    else
+                    {
+                        VariableBlank();
+                    }
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else if (rdoGuildVariable.Checked)
+            {
+                cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
+                // Do not update if the wrong type of variable is saved
+                if (mMyCommand.VariableType == VariableType.GuildVariable)
+                {
+                    var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                    if (index > -1)
+                    {
+                        cmbVariable.SelectedIndex = index;
+                    }
+                    else
+                    {
+                        VariableBlank();
+                    }
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+
+            nudTeamID.Value = Math.Clamp(mMyCommand.PVPTeamID, - 1, 1000);
+        }
+
+        private void VariableBlank()
+        {
+            if (cmbVariable.Items.Count > 0)
+            {
+                cmbVariable.SelectedIndex = 0;
+            }
+            else
+            {
+                cmbVariable.SelectedIndex = -1;
+                cmbVariable.Text = "";
+            }
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.resx
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePVPTeam.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -66,7 +66,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             var changePlayerNameTreeNode = new TreeNode("Change Player Name");
             var resetStatPointTreeNode = new TreeNode("Reset Stat Point Allocations");
             var castSpellOnTreeNode = new TreeNode("Cast Spell On");
-            var playerControlTreeNode = new TreeNode("Player Control", new TreeNode[] { restoreHPTreeNode, restoreMPTreeNode, levelUpTreeNode, giveExperienceTreeNode, changeLevelTreeNode, changeSpellsTreeNode, changeItemsTreeNode, changeSpriteTreeNode, changePlayerColorTreeNode, changeFaceTreeNode, changeGenderTreeNode, setAccessTreeNode, changeClassTreeNode, equipUneqiupTreeNode, changeNameColorTreeNode, changePlayerLabelTreeNode, changePlayerNameTreeNode, resetStatPointTreeNode, castSpellOnTreeNode });
+            var changePVPTeamTreeNode = new TreeNode("Change PVP Team");
+            var playerControlTreeNode = new TreeNode("Player Control", new TreeNode[] { restoreHPTreeNode, restoreMPTreeNode, levelUpTreeNode, giveExperienceTreeNode, changeLevelTreeNode, changeSpellsTreeNode, changeItemsTreeNode, changeSpriteTreeNode, changePlayerColorTreeNode, changeFaceTreeNode, changeGenderTreeNode, setAccessTreeNode, changeClassTreeNode, equipUneqiupTreeNode, changeNameColorTreeNode, changePlayerLabelTreeNode, changePlayerNameTreeNode, resetStatPointTreeNode, castSpellOnTreeNode, changePVPTeamTreeNode});
             var warpPlayerTreeNode = new TreeNode("Warp Player");
             var setMoveRouteTreeNode = new TreeNode("Set Move Route");
             var waitForRouteCompleteTreeNode = new TreeNode("Wait for Route Completion");
@@ -1023,6 +1024,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             setGuildBankSlotsTreeNode.Text = "Set Guild Bank Slots Count";
             guildsTreeNode.Name = "guilds";
             guildsTreeNode.Text = "Guilds";
+            changePVPTeamTreeNode.Name = "changepvpteam";
+            changePVPTeamTreeNode.Tag = (int)EventCommandType.SetPVPTeam;
+            changePVPTeamTreeNode.Text = "Change PVP Team";
             lstCommands.Nodes.AddRange(new TreeNode[] { dialogueTreeNode, logicFlowTreeNode, playerControlTreeNode, movementTreeNode, specialEffectsTreeNode, questControlTreeNode, etcTreeNode, shopAndBankTreeNode, guildsTreeNode });
             lstCommands.Size = new Size(500, 536);
             lstCommands.TabIndex = 2;

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -762,6 +762,10 @@ namespace Intersect.Editor.Forms.Editors.Events
                     tmpCommand = new ScreenFadeCommand();
 
                     break;
+                case EventCommandType.SetPVPTeam:
+                    tmpCommand = new SetPVPTeamCommand();
+
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -1406,6 +1410,10 @@ namespace Intersect.Editor.Forms.Editors.Events
                     break;
                 case EventCommandType.Fade:
                     cmdWindow = new EventCommand_ScreenFade((ScreenFadeCommand)command, this);
+
+                    break;
+                case EventCommandType.SetPVPTeam:
+                    cmdWindow = new EventCommandChangePVPTeam((SetPVPTeamCommand)command, this);
 
                     break;
                 default:

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -1888,6 +1888,9 @@ Tick timer saved in server config.json.";
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString CastSpellOn = @"Cast Spell '{00}' [include self: {01}, include party: {02}; include guild: {03})";
 
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ChangePVPTeam = @"Change PVP Team '{00}'";
+
             public static LocalizedString changename = @"Change Name to Variable: {00}";
 
             public static LocalizedString changeitems = @"Change Player Items [{00}]";
@@ -2020,6 +2023,10 @@ Tick timer saved in server config.json.";
             public static LocalizedString give = @"Give: Item {00}";
 
             public static LocalizedString giveexp = @"Give Player {00} Experience";
+
+            public static LocalizedString pvpteam = @"Set PVP Team {00}";
+
+            public static LocalizedString setpvpteam = @"Set PVP Team {00}";
 
             public static LocalizedString globalswitch = @"Set Global Switch {00} to {01}";
 
@@ -2341,6 +2348,7 @@ Tick timer saved in server config.json.";
                 {"setguildbankslots", @"Set Guild Bank Slots Count"},
                 {"resetstatallocations", @"Reset Stat Point Allocations"},
                 {"castspellon", @"Cast Spell On"},
+                {"changepvpteam", @"Change PVP Team"},
                 {"fade", @"Screen Fade"},
             };
 
@@ -2940,6 +2948,36 @@ Tick timer saved in server config.json.";
             public static LocalizedString okay = @"Ok";
 
             public static LocalizedString title = @"Give Experience";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString AmountType = @"Amount Type";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Variable = @"Variable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Manual = @"Manual";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PlayerVariable = @"Player Variable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString ServerVariable = @"Global Variable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString GuildVariable = @"Guild Variable";
+
+        }
+        public partial struct EventSetPVPTeam
+        {
+
+            public static LocalizedString cancel = @"Cancel";
+
+            public static LocalizedString label = @"Set PVP Team:";
+
+            public static LocalizedString okay = @"Ok";
+
+            public static LocalizedString title = @"Set PVP Team";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString AmountType = @"Amount Type";

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1540,6 +1540,11 @@ namespace Intersect.Server.Entities
                 {
                     return;
                 }
+
+                if (player.PVPTeam == targetPlayer.PVPTeam || targetPlayer.PVPTeam == -1 || player.PVPTeam == -1)
+                {
+                    return;
+                }
             }
 
             if (parentSpell == null)
@@ -1638,6 +1643,11 @@ namespace Intersect.Server.Entities
                     }
 
                     if (MapController.Get(target.MapId).ZoneType == MapZone.Safe)
+                    {
+                        return;
+                    }
+
+                    if (player.PVPTeam == targetPlayer.PVPTeam || targetPlayer.PVPTeam == -1 || player.PVPTeam ==-1)
                     {
                         return;
                     }
@@ -1831,6 +1841,11 @@ namespace Intersect.Server.Entities
                 }
 
                 if (MapController.Get(target.MapId)?.ZoneType == MapZone.Safe)
+                {
+                    return;
+                }
+
+                if (player.PVPTeam == targetPlayer.PVPTeam || targetPlayer.PVPTeam == -1 || player.PVPTeam == -1)
                 {
                     return;
                 }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -733,6 +733,38 @@ namespace Intersect.Server.Entities.Events
             PacketSender.SendChatMsg(player, Strings.Player.powerchanged, ChatMessageType.Notice, Color.Red);
         }
 
+        //Change PVPTeam Command
+        private static void ProcessCommand(
+            SetPVPTeamCommand command,
+            Player player,
+            Event instance,
+            CommandInstance stackInfo,
+            Stack<CommandInstance> callStack
+        )
+        {
+            int PVPTeamID = command.PVPTeamID;
+
+            if (command.UseVariable)
+            {
+                switch (command.VariableType)
+                {
+                    case VariableType.PlayerVariable:
+                        PVPTeamID = (int)player.GetVariableValue(command.VariableId).Integer;
+
+                        break;
+                    case VariableType.ServerVariable:
+                        PVPTeamID = (int)ServerVariableBase.Get(command.VariableId)?.Value.Integer;
+
+                        break;
+
+                    case VariableType.GuildVariable:
+                        PVPTeamID = (int)player.Guild?.GetVariableValue(command.VariableId)?.Integer;
+
+                        break;
+                }
+            }
+        }
+
         //Warp Player Command
         private static void ProcessCommand(
             WarpCommand command,

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -70,6 +70,7 @@ namespace Intersect.Server.Entities
         public new int[] MaxVitals => GetMaxVitals();
 
         //Name, X, Y, Dir, Etc all in the base Entity Class
+        public int PVPTeam { get; set; } = -1;
         public Guid ClassId { get; set; }
 
         [NotMapped]


### PR DESCRIPTION
Allows you to configure friendly fire. Players with the same team ID will not receive damage, and players with ID=-1 will not receive damage and take part in pvp.

Fixed: ID -1 made players immortal when they themselves could deal damage