### PR TITLE
fix: equipment dont showing stat info on crafting

### DIFF
--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -329,7 +329,7 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
             {
                 // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
-                if (statModifiers != default || mItem.StatRanges?.Length == 0)
+                if (statModifiers != default || mItem.StatRanges?.Length == 0 || (mItem.StatRanges != default && mItem.StatRanges[i].LowRange == 0 && mItem.StatRanges[i].HighRange == 0))
                 {
                     var flatStat = mItem.StatsGiven[i];
                     if (statModifiers != default)


### PR DESCRIPTION
resolves #2150

there was only one more condition missing, the equipment would only follow the standard intersect behavior if Stat.Range.Lenght was 0, but we must also be ensured that it exists and the current stat is 0 for low and high to also continue with the standard behavior.

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/63019821/08200338-84b7-404d-a257-d26ecc83044f)
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/63019821/8f3b9842-4704-4b64-bdb9-0da6ecf1a158)
