### PR TITLE
fix: add more equip checks for more conditions

### DIFF
--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -186,6 +186,7 @@ namespace Intersect.Server.Entities.Events
         )
         {
             ProcessVariableModification(command, (dynamic)command.Modification, player, instance);
+            player.UnequipInvalidItems();
         }
 
         //Set Self Switch Command
@@ -644,6 +645,7 @@ namespace Intersect.Server.Entities.Events
         {
             player.Gender = command.Gender;
             PacketSender.SendEntityDataToProximity(player);
+            player.UnequipInvalidItems();
         }
 
         //Change Name Color Command
@@ -734,6 +736,7 @@ namespace Intersect.Server.Entities.Events
 
             PacketSender.SendEntityDataToProximity(player);
             PacketSender.SendChatMsg(player, Strings.Player.powerchanged, ChatMessageType.Notice, Color.Red);
+            player.UnequipInvalidItems();
         }
 
         //Warp Player Command
@@ -1494,6 +1497,7 @@ namespace Intersect.Server.Entities.Events
                 // Send the members a notification, then start wiping the guild from existence through sheer willpower!
                 PacketSender.SendGuildMsg(player, Strings.Guilds.DisbandGuild.ToString(player.Guild.Name), CustomColors.Alerts.Info);
                 Guild.DeleteGuild(player.Guild, player);
+                player.UnequipInvalidItems();
 
                 // :(
                 success = true;

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1392,6 +1392,7 @@ namespace Intersect.Server.Entities
                     }
                 }
             }
+            UnequipInvalidItems();
         }
 
         public override void TryAttack(Entity target,
@@ -2005,6 +2006,8 @@ namespace Intersect.Server.Entities
                 }
                 PacketSender.SendEntityPositionToAll(this);
             }
+
+            UnequipInvalidItems();
         }
 
         /// <summary>
@@ -2803,6 +2806,7 @@ namespace Intersect.Server.Entities
                 // Start common events related to inventory changes.
                 EnqueueStartCommonEvent(item.Descriptor?.GetEventTrigger(ItemEventTriggers.OnPickup));
                 StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+                UnequipInvalidItems();
 
                 return true;
             }
@@ -3136,6 +3140,7 @@ namespace Intersect.Server.Entities
             }
 
             EnqueueStartCommonEvent(itemDescriptor.GetEventTrigger(ItemEventTriggers.OnDrop));
+            UnequipInvalidItems();
             StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
             UpdateGatherItemQuests(itemDescriptor.Id);
             PacketSender.SendInventoryItemUpdate(this, slotIndex);
@@ -3482,6 +3487,7 @@ namespace Intersect.Server.Entities
 
             // Start common events related to inventory changes.
             StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+            UnequipInvalidItems();
 
             return true;
 
@@ -3573,6 +3579,7 @@ namespace Intersect.Server.Entities
 
             // Start common events related to inventory changes.
             StartCommonEventsWithTrigger(CommonEventTrigger.InventoryChanged);
+            UnequipInvalidItems();
 
             return true;
         }
@@ -5288,6 +5295,7 @@ namespace Intersect.Server.Entities
             {
                 Spells[spellSlot].Set(Spell.None);
                 PacketSender.SendPlayerSpellUpdate(this, spellSlot);
+                UnequipInvalidItems();
             }
             else
             {
@@ -5335,6 +5343,7 @@ namespace Intersect.Server.Entities
 
             slot.Set(Spell.None);
             PacketSender.SendPlayerSpellUpdate(this, slotIndex);
+            UnequipInvalidItems();
 
             return true;
         }
@@ -5781,6 +5790,7 @@ namespace Intersect.Server.Entities
             }
             
             CacheEquipmentTriggers();
+            UnequipInvalidItems();
         }
 
         [NotMapped, JsonIgnore]
@@ -5903,6 +5913,7 @@ namespace Intersect.Server.Entities
                 StatPoints--;
                 PacketSender.SendEntityStats(this);
                 PacketSender.SendPointsTo(this);
+                UnequipInvalidItems();
             }
         }
 
@@ -6189,6 +6200,7 @@ namespace Intersect.Server.Entities
                     }
                 }
             }
+            UnequipInvalidItems();
         }
 
         public void CompleteQuestTask(Guid questId, Guid taskId)
@@ -6252,6 +6264,7 @@ namespace Intersect.Server.Entities
                     PacketSender.SendQuestsProgress(this);
                 }
             }
+            UnequipInvalidItems();
         }
 
         public void CompleteQuest(Guid questId, bool skipCompletionEvent)
@@ -6277,6 +6290,7 @@ namespace Intersect.Server.Entities
                     PacketSender.SendQuestsProgress(this);
                 }
             }
+            UnequipInvalidItems();
         }
 
         private void UpdateGatherItemQuests(Guid itemId)
@@ -6322,6 +6336,7 @@ namespace Intersect.Server.Entities
                     }
                 }
             }
+            UnequipInvalidItems();
         }
 
         //Switches and Variables

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -2778,6 +2778,8 @@ namespace Intersect.Server.Networking
                     /// ???
                     break;
             }
+
+            player.UnequipInvalidItems();
         }
 
         //GuildInviteAcceptPacket
@@ -2901,6 +2903,7 @@ namespace Intersect.Server.Networking
 
             // Send the newly updated player information to their surroundings.
             PacketSender.SendEntityDataToProximity(player);
+            player.UnequipInvalidItems();
 
         }
 


### PR DESCRIPTION
resolves #2170 

I tried to add more checks for many things that happen in real time that could be equipment conditions, some tiny things are not yet covered, but this should already solve the problem for most of our developers

More checks have been added in:
Variable change
Inventory change
Class change
Spells change
Stat change
Power Level change
Some quests changes
Gender change
Guild Rank changes
Maybe some others, but I don't remember