### PR TITLE
enhancement: trade offer accepted

### DIFF
--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -200,6 +200,7 @@ namespace Intersect.Client.Interface.Game.Trades
         void trade_Clicked(Base sender, ClickedEventArgs arguments)
         {
             mTrade.Text = Strings.Trading.pending;
+            mTrade.IsDisabled = true;
             PacketSender.SendAcceptTrade();
         }
 

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1488,6 +1488,9 @@ namespace Intersect.Server.Localization
                 @"Out of inventory space. Some of your items have been dropped on the ground!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString OfferAccepted = @"{00} has accepted your offer. Please confirm the trade.";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString offerinvalid = @"Invalid item selected to offer!";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -2267,6 +2267,12 @@ namespace Intersect.Server.Networking
                 player.Trading.Counterparty.Trading.Counterparty = null;
                 player.Trading.Counterparty = null;
             }
+            else
+            {
+                PacketSender.SendChatMsg(
+                    player.Trading.Counterparty, Strings.Trading.OfferAccepted.ToString(player.Name), ChatMessageType.Trading, CustomColors.Alerts.Accepted
+                );
+            }
         }
 
         //DeclineTradePacket


### PR DESCRIPTION
- The trade button is now disabled upon pressing it.
- Players will now receive an informative message when the counterparty accepts theirs offer, indicating readiness for the trade to proceed.

Preview:
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/1d353871-4a60-4d5b-8d7a-060fa5647315)
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/79033676-3adc-44bd-a075-b2aed0d2847d) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/12b9604e-01b2-4f04-8395-6c2f4529aebf)

