### PR TITLE
fix: editor NSE for instance type strings

### DIFF
--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -122,7 +122,7 @@ public partial class FrmMapLayers : DockContent
         // We do not want to iterate over the "NoChange" enum
         foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
         {
-            cmbInstanceType.Items.Add(instanceType.ToString());
+            cmbInstanceType.Items.Add(Strings.MapInstance.InstanceTypes[instanceType]);
         }
         cmbInstanceType.SelectedIndex = 0;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
@@ -50,7 +50,7 @@ public partial class EventCommandWarp : UserControl
         // We do not want to iterate over the "NoChange" enum
         foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
         {
-            cmbInstanceType.Items.Add(instanceType.ToString());
+            cmbInstanceType.Items.Add(Strings.MapInstance.InstanceTypes[instanceType]);
         }
         cmbInstanceType.SelectedIndex = (int) mMyCommand.InstanceType;
     }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4195,6 +4195,18 @@ Tick timer saved in server config.json.";
 
     }
 
+    public partial struct MapInstance
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<MapInstanceType, LocalizedString> InstanceTypes = new Dictionary<MapInstanceType, LocalizedString>
+        {
+            {MapInstanceType.Overworld, @"Overworld" },
+            {MapInstanceType.Personal, @"Personal" },
+            {MapInstanceType.Guild, @"Guild" },
+            {MapInstanceType.Shared, @"Shared" }
+        };
+    }
+
     public partial struct MapLayers
     {
 
@@ -4247,14 +4259,6 @@ Tick timer saved in server config.json.";
 
     public partial struct Mapping
     {
-        public static LocaleDictionary<MapInstanceType, LocalizedString> InstanceTypes = new LocaleDictionary<MapInstanceType, LocalizedString>()
-        {
-            {MapInstanceType.Overworld, @"Overworld"},
-            {MapInstanceType.Personal, @"Personal"},
-            {MapInstanceType.Guild, @"Guild"},
-            {MapInstanceType.Shared, @"Shared"},
-        };
-
         public static LocalizedString createmap = @"Create new map.";
 
         public static LocalizedString createmapdialogue = @"Do you want to create a map here?";


### PR DESCRIPTION
Should fix #2259 

Instance type strings is not used at all plus, it's triggering an NSE when starting the game editor.
They were hardcoded to use their enum strings instead of their localized strings.

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/80fe6390-8c4a-4a5e-97fb-fc85704c13c2)

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/6b413759-f6c1-4453-90f2-3d03fafe9c25)

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/7f70e76d-23ae-456e-b0e0-19bd615a769d)

Preview Note: edited the overworld type string in order to show up that the values aren't hard-coded anymore.
