### PR TITLE
fix: disconnection error message when returning to the main menu

### DIFF
--- a/Intersect (Core)/Network/Packets/Client/LogoutPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/LogoutPacket.cs
@@ -10,13 +10,17 @@ namespace Intersect.Network.Packets.Client
         {
         }
 
-        public LogoutPacket(bool returnToCharSelect)
+        public LogoutPacket(bool returnToCharSelect, bool returnToMainMenu)
         {
             ReturningToCharSelect = returnToCharSelect;
+            ReturningToMainMenu = returnToMainMenu;
         }
 
         [Key(0)]
         public bool ReturningToCharSelect { get; set; }
+
+        [Key(1)]
+        public bool ReturningToMainMenu { get; set; }
 
     }
 

--- a/Intersect.Client/Core/Main.cs
+++ b/Intersect.Client/Core/Main.cs
@@ -194,11 +194,8 @@ namespace Intersect.Client.Core
         {
             if (Globals.ConnectionLost)
             {
-                Main.Logout(false);
-                Interface.Interface.ShowError(Strings.Errors.LostConnection);
-
+                Logout(false, true);
                 Globals.ConnectionLost = false;
-
                 return;
             }
 
@@ -328,7 +325,7 @@ namespace Intersect.Client.Core
             Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
         }
 
-        public static void Logout(bool characterSelect, bool skipFade = false)
+        public static void Logout(bool characterSelect, bool mainMenu, bool skipFade = false)
         {
             Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
             if (skipFade)
@@ -342,7 +339,7 @@ namespace Intersect.Client.Core
 
             if (!ClientContext.IsSinglePlayer)
             {
-                PacketSender.SendLogout(characterSelect);
+                PacketSender.SendLogout(characterSelect, mainMenu);
             }
 
             Globals.LoggedIn = false;

--- a/Intersect.Client/Interface/Game/EscapeMenu.cs
+++ b/Intersect.Client/Interface/Game/EscapeMenu.cs
@@ -149,7 +149,7 @@ namespace Intersect.Client.Interface.Game
                 Globals.Me.CombatTimer = 0;
             }
 
-            Main.Logout(true);
+            Main.Logout(true, false);
         }
 
         private void LogoutToMainMenu(object sender, EventArgs e)
@@ -159,7 +159,7 @@ namespace Intersect.Client.Interface.Game
                 Globals.Me.CombatTimer = 0;
             }
 
-            Main.Logout(false);
+            Main.Logout(false, true);
         }
 
         private void ExitToDesktop(object sender, EventArgs e)

--- a/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
@@ -204,8 +204,6 @@ namespace Intersect.Client.Interface.Menu
             {
                 Hide();
                 mMainMenu.Show();
-                Interface.ShowError(Strings.Errors.LostConnection);
-
                 return;
             }
 

--- a/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
+++ b/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
@@ -102,7 +102,6 @@ namespace Intersect.Client.Interface.Menu
             {
                 Hide();
                 mMainMenu.Show();
-                Interface.ShowError(Strings.Errors.LostConnection);
             }
 
             // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.

--- a/Intersect.Client/Interface/Menu/RegisterWindow.cs
+++ b/Intersect.Client/Interface/Menu/RegisterWindow.cs
@@ -153,7 +153,6 @@ namespace Intersect.Client.Interface.Menu
             {
                 Hide();
                 mMainMenu.Show();
-                Interface.ShowError(Strings.Errors.LostConnection);
             }
 
             // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.

--- a/Intersect.Client/Interface/Menu/ResetPasswordWindow.cs
+++ b/Intersect.Client/Interface/Menu/ResetPasswordWindow.cs
@@ -144,7 +144,6 @@ namespace Intersect.Client.Interface.Menu
             {
                 Hide();
                 mMainMenu.Show();
-                Interface.ShowError(Strings.Errors.LostConnection);
             }
         }
 

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -123,7 +123,6 @@ namespace Intersect.Client.Interface.Menu
             {
                 Hide();
                 mMainMenu.Show();
-                Interface.ShowError(Strings.Errors.LostConnection);
             }
 
             // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
@@ -344,7 +343,7 @@ namespace Intersect.Client.Interface.Menu
 
         private void mLogoutButton_Clicked(Base sender, ClickedEventArgs arguments)
         {
-            Main.Logout(false, skipFade: true);
+            Main.Logout(false, true, skipFade: true);
             mMainMenu.Reset();
         }
 

--- a/Intersect.Client/Networking/PacketSender.cs
+++ b/Intersect.Client/Networking/PacketSender.cs
@@ -28,9 +28,9 @@ namespace Intersect.Client.Networking
             Network.SendPacket(new LoginPacket(username, password));
         }
 
-        public static void SendLogout(bool characterSelect = false)
+        public static void SendLogout(bool characterSelect = false, bool mainMenu = true)
         {
-            Network.SendPacket(new LogoutPacket(characterSelect));
+            Network.SendPacket(new LogoutPacket(characterSelect, mainMenu));
         }
 
         public static void SendNeedMap(params ObjectCacheKey<MapBase>[] cacheKeys)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -663,6 +663,13 @@ namespace Intersect.Server.Networking
                 client.Entity = default;
                 PacketSender.SendPlayerCharacters(client, skipLoadingRelationships: true);
             }
+            else if(packet.ReturningToMainMenu)
+            {
+                Log.Debug($"[{nameof(LogoutPacket)}] Returning to main menu from player {client.Entity?.Id} ({client.User?.Id})");
+                client.Entity?.TryLogout(false, true);
+                client.Entity = default;
+                client.SetUser(null);
+            }
             else
             {
                 client.Logout();


### PR DESCRIPTION
resolves #2251 

Small explanation about:
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/63019821/498cec64-da0b-4a04-a1eb-96a6f4f76194)
When we pressed the logout button, it only considered whether it was changing characters or not, if it was changing characters then it kept the account logged in, if it wasn't changing, it disconnected the client.

The change I am proposing is to consider that by pressing the logout button, we are going to the main menu, where the client must still be logged in, but without a logged in user

Another problem solved is that when the connection actually drops, we always received 2 disconnection alerts, one from the interface and the other from the packet handler "onDisconnect", I removed all the interface warnings to leave just one real one where it actually makes more sense to have.

video showing working:
https://www.ascensiongamedev.com/resources/filehost/f6f57417e8ef969e643e902315fdf628.mp4