### PR TITLE
bug fix #2231

### DIFF
--- a/Intersect.Server.Core/Entities/Combat/DoT.cs
+++ b/Intersect.Server.Core/Entities/Combat/DoT.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -47,7 +47,7 @@ namespace Intersect.Server.Entities.Combat
             
 
             mInterval = Timing.Global.Milliseconds + SpellBase.Combat.HotDotInterval;
-            Count = SpellBase.Combat.Duration / SpellBase.Combat.HotDotInterval - 1;
+            Count = (SpellBase.Combat.Duration + SpellBase.Combat.HotDotInterval - 1) / SpellBase.Combat.HotDotInterval;
             target.DoT.TryAdd(Id, this);
             target.CachedDots = target.DoT.Values.ToArray();
 


### PR DESCRIPTION
Fixes #2231 

This ensures that any remainder from the division is accounted for, avoiding the loss of ticks.