### PR TITLE
fix: don't clear current target when taunted

### DIFF
--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -120,7 +120,7 @@ namespace Intersect.Client.Core
                 {
                     // We've closed our windows, don't do anything else. :)
                 }
-                else if (Globals.Me != null && Globals.Me.TargetIndex != Guid.Empty)
+                else if (Globals.Me != null && Globals.Me.TargetIndex != Guid.Empty && !Globals.Me.Status.Any(s => s.Type == Enums.SpellEffect.Taunt))
                 {
                     Globals.Me.ClearTarget();
                 }


### PR DESCRIPTION
This PR Fixes #2253

- Expected behavior: taunt's effect forces it's target to be the caster, removing the target shouldn't be possible.
- Current-not-expected behavior: pressing the esc / menu key clears the current target while taunted.

- After this PR: taunt's effect forces it's target to be the caster, removing the target is not possible at all
