### PR TITLE
enhancement: extend server statistics on startup

### DIFF
--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -4,6 +4,9 @@ using System.Resources;
 using System.Runtime.InteropServices;
 using CommandLine;
 using Intersect.Factories;
+using Intersect.GameObjects;
+using Intersect.GameObjects.Events;
+using Intersect.GameObjects.Maps;
 using Intersect.Logging;
 using Intersect.Network;
 using Intersect.Plugins;
@@ -266,12 +269,20 @@ namespace Intersect.Server.Core
                 return false;
             }
 
-            Console.WriteLine();
-
-            Console.WriteLine(Strings.Commandoutput.playercount.ToString(Player.Count()));
-            Console.WriteLine(Strings.Commandoutput.gametime.ToString(Time.GetTime().ToString("F")));
-
             Time.Update();
+
+            Console.WriteLine();
+            Console.WriteLine(Strings.Commandoutput.ServerInfo);
+            Console.WriteLine(Strings.Commandoutput.AccountCount.ToString(Database.PlayerData.User.Count()));
+            Console.WriteLine(Strings.Commandoutput.CharacterCount.ToString(Player.Count()));
+            Console.WriteLine(Strings.Commandoutput.NpcCount.ToString(NpcBase.Lookup.Count));
+            Console.WriteLine(Strings.Commandoutput.SpellCount.ToString(SpellBase.Lookup.Count));
+            Console.WriteLine(Strings.Commandoutput.MapCount.ToString(MapBase.Lookup.Count));
+            Console.WriteLine(Strings.Commandoutput.EventCount.ToString(EventBase.Lookup.Count));
+            Console.WriteLine(Strings.Commandoutput.ItemCount.ToString(ItemBase.Lookup.Count));
+            Console.WriteLine();
+            Console.WriteLine(Strings.Commandoutput.gametime.ToString(Time.GetTime().ToString("F")));
+            Console.WriteLine();
 
             PacketSender.CacheGameDataPacket();
 
@@ -297,6 +308,7 @@ namespace Intersect.Server.Core
             Console.WriteLine(@"Copyright (C) 2020 Ascension Game Dev");
             Console.WriteLine(Strings.Intro.version.ToString(Assembly.GetExecutingAssembly().GetName().Version));
             Console.WriteLine(Strings.Intro.support);
+            Console.WriteLine();
             Console.WriteLine(Strings.Intro.loading);
         }
 

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -508,7 +508,29 @@ namespace Intersect.Server.Localization
             public readonly LocalizedString parseerror =
                 @"Parse Error: Parameter could not be read. Type {00} {01} for usage information.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString playercount = @"Server has {00} registered players.";
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString ServerInfo = @"Server has:";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString AccountCount = @" - {00} accounts.";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString CharacterCount = @" - {00} characters.";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString NpcCount = @" - {00} NPCs.";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString SpellCount = @" - {00} spells.";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString MapCount = @" - {00} maps.";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString EventCount = @" - {00} events.";
+            
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString ItemCount = @" - {00} items.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] public readonly LocalizedString powerchanged = @"{00} has had their power updated!";
 


### PR DESCRIPTION
This enhancement PR extends server statistics information on startup

### Preview:

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/e2de573b-5817-415d-bd83-4045416be0a9) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/e4e5b9e2-4c02-4292-ad7e-f720c07c9ab8)

### Benefits:

- Provides Motivation for Developers: By displaying server statistics during development, developers can gain a sense of progress and achievement, which can boost motivation and productivity.  

- Facilitates Performance Analysis: The additional server statistics can serve as a valuable tool for performance analysis. By monitoring these statistics, developers can identify potential bottlenecks or performance issues, enabling proactive optimization of the server.

### First/Fresh startup:

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/c3df66d7-4dc2-40ca-804c-bf34d6a4800e)
