### PR TITLE
Fix: Proper operation of projectile

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -218,12 +218,6 @@ namespace Intersect.Server.Entities
         [NotMapped, JsonIgnore]
         public bool IsFading { get; set; }
 
-        /// <summary>
-        /// Reference stored of the last weapon used for an auto-attack
-        /// </summary>
-        [NotMapped, JsonIgnore]
-        public ItemBase LastAttackingWeapon { get; set; }
-
         // Instancing
         public MapInstanceType InstanceType { get; set; } = MapInstanceType.Overworld;
 
@@ -1489,7 +1483,6 @@ namespace Intersect.Server.Entities
         {
             if (isAutoAttack)
             {
-                EnqueueStartCommonEvent(LastAttackingWeapon?.GetEventTrigger(ItemEventTriggers.OnHit));
                 foreach (var trigger in CachedEquipmentOnHitTriggers)
                 {
                     EnqueueStartCommonEvent(trigger);
@@ -1603,8 +1596,6 @@ namespace Intersect.Server.Entities
                     }
                 }
             }
-
-            LastAttackingWeapon = weapon;
 
             if (weapon != null)
             {
@@ -5800,7 +5791,7 @@ namespace Intersect.Server.Entities
 
                 // We have special logic for handling weapons, so the player can't hot-swap their weapon and get a different on-hit event to proc
                 // As a result, don't cache them, instead use property "LastAttackingWeapon"
-                if (onHit != null && slot != Options.WeaponIndex)
+                if (onHit != null)
                 {
                     CachedEquipmentOnHitTriggers.Add(onHit);
                 }


### PR DESCRIPTION
Fixes: #2226 

In the new commit adding the ability to add common events to weapons or items, there was a problem with incorrect inheritance in the case of projectile weapons and melee weapons.
The video is on the bugs discord channel because it's too big.
Here I am posting a smaller picture of what the situation looks like after fixing the error, in my opinion.
[bandicam 2024-04-12 08-21-31-021.zip](https://github.com/AscensionGameDev/Intersect-Engine/files/14954724/bandicam.2024-04-12.08-21-31-021.zip)
