### PR TITLE
feature: ability to highlight selected NPC with declared spawn

### DIFF
--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1004,7 +1004,8 @@ namespace Intersect.Editor.Core
                         // Check if the current spawn is selected
                         var spawnColor = System.Drawing.Color.White;
                         var selectedNpcIndex = Globals.MapLayersWindow.lstMapNpcs.SelectedIndex;
-                        if (selectedNpcIndex > -1 && tmpMap.Spawns[i] == tmpMap.Spawns[selectedNpcIndex])
+                        if (selectedNpcIndex > -1 && selectedNpcIndex < tmpMap.Spawns.Count &&
+                            tmpMap.Spawns[i] == tmpMap.Spawns[selectedNpcIndex])
                         {
                             // Calculate pulsating color: adjusts denominator to change speed of pulsation.
                             var currentTime = Timing.Global.MillisecondsUtc;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
@@ -1177,10 +1177,11 @@ namespace Intersect.Editor.Forms.DockingElements
             // lblNpcCount
             //
             this.lblNpcCount.AutoSize = true;
+            this.lblNpcCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.lblNpcCount.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lblNpcCount.Location = new System.Drawing.Point(5, 365);
+            this.lblNpcCount.Location = new System.Drawing.Point(7, 362);
             this.lblNpcCount.Name = "lblNpcCount";
-            this.lblNpcCount.Size = new System.Drawing.Size(0, 13);
+            this.lblNpcCount.Size = new System.Drawing.Size(0, 16);
             this.lblNpcCount.TabIndex = 13;
             //
             // grpSpawnLoc
@@ -1190,7 +1191,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpSpawnLoc.Controls.Add(this.rbRandom);
             this.grpSpawnLoc.Controls.Add(this.rbDeclared);
             this.grpSpawnLoc.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpawnLoc.Location = new System.Drawing.Point(7, 388);
+            this.grpSpawnLoc.Location = new System.Drawing.Point(7, 390);
             this.grpSpawnLoc.Name = "grpSpawnLoc";
             this.grpSpawnLoc.Size = new System.Drawing.Size(259, 46);
             this.grpSpawnLoc.TabIndex = 11;
@@ -1203,7 +1204,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpSpawnDirection.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
             this.grpSpawnDirection.Controls.Add(this.cmbDir);
             this.grpSpawnDirection.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpawnDirection.Location = new System.Drawing.Point(7, 444);
+            this.grpSpawnDirection.Location = new System.Drawing.Point(7, 445);
             this.grpSpawnDirection.Name = "grpSpawnDirection";
             this.grpSpawnDirection.Size = new System.Drawing.Size(259, 46);
             this.grpSpawnDirection.TabIndex = 11;
@@ -1229,7 +1230,7 @@ namespace Intersect.Editor.Forms.DockingElements
             "Down",
             "Left",
             "Right"});
-            this.cmbDir.Location = new System.Drawing.Point(7, 16);
+            this.cmbDir.Location = new System.Drawing.Point(7, 18);
             this.cmbDir.Name = "cmbDir";
             this.cmbDir.Size = new System.Drawing.Size(246, 20);
             this.cmbDir.TabIndex = 3;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
@@ -105,11 +105,14 @@ namespace Intersect.Editor.Forms.DockingElements
             this.btnAddMapNpc = new DarkUI.Controls.DarkButton();
             this.cmbNpc = new DarkUI.Controls.DarkComboBox();
             this.grpSpawnLoc = new DarkUI.Controls.DarkGroupBox();
+            this.grpSpawnDirection = new DarkGroupBox();
             this.cmbDir = new DarkUI.Controls.DarkComboBox();
-            this.lblDir = new System.Windows.Forms.Label();
             this.rbRandom = new DarkUI.Controls.DarkRadioButton();
             this.rbDeclared = new DarkUI.Controls.DarkRadioButton();
+            this.lblNpcCount = new Label();
             this.lstMapNpcs = new System.Windows.Forms.ListBox();
+            this.npcColorPulseDialog = new ColorDialog();
+            this.btnNpcPulseColor = new DarkButton();
             this.btnTileHeader = new DarkUI.Controls.DarkButton();
             this.btnAttributeHeader = new DarkUI.Controls.DarkButton();
             this.btnLightsHeader = new DarkUI.Controls.DarkButton();
@@ -169,6 +172,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpAnimation.SuspendLayout();
             this.grpNpcList.SuspendLayout();
             this.grpSpawnLoc.SuspendLayout();
+            this.grpSpawnDirection.SuspendLayout();
             this.panel1.SuspendLayout();
             this.pnlAttributes.SuspendLayout();
             this.grpCritter.SuspendLayout();
@@ -1108,29 +1112,29 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpNpcList.Controls.Add(this.btnAddMapNpc);
             this.grpNpcList.Controls.Add(this.cmbNpc);
             this.grpNpcList.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNpcList.Location = new System.Drawing.Point(7, 277);
+            this.grpNpcList.Location = new System.Drawing.Point(7, 10);
             this.grpNpcList.Name = "grpNpcList";
-            this.grpNpcList.Size = new System.Drawing.Size(259, 156);
+            this.grpNpcList.Size = new System.Drawing.Size(259, 80);
             this.grpNpcList.TabIndex = 12;
             this.grpNpcList.TabStop = false;
-            this.grpNpcList.Text = "Add/Remove Map NPCs";
+            this.grpNpcList.Text = "Add or Remove NPC Spawn:";
             //
             // btnRemoveMapNpc
             //
-            this.btnRemoveMapNpc.Location = new System.Drawing.Point(147, 47);
+            this.btnRemoveMapNpc.Location = new System.Drawing.Point(142, 50);
             this.btnRemoveMapNpc.Name = "btnRemoveMapNpc";
             this.btnRemoveMapNpc.Padding = new System.Windows.Forms.Padding(5);
-            this.btnRemoveMapNpc.Size = new System.Drawing.Size(75, 23);
+            this.btnRemoveMapNpc.Size = new System.Drawing.Size(80, 20);
             this.btnRemoveMapNpc.TabIndex = 6;
             this.btnRemoveMapNpc.Text = "Remove";
             this.btnRemoveMapNpc.Click += new System.EventHandler(this.btnRemoveMapNpc_Click);
             //
             // btnAddMapNpc
             //
-            this.btnAddMapNpc.Location = new System.Drawing.Point(26, 47);
+            this.btnAddMapNpc.Location = new System.Drawing.Point(21, 50);
             this.btnAddMapNpc.Name = "btnAddMapNpc";
             this.btnAddMapNpc.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAddMapNpc.Size = new System.Drawing.Size(75, 23);
+            this.btnAddMapNpc.Size = new System.Drawing.Size(80, 20);
             this.btnAddMapNpc.TabIndex = 5;
             this.btnAddMapNpc.Text = "Add";
             this.btnAddMapNpc.Click += new System.EventHandler(this.btnAddMapNpc_Click);
@@ -1148,29 +1152,63 @@ namespace Intersect.Editor.Forms.DockingElements
             this.cmbNpc.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cmbNpc.ForeColor = System.Drawing.Color.Gainsboro;
             this.cmbNpc.FormattingEnabled = true;
-            this.cmbNpc.Location = new System.Drawing.Point(6, 18);
+            this.cmbNpc.Location = new System.Drawing.Point(6, 20);
             this.cmbNpc.Name = "cmbNpc";
-            this.cmbNpc.Size = new System.Drawing.Size(247, 21);
+            this.cmbNpc.Size = new System.Drawing.Size(247, 18);
             this.cmbNpc.TabIndex = 4;
             this.cmbNpc.Text = null;
             this.cmbNpc.TextPadding = new System.Windows.Forms.Padding(2);
             this.cmbNpc.SelectedIndexChanged += new System.EventHandler(this.cmbNpc_SelectedIndexChanged);
             //
+            // lstMapNpcs
+            //
+            this.lstMapNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.lstMapNpcs.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.lstMapNpcs.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lstMapNpcs.FormattingEnabled = true;
+            this.lstMapNpcs.Location = new System.Drawing.Point(7, 100);
+            this.lstMapNpcs.Name = "lstMapNpcs";
+            this.lstMapNpcs.Size = new System.Drawing.Size(259, 270);
+            this.lstMapNpcs.TabIndex = 10;
+            this.lstMapNpcs.Click += new System.EventHandler(this.lstMapNpcs_Click);
+            this.lstMapNpcs.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lstMapNpcs_MouseDown);
+            this.lstMapNpcs.SelectedIndexChanged += new System.EventHandler(this.lstMapNpcs_SelectedIndexChanged);
+            //
+            // lblNpcCount
+            //
+            this.lblNpcCount.AutoSize = true;
+            this.lblNpcCount.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lblNpcCount.Location = new System.Drawing.Point(5, 365);
+            this.lblNpcCount.Name = "lblNpcCount";
+            this.lblNpcCount.Size = new System.Drawing.Size(0, 13);
+            this.lblNpcCount.TabIndex = 13;
+            //
             // grpSpawnLoc
             //
             this.grpSpawnLoc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
             this.grpSpawnLoc.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpSpawnLoc.Controls.Add(this.cmbDir);
-            this.grpSpawnLoc.Controls.Add(this.lblDir);
             this.grpSpawnLoc.Controls.Add(this.rbRandom);
             this.grpSpawnLoc.Controls.Add(this.rbDeclared);
             this.grpSpawnLoc.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpawnLoc.Location = new System.Drawing.Point(5, 183);
+            this.grpSpawnLoc.Location = new System.Drawing.Point(7, 388);
             this.grpSpawnLoc.Name = "grpSpawnLoc";
-            this.grpSpawnLoc.Size = new System.Drawing.Size(259, 81);
+            this.grpSpawnLoc.Size = new System.Drawing.Size(259, 46);
             this.grpSpawnLoc.TabIndex = 11;
             this.grpSpawnLoc.TabStop = false;
             this.grpSpawnLoc.Text = "Spawn Location: Random";
+            //
+            // grpSpawnDirection
+            //
+            this.grpSpawnDirection.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpSpawnDirection.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpSpawnDirection.Controls.Add(this.cmbDir);
+            this.grpSpawnDirection.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpSpawnDirection.Location = new System.Drawing.Point(7, 444);
+            this.grpSpawnDirection.Name = "grpSpawnDirection";
+            this.grpSpawnDirection.Size = new System.Drawing.Size(259, 46);
+            this.grpSpawnDirection.TabIndex = 11;
+            this.grpSpawnDirection.TabStop = false;
+            this.grpSpawnDirection.Text = "Spawn Direction:";
             //
             // cmbDir
             //
@@ -1191,28 +1229,19 @@ namespace Intersect.Editor.Forms.DockingElements
             "Down",
             "Left",
             "Right"});
-            this.cmbDir.Location = new System.Drawing.Point(5, 54);
+            this.cmbDir.Location = new System.Drawing.Point(7, 16);
             this.cmbDir.Name = "cmbDir";
-            this.cmbDir.Size = new System.Drawing.Size(248, 21);
+            this.cmbDir.Size = new System.Drawing.Size(246, 20);
             this.cmbDir.TabIndex = 3;
             this.cmbDir.Text = "Random";
             this.cmbDir.TextPadding = new System.Windows.Forms.Padding(2);
             this.cmbDir.SelectedIndexChanged += new System.EventHandler(this.cmbDir_SelectedIndexChanged);
             //
-            // lblDir
-            //
-            this.lblDir.AutoSize = true;
-            this.lblDir.Location = new System.Drawing.Point(5, 40);
-            this.lblDir.Name = "lblDir";
-            this.lblDir.Size = new System.Drawing.Size(52, 13);
-            this.lblDir.TabIndex = 2;
-            this.lblDir.Text = "Direction:";
-            //
             // rbRandom
             //
             this.rbRandom.AutoSize = true;
             this.rbRandom.Checked = true;
-            this.rbRandom.Location = new System.Drawing.Point(117, 20);
+            this.rbRandom.Location = new System.Drawing.Point(137, 18);
             this.rbRandom.Name = "rbRandom";
             this.rbRandom.Size = new System.Drawing.Size(65, 17);
             this.rbRandom.TabIndex = 1;
@@ -1223,24 +1252,22 @@ namespace Intersect.Editor.Forms.DockingElements
             // rbDeclared
             //
             this.rbDeclared.AutoSize = true;
-            this.rbDeclared.Location = new System.Drawing.Point(9, 20);
+            this.rbDeclared.Location = new System.Drawing.Point(37, 18);
             this.rbDeclared.Name = "rbDeclared";
             this.rbDeclared.Size = new System.Drawing.Size(68, 17);
             this.rbDeclared.TabIndex = 0;
             this.rbDeclared.Text = "Declared";
-            //
-            // lstMapNpcs
-            //
-            this.lstMapNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstMapNpcs.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lstMapNpcs.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstMapNpcs.FormattingEnabled = true;
-            this.lstMapNpcs.Location = new System.Drawing.Point(5, 6);
-            this.lstMapNpcs.Name = "lstMapNpcs";
-            this.lstMapNpcs.Size = new System.Drawing.Size(259, 171);
-            this.lstMapNpcs.TabIndex = 10;
-            this.lstMapNpcs.Click += new System.EventHandler(this.lstMapNpcs_Click);
-            this.lstMapNpcs.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lstMapNpcs_MouseDown);
+            // 
+            // btnNpcPulseColor
+            // 
+            btnNpcPulseColor.Location = new System.Drawing.Point(7, 505);
+            btnNpcPulseColor.Margin = new Padding(4, 3, 4, 3);
+            btnNpcPulseColor.Name = "btnNpcPulseColor";
+            btnNpcPulseColor.Padding = new Padding(6);
+            btnNpcPulseColor.Size = new Size(259, 24);
+            btnNpcPulseColor.TabIndex = 4;
+            btnNpcPulseColor.Text = "Selected NPC highlight color";
+            btnNpcPulseColor.Click += btnNpcPulseColor_Click;
             //
             // btnTileHeader
             //
@@ -1596,8 +1623,11 @@ namespace Intersect.Editor.Forms.DockingElements
             // pnlNpcs
             //
             this.pnlNpcs.Controls.Add(this.grpNpcList);
+            this.pnlNpcs.Controls.Add(this.lblNpcCount);
             this.pnlNpcs.Controls.Add(this.lstMapNpcs);
             this.pnlNpcs.Controls.Add(this.grpSpawnLoc);
+            this.pnlNpcs.Controls.Add(this.grpSpawnDirection);
+            this.pnlNpcs.Controls.Add(this.btnNpcPulseColor);
             this.pnlNpcs.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlNpcs.Location = new System.Drawing.Point(0, 0);
             this.pnlNpcs.Name = "pnlNpcs";
@@ -1830,7 +1860,9 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpAnimation.PerformLayout();
             this.grpNpcList.ResumeLayout(false);
             this.grpSpawnLoc.ResumeLayout(false);
+            this.grpSpawnDirection.ResumeLayout(false);
             this.grpSpawnLoc.PerformLayout();
+            this.grpSpawnDirection.PerformLayout();
             this.panel1.ResumeLayout(false);
             this.pnlAttributes.ResumeLayout(false);
             this.pnlAttributes.PerformLayout();
@@ -1897,11 +1929,14 @@ namespace Intersect.Editor.Forms.DockingElements
         private DarkButton btnAddMapNpc;
         private DarkComboBox cmbNpc;
         private DarkGroupBox grpSpawnLoc;
+        private DarkGroupBox grpSpawnDirection;
         private DarkComboBox cmbDir;
-        private System.Windows.Forms.Label lblDir;
         public DarkRadioButton rbRandom;
         public DarkRadioButton rbDeclared;
+        private Label lblNpcCount;
         public System.Windows.Forms.ListBox lstMapNpcs;
+        private ColorDialog npcColorPulseDialog;
+        private Button btnNpcPulseColor;
         private System.Windows.Forms.Label lblLightInstructions;
         private System.Windows.Forms.Label lblEventInstructions;
         public Controls.LightEditorCtrl lightEditor;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -907,16 +907,12 @@ namespace Intersect.Editor.Forms.DockingElements
                 return;
             }
 
-            cmbNpc.SelectedIndex = NpcBase.ListIndex(Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId);
-            cmbDir.SelectedIndex = (int)Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction;
-            if (Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X >= 0)
-            {
-                rbDeclared.Checked = true;
-            }
-            else
-            {
-                rbRandom.Checked = true;
-            }
+            var selectedSpawn = Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex];
+
+            cmbNpc.SelectedIndex = NpcBase.ListIndex(selectedSpawn.NpcId);
+            cmbDir.SelectedIndex = (int)selectedSpawn.Direction;
+            rbDeclared.Checked = selectedSpawn.X >= 0;
+            rbRandom.Checked = !rbDeclared.Checked;
 
             UpdateSpawnLocationLabel();
         }
@@ -936,7 +932,7 @@ namespace Intersect.Editor.Forms.DockingElements
         public void UpdateSpawnLocationLabel()
         {
             grpSpawnLoc.Text = rbDeclared.Checked ? Strings.NpcSpawns.spawndeclared : Strings.NpcSpawns.spawnrandom;
-            grpSpawnLoc.ForeColor = rbDeclared.Checked ? System.Drawing.Color.LawnGreen : System.Drawing.Color.DeepPink;
+            grpSpawnLoc.ForeColor = rbDeclared.Checked ? System.Drawing.Color.LawnGreen : System.Drawing.Color.HotPink;
         }
 
         private void cmbDir_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -56,6 +56,8 @@ namespace Intersect.Editor.Forms.DockingElements
 
         private bool mTMouseDown;
 
+        public static System.Drawing.Color NpcPulseColor;
+
         public FrmMapLayers()
         {
             InitializeComponent();
@@ -72,6 +74,9 @@ namespace Intersect.Editor.Forms.DockingElements
         {
             cmbAutotile.SelectedIndex = 0;
 
+            // Selected Npc highlight color from preferences
+            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+            
             //See if we can use the old style icons instead of a combobox
             if (Options.Instance.MapOpts.Layers.All.Count <= mMapLayers.Count)
             {
@@ -825,6 +830,8 @@ namespace Intersect.Editor.Forms.DockingElements
                     }
                 }
             }
+
+            UpdateNpcCountLabel();
         }
 
         private void frmMapLayers_DockStateChanged(object sender, EventArgs e)
@@ -849,6 +856,8 @@ namespace Intersect.Editor.Forms.DockingElements
                 lstMapNpcs.Items.Add(NpcBase.GetName(n.NpcId));
                 lstMapNpcs.SelectedIndex = lstMapNpcs.Items.Count - 1;
             }
+
+            UpdateNpcCountLabel();
         }
 
         private void btnRemoveMapNpc_Click(object sender, EventArgs e)
@@ -872,23 +881,44 @@ namespace Intersect.Editor.Forms.DockingElements
 
                 Core.Graphics.TilePreviewUpdated = true;
             }
+
+            UpdateNpcCountLabel();
+        }
+
+        private void UpdateNpcCountLabel()
+        {
+            lblNpcCount.Text = Strings.NpcSpawns.SpawnCount.ToString(lstMapNpcs.Items.Count);
         }
 
         private void lstMapNpcs_Click(object sender, EventArgs e)
         {
-            if (lstMapNpcs.Items.Count > 0 && lstMapNpcs.SelectedIndex > -1)
+            lstMapNpcs_Update();
+        }
+        
+        private void lstMapNpcs_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            lstMapNpcs_Update();
+        }
+
+        private void lstMapNpcs_Update()
+        {
+            if (lstMapNpcs.Items.Count <= 0 || lstMapNpcs.SelectedIndex <= -1)
             {
-                cmbNpc.SelectedIndex = NpcBase.ListIndex(Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId);
-                cmbDir.SelectedIndex = (int) Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction;
-                if (Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X >= 0)
-                {
-                    rbDeclared.Checked = true;
-                }
-                else
-                {
-                    rbRandom.Checked = true;
-                }
+                return;
             }
+
+            cmbNpc.SelectedIndex = NpcBase.ListIndex(Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId);
+            cmbDir.SelectedIndex = (int)Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction;
+            if (Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X >= 0)
+            {
+                rbDeclared.Checked = true;
+            }
+            else
+            {
+                rbRandom.Checked = true;
+            }
+
+            UpdateSpawnLocationLabel();
         }
 
         private void rbRandom_Click(object sender, EventArgs e)
@@ -898,7 +928,15 @@ namespace Intersect.Editor.Forms.DockingElements
                 Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X = -1;
                 Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Y = -1;
                 Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction = NpcSpawnDirection.Random;
+                Core.Graphics.TilePreviewUpdated = true;
+                UpdateSpawnLocationLabel();
             }
+        }
+        
+        public void UpdateSpawnLocationLabel()
+        {
+            grpSpawnLoc.Text = rbDeclared.Checked ? Strings.NpcSpawns.spawndeclared : Strings.NpcSpawns.spawnrandom;
+            grpSpawnLoc.ForeColor = rbDeclared.Checked ? System.Drawing.Color.LawnGreen : System.Drawing.Color.DeepPink;
         }
 
         private void cmbDir_SelectedIndexChanged(object sender, EventArgs e)
@@ -1158,10 +1196,12 @@ namespace Intersect.Editor.Forms.DockingElements
             cmbCritterLayer.SelectedIndex = 1;
 
             //NPCS Tab
-            grpSpawnLoc.Text = rbDeclared.Checked ? Strings.NpcSpawns.spawndeclared : Strings.NpcSpawns.spawnrandom;
+            grpSpawnDirection.Text = Strings.NpcSpawns.Direction;
             rbDeclared.Text = Strings.NpcSpawns.declaredlocation;
             rbRandom.Text = Strings.NpcSpawns.randomlocation;
-            lblDir.Text = Strings.NpcSpawns.direction;
+            btnNpcPulseColor.Text = Strings.NpcSpawns.PulseColorButton;
+            UpdateSpawnLocationLabel();
+            UpdateNpcCountLabel();
             cmbDir.Items.Clear();
             cmbDir.Items.Add(Strings.NpcSpawns.randomdirection);
             for (var i = 0; i < 4; i++)
@@ -1169,7 +1209,7 @@ namespace Intersect.Editor.Forms.DockingElements
                 cmbDir.Items.Add(Strings.Direction.dir[(Direction)i]);
             }
 
-            grpNpcList.Text = Strings.NpcSpawns.addremove;
+            grpNpcList.Text = Strings.NpcSpawns.AddRemove;
             btnAddMapNpc.Text = Strings.NpcSpawns.add;
             btnRemoveMapNpc.Text = Strings.NpcSpawns.remove;
 
@@ -1381,6 +1421,16 @@ namespace Intersect.Editor.Forms.DockingElements
         private void chkChangeInstance_CheckedChanged(object sender, EventArgs e)
         {
             grpInstanceSettings.Visible = chkChangeInstance.Checked;
+        }
+
+        private void btnNpcPulseColor_Click(object sender, EventArgs e)
+        {
+            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+            npcColorPulseDialog.Color = NpcPulseColor == default ? System.Drawing.Color.Red : NpcPulseColor;
+            npcColorPulseDialog.FullOpen = true;
+            npcColorPulseDialog.ShowDialog();
+            Preferences.SavePreference("NpcPulseColor", npcColorPulseDialog.Color.ToArgb().ToString());
+            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
         }
     }
 

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -108,6 +108,18 @@ namespace Intersect.Editor.Forms.Helpers
         public static Color ColorForeground { get; set; } = Color.Black;
 
         /// <summary>
+        /// Interpolates between two colors by a given ratio.
+        /// </summary>
+        public static Color ColorInterpolate(Color color1, Color color2, float ratio)
+        {
+            byte a = (byte)((color2.A - color1.A) * ratio + color1.A);
+            byte r = (byte)((color2.R - color1.R) * ratio + color1.R);
+            byte g = (byte)((color2.G - color1.G) * ratio + color1.G);
+            byte b = (byte)((color2.B - color1.B) * ratio + color1.B);
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        /// <summary>
         /// Mutable selection tile color for all grids, default <see cref="Color.Red"/>.
         /// </summary>
         public static Color ColorSelection { get; set; } = Color.Red;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4577,20 +4577,27 @@ Tick timer saved in server config.json.";
 
         public partial struct NpcSpawns
         {
-
             public static LocalizedString add = @"Add";
 
-            public static LocalizedString addremove = @"Add/Remove Map NPCs";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString AddRemove = @"Add or Remove NPC Spawn:";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PulseColorButton = @"Selected NPC highlight color";
 
             public static LocalizedString declaredlocation = @"Declared";
 
-            public static LocalizedString direction = @"Direction:";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Direction = @"Spawn Direction:";
 
             public static LocalizedString randomdirection = @"Random";
 
             public static LocalizedString randomlocation = @"Random";
 
             public static LocalizedString remove = @"Remove";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString SpawnCount = @"Spawn Count: {00}";
 
             public static LocalizedString spawndeclared = @"Spawn Location: Declared";
 


### PR DESCRIPTION
### (Editor feature and QoL update)

- Adds the ability to highlight selected NPC with declared spawn within the map grid
  (Resolves #1055)
- Adds configurable pulsating color for selected NPC spawns
- QoL enhancements and fixes for declared/random spawns:
  - Differently colored text as visual aid
  - Pressing the random checkbox for spawn location updates the grid preview
- QoL enhancements on forms organization within the NPCs map layers tab
- Adds a spawn counter under the NPC list

### Preview:


https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f12c5ff8-e6c9-4e11-b6f2-8347f88630a7




