### PR TITLE
chore: long value type for Vitals, Exp and ConsumableData

### DIFF
--- a/Intersect (Core)/GameObjects/ClassBase.cs
+++ b/Intersect (Core)/GameObjects/ClassBase.cs
@@ -22,7 +22,7 @@ namespace Intersect.GameObjects
         public int[] BaseStat = new int[Enum.GetValues<Stat>().Length];
 
         [NotMapped]
-        public int[] BaseVital = new int[Enum.GetValues<Vital>().Length];
+        public long[] BaseVital = new long[Enum.GetValues<Vital>().Length];
 
         [NotMapped]
         public Dictionary<int, long> ExperienceOverrides = new Dictionary<int, long>();
@@ -46,10 +46,10 @@ namespace Intersect.GameObjects
         public int[] StatIncrease = new int[Enum.GetValues<Stat>().Length];
 
         [NotMapped]
-        public int[] VitalIncrease = new int[Enum.GetValues<Vital>().Length];
+        public long[] VitalIncrease = new long[Enum.GetValues<Vital>().Length];
 
         [NotMapped]
-        public int[] VitalRegen = new int[Enum.GetValues<Vital>().Length];
+        public long[] VitalRegen = new long[Enum.GetValues<Vital>().Length];
 
         [JsonConstructor]
         public ClassBase(Guid id) : base(id)
@@ -171,8 +171,8 @@ namespace Intersect.GameObjects
         [JsonIgnore]
         public string JsonBaseVitals
         {
-            get => DatabaseUtils.SaveIntArray(BaseVital, Enum.GetValues<Vital>().Length);
-            set => BaseVital = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(BaseVital, Enum.GetValues<Vital>().Length);
+            set => BaseVital = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         //Starting Items
@@ -216,8 +216,8 @@ namespace Intersect.GameObjects
         [Column("VitalIncreases")]
         public string VitalIncreaseJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalIncrease, Enum.GetValues<Vital>().Length);
-            set => VitalIncrease = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalIncrease, Enum.GetValues<Vital>().Length);
+            set => VitalIncrease = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         //Vital Regen %
@@ -225,8 +225,8 @@ namespace Intersect.GameObjects
         [Column("VitalRegen")]
         public string RegenJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalRegen, Enum.GetValues<Vital>().Length);
-            set => VitalRegen = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalRegen, Enum.GetValues<Vital>().Length);
+            set => VitalRegen = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         [JsonIgnore]

--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -261,23 +261,23 @@ namespace Intersect.GameObjects
         [JsonIgnore]
         public string VitalsJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalsGiven, Enum.GetValues<Vital>().Length);
-            set => VitalsGiven = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalsGiven, Enum.GetValues<Vital>().Length);
+            set => VitalsGiven = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         [NotMapped]
-        public int[] VitalsGiven { get; set; }
+        public long[] VitalsGiven { get; set; }
 
         [Column("VitalsRegen")]
         [JsonIgnore]
         public string VitalsRegenJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalsRegen, Enum.GetValues<Vital>().Length);
-            set => VitalsRegen = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalsRegen, Enum.GetValues<Vital>().Length);
+            set => VitalsRegen = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         [NotMapped]
-        public int[] VitalsRegen { get; set; }
+        public long[] VitalsRegen { get; set; }
 
         [Column("PercentageVitalsGiven")]
         [JsonIgnore]
@@ -485,8 +485,8 @@ namespace Intersect.GameObjects
             Speed = 10; // Set to 10 by default.
             StatsGiven = new int[Enum.GetValues<Stat>().Length];
             PercentageStatsGiven = new int[Enum.GetValues<Stat>().Length];
-            VitalsGiven = new int[Enum.GetValues<Vital>().Length];
-            VitalsRegen = new int[Enum.GetValues<Vital>().Length];
+            VitalsGiven = new long[Enum.GetValues<Vital>().Length];
+            VitalsRegen = new long[Enum.GetValues<Vital>().Length];
             PercentageVitalsGiven = new int[Enum.GetValues<Vital>().Length];
             Consumable = new ConsumableData();
             Effects = new List<EffectData>();
@@ -499,7 +499,7 @@ namespace Intersect.GameObjects
     {
         public ConsumableType Type { get; set; }
 
-        public int Value { get; set; }
+        public long Value { get; set; }
 
         public int Percentage { get; set; }
     }

--- a/Intersect (Core)/GameObjects/NpcBase.cs
+++ b/Intersect (Core)/GameObjects/NpcBase.cs
@@ -21,7 +21,7 @@ namespace Intersect.GameObjects
         public List<Drop> Drops = new List<Drop>();
 
         [NotMapped]
-        public int[] MaxVital = new int[Enum.GetValues<Vital>().Length];
+        public long[] MaxVital = new long[Enum.GetValues<Vital>().Length];
 
         [NotMapped]
         public ConditionLists PlayerCanAttackConditions = new ConditionLists();
@@ -33,7 +33,7 @@ namespace Intersect.GameObjects
         public int[] Stats = new int[Enum.GetValues<Stat>().Length];
 
         [NotMapped]
-        public int[] VitalRegen = new int[Enum.GetValues<Vital>().Length];
+        public long[] VitalRegen = new long[Enum.GetValues<Vital>().Length];
 
         [NotMapped]
         public List<SpellEffect> Immunities = new List<SpellEffect>();
@@ -184,8 +184,8 @@ namespace Intersect.GameObjects
         [JsonIgnore]
         public string JsonMaxVital
         {
-            get => DatabaseUtils.SaveIntArray(MaxVital, Enum.GetValues<Vital>().Length);
-            set => DatabaseUtils.LoadIntArray(ref MaxVital, value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(MaxVital, Enum.GetValues<Vital>().Length);
+            set => DatabaseUtils.LoadLongArray(ref MaxVital, value, Enum.GetValues<Vital>().Length);
         }
 
         //NPC vs NPC Combat
@@ -246,8 +246,8 @@ namespace Intersect.GameObjects
         [Column("VitalRegen")]
         public string RegenJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalRegen, Enum.GetValues<Vital>().Length);
-            set => VitalRegen = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalRegen, Enum.GetValues<Vital>().Length);
+            set => VitalRegen = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         /// <inheritdoc />

--- a/Intersect (Core)/GameObjects/SpellBase.cs
+++ b/Intersect (Core)/GameObjects/SpellBase.cs
@@ -16,7 +16,7 @@ namespace Intersect.GameObjects
     public partial class SpellBase : DatabaseObject<SpellBase>, IFolderable
     {
         [NotMapped]
-        public int[] VitalCost = new int[Enum.GetValues<Vital>().Length];
+        public long[] VitalCost = new long[Enum.GetValues<Vital>().Length];
 
         [JsonConstructor]
         public SpellBase(Guid id) : base(id)
@@ -134,8 +134,8 @@ namespace Intersect.GameObjects
         [JsonIgnore]
         public string VitalCostJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalCost, Enum.GetValues<Vital>().Length);
-            set => VitalCost = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalCost, Enum.GetValues<Vital>().Length);
+            set => VitalCost = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         /// <inheritdoc />
@@ -167,7 +167,7 @@ namespace Intersect.GameObjects
     public partial class SpellCombatData
     {
         [NotMapped]
-        public int[] VitalDiff = new int[Enum.GetValues<Vital>().Length];
+        public long[] VitalDiff = new long[Enum.GetValues<Vital>().Length];
 
         public int CritChance { get; set; }
 
@@ -198,8 +198,8 @@ namespace Intersect.GameObjects
         [JsonIgnore]
         public string VitalDiffJson
         {
-            get => DatabaseUtils.SaveIntArray(VitalDiff, Enum.GetValues<Vital>().Length);
-            set => VitalDiff = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(VitalDiff, Enum.GetValues<Vital>().Length);
+            set => VitalDiff = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         //Buff/Debuff Data

--- a/Intersect (Core)/Network/Packets/Server/EntityPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityPacket.cs
@@ -55,10 +55,10 @@ namespace Intersect.Network.Packets.Server
         public Guid[] Animations { get; set; }
 
         [Key(15)]
-        public int[] Vital { get; set; }
+        public long[] Vital { get; set; }
 
         [Key(16)]
-        public int[] MaxVital { get; set; }
+        public long[] MaxVital { get; set; }
 
         [Key(17)]
         public int[] Stats { get; set; }

--- a/Intersect (Core)/Network/Packets/Server/EntityVitalsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityVitalsPacket.cs
@@ -17,8 +17,8 @@ namespace Intersect.Network.Packets.Server
             Guid id,
             EntityType type,
             Guid mapId,
-            int[] vitals,
-            int[] maxVitals,
+            long[] vitals,
+            long[] maxVitals,
             StatusPacket[] statusEffects,
             long combatTimeRemaining
         )
@@ -46,10 +46,10 @@ namespace Intersect.Network.Packets.Server
         public Guid MapId { get; set; }
 
         [Key(3)]
-        public int[] Vitals { get; set; }
+        public long[] Vitals { get; set; }
 
         [Key(4)]
-        public int[] MaxVitals { get; set; }
+        public long[] MaxVitals { get; set; }
 
         [Key(5)]
         public StatusPacket[] StatusEffects { get; set; }

--- a/Intersect (Core)/Network/Packets/Server/MapEntityVitalsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapEntityVitalsPacket.cs
@@ -36,10 +36,10 @@ namespace Intersect.Network.Packets.Server
         public Enums.EntityType Type { get; set; }
 
         [Key(2)]
-        public int[] Vitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] Vitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         [Key(3)]
-        public int[] MaxVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] MaxVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         [Key(4)]
         public long CombatTimeRemaining { get; set; }

--- a/Intersect (Core)/Network/Packets/Server/PartyMemberPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PartyMemberPacket.cs
@@ -11,7 +11,7 @@ namespace Intersect.Network.Packets.Server
         {
         }
 
-        public PartyMemberPacket(Guid id, string name, int[] vital, int[] maxVital, int level)
+        public PartyMemberPacket(Guid id, string name, long[] vital, long[] maxVital, int level)
         {
             Id = id;
             Name = name;
@@ -27,10 +27,10 @@ namespace Intersect.Network.Packets.Server
         public string Name { get; set; }
 
         [Key(2)]
-        public int[] Vital { get; set; }
+        public long[] Vital { get; set; }
 
         [Key(3)]
-        public int[] MaxVital { get; set; }
+        public long[] MaxVital { get; set; }
 
         [Key(4)]
         public int Level { get; set; }

--- a/Intersect (Core)/Network/Packets/Server/StatusPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/StatusPacket.cs
@@ -19,7 +19,7 @@ namespace Intersect.Network.Packets.Server
             string transformSprite,
             long timeRemaining,
             long totalDuration,
-            int[] vitalShields
+            long[] vitalShields
         )
         {
             SpellId = spellId;
@@ -46,7 +46,7 @@ namespace Intersect.Network.Packets.Server
         public long TotalDuration { get; set; }
 
         [Key(5)]
-        public int[] VitalShields { get; set; }
+        public long[] VitalShields { get; set; }
 
     }
 

--- a/Intersect (Core)/Utilities/DatabaseUtils.cs
+++ b/Intersect (Core)/Utilities/DatabaseUtils.cs
@@ -57,6 +57,42 @@ namespace Intersect.Utilities
             return JsonConvert.SerializeObject(output);
         }
 
+        public static long[] LoadLongArray(string json, long arrayLen)
+        {
+            var output = new long[arrayLen];
+            var jsonList = json != null ? JsonConvert.DeserializeObject<List<long>>(json) : new List<long>();
+
+            for (var i = 0; i < arrayLen && i < jsonList.Count; i++)
+            {
+                output[i] = jsonList[i];
+            }
+
+            return output;
+        }
+
+        public static void LoadLongArray(ref long[] output, string json, long arrayLen)
+        {
+            var jsonList = JsonConvert.DeserializeObject<List<long>>(json);
+
+            for (var i = 0; i < arrayLen && i < jsonList.Count; i++)
+            {
+                output[i] = jsonList[i];
+            }
+        }
+
+        public static string SaveLongArray(long[] array, long arrayLen)
+        {
+            array ??= new long[arrayLen];
+
+            var output = new List<long>();
+            for (var i = 0; i < arrayLen; i++)
+            {
+                output.Add(i < array.Length ? array[i] : 0);
+            }
+
+            return JsonConvert.SerializeObject(output);
+        }
+
         public static string SaveColor(Color color)
         {
             if (color == null)

--- a/Intersect.Client.Framework/Entities/IEntity.cs
+++ b/Intersect.Client.Framework/Entities/IEntity.cs
@@ -43,8 +43,8 @@ namespace Intersect.Client.Framework.Entities
         byte Z { get; }
         int Level { get; }
         IReadOnlyList<int> Stats { get; }
-        IReadOnlyList<int> Vitals { get; }
-        IReadOnlyList<int> MaxVitals { get; }
+        IReadOnlyList<long> Vitals { get; }
+        IReadOnlyList<long> MaxVitals { get; }
         IReadOnlyList<IItem> Items { get; }
         IReadOnlyList<int> EquipmentSlots { get; }
         IReadOnlyList<Guid> Spells { get; }

--- a/Intersect.Client.Framework/Entities/IPartyMember.cs
+++ b/Intersect.Client.Framework/Entities/IPartyMember.cs
@@ -6,8 +6,8 @@ namespace Intersect.Client.Framework.Entities
     {
         Guid Id { get; set; }
         int Level { get; set; }
-        int[] MaxVital { get; set; }
+        long[] MaxVital { get; set; }
         string Name { get; set; }
-        int[] Vital { get; set; }
+        long[] Vital { get; set; }
     }
 }

--- a/Intersect.Client.Framework/Entities/IStatus.cs
+++ b/Intersect.Client.Framework/Entities/IStatus.cs
@@ -6,7 +6,7 @@ namespace Intersect.Client.Framework.Entities
     public interface IStatus
     {
         string Data { get; set; }
-        int[] Shield { get; set; }
+        long[] Shield { get; set; }
         Guid SpellId { get; set; }
         long TimeRecevied { get; set; }
         long TimeRemaining { get; set; }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -116,9 +116,9 @@ namespace Intersect.Client.Entities
         public int Level { get; set; } = 1;
 
         //Vitals & Stats
-        public int[] MaxVital { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
-        IReadOnlyList<int> IEntity.MaxVitals => MaxVital.ToList();
+        IReadOnlyList<long> IEntity.MaxVitals => MaxVital.ToList();
 
         protected Pointf mOrigin = Pointf.Empty;
 
@@ -208,9 +208,9 @@ namespace Intersect.Client.Entities
 
         public NpcAggression Aggression { get; set; }
 
-        public int[] Vital { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
-        IReadOnlyList<int> IEntity.Vitals => Vital.ToList();
+        IReadOnlyList<long> IEntity.Vitals => Vital.ToList();
 
         public int WalkFrame { get; set; }
 
@@ -1647,9 +1647,9 @@ namespace Intersect.Client.Entities
             return y;
         }
 
-        public int GetShieldSize()
+        public long GetShieldSize()
         {
-            var shieldSize = 0;
+            long shieldSize = 0;
             foreach (var status in Status)
             {
                 if (status.Type == SpellEffect.Shield)

--- a/Intersect.Client/Entities/PartyMember.cs
+++ b/Intersect.Client/Entities/PartyMember.cs
@@ -12,13 +12,13 @@ namespace Intersect.Client.Entities
 
         public int Level { get; set; }
 
-        public int[] MaxVital { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         public string Name { get; set; }
 
-        public int[] Vital { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
-        public PartyMember(Guid id, string name, int[] vital, int[] maxVital, int level)
+        public PartyMember(Guid id, string name, long[] vital, long[] maxVital, int level)
         {
             Id = id;
             Name = name;

--- a/Intersect.Client/Entities/Status.cs
+++ b/Intersect.Client/Entities/Status.cs
@@ -11,7 +11,7 @@ namespace Intersect.Client.Entities
 
         public string Data { get; set; } = "";
 
-        public int[] Shield { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         public Guid SpellId { get; set; }
 

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -76,11 +76,11 @@ namespace Intersect.Client.Interface.Game.Character
 
         Label mHpRegen;
 
-        int HpRegenAmount;
+        long HpRegenAmount;
 
         Label mManaRegen;
 
-        int ManaRegenAmount;
+        long ManaRegenAmount;
 
         Label mLifeSteal;
 

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using Intersect.Client.Entities.Events;
@@ -689,13 +685,13 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             float targetShieldSize;
             var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Health];
             var barPercentageSetting = Globals.Database.ShowHealthAsPercentage;
-            var entityVital = (float)MyEntity.Vital[(int)Vital.Health];
-            var entityMaxVital = (float)MyEntity.MaxVital[(int)Vital.Health];
+            var entityVital = MyEntity.Vital[(int)Vital.Health];
+            var entityMaxVital = MyEntity.MaxVital[(int)Vital.Health];
 
             if (entityVital > 0)
             {
                 
-                var shieldSize = (float)MyEntity.GetShieldSize();
+                var shieldSize = MyEntity.GetShieldSize();
                 var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
                     ? HpBackground.Width
                     : HpBackground.Height;
@@ -707,8 +703,8 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     entityMaxVital = shieldSize + entityVital;
                 }
 
-                var entityVitalRatio = entityVital / entityMaxVital;
-                var entityShieldRatio = shieldSize / entityMaxVital;
+                var entityVitalRatio = (float)entityVital / entityMaxVital;
+                var entityShieldRatio = (float)shieldSize / entityMaxVital;
                 var hpPercentage = entityVitalRatio * 100;
                 var hpPercentageText = $"{hpPercentage:0.##}%";
                 var hpValueText = Strings.EntityBox.vital0val.ToString(entityVital, entityMaxVital);
@@ -759,13 +755,13 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             float targetMpSize;
             var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Mana];
             var barPercentageSetting = Globals.Database.ShowManaAsPercentage;
-            var entityVital = (float)MyEntity.Vital[(int)Vital.Mana];
-            var entityMaxVital = (float)MyEntity.MaxVital[(int)Vital.Mana];
+            var entityVital = MyEntity.Vital[(int)Vital.Mana];
+            var entityMaxVital = MyEntity.MaxVital[(int)Vital.Mana];
 
             if (entityVital > 0)
             {
                 
-                var entityVitalRatio = entityVital / entityMaxVital;
+                var entityVitalRatio = (float)entityVital / entityMaxVital;
                 var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
                     ? MpBackground.Width
                     : MpBackground.Height;

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -108,7 +108,7 @@ namespace Intersect.Server.Entities.Combat
             {
                 foreach (var vital in Enum.GetValues<Vital>())
                 {
-                    var vitalDiff = Math.Abs(spell.Combat.VitalDiff[(int)vital]);
+                    long vitalDiff = Math.Abs(spell.Combat.VitalDiff[(int)vital]);
 
                     // If the user did not configure for this vital to have a mana shield, ignore it
                     if (vitalDiff == 0 && vital == Vital.Mana)
@@ -213,7 +213,7 @@ namespace Intersect.Server.Entities.Combat
             }
         }
 
-        public int[] Shield { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         public void TryRemoveStatus()
         {
@@ -249,7 +249,7 @@ namespace Intersect.Server.Entities.Combat
             }
         }
 
-        public void DamageShield(Vital vital, ref int amount)
+        public void DamageShield(Vital vital, ref long amount)
         {
             if (Type == SpellEffect.Shield)
             {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -28,7 +28,7 @@ namespace Intersect.Server.Entities
 
         public Guid MapInstanceId = Guid.Empty;
 
-        [JsonProperty("MaxVitals"), NotMapped] private int[] _maxVital = new int[Enum.GetValues<Vital>().Length];
+        [JsonProperty("MaxVitals"), NotMapped] private long[] _maxVital = new long[Enum.GetValues<Vital>().Length];
 
         [NotMapped, JsonIgnore] public Combat.Stat[] Stat = new Combat.Stat[Enum.GetValues<Stat>().Length];
 
@@ -98,18 +98,18 @@ namespace Intersect.Server.Entities
         [JsonIgnore, Column("Vitals")]
         public string VitalsJson
         {
-            get => DatabaseUtils.SaveIntArray(mVitals, Enum.GetValues<Vital>().Length);
-            set => mVitals = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Vital>().Length);
+            get => DatabaseUtils.SaveLongArray(mVitals, Enum.GetValues<Vital>().Length);
+            set => mVitals = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
         }
 
         [JsonProperty("Vitals"), NotMapped]
-        private int[] mVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        private long[] mVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         [JsonIgnore, NotMapped]
-        private int[] mOldVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        private long[] mOldVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         [JsonIgnore, NotMapped]
-        private int[] mOldMaxVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+        private long[] mOldMaxVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
         //Stats based on npc settings, class settings, etc for quick calculations
         [JsonIgnore, Column(nameof(BaseStats))]
@@ -1349,25 +1349,25 @@ namespace Intersect.Server.Entities
         {
         }
 
-        public int GetVital(int vital)
+        public long GetVital(int vital)
         {
             return mVitals[vital];
         }
 
-        public int[] GetVitals()
+        public long[] GetVitals()
         {
-            var vitals = new int[Enum.GetValues<Vital>().Length];
+            var vitals = new long[Enum.GetValues<Vital>().Length];
             Array.Copy(mVitals, 0, vitals, 0, Enum.GetValues<Vital>().Length);
 
             return vitals;
         }
 
-        public int GetVital(Vital vital)
+        public long GetVital(Vital vital)
         {
             return GetVital((int)vital);
         }
 
-        public void SetVital(int vital, int value)
+        public void SetVital(int vital, long value)
         {
             if (value < 0)
             {
@@ -1382,24 +1382,24 @@ namespace Intersect.Server.Entities
             mVitals[vital] = value;
         }
 
-        public void SetVital(Vital vital, int value)
+        public void SetVital(Vital vital, long value)
         {
             SetVital((int)vital, value);
         }
 
-        public virtual int GetMaxVital(int vital)
+        public virtual long GetMaxVital(int vital)
         {
             return _maxVital[vital];
         }
 
-        public virtual int GetMaxVital(Vital vital)
+        public virtual long GetMaxVital(Vital vital)
         {
             return GetMaxVital((int)vital);
         }
 
-        public int[] GetMaxVitals()
+        public long[] GetMaxVitals()
         {
-            var vitals = new int[Enum.GetValues<Vital>().Length];
+            var vitals = new long[Enum.GetValues<Vital>().Length];
             for (var vitalIndex = 0; vitalIndex < vitals.Length; ++vitalIndex)
             {
                 vitals[vitalIndex] = GetMaxVital(vitalIndex);
@@ -1408,7 +1408,7 @@ namespace Intersect.Server.Entities
             return vitals;
         }
 
-        public void SetMaxVital(int vital, int value)
+        public void SetMaxVital(int vital, long value)
         {
             if (value <= 0 && vital == (int)Vital.Health)
             {
@@ -1427,7 +1427,7 @@ namespace Intersect.Server.Entities
             }
         }
 
-        public void SetMaxVital(Vital vital, int value)
+        public void SetMaxVital(Vital vital, long value)
         {
             SetMaxVital((int)vital, value);
         }
@@ -1448,7 +1448,7 @@ namespace Intersect.Server.Entities
             SetVital(vital, GetMaxVital(vital));
         }
 
-        public void AddVital(Vital vital, int amount)
+        public void AddVital(Vital vital, long amount)
         {
             if (!Enum.IsDefined(vital))
             {
@@ -1457,11 +1457,11 @@ namespace Intersect.Server.Entities
 
             var vitalId = (int)vital;
             var maxVitalValue = GetMaxVital(vitalId);
-            var safeAmount = Math.Min(amount, int.MaxValue - maxVitalValue);
+            var safeAmount = Math.Min(amount, long.MaxValue - maxVitalValue);
             SetVital(vital, GetVital(vital) + safeAmount);
         }
 
-        public void SubVital(Vital vital, int amount)
+        public void SubVital(Vital vital, long amount)
         {
             if (!Enum.IsDefined(vital))
             {
@@ -1883,8 +1883,8 @@ namespace Intersect.Server.Entities
 
         public void Attack(
             Entity enemy,
-            int baseDamage,
-            int secondaryDamage,
+            long baseDamage,
+            long secondaryDamage,
             DamageType damageType,
             Stat scalingStat,
             int scaling,
@@ -3065,10 +3065,10 @@ namespace Intersect.Server.Entities
             for (var i = 0; i < statuses.Length; i++)
             {
                 var status = statuses[i];
-                int[] vitalShields = null;
+                long[] vitalShields = null;
                 if (status.Type == SpellEffect.Shield)
                 {
-                    vitalShields = new int[Enum.GetValues<Vital>().Length];
+                    vitalShields = new long[Enum.GetValues<Vital>().Length];
                     for (var x = 0; x < Enum.GetValues<Vital>().Length; x++)
                     {
                         vitalShields[x] = status.Shield[x];

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -1576,7 +1576,7 @@ namespace Intersect.Server.Entities
                 }
 
                 var vitalRegenRate = Base.VitalRegen[vitalId] / 100f;
-                var regenValue = (int)Math.Max(1, maxVitalValue * vitalRegenRate) *
+                var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
                                  Math.Abs(Math.Sign(vitalRegenRate));
 
                 AddVital(vital, regenValue);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -67,7 +67,7 @@ namespace Intersect.Server.Entities
         public static int OnlineCount => OnlinePlayers.Count;
 
         [JsonProperty("MaxVitals"), NotMapped]
-        public new int[] MaxVitals => GetMaxVitals();
+        public new long[] MaxVitals => GetMaxVitals();
 
         //Name, X, Y, Dir, Etc all in the base Entity Class
         public Guid ClassId { get; set; }
@@ -1102,22 +1102,22 @@ namespace Intersect.Server.Entities
                 }
 
                 var vitalRegenRate = (playerClass.VitalRegen[vitalId] + GetEquipmentVitalRegen(vital)) / 100f;
-                var regenValue = (int)Math.Max(1, maxVitalValue * vitalRegenRate) *
+                var regenValue = (long)Math.Max(1, maxVitalValue * vitalRegenRate) *
                                  Math.Abs(Math.Sign(vitalRegenRate));
 
                 AddVital(vital, regenValue);
             }
         }
 
-        public override int GetMaxVital(int vital)
+        public override long GetMaxVital(int vital)
         {
             var classDescriptor = ClassBase.Get(this.ClassId);
-            var classVital = 20;
+            long classVital = 20;
             if (classDescriptor != null)
             {
                 if (classDescriptor.IncreasePercentage)
                 {
-                    classVital = (int)(classDescriptor.BaseVital[vital] *
+                    classVital = (long)(classDescriptor.BaseVital[vital] *
                                         Math.Pow(1 + (double)classDescriptor.VitalIncrease[vital] / 100, Level - 1));
                 }
                 else
@@ -1128,14 +1128,7 @@ namespace Intersect.Server.Entities
 
             var baseVital = classVital;
 
-            // TODO: Alternate implementation for the loop
-            //            classVital += Equipment?.Select(equipment => ItemBase.Get(Items.ElementAt(equipment)?.ItemId ?? Guid.Empty))
-            //                .Sum(
-            //                    itemDescriptor => itemDescriptor.VitalsGiven[vital] +
-            //                                      (itemDescriptor.PercentageVitalsGiven[vital] * baseVital) / 100
-            //                ) ?? 0;
             // Loop through equipment and see if any items grant vital buffs
-
             foreach (var item in EquippedItems.ToArray())
             {
                 if (ItemBase.TryGet(item.ItemId, out var descriptor))
@@ -1157,7 +1150,7 @@ namespace Intersect.Server.Entities
             return classVital;
         }
 
-        public override int GetMaxVital(Vital vital)
+        public override long GetMaxVital(Vital vital)
         {
             return GetMaxVital((int)vital);
         }
@@ -3257,9 +3250,9 @@ namespace Intersect.Server.Entities
 
                         return;
                     case ItemType.Consumable:
-                        var value = 0;
                         var color = CustomColors.Items.ConsumeHp;
                         var die = false;
+                        long value;
 
                         switch (itemBase.Consumable.Type)
                         {
@@ -3293,7 +3286,7 @@ namespace Intersect.Server.Entities
 
                             case ConsumableType.Experience:
                                 value = itemBase.Consumable.Value +
-                                        (int)(GetExperienceToNextLevel(Level) * itemBase.Consumable.Percentage / 100);
+                                        (GetExperienceToNextLevel(Level) * itemBase.Consumable.Percentage / 100);
 
                                 GiveExperience(value);
                                 color = CustomColors.Items.ConsumeExp;
@@ -3742,9 +3735,9 @@ namespace Intersect.Server.Entities
             return value;
         }
 
-        public int GetEquipmentVitalRegen(Vital vital)
+        public long GetEquipmentVitalRegen(Vital vital)
         {
-            var regen = 0;
+            long regen = 0;
 
             foreach (var item in EquippedItems)
             {

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -194,7 +194,7 @@ namespace Intersect.Server.Entities
                 if (vitalValue < maxVitalValue)
                 {
                     var vitalRegenRate = Base.VitalRegen / 100f;
-                    var regenValue = (int) Math.Max(1, maxVitalValue * vitalRegenRate) *
+                    var regenValue = (long) Math.Max(1, maxVitalValue * vitalRegenRate) *
                                      Math.Abs(Math.Sign(vitalRegenRate));
 
                     AddVital(vital, regenValue);

--- a/Intersect.Server.Core/General/Formulas.cs
+++ b/Intersect.Server.Core/General/Formulas.cs
@@ -54,8 +54,8 @@ namespace Intersect.Server.General
             }
         }
 
-        public static int CalculateDamage(
-            int baseDamage,
+        public static long CalculateDamage(
+            long baseDamage,
             DamageType damageType,
             Stat scalingStat,
             int scaling,
@@ -162,7 +162,7 @@ namespace Intersect.Server.General
                     result = -result;
                 }
 
-                return (int) Math.Round(result);
+                return (long) Math.Round(result);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
We previously updated the EXP values to long type so we could store values from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807, but we didn't quite updated everything else related to this, plus, we ended up with lack of support for large values on vitals and consumable data... this chore PR makes sure to cover the missing stuff

### Preview:  
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/2a700bc3-9fbe-4cae-b439-ff3036195b9f)
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/ad8d85cf-ece0-4202-aa38-66ad8feaa9e2) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/5a60cc84-9f6a-41c8-b1bb-069ad2a88f3a) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f70160b2-a4fa-4085-9d68-4f473e5d874a) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/879c9a82-03c4-4804-9c63-adbaf8d2daaa)
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/17de27b9-aeea-4193-810b-c3d8e330d176)


https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/ca1df184-d91e-47b4-ba37-2bd241c8819e



