### PR TITLE
fix: map boundary checks for projectiles

### DIFF
--- a/Intersect.Server.Core/Entities/Projectile.cs
+++ b/Intersect.Server.Core/Entities/Projectile.cs
@@ -374,11 +374,12 @@ namespace Intersect.Server.Entities
             var killSpawn = false;
             var map = MapController.Get(spawn.MapId);
 
-            if (Math.Round(newx) < 0)
+            if (Math.Floor(newx) < 0)
             {
-                if (MapController.Get(map.Left) != null)
+                var leftMap = MapController.Get(map.Left);
+                if (leftMap != null)
                 {
-                    newMapId = MapController.Get(spawn.MapId).Left;
+                    newMapId = leftMap.Id;
                     newx = Options.MapWidth - 1;
                 }
                 else
@@ -387,11 +388,12 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (Math.Round(newx) > Options.MapWidth - 1)
+            if (Math.Ceiling(newx) > Options.MapWidth)
             {
-                if (MapController.Get(map.Right) != null)
+                var rightMap = MapController.Get(map.Right);
+                if (rightMap != null)
                 {
-                    newMapId = MapController.Get(spawn.MapId).Right;
+                    newMapId = rightMap.Id;
                     newx = 0;
                 }
                 else
@@ -400,11 +402,12 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (Math.Round(newy) < 0)
+            if (Math.Floor(newy) < 0)
             {
-                if (MapController.Get(map.Up) != null)
+                var upMap = MapController.Get(map.Up);
+                if (upMap != null)
                 {
-                    newMapId = MapController.Get(spawn.MapId).Up;
+                    newMapId = upMap.Id;
                     newy = Options.MapHeight - 1;
                 }
                 else
@@ -413,11 +416,12 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (Math.Round(newy) > Options.MapHeight - 1)
+            if (Math.Ceiling(newy) > Options.MapHeight)
             {
-                if (MapController.Get(map.Down) != null)
+                var downMap = MapController.Get(map.Down);
+                if (downMap != null)
                 {
-                    newMapId = MapController.Get(spawn.MapId).Down;
+                    newMapId = downMap.Id;
                     newy = 0;
                 }
                 else


### PR DESCRIPTION
Did some research on this today, this PR should fix #2195 
Here are some of the tests i did when trying to figure this out:

By default maps have (0+31x0+25) tiles `("MapWidth": 32, "MapHeight": 26)` (x,y) 
- shooting from 0,0 to the left map: projectiles goes to next map fine
- shooting  from 0,25 to the left map: projectiles does not go to next map (bug)
- shooting diagonally from 31,0 to the right map: projectiles does not go to next map (bug)
- shooting diagonally from 0,25 to the left map: projectiles doesn't not go to next map (bug)

The issue seems to be related to the way we're checking the boundaries of the map. We're using `Math.Round(newx)` and `Math.Round(newy)` to determine if the projectile has hit the edge of the map. This could cause issues if the projectile's `x` or `y` position is exactly at the edge of the map, because `Math.Round()` rounds to the nearest integer, which could be either inside or outside the map depending on the exact floating point value... 

Instead, we should use `Math.Floor()` for checking the `left and top edges` and `Math.Ceiling()` for checking the `right and bottom` edges. This ensures that the projectile will transition to the next map as soon as it crosses the boundary. The reason for using `Math.Floor()` for the left and top edges and `Math.Ceiling()` for the right and bottom edges is due to how these functions round numbers and how coordinates are typically represented in a 2D grid, where the point `(0,0)` usually represents the top-left corner. If a projectile is at an x coordinate of 0.5, `Math.Floor(newx)` will round down to 0, which is still within the current map. But if the projectile is at an x coordinate of -0.5, `Math.Floor(newx)` will round down to -1, which is outside the current map, triggering the transition to the left map. Similarly, if a projectile is at an x coordinate of 30.5 in a 31-width map, `Math.Ceiling(newx)` will round up to 31, which is outside the current map, triggering the transition to the right map. But if the projectile is at an x coordinate of 30.5 and we use `Math.Floor(newx)`, it will round down to 30, which is still within the current map, **and the transition won't be triggered.**

So..
- `Math.Floor()` is used for the left and top edges to ensure the transition is triggered as soon as the projectile crosses the boundary to the left or above
- `Math.Ceiling()` is used for the right and bottom edges to ensure the transition is triggered as soon as the projectile crosses the boundary to the right or below.


### Results 

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/a119df03-8267-4b4c-892c-3d14b30ae34b


