### PR TITLE
fix: set LastAttackingWeapon for EquipmentOnHitTriggers

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1412,6 +1412,8 @@ namespace Intersect.Server.Entities
                 return;
             }
 
+            LastAttackingWeapon = parentItem;
+
             //If Entity is resource, check for the correct tool and make sure its not a spell cast.
             if (target is Resource resource)
             {


### PR DESCRIPTION
Fixes #2226 which reported an issue where LastAttackingWeapon wasn’t updated when shooting projectiles and spells, resulting in it not being properly used for CachedEquipmentOnHitTriggers

reference: https://github.com/AscensionGameDev/Intersect-Engine/issues/2226#issuecomment-2094495791


Results:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f2495235-875c-4f0b-b33e-c7b5f9647b55


