### PR TITLE
feature: amount range for item drops

### DIFF
--- a/Intersect (Core)/GameObjects/Drop.cs
+++ b/Intersect (Core)/GameObjects/Drop.cs
@@ -9,5 +9,7 @@ namespace Intersect.GameObjects
         public Guid ItemId { get; set; }
 
         public int Quantity { get; set; }
+
+        public int MinQuantity { get; set; }
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
@@ -30,2259 +30,2188 @@ namespace Intersect.Editor.Forms.Editors
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmNpc));
-            this.grpNpcs = new DarkUI.Controls.DarkGroupBox();
-            this.btnClearSearch = new DarkUI.Controls.DarkButton();
-            this.txtSearch = new DarkUI.Controls.DarkTextBox();
-            this.lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
-            this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
-            this.lblAlpha = new System.Windows.Forms.Label();
-            this.lblBlue = new System.Windows.Forms.Label();
-            this.lblGreen = new System.Windows.Forms.Label();
-            this.lblRed = new System.Windows.Forms.Label();
-            this.nudRgbaA = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudRgbaB = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudRgbaG = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudRgbaR = new DarkUI.Controls.DarkNumericUpDown();
-            this.btnAddFolder = new DarkUI.Controls.DarkButton();
-            this.lblFolder = new System.Windows.Forms.Label();
-            this.cmbFolder = new DarkUI.Controls.DarkComboBox();
-            this.lblLevel = new System.Windows.Forms.Label();
-            this.nudLevel = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbSprite = new DarkUI.Controls.DarkComboBox();
-            this.lblPic = new System.Windows.Forms.Label();
-            this.picNpc = new System.Windows.Forms.PictureBox();
-            this.lblName = new System.Windows.Forms.Label();
-            this.txtName = new DarkUI.Controls.DarkTextBox();
-            this.nudSpawnDuration = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblSpawnDuration = new System.Windows.Forms.Label();
-            this.nudSightRange = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblSightRange = new System.Windows.Forms.Label();
-            this.grpStats = new DarkUI.Controls.DarkGroupBox();
-            this.nudExp = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudMana = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudHp = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudSpd = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudMR = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudDef = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudMag = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudStr = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblSpd = new System.Windows.Forms.Label();
-            this.lblMR = new System.Windows.Forms.Label();
-            this.lblDef = new System.Windows.Forms.Label();
-            this.lblMag = new System.Windows.Forms.Label();
-            this.lblStr = new System.Windows.Forms.Label();
-            this.lblMana = new System.Windows.Forms.Label();
-            this.lblHP = new System.Windows.Forms.Label();
-            this.lblExp = new System.Windows.Forms.Label();
-            this.pnlContainer = new System.Windows.Forms.Panel();
-            this.grpImmunities = new DarkUI.Controls.DarkGroupBox();
-            this.nudTenacity = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblTenacity = new System.Windows.Forms.Label();
-            this.chkTaunt = new DarkUI.Controls.DarkCheckBox();
-            this.chkSleep = new DarkUI.Controls.DarkCheckBox();
-            this.chkTransform = new DarkUI.Controls.DarkCheckBox();
-            this.chkBlind = new DarkUI.Controls.DarkCheckBox();
-            this.chkSnare = new DarkUI.Controls.DarkCheckBox();
-            this.chkStun = new DarkUI.Controls.DarkCheckBox();
-            this.chkSilence = new DarkUI.Controls.DarkCheckBox();
-            this.chkKnockback = new DarkUI.Controls.DarkCheckBox();
-            this.grpCombat = new DarkUI.Controls.DarkGroupBox();
-            this.grpAttackSpeed = new DarkUI.Controls.DarkGroupBox();
-            this.nudAttackSpeedValue = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblAttackSpeedValue = new System.Windows.Forms.Label();
-            this.cmbAttackSpeedModifier = new DarkUI.Controls.DarkComboBox();
-            this.lblAttackSpeedModifier = new System.Windows.Forms.Label();
-            this.nudCritMultiplier = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblCritMultiplier = new System.Windows.Forms.Label();
-            this.nudScaling = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudDamage = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudCritChance = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbScalingStat = new DarkUI.Controls.DarkComboBox();
-            this.lblScalingStat = new System.Windows.Forms.Label();
-            this.lblScaling = new System.Windows.Forms.Label();
-            this.cmbDamageType = new DarkUI.Controls.DarkComboBox();
-            this.lblDamageType = new System.Windows.Forms.Label();
-            this.lblCritChance = new System.Windows.Forms.Label();
-            this.cmbAttackAnimation = new DarkUI.Controls.DarkComboBox();
-            this.lblAttackAnimation = new System.Windows.Forms.Label();
-            this.lblDamage = new System.Windows.Forms.Label();
-            this.grpCommonEvents = new DarkUI.Controls.DarkGroupBox();
-            this.cmbOnDeathEventParty = new DarkUI.Controls.DarkComboBox();
-            this.lblOnDeathEventParty = new System.Windows.Forms.Label();
-            this.cmbOnDeathEventKiller = new DarkUI.Controls.DarkComboBox();
-            this.lblOnDeathEventKiller = new System.Windows.Forms.Label();
-            this.grpBehavior = new DarkUI.Controls.DarkGroupBox();
-            this.nudResetRadius = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblResetRadius = new System.Windows.Forms.Label();
-            this.chkFocusDamageDealer = new DarkUI.Controls.DarkCheckBox();
-            this.nudFlee = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblFlee = new System.Windows.Forms.Label();
-            this.chkSwarm = new DarkUI.Controls.DarkCheckBox();
-            this.grpConditions = new DarkUI.Controls.DarkGroupBox();
-            this.btnAttackOnSightCond = new DarkUI.Controls.DarkButton();
-            this.btnPlayerCanAttackCond = new DarkUI.Controls.DarkButton();
-            this.btnPlayerFriendProtectorCond = new DarkUI.Controls.DarkButton();
-            this.lblMovement = new System.Windows.Forms.Label();
-            this.cmbMovement = new DarkUI.Controls.DarkComboBox();
-            this.chkAggressive = new DarkUI.Controls.DarkCheckBox();
-            this.grpRegen = new DarkUI.Controls.DarkGroupBox();
-            this.nudMpRegen = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudHpRegen = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblHpRegen = new System.Windows.Forms.Label();
-            this.lblManaRegen = new System.Windows.Forms.Label();
-            this.lblRegenHint = new System.Windows.Forms.Label();
-            this.grpDrops = new DarkUI.Controls.DarkGroupBox();
-            this.chkIndividualLoot = new DarkUI.Controls.DarkCheckBox();
-            this.btnDropRemove = new DarkUI.Controls.DarkButton();
-            this.btnDropAdd = new DarkUI.Controls.DarkButton();
-            this.lstDrops = new System.Windows.Forms.ListBox();
-            this.nudDropAmount = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudDropChance = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbDropItem = new DarkUI.Controls.DarkComboBox();
-            this.lblDropAmount = new System.Windows.Forms.Label();
-            this.lblDropChance = new System.Windows.Forms.Label();
-            this.lblDropItem = new System.Windows.Forms.Label();
-            this.grpNpcVsNpc = new DarkUI.Controls.DarkGroupBox();
-            this.cmbHostileNPC = new DarkUI.Controls.DarkComboBox();
-            this.lblNPC = new System.Windows.Forms.Label();
-            this.btnRemoveAggro = new DarkUI.Controls.DarkButton();
-            this.btnAddAggro = new DarkUI.Controls.DarkButton();
-            this.lstAggro = new System.Windows.Forms.ListBox();
-            this.chkAttackAllies = new DarkUI.Controls.DarkCheckBox();
-            this.chkEnabled = new DarkUI.Controls.DarkCheckBox();
-            this.grpSpells = new DarkUI.Controls.DarkGroupBox();
-            this.cmbSpell = new DarkUI.Controls.DarkComboBox();
-            this.cmbFreq = new DarkUI.Controls.DarkComboBox();
-            this.lblFreq = new System.Windows.Forms.Label();
-            this.lblSpell = new System.Windows.Forms.Label();
-            this.btnRemove = new DarkUI.Controls.DarkButton();
-            this.btnAdd = new DarkUI.Controls.DarkButton();
-            this.lstSpells = new System.Windows.Forms.ListBox();
-            this.btnCancel = new DarkUI.Controls.DarkButton();
-            this.btnSave = new DarkUI.Controls.DarkButton();
-            this.toolStrip = new DarkUI.Controls.DarkToolStrip();
-            this.toolStripItemNew = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemDelete = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.btnAlphabetical = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemCopy = new System.Windows.Forms.ToolStripButton();
-            this.toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
-            this.grpNpcs.SuspendLayout();
-            this.grpGeneral.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaA)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaB)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaG)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaR)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudLevel)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.picNpc)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpawnDuration)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSightRange)).BeginInit();
-            this.grpStats.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudExp)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMana)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHp)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpd)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMR)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDef)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMag)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudStr)).BeginInit();
-            this.pnlContainer.SuspendLayout();
-            this.grpImmunities.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudTenacity)).BeginInit();
-            this.grpCombat.SuspendLayout();
-            this.grpAttackSpeed.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAttackSpeedValue)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudCritMultiplier)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudScaling)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDamage)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudCritChance)).BeginInit();
-            this.grpCommonEvents.SuspendLayout();
-            this.grpBehavior.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudResetRadius)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudFlee)).BeginInit();
-            this.grpConditions.SuspendLayout();
-            this.grpRegen.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMpRegen)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHpRegen)).BeginInit();
-            this.grpDrops.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropAmount)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropChance)).BeginInit();
-            this.grpNpcVsNpc.SuspendLayout();
-            this.grpSpells.SuspendLayout();
-            this.toolStrip.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmNpc));
+            grpNpcs = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Controls.GameObjectList();
+            grpGeneral = new DarkGroupBox();
+            lblAlpha = new Label();
+            lblBlue = new Label();
+            lblGreen = new Label();
+            lblRed = new Label();
+            nudRgbaA = new DarkNumericUpDown();
+            nudRgbaB = new DarkNumericUpDown();
+            nudRgbaG = new DarkNumericUpDown();
+            nudRgbaR = new DarkNumericUpDown();
+            btnAddFolder = new DarkButton();
+            lblFolder = new Label();
+            cmbFolder = new DarkComboBox();
+            lblLevel = new Label();
+            nudLevel = new DarkNumericUpDown();
+            cmbSprite = new DarkComboBox();
+            lblPic = new Label();
+            picNpc = new PictureBox();
+            lblName = new Label();
+            txtName = new DarkTextBox();
+            nudSpawnDuration = new DarkNumericUpDown();
+            lblSpawnDuration = new Label();
+            nudSightRange = new DarkNumericUpDown();
+            lblSightRange = new Label();
+            grpStats = new DarkGroupBox();
+            nudExp = new DarkNumericUpDown();
+            nudMana = new DarkNumericUpDown();
+            nudHp = new DarkNumericUpDown();
+            nudSpd = new DarkNumericUpDown();
+            nudMR = new DarkNumericUpDown();
+            nudDef = new DarkNumericUpDown();
+            nudMag = new DarkNumericUpDown();
+            nudStr = new DarkNumericUpDown();
+            lblSpd = new Label();
+            lblMR = new Label();
+            lblDef = new Label();
+            lblMag = new Label();
+            lblStr = new Label();
+            lblMana = new Label();
+            lblHP = new Label();
+            lblExp = new Label();
+            pnlContainer = new Panel();
+            grpImmunities = new DarkGroupBox();
+            nudTenacity = new DarkNumericUpDown();
+            lblTenacity = new Label();
+            chkTaunt = new DarkCheckBox();
+            chkSleep = new DarkCheckBox();
+            chkTransform = new DarkCheckBox();
+            chkBlind = new DarkCheckBox();
+            chkSnare = new DarkCheckBox();
+            chkStun = new DarkCheckBox();
+            chkSilence = new DarkCheckBox();
+            chkKnockback = new DarkCheckBox();
+            grpCombat = new DarkGroupBox();
+            grpAttackSpeed = new DarkGroupBox();
+            nudAttackSpeedValue = new DarkNumericUpDown();
+            lblAttackSpeedValue = new Label();
+            cmbAttackSpeedModifier = new DarkComboBox();
+            lblAttackSpeedModifier = new Label();
+            nudCritMultiplier = new DarkNumericUpDown();
+            lblCritMultiplier = new Label();
+            nudScaling = new DarkNumericUpDown();
+            nudDamage = new DarkNumericUpDown();
+            nudCritChance = new DarkNumericUpDown();
+            cmbScalingStat = new DarkComboBox();
+            lblScalingStat = new Label();
+            lblScaling = new Label();
+            cmbDamageType = new DarkComboBox();
+            lblDamageType = new Label();
+            lblCritChance = new Label();
+            cmbAttackAnimation = new DarkComboBox();
+            lblAttackAnimation = new Label();
+            lblDamage = new Label();
+            grpCommonEvents = new DarkGroupBox();
+            cmbOnDeathEventParty = new DarkComboBox();
+            lblOnDeathEventParty = new Label();
+            cmbOnDeathEventKiller = new DarkComboBox();
+            lblOnDeathEventKiller = new Label();
+            grpBehavior = new DarkGroupBox();
+            nudResetRadius = new DarkNumericUpDown();
+            lblResetRadius = new Label();
+            chkFocusDamageDealer = new DarkCheckBox();
+            nudFlee = new DarkNumericUpDown();
+            lblFlee = new Label();
+            chkSwarm = new DarkCheckBox();
+            grpConditions = new DarkGroupBox();
+            btnAttackOnSightCond = new DarkButton();
+            btnPlayerCanAttackCond = new DarkButton();
+            btnPlayerFriendProtectorCond = new DarkButton();
+            lblMovement = new Label();
+            cmbMovement = new DarkComboBox();
+            chkAggressive = new DarkCheckBox();
+            grpRegen = new DarkGroupBox();
+            nudMpRegen = new DarkNumericUpDown();
+            nudHpRegen = new DarkNumericUpDown();
+            lblHpRegen = new Label();
+            lblManaRegen = new Label();
+            lblRegenHint = new Label();
+            grpDrops = new DarkGroupBox();
+            nudDropMinAmount = new DarkNumericUpDown();
+            lblDropMinAmount = new Label();
+            chkIndividualLoot = new DarkCheckBox();
+            btnDropRemove = new DarkButton();
+            btnDropAdd = new DarkButton();
+            lstDrops = new ListBox();
+            nudDropAmount = new DarkNumericUpDown();
+            nudDropChance = new DarkNumericUpDown();
+            cmbDropItem = new DarkComboBox();
+            lblDropAmount = new Label();
+            lblDropChance = new Label();
+            lblDropItem = new Label();
+            grpNpcVsNpc = new DarkGroupBox();
+            cmbHostileNPC = new DarkComboBox();
+            lblNPC = new Label();
+            btnRemoveAggro = new DarkButton();
+            btnAddAggro = new DarkButton();
+            lstAggro = new ListBox();
+            chkAttackAllies = new DarkCheckBox();
+            chkEnabled = new DarkCheckBox();
+            grpSpells = new DarkGroupBox();
+            cmbSpell = new DarkComboBox();
+            cmbFreq = new DarkComboBox();
+            lblFreq = new Label();
+            lblSpell = new Label();
+            btnRemove = new DarkButton();
+            btnAdd = new DarkButton();
+            lstSpells = new ListBox();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            toolStripItemDelete = new ToolStripButton();
+            toolStripSeparator2 = new ToolStripSeparator();
+            btnAlphabetical = new ToolStripButton();
+            toolStripSeparator4 = new ToolStripSeparator();
+            toolStripItemCopy = new ToolStripButton();
+            toolStripItemPaste = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            toolStripItemUndo = new ToolStripButton();
+            grpNpcs.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaA).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaB).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaG).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaR).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudLevel).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)picNpc).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSightRange).BeginInit();
+            grpStats.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExp).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudMana).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudHp).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpd).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudMR).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDef).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudMag).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudStr).BeginInit();
+            pnlContainer.SuspendLayout();
+            grpImmunities.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTenacity).BeginInit();
+            grpCombat.SuspendLayout();
+            grpAttackSpeed.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudAttackSpeedValue).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritMultiplier).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudScaling).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamage).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritChance).BeginInit();
+            grpCommonEvents.SuspendLayout();
+            grpBehavior.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudResetRadius).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudFlee).BeginInit();
+            grpConditions.SuspendLayout();
+            grpRegen.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudMpRegen).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).BeginInit();
+            grpDrops.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropAmount).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropChance).BeginInit();
+            grpNpcVsNpc.SuspendLayout();
+            grpSpells.SuspendLayout();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // grpNpcs
             // 
-            this.grpNpcs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpNpcs.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpNpcs.Controls.Add(this.btnClearSearch);
-            this.grpNpcs.Controls.Add(this.txtSearch);
-            this.grpNpcs.Controls.Add(this.lstGameObjects);
-            this.grpNpcs.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNpcs.Location = new System.Drawing.Point(3, 28);
-            this.grpNpcs.Name = "grpNpcs";
-            this.grpNpcs.Size = new System.Drawing.Size(200, 557);
-            this.grpNpcs.TabIndex = 13;
-            this.grpNpcs.TabStop = false;
-            this.grpNpcs.Text = "NPCs";
+            grpNpcs.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpNpcs.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpNpcs.Controls.Add(btnClearSearch);
+            grpNpcs.Controls.Add(txtSearch);
+            grpNpcs.Controls.Add(lstGameObjects);
+            grpNpcs.ForeColor = System.Drawing.Color.Gainsboro;
+            grpNpcs.Location = new System.Drawing.Point(4, 32);
+            grpNpcs.Margin = new Padding(4, 3, 4, 3);
+            grpNpcs.Name = "grpNpcs";
+            grpNpcs.Padding = new Padding(4, 3, 4, 3);
+            grpNpcs.Size = new Size(233, 643);
+            grpNpcs.TabIndex = 13;
+            grpNpcs.TabStop = false;
+            grpNpcs.Text = "NPCs";
             // 
             // btnClearSearch
             // 
-            this.btnClearSearch.Location = new System.Drawing.Point(175, 19);
-            this.btnClearSearch.Name = "btnClearSearch";
-            this.btnClearSearch.Padding = new System.Windows.Forms.Padding(5);
-            this.btnClearSearch.Size = new System.Drawing.Size(18, 20);
-            this.btnClearSearch.TabIndex = 34;
-            this.btnClearSearch.Text = "X";
-            this.btnClearSearch.Click += new System.EventHandler(this.btnClearSearch_Click);
+            btnClearSearch.Location = new System.Drawing.Point(204, 22);
+            btnClearSearch.Margin = new Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new Padding(6);
+            btnClearSearch.Size = new Size(21, 23);
+            btnClearSearch.TabIndex = 34;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
             // 
             // txtSearch
             // 
-            this.txtSearch.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtSearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtSearch.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtSearch.Location = new System.Drawing.Point(5, 19);
-            this.txtSearch.Name = "txtSearch";
-            this.txtSearch.Size = new System.Drawing.Size(165, 20);
-            this.txtSearch.TabIndex = 33;
-            this.txtSearch.Text = "Search...";
-            this.txtSearch.Click += new System.EventHandler(this.txtSearch_Click);
-            this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
-            this.txtSearch.Enter += new System.EventHandler(this.txtSearch_Enter);
-            this.txtSearch.Leave += new System.EventHandler(this.txtSearch_Leave);
+            txtSearch.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSearch.BorderStyle = BorderStyle.FixedSingle;
+            txtSearch.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSearch.Location = new System.Drawing.Point(6, 22);
+            txtSearch.Margin = new Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new Size(192, 23);
+            txtSearch.TabIndex = 33;
+            txtSearch.Text = "Search...";
+            txtSearch.Click += txtSearch_Click;
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            txtSearch.Enter += txtSearch_Enter;
+            txtSearch.Leave += txtSearch_Leave;
             // 
             // lstGameObjects
             // 
-            this.lstGameObjects.AllowDrop = true;
-            this.lstGameObjects.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstGameObjects.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstGameObjects.HideSelection = false;
-            this.lstGameObjects.ImageIndex = 0;
-            this.lstGameObjects.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(150)))), ((int)(((byte)(150)))), ((int)(((byte)(150)))));
-            this.lstGameObjects.Location = new System.Drawing.Point(5, 46);
-            this.lstGameObjects.Name = "lstGameObjects";
-            this.lstGameObjects.SelectedImageIndex = 0;
-            this.lstGameObjects.Size = new System.Drawing.Size(190, 505);
-            this.lstGameObjects.TabIndex = 32;
+            lstGameObjects.AllowDrop = true;
+            lstGameObjects.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstGameObjects.BorderStyle = BorderStyle.None;
+            lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
+            lstGameObjects.HideSelection = false;
+            lstGameObjects.ImageIndex = 0;
+            lstGameObjects.LineColor = System.Drawing.Color.FromArgb(150, 150, 150);
+            lstGameObjects.Location = new System.Drawing.Point(6, 53);
+            lstGameObjects.Margin = new Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.SelectedImageIndex = 0;
+            lstGameObjects.Size = new Size(222, 583);
+            lstGameObjects.TabIndex = 32;
             // 
             // grpGeneral
             // 
-            this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpGeneral.Controls.Add(this.lblAlpha);
-            this.grpGeneral.Controls.Add(this.lblBlue);
-            this.grpGeneral.Controls.Add(this.lblGreen);
-            this.grpGeneral.Controls.Add(this.lblRed);
-            this.grpGeneral.Controls.Add(this.nudRgbaA);
-            this.grpGeneral.Controls.Add(this.nudRgbaB);
-            this.grpGeneral.Controls.Add(this.nudRgbaG);
-            this.grpGeneral.Controls.Add(this.nudRgbaR);
-            this.grpGeneral.Controls.Add(this.btnAddFolder);
-            this.grpGeneral.Controls.Add(this.lblFolder);
-            this.grpGeneral.Controls.Add(this.cmbFolder);
-            this.grpGeneral.Controls.Add(this.lblLevel);
-            this.grpGeneral.Controls.Add(this.nudLevel);
-            this.grpGeneral.Controls.Add(this.cmbSprite);
-            this.grpGeneral.Controls.Add(this.lblPic);
-            this.grpGeneral.Controls.Add(this.picNpc);
-            this.grpGeneral.Controls.Add(this.lblName);
-            this.grpGeneral.Controls.Add(this.txtName);
-            this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpGeneral.Location = new System.Drawing.Point(9, 5);
-            this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(207, 286);
-            this.grpGeneral.TabIndex = 14;
-            this.grpGeneral.TabStop = false;
-            this.grpGeneral.Text = "General";
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(lblAlpha);
+            grpGeneral.Controls.Add(lblBlue);
+            grpGeneral.Controls.Add(lblGreen);
+            grpGeneral.Controls.Add(lblRed);
+            grpGeneral.Controls.Add(nudRgbaA);
+            grpGeneral.Controls.Add(nudRgbaB);
+            grpGeneral.Controls.Add(nudRgbaG);
+            grpGeneral.Controls.Add(nudRgbaR);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(lblLevel);
+            grpGeneral.Controls.Add(nudLevel);
+            grpGeneral.Controls.Add(cmbSprite);
+            grpGeneral.Controls.Add(lblPic);
+            grpGeneral.Controls.Add(picNpc);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(10, 6);
+            grpGeneral.Margin = new Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new Padding(4, 3, 4, 3);
+            grpGeneral.Size = new Size(241, 330);
+            grpGeneral.TabIndex = 14;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
             // 
             // lblAlpha
             // 
-            this.lblAlpha.AutoSize = true;
-            this.lblAlpha.Location = new System.Drawing.Point(108, 262);
-            this.lblAlpha.Name = "lblAlpha";
-            this.lblAlpha.Size = new System.Drawing.Size(37, 13);
-            this.lblAlpha.TabIndex = 78;
-            this.lblAlpha.Text = "Alpha:";
+            lblAlpha.AutoSize = true;
+            lblAlpha.Location = new System.Drawing.Point(126, 302);
+            lblAlpha.Margin = new Padding(4, 0, 4, 0);
+            lblAlpha.Name = "lblAlpha";
+            lblAlpha.Size = new Size(41, 15);
+            lblAlpha.TabIndex = 78;
+            lblAlpha.Text = "Alpha:";
             // 
             // lblBlue
             // 
-            this.lblBlue.AutoSize = true;
-            this.lblBlue.Location = new System.Drawing.Point(108, 236);
-            this.lblBlue.Name = "lblBlue";
-            this.lblBlue.Size = new System.Drawing.Size(31, 13);
-            this.lblBlue.TabIndex = 77;
-            this.lblBlue.Text = "Blue:";
+            lblBlue.AutoSize = true;
+            lblBlue.Location = new System.Drawing.Point(126, 272);
+            lblBlue.Margin = new Padding(4, 0, 4, 0);
+            lblBlue.Name = "lblBlue";
+            lblBlue.Size = new Size(33, 15);
+            lblBlue.TabIndex = 77;
+            lblBlue.Text = "Blue:";
             // 
             // lblGreen
             // 
-            this.lblGreen.AutoSize = true;
-            this.lblGreen.Location = new System.Drawing.Point(9, 262);
-            this.lblGreen.Name = "lblGreen";
-            this.lblGreen.Size = new System.Drawing.Size(39, 13);
-            this.lblGreen.TabIndex = 76;
-            this.lblGreen.Text = "Green:";
+            lblGreen.AutoSize = true;
+            lblGreen.Location = new System.Drawing.Point(10, 302);
+            lblGreen.Margin = new Padding(4, 0, 4, 0);
+            lblGreen.Name = "lblGreen";
+            lblGreen.Size = new Size(41, 15);
+            lblGreen.TabIndex = 76;
+            lblGreen.Text = "Green:";
             // 
             // lblRed
             // 
-            this.lblRed.AutoSize = true;
-            this.lblRed.Location = new System.Drawing.Point(9, 236);
-            this.lblRed.Name = "lblRed";
-            this.lblRed.Size = new System.Drawing.Size(30, 13);
-            this.lblRed.TabIndex = 75;
-            this.lblRed.Text = "Red:";
+            lblRed.AutoSize = true;
+            lblRed.Location = new System.Drawing.Point(10, 272);
+            lblRed.Margin = new Padding(4, 0, 4, 0);
+            lblRed.Name = "lblRed";
+            lblRed.Size = new Size(30, 15);
+            lblRed.TabIndex = 75;
+            lblRed.Text = "Red:";
             // 
             // nudRgbaA
             // 
-            this.nudRgbaA.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudRgbaA.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudRgbaA.Location = new System.Drawing.Point(153, 260);
-            this.nudRgbaA.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaA.Name = "nudRgbaA";
-            this.nudRgbaA.Size = new System.Drawing.Size(42, 20);
-            this.nudRgbaA.TabIndex = 74;
-            this.nudRgbaA.Value = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaA.ValueChanged += new System.EventHandler(this.nudRgbaA_ValueChanged);
+            nudRgbaA.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudRgbaA.ForeColor = System.Drawing.Color.Gainsboro;
+            nudRgbaA.Location = new System.Drawing.Point(178, 300);
+            nudRgbaA.Margin = new Padding(4, 3, 4, 3);
+            nudRgbaA.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaA.Name = "nudRgbaA";
+            nudRgbaA.Size = new Size(49, 23);
+            nudRgbaA.TabIndex = 74;
+            nudRgbaA.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaA.ValueChanged += nudRgbaA_ValueChanged;
             // 
             // nudRgbaB
             // 
-            this.nudRgbaB.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudRgbaB.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudRgbaB.Location = new System.Drawing.Point(153, 234);
-            this.nudRgbaB.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaB.Name = "nudRgbaB";
-            this.nudRgbaB.Size = new System.Drawing.Size(42, 20);
-            this.nudRgbaB.TabIndex = 73;
-            this.nudRgbaB.Value = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaB.ValueChanged += new System.EventHandler(this.nudRgbaB_ValueChanged);
+            nudRgbaB.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudRgbaB.ForeColor = System.Drawing.Color.Gainsboro;
+            nudRgbaB.Location = new System.Drawing.Point(178, 270);
+            nudRgbaB.Margin = new Padding(4, 3, 4, 3);
+            nudRgbaB.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaB.Name = "nudRgbaB";
+            nudRgbaB.Size = new Size(49, 23);
+            nudRgbaB.TabIndex = 73;
+            nudRgbaB.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaB.ValueChanged += nudRgbaB_ValueChanged;
             // 
             // nudRgbaG
             // 
-            this.nudRgbaG.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudRgbaG.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudRgbaG.Location = new System.Drawing.Point(55, 260);
-            this.nudRgbaG.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaG.Name = "nudRgbaG";
-            this.nudRgbaG.Size = new System.Drawing.Size(42, 20);
-            this.nudRgbaG.TabIndex = 72;
-            this.nudRgbaG.Value = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaG.ValueChanged += new System.EventHandler(this.nudRgbaG_ValueChanged);
+            nudRgbaG.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudRgbaG.ForeColor = System.Drawing.Color.Gainsboro;
+            nudRgbaG.Location = new System.Drawing.Point(64, 300);
+            nudRgbaG.Margin = new Padding(4, 3, 4, 3);
+            nudRgbaG.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaG.Name = "nudRgbaG";
+            nudRgbaG.Size = new Size(49, 23);
+            nudRgbaG.TabIndex = 72;
+            nudRgbaG.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaG.ValueChanged += nudRgbaG_ValueChanged;
             // 
             // nudRgbaR
             // 
-            this.nudRgbaR.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudRgbaR.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudRgbaR.Location = new System.Drawing.Point(55, 234);
-            this.nudRgbaR.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaR.Name = "nudRgbaR";
-            this.nudRgbaR.Size = new System.Drawing.Size(42, 20);
-            this.nudRgbaR.TabIndex = 71;
-            this.nudRgbaR.Value = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudRgbaR.ValueChanged += new System.EventHandler(this.nudRgbaR_ValueChanged);
+            nudRgbaR.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudRgbaR.ForeColor = System.Drawing.Color.Gainsboro;
+            nudRgbaR.Location = new System.Drawing.Point(64, 270);
+            nudRgbaR.Margin = new Padding(4, 3, 4, 3);
+            nudRgbaR.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaR.Name = "nudRgbaR";
+            nudRgbaR.Size = new Size(49, 23);
+            nudRgbaR.TabIndex = 71;
+            nudRgbaR.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaR.ValueChanged += nudRgbaR_ValueChanged;
             // 
             // btnAddFolder
             // 
-            this.btnAddFolder.Location = new System.Drawing.Point(177, 47);
-            this.btnAddFolder.Name = "btnAddFolder";
-            this.btnAddFolder.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAddFolder.Size = new System.Drawing.Size(18, 21);
-            this.btnAddFolder.TabIndex = 67;
-            this.btnAddFolder.Text = "+";
-            this.btnAddFolder.Click += new System.EventHandler(this.btnAddFolder_Click);
+            btnAddFolder.Location = new System.Drawing.Point(206, 54);
+            btnAddFolder.Margin = new Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new Padding(6);
+            btnAddFolder.Size = new Size(21, 24);
+            btnAddFolder.TabIndex = 67;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
             // 
             // lblFolder
             // 
-            this.lblFolder.AutoSize = true;
-            this.lblFolder.Location = new System.Drawing.Point(9, 51);
-            this.lblFolder.Name = "lblFolder";
-            this.lblFolder.Size = new System.Drawing.Size(39, 13);
-            this.lblFolder.TabIndex = 66;
-            this.lblFolder.Text = "Folder:";
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(10, 59);
+            lblFolder.Margin = new Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new Size(43, 15);
+            lblFolder.TabIndex = 66;
+            lblFolder.Text = "Folder:";
             // 
             // cmbFolder
             // 
-            this.cmbFolder.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbFolder.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbFolder.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbFolder.DrawDropdownHoverOutline = false;
-            this.cmbFolder.DrawFocusRectangle = false;
-            this.cmbFolder.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbFolder.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbFolder.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbFolder.FormattingEnabled = true;
-            this.cmbFolder.Location = new System.Drawing.Point(60, 47);
-            this.cmbFolder.Name = "cmbFolder";
-            this.cmbFolder.Size = new System.Drawing.Size(113, 21);
-            this.cmbFolder.TabIndex = 65;
-            this.cmbFolder.Text = null;
-            this.cmbFolder.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbFolder.SelectedIndexChanged += new System.EventHandler(this.cmbFolder_SelectedIndexChanged);
+            cmbFolder.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFolder.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFolder.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFolder.DrawDropdownHoverOutline = false;
+            cmbFolder.DrawFocusRectangle = false;
+            cmbFolder.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFolder.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFolder.FlatStyle = FlatStyle.Flat;
+            cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(70, 54);
+            cmbFolder.Margin = new Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new Size(131, 24);
+            cmbFolder.TabIndex = 65;
+            cmbFolder.Text = null;
+            cmbFolder.TextPadding = new Padding(2);
+            cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
             // 
             // lblLevel
             // 
-            this.lblLevel.AutoSize = true;
-            this.lblLevel.Location = new System.Drawing.Point(9, 79);
-            this.lblLevel.Name = "lblLevel";
-            this.lblLevel.Size = new System.Drawing.Size(36, 13);
-            this.lblLevel.TabIndex = 64;
-            this.lblLevel.Text = "Level:";
+            lblLevel.AutoSize = true;
+            lblLevel.Location = new System.Drawing.Point(10, 91);
+            lblLevel.Margin = new Padding(4, 0, 4, 0);
+            lblLevel.Name = "lblLevel";
+            lblLevel.Size = new Size(37, 15);
+            lblLevel.TabIndex = 64;
+            lblLevel.Text = "Level:";
             // 
             // nudLevel
             // 
-            this.nudLevel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudLevel.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudLevel.Location = new System.Drawing.Point(60, 77);
-            this.nudLevel.Maximum = new decimal(new int[] {
-            2147483647,
-            0,
-            0,
-            0});
-            this.nudLevel.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nudLevel.Name = "nudLevel";
-            this.nudLevel.Size = new System.Drawing.Size(134, 20);
-            this.nudLevel.TabIndex = 63;
-            this.nudLevel.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nudLevel.ValueChanged += new System.EventHandler(this.nudLevel_ValueChanged);
+            nudLevel.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudLevel.ForeColor = System.Drawing.Color.Gainsboro;
+            nudLevel.Location = new System.Drawing.Point(70, 89);
+            nudLevel.Margin = new Padding(4, 3, 4, 3);
+            nudLevel.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            nudLevel.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudLevel.Name = "nudLevel";
+            nudLevel.Size = new Size(156, 23);
+            nudLevel.TabIndex = 63;
+            nudLevel.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudLevel.ValueChanged += nudLevel_ValueChanged;
             // 
             // cmbSprite
             // 
-            this.cmbSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbSprite.DrawDropdownHoverOutline = false;
-            this.cmbSprite.DrawFocusRectangle = false;
-            this.cmbSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbSprite.FormattingEnabled = true;
-            this.cmbSprite.Items.AddRange(new object[] {
-            "None"});
-            this.cmbSprite.Location = new System.Drawing.Point(60, 105);
-            this.cmbSprite.Name = "cmbSprite";
-            this.cmbSprite.Size = new System.Drawing.Size(134, 21);
-            this.cmbSprite.TabIndex = 11;
-            this.cmbSprite.Text = "None";
-            this.cmbSprite.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbSprite.SelectedIndexChanged += new System.EventHandler(this.cmbSprite_SelectedIndexChanged);
+            cmbSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbSprite.DrawDropdownHoverOutline = false;
+            cmbSprite.DrawFocusRectangle = false;
+            cmbSprite.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSprite.FlatStyle = FlatStyle.Flat;
+            cmbSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbSprite.FormattingEnabled = true;
+            cmbSprite.Items.AddRange(new object[] { "None" });
+            cmbSprite.Location = new System.Drawing.Point(70, 121);
+            cmbSprite.Margin = new Padding(4, 3, 4, 3);
+            cmbSprite.Name = "cmbSprite";
+            cmbSprite.Size = new Size(156, 24);
+            cmbSprite.TabIndex = 11;
+            cmbSprite.Text = "None";
+            cmbSprite.TextPadding = new Padding(2);
+            cmbSprite.SelectedIndexChanged += cmbSprite_SelectedIndexChanged;
             // 
             // lblPic
             // 
-            this.lblPic.AutoSize = true;
-            this.lblPic.Location = new System.Drawing.Point(9, 108);
-            this.lblPic.Name = "lblPic";
-            this.lblPic.Size = new System.Drawing.Size(37, 13);
-            this.lblPic.TabIndex = 6;
-            this.lblPic.Text = "Sprite:";
+            lblPic.AutoSize = true;
+            lblPic.Location = new System.Drawing.Point(10, 125);
+            lblPic.Margin = new Padding(4, 0, 4, 0);
+            lblPic.Name = "lblPic";
+            lblPic.Size = new Size(40, 15);
+            lblPic.TabIndex = 6;
+            lblPic.Text = "Sprite:";
             // 
             // picNpc
             // 
-            this.picNpc.BackColor = System.Drawing.Color.Black;
-            this.picNpc.Location = new System.Drawing.Point(55, 133);
-            this.picNpc.Name = "picNpc";
-            this.picNpc.Size = new System.Drawing.Size(96, 96);
-            this.picNpc.TabIndex = 4;
-            this.picNpc.TabStop = false;
+            picNpc.BackColor = System.Drawing.Color.Black;
+            picNpc.Location = new System.Drawing.Point(64, 153);
+            picNpc.Margin = new Padding(4, 3, 4, 3);
+            picNpc.Name = "picNpc";
+            picNpc.Size = new Size(112, 111);
+            picNpc.TabIndex = 4;
+            picNpc.TabStop = false;
             // 
             // lblName
             // 
-            this.lblName.AutoSize = true;
-            this.lblName.Location = new System.Drawing.Point(9, 21);
-            this.lblName.Name = "lblName";
-            this.lblName.Size = new System.Drawing.Size(38, 13);
-            this.lblName.TabIndex = 1;
-            this.lblName.Text = "Name:";
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(10, 24);
+            lblName.Margin = new Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(42, 15);
+            lblName.TabIndex = 1;
+            lblName.Text = "Name:";
             // 
             // txtName
             // 
-            this.txtName.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtName.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtName.Location = new System.Drawing.Point(60, 19);
-            this.txtName.Name = "txtName";
-            this.txtName.Size = new System.Drawing.Size(135, 20);
-            this.txtName.TabIndex = 0;
-            this.txtName.TextChanged += new System.EventHandler(this.txtName_TextChanged);
+            txtName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtName.BorderStyle = BorderStyle.FixedSingle;
+            txtName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtName.Location = new System.Drawing.Point(70, 22);
+            txtName.Margin = new Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new Size(157, 23);
+            txtName.TabIndex = 0;
+            txtName.TextChanged += txtName_TextChanged;
             // 
             // nudSpawnDuration
             // 
-            this.nudSpawnDuration.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudSpawnDuration.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudSpawnDuration.Location = new System.Drawing.Point(102, 157);
-            this.nudSpawnDuration.Maximum = new decimal(new int[] {
-            2147483647,
-            0,
-            0,
-            0});
-            this.nudSpawnDuration.Name = "nudSpawnDuration";
-            this.nudSpawnDuration.Size = new System.Drawing.Size(116, 20);
-            this.nudSpawnDuration.TabIndex = 61;
-            this.nudSpawnDuration.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudSpawnDuration.ValueChanged += new System.EventHandler(this.nudSpawnDuration_ValueChanged);
+            nudSpawnDuration.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpawnDuration.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpawnDuration.Location = new System.Drawing.Point(119, 181);
+            nudSpawnDuration.Margin = new Padding(4, 3, 4, 3);
+            nudSpawnDuration.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            nudSpawnDuration.Name = "nudSpawnDuration";
+            nudSpawnDuration.Size = new Size(135, 23);
+            nudSpawnDuration.TabIndex = 61;
+            nudSpawnDuration.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudSpawnDuration.ValueChanged += nudSpawnDuration_ValueChanged;
             // 
             // lblSpawnDuration
             // 
-            this.lblSpawnDuration.AutoSize = true;
-            this.lblSpawnDuration.Location = new System.Drawing.Point(10, 159);
-            this.lblSpawnDuration.Name = "lblSpawnDuration";
-            this.lblSpawnDuration.Size = new System.Drawing.Size(86, 13);
-            this.lblSpawnDuration.TabIndex = 7;
-            this.lblSpawnDuration.Text = "Spawn Duration:";
+            lblSpawnDuration.AutoSize = true;
+            lblSpawnDuration.Location = new System.Drawing.Point(12, 183);
+            lblSpawnDuration.Margin = new Padding(4, 0, 4, 0);
+            lblSpawnDuration.Name = "lblSpawnDuration";
+            lblSpawnDuration.Size = new Size(94, 15);
+            lblSpawnDuration.TabIndex = 7;
+            lblSpawnDuration.Text = "Spawn Duration:";
             // 
             // nudSightRange
             // 
-            this.nudSightRange.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudSightRange.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudSightRange.Location = new System.Drawing.Point(102, 69);
-            this.nudSightRange.Maximum = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
-            this.nudSightRange.Name = "nudSightRange";
-            this.nudSightRange.Size = new System.Drawing.Size(116, 20);
-            this.nudSightRange.TabIndex = 62;
-            this.nudSightRange.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudSightRange.ValueChanged += new System.EventHandler(this.nudSightRange_ValueChanged);
+            nudSightRange.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSightRange.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSightRange.Location = new System.Drawing.Point(119, 80);
+            nudSightRange.Margin = new Padding(4, 3, 4, 3);
+            nudSightRange.Maximum = new decimal(new int[] { 20, 0, 0, 0 });
+            nudSightRange.Name = "nudSightRange";
+            nudSightRange.Size = new Size(135, 23);
+            nudSightRange.TabIndex = 62;
+            nudSightRange.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudSightRange.ValueChanged += nudSightRange_ValueChanged;
             // 
             // lblSightRange
             // 
-            this.lblSightRange.AutoSize = true;
-            this.lblSightRange.Location = new System.Drawing.Point(10, 71);
-            this.lblSightRange.Name = "lblSightRange";
-            this.lblSightRange.Size = new System.Drawing.Size(69, 13);
-            this.lblSightRange.TabIndex = 12;
-            this.lblSightRange.Text = "Sight Range:";
+            lblSightRange.AutoSize = true;
+            lblSightRange.Location = new System.Drawing.Point(12, 82);
+            lblSightRange.Margin = new Padding(4, 0, 4, 0);
+            lblSightRange.Name = "lblSightRange";
+            lblSightRange.Size = new Size(73, 15);
+            lblSightRange.TabIndex = 12;
+            lblSightRange.Text = "Sight Range:";
             // 
             // grpStats
             // 
-            this.grpStats.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpStats.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpStats.Controls.Add(this.nudExp);
-            this.grpStats.Controls.Add(this.nudMana);
-            this.grpStats.Controls.Add(this.nudHp);
-            this.grpStats.Controls.Add(this.nudSpd);
-            this.grpStats.Controls.Add(this.nudMR);
-            this.grpStats.Controls.Add(this.nudDef);
-            this.grpStats.Controls.Add(this.nudMag);
-            this.grpStats.Controls.Add(this.nudStr);
-            this.grpStats.Controls.Add(this.lblSpd);
-            this.grpStats.Controls.Add(this.lblMR);
-            this.grpStats.Controls.Add(this.lblDef);
-            this.grpStats.Controls.Add(this.lblMag);
-            this.grpStats.Controls.Add(this.lblStr);
-            this.grpStats.Controls.Add(this.lblMana);
-            this.grpStats.Controls.Add(this.lblHP);
-            this.grpStats.Controls.Add(this.lblExp);
-            this.grpStats.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpStats.Location = new System.Drawing.Point(9, 426);
-            this.grpStats.Name = "grpStats";
-            this.grpStats.Size = new System.Drawing.Size(207, 213);
-            this.grpStats.TabIndex = 15;
-            this.grpStats.TabStop = false;
-            this.grpStats.Text = "Stats:";
+            grpStats.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpStats.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpStats.Controls.Add(nudExp);
+            grpStats.Controls.Add(nudMana);
+            grpStats.Controls.Add(nudHp);
+            grpStats.Controls.Add(nudSpd);
+            grpStats.Controls.Add(nudMR);
+            grpStats.Controls.Add(nudDef);
+            grpStats.Controls.Add(nudMag);
+            grpStats.Controls.Add(nudStr);
+            grpStats.Controls.Add(lblSpd);
+            grpStats.Controls.Add(lblMR);
+            grpStats.Controls.Add(lblDef);
+            grpStats.Controls.Add(lblMag);
+            grpStats.Controls.Add(lblStr);
+            grpStats.Controls.Add(lblMana);
+            grpStats.Controls.Add(lblHP);
+            grpStats.Controls.Add(lblExp);
+            grpStats.ForeColor = System.Drawing.Color.Gainsboro;
+            grpStats.Location = new System.Drawing.Point(10, 492);
+            grpStats.Margin = new Padding(4, 3, 4, 3);
+            grpStats.Name = "grpStats";
+            grpStats.Padding = new Padding(4, 3, 4, 3);
+            grpStats.Size = new Size(241, 246);
+            grpStats.TabIndex = 15;
+            grpStats.TabStop = false;
+            grpStats.Text = "Stats:";
             // 
             // nudExp
             // 
-            this.nudExp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudExp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudExp.Location = new System.Drawing.Point(105, 165);
-            this.nudExp.Maximum = new decimal(new int[] {
-            1410065407,
-            2,
-            0,
-            0});
-            this.nudExp.Name = "nudExp";
-            this.nudExp.Size = new System.Drawing.Size(77, 20);
-            this.nudExp.TabIndex = 45;
-            this.nudExp.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudExp.ValueChanged += new System.EventHandler(this.nudExp_ValueChanged);
+            nudExp.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudExp.ForeColor = System.Drawing.Color.Gainsboro;
+            nudExp.Location = new System.Drawing.Point(122, 190);
+            nudExp.Margin = new Padding(4, 3, 4, 3);
+            nudExp.Maximum = new decimal(new int[] { 1410065407, 2, 0, 0 });
+            nudExp.Name = "nudExp";
+            nudExp.Size = new Size(90, 23);
+            nudExp.TabIndex = 45;
+            nudExp.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudExp.ValueChanged += nudExp_ValueChanged;
             // 
             // nudMana
             // 
-            this.nudMana.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMana.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMana.Location = new System.Drawing.Point(105, 35);
-            this.nudMana.Maximum = new decimal(new int[] {
-            1000000,
-            0,
-            0,
-            0});
-            this.nudMana.Name = "nudMana";
-            this.nudMana.Size = new System.Drawing.Size(77, 20);
-            this.nudMana.TabIndex = 44;
-            this.nudMana.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMana.ValueChanged += new System.EventHandler(this.nudMana_ValueChanged);
+            nudMana.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMana.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMana.Location = new System.Drawing.Point(122, 40);
+            nudMana.Margin = new Padding(4, 3, 4, 3);
+            nudMana.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudMana.Name = "nudMana";
+            nudMana.Size = new Size(90, 23);
+            nudMana.TabIndex = 44;
+            nudMana.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMana.ValueChanged += nudMana_ValueChanged;
             // 
             // nudHp
             // 
-            this.nudHp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudHp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudHp.Location = new System.Drawing.Point(12, 35);
-            this.nudHp.Maximum = new decimal(new int[] {
-            1000000,
-            0,
-            0,
-            0});
-            this.nudHp.Name = "nudHp";
-            this.nudHp.Size = new System.Drawing.Size(77, 20);
-            this.nudHp.TabIndex = 43;
-            this.nudHp.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudHp.ValueChanged += new System.EventHandler(this.nudHp_ValueChanged);
+            nudHp.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHp.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHp.Location = new System.Drawing.Point(14, 40);
+            nudHp.Margin = new Padding(4, 3, 4, 3);
+            nudHp.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudHp.Name = "nudHp";
+            nudHp.Size = new Size(90, 23);
+            nudHp.TabIndex = 43;
+            nudHp.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHp.ValueChanged += nudHp_ValueChanged;
             // 
             // nudSpd
             // 
-            this.nudSpd.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudSpd.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudSpd.Location = new System.Drawing.Point(13, 165);
-            this.nudSpd.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudSpd.Name = "nudSpd";
-            this.nudSpd.Size = new System.Drawing.Size(77, 20);
-            this.nudSpd.TabIndex = 42;
-            this.nudSpd.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudSpd.ValueChanged += new System.EventHandler(this.nudSpd_ValueChanged);
+            nudSpd.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpd.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpd.Location = new System.Drawing.Point(15, 190);
+            nudSpd.Margin = new Padding(4, 3, 4, 3);
+            nudSpd.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudSpd.Name = "nudSpd";
+            nudSpd.Size = new Size(90, 23);
+            nudSpd.TabIndex = 42;
+            nudSpd.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudSpd.ValueChanged += nudSpd_ValueChanged;
             // 
             // nudMR
             // 
-            this.nudMR.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMR.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMR.Location = new System.Drawing.Point(105, 123);
-            this.nudMR.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudMR.Name = "nudMR";
-            this.nudMR.Size = new System.Drawing.Size(79, 20);
-            this.nudMR.TabIndex = 41;
-            this.nudMR.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMR.ValueChanged += new System.EventHandler(this.nudMR_ValueChanged);
+            nudMR.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMR.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMR.Location = new System.Drawing.Point(122, 142);
+            nudMR.Margin = new Padding(4, 3, 4, 3);
+            nudMR.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudMR.Name = "nudMR";
+            nudMR.Size = new Size(92, 23);
+            nudMR.TabIndex = 41;
+            nudMR.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMR.ValueChanged += nudMR_ValueChanged;
             // 
             // nudDef
             // 
-            this.nudDef.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDef.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDef.Location = new System.Drawing.Point(12, 123);
-            this.nudDef.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudDef.Name = "nudDef";
-            this.nudDef.Size = new System.Drawing.Size(79, 20);
-            this.nudDef.TabIndex = 40;
-            this.nudDef.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudDef.ValueChanged += new System.EventHandler(this.nudDef_ValueChanged);
+            nudDef.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDef.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDef.Location = new System.Drawing.Point(14, 142);
+            nudDef.Margin = new Padding(4, 3, 4, 3);
+            nudDef.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudDef.Name = "nudDef";
+            nudDef.Size = new Size(92, 23);
+            nudDef.TabIndex = 40;
+            nudDef.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudDef.ValueChanged += nudDef_ValueChanged;
             // 
             // nudMag
             // 
-            this.nudMag.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMag.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMag.Location = new System.Drawing.Point(105, 80);
-            this.nudMag.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudMag.Name = "nudMag";
-            this.nudMag.Size = new System.Drawing.Size(77, 20);
-            this.nudMag.TabIndex = 39;
-            this.nudMag.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMag.ValueChanged += new System.EventHandler(this.nudMag_ValueChanged);
+            nudMag.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMag.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMag.Location = new System.Drawing.Point(122, 92);
+            nudMag.Margin = new Padding(4, 3, 4, 3);
+            nudMag.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudMag.Name = "nudMag";
+            nudMag.Size = new Size(90, 23);
+            nudMag.TabIndex = 39;
+            nudMag.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMag.ValueChanged += nudMag_ValueChanged;
             // 
             // nudStr
             // 
-            this.nudStr.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudStr.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudStr.Location = new System.Drawing.Point(13, 80);
-            this.nudStr.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudStr.Name = "nudStr";
-            this.nudStr.Size = new System.Drawing.Size(77, 20);
-            this.nudStr.TabIndex = 38;
-            this.nudStr.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudStr.ValueChanged += new System.EventHandler(this.nudStr_ValueChanged);
+            nudStr.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudStr.ForeColor = System.Drawing.Color.Gainsboro;
+            nudStr.Location = new System.Drawing.Point(15, 92);
+            nudStr.Margin = new Padding(4, 3, 4, 3);
+            nudStr.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudStr.Name = "nudStr";
+            nudStr.Size = new Size(90, 23);
+            nudStr.TabIndex = 38;
+            nudStr.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudStr.ValueChanged += nudStr_ValueChanged;
             // 
             // lblSpd
             // 
-            this.lblSpd.AutoSize = true;
-            this.lblSpd.Location = new System.Drawing.Point(10, 152);
-            this.lblSpd.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblSpd.Name = "lblSpd";
-            this.lblSpd.Size = new System.Drawing.Size(71, 13);
-            this.lblSpd.TabIndex = 37;
-            this.lblSpd.Text = "Move Speed:";
+            lblSpd.AutoSize = true;
+            lblSpd.Location = new System.Drawing.Point(12, 175);
+            lblSpd.Margin = new Padding(2, 0, 2, 0);
+            lblSpd.Name = "lblSpd";
+            lblSpd.Size = new Size(75, 15);
+            lblSpd.TabIndex = 37;
+            lblSpd.Text = "Move Speed:";
             // 
             // lblMR
             // 
-            this.lblMR.AutoSize = true;
-            this.lblMR.Location = new System.Drawing.Point(104, 107);
-            this.lblMR.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblMR.Name = "lblMR";
-            this.lblMR.Size = new System.Drawing.Size(71, 13);
-            this.lblMR.TabIndex = 36;
-            this.lblMR.Text = "Magic Resist:";
+            lblMR.AutoSize = true;
+            lblMR.Location = new System.Drawing.Point(121, 123);
+            lblMR.Margin = new Padding(2, 0, 2, 0);
+            lblMR.Name = "lblMR";
+            lblMR.Size = new Size(76, 15);
+            lblMR.TabIndex = 36;
+            lblMR.Text = "Magic Resist:";
             // 
             // lblDef
             // 
-            this.lblDef.AutoSize = true;
-            this.lblDef.Location = new System.Drawing.Point(9, 107);
-            this.lblDef.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblDef.Name = "lblDef";
-            this.lblDef.Size = new System.Drawing.Size(37, 13);
-            this.lblDef.TabIndex = 35;
-            this.lblDef.Text = "Armor:";
+            lblDef.AutoSize = true;
+            lblDef.Location = new System.Drawing.Point(10, 123);
+            lblDef.Margin = new Padding(2, 0, 2, 0);
+            lblDef.Name = "lblDef";
+            lblDef.Size = new Size(44, 15);
+            lblDef.TabIndex = 35;
+            lblDef.Text = "Armor:";
             // 
             // lblMag
             // 
-            this.lblMag.AutoSize = true;
-            this.lblMag.Location = new System.Drawing.Point(106, 63);
-            this.lblMag.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblMag.Name = "lblMag";
-            this.lblMag.Size = new System.Drawing.Size(39, 13);
-            this.lblMag.TabIndex = 34;
-            this.lblMag.Text = "Magic:";
+            lblMag.AutoSize = true;
+            lblMag.Location = new System.Drawing.Point(124, 73);
+            lblMag.Margin = new Padding(2, 0, 2, 0);
+            lblMag.Name = "lblMag";
+            lblMag.Size = new Size(43, 15);
+            lblMag.TabIndex = 34;
+            lblMag.Text = "Magic:";
             // 
             // lblStr
             // 
-            this.lblStr.AutoSize = true;
-            this.lblStr.Location = new System.Drawing.Point(9, 64);
-            this.lblStr.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblStr.Name = "lblStr";
-            this.lblStr.Size = new System.Drawing.Size(50, 13);
-            this.lblStr.TabIndex = 33;
-            this.lblStr.Text = "Strength:";
+            lblStr.AutoSize = true;
+            lblStr.Location = new System.Drawing.Point(10, 74);
+            lblStr.Margin = new Padding(2, 0, 2, 0);
+            lblStr.Name = "lblStr";
+            lblStr.Size = new Size(55, 15);
+            lblStr.TabIndex = 33;
+            lblStr.Text = "Strength:";
             // 
             // lblMana
             // 
-            this.lblMana.AutoSize = true;
-            this.lblMana.Location = new System.Drawing.Point(108, 18);
-            this.lblMana.Name = "lblMana";
-            this.lblMana.Size = new System.Drawing.Size(37, 13);
-            this.lblMana.TabIndex = 15;
-            this.lblMana.Text = "Mana:";
+            lblMana.AutoSize = true;
+            lblMana.Location = new System.Drawing.Point(126, 21);
+            lblMana.Margin = new Padding(4, 0, 4, 0);
+            lblMana.Name = "lblMana";
+            lblMana.Size = new Size(40, 15);
+            lblMana.TabIndex = 15;
+            lblMana.Text = "Mana:";
             // 
             // lblHP
             // 
-            this.lblHP.AutoSize = true;
-            this.lblHP.Location = new System.Drawing.Point(10, 19);
-            this.lblHP.Name = "lblHP";
-            this.lblHP.Size = new System.Drawing.Size(25, 13);
-            this.lblHP.TabIndex = 14;
-            this.lblHP.Text = "HP:";
+            lblHP.AutoSize = true;
+            lblHP.Location = new System.Drawing.Point(12, 22);
+            lblHP.Margin = new Padding(4, 0, 4, 0);
+            lblHP.Name = "lblHP";
+            lblHP.Size = new Size(26, 15);
+            lblHP.TabIndex = 14;
+            lblHP.Text = "HP:";
             // 
             // lblExp
             // 
-            this.lblExp.AutoSize = true;
-            this.lblExp.Location = new System.Drawing.Point(106, 152);
-            this.lblExp.Name = "lblExp";
-            this.lblExp.Size = new System.Drawing.Size(28, 13);
-            this.lblExp.TabIndex = 11;
-            this.lblExp.Text = "Exp:";
+            lblExp.AutoSize = true;
+            lblExp.Location = new System.Drawing.Point(124, 175);
+            lblExp.Margin = new Padding(4, 0, 4, 0);
+            lblExp.Name = "lblExp";
+            lblExp.Size = new Size(29, 15);
+            lblExp.TabIndex = 11;
+            lblExp.Text = "Exp:";
             // 
             // pnlContainer
             // 
-            this.pnlContainer.AutoScroll = true;
-            this.pnlContainer.Controls.Add(this.grpImmunities);
-            this.pnlContainer.Controls.Add(this.grpCombat);
-            this.pnlContainer.Controls.Add(this.grpCommonEvents);
-            this.pnlContainer.Controls.Add(this.grpBehavior);
-            this.pnlContainer.Controls.Add(this.grpRegen);
-            this.pnlContainer.Controls.Add(this.grpDrops);
-            this.pnlContainer.Controls.Add(this.grpNpcVsNpc);
-            this.pnlContainer.Controls.Add(this.grpSpells);
-            this.pnlContainer.Controls.Add(this.grpGeneral);
-            this.pnlContainer.Controls.Add(this.grpStats);
-            this.pnlContainer.Location = new System.Drawing.Point(216, 34);
-            this.pnlContainer.Name = "pnlContainer";
-            this.pnlContainer.Size = new System.Drawing.Size(975, 550);
-            this.pnlContainer.TabIndex = 17;
+            pnlContainer.AutoScroll = true;
+            pnlContainer.Controls.Add(grpImmunities);
+            pnlContainer.Controls.Add(grpCombat);
+            pnlContainer.Controls.Add(grpCommonEvents);
+            pnlContainer.Controls.Add(grpBehavior);
+            pnlContainer.Controls.Add(grpRegen);
+            pnlContainer.Controls.Add(grpDrops);
+            pnlContainer.Controls.Add(grpNpcVsNpc);
+            pnlContainer.Controls.Add(grpSpells);
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Controls.Add(grpStats);
+            pnlContainer.Location = new System.Drawing.Point(252, 39);
+            pnlContainer.Margin = new Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new Size(1138, 635);
+            pnlContainer.TabIndex = 17;
             // 
             // grpImmunities
             // 
-            this.grpImmunities.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpImmunities.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpImmunities.Controls.Add(this.nudTenacity);
-            this.grpImmunities.Controls.Add(this.lblTenacity);
-            this.grpImmunities.Controls.Add(this.chkTaunt);
-            this.grpImmunities.Controls.Add(this.chkSleep);
-            this.grpImmunities.Controls.Add(this.chkTransform);
-            this.grpImmunities.Controls.Add(this.chkBlind);
-            this.grpImmunities.Controls.Add(this.chkSnare);
-            this.grpImmunities.Controls.Add(this.chkStun);
-            this.grpImmunities.Controls.Add(this.chkSilence);
-            this.grpImmunities.Controls.Add(this.chkKnockback);
-            this.grpImmunities.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpImmunities.Location = new System.Drawing.Point(459, 439);
-            this.grpImmunities.Margin = new System.Windows.Forms.Padding(2);
-            this.grpImmunities.Name = "grpImmunities";
-            this.grpImmunities.Padding = new System.Windows.Forms.Padding(2);
-            this.grpImmunities.Size = new System.Drawing.Size(255, 181);
-            this.grpImmunities.TabIndex = 33;
-            this.grpImmunities.TabStop = false;
-            this.grpImmunities.Text = "Immunities";
+            grpImmunities.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpImmunities.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpImmunities.Controls.Add(nudTenacity);
+            grpImmunities.Controls.Add(lblTenacity);
+            grpImmunities.Controls.Add(chkTaunt);
+            grpImmunities.Controls.Add(chkSleep);
+            grpImmunities.Controls.Add(chkTransform);
+            grpImmunities.Controls.Add(chkBlind);
+            grpImmunities.Controls.Add(chkSnare);
+            grpImmunities.Controls.Add(chkStun);
+            grpImmunities.Controls.Add(chkSilence);
+            grpImmunities.Controls.Add(chkKnockback);
+            grpImmunities.ForeColor = System.Drawing.Color.Gainsboro;
+            grpImmunities.Location = new System.Drawing.Point(536, 507);
+            grpImmunities.Margin = new Padding(2);
+            grpImmunities.Name = "grpImmunities";
+            grpImmunities.Padding = new Padding(2);
+            grpImmunities.Size = new Size(298, 209);
+            grpImmunities.TabIndex = 33;
+            grpImmunities.TabStop = false;
+            grpImmunities.Text = "Immunities";
             // 
             // nudTenacity
             // 
-            this.nudTenacity.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudTenacity.DecimalPlaces = 2;
-            this.nudTenacity.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudTenacity.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.nudTenacity.Location = new System.Drawing.Point(13, 139);
-            this.nudTenacity.Name = "nudTenacity";
-            this.nudTenacity.Size = new System.Drawing.Size(236, 20);
-            this.nudTenacity.TabIndex = 79;
-            this.nudTenacity.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudTenacity.ValueChanged += new System.EventHandler(this.nudTenacity_ValueChanged);
+            nudTenacity.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudTenacity.DecimalPlaces = 2;
+            nudTenacity.ForeColor = System.Drawing.Color.Gainsboro;
+            nudTenacity.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
+            nudTenacity.Location = new System.Drawing.Point(15, 160);
+            nudTenacity.Margin = new Padding(4, 3, 4, 3);
+            nudTenacity.Name = "nudTenacity";
+            nudTenacity.Size = new Size(275, 23);
+            nudTenacity.TabIndex = 79;
+            nudTenacity.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudTenacity.ValueChanged += nudTenacity_ValueChanged;
             // 
             // lblTenacity
             // 
-            this.lblTenacity.AutoSize = true;
-            this.lblTenacity.Location = new System.Drawing.Point(5, 122);
-            this.lblTenacity.Name = "lblTenacity";
-            this.lblTenacity.Size = new System.Drawing.Size(68, 13);
-            this.lblTenacity.TabIndex = 79;
-            this.lblTenacity.Text = "Tenacity (%):";
+            lblTenacity.AutoSize = true;
+            lblTenacity.Location = new System.Drawing.Point(6, 141);
+            lblTenacity.Margin = new Padding(4, 0, 4, 0);
+            lblTenacity.Name = "lblTenacity";
+            lblTenacity.Size = new Size(74, 15);
+            lblTenacity.TabIndex = 79;
+            lblTenacity.Text = "Tenacity (%):";
             // 
             // chkTaunt
             // 
-            this.chkTaunt.AutoSize = true;
-            this.chkTaunt.Location = new System.Drawing.Point(176, 95);
-            this.chkTaunt.Name = "chkTaunt";
-            this.chkTaunt.Size = new System.Drawing.Size(54, 17);
-            this.chkTaunt.TabIndex = 86;
-            this.chkTaunt.Text = "Taunt";
-            this.chkTaunt.CheckedChanged += new System.EventHandler(this.chkTaunt_CheckedChanged);
+            chkTaunt.AutoSize = true;
+            chkTaunt.Location = new System.Drawing.Point(205, 110);
+            chkTaunt.Margin = new Padding(4, 3, 4, 3);
+            chkTaunt.Name = "chkTaunt";
+            chkTaunt.Size = new Size(55, 19);
+            chkTaunt.TabIndex = 86;
+            chkTaunt.Text = "Taunt";
+            chkTaunt.CheckedChanged += chkTaunt_CheckedChanged;
             // 
             // chkSleep
             // 
-            this.chkSleep.AutoSize = true;
-            this.chkSleep.Location = new System.Drawing.Point(13, 95);
-            this.chkSleep.Name = "chkSleep";
-            this.chkSleep.Size = new System.Drawing.Size(53, 17);
-            this.chkSleep.TabIndex = 85;
-            this.chkSleep.Text = "Sleep";
-            this.chkSleep.CheckedChanged += new System.EventHandler(this.chkSleep_CheckedChanged);
+            chkSleep.AutoSize = true;
+            chkSleep.Location = new System.Drawing.Point(15, 110);
+            chkSleep.Margin = new Padding(4, 3, 4, 3);
+            chkSleep.Name = "chkSleep";
+            chkSleep.Size = new Size(54, 19);
+            chkSleep.TabIndex = 85;
+            chkSleep.Text = "Sleep";
+            chkSleep.CheckedChanged += chkSleep_CheckedChanged;
             // 
             // chkTransform
             // 
-            this.chkTransform.AutoSize = true;
-            this.chkTransform.Location = new System.Drawing.Point(176, 72);
-            this.chkTransform.Name = "chkTransform";
-            this.chkTransform.Size = new System.Drawing.Size(73, 17);
-            this.chkTransform.TabIndex = 84;
-            this.chkTransform.Text = "Transform";
-            this.chkTransform.CheckedChanged += new System.EventHandler(this.chkTransform_CheckedChanged);
+            chkTransform.AutoSize = true;
+            chkTransform.Location = new System.Drawing.Point(205, 83);
+            chkTransform.Margin = new Padding(4, 3, 4, 3);
+            chkTransform.Name = "chkTransform";
+            chkTransform.Size = new Size(79, 19);
+            chkTransform.TabIndex = 84;
+            chkTransform.Text = "Transform";
+            chkTransform.CheckedChanged += chkTransform_CheckedChanged;
             // 
             // chkBlind
             // 
-            this.chkBlind.AutoSize = true;
-            this.chkBlind.Location = new System.Drawing.Point(13, 72);
-            this.chkBlind.Name = "chkBlind";
-            this.chkBlind.Size = new System.Drawing.Size(49, 17);
-            this.chkBlind.TabIndex = 83;
-            this.chkBlind.Text = "Blind";
-            this.chkBlind.CheckedChanged += new System.EventHandler(this.chkBlind_CheckedChanged);
+            chkBlind.AutoSize = true;
+            chkBlind.Location = new System.Drawing.Point(15, 83);
+            chkBlind.Margin = new Padding(4, 3, 4, 3);
+            chkBlind.Name = "chkBlind";
+            chkBlind.Size = new Size(53, 19);
+            chkBlind.TabIndex = 83;
+            chkBlind.Text = "Blind";
+            chkBlind.CheckedChanged += chkBlind_CheckedChanged;
             // 
             // chkSnare
             // 
-            this.chkSnare.AutoSize = true;
-            this.chkSnare.Location = new System.Drawing.Point(176, 49);
-            this.chkSnare.Name = "chkSnare";
-            this.chkSnare.Size = new System.Drawing.Size(54, 17);
-            this.chkSnare.TabIndex = 82;
-            this.chkSnare.Text = "Snare";
-            this.chkSnare.CheckedChanged += new System.EventHandler(this.chkSnare_CheckedChanged);
+            chkSnare.AutoSize = true;
+            chkSnare.Location = new System.Drawing.Point(205, 57);
+            chkSnare.Margin = new Padding(4, 3, 4, 3);
+            chkSnare.Name = "chkSnare";
+            chkSnare.Size = new Size(55, 19);
+            chkSnare.TabIndex = 82;
+            chkSnare.Text = "Snare";
+            chkSnare.CheckedChanged += chkSnare_CheckedChanged;
             // 
             // chkStun
             // 
-            this.chkStun.AutoSize = true;
-            this.chkStun.Location = new System.Drawing.Point(13, 49);
-            this.chkStun.Name = "chkStun";
-            this.chkStun.Size = new System.Drawing.Size(48, 17);
-            this.chkStun.TabIndex = 81;
-            this.chkStun.Text = "Stun";
-            this.chkStun.CheckedChanged += new System.EventHandler(this.chkStun_CheckedChanged);
+            chkStun.AutoSize = true;
+            chkStun.Location = new System.Drawing.Point(15, 57);
+            chkStun.Margin = new Padding(4, 3, 4, 3);
+            chkStun.Name = "chkStun";
+            chkStun.Size = new Size(50, 19);
+            chkStun.TabIndex = 81;
+            chkStun.Text = "Stun";
+            chkStun.CheckedChanged += chkStun_CheckedChanged;
             // 
             // chkSilence
             // 
-            this.chkSilence.AutoSize = true;
-            this.chkSilence.Location = new System.Drawing.Point(176, 26);
-            this.chkSilence.Name = "chkSilence";
-            this.chkSilence.Size = new System.Drawing.Size(61, 17);
-            this.chkSilence.TabIndex = 80;
-            this.chkSilence.Text = "Silence";
-            this.chkSilence.CheckedChanged += new System.EventHandler(this.chkSilence_CheckedChanged);
+            chkSilence.AutoSize = true;
+            chkSilence.Location = new System.Drawing.Point(205, 30);
+            chkSilence.Margin = new Padding(4, 3, 4, 3);
+            chkSilence.Name = "chkSilence";
+            chkSilence.Size = new Size(63, 19);
+            chkSilence.TabIndex = 80;
+            chkSilence.Text = "Silence";
+            chkSilence.CheckedChanged += chkSilence_CheckedChanged;
             // 
             // chkKnockback
             // 
-            this.chkKnockback.AutoSize = true;
-            this.chkKnockback.Location = new System.Drawing.Point(13, 26);
-            this.chkKnockback.Name = "chkKnockback";
-            this.chkKnockback.Size = new System.Drawing.Size(81, 17);
-            this.chkKnockback.TabIndex = 79;
-            this.chkKnockback.Text = "Knockback";
-            this.chkKnockback.CheckedChanged += new System.EventHandler(this.chkKnockback_CheckedChanged);
+            chkKnockback.AutoSize = true;
+            chkKnockback.Location = new System.Drawing.Point(15, 30);
+            chkKnockback.Margin = new Padding(4, 3, 4, 3);
+            chkKnockback.Name = "chkKnockback";
+            chkKnockback.Size = new Size(84, 19);
+            chkKnockback.TabIndex = 79;
+            chkKnockback.Text = "Knockback";
+            chkKnockback.CheckedChanged += chkKnockback_CheckedChanged;
             // 
             // grpCombat
             // 
-            this.grpCombat.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpCombat.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpCombat.Controls.Add(this.grpAttackSpeed);
-            this.grpCombat.Controls.Add(this.nudCritMultiplier);
-            this.grpCombat.Controls.Add(this.lblCritMultiplier);
-            this.grpCombat.Controls.Add(this.nudScaling);
-            this.grpCombat.Controls.Add(this.nudDamage);
-            this.grpCombat.Controls.Add(this.nudCritChance);
-            this.grpCombat.Controls.Add(this.cmbScalingStat);
-            this.grpCombat.Controls.Add(this.lblScalingStat);
-            this.grpCombat.Controls.Add(this.lblScaling);
-            this.grpCombat.Controls.Add(this.cmbDamageType);
-            this.grpCombat.Controls.Add(this.lblDamageType);
-            this.grpCombat.Controls.Add(this.lblCritChance);
-            this.grpCombat.Controls.Add(this.cmbAttackAnimation);
-            this.grpCombat.Controls.Add(this.lblAttackAnimation);
-            this.grpCombat.Controls.Add(this.lblDamage);
-            this.grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpCombat.Location = new System.Drawing.Point(459, 5);
-            this.grpCombat.Name = "grpCombat";
-            this.grpCombat.Size = new System.Drawing.Size(255, 429);
-            this.grpCombat.TabIndex = 17;
-            this.grpCombat.TabStop = false;
-            this.grpCombat.Text = "Combat";
+            grpCombat.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpCombat.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpCombat.Controls.Add(grpAttackSpeed);
+            grpCombat.Controls.Add(nudCritMultiplier);
+            grpCombat.Controls.Add(lblCritMultiplier);
+            grpCombat.Controls.Add(nudScaling);
+            grpCombat.Controls.Add(nudDamage);
+            grpCombat.Controls.Add(nudCritChance);
+            grpCombat.Controls.Add(cmbScalingStat);
+            grpCombat.Controls.Add(lblScalingStat);
+            grpCombat.Controls.Add(lblScaling);
+            grpCombat.Controls.Add(cmbDamageType);
+            grpCombat.Controls.Add(lblDamageType);
+            grpCombat.Controls.Add(lblCritChance);
+            grpCombat.Controls.Add(cmbAttackAnimation);
+            grpCombat.Controls.Add(lblAttackAnimation);
+            grpCombat.Controls.Add(lblDamage);
+            grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
+            grpCombat.Location = new System.Drawing.Point(536, 6);
+            grpCombat.Margin = new Padding(4, 3, 4, 3);
+            grpCombat.Name = "grpCombat";
+            grpCombat.Padding = new Padding(4, 3, 4, 3);
+            grpCombat.Size = new Size(298, 495);
+            grpCombat.TabIndex = 17;
+            grpCombat.TabStop = false;
+            grpCombat.Text = "Combat";
             // 
             // grpAttackSpeed
             // 
-            this.grpAttackSpeed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpAttackSpeed.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpAttackSpeed.Controls.Add(this.nudAttackSpeedValue);
-            this.grpAttackSpeed.Controls.Add(this.lblAttackSpeedValue);
-            this.grpAttackSpeed.Controls.Add(this.cmbAttackSpeedModifier);
-            this.grpAttackSpeed.Controls.Add(this.lblAttackSpeedModifier);
-            this.grpAttackSpeed.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpAttackSpeed.Location = new System.Drawing.Point(13, 332);
-            this.grpAttackSpeed.Name = "grpAttackSpeed";
-            this.grpAttackSpeed.Size = new System.Drawing.Size(236, 90);
-            this.grpAttackSpeed.TabIndex = 64;
-            this.grpAttackSpeed.TabStop = false;
-            this.grpAttackSpeed.Text = "Attack Speed";
+            grpAttackSpeed.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpAttackSpeed.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpAttackSpeed.Controls.Add(nudAttackSpeedValue);
+            grpAttackSpeed.Controls.Add(lblAttackSpeedValue);
+            grpAttackSpeed.Controls.Add(cmbAttackSpeedModifier);
+            grpAttackSpeed.Controls.Add(lblAttackSpeedModifier);
+            grpAttackSpeed.ForeColor = System.Drawing.Color.Gainsboro;
+            grpAttackSpeed.Location = new System.Drawing.Point(15, 383);
+            grpAttackSpeed.Margin = new Padding(4, 3, 4, 3);
+            grpAttackSpeed.Name = "grpAttackSpeed";
+            grpAttackSpeed.Padding = new Padding(4, 3, 4, 3);
+            grpAttackSpeed.Size = new Size(275, 104);
+            grpAttackSpeed.TabIndex = 64;
+            grpAttackSpeed.TabStop = false;
+            grpAttackSpeed.Text = "Attack Speed";
             // 
             // nudAttackSpeedValue
             // 
-            this.nudAttackSpeedValue.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudAttackSpeedValue.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudAttackSpeedValue.Location = new System.Drawing.Point(60, 58);
-            this.nudAttackSpeedValue.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudAttackSpeedValue.Name = "nudAttackSpeedValue";
-            this.nudAttackSpeedValue.Size = new System.Drawing.Size(158, 20);
-            this.nudAttackSpeedValue.TabIndex = 56;
-            this.nudAttackSpeedValue.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudAttackSpeedValue.ValueChanged += new System.EventHandler(this.nudAttackSpeedValue_ValueChanged);
+            nudAttackSpeedValue.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudAttackSpeedValue.ForeColor = System.Drawing.Color.Gainsboro;
+            nudAttackSpeedValue.Location = new System.Drawing.Point(70, 67);
+            nudAttackSpeedValue.Margin = new Padding(4, 3, 4, 3);
+            nudAttackSpeedValue.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            nudAttackSpeedValue.Name = "nudAttackSpeedValue";
+            nudAttackSpeedValue.Size = new Size(184, 23);
+            nudAttackSpeedValue.TabIndex = 56;
+            nudAttackSpeedValue.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudAttackSpeedValue.ValueChanged += nudAttackSpeedValue_ValueChanged;
             // 
             // lblAttackSpeedValue
             // 
-            this.lblAttackSpeedValue.AutoSize = true;
-            this.lblAttackSpeedValue.Location = new System.Drawing.Point(9, 60);
-            this.lblAttackSpeedValue.Name = "lblAttackSpeedValue";
-            this.lblAttackSpeedValue.Size = new System.Drawing.Size(37, 13);
-            this.lblAttackSpeedValue.TabIndex = 29;
-            this.lblAttackSpeedValue.Text = "Value:";
+            lblAttackSpeedValue.AutoSize = true;
+            lblAttackSpeedValue.Location = new System.Drawing.Point(10, 69);
+            lblAttackSpeedValue.Margin = new Padding(4, 0, 4, 0);
+            lblAttackSpeedValue.Name = "lblAttackSpeedValue";
+            lblAttackSpeedValue.Size = new Size(38, 15);
+            lblAttackSpeedValue.TabIndex = 29;
+            lblAttackSpeedValue.Text = "Value:";
             // 
             // cmbAttackSpeedModifier
             // 
-            this.cmbAttackSpeedModifier.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbAttackSpeedModifier.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbAttackSpeedModifier.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbAttackSpeedModifier.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbAttackSpeedModifier.DrawDropdownHoverOutline = false;
-            this.cmbAttackSpeedModifier.DrawFocusRectangle = false;
-            this.cmbAttackSpeedModifier.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbAttackSpeedModifier.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbAttackSpeedModifier.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbAttackSpeedModifier.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbAttackSpeedModifier.FormattingEnabled = true;
-            this.cmbAttackSpeedModifier.Location = new System.Drawing.Point(60, 24);
-            this.cmbAttackSpeedModifier.Name = "cmbAttackSpeedModifier";
-            this.cmbAttackSpeedModifier.Size = new System.Drawing.Size(158, 21);
-            this.cmbAttackSpeedModifier.TabIndex = 28;
-            this.cmbAttackSpeedModifier.Text = null;
-            this.cmbAttackSpeedModifier.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbAttackSpeedModifier.SelectedIndexChanged += new System.EventHandler(this.cmbAttackSpeedModifier_SelectedIndexChanged);
+            cmbAttackSpeedModifier.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbAttackSpeedModifier.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbAttackSpeedModifier.BorderStyle = ButtonBorderStyle.Solid;
+            cmbAttackSpeedModifier.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbAttackSpeedModifier.DrawDropdownHoverOutline = false;
+            cmbAttackSpeedModifier.DrawFocusRectangle = false;
+            cmbAttackSpeedModifier.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbAttackSpeedModifier.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbAttackSpeedModifier.FlatStyle = FlatStyle.Flat;
+            cmbAttackSpeedModifier.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbAttackSpeedModifier.FormattingEnabled = true;
+            cmbAttackSpeedModifier.Location = new System.Drawing.Point(70, 28);
+            cmbAttackSpeedModifier.Margin = new Padding(4, 3, 4, 3);
+            cmbAttackSpeedModifier.Name = "cmbAttackSpeedModifier";
+            cmbAttackSpeedModifier.Size = new Size(184, 24);
+            cmbAttackSpeedModifier.TabIndex = 28;
+            cmbAttackSpeedModifier.Text = null;
+            cmbAttackSpeedModifier.TextPadding = new Padding(2);
+            cmbAttackSpeedModifier.SelectedIndexChanged += cmbAttackSpeedModifier_SelectedIndexChanged;
             // 
             // lblAttackSpeedModifier
             // 
-            this.lblAttackSpeedModifier.AutoSize = true;
-            this.lblAttackSpeedModifier.Location = new System.Drawing.Point(9, 27);
-            this.lblAttackSpeedModifier.Name = "lblAttackSpeedModifier";
-            this.lblAttackSpeedModifier.Size = new System.Drawing.Size(47, 13);
-            this.lblAttackSpeedModifier.TabIndex = 0;
-            this.lblAttackSpeedModifier.Text = "Modifier:";
+            lblAttackSpeedModifier.AutoSize = true;
+            lblAttackSpeedModifier.Location = new System.Drawing.Point(10, 31);
+            lblAttackSpeedModifier.Margin = new Padding(4, 0, 4, 0);
+            lblAttackSpeedModifier.Name = "lblAttackSpeedModifier";
+            lblAttackSpeedModifier.Size = new Size(55, 15);
+            lblAttackSpeedModifier.TabIndex = 0;
+            lblAttackSpeedModifier.Text = "Modifier:";
             // 
             // nudCritMultiplier
             // 
-            this.nudCritMultiplier.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudCritMultiplier.DecimalPlaces = 2;
-            this.nudCritMultiplier.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudCritMultiplier.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.nudCritMultiplier.Location = new System.Drawing.Point(13, 117);
-            this.nudCritMultiplier.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.nudCritMultiplier.Name = "nudCritMultiplier";
-            this.nudCritMultiplier.Size = new System.Drawing.Size(236, 20);
-            this.nudCritMultiplier.TabIndex = 63;
-            this.nudCritMultiplier.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudCritMultiplier.ValueChanged += new System.EventHandler(this.nudCritMultiplier_ValueChanged);
+            nudCritMultiplier.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudCritMultiplier.DecimalPlaces = 2;
+            nudCritMultiplier.ForeColor = System.Drawing.Color.Gainsboro;
+            nudCritMultiplier.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
+            nudCritMultiplier.Location = new System.Drawing.Point(15, 135);
+            nudCritMultiplier.Margin = new Padding(4, 3, 4, 3);
+            nudCritMultiplier.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudCritMultiplier.Name = "nudCritMultiplier";
+            nudCritMultiplier.Size = new Size(275, 23);
+            nudCritMultiplier.TabIndex = 63;
+            nudCritMultiplier.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudCritMultiplier.ValueChanged += nudCritMultiplier_ValueChanged;
             // 
             // lblCritMultiplier
             // 
-            this.lblCritMultiplier.AutoSize = true;
-            this.lblCritMultiplier.Location = new System.Drawing.Point(10, 103);
-            this.lblCritMultiplier.Name = "lblCritMultiplier";
-            this.lblCritMultiplier.Size = new System.Drawing.Size(135, 13);
-            this.lblCritMultiplier.TabIndex = 62;
-            this.lblCritMultiplier.Text = "Crit Multiplier (Default 1.5x):";
+            lblCritMultiplier.AutoSize = true;
+            lblCritMultiplier.Location = new System.Drawing.Point(12, 119);
+            lblCritMultiplier.Margin = new Padding(4, 0, 4, 0);
+            lblCritMultiplier.Name = "lblCritMultiplier";
+            lblCritMultiplier.Size = new Size(156, 15);
+            lblCritMultiplier.TabIndex = 62;
+            lblCritMultiplier.Text = "Crit Multiplier (Default 1.5x):";
             // 
             // nudScaling
             // 
-            this.nudScaling.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudScaling.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudScaling.Location = new System.Drawing.Point(12, 257);
-            this.nudScaling.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudScaling.Name = "nudScaling";
-            this.nudScaling.Size = new System.Drawing.Size(237, 20);
-            this.nudScaling.TabIndex = 61;
-            this.nudScaling.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudScaling.ValueChanged += new System.EventHandler(this.nudScaling_ValueChanged);
+            nudScaling.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudScaling.ForeColor = System.Drawing.Color.Gainsboro;
+            nudScaling.Location = new System.Drawing.Point(14, 297);
+            nudScaling.Margin = new Padding(4, 3, 4, 3);
+            nudScaling.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudScaling.Name = "nudScaling";
+            nudScaling.Size = new Size(276, 23);
+            nudScaling.TabIndex = 61;
+            nudScaling.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudScaling.ValueChanged += nudScaling_ValueChanged;
             // 
             // nudDamage
             // 
-            this.nudDamage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDamage.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDamage.Location = new System.Drawing.Point(12, 34);
-            this.nudDamage.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudDamage.Name = "nudDamage";
-            this.nudDamage.Size = new System.Drawing.Size(237, 20);
-            this.nudDamage.TabIndex = 60;
-            this.nudDamage.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudDamage.ValueChanged += new System.EventHandler(this.nudDamage_ValueChanged);
+            nudDamage.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDamage.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDamage.Location = new System.Drawing.Point(14, 39);
+            nudDamage.Margin = new Padding(4, 3, 4, 3);
+            nudDamage.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            nudDamage.Name = "nudDamage";
+            nudDamage.Size = new Size(276, 23);
+            nudDamage.TabIndex = 60;
+            nudDamage.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudDamage.ValueChanged += nudDamage_ValueChanged;
             // 
             // nudCritChance
             // 
-            this.nudCritChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudCritChance.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudCritChance.Location = new System.Drawing.Point(13, 75);
-            this.nudCritChance.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.nudCritChance.Name = "nudCritChance";
-            this.nudCritChance.Size = new System.Drawing.Size(236, 20);
-            this.nudCritChance.TabIndex = 59;
-            this.nudCritChance.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudCritChance.ValueChanged += new System.EventHandler(this.nudCritChance_ValueChanged);
+            nudCritChance.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudCritChance.ForeColor = System.Drawing.Color.Gainsboro;
+            nudCritChance.Location = new System.Drawing.Point(15, 87);
+            nudCritChance.Margin = new Padding(4, 3, 4, 3);
+            nudCritChance.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            nudCritChance.Name = "nudCritChance";
+            nudCritChance.Size = new Size(275, 23);
+            nudCritChance.TabIndex = 59;
+            nudCritChance.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudCritChance.ValueChanged += nudCritChance_ValueChanged;
             // 
             // cmbScalingStat
             // 
-            this.cmbScalingStat.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbScalingStat.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbScalingStat.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbScalingStat.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbScalingStat.DrawDropdownHoverOutline = false;
-            this.cmbScalingStat.DrawFocusRectangle = false;
-            this.cmbScalingStat.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbScalingStat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbScalingStat.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbScalingStat.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbScalingStat.FormattingEnabled = true;
-            this.cmbScalingStat.Location = new System.Drawing.Point(13, 208);
-            this.cmbScalingStat.Name = "cmbScalingStat";
-            this.cmbScalingStat.Size = new System.Drawing.Size(236, 21);
-            this.cmbScalingStat.TabIndex = 58;
-            this.cmbScalingStat.Text = null;
-            this.cmbScalingStat.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbScalingStat.SelectedIndexChanged += new System.EventHandler(this.cmbScalingStat_SelectedIndexChanged);
+            cmbScalingStat.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbScalingStat.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbScalingStat.BorderStyle = ButtonBorderStyle.Solid;
+            cmbScalingStat.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbScalingStat.DrawDropdownHoverOutline = false;
+            cmbScalingStat.DrawFocusRectangle = false;
+            cmbScalingStat.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbScalingStat.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbScalingStat.FlatStyle = FlatStyle.Flat;
+            cmbScalingStat.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbScalingStat.FormattingEnabled = true;
+            cmbScalingStat.Location = new System.Drawing.Point(15, 240);
+            cmbScalingStat.Margin = new Padding(4, 3, 4, 3);
+            cmbScalingStat.Name = "cmbScalingStat";
+            cmbScalingStat.Size = new Size(275, 24);
+            cmbScalingStat.TabIndex = 58;
+            cmbScalingStat.Text = null;
+            cmbScalingStat.TextPadding = new Padding(2);
+            cmbScalingStat.SelectedIndexChanged += cmbScalingStat_SelectedIndexChanged;
             // 
             // lblScalingStat
             // 
-            this.lblScalingStat.AutoSize = true;
-            this.lblScalingStat.Location = new System.Drawing.Point(10, 191);
-            this.lblScalingStat.Name = "lblScalingStat";
-            this.lblScalingStat.Size = new System.Drawing.Size(67, 13);
-            this.lblScalingStat.TabIndex = 57;
-            this.lblScalingStat.Text = "Scaling Stat:";
+            lblScalingStat.AutoSize = true;
+            lblScalingStat.Location = new System.Drawing.Point(12, 220);
+            lblScalingStat.Margin = new Padding(4, 0, 4, 0);
+            lblScalingStat.Name = "lblScalingStat";
+            lblScalingStat.Size = new Size(71, 15);
+            lblScalingStat.TabIndex = 57;
+            lblScalingStat.Text = "Scaling Stat:";
             // 
             // lblScaling
             // 
-            this.lblScaling.AutoSize = true;
-            this.lblScaling.Location = new System.Drawing.Point(9, 237);
-            this.lblScaling.Name = "lblScaling";
-            this.lblScaling.Size = new System.Drawing.Size(84, 13);
-            this.lblScaling.TabIndex = 56;
-            this.lblScaling.Text = "Scaling Amount:";
+            lblScaling.AutoSize = true;
+            lblScaling.Location = new System.Drawing.Point(10, 273);
+            lblScaling.Margin = new Padding(4, 0, 4, 0);
+            lblScaling.Name = "lblScaling";
+            lblScaling.Size = new Size(95, 15);
+            lblScaling.TabIndex = 56;
+            lblScaling.Text = "Scaling Amount:";
             // 
             // cmbDamageType
             // 
-            this.cmbDamageType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbDamageType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbDamageType.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbDamageType.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbDamageType.DrawDropdownHoverOutline = false;
-            this.cmbDamageType.DrawFocusRectangle = false;
-            this.cmbDamageType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbDamageType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbDamageType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbDamageType.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbDamageType.FormattingEnabled = true;
-            this.cmbDamageType.Items.AddRange(new object[] {
-            "Physical",
-            "Magic",
-            "True"});
-            this.cmbDamageType.Location = new System.Drawing.Point(12, 162);
-            this.cmbDamageType.Name = "cmbDamageType";
-            this.cmbDamageType.Size = new System.Drawing.Size(236, 21);
-            this.cmbDamageType.TabIndex = 54;
-            this.cmbDamageType.Text = "Physical";
-            this.cmbDamageType.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbDamageType.SelectedIndexChanged += new System.EventHandler(this.cmbDamageType_SelectedIndexChanged);
+            cmbDamageType.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDamageType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDamageType.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDamageType.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDamageType.DrawDropdownHoverOutline = false;
+            cmbDamageType.DrawFocusRectangle = false;
+            cmbDamageType.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDamageType.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDamageType.FlatStyle = FlatStyle.Flat;
+            cmbDamageType.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDamageType.FormattingEnabled = true;
+            cmbDamageType.Items.AddRange(new object[] { "Physical", "Magic", "True" });
+            cmbDamageType.Location = new System.Drawing.Point(14, 187);
+            cmbDamageType.Margin = new Padding(4, 3, 4, 3);
+            cmbDamageType.Name = "cmbDamageType";
+            cmbDamageType.Size = new Size(275, 24);
+            cmbDamageType.TabIndex = 54;
+            cmbDamageType.Text = "Physical";
+            cmbDamageType.TextPadding = new Padding(2);
+            cmbDamageType.SelectedIndexChanged += cmbDamageType_SelectedIndexChanged;
             // 
             // lblDamageType
             // 
-            this.lblDamageType.AutoSize = true;
-            this.lblDamageType.Location = new System.Drawing.Point(9, 145);
-            this.lblDamageType.Name = "lblDamageType";
-            this.lblDamageType.Size = new System.Drawing.Size(77, 13);
-            this.lblDamageType.TabIndex = 53;
-            this.lblDamageType.Text = "Damage Type:";
+            lblDamageType.AutoSize = true;
+            lblDamageType.Location = new System.Drawing.Point(10, 167);
+            lblDamageType.Margin = new Padding(4, 0, 4, 0);
+            lblDamageType.Name = "lblDamageType";
+            lblDamageType.Size = new Size(81, 15);
+            lblDamageType.TabIndex = 53;
+            lblDamageType.Text = "Damage Type:";
             // 
             // lblCritChance
             // 
-            this.lblCritChance.AutoSize = true;
-            this.lblCritChance.Location = new System.Drawing.Point(9, 62);
-            this.lblCritChance.Name = "lblCritChance";
-            this.lblCritChance.Size = new System.Drawing.Size(82, 13);
-            this.lblCritChance.TabIndex = 52;
-            this.lblCritChance.Text = "Crit Chance (%):";
+            lblCritChance.AutoSize = true;
+            lblCritChance.Location = new System.Drawing.Point(10, 72);
+            lblCritChance.Margin = new Padding(4, 0, 4, 0);
+            lblCritChance.Name = "lblCritChance";
+            lblCritChance.Size = new Size(93, 15);
+            lblCritChance.TabIndex = 52;
+            lblCritChance.Text = "Crit Chance (%):";
             // 
             // cmbAttackAnimation
             // 
-            this.cmbAttackAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbAttackAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbAttackAnimation.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbAttackAnimation.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbAttackAnimation.DrawDropdownHoverOutline = false;
-            this.cmbAttackAnimation.DrawFocusRectangle = false;
-            this.cmbAttackAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbAttackAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbAttackAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbAttackAnimation.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbAttackAnimation.FormattingEnabled = true;
-            this.cmbAttackAnimation.Location = new System.Drawing.Point(12, 300);
-            this.cmbAttackAnimation.Name = "cmbAttackAnimation";
-            this.cmbAttackAnimation.Size = new System.Drawing.Size(237, 21);
-            this.cmbAttackAnimation.TabIndex = 50;
-            this.cmbAttackAnimation.Text = null;
-            this.cmbAttackAnimation.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbAttackAnimation.SelectedIndexChanged += new System.EventHandler(this.cmbAttackAnimation_SelectedIndexChanged);
+            cmbAttackAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbAttackAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbAttackAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbAttackAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbAttackAnimation.DrawDropdownHoverOutline = false;
+            cmbAttackAnimation.DrawFocusRectangle = false;
+            cmbAttackAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbAttackAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbAttackAnimation.FlatStyle = FlatStyle.Flat;
+            cmbAttackAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbAttackAnimation.FormattingEnabled = true;
+            cmbAttackAnimation.Location = new System.Drawing.Point(14, 346);
+            cmbAttackAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbAttackAnimation.Name = "cmbAttackAnimation";
+            cmbAttackAnimation.Size = new Size(276, 24);
+            cmbAttackAnimation.TabIndex = 50;
+            cmbAttackAnimation.Text = null;
+            cmbAttackAnimation.TextPadding = new Padding(2);
+            cmbAttackAnimation.SelectedIndexChanged += cmbAttackAnimation_SelectedIndexChanged;
             // 
             // lblAttackAnimation
             // 
-            this.lblAttackAnimation.AutoSize = true;
-            this.lblAttackAnimation.Location = new System.Drawing.Point(9, 285);
-            this.lblAttackAnimation.Name = "lblAttackAnimation";
-            this.lblAttackAnimation.Size = new System.Drawing.Size(90, 13);
-            this.lblAttackAnimation.TabIndex = 49;
-            this.lblAttackAnimation.Text = "Attack Animation:";
+            lblAttackAnimation.AutoSize = true;
+            lblAttackAnimation.Location = new System.Drawing.Point(10, 329);
+            lblAttackAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblAttackAnimation.Name = "lblAttackAnimation";
+            lblAttackAnimation.Size = new Size(103, 15);
+            lblAttackAnimation.TabIndex = 49;
+            lblAttackAnimation.Text = "Attack Animation:";
             // 
             // lblDamage
             // 
-            this.lblDamage.AutoSize = true;
-            this.lblDamage.Location = new System.Drawing.Point(9, 18);
-            this.lblDamage.Name = "lblDamage";
-            this.lblDamage.Size = new System.Drawing.Size(77, 13);
-            this.lblDamage.TabIndex = 48;
-            this.lblDamage.Text = "Base Damage:";
+            lblDamage.AutoSize = true;
+            lblDamage.Location = new System.Drawing.Point(10, 21);
+            lblDamage.Margin = new Padding(4, 0, 4, 0);
+            lblDamage.Name = "lblDamage";
+            lblDamage.Size = new Size(81, 15);
+            lblDamage.TabIndex = 48;
+            lblDamage.Text = "Base Damage:";
             // 
             // grpCommonEvents
             // 
-            this.grpCommonEvents.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpCommonEvents.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpCommonEvents.Controls.Add(this.cmbOnDeathEventParty);
-            this.grpCommonEvents.Controls.Add(this.lblOnDeathEventParty);
-            this.grpCommonEvents.Controls.Add(this.cmbOnDeathEventKiller);
-            this.grpCommonEvents.Controls.Add(this.lblOnDeathEventKiller);
-            this.grpCommonEvents.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpCommonEvents.Location = new System.Drawing.Point(9, 299);
-            this.grpCommonEvents.Margin = new System.Windows.Forms.Padding(2);
-            this.grpCommonEvents.Name = "grpCommonEvents";
-            this.grpCommonEvents.Padding = new System.Windows.Forms.Padding(2);
-            this.grpCommonEvents.Size = new System.Drawing.Size(207, 116);
-            this.grpCommonEvents.TabIndex = 32;
-            this.grpCommonEvents.TabStop = false;
-            this.grpCommonEvents.Text = "Common Events";
+            grpCommonEvents.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpCommonEvents.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpCommonEvents.Controls.Add(cmbOnDeathEventParty);
+            grpCommonEvents.Controls.Add(lblOnDeathEventParty);
+            grpCommonEvents.Controls.Add(cmbOnDeathEventKiller);
+            grpCommonEvents.Controls.Add(lblOnDeathEventKiller);
+            grpCommonEvents.ForeColor = System.Drawing.Color.Gainsboro;
+            grpCommonEvents.Location = new System.Drawing.Point(10, 345);
+            grpCommonEvents.Margin = new Padding(2);
+            grpCommonEvents.Name = "grpCommonEvents";
+            grpCommonEvents.Padding = new Padding(2);
+            grpCommonEvents.Size = new Size(241, 134);
+            grpCommonEvents.TabIndex = 32;
+            grpCommonEvents.TabStop = false;
+            grpCommonEvents.Text = "Common Events";
             // 
             // cmbOnDeathEventParty
             // 
-            this.cmbOnDeathEventParty.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbOnDeathEventParty.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbOnDeathEventParty.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbOnDeathEventParty.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbOnDeathEventParty.DrawDropdownHoverOutline = false;
-            this.cmbOnDeathEventParty.DrawFocusRectangle = false;
-            this.cmbOnDeathEventParty.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbOnDeathEventParty.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbOnDeathEventParty.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbOnDeathEventParty.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbOnDeathEventParty.FormattingEnabled = true;
-            this.cmbOnDeathEventParty.Location = new System.Drawing.Point(12, 80);
-            this.cmbOnDeathEventParty.Name = "cmbOnDeathEventParty";
-            this.cmbOnDeathEventParty.Size = new System.Drawing.Size(182, 21);
-            this.cmbOnDeathEventParty.TabIndex = 21;
-            this.cmbOnDeathEventParty.Text = null;
-            this.cmbOnDeathEventParty.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbOnDeathEventParty.SelectedIndexChanged += new System.EventHandler(this.cmbOnDeathEventParty_SelectedIndexChanged);
+            cmbOnDeathEventParty.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbOnDeathEventParty.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbOnDeathEventParty.BorderStyle = ButtonBorderStyle.Solid;
+            cmbOnDeathEventParty.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbOnDeathEventParty.DrawDropdownHoverOutline = false;
+            cmbOnDeathEventParty.DrawFocusRectangle = false;
+            cmbOnDeathEventParty.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbOnDeathEventParty.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbOnDeathEventParty.FlatStyle = FlatStyle.Flat;
+            cmbOnDeathEventParty.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbOnDeathEventParty.FormattingEnabled = true;
+            cmbOnDeathEventParty.Location = new System.Drawing.Point(14, 92);
+            cmbOnDeathEventParty.Margin = new Padding(4, 3, 4, 3);
+            cmbOnDeathEventParty.Name = "cmbOnDeathEventParty";
+            cmbOnDeathEventParty.Size = new Size(212, 24);
+            cmbOnDeathEventParty.TabIndex = 21;
+            cmbOnDeathEventParty.Text = null;
+            cmbOnDeathEventParty.TextPadding = new Padding(2);
+            cmbOnDeathEventParty.SelectedIndexChanged += cmbOnDeathEventParty_SelectedIndexChanged;
             // 
             // lblOnDeathEventParty
             // 
-            this.lblOnDeathEventParty.AutoSize = true;
-            this.lblOnDeathEventParty.Location = new System.Drawing.Point(9, 64);
-            this.lblOnDeathEventParty.Name = "lblOnDeathEventParty";
-            this.lblOnDeathEventParty.Size = new System.Drawing.Size(103, 13);
-            this.lblOnDeathEventParty.TabIndex = 20;
-            this.lblOnDeathEventParty.Text = "On Death (for party):";
+            lblOnDeathEventParty.AutoSize = true;
+            lblOnDeathEventParty.Location = new System.Drawing.Point(10, 74);
+            lblOnDeathEventParty.Margin = new Padding(4, 0, 4, 0);
+            lblOnDeathEventParty.Name = "lblOnDeathEventParty";
+            lblOnDeathEventParty.Size = new Size(116, 15);
+            lblOnDeathEventParty.TabIndex = 20;
+            lblOnDeathEventParty.Text = "On Death (for party):";
             // 
             // cmbOnDeathEventKiller
             // 
-            this.cmbOnDeathEventKiller.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbOnDeathEventKiller.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbOnDeathEventKiller.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbOnDeathEventKiller.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbOnDeathEventKiller.DrawDropdownHoverOutline = false;
-            this.cmbOnDeathEventKiller.DrawFocusRectangle = false;
-            this.cmbOnDeathEventKiller.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbOnDeathEventKiller.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbOnDeathEventKiller.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbOnDeathEventKiller.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbOnDeathEventKiller.FormattingEnabled = true;
-            this.cmbOnDeathEventKiller.Location = new System.Drawing.Point(12, 36);
-            this.cmbOnDeathEventKiller.Name = "cmbOnDeathEventKiller";
-            this.cmbOnDeathEventKiller.Size = new System.Drawing.Size(182, 21);
-            this.cmbOnDeathEventKiller.TabIndex = 19;
-            this.cmbOnDeathEventKiller.Text = null;
-            this.cmbOnDeathEventKiller.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbOnDeathEventKiller.SelectedIndexChanged += new System.EventHandler(this.cmbOnDeathEventKiller_SelectedIndexChanged);
+            cmbOnDeathEventKiller.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbOnDeathEventKiller.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbOnDeathEventKiller.BorderStyle = ButtonBorderStyle.Solid;
+            cmbOnDeathEventKiller.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbOnDeathEventKiller.DrawDropdownHoverOutline = false;
+            cmbOnDeathEventKiller.DrawFocusRectangle = false;
+            cmbOnDeathEventKiller.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbOnDeathEventKiller.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbOnDeathEventKiller.FlatStyle = FlatStyle.Flat;
+            cmbOnDeathEventKiller.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbOnDeathEventKiller.FormattingEnabled = true;
+            cmbOnDeathEventKiller.Location = new System.Drawing.Point(14, 42);
+            cmbOnDeathEventKiller.Margin = new Padding(4, 3, 4, 3);
+            cmbOnDeathEventKiller.Name = "cmbOnDeathEventKiller";
+            cmbOnDeathEventKiller.Size = new Size(212, 24);
+            cmbOnDeathEventKiller.TabIndex = 19;
+            cmbOnDeathEventKiller.Text = null;
+            cmbOnDeathEventKiller.TextPadding = new Padding(2);
+            cmbOnDeathEventKiller.SelectedIndexChanged += cmbOnDeathEventKiller_SelectedIndexChanged;
             // 
             // lblOnDeathEventKiller
             // 
-            this.lblOnDeathEventKiller.AutoSize = true;
-            this.lblOnDeathEventKiller.Location = new System.Drawing.Point(9, 20);
-            this.lblOnDeathEventKiller.Name = "lblOnDeathEventKiller";
-            this.lblOnDeathEventKiller.Size = new System.Drawing.Size(101, 13);
-            this.lblOnDeathEventKiller.TabIndex = 18;
-            this.lblOnDeathEventKiller.Text = "On Death (for killer):";
+            lblOnDeathEventKiller.AutoSize = true;
+            lblOnDeathEventKiller.Location = new System.Drawing.Point(10, 23);
+            lblOnDeathEventKiller.Margin = new Padding(4, 0, 4, 0);
+            lblOnDeathEventKiller.Name = "lblOnDeathEventKiller";
+            lblOnDeathEventKiller.Size = new Size(114, 15);
+            lblOnDeathEventKiller.TabIndex = 18;
+            lblOnDeathEventKiller.Text = "On Death (for killer):";
             // 
             // grpBehavior
             // 
-            this.grpBehavior.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpBehavior.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpBehavior.Controls.Add(this.nudResetRadius);
-            this.grpBehavior.Controls.Add(this.lblResetRadius);
-            this.grpBehavior.Controls.Add(this.chkFocusDamageDealer);
-            this.grpBehavior.Controls.Add(this.nudSpawnDuration);
-            this.grpBehavior.Controls.Add(this.lblSpawnDuration);
-            this.grpBehavior.Controls.Add(this.nudFlee);
-            this.grpBehavior.Controls.Add(this.lblFlee);
-            this.grpBehavior.Controls.Add(this.chkSwarm);
-            this.grpBehavior.Controls.Add(this.grpConditions);
-            this.grpBehavior.Controls.Add(this.lblMovement);
-            this.grpBehavior.Controls.Add(this.cmbMovement);
-            this.grpBehavior.Controls.Add(this.chkAggressive);
-            this.grpBehavior.Controls.Add(this.nudSightRange);
-            this.grpBehavior.Controls.Add(this.lblSightRange);
-            this.grpBehavior.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpBehavior.Location = new System.Drawing.Point(723, 5);
-            this.grpBehavior.Name = "grpBehavior";
-            this.grpBehavior.Size = new System.Drawing.Size(226, 339);
-            this.grpBehavior.TabIndex = 32;
-            this.grpBehavior.TabStop = false;
-            this.grpBehavior.Text = "Behavior:";
+            grpBehavior.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpBehavior.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpBehavior.Controls.Add(nudResetRadius);
+            grpBehavior.Controls.Add(lblResetRadius);
+            grpBehavior.Controls.Add(chkFocusDamageDealer);
+            grpBehavior.Controls.Add(nudSpawnDuration);
+            grpBehavior.Controls.Add(lblSpawnDuration);
+            grpBehavior.Controls.Add(nudFlee);
+            grpBehavior.Controls.Add(lblFlee);
+            grpBehavior.Controls.Add(chkSwarm);
+            grpBehavior.Controls.Add(grpConditions);
+            grpBehavior.Controls.Add(lblMovement);
+            grpBehavior.Controls.Add(cmbMovement);
+            grpBehavior.Controls.Add(chkAggressive);
+            grpBehavior.Controls.Add(nudSightRange);
+            grpBehavior.Controls.Add(lblSightRange);
+            grpBehavior.ForeColor = System.Drawing.Color.Gainsboro;
+            grpBehavior.Location = new System.Drawing.Point(844, 6);
+            grpBehavior.Margin = new Padding(4, 3, 4, 3);
+            grpBehavior.Name = "grpBehavior";
+            grpBehavior.Padding = new Padding(4, 3, 4, 3);
+            grpBehavior.Size = new Size(264, 391);
+            grpBehavior.TabIndex = 32;
+            grpBehavior.TabStop = false;
+            grpBehavior.Text = "Behavior:";
             // 
             // nudResetRadius
             // 
-            this.nudResetRadius.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudResetRadius.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudResetRadius.Location = new System.Drawing.Point(102, 98);
-            this.nudResetRadius.Maximum = new decimal(new int[] {
-            9999,
-            0,
-            0,
-            0});
-            this.nudResetRadius.Name = "nudResetRadius";
-            this.nudResetRadius.Size = new System.Drawing.Size(116, 20);
-            this.nudResetRadius.TabIndex = 76;
-            this.nudResetRadius.Value = new decimal(new int[] {
-            9999,
-            0,
-            0,
-            0});
-            this.nudResetRadius.ValueChanged += new System.EventHandler(this.nudResetRadius_ValueChanged);
+            nudResetRadius.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudResetRadius.ForeColor = System.Drawing.Color.Gainsboro;
+            nudResetRadius.Location = new System.Drawing.Point(119, 113);
+            nudResetRadius.Margin = new Padding(4, 3, 4, 3);
+            nudResetRadius.Maximum = new decimal(new int[] { 9999, 0, 0, 0 });
+            nudResetRadius.Name = "nudResetRadius";
+            nudResetRadius.Size = new Size(135, 23);
+            nudResetRadius.TabIndex = 76;
+            nudResetRadius.Value = new decimal(new int[] { 9999, 0, 0, 0 });
+            nudResetRadius.ValueChanged += nudResetRadius_ValueChanged;
             // 
             // lblResetRadius
             // 
-            this.lblResetRadius.AutoSize = true;
-            this.lblResetRadius.Location = new System.Drawing.Point(10, 100);
-            this.lblResetRadius.Name = "lblResetRadius";
-            this.lblResetRadius.Size = new System.Drawing.Size(74, 13);
-            this.lblResetRadius.TabIndex = 75;
-            this.lblResetRadius.Text = "Reset Radius:";
+            lblResetRadius.AutoSize = true;
+            lblResetRadius.Location = new System.Drawing.Point(12, 115);
+            lblResetRadius.Margin = new Padding(4, 0, 4, 0);
+            lblResetRadius.Name = "lblResetRadius";
+            lblResetRadius.Size = new Size(76, 15);
+            lblResetRadius.TabIndex = 75;
+            lblResetRadius.Text = "Reset Radius:";
             // 
             // chkFocusDamageDealer
             // 
-            this.chkFocusDamageDealer.AutoSize = true;
-            this.chkFocusDamageDealer.Location = new System.Drawing.Point(13, 42);
-            this.chkFocusDamageDealer.Name = "chkFocusDamageDealer";
-            this.chkFocusDamageDealer.Size = new System.Drawing.Size(174, 17);
-            this.chkFocusDamageDealer.TabIndex = 71;
-            this.chkFocusDamageDealer.Text = "Focus Highest Damage Dealer:";
-            this.chkFocusDamageDealer.CheckedChanged += new System.EventHandler(this.chkFocusDamageDealer_CheckedChanged);
+            chkFocusDamageDealer.AutoSize = true;
+            chkFocusDamageDealer.Location = new System.Drawing.Point(15, 48);
+            chkFocusDamageDealer.Margin = new Padding(4, 3, 4, 3);
+            chkFocusDamageDealer.Name = "chkFocusDamageDealer";
+            chkFocusDamageDealer.Size = new Size(187, 19);
+            chkFocusDamageDealer.TabIndex = 71;
+            chkFocusDamageDealer.Text = "Focus Highest Damage Dealer:";
+            chkFocusDamageDealer.CheckedChanged += chkFocusDamageDealer_CheckedChanged;
             // 
             // nudFlee
             // 
-            this.nudFlee.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudFlee.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudFlee.Location = new System.Drawing.Point(102, 186);
-            this.nudFlee.Name = "nudFlee";
-            this.nudFlee.Size = new System.Drawing.Size(116, 20);
-            this.nudFlee.TabIndex = 70;
-            this.nudFlee.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudFlee.ValueChanged += new System.EventHandler(this.nudFlee_ValueChanged);
+            nudFlee.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudFlee.ForeColor = System.Drawing.Color.Gainsboro;
+            nudFlee.Location = new System.Drawing.Point(119, 215);
+            nudFlee.Margin = new Padding(4, 3, 4, 3);
+            nudFlee.Name = "nudFlee";
+            nudFlee.Size = new Size(135, 23);
+            nudFlee.TabIndex = 70;
+            nudFlee.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudFlee.ValueChanged += nudFlee_ValueChanged;
             // 
             // lblFlee
             // 
-            this.lblFlee.AutoSize = true;
-            this.lblFlee.Location = new System.Drawing.Point(10, 188);
-            this.lblFlee.Name = "lblFlee";
-            this.lblFlee.Size = new System.Drawing.Size(75, 13);
-            this.lblFlee.TabIndex = 69;
-            this.lblFlee.Text = "Flee Health %:";
+            lblFlee.AutoSize = true;
+            lblFlee.Location = new System.Drawing.Point(12, 217);
+            lblFlee.Margin = new Padding(4, 0, 4, 0);
+            lblFlee.Name = "lblFlee";
+            lblFlee.Size = new Size(82, 15);
+            lblFlee.TabIndex = 69;
+            lblFlee.Text = "Flee Health %:";
             // 
             // chkSwarm
             // 
-            this.chkSwarm.AutoSize = true;
-            this.chkSwarm.Location = new System.Drawing.Point(162, 17);
-            this.chkSwarm.Name = "chkSwarm";
-            this.chkSwarm.Size = new System.Drawing.Size(58, 17);
-            this.chkSwarm.TabIndex = 67;
-            this.chkSwarm.Text = "Swarm";
-            this.chkSwarm.CheckedChanged += new System.EventHandler(this.chkSwarm_CheckedChanged);
+            chkSwarm.AutoSize = true;
+            chkSwarm.Location = new System.Drawing.Point(189, 20);
+            chkSwarm.Margin = new Padding(4, 3, 4, 3);
+            chkSwarm.Name = "chkSwarm";
+            chkSwarm.Size = new Size(62, 19);
+            chkSwarm.TabIndex = 67;
+            chkSwarm.Text = "Swarm";
+            chkSwarm.CheckedChanged += chkSwarm_CheckedChanged;
             // 
             // grpConditions
             // 
-            this.grpConditions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpConditions.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpConditions.Controls.Add(this.btnAttackOnSightCond);
-            this.grpConditions.Controls.Add(this.btnPlayerCanAttackCond);
-            this.grpConditions.Controls.Add(this.btnPlayerFriendProtectorCond);
-            this.grpConditions.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpConditions.Location = new System.Drawing.Point(10, 215);
-            this.grpConditions.Name = "grpConditions";
-            this.grpConditions.Size = new System.Drawing.Size(208, 108);
-            this.grpConditions.TabIndex = 66;
-            this.grpConditions.TabStop = false;
-            this.grpConditions.Text = "Conditions:";
+            grpConditions.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpConditions.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpConditions.Controls.Add(btnAttackOnSightCond);
+            grpConditions.Controls.Add(btnPlayerCanAttackCond);
+            grpConditions.Controls.Add(btnPlayerFriendProtectorCond);
+            grpConditions.ForeColor = System.Drawing.Color.Gainsboro;
+            grpConditions.Location = new System.Drawing.Point(12, 248);
+            grpConditions.Margin = new Padding(4, 3, 4, 3);
+            grpConditions.Name = "grpConditions";
+            grpConditions.Padding = new Padding(4, 3, 4, 3);
+            grpConditions.Size = new Size(243, 125);
+            grpConditions.TabIndex = 66;
+            grpConditions.TabStop = false;
+            grpConditions.Text = "Conditions:";
             // 
             // btnAttackOnSightCond
             // 
-            this.btnAttackOnSightCond.Location = new System.Drawing.Point(6, 48);
-            this.btnAttackOnSightCond.Name = "btnAttackOnSightCond";
-            this.btnAttackOnSightCond.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAttackOnSightCond.Size = new System.Drawing.Size(195, 23);
-            this.btnAttackOnSightCond.TabIndex = 47;
-            this.btnAttackOnSightCond.Text = "Should Not Attack Player On Sight";
-            this.btnAttackOnSightCond.Click += new System.EventHandler(this.btnAttackOnSightCond_Click);
+            btnAttackOnSightCond.Location = new System.Drawing.Point(7, 55);
+            btnAttackOnSightCond.Margin = new Padding(4, 3, 4, 3);
+            btnAttackOnSightCond.Name = "btnAttackOnSightCond";
+            btnAttackOnSightCond.Padding = new Padding(6);
+            btnAttackOnSightCond.Size = new Size(227, 27);
+            btnAttackOnSightCond.TabIndex = 47;
+            btnAttackOnSightCond.Text = "Should Not Attack Player On Sight";
+            btnAttackOnSightCond.Click += btnAttackOnSightCond_Click;
             // 
             // btnPlayerCanAttackCond
             // 
-            this.btnPlayerCanAttackCond.Location = new System.Drawing.Point(6, 77);
-            this.btnPlayerCanAttackCond.Name = "btnPlayerCanAttackCond";
-            this.btnPlayerCanAttackCond.Padding = new System.Windows.Forms.Padding(5);
-            this.btnPlayerCanAttackCond.Size = new System.Drawing.Size(195, 23);
-            this.btnPlayerCanAttackCond.TabIndex = 46;
-            this.btnPlayerCanAttackCond.Text = "Player Can Attack (Default: True)";
-            this.btnPlayerCanAttackCond.Click += new System.EventHandler(this.btnPlayerCanAttackCond_Click);
+            btnPlayerCanAttackCond.Location = new System.Drawing.Point(7, 89);
+            btnPlayerCanAttackCond.Margin = new Padding(4, 3, 4, 3);
+            btnPlayerCanAttackCond.Name = "btnPlayerCanAttackCond";
+            btnPlayerCanAttackCond.Padding = new Padding(6);
+            btnPlayerCanAttackCond.Size = new Size(227, 27);
+            btnPlayerCanAttackCond.TabIndex = 46;
+            btnPlayerCanAttackCond.Text = "Player Can Attack (Default: True)";
+            btnPlayerCanAttackCond.Click += btnPlayerCanAttackCond_Click;
             // 
             // btnPlayerFriendProtectorCond
             // 
-            this.btnPlayerFriendProtectorCond.Location = new System.Drawing.Point(6, 19);
-            this.btnPlayerFriendProtectorCond.Name = "btnPlayerFriendProtectorCond";
-            this.btnPlayerFriendProtectorCond.Padding = new System.Windows.Forms.Padding(5);
-            this.btnPlayerFriendProtectorCond.Size = new System.Drawing.Size(195, 23);
-            this.btnPlayerFriendProtectorCond.TabIndex = 44;
-            this.btnPlayerFriendProtectorCond.Text = "Player Friend/Protector";
-            this.btnPlayerFriendProtectorCond.Click += new System.EventHandler(this.btnPlayerFriendProtectorCond_Click);
+            btnPlayerFriendProtectorCond.Location = new System.Drawing.Point(7, 22);
+            btnPlayerFriendProtectorCond.Margin = new Padding(4, 3, 4, 3);
+            btnPlayerFriendProtectorCond.Name = "btnPlayerFriendProtectorCond";
+            btnPlayerFriendProtectorCond.Padding = new Padding(6);
+            btnPlayerFriendProtectorCond.Size = new Size(227, 27);
+            btnPlayerFriendProtectorCond.TabIndex = 44;
+            btnPlayerFriendProtectorCond.Text = "Player Friend/Protector";
+            btnPlayerFriendProtectorCond.Click += btnPlayerFriendProtectorCond_Click;
             // 
             // lblMovement
             // 
-            this.lblMovement.AutoSize = true;
-            this.lblMovement.Location = new System.Drawing.Point(10, 130);
-            this.lblMovement.Name = "lblMovement";
-            this.lblMovement.Size = new System.Drawing.Size(60, 13);
-            this.lblMovement.TabIndex = 65;
-            this.lblMovement.Text = "Movement:";
+            lblMovement.AutoSize = true;
+            lblMovement.Location = new System.Drawing.Point(12, 150);
+            lblMovement.Margin = new Padding(4, 0, 4, 0);
+            lblMovement.Name = "lblMovement";
+            lblMovement.Size = new Size(68, 15);
+            lblMovement.TabIndex = 65;
+            lblMovement.Text = "Movement:";
             // 
             // cmbMovement
             // 
-            this.cmbMovement.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbMovement.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbMovement.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbMovement.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbMovement.DrawDropdownHoverOutline = false;
-            this.cmbMovement.DrawFocusRectangle = false;
-            this.cmbMovement.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbMovement.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbMovement.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbMovement.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbMovement.FormattingEnabled = true;
-            this.cmbMovement.Items.AddRange(new object[] {
-            "Move Randomly",
-            "Turn Randomly",
-            "No Movement"});
-            this.cmbMovement.Location = new System.Drawing.Point(102, 127);
-            this.cmbMovement.Name = "cmbMovement";
-            this.cmbMovement.Size = new System.Drawing.Size(116, 21);
-            this.cmbMovement.TabIndex = 64;
-            this.cmbMovement.Text = "Move Randomly";
-            this.cmbMovement.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbMovement.SelectedIndexChanged += new System.EventHandler(this.cmbMovement_SelectedIndexChanged);
+            cmbMovement.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbMovement.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbMovement.BorderStyle = ButtonBorderStyle.Solid;
+            cmbMovement.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbMovement.DrawDropdownHoverOutline = false;
+            cmbMovement.DrawFocusRectangle = false;
+            cmbMovement.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbMovement.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbMovement.FlatStyle = FlatStyle.Flat;
+            cmbMovement.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbMovement.FormattingEnabled = true;
+            cmbMovement.Items.AddRange(new object[] { "Move Randomly", "Turn Randomly", "No Movement" });
+            cmbMovement.Location = new System.Drawing.Point(119, 147);
+            cmbMovement.Margin = new Padding(4, 3, 4, 3);
+            cmbMovement.Name = "cmbMovement";
+            cmbMovement.Size = new Size(135, 24);
+            cmbMovement.TabIndex = 64;
+            cmbMovement.Text = "Move Randomly";
+            cmbMovement.TextPadding = new Padding(2);
+            cmbMovement.SelectedIndexChanged += cmbMovement_SelectedIndexChanged;
             // 
             // chkAggressive
             // 
-            this.chkAggressive.AutoSize = true;
-            this.chkAggressive.Location = new System.Drawing.Point(13, 17);
-            this.chkAggressive.Name = "chkAggressive";
-            this.chkAggressive.Size = new System.Drawing.Size(78, 17);
-            this.chkAggressive.TabIndex = 1;
-            this.chkAggressive.Text = "Aggressive";
-            this.chkAggressive.CheckedChanged += new System.EventHandler(this.chkAggressive_CheckedChanged);
+            chkAggressive.AutoSize = true;
+            chkAggressive.Location = new System.Drawing.Point(15, 20);
+            chkAggressive.Margin = new Padding(4, 3, 4, 3);
+            chkAggressive.Name = "chkAggressive";
+            chkAggressive.Size = new Size(83, 19);
+            chkAggressive.TabIndex = 1;
+            chkAggressive.Text = "Aggressive";
+            chkAggressive.CheckedChanged += chkAggressive_CheckedChanged;
             // 
             // grpRegen
             // 
-            this.grpRegen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpRegen.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpRegen.Controls.Add(this.nudMpRegen);
-            this.grpRegen.Controls.Add(this.nudHpRegen);
-            this.grpRegen.Controls.Add(this.lblHpRegen);
-            this.grpRegen.Controls.Add(this.lblManaRegen);
-            this.grpRegen.Controls.Add(this.lblRegenHint);
-            this.grpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpRegen.Location = new System.Drawing.Point(222, 5);
-            this.grpRegen.Margin = new System.Windows.Forms.Padding(2);
-            this.grpRegen.Name = "grpRegen";
-            this.grpRegen.Padding = new System.Windows.Forms.Padding(2);
-            this.grpRegen.Size = new System.Drawing.Size(230, 118);
-            this.grpRegen.TabIndex = 31;
-            this.grpRegen.TabStop = false;
-            this.grpRegen.Text = "Regen";
+            grpRegen.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpRegen.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpRegen.Controls.Add(nudMpRegen);
+            grpRegen.Controls.Add(nudHpRegen);
+            grpRegen.Controls.Add(lblHpRegen);
+            grpRegen.Controls.Add(lblManaRegen);
+            grpRegen.Controls.Add(lblRegenHint);
+            grpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            grpRegen.Location = new System.Drawing.Point(259, 6);
+            grpRegen.Margin = new Padding(2);
+            grpRegen.Name = "grpRegen";
+            grpRegen.Padding = new Padding(2);
+            grpRegen.Size = new Size(268, 136);
+            grpRegen.TabIndex = 31;
+            grpRegen.TabStop = false;
+            grpRegen.Text = "Regen";
             // 
             // nudMpRegen
             // 
-            this.nudMpRegen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMpRegen.Location = new System.Drawing.Point(120, 41);
-            this.nudMpRegen.Name = "nudMpRegen";
-            this.nudMpRegen.Size = new System.Drawing.Size(100, 20);
-            this.nudMpRegen.TabIndex = 31;
-            this.nudMpRegen.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMpRegen.ValueChanged += new System.EventHandler(this.nudMpRegen_ValueChanged);
+            nudMpRegen.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMpRegen.Location = new System.Drawing.Point(140, 47);
+            nudMpRegen.Margin = new Padding(4, 3, 4, 3);
+            nudMpRegen.Name = "nudMpRegen";
+            nudMpRegen.Size = new Size(117, 23);
+            nudMpRegen.TabIndex = 31;
+            nudMpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMpRegen.ValueChanged += nudMpRegen_ValueChanged;
             // 
             // nudHpRegen
             // 
-            this.nudHpRegen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudHpRegen.Location = new System.Drawing.Point(11, 41);
-            this.nudHpRegen.Name = "nudHpRegen";
-            this.nudHpRegen.Size = new System.Drawing.Size(100, 20);
-            this.nudHpRegen.TabIndex = 30;
-            this.nudHpRegen.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudHpRegen.ValueChanged += new System.EventHandler(this.nudHpRegen_ValueChanged);
+            nudHpRegen.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHpRegen.Location = new System.Drawing.Point(13, 47);
+            nudHpRegen.Margin = new Padding(4, 3, 4, 3);
+            nudHpRegen.Name = "nudHpRegen";
+            nudHpRegen.Size = new Size(117, 23);
+            nudHpRegen.TabIndex = 30;
+            nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
             // 
             // lblHpRegen
             // 
-            this.lblHpRegen.AutoSize = true;
-            this.lblHpRegen.Location = new System.Drawing.Point(8, 22);
-            this.lblHpRegen.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblHpRegen.Name = "lblHpRegen";
-            this.lblHpRegen.Size = new System.Drawing.Size(42, 13);
-            this.lblHpRegen.TabIndex = 26;
-            this.lblHpRegen.Text = "HP: (%)";
+            lblHpRegen.AutoSize = true;
+            lblHpRegen.Location = new System.Drawing.Point(9, 25);
+            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
+            lblHpRegen.Name = "lblHpRegen";
+            lblHpRegen.Size = new Size(47, 15);
+            lblHpRegen.TabIndex = 26;
+            lblHpRegen.Text = "HP: (%)";
             // 
             // lblManaRegen
             // 
-            this.lblManaRegen.AutoSize = true;
-            this.lblManaRegen.Location = new System.Drawing.Point(117, 22);
-            this.lblManaRegen.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblManaRegen.Name = "lblManaRegen";
-            this.lblManaRegen.Size = new System.Drawing.Size(54, 13);
-            this.lblManaRegen.TabIndex = 27;
-            this.lblManaRegen.Text = "Mana: (%)";
+            lblManaRegen.AutoSize = true;
+            lblManaRegen.Location = new System.Drawing.Point(136, 25);
+            lblManaRegen.Margin = new Padding(2, 0, 2, 0);
+            lblManaRegen.Name = "lblManaRegen";
+            lblManaRegen.Size = new Size(61, 15);
+            lblManaRegen.TabIndex = 27;
+            lblManaRegen.Text = "Mana: (%)";
             // 
             // lblRegenHint
             // 
-            this.lblRegenHint.Location = new System.Drawing.Point(6, 69);
-            this.lblRegenHint.Name = "lblRegenHint";
-            this.lblRegenHint.Size = new System.Drawing.Size(214, 44);
-            this.lblRegenHint.TabIndex = 0;
-            this.lblRegenHint.Text = "% of HP/Mana to restore per tick.\r\n\r\nTick timer saved in server config.json.";
+            lblRegenHint.Location = new System.Drawing.Point(7, 80);
+            lblRegenHint.Margin = new Padding(4, 0, 4, 0);
+            lblRegenHint.Name = "lblRegenHint";
+            lblRegenHint.Size = new Size(250, 51);
+            lblRegenHint.TabIndex = 0;
+            lblRegenHint.Text = "% of HP/Mana to restore per tick.\r\n\r\nTick timer saved in server config.json.";
             // 
             // grpDrops
             // 
-            this.grpDrops.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpDrops.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpDrops.Controls.Add(this.chkIndividualLoot);
-            this.grpDrops.Controls.Add(this.btnDropRemove);
-            this.grpDrops.Controls.Add(this.btnDropAdd);
-            this.grpDrops.Controls.Add(this.lstDrops);
-            this.grpDrops.Controls.Add(this.nudDropAmount);
-            this.grpDrops.Controls.Add(this.nudDropChance);
-            this.grpDrops.Controls.Add(this.cmbDropItem);
-            this.grpDrops.Controls.Add(this.lblDropAmount);
-            this.grpDrops.Controls.Add(this.lblDropChance);
-            this.grpDrops.Controls.Add(this.lblDropItem);
-            this.grpDrops.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpDrops.Location = new System.Drawing.Point(224, 354);
-            this.grpDrops.Name = "grpDrops";
-            this.grpDrops.Size = new System.Drawing.Size(228, 285);
-            this.grpDrops.TabIndex = 30;
-            this.grpDrops.TabStop = false;
-            this.grpDrops.Text = "Drops";
+            grpDrops.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpDrops.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpDrops.Controls.Add(nudDropMinAmount);
+            grpDrops.Controls.Add(lblDropMinAmount);
+            grpDrops.Controls.Add(chkIndividualLoot);
+            grpDrops.Controls.Add(btnDropRemove);
+            grpDrops.Controls.Add(btnDropAdd);
+            grpDrops.Controls.Add(lstDrops);
+            grpDrops.Controls.Add(nudDropAmount);
+            grpDrops.Controls.Add(nudDropChance);
+            grpDrops.Controls.Add(cmbDropItem);
+            grpDrops.Controls.Add(lblDropAmount);
+            grpDrops.Controls.Add(lblDropChance);
+            grpDrops.Controls.Add(lblDropItem);
+            grpDrops.ForeColor = System.Drawing.Color.Gainsboro;
+            grpDrops.Location = new System.Drawing.Point(261, 408);
+            grpDrops.Margin = new Padding(4, 3, 4, 3);
+            grpDrops.Name = "grpDrops";
+            grpDrops.Padding = new Padding(4, 3, 4, 3);
+            grpDrops.Size = new Size(266, 329);
+            grpDrops.TabIndex = 30;
+            grpDrops.TabStop = false;
+            grpDrops.Text = "Drops";
+            // 
+            // nudDropMinAmount
+            // 
+            nudDropMinAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropMinAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropMinAmount.Location = new System.Drawing.Point(20, 178);
+            nudDropMinAmount.Margin = new Padding(4, 3, 4, 3);
+            nudDropMinAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
+            nudDropMinAmount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropMinAmount.Name = "nudDropMinAmount";
+            nudDropMinAmount.Size = new Size(108, 23);
+            nudDropMinAmount.TabIndex = 80;
+            nudDropMinAmount.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropMinAmount.ValueChanged += nudDropMinAmount_ValueChanged;
+            // 
+            // lblDropMinAmount
+            // 
+            lblDropMinAmount.AutoSize = true;
+            lblDropMinAmount.Location = new System.Drawing.Point(20, 156);
+            lblDropMinAmount.Margin = new Padding(4, 0, 4, 0);
+            lblDropMinAmount.Name = "lblDropMinAmount";
+            lblDropMinAmount.Size = new Size(78, 15);
+            lblDropMinAmount.TabIndex = 79;
+            lblDropMinAmount.Text = "Min Amount:";
             // 
             // chkIndividualLoot
             // 
-            this.chkIndividualLoot.AutoSize = true;
-            this.chkIndividualLoot.Location = new System.Drawing.Point(17, 230);
-            this.chkIndividualLoot.Name = "chkIndividualLoot";
-            this.chkIndividualLoot.Size = new System.Drawing.Size(165, 17);
-            this.chkIndividualLoot.TabIndex = 78;
-            this.chkIndividualLoot.Text = "Spawn Loot for all Attackers?";
-            this.chkIndividualLoot.CheckedChanged += new System.EventHandler(this.chkIndividualLoot_CheckedChanged);
+            chkIndividualLoot.AutoSize = true;
+            chkIndividualLoot.Location = new System.Drawing.Point(20, 265);
+            chkIndividualLoot.Margin = new Padding(4, 3, 4, 3);
+            chkIndividualLoot.Name = "chkIndividualLoot";
+            chkIndividualLoot.Size = new Size(178, 19);
+            chkIndividualLoot.TabIndex = 78;
+            chkIndividualLoot.Text = "Spawn Loot for all Attackers?";
+            chkIndividualLoot.CheckedChanged += chkIndividualLoot_CheckedChanged;
             // 
             // btnDropRemove
             // 
-            this.btnDropRemove.Location = new System.Drawing.Point(143, 256);
-            this.btnDropRemove.Name = "btnDropRemove";
-            this.btnDropRemove.Padding = new System.Windows.Forms.Padding(5);
-            this.btnDropRemove.Size = new System.Drawing.Size(75, 23);
-            this.btnDropRemove.TabIndex = 64;
-            this.btnDropRemove.Text = "Remove";
-            this.btnDropRemove.Click += new System.EventHandler(this.btnDropRemove_Click);
+            btnDropRemove.Location = new System.Drawing.Point(167, 295);
+            btnDropRemove.Margin = new Padding(4, 3, 4, 3);
+            btnDropRemove.Name = "btnDropRemove";
+            btnDropRemove.Padding = new Padding(6);
+            btnDropRemove.Size = new Size(88, 27);
+            btnDropRemove.TabIndex = 64;
+            btnDropRemove.Text = "Remove";
+            btnDropRemove.Click += btnDropRemove_Click;
             // 
             // btnDropAdd
             // 
-            this.btnDropAdd.Location = new System.Drawing.Point(15, 256);
-            this.btnDropAdd.Name = "btnDropAdd";
-            this.btnDropAdd.Padding = new System.Windows.Forms.Padding(5);
-            this.btnDropAdd.Size = new System.Drawing.Size(75, 23);
-            this.btnDropAdd.TabIndex = 63;
-            this.btnDropAdd.Text = "Add";
-            this.btnDropAdd.Click += new System.EventHandler(this.btnDropAdd_Click);
+            btnDropAdd.Location = new System.Drawing.Point(18, 295);
+            btnDropAdd.Margin = new Padding(4, 3, 4, 3);
+            btnDropAdd.Name = "btnDropAdd";
+            btnDropAdd.Padding = new Padding(6);
+            btnDropAdd.Size = new Size(88, 27);
+            btnDropAdd.TabIndex = 63;
+            btnDropAdd.Text = "Add";
+            btnDropAdd.Click += btnDropAdd_Click;
             // 
             // lstDrops
             // 
-            this.lstDrops.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstDrops.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lstDrops.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstDrops.FormattingEnabled = true;
-            this.lstDrops.Location = new System.Drawing.Point(15, 19);
-            this.lstDrops.Name = "lstDrops";
-            this.lstDrops.Size = new System.Drawing.Size(203, 67);
-            this.lstDrops.TabIndex = 62;
-            this.lstDrops.SelectedIndexChanged += new System.EventHandler(this.lstDrops_SelectedIndexChanged);
+            lstDrops.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstDrops.BorderStyle = BorderStyle.FixedSingle;
+            lstDrops.ForeColor = System.Drawing.Color.Gainsboro;
+            lstDrops.FormattingEnabled = true;
+            lstDrops.ItemHeight = 15;
+            lstDrops.Location = new System.Drawing.Point(18, 22);
+            lstDrops.Margin = new Padding(4, 3, 4, 3);
+            lstDrops.Name = "lstDrops";
+            lstDrops.Size = new Size(236, 77);
+            lstDrops.TabIndex = 62;
+            lstDrops.SelectedIndexChanged += lstDrops_SelectedIndexChanged;
             // 
             // nudDropAmount
             // 
-            this.nudDropAmount.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDropAmount.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDropAmount.Location = new System.Drawing.Point(17, 153);
-            this.nudDropAmount.Maximum = new decimal(new int[] {
-            10000000,
-            0,
-            0,
-            0});
-            this.nudDropAmount.Name = "nudDropAmount";
-            this.nudDropAmount.Size = new System.Drawing.Size(201, 20);
-            this.nudDropAmount.TabIndex = 61;
-            this.nudDropAmount.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nudDropAmount.ValueChanged += new System.EventHandler(this.nudDropAmount_ValueChanged);
+            nudDropAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropAmount.Location = new System.Drawing.Point(147, 178);
+            nudDropAmount.Margin = new Padding(4, 3, 4, 3);
+            nudDropAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
+            nudDropAmount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropAmount.Name = "nudDropAmount";
+            nudDropAmount.Size = new Size(108, 23);
+            nudDropAmount.TabIndex = 61;
+            nudDropAmount.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropAmount.ValueChanged += nudDropAmount_ValueChanged;
             // 
             // nudDropChance
             // 
-            this.nudDropChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDropChance.DecimalPlaces = 2;
-            this.nudDropChance.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDropChance.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.nudDropChance.Location = new System.Drawing.Point(17, 200);
-            this.nudDropChance.Name = "nudDropChance";
-            this.nudDropChance.Size = new System.Drawing.Size(201, 20);
-            this.nudDropChance.TabIndex = 60;
-            this.nudDropChance.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudDropChance.ValueChanged += new System.EventHandler(this.nudDropChance_ValueChanged);
+            nudDropChance.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropChance.DecimalPlaces = 2;
+            nudDropChance.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropChance.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
+            nudDropChance.Location = new System.Drawing.Point(20, 231);
+            nudDropChance.Margin = new Padding(4, 3, 4, 3);
+            nudDropChance.Name = "nudDropChance";
+            nudDropChance.Size = new Size(234, 23);
+            nudDropChance.TabIndex = 60;
+            nudDropChance.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudDropChance.ValueChanged += nudDropChance_ValueChanged;
             // 
             // cmbDropItem
             // 
-            this.cmbDropItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbDropItem.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbDropItem.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbDropItem.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbDropItem.DrawDropdownHoverOutline = false;
-            this.cmbDropItem.DrawFocusRectangle = false;
-            this.cmbDropItem.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbDropItem.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbDropItem.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbDropItem.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbDropItem.FormattingEnabled = true;
-            this.cmbDropItem.Location = new System.Drawing.Point(17, 110);
-            this.cmbDropItem.Name = "cmbDropItem";
-            this.cmbDropItem.Size = new System.Drawing.Size(201, 21);
-            this.cmbDropItem.TabIndex = 17;
-            this.cmbDropItem.Text = null;
-            this.cmbDropItem.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbDropItem.SelectedIndexChanged += new System.EventHandler(this.cmbDropItem_SelectedIndexChanged);
+            cmbDropItem.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDropItem.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDropItem.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDropItem.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDropItem.DrawDropdownHoverOutline = false;
+            cmbDropItem.DrawFocusRectangle = false;
+            cmbDropItem.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDropItem.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDropItem.FlatStyle = FlatStyle.Flat;
+            cmbDropItem.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDropItem.FormattingEnabled = true;
+            cmbDropItem.Location = new System.Drawing.Point(20, 127);
+            cmbDropItem.Margin = new Padding(4, 3, 4, 3);
+            cmbDropItem.Name = "cmbDropItem";
+            cmbDropItem.Size = new Size(234, 24);
+            cmbDropItem.TabIndex = 17;
+            cmbDropItem.Text = null;
+            cmbDropItem.TextPadding = new Padding(2);
+            cmbDropItem.SelectedIndexChanged += cmbDropItem_SelectedIndexChanged;
             // 
             // lblDropAmount
             // 
-            this.lblDropAmount.AutoSize = true;
-            this.lblDropAmount.Location = new System.Drawing.Point(14, 136);
-            this.lblDropAmount.Name = "lblDropAmount";
-            this.lblDropAmount.Size = new System.Drawing.Size(46, 13);
-            this.lblDropAmount.TabIndex = 15;
-            this.lblDropAmount.Text = "Amount:";
+            lblDropAmount.AutoSize = true;
+            lblDropAmount.Location = new System.Drawing.Point(147, 156);
+            lblDropAmount.Margin = new Padding(4, 0, 4, 0);
+            lblDropAmount.Name = "lblDropAmount";
+            lblDropAmount.Size = new Size(80, 15);
+            lblDropAmount.TabIndex = 15;
+            lblDropAmount.Text = "Max Amount:";
             // 
             // lblDropChance
             // 
-            this.lblDropChance.AutoSize = true;
-            this.lblDropChance.Location = new System.Drawing.Point(14, 181);
-            this.lblDropChance.Name = "lblDropChance";
-            this.lblDropChance.Size = new System.Drawing.Size(64, 13);
-            this.lblDropChance.TabIndex = 13;
-            this.lblDropChance.Text = "Chance (%):";
+            lblDropChance.AutoSize = true;
+            lblDropChance.Location = new System.Drawing.Point(16, 209);
+            lblDropChance.Margin = new Padding(4, 0, 4, 0);
+            lblDropChance.Name = "lblDropChance";
+            lblDropChance.Size = new Size(71, 15);
+            lblDropChance.TabIndex = 13;
+            lblDropChance.Text = "Chance (%):";
             // 
             // lblDropItem
             // 
-            this.lblDropItem.AutoSize = true;
-            this.lblDropItem.Location = new System.Drawing.Point(12, 93);
-            this.lblDropItem.Name = "lblDropItem";
-            this.lblDropItem.Size = new System.Drawing.Size(30, 13);
-            this.lblDropItem.TabIndex = 11;
-            this.lblDropItem.Text = "Item:";
+            lblDropItem.AutoSize = true;
+            lblDropItem.Location = new System.Drawing.Point(14, 107);
+            lblDropItem.Margin = new Padding(4, 0, 4, 0);
+            lblDropItem.Name = "lblDropItem";
+            lblDropItem.Size = new Size(34, 15);
+            lblDropItem.TabIndex = 11;
+            lblDropItem.Text = "Item:";
             // 
             // grpNpcVsNpc
             // 
-            this.grpNpcVsNpc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpNpcVsNpc.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpNpcVsNpc.Controls.Add(this.cmbHostileNPC);
-            this.grpNpcVsNpc.Controls.Add(this.lblNPC);
-            this.grpNpcVsNpc.Controls.Add(this.btnRemoveAggro);
-            this.grpNpcVsNpc.Controls.Add(this.btnAddAggro);
-            this.grpNpcVsNpc.Controls.Add(this.lstAggro);
-            this.grpNpcVsNpc.Controls.Add(this.chkAttackAllies);
-            this.grpNpcVsNpc.Controls.Add(this.chkEnabled);
-            this.grpNpcVsNpc.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpNpcVsNpc.Location = new System.Drawing.Point(723, 350);
-            this.grpNpcVsNpc.Name = "grpNpcVsNpc";
-            this.grpNpcVsNpc.Size = new System.Drawing.Size(226, 289);
-            this.grpNpcVsNpc.TabIndex = 29;
-            this.grpNpcVsNpc.TabStop = false;
-            this.grpNpcVsNpc.Text = "NPC vs NPC Combat/Hostility ";
+            grpNpcVsNpc.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpNpcVsNpc.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpNpcVsNpc.Controls.Add(cmbHostileNPC);
+            grpNpcVsNpc.Controls.Add(lblNPC);
+            grpNpcVsNpc.Controls.Add(btnRemoveAggro);
+            grpNpcVsNpc.Controls.Add(btnAddAggro);
+            grpNpcVsNpc.Controls.Add(lstAggro);
+            grpNpcVsNpc.Controls.Add(chkAttackAllies);
+            grpNpcVsNpc.Controls.Add(chkEnabled);
+            grpNpcVsNpc.ForeColor = System.Drawing.Color.Gainsboro;
+            grpNpcVsNpc.Location = new System.Drawing.Point(844, 404);
+            grpNpcVsNpc.Margin = new Padding(4, 3, 4, 3);
+            grpNpcVsNpc.Name = "grpNpcVsNpc";
+            grpNpcVsNpc.Padding = new Padding(4, 3, 4, 3);
+            grpNpcVsNpc.Size = new Size(264, 333);
+            grpNpcVsNpc.TabIndex = 29;
+            grpNpcVsNpc.TabStop = false;
+            grpNpcVsNpc.Text = "NPC vs NPC Combat/Hostility ";
             // 
             // cmbHostileNPC
             // 
-            this.cmbHostileNPC.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbHostileNPC.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbHostileNPC.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbHostileNPC.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbHostileNPC.DrawDropdownHoverOutline = false;
-            this.cmbHostileNPC.DrawFocusRectangle = false;
-            this.cmbHostileNPC.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbHostileNPC.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbHostileNPC.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbHostileNPC.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbHostileNPC.FormattingEnabled = true;
-            this.cmbHostileNPC.Location = new System.Drawing.Point(10, 84);
-            this.cmbHostileNPC.Name = "cmbHostileNPC";
-            this.cmbHostileNPC.Size = new System.Drawing.Size(208, 21);
-            this.cmbHostileNPC.TabIndex = 45;
-            this.cmbHostileNPC.Text = null;
-            this.cmbHostileNPC.TextPadding = new System.Windows.Forms.Padding(2);
+            cmbHostileNPC.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbHostileNPC.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbHostileNPC.BorderStyle = ButtonBorderStyle.Solid;
+            cmbHostileNPC.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbHostileNPC.DrawDropdownHoverOutline = false;
+            cmbHostileNPC.DrawFocusRectangle = false;
+            cmbHostileNPC.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbHostileNPC.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbHostileNPC.FlatStyle = FlatStyle.Flat;
+            cmbHostileNPC.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbHostileNPC.FormattingEnabled = true;
+            cmbHostileNPC.Location = new System.Drawing.Point(12, 97);
+            cmbHostileNPC.Margin = new Padding(4, 3, 4, 3);
+            cmbHostileNPC.Name = "cmbHostileNPC";
+            cmbHostileNPC.Size = new Size(242, 24);
+            cmbHostileNPC.TabIndex = 45;
+            cmbHostileNPC.Text = null;
+            cmbHostileNPC.TextPadding = new Padding(2);
             // 
             // lblNPC
             // 
-            this.lblNPC.AutoSize = true;
-            this.lblNPC.Location = new System.Drawing.Point(13, 65);
-            this.lblNPC.Name = "lblNPC";
-            this.lblNPC.Size = new System.Drawing.Size(32, 13);
-            this.lblNPC.TabIndex = 44;
-            this.lblNPC.Text = "NPC:";
+            lblNPC.AutoSize = true;
+            lblNPC.Location = new System.Drawing.Point(15, 75);
+            lblNPC.Margin = new Padding(4, 0, 4, 0);
+            lblNPC.Name = "lblNPC";
+            lblNPC.Size = new Size(34, 15);
+            lblNPC.TabIndex = 44;
+            lblNPC.Text = "NPC:";
             // 
             // btnRemoveAggro
             // 
-            this.btnRemoveAggro.Location = new System.Drawing.Point(143, 260);
-            this.btnRemoveAggro.Name = "btnRemoveAggro";
-            this.btnRemoveAggro.Padding = new System.Windows.Forms.Padding(5);
-            this.btnRemoveAggro.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveAggro.TabIndex = 43;
-            this.btnRemoveAggro.Text = "Remove";
-            this.btnRemoveAggro.Click += new System.EventHandler(this.btnRemoveAggro_Click);
+            btnRemoveAggro.Location = new System.Drawing.Point(167, 300);
+            btnRemoveAggro.Margin = new Padding(4, 3, 4, 3);
+            btnRemoveAggro.Name = "btnRemoveAggro";
+            btnRemoveAggro.Padding = new Padding(6);
+            btnRemoveAggro.Size = new Size(88, 27);
+            btnRemoveAggro.TabIndex = 43;
+            btnRemoveAggro.Text = "Remove";
+            btnRemoveAggro.Click += btnRemoveAggro_Click;
             // 
             // btnAddAggro
             // 
-            this.btnAddAggro.Location = new System.Drawing.Point(10, 260);
-            this.btnAddAggro.Name = "btnAddAggro";
-            this.btnAddAggro.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAddAggro.Size = new System.Drawing.Size(75, 23);
-            this.btnAddAggro.TabIndex = 42;
-            this.btnAddAggro.Text = "Add";
-            this.btnAddAggro.Click += new System.EventHandler(this.btnAddAggro_Click);
+            btnAddAggro.Location = new System.Drawing.Point(12, 300);
+            btnAddAggro.Margin = new Padding(4, 3, 4, 3);
+            btnAddAggro.Name = "btnAddAggro";
+            btnAddAggro.Padding = new Padding(6);
+            btnAddAggro.Size = new Size(88, 27);
+            btnAddAggro.TabIndex = 42;
+            btnAddAggro.Text = "Add";
+            btnAddAggro.Click += btnAddAggro_Click;
             // 
             // lstAggro
             // 
-            this.lstAggro.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstAggro.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lstAggro.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstAggro.FormattingEnabled = true;
-            this.lstAggro.Items.AddRange(new object[] {
-            "NPC:"});
-            this.lstAggro.Location = new System.Drawing.Point(10, 119);
-            this.lstAggro.Name = "lstAggro";
-            this.lstAggro.Size = new System.Drawing.Size(208, 132);
-            this.lstAggro.TabIndex = 41;
+            lstAggro.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstAggro.BorderStyle = BorderStyle.FixedSingle;
+            lstAggro.ForeColor = System.Drawing.Color.Gainsboro;
+            lstAggro.FormattingEnabled = true;
+            lstAggro.ItemHeight = 15;
+            lstAggro.Items.AddRange(new object[] { "NPC:" });
+            lstAggro.Location = new System.Drawing.Point(12, 137);
+            lstAggro.Margin = new Padding(4, 3, 4, 3);
+            lstAggro.Name = "lstAggro";
+            lstAggro.Size = new Size(242, 152);
+            lstAggro.TabIndex = 41;
             // 
             // chkAttackAllies
             // 
-            this.chkAttackAllies.AutoSize = true;
-            this.chkAttackAllies.Location = new System.Drawing.Point(10, 40);
-            this.chkAttackAllies.Name = "chkAttackAllies";
-            this.chkAttackAllies.Size = new System.Drawing.Size(90, 17);
-            this.chkAttackAllies.TabIndex = 1;
-            this.chkAttackAllies.Text = "Attack Allies?";
-            this.chkAttackAllies.CheckedChanged += new System.EventHandler(this.chkAttackAllies_CheckedChanged);
+            chkAttackAllies.AutoSize = true;
+            chkAttackAllies.Location = new System.Drawing.Point(12, 46);
+            chkAttackAllies.Margin = new Padding(4, 3, 4, 3);
+            chkAttackAllies.Name = "chkAttackAllies";
+            chkAttackAllies.Size = new Size(96, 19);
+            chkAttackAllies.TabIndex = 1;
+            chkAttackAllies.Text = "Attack Allies?";
+            chkAttackAllies.CheckedChanged += chkAttackAllies_CheckedChanged;
             // 
             // chkEnabled
             // 
-            this.chkEnabled.AutoSize = true;
-            this.chkEnabled.Location = new System.Drawing.Point(10, 17);
-            this.chkEnabled.Name = "chkEnabled";
-            this.chkEnabled.Size = new System.Drawing.Size(71, 17);
-            this.chkEnabled.TabIndex = 0;
-            this.chkEnabled.Text = "Enabled?";
-            this.chkEnabled.CheckedChanged += new System.EventHandler(this.chkEnabled_CheckedChanged);
+            chkEnabled.AutoSize = true;
+            chkEnabled.Location = new System.Drawing.Point(12, 20);
+            chkEnabled.Margin = new Padding(4, 3, 4, 3);
+            chkEnabled.Name = "chkEnabled";
+            chkEnabled.Size = new Size(73, 19);
+            chkEnabled.TabIndex = 0;
+            chkEnabled.Text = "Enabled?";
+            chkEnabled.CheckedChanged += chkEnabled_CheckedChanged;
             // 
             // grpSpells
             // 
-            this.grpSpells.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpSpells.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpSpells.Controls.Add(this.cmbSpell);
-            this.grpSpells.Controls.Add(this.cmbFreq);
-            this.grpSpells.Controls.Add(this.lblFreq);
-            this.grpSpells.Controls.Add(this.lblSpell);
-            this.grpSpells.Controls.Add(this.btnRemove);
-            this.grpSpells.Controls.Add(this.btnAdd);
-            this.grpSpells.Controls.Add(this.lstSpells);
-            this.grpSpells.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpSpells.Location = new System.Drawing.Point(224, 128);
-            this.grpSpells.Name = "grpSpells";
-            this.grpSpells.Size = new System.Drawing.Size(228, 216);
-            this.grpSpells.TabIndex = 28;
-            this.grpSpells.TabStop = false;
-            this.grpSpells.Text = "Spells";
+            grpSpells.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpSpells.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpSpells.Controls.Add(cmbSpell);
+            grpSpells.Controls.Add(cmbFreq);
+            grpSpells.Controls.Add(lblFreq);
+            grpSpells.Controls.Add(lblSpell);
+            grpSpells.Controls.Add(btnRemove);
+            grpSpells.Controls.Add(btnAdd);
+            grpSpells.Controls.Add(lstSpells);
+            grpSpells.ForeColor = System.Drawing.Color.Gainsboro;
+            grpSpells.Location = new System.Drawing.Point(261, 148);
+            grpSpells.Margin = new Padding(4, 3, 4, 3);
+            grpSpells.Name = "grpSpells";
+            grpSpells.Padding = new Padding(4, 3, 4, 3);
+            grpSpells.Size = new Size(266, 249);
+            grpSpells.TabIndex = 28;
+            grpSpells.TabStop = false;
+            grpSpells.Text = "Spells";
             // 
             // cmbSpell
             // 
-            this.cmbSpell.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbSpell.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbSpell.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbSpell.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbSpell.DrawDropdownHoverOutline = false;
-            this.cmbSpell.DrawFocusRectangle = false;
-            this.cmbSpell.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbSpell.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbSpell.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbSpell.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbSpell.FormattingEnabled = true;
-            this.cmbSpell.Location = new System.Drawing.Point(15, 125);
-            this.cmbSpell.Name = "cmbSpell";
-            this.cmbSpell.Size = new System.Drawing.Size(203, 21);
-            this.cmbSpell.TabIndex = 43;
-            this.cmbSpell.Text = null;
-            this.cmbSpell.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbSpell.SelectedIndexChanged += new System.EventHandler(this.cmbSpell_SelectedIndexChanged);
+            cmbSpell.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbSpell.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbSpell.BorderStyle = ButtonBorderStyle.Solid;
+            cmbSpell.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbSpell.DrawDropdownHoverOutline = false;
+            cmbSpell.DrawFocusRectangle = false;
+            cmbSpell.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbSpell.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSpell.FlatStyle = FlatStyle.Flat;
+            cmbSpell.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbSpell.FormattingEnabled = true;
+            cmbSpell.Location = new System.Drawing.Point(18, 144);
+            cmbSpell.Margin = new Padding(4, 3, 4, 3);
+            cmbSpell.Name = "cmbSpell";
+            cmbSpell.Size = new Size(236, 24);
+            cmbSpell.TabIndex = 43;
+            cmbSpell.Text = null;
+            cmbSpell.TextPadding = new Padding(2);
+            cmbSpell.SelectedIndexChanged += cmbSpell_SelectedIndexChanged;
             // 
             // cmbFreq
             // 
-            this.cmbFreq.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbFreq.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbFreq.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbFreq.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbFreq.DrawDropdownHoverOutline = false;
-            this.cmbFreq.DrawFocusRectangle = false;
-            this.cmbFreq.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbFreq.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbFreq.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbFreq.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbFreq.FormattingEnabled = true;
-            this.cmbFreq.Items.AddRange(new object[] {
-            "Not Very Often",
-            "Not Often",
-            "Normal",
-            "Often",
-            "Very Often"});
-            this.cmbFreq.Location = new System.Drawing.Point(79, 187);
-            this.cmbFreq.Name = "cmbFreq";
-            this.cmbFreq.Size = new System.Drawing.Size(139, 21);
-            this.cmbFreq.TabIndex = 42;
-            this.cmbFreq.Text = "Not Very Often";
-            this.cmbFreq.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbFreq.SelectedIndexChanged += new System.EventHandler(this.cmbFreq_SelectedIndexChanged);
+            cmbFreq.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFreq.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFreq.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFreq.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFreq.DrawDropdownHoverOutline = false;
+            cmbFreq.DrawFocusRectangle = false;
+            cmbFreq.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFreq.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFreq.FlatStyle = FlatStyle.Flat;
+            cmbFreq.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFreq.FormattingEnabled = true;
+            cmbFreq.Items.AddRange(new object[] { "Not Very Often", "Not Often", "Normal", "Often", "Very Often" });
+            cmbFreq.Location = new System.Drawing.Point(92, 216);
+            cmbFreq.Margin = new Padding(4, 3, 4, 3);
+            cmbFreq.Name = "cmbFreq";
+            cmbFreq.Size = new Size(162, 24);
+            cmbFreq.TabIndex = 42;
+            cmbFreq.Text = "Not Very Often";
+            cmbFreq.TextPadding = new Padding(2);
+            cmbFreq.SelectedIndexChanged += cmbFreq_SelectedIndexChanged;
             // 
             // lblFreq
             // 
-            this.lblFreq.AutoSize = true;
-            this.lblFreq.Location = new System.Drawing.Point(12, 190);
-            this.lblFreq.Name = "lblFreq";
-            this.lblFreq.Size = new System.Drawing.Size(61, 13);
-            this.lblFreq.TabIndex = 41;
-            this.lblFreq.Text = "Frequence:";
+            lblFreq.AutoSize = true;
+            lblFreq.Location = new System.Drawing.Point(14, 219);
+            lblFreq.Margin = new Padding(4, 0, 4, 0);
+            lblFreq.Name = "lblFreq";
+            lblFreq.Size = new Size(65, 15);
+            lblFreq.TabIndex = 41;
+            lblFreq.Text = "Frequence:";
             // 
             // lblSpell
             // 
-            this.lblSpell.AutoSize = true;
-            this.lblSpell.Location = new System.Drawing.Point(14, 107);
-            this.lblSpell.Name = "lblSpell";
-            this.lblSpell.Size = new System.Drawing.Size(33, 13);
-            this.lblSpell.TabIndex = 39;
-            this.lblSpell.Text = "Spell:";
+            lblSpell.AutoSize = true;
+            lblSpell.Location = new System.Drawing.Point(16, 123);
+            lblSpell.Margin = new Padding(4, 0, 4, 0);
+            lblSpell.Name = "lblSpell";
+            lblSpell.Size = new Size(35, 15);
+            lblSpell.TabIndex = 39;
+            lblSpell.Text = "Spell:";
             // 
             // btnRemove
             // 
-            this.btnRemove.Location = new System.Drawing.Point(143, 154);
-            this.btnRemove.Name = "btnRemove";
-            this.btnRemove.Padding = new System.Windows.Forms.Padding(5);
-            this.btnRemove.Size = new System.Drawing.Size(75, 23);
-            this.btnRemove.TabIndex = 38;
-            this.btnRemove.Text = "Remove";
-            this.btnRemove.Click += new System.EventHandler(this.btnRemove_Click);
+            btnRemove.Location = new System.Drawing.Point(167, 178);
+            btnRemove.Margin = new Padding(4, 3, 4, 3);
+            btnRemove.Name = "btnRemove";
+            btnRemove.Padding = new Padding(6);
+            btnRemove.Size = new Size(88, 27);
+            btnRemove.TabIndex = 38;
+            btnRemove.Text = "Remove";
+            btnRemove.Click += btnRemove_Click;
             // 
             // btnAdd
             // 
-            this.btnAdd.Location = new System.Drawing.Point(15, 154);
-            this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAdd.Size = new System.Drawing.Size(75, 23);
-            this.btnAdd.TabIndex = 37;
-            this.btnAdd.Text = "Add";
-            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            btnAdd.Location = new System.Drawing.Point(18, 178);
+            btnAdd.Margin = new Padding(4, 3, 4, 3);
+            btnAdd.Name = "btnAdd";
+            btnAdd.Padding = new Padding(6);
+            btnAdd.Size = new Size(88, 27);
+            btnAdd.TabIndex = 37;
+            btnAdd.Text = "Add";
+            btnAdd.Click += btnAdd_Click;
             // 
             // lstSpells
             // 
-            this.lstSpells.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstSpells.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lstSpells.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstSpells.FormattingEnabled = true;
-            this.lstSpells.Location = new System.Drawing.Point(15, 19);
-            this.lstSpells.Name = "lstSpells";
-            this.lstSpells.Size = new System.Drawing.Size(203, 80);
-            this.lstSpells.TabIndex = 29;
-            this.lstSpells.SelectedIndexChanged += new System.EventHandler(this.lstSpells_SelectedIndexChanged);
+            lstSpells.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstSpells.BorderStyle = BorderStyle.FixedSingle;
+            lstSpells.ForeColor = System.Drawing.Color.Gainsboro;
+            lstSpells.FormattingEnabled = true;
+            lstSpells.ItemHeight = 15;
+            lstSpells.Location = new System.Drawing.Point(18, 22);
+            lstSpells.Margin = new Padding(4, 3, 4, 3);
+            lstSpells.Name = "lstSpells";
+            lstSpells.Size = new Size(236, 92);
+            lstSpells.TabIndex = 29;
+            lstSpells.SelectedIndexChanged += lstSpells_SelectedIndexChanged;
             // 
             // btnCancel
             // 
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(1001, 595);
-            this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
-            this.btnCancel.Size = new System.Drawing.Size(190, 27);
-            this.btnCancel.TabIndex = 21;
-            this.btnCancel.Text = "Cancel";
-            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(1168, 687);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6);
+            btnCancel.Size = new Size(222, 31);
+            btnCancel.TabIndex = 21;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(796, 595);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Padding = new System.Windows.Forms.Padding(5);
-            this.btnSave.Size = new System.Drawing.Size(190, 27);
-            this.btnSave.TabIndex = 18;
-            this.btnSave.Text = "Save";
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            btnSave.Location = new System.Drawing.Point(929, 687);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6);
+            btnSave.Size = new Size(222, 31);
+            btnSave.TabIndex = 18;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
             // 
             // toolStrip
             // 
-            this.toolStrip.AutoSize = false;
-            this.toolStrip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.toolStrip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripItemNew,
-            this.toolStripSeparator1,
-            this.toolStripItemDelete,
-            this.toolStripSeparator2,
-            this.btnAlphabetical,
-            this.toolStripSeparator4,
-            this.toolStripItemCopy,
-            this.toolStripItemPaste,
-            this.toolStripSeparator3,
-            this.toolStripItemUndo});
-            this.toolStrip.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip.Name = "toolStrip";
-            this.toolStrip.Padding = new System.Windows.Forms.Padding(5, 0, 1, 0);
-            this.toolStrip.Size = new System.Drawing.Size(1194, 25);
-            this.toolStrip.TabIndex = 45;
-            this.toolStrip.Text = "toolStrip1";
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(6, 0, 1, 0);
+            toolStrip.Size = new Size(1393, 29);
+            toolStrip.TabIndex = 45;
+            toolStrip.Text = "toolStrip1";
             // 
             // toolStripItemNew
             // 
-            this.toolStripItemNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemNew.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemNew.Image")));
-            this.toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemNew.Name = "toolStripItemNew";
-            this.toolStripItemNew.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemNew.Text = "New";
-            this.toolStripItemNew.Click += new System.EventHandler(this.toolStripItemNew_Click);
+            toolStripItemNew.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
             // 
             // toolStripSeparator1
             // 
-            this.toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator1.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new Size(6, 29);
             // 
             // toolStripItemDelete
             // 
-            this.toolStripItemDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemDelete.Enabled = false;
-            this.toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemDelete.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemDelete.Image")));
-            this.toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemDelete.Name = "toolStripItemDelete";
-            this.toolStripItemDelete.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemDelete.Text = "Delete";
-            this.toolStripItemDelete.Click += new System.EventHandler(this.toolStripItemDelete_Click);
+            toolStripItemDelete.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
             // 
             // toolStripSeparator2
             // 
-            this.toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator2.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new Size(6, 29);
             // 
             // btnAlphabetical
             // 
-            this.btnAlphabetical.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.btnAlphabetical.Image = ((System.Drawing.Image)(resources.GetObject("btnAlphabetical.Image")));
-            this.btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.btnAlphabetical.Name = "btnAlphabetical";
-            this.btnAlphabetical.Size = new System.Drawing.Size(23, 22);
-            this.btnAlphabetical.Text = "Order Chronologically";
-            this.btnAlphabetical.Click += new System.EventHandler(this.btnAlphabetical_Click);
+            btnAlphabetical.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new Size(23, 26);
+            btnAlphabetical.Text = "Order Chronologically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
             // 
             // toolStripSeparator4
             // 
-            this.toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator4.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new Size(6, 29);
             // 
             // toolStripItemCopy
             // 
-            this.toolStripItemCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemCopy.Enabled = false;
-            this.toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemCopy.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemCopy.Image")));
-            this.toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemCopy.Name = "toolStripItemCopy";
-            this.toolStripItemCopy.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemCopy.Text = "Copy";
-            this.toolStripItemCopy.Click += new System.EventHandler(this.toolStripItemCopy_Click);
+            toolStripItemCopy.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
             // 
             // toolStripItemPaste
             // 
-            this.toolStripItemPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemPaste.Enabled = false;
-            this.toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemPaste.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemPaste.Image")));
-            this.toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemPaste.Name = "toolStripItemPaste";
-            this.toolStripItemPaste.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemPaste.Text = "Paste";
-            this.toolStripItemPaste.Click += new System.EventHandler(this.toolStripItemPaste_Click);
+            toolStripItemPaste.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
             // 
             // toolStripSeparator3
             // 
-            this.toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator3.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new Size(6, 29);
             // 
             // toolStripItemUndo
             // 
-            this.toolStripItemUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemUndo.Enabled = false;
-            this.toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemUndo.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemUndo.Image")));
-            this.toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemUndo.Name = "toolStripItemUndo";
-            this.toolStripItemUndo.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemUndo.Text = "Undo";
-            this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
+            toolStripItemUndo.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
             // 
             // FrmNpc
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoSize = true;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.ClientSize = new System.Drawing.Size(1194, 631);
-            this.ControlBox = false;
-            this.Controls.Add(this.toolStrip);
-            this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.grpNpcs);
-            this.Controls.Add(this.pnlContainer);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.KeyPreview = true;
-            this.MaximizeBox = false;
-            this.Name = "FrmNpc";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "NPC Editor";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.frmNpc_FormClosed);
-            this.Load += new System.EventHandler(this.frmNpc_Load);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
-            this.grpNpcs.ResumeLayout(false);
-            this.grpNpcs.PerformLayout();
-            this.grpGeneral.ResumeLayout(false);
-            this.grpGeneral.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaA)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaB)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaG)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudRgbaR)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudLevel)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.picNpc)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpawnDuration)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSightRange)).EndInit();
-            this.grpStats.ResumeLayout(false);
-            this.grpStats.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudExp)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMana)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHp)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpd)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMR)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDef)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMag)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudStr)).EndInit();
-            this.pnlContainer.ResumeLayout(false);
-            this.grpImmunities.ResumeLayout(false);
-            this.grpImmunities.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudTenacity)).EndInit();
-            this.grpCombat.ResumeLayout(false);
-            this.grpCombat.PerformLayout();
-            this.grpAttackSpeed.ResumeLayout(false);
-            this.grpAttackSpeed.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAttackSpeedValue)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudCritMultiplier)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudScaling)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDamage)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudCritChance)).EndInit();
-            this.grpCommonEvents.ResumeLayout(false);
-            this.grpCommonEvents.PerformLayout();
-            this.grpBehavior.ResumeLayout(false);
-            this.grpBehavior.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudResetRadius)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudFlee)).EndInit();
-            this.grpConditions.ResumeLayout(false);
-            this.grpRegen.ResumeLayout(false);
-            this.grpRegen.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMpRegen)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHpRegen)).EndInit();
-            this.grpDrops.ResumeLayout(false);
-            this.grpDrops.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropAmount)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropChance)).EndInit();
-            this.grpNpcVsNpc.ResumeLayout(false);
-            this.grpNpcVsNpc.PerformLayout();
-            this.grpSpells.ResumeLayout(false);
-            this.grpSpells.PerformLayout();
-            this.toolStrip.ResumeLayout(false);
-            this.toolStrip.PerformLayout();
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            ClientSize = new Size(1393, 728);
+            ControlBox = false;
+            Controls.Add(toolStrip);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(grpNpcs);
+            Controls.Add(pnlContainer);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            KeyPreview = true;
+            Margin = new Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            Name = "FrmNpc";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "NPC Editor";
+            FormClosed += frmNpc_FormClosed;
+            Load += frmNpc_Load;
+            KeyDown += form_KeyDown;
+            grpNpcs.ResumeLayout(false);
+            grpNpcs.PerformLayout();
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaA).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaB).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaG).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudRgbaR).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudLevel).EndInit();
+            ((System.ComponentModel.ISupportInitialize)picNpc).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSightRange).EndInit();
+            grpStats.ResumeLayout(false);
+            grpStats.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExp).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudMana).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudHp).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpd).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudMR).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDef).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudMag).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudStr).EndInit();
+            pnlContainer.ResumeLayout(false);
+            grpImmunities.ResumeLayout(false);
+            grpImmunities.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTenacity).EndInit();
+            grpCombat.ResumeLayout(false);
+            grpCombat.PerformLayout();
+            grpAttackSpeed.ResumeLayout(false);
+            grpAttackSpeed.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudAttackSpeedValue).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritMultiplier).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudScaling).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamage).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritChance).EndInit();
+            grpCommonEvents.ResumeLayout(false);
+            grpCommonEvents.PerformLayout();
+            grpBehavior.ResumeLayout(false);
+            grpBehavior.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudResetRadius).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudFlee).EndInit();
+            grpConditions.ResumeLayout(false);
+            grpRegen.ResumeLayout(false);
+            grpRegen.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudMpRegen).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).EndInit();
+            grpDrops.ResumeLayout(false);
+            grpDrops.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropAmount).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropChance).EndInit();
+            grpNpcVsNpc.ResumeLayout(false);
+            grpNpcVsNpc.PerformLayout();
+            grpSpells.ResumeLayout(false);
+            grpSpells.PerformLayout();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
         }
 
         #endregion
@@ -2427,5 +2356,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkStun;
         private DarkCheckBox chkSilence;
         private DarkCheckBox chkKnockback;
+        private DarkNumericUpDown nudDropMinAmount;
+        private Label lblDropMinAmount;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -219,6 +219,7 @@ namespace Intersect.Editor.Forms.Editors
             grpDrops.Text = Strings.NpcEditor.drops;
             lblDropItem.Text = Strings.NpcEditor.dropitem;
             lblDropAmount.Text = Strings.NpcEditor.dropamount;
+            lblDropMinAmount.Text = Strings.NpcEditor.DropMinAmount;
             lblDropChance.Text = Strings.NpcEditor.dropchance;
             btnDropAdd.Text = Strings.NpcEditor.dropadd;
             btnDropRemove.Text = Strings.NpcEditor.dropremove;
@@ -453,8 +454,8 @@ namespace Intersect.Editor.Forms.Editors
                 {
                     lstDrops.Items.Add(
                         Strings.NpcEditor.dropdisplay.ToString(
-                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
-                            mEditorItem.Drops[i].Chance
+                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].MinQuantity,
+                            mEditorItem.Drops[i].Quantity, mEditorItem.Drops[i].Chance
                         )
                     );
                 }
@@ -733,25 +734,34 @@ namespace Intersect.Editor.Forms.Editors
 
         private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
-                mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+                return;
             }
 
+            mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
             UpdateDropValues(true);
         }
 
         private void nudDropAmount_ValueChanged(object sender, EventArgs e)
         {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
-
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
                 return;
             }
 
-            mEditorItem.Drops[(int)lstDrops.SelectedIndex].Quantity = (int)nudDropAmount.Value;
+            mEditorItem.Drops[lstDrops.SelectedIndex].Quantity = (int)nudDropAmount.Value;
+            UpdateDropValues(true);
+        }
+
+        private void nudDropMinAmount_ValueChanged(object sender, EventArgs e)
+        {
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
+            {
+                return;
+            }
+
+            mEditorItem.Drops[lstDrops.SelectedIndex].MinQuantity = (int)nudDropMinAmount.Value;
             UpdateDropValues(true);
         }
 
@@ -761,6 +771,7 @@ namespace Intersect.Editor.Forms.Editors
             {
                 cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
                 nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
+                nudDropMinAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].MinQuantity;
                 nudDropChance.Value = (decimal)mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
             }
         }
@@ -770,6 +781,7 @@ namespace Intersect.Editor.Forms.Editors
             mEditorItem.Drops.Add(new Drop());
             mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
             mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int)nudDropAmount.Value;
+            mEditorItem.Drops[mEditorItem.Drops.Count - 1].MinQuantity = (int)nudDropMinAmount.Value;
             mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double)nudDropChance.Value;
 
             UpdateDropValues();
@@ -789,7 +801,7 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudDropChance_ValueChanged(object sender, EventArgs e)
         {
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
                 return;
             }

--- a/Intersect.Editor/Forms/Editors/frmNpc.resx
+++ b/Intersect.Editor/Forms/Editors/frmNpc.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.Designer.cs
@@ -30,1069 +30,1103 @@ namespace Intersect.Editor.Forms.Editors
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmResource));
-            this.grpResources = new DarkUI.Controls.DarkGroupBox();
-            this.btnClearSearch = new DarkUI.Controls.DarkButton();
-            this.txtSearch = new DarkUI.Controls.DarkTextBox();
-            this.lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
-            this.grpGeneral = new DarkUI.Controls.DarkGroupBox();
-            this.btnAddFolder = new DarkUI.Controls.DarkButton();
-            this.lblFolder = new System.Windows.Forms.Label();
-            this.cmbFolder = new DarkUI.Controls.DarkComboBox();
-            this.nudMaxHp = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudMinHp = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudSpawnDuration = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbAnimation = new DarkUI.Controls.DarkComboBox();
-            this.lblAnimation = new System.Windows.Forms.Label();
-            this.lblMaxHp = new System.Windows.Forms.Label();
-            this.lblSpawnDuration = new System.Windows.Forms.Label();
-            this.chkWalkableAfter = new DarkUI.Controls.DarkCheckBox();
-            this.chkWalkableBefore = new DarkUI.Controls.DarkCheckBox();
-            this.cmbToolType = new DarkUI.Controls.DarkComboBox();
-            this.lblToolType = new System.Windows.Forms.Label();
-            this.lblHP = new System.Windows.Forms.Label();
-            this.lblName = new System.Windows.Forms.Label();
-            this.txtName = new DarkUI.Controls.DarkTextBox();
-            this.btnRequirements = new DarkUI.Controls.DarkButton();
-            this.grpGraphics = new DarkUI.Controls.DarkGroupBox();
-            this.chkExhaustedBelowEntities = new DarkUI.Controls.DarkCheckBox();
-            this.chkInitialBelowEntities = new DarkUI.Controls.DarkCheckBox();
-            this.chkExhaustedFromTileset = new DarkUI.Controls.DarkCheckBox();
-            this.chkInitialFromTileset = new DarkUI.Controls.DarkCheckBox();
-            this.exhaustedGraphicContainer = new System.Windows.Forms.Panel();
-            this.picEndResource = new System.Windows.Forms.PictureBox();
-            this.initalGraphicContainer = new System.Windows.Forms.Panel();
-            this.picInitialResource = new System.Windows.Forms.PictureBox();
-            this.cmbEndSprite = new DarkUI.Controls.DarkComboBox();
-            this.lblPic2 = new System.Windows.Forms.Label();
-            this.cmbInitialSprite = new DarkUI.Controls.DarkComboBox();
-            this.lblPic = new System.Windows.Forms.Label();
-            this.tmrRender = new System.Windows.Forms.Timer(this.components);
-            this.pnlContainer = new System.Windows.Forms.Panel();
-            this.grpRequirements = new DarkUI.Controls.DarkGroupBox();
-            this.lblCannotHarvest = new System.Windows.Forms.Label();
-            this.txtCannotHarvest = new DarkUI.Controls.DarkTextBox();
-            this.grpCommonEvent = new DarkUI.Controls.DarkGroupBox();
-            this.cmbEvent = new DarkUI.Controls.DarkComboBox();
-            this.lblEvent = new System.Windows.Forms.Label();
-            this.grpRegen = new DarkUI.Controls.DarkGroupBox();
-            this.nudHpRegen = new DarkUI.Controls.DarkNumericUpDown();
-            this.lblHpRegen = new System.Windows.Forms.Label();
-            this.lblRegenHint = new System.Windows.Forms.Label();
-            this.grpDrops = new DarkUI.Controls.DarkGroupBox();
-            this.btnDropRemove = new DarkUI.Controls.DarkButton();
-            this.btnDropAdd = new DarkUI.Controls.DarkButton();
-            this.lstDrops = new System.Windows.Forms.ListBox();
-            this.nudDropAmount = new DarkUI.Controls.DarkNumericUpDown();
-            this.nudDropChance = new DarkUI.Controls.DarkNumericUpDown();
-            this.cmbDropItem = new DarkUI.Controls.DarkComboBox();
-            this.lblDropAmount = new System.Windows.Forms.Label();
-            this.lblDropChance = new System.Windows.Forms.Label();
-            this.lblDropItem = new System.Windows.Forms.Label();
-            this.btnCancel = new DarkUI.Controls.DarkButton();
-            this.btnSave = new DarkUI.Controls.DarkButton();
-            this.toolStrip = new DarkUI.Controls.DarkToolStrip();
-            this.toolStripItemNew = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemDelete = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.btnAlphabetical = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemCopy = new System.Windows.Forms.ToolStripButton();
-            this.toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
-            this.grpResources.SuspendLayout();
-            this.grpGeneral.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMaxHp)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinHp)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpawnDuration)).BeginInit();
-            this.grpGraphics.SuspendLayout();
-            this.exhaustedGraphicContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.picEndResource)).BeginInit();
-            this.initalGraphicContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.picInitialResource)).BeginInit();
-            this.pnlContainer.SuspendLayout();
-            this.grpRequirements.SuspendLayout();
-            this.grpCommonEvent.SuspendLayout();
-            this.grpRegen.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHpRegen)).BeginInit();
-            this.grpDrops.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropAmount)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropChance)).BeginInit();
-            this.toolStrip.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmResource));
+            grpResources = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Controls.GameObjectList();
+            grpGeneral = new DarkGroupBox();
+            btnAddFolder = new DarkButton();
+            lblFolder = new Label();
+            cmbFolder = new DarkComboBox();
+            nudMaxHp = new DarkNumericUpDown();
+            nudMinHp = new DarkNumericUpDown();
+            nudSpawnDuration = new DarkNumericUpDown();
+            cmbAnimation = new DarkComboBox();
+            lblAnimation = new Label();
+            lblMaxHp = new Label();
+            lblSpawnDuration = new Label();
+            chkWalkableAfter = new DarkCheckBox();
+            chkWalkableBefore = new DarkCheckBox();
+            cmbToolType = new DarkComboBox();
+            lblToolType = new Label();
+            lblHP = new Label();
+            lblName = new Label();
+            txtName = new DarkTextBox();
+            btnRequirements = new DarkButton();
+            grpGraphics = new DarkGroupBox();
+            chkExhaustedBelowEntities = new DarkCheckBox();
+            chkInitialBelowEntities = new DarkCheckBox();
+            chkExhaustedFromTileset = new DarkCheckBox();
+            chkInitialFromTileset = new DarkCheckBox();
+            exhaustedGraphicContainer = new Panel();
+            picEndResource = new PictureBox();
+            initalGraphicContainer = new Panel();
+            picInitialResource = new PictureBox();
+            cmbEndSprite = new DarkComboBox();
+            lblPic2 = new Label();
+            cmbInitialSprite = new DarkComboBox();
+            lblPic = new Label();
+            tmrRender = new System.Windows.Forms.Timer(components);
+            pnlContainer = new Panel();
+            grpRequirements = new DarkGroupBox();
+            lblCannotHarvest = new Label();
+            txtCannotHarvest = new DarkTextBox();
+            grpCommonEvent = new DarkGroupBox();
+            cmbEvent = new DarkComboBox();
+            lblEvent = new Label();
+            grpRegen = new DarkGroupBox();
+            nudHpRegen = new DarkNumericUpDown();
+            lblHpRegen = new Label();
+            lblRegenHint = new Label();
+            grpDrops = new DarkGroupBox();
+            btnDropRemove = new DarkButton();
+            btnDropAdd = new DarkButton();
+            lstDrops = new ListBox();
+            nudDropAmount = new DarkNumericUpDown();
+            nudDropChance = new DarkNumericUpDown();
+            cmbDropItem = new DarkComboBox();
+            lblDropAmount = new Label();
+            lblDropChance = new Label();
+            lblDropItem = new Label();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            toolStripItemDelete = new ToolStripButton();
+            toolStripSeparator2 = new ToolStripSeparator();
+            btnAlphabetical = new ToolStripButton();
+            toolStripSeparator4 = new ToolStripSeparator();
+            toolStripItemCopy = new ToolStripButton();
+            toolStripItemPaste = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            toolStripItemUndo = new ToolStripButton();
+            nudDropMinAmount = new DarkNumericUpDown();
+            lblDropMinAmount = new Label();
+            grpResources.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudMaxHp).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudMinHp).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).BeginInit();
+            grpGraphics.SuspendLayout();
+            exhaustedGraphicContainer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)picEndResource).BeginInit();
+            initalGraphicContainer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)picInitialResource).BeginInit();
+            pnlContainer.SuspendLayout();
+            grpRequirements.SuspendLayout();
+            grpCommonEvent.SuspendLayout();
+            grpRegen.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).BeginInit();
+            grpDrops.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropAmount).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropChance).BeginInit();
+            toolStrip.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).BeginInit();
+            SuspendLayout();
             // 
             // grpResources
             // 
-            this.grpResources.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpResources.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpResources.Controls.Add(this.btnClearSearch);
-            this.grpResources.Controls.Add(this.txtSearch);
-            this.grpResources.Controls.Add(this.lstGameObjects);
-            this.grpResources.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpResources.Location = new System.Drawing.Point(12, 39);
-            this.grpResources.Name = "grpResources";
-            this.grpResources.Size = new System.Drawing.Size(203, 550);
-            this.grpResources.TabIndex = 14;
-            this.grpResources.TabStop = false;
-            this.grpResources.Text = "Resources";
+            grpResources.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpResources.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpResources.Controls.Add(btnClearSearch);
+            grpResources.Controls.Add(txtSearch);
+            grpResources.Controls.Add(lstGameObjects);
+            grpResources.ForeColor = System.Drawing.Color.Gainsboro;
+            grpResources.Location = new System.Drawing.Point(14, 45);
+            grpResources.Margin = new Padding(4, 3, 4, 3);
+            grpResources.Name = "grpResources";
+            grpResources.Padding = new Padding(4, 3, 4, 3);
+            grpResources.Size = new Size(237, 635);
+            grpResources.TabIndex = 14;
+            grpResources.TabStop = false;
+            grpResources.Text = "Resources";
             // 
             // btnClearSearch
             // 
-            this.btnClearSearch.Location = new System.Drawing.Point(179, 19);
-            this.btnClearSearch.Name = "btnClearSearch";
-            this.btnClearSearch.Padding = new System.Windows.Forms.Padding(5);
-            this.btnClearSearch.Size = new System.Drawing.Size(18, 20);
-            this.btnClearSearch.TabIndex = 34;
-            this.btnClearSearch.Text = "X";
-            this.btnClearSearch.Click += new System.EventHandler(this.btnClearSearch_Click);
+            btnClearSearch.Location = new System.Drawing.Point(209, 22);
+            btnClearSearch.Margin = new Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new Padding(6, 6, 6, 6);
+            btnClearSearch.Size = new Size(21, 23);
+            btnClearSearch.TabIndex = 34;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
             // 
             // txtSearch
             // 
-            this.txtSearch.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtSearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtSearch.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtSearch.Location = new System.Drawing.Point(6, 19);
-            this.txtSearch.Name = "txtSearch";
-            this.txtSearch.Size = new System.Drawing.Size(167, 20);
-            this.txtSearch.TabIndex = 33;
-            this.txtSearch.Text = "Search...";
-            this.txtSearch.Click += new System.EventHandler(this.txtSearch_Click);
-            this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
-            this.txtSearch.Enter += new System.EventHandler(this.txtSearch_Enter);
-            this.txtSearch.Leave += new System.EventHandler(this.txtSearch_Leave);
+            txtSearch.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSearch.BorderStyle = BorderStyle.FixedSingle;
+            txtSearch.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSearch.Location = new System.Drawing.Point(7, 22);
+            txtSearch.Margin = new Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new Size(194, 23);
+            txtSearch.TabIndex = 33;
+            txtSearch.Text = "Search...";
+            txtSearch.Click += txtSearch_Click;
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            txtSearch.Enter += txtSearch_Enter;
+            txtSearch.Leave += txtSearch_Leave;
             // 
             // lstGameObjects
             // 
-            this.lstGameObjects.AllowDrop = true;
-            this.lstGameObjects.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstGameObjects.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstGameObjects.HideSelection = false;
-            this.lstGameObjects.ImageIndex = 0;
-            this.lstGameObjects.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(150)))), ((int)(((byte)(150)))), ((int)(((byte)(150)))));
-            this.lstGameObjects.Location = new System.Drawing.Point(6, 45);
-            this.lstGameObjects.Name = "lstGameObjects";
-            this.lstGameObjects.SelectedImageIndex = 0;
-            this.lstGameObjects.Size = new System.Drawing.Size(191, 496);
-            this.lstGameObjects.TabIndex = 32;
+            lstGameObjects.AllowDrop = true;
+            lstGameObjects.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstGameObjects.BorderStyle = BorderStyle.None;
+            lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
+            lstGameObjects.HideSelection = false;
+            lstGameObjects.ImageIndex = 0;
+            lstGameObjects.LineColor = System.Drawing.Color.FromArgb(150, 150, 150);
+            lstGameObjects.Location = new System.Drawing.Point(7, 52);
+            lstGameObjects.Margin = new Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.SelectedImageIndex = 0;
+            lstGameObjects.Size = new Size(223, 572);
+            lstGameObjects.TabIndex = 32;
             // 
             // grpGeneral
             // 
-            this.grpGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpGeneral.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpGeneral.Controls.Add(this.btnAddFolder);
-            this.grpGeneral.Controls.Add(this.lblFolder);
-            this.grpGeneral.Controls.Add(this.cmbFolder);
-            this.grpGeneral.Controls.Add(this.nudMaxHp);
-            this.grpGeneral.Controls.Add(this.nudMinHp);
-            this.grpGeneral.Controls.Add(this.nudSpawnDuration);
-            this.grpGeneral.Controls.Add(this.cmbAnimation);
-            this.grpGeneral.Controls.Add(this.lblAnimation);
-            this.grpGeneral.Controls.Add(this.lblMaxHp);
-            this.grpGeneral.Controls.Add(this.lblSpawnDuration);
-            this.grpGeneral.Controls.Add(this.chkWalkableAfter);
-            this.grpGeneral.Controls.Add(this.chkWalkableBefore);
-            this.grpGeneral.Controls.Add(this.cmbToolType);
-            this.grpGeneral.Controls.Add(this.lblToolType);
-            this.grpGeneral.Controls.Add(this.lblHP);
-            this.grpGeneral.Controls.Add(this.lblName);
-            this.grpGeneral.Controls.Add(this.txtName);
-            this.grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpGeneral.Location = new System.Drawing.Point(0, 0);
-            this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(223, 281);
-            this.grpGeneral.TabIndex = 15;
-            this.grpGeneral.TabStop = false;
-            this.grpGeneral.Text = "General";
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(nudMaxHp);
+            grpGeneral.Controls.Add(nudMinHp);
+            grpGeneral.Controls.Add(nudSpawnDuration);
+            grpGeneral.Controls.Add(cmbAnimation);
+            grpGeneral.Controls.Add(lblAnimation);
+            grpGeneral.Controls.Add(lblMaxHp);
+            grpGeneral.Controls.Add(lblSpawnDuration);
+            grpGeneral.Controls.Add(chkWalkableAfter);
+            grpGeneral.Controls.Add(chkWalkableBefore);
+            grpGeneral.Controls.Add(cmbToolType);
+            grpGeneral.Controls.Add(lblToolType);
+            grpGeneral.Controls.Add(lblHP);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(0, 0);
+            grpGeneral.Margin = new Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new Padding(4, 3, 4, 3);
+            grpGeneral.Size = new Size(260, 324);
+            grpGeneral.TabIndex = 15;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
             // 
             // btnAddFolder
             // 
-            this.btnAddFolder.Location = new System.Drawing.Point(192, 45);
-            this.btnAddFolder.Name = "btnAddFolder";
-            this.btnAddFolder.Padding = new System.Windows.Forms.Padding(5);
-            this.btnAddFolder.Size = new System.Drawing.Size(18, 21);
-            this.btnAddFolder.TabIndex = 52;
-            this.btnAddFolder.Text = "+";
-            this.btnAddFolder.Click += new System.EventHandler(this.btnAddFolder_Click);
+            btnAddFolder.Location = new System.Drawing.Point(224, 52);
+            btnAddFolder.Margin = new Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new Padding(6, 6, 6, 6);
+            btnAddFolder.Size = new Size(21, 24);
+            btnAddFolder.TabIndex = 52;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
             // 
             // lblFolder
             // 
-            this.lblFolder.AutoSize = true;
-            this.lblFolder.Location = new System.Drawing.Point(6, 48);
-            this.lblFolder.Name = "lblFolder";
-            this.lblFolder.Size = new System.Drawing.Size(39, 13);
-            this.lblFolder.TabIndex = 51;
-            this.lblFolder.Text = "Folder:";
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(7, 55);
+            lblFolder.Margin = new Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new Size(43, 15);
+            lblFolder.TabIndex = 51;
+            lblFolder.Text = "Folder:";
             // 
             // cmbFolder
             // 
-            this.cmbFolder.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbFolder.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbFolder.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbFolder.DrawDropdownHoverOutline = false;
-            this.cmbFolder.DrawFocusRectangle = false;
-            this.cmbFolder.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbFolder.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbFolder.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbFolder.FormattingEnabled = true;
-            this.cmbFolder.Location = new System.Drawing.Point(75, 45);
-            this.cmbFolder.Name = "cmbFolder";
-            this.cmbFolder.Size = new System.Drawing.Size(113, 21);
-            this.cmbFolder.TabIndex = 50;
-            this.cmbFolder.Text = null;
-            this.cmbFolder.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbFolder.SelectedIndexChanged += new System.EventHandler(this.cmbFolder_SelectedIndexChanged);
+            cmbFolder.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFolder.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFolder.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFolder.DrawDropdownHoverOutline = false;
+            cmbFolder.DrawFocusRectangle = false;
+            cmbFolder.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFolder.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFolder.FlatStyle = FlatStyle.Flat;
+            cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(88, 52);
+            cmbFolder.Margin = new Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new Size(131, 24);
+            cmbFolder.TabIndex = 50;
+            cmbFolder.Text = null;
+            cmbFolder.TextPadding = new Padding(2);
+            cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
             // 
             // nudMaxHp
             // 
-            this.nudMaxHp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMaxHp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMaxHp.Location = new System.Drawing.Point(75, 125);
-            this.nudMaxHp.Maximum = new decimal(new int[] {
-            1000000,
-            0,
-            0,
-            0});
-            this.nudMaxHp.Name = "nudMaxHp";
-            this.nudMaxHp.Size = new System.Drawing.Size(135, 20);
-            this.nudMaxHp.TabIndex = 42;
-            this.nudMaxHp.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMaxHp.ValueChanged += new System.EventHandler(this.nudMaxHp_ValueChanged);
+            nudMaxHp.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMaxHp.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMaxHp.Location = new System.Drawing.Point(88, 144);
+            nudMaxHp.Margin = new Padding(4, 3, 4, 3);
+            nudMaxHp.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudMaxHp.Name = "nudMaxHp";
+            nudMaxHp.Size = new Size(158, 23);
+            nudMaxHp.TabIndex = 42;
+            nudMaxHp.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMaxHp.ValueChanged += nudMaxHp_ValueChanged;
             // 
             // nudMinHp
             // 
-            this.nudMinHp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudMinHp.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudMinHp.Location = new System.Drawing.Point(75, 99);
-            this.nudMinHp.Maximum = new decimal(new int[] {
-            1000000,
-            0,
-            0,
-            0});
-            this.nudMinHp.Name = "nudMinHp";
-            this.nudMinHp.Size = new System.Drawing.Size(135, 20);
-            this.nudMinHp.TabIndex = 41;
-            this.nudMinHp.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudMinHp.ValueChanged += new System.EventHandler(this.nudMinHp_ValueChanged);
+            nudMinHp.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudMinHp.ForeColor = System.Drawing.Color.Gainsboro;
+            nudMinHp.Location = new System.Drawing.Point(88, 114);
+            nudMinHp.Margin = new Padding(4, 3, 4, 3);
+            nudMinHp.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            nudMinHp.Name = "nudMinHp";
+            nudMinHp.Size = new Size(158, 23);
+            nudMinHp.TabIndex = 41;
+            nudMinHp.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudMinHp.ValueChanged += nudMinHp_ValueChanged;
             // 
             // nudSpawnDuration
             // 
-            this.nudSpawnDuration.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudSpawnDuration.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudSpawnDuration.Location = new System.Drawing.Point(123, 151);
-            this.nudSpawnDuration.Maximum = new decimal(new int[] {
-            2147483647,
-            0,
-            0,
-            0});
-            this.nudSpawnDuration.Name = "nudSpawnDuration";
-            this.nudSpawnDuration.Size = new System.Drawing.Size(87, 20);
-            this.nudSpawnDuration.TabIndex = 40;
-            this.nudSpawnDuration.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudSpawnDuration.ValueChanged += new System.EventHandler(this.nudSpawnDuration_ValueChanged);
+            nudSpawnDuration.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpawnDuration.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpawnDuration.Location = new System.Drawing.Point(144, 174);
+            nudSpawnDuration.Margin = new Padding(4, 3, 4, 3);
+            nudSpawnDuration.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            nudSpawnDuration.Name = "nudSpawnDuration";
+            nudSpawnDuration.Size = new Size(102, 23);
+            nudSpawnDuration.TabIndex = 40;
+            nudSpawnDuration.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudSpawnDuration.ValueChanged += nudSpawnDuration_ValueChanged;
             // 
             // cmbAnimation
             // 
-            this.cmbAnimation.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbAnimation.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbAnimation.DrawDropdownHoverOutline = false;
-            this.cmbAnimation.DrawFocusRectangle = false;
-            this.cmbAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbAnimation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbAnimation.FormattingEnabled = true;
-            this.cmbAnimation.Location = new System.Drawing.Point(75, 179);
-            this.cmbAnimation.Name = "cmbAnimation";
-            this.cmbAnimation.Size = new System.Drawing.Size(135, 21);
-            this.cmbAnimation.TabIndex = 39;
-            this.cmbAnimation.Text = null;
-            this.cmbAnimation.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbAnimation.SelectedIndexChanged += new System.EventHandler(this.cmbAnimation_SelectedIndexChanged);
+            cmbAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbAnimation.DrawDropdownHoverOutline = false;
+            cmbAnimation.DrawFocusRectangle = false;
+            cmbAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbAnimation.FlatStyle = FlatStyle.Flat;
+            cmbAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbAnimation.FormattingEnabled = true;
+            cmbAnimation.Location = new System.Drawing.Point(88, 207);
+            cmbAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbAnimation.Name = "cmbAnimation";
+            cmbAnimation.Size = new Size(157, 24);
+            cmbAnimation.TabIndex = 39;
+            cmbAnimation.Text = null;
+            cmbAnimation.TextPadding = new Padding(2);
+            cmbAnimation.SelectedIndexChanged += cmbAnimation_SelectedIndexChanged;
             // 
             // lblAnimation
             // 
-            this.lblAnimation.AutoSize = true;
-            this.lblAnimation.Location = new System.Drawing.Point(6, 182);
-            this.lblAnimation.Name = "lblAnimation";
-            this.lblAnimation.Size = new System.Drawing.Size(56, 13);
-            this.lblAnimation.TabIndex = 36;
-            this.lblAnimation.Text = "Animation:";
+            lblAnimation.AutoSize = true;
+            lblAnimation.Location = new System.Drawing.Point(7, 210);
+            lblAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblAnimation.Name = "lblAnimation";
+            lblAnimation.Size = new Size(66, 15);
+            lblAnimation.TabIndex = 36;
+            lblAnimation.Text = "Animation:";
             // 
             // lblMaxHp
             // 
-            this.lblMaxHp.AutoSize = true;
-            this.lblMaxHp.Location = new System.Drawing.Point(6, 127);
-            this.lblMaxHp.Name = "lblMaxHp";
-            this.lblMaxHp.Size = new System.Drawing.Size(48, 13);
-            this.lblMaxHp.TabIndex = 35;
-            this.lblMaxHp.Text = "Max HP:";
+            lblMaxHp.AutoSize = true;
+            lblMaxHp.Location = new System.Drawing.Point(7, 147);
+            lblMaxHp.Margin = new Padding(4, 0, 4, 0);
+            lblMaxHp.Name = "lblMaxHp";
+            lblMaxHp.Size = new Size(52, 15);
+            lblMaxHp.TabIndex = 35;
+            lblMaxHp.Text = "Max HP:";
             // 
             // lblSpawnDuration
             // 
-            this.lblSpawnDuration.AutoSize = true;
-            this.lblSpawnDuration.Location = new System.Drawing.Point(6, 155);
-            this.lblSpawnDuration.Name = "lblSpawnDuration";
-            this.lblSpawnDuration.Size = new System.Drawing.Size(86, 13);
-            this.lblSpawnDuration.TabIndex = 32;
-            this.lblSpawnDuration.Text = "Spawn Duration:";
+            lblSpawnDuration.AutoSize = true;
+            lblSpawnDuration.Location = new System.Drawing.Point(7, 179);
+            lblSpawnDuration.Margin = new Padding(4, 0, 4, 0);
+            lblSpawnDuration.Name = "lblSpawnDuration";
+            lblSpawnDuration.Size = new Size(94, 15);
+            lblSpawnDuration.TabIndex = 32;
+            lblSpawnDuration.Text = "Spawn Duration:";
             // 
             // chkWalkableAfter
             // 
-            this.chkWalkableAfter.Location = new System.Drawing.Point(6, 229);
-            this.chkWalkableAfter.Name = "chkWalkableAfter";
-            this.chkWalkableAfter.Size = new System.Drawing.Size(211, 17);
-            this.chkWalkableAfter.TabIndex = 31;
-            this.chkWalkableAfter.Text = "Walkable after resource removal?";
-            this.chkWalkableAfter.CheckedChanged += new System.EventHandler(this.chkWalkableAfter_CheckedChanged);
+            chkWalkableAfter.Location = new System.Drawing.Point(7, 264);
+            chkWalkableAfter.Margin = new Padding(4, 3, 4, 3);
+            chkWalkableAfter.Name = "chkWalkableAfter";
+            chkWalkableAfter.Size = new Size(246, 20);
+            chkWalkableAfter.TabIndex = 31;
+            chkWalkableAfter.Text = "Walkable after resource removal?";
+            chkWalkableAfter.CheckedChanged += chkWalkableAfter_CheckedChanged;
             // 
             // chkWalkableBefore
             // 
-            this.chkWalkableBefore.Location = new System.Drawing.Point(6, 206);
-            this.chkWalkableBefore.Name = "chkWalkableBefore";
-            this.chkWalkableBefore.Size = new System.Drawing.Size(211, 17);
-            this.chkWalkableBefore.TabIndex = 30;
-            this.chkWalkableBefore.Text = "Walkable before resource removal?";
-            this.chkWalkableBefore.CheckedChanged += new System.EventHandler(this.chkWalkableBefore_CheckedChanged);
+            chkWalkableBefore.Location = new System.Drawing.Point(7, 238);
+            chkWalkableBefore.Margin = new Padding(4, 3, 4, 3);
+            chkWalkableBefore.Name = "chkWalkableBefore";
+            chkWalkableBefore.Size = new Size(246, 20);
+            chkWalkableBefore.TabIndex = 30;
+            chkWalkableBefore.Text = "Walkable before resource removal?";
+            chkWalkableBefore.CheckedChanged += chkWalkableBefore_CheckedChanged;
             // 
             // cmbToolType
             // 
-            this.cmbToolType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbToolType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbToolType.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbToolType.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbToolType.DrawDropdownHoverOutline = false;
-            this.cmbToolType.DrawFocusRectangle = false;
-            this.cmbToolType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbToolType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbToolType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbToolType.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbToolType.FormattingEnabled = true;
-            this.cmbToolType.Location = new System.Drawing.Point(75, 72);
-            this.cmbToolType.Name = "cmbToolType";
-            this.cmbToolType.Size = new System.Drawing.Size(135, 21);
-            this.cmbToolType.TabIndex = 29;
-            this.cmbToolType.Text = null;
-            this.cmbToolType.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbToolType.SelectedIndexChanged += new System.EventHandler(this.cmbToolType_SelectedIndexChanged);
+            cmbToolType.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbToolType.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbToolType.BorderStyle = ButtonBorderStyle.Solid;
+            cmbToolType.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbToolType.DrawDropdownHoverOutline = false;
+            cmbToolType.DrawFocusRectangle = false;
+            cmbToolType.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbToolType.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbToolType.FlatStyle = FlatStyle.Flat;
+            cmbToolType.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbToolType.FormattingEnabled = true;
+            cmbToolType.Location = new System.Drawing.Point(88, 83);
+            cmbToolType.Margin = new Padding(4, 3, 4, 3);
+            cmbToolType.Name = "cmbToolType";
+            cmbToolType.Size = new Size(157, 24);
+            cmbToolType.TabIndex = 29;
+            cmbToolType.Text = null;
+            cmbToolType.TextPadding = new Padding(2);
+            cmbToolType.SelectedIndexChanged += cmbToolType_SelectedIndexChanged;
             // 
             // lblToolType
             // 
-            this.lblToolType.AutoSize = true;
-            this.lblToolType.Location = new System.Drawing.Point(6, 75);
-            this.lblToolType.Name = "lblToolType";
-            this.lblToolType.Size = new System.Drawing.Size(58, 13);
-            this.lblToolType.TabIndex = 28;
-            this.lblToolType.Text = "Tool Type:";
+            lblToolType.AutoSize = true;
+            lblToolType.Location = new System.Drawing.Point(7, 87);
+            lblToolType.Margin = new Padding(4, 0, 4, 0);
+            lblToolType.Name = "lblToolType";
+            lblToolType.Size = new Size(59, 15);
+            lblToolType.TabIndex = 28;
+            lblToolType.Text = "Tool Type:";
             // 
             // lblHP
             // 
-            this.lblHP.AutoSize = true;
-            this.lblHP.Location = new System.Drawing.Point(6, 101);
-            this.lblHP.Name = "lblHP";
-            this.lblHP.Size = new System.Drawing.Size(45, 13);
-            this.lblHP.TabIndex = 16;
-            this.lblHP.Text = "Min HP:";
+            lblHP.AutoSize = true;
+            lblHP.Location = new System.Drawing.Point(7, 117);
+            lblHP.Margin = new Padding(4, 0, 4, 0);
+            lblHP.Name = "lblHP";
+            lblHP.Size = new Size(50, 15);
+            lblHP.TabIndex = 16;
+            lblHP.Text = "Min HP:";
             // 
             // lblName
             // 
-            this.lblName.AutoSize = true;
-            this.lblName.Location = new System.Drawing.Point(6, 20);
-            this.lblName.Name = "lblName";
-            this.lblName.Size = new System.Drawing.Size(38, 13);
-            this.lblName.TabIndex = 3;
-            this.lblName.Text = "Name:";
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(7, 23);
+            lblName.Margin = new Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(42, 15);
+            lblName.TabIndex = 3;
+            lblName.Text = "Name:";
             // 
             // txtName
             // 
-            this.txtName.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtName.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtName.Location = new System.Drawing.Point(75, 20);
-            this.txtName.Name = "txtName";
-            this.txtName.Size = new System.Drawing.Size(135, 20);
-            this.txtName.TabIndex = 2;
-            this.txtName.TextChanged += new System.EventHandler(this.txtName_TextChanged);
+            txtName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtName.BorderStyle = BorderStyle.FixedSingle;
+            txtName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtName.Location = new System.Drawing.Point(88, 23);
+            txtName.Margin = new Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new Size(157, 23);
+            txtName.TabIndex = 2;
+            txtName.TextChanged += txtName_TextChanged;
             // 
             // btnRequirements
             // 
-            this.btnRequirements.Location = new System.Drawing.Point(8, 18);
-            this.btnRequirements.Name = "btnRequirements";
-            this.btnRequirements.Padding = new System.Windows.Forms.Padding(5);
-            this.btnRequirements.Size = new System.Drawing.Size(225, 23);
-            this.btnRequirements.TabIndex = 38;
-            this.btnRequirements.Text = "Harvesting Requirements";
-            this.btnRequirements.Click += new System.EventHandler(this.btnRequirements_Click);
+            btnRequirements.Location = new System.Drawing.Point(9, 21);
+            btnRequirements.Margin = new Padding(4, 3, 4, 3);
+            btnRequirements.Name = "btnRequirements";
+            btnRequirements.Padding = new Padding(6, 6, 6, 6);
+            btnRequirements.Size = new Size(262, 27);
+            btnRequirements.TabIndex = 38;
+            btnRequirements.Text = "Harvesting Requirements";
+            btnRequirements.Click += btnRequirements_Click;
             // 
             // grpGraphics
             // 
-            this.grpGraphics.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpGraphics.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpGraphics.Controls.Add(this.chkExhaustedBelowEntities);
-            this.grpGraphics.Controls.Add(this.chkInitialBelowEntities);
-            this.grpGraphics.Controls.Add(this.chkExhaustedFromTileset);
-            this.grpGraphics.Controls.Add(this.chkInitialFromTileset);
-            this.grpGraphics.Controls.Add(this.exhaustedGraphicContainer);
-            this.grpGraphics.Controls.Add(this.initalGraphicContainer);
-            this.grpGraphics.Controls.Add(this.cmbEndSprite);
-            this.grpGraphics.Controls.Add(this.lblPic2);
-            this.grpGraphics.Controls.Add(this.cmbInitialSprite);
-            this.grpGraphics.Controls.Add(this.lblPic);
-            this.grpGraphics.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpGraphics.Location = new System.Drawing.Point(0, 282);
-            this.grpGraphics.Name = "grpGraphics";
-            this.grpGraphics.Size = new System.Drawing.Size(706, 454);
-            this.grpGraphics.TabIndex = 16;
-            this.grpGraphics.TabStop = false;
-            this.grpGraphics.Text = "Graphics";
+            grpGraphics.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGraphics.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGraphics.Controls.Add(chkExhaustedBelowEntities);
+            grpGraphics.Controls.Add(chkInitialBelowEntities);
+            grpGraphics.Controls.Add(chkExhaustedFromTileset);
+            grpGraphics.Controls.Add(chkInitialFromTileset);
+            grpGraphics.Controls.Add(exhaustedGraphicContainer);
+            grpGraphics.Controls.Add(initalGraphicContainer);
+            grpGraphics.Controls.Add(cmbEndSprite);
+            grpGraphics.Controls.Add(lblPic2);
+            grpGraphics.Controls.Add(cmbInitialSprite);
+            grpGraphics.Controls.Add(lblPic);
+            grpGraphics.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGraphics.Location = new System.Drawing.Point(0, 325);
+            grpGraphics.Margin = new Padding(4, 3, 4, 3);
+            grpGraphics.Name = "grpGraphics";
+            grpGraphics.Padding = new Padding(4, 3, 4, 3);
+            grpGraphics.Size = new Size(824, 524);
+            grpGraphics.TabIndex = 16;
+            grpGraphics.TabStop = false;
+            grpGraphics.Text = "Graphics";
             // 
             // chkExhaustedBelowEntities
             // 
-            this.chkExhaustedBelowEntities.Location = new System.Drawing.Point(597, 13);
-            this.chkExhaustedBelowEntities.Name = "chkExhaustedBelowEntities";
-            this.chkExhaustedBelowEntities.Size = new System.Drawing.Size(98, 21);
-            this.chkExhaustedBelowEntities.TabIndex = 35;
-            this.chkExhaustedBelowEntities.Text = "Below Entities";
-            this.chkExhaustedBelowEntities.CheckedChanged += new System.EventHandler(this.chkExhaustedBelowEntities_CheckedChanged);
+            chkExhaustedBelowEntities.Location = new System.Drawing.Point(696, 15);
+            chkExhaustedBelowEntities.Margin = new Padding(4, 3, 4, 3);
+            chkExhaustedBelowEntities.Name = "chkExhaustedBelowEntities";
+            chkExhaustedBelowEntities.Size = new Size(114, 24);
+            chkExhaustedBelowEntities.TabIndex = 35;
+            chkExhaustedBelowEntities.Text = "Below Entities";
+            chkExhaustedBelowEntities.CheckedChanged += chkExhaustedBelowEntities_CheckedChanged;
             // 
             // chkInitialBelowEntities
             // 
-            this.chkInitialBelowEntities.Location = new System.Drawing.Point(245, 13);
-            this.chkInitialBelowEntities.Name = "chkInitialBelowEntities";
-            this.chkInitialBelowEntities.Size = new System.Drawing.Size(98, 21);
-            this.chkInitialBelowEntities.TabIndex = 34;
-            this.chkInitialBelowEntities.Text = "Below Entities";
-            this.chkInitialBelowEntities.CheckedChanged += new System.EventHandler(this.chkInitialBelowEntities_CheckedChanged);
+            chkInitialBelowEntities.Location = new System.Drawing.Point(286, 15);
+            chkInitialBelowEntities.Margin = new Padding(4, 3, 4, 3);
+            chkInitialBelowEntities.Name = "chkInitialBelowEntities";
+            chkInitialBelowEntities.Size = new Size(114, 24);
+            chkInitialBelowEntities.TabIndex = 34;
+            chkInitialBelowEntities.Text = "Below Entities";
+            chkInitialBelowEntities.CheckedChanged += chkInitialBelowEntities_CheckedChanged;
             // 
             // chkExhaustedFromTileset
             // 
-            this.chkExhaustedFromTileset.Location = new System.Drawing.Point(597, 32);
-            this.chkExhaustedFromTileset.Name = "chkExhaustedFromTileset";
-            this.chkExhaustedFromTileset.Size = new System.Drawing.Size(98, 21);
-            this.chkExhaustedFromTileset.TabIndex = 33;
-            this.chkExhaustedFromTileset.Text = "From Tileset";
-            this.chkExhaustedFromTileset.CheckedChanged += new System.EventHandler(this.chkExhaustedFromTileset_CheckedChanged);
+            chkExhaustedFromTileset.Location = new System.Drawing.Point(696, 37);
+            chkExhaustedFromTileset.Margin = new Padding(4, 3, 4, 3);
+            chkExhaustedFromTileset.Name = "chkExhaustedFromTileset";
+            chkExhaustedFromTileset.Size = new Size(114, 24);
+            chkExhaustedFromTileset.TabIndex = 33;
+            chkExhaustedFromTileset.Text = "From Tileset";
+            chkExhaustedFromTileset.CheckedChanged += chkExhaustedFromTileset_CheckedChanged;
             // 
             // chkInitialFromTileset
             // 
-            this.chkInitialFromTileset.Location = new System.Drawing.Point(245, 32);
-            this.chkInitialFromTileset.Name = "chkInitialFromTileset";
-            this.chkInitialFromTileset.Size = new System.Drawing.Size(98, 21);
-            this.chkInitialFromTileset.TabIndex = 32;
-            this.chkInitialFromTileset.Text = "From Tileset";
-            this.chkInitialFromTileset.CheckedChanged += new System.EventHandler(this.chkInitialFromTileset_CheckedChanged);
+            chkInitialFromTileset.Location = new System.Drawing.Point(286, 37);
+            chkInitialFromTileset.Margin = new Padding(4, 3, 4, 3);
+            chkInitialFromTileset.Name = "chkInitialFromTileset";
+            chkInitialFromTileset.Size = new Size(114, 24);
+            chkInitialFromTileset.TabIndex = 32;
+            chkInitialFromTileset.Text = "From Tileset";
+            chkInitialFromTileset.CheckedChanged += chkInitialFromTileset_CheckedChanged;
             // 
             // exhaustedGraphicContainer
             // 
-            this.exhaustedGraphicContainer.AutoScroll = true;
-            this.exhaustedGraphicContainer.Controls.Add(this.picEndResource);
-            this.exhaustedGraphicContainer.Location = new System.Drawing.Point(365, 62);
-            this.exhaustedGraphicContainer.Name = "exhaustedGraphicContainer";
-            this.exhaustedGraphicContainer.Size = new System.Drawing.Size(330, 386);
-            this.exhaustedGraphicContainer.TabIndex = 25;
+            exhaustedGraphicContainer.AutoScroll = true;
+            exhaustedGraphicContainer.Controls.Add(picEndResource);
+            exhaustedGraphicContainer.Location = new System.Drawing.Point(426, 72);
+            exhaustedGraphicContainer.Margin = new Padding(4, 3, 4, 3);
+            exhaustedGraphicContainer.Name = "exhaustedGraphicContainer";
+            exhaustedGraphicContainer.Size = new Size(385, 445);
+            exhaustedGraphicContainer.TabIndex = 25;
             // 
             // picEndResource
             // 
-            this.picEndResource.Location = new System.Drawing.Point(0, 0);
-            this.picEndResource.Name = "picEndResource";
-            this.picEndResource.Size = new System.Drawing.Size(182, 290);
-            this.picEndResource.TabIndex = 2;
-            this.picEndResource.TabStop = false;
-            this.picEndResource.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picExhustedResource_MouseDown);
-            this.picEndResource.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picExhaustedResource_MouseMove);
-            this.picEndResource.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picExhaustedResource_MouseUp);
+            picEndResource.Location = new System.Drawing.Point(0, 0);
+            picEndResource.Margin = new Padding(4, 3, 4, 3);
+            picEndResource.Name = "picEndResource";
+            picEndResource.Size = new Size(212, 335);
+            picEndResource.TabIndex = 2;
+            picEndResource.TabStop = false;
+            picEndResource.MouseDown += picExhustedResource_MouseDown;
+            picEndResource.MouseMove += picExhaustedResource_MouseMove;
+            picEndResource.MouseUp += picExhaustedResource_MouseUp;
             // 
             // initalGraphicContainer
             // 
-            this.initalGraphicContainer.AutoScroll = true;
-            this.initalGraphicContainer.Controls.Add(this.picInitialResource);
-            this.initalGraphicContainer.Location = new System.Drawing.Point(13, 62);
-            this.initalGraphicContainer.Name = "initalGraphicContainer";
-            this.initalGraphicContainer.Size = new System.Drawing.Size(330, 386);
-            this.initalGraphicContainer.TabIndex = 24;
+            initalGraphicContainer.AutoScroll = true;
+            initalGraphicContainer.Controls.Add(picInitialResource);
+            initalGraphicContainer.Location = new System.Drawing.Point(15, 72);
+            initalGraphicContainer.Margin = new Padding(4, 3, 4, 3);
+            initalGraphicContainer.Name = "initalGraphicContainer";
+            initalGraphicContainer.Size = new Size(385, 445);
+            initalGraphicContainer.TabIndex = 24;
             // 
             // picInitialResource
             // 
-            this.picInitialResource.Location = new System.Drawing.Point(0, 0);
-            this.picInitialResource.Name = "picInitialResource";
-            this.picInitialResource.Size = new System.Drawing.Size(180, 290);
-            this.picInitialResource.TabIndex = 2;
-            this.picInitialResource.TabStop = false;
-            this.picInitialResource.MouseDown += new System.Windows.Forms.MouseEventHandler(this.picInitialResource_MouseDown);
-            this.picInitialResource.MouseMove += new System.Windows.Forms.MouseEventHandler(this.picInitialResource_MouseMove);
-            this.picInitialResource.MouseUp += new System.Windows.Forms.MouseEventHandler(this.picInitialResource_MouseUp);
+            picInitialResource.Location = new System.Drawing.Point(0, 0);
+            picInitialResource.Margin = new Padding(4, 3, 4, 3);
+            picInitialResource.Name = "picInitialResource";
+            picInitialResource.Size = new Size(210, 335);
+            picInitialResource.TabIndex = 2;
+            picInitialResource.TabStop = false;
+            picInitialResource.MouseDown += picInitialResource_MouseDown;
+            picInitialResource.MouseMove += picInitialResource_MouseMove;
+            picInitialResource.MouseUp += picInitialResource_MouseUp;
             // 
             // cmbEndSprite
             // 
-            this.cmbEndSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbEndSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbEndSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbEndSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbEndSprite.DrawDropdownHoverOutline = false;
-            this.cmbEndSprite.DrawFocusRectangle = false;
-            this.cmbEndSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbEndSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbEndSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbEndSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbEndSprite.FormattingEnabled = true;
-            this.cmbEndSprite.Items.AddRange(new object[] {
-            "None"});
-            this.cmbEndSprite.Location = new System.Drawing.Point(365, 32);
-            this.cmbEndSprite.Name = "cmbEndSprite";
-            this.cmbEndSprite.Size = new System.Drawing.Size(196, 21);
-            this.cmbEndSprite.TabIndex = 16;
-            this.cmbEndSprite.Text = "None";
-            this.cmbEndSprite.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbEndSprite.SelectedIndexChanged += new System.EventHandler(this.cmbEndSprite_SelectedIndexChanged);
+            cmbEndSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbEndSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbEndSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbEndSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbEndSprite.DrawDropdownHoverOutline = false;
+            cmbEndSprite.DrawFocusRectangle = false;
+            cmbEndSprite.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbEndSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbEndSprite.FlatStyle = FlatStyle.Flat;
+            cmbEndSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbEndSprite.FormattingEnabled = true;
+            cmbEndSprite.Items.AddRange(new object[] { "None" });
+            cmbEndSprite.Location = new System.Drawing.Point(426, 37);
+            cmbEndSprite.Margin = new Padding(4, 3, 4, 3);
+            cmbEndSprite.Name = "cmbEndSprite";
+            cmbEndSprite.Size = new Size(228, 24);
+            cmbEndSprite.TabIndex = 16;
+            cmbEndSprite.Text = "None";
+            cmbEndSprite.TextPadding = new Padding(2);
+            cmbEndSprite.SelectedIndexChanged += cmbEndSprite_SelectedIndexChanged;
             // 
             // lblPic2
             // 
-            this.lblPic2.AutoSize = true;
-            this.lblPic2.Location = new System.Drawing.Point(362, 16);
-            this.lblPic2.Name = "lblPic2";
-            this.lblPic2.Size = new System.Drawing.Size(96, 13);
-            this.lblPic2.TabIndex = 15;
-            this.lblPic2.Text = "Removed Graphic:";
+            lblPic2.AutoSize = true;
+            lblPic2.Location = new System.Drawing.Point(422, 18);
+            lblPic2.Margin = new Padding(4, 0, 4, 0);
+            lblPic2.Name = "lblPic2";
+            lblPic2.Size = new Size(104, 15);
+            lblPic2.TabIndex = 15;
+            lblPic2.Text = "Removed Graphic:";
             // 
             // cmbInitialSprite
             // 
-            this.cmbInitialSprite.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbInitialSprite.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbInitialSprite.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbInitialSprite.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbInitialSprite.DrawDropdownHoverOutline = false;
-            this.cmbInitialSprite.DrawFocusRectangle = false;
-            this.cmbInitialSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbInitialSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbInitialSprite.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbInitialSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbInitialSprite.FormattingEnabled = true;
-            this.cmbInitialSprite.Items.AddRange(new object[] {
-            "None"});
-            this.cmbInitialSprite.Location = new System.Drawing.Point(13, 32);
-            this.cmbInitialSprite.Name = "cmbInitialSprite";
-            this.cmbInitialSprite.Size = new System.Drawing.Size(195, 21);
-            this.cmbInitialSprite.TabIndex = 14;
-            this.cmbInitialSprite.Text = "None";
-            this.cmbInitialSprite.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbInitialSprite.SelectedIndexChanged += new System.EventHandler(this.cmbInitialSprite_SelectedIndexChanged);
+            cmbInitialSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbInitialSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbInitialSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbInitialSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbInitialSprite.DrawDropdownHoverOutline = false;
+            cmbInitialSprite.DrawFocusRectangle = false;
+            cmbInitialSprite.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbInitialSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbInitialSprite.FlatStyle = FlatStyle.Flat;
+            cmbInitialSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbInitialSprite.FormattingEnabled = true;
+            cmbInitialSprite.Items.AddRange(new object[] { "None" });
+            cmbInitialSprite.Location = new System.Drawing.Point(15, 37);
+            cmbInitialSprite.Margin = new Padding(4, 3, 4, 3);
+            cmbInitialSprite.Name = "cmbInitialSprite";
+            cmbInitialSprite.Size = new Size(227, 24);
+            cmbInitialSprite.TabIndex = 14;
+            cmbInitialSprite.Text = "None";
+            cmbInitialSprite.TextPadding = new Padding(2);
+            cmbInitialSprite.SelectedIndexChanged += cmbInitialSprite_SelectedIndexChanged;
             // 
             // lblPic
             // 
-            this.lblPic.AutoSize = true;
-            this.lblPic.Location = new System.Drawing.Point(10, 16);
-            this.lblPic.Name = "lblPic";
-            this.lblPic.Size = new System.Drawing.Size(74, 13);
-            this.lblPic.TabIndex = 13;
-            this.lblPic.Text = "Initial Graphic:";
+            lblPic.AutoSize = true;
+            lblPic.Location = new System.Drawing.Point(12, 18);
+            lblPic.Margin = new Padding(4, 0, 4, 0);
+            lblPic.Name = "lblPic";
+            lblPic.Size = new Size(83, 15);
+            lblPic.TabIndex = 13;
+            lblPic.Text = "Initial Graphic:";
             // 
             // tmrRender
             // 
-            this.tmrRender.Enabled = true;
-            this.tmrRender.Interval = 10;
-            this.tmrRender.Tick += new System.EventHandler(this.tmrRender_Tick);
+            tmrRender.Enabled = true;
+            tmrRender.Interval = 10;
+            tmrRender.Tick += tmrRender_Tick;
             // 
             // pnlContainer
             // 
-            this.pnlContainer.AutoScroll = true;
-            this.pnlContainer.Controls.Add(this.grpRequirements);
-            this.pnlContainer.Controls.Add(this.grpCommonEvent);
-            this.pnlContainer.Controls.Add(this.grpRegen);
-            this.pnlContainer.Controls.Add(this.grpDrops);
-            this.pnlContainer.Controls.Add(this.grpGeneral);
-            this.pnlContainer.Controls.Add(this.grpGraphics);
-            this.pnlContainer.Location = new System.Drawing.Point(221, 39);
-            this.pnlContainer.Name = "pnlContainer";
-            this.pnlContainer.Size = new System.Drawing.Size(731, 550);
-            this.pnlContainer.TabIndex = 18;
-            this.pnlContainer.Visible = false;
+            pnlContainer.AutoScroll = true;
+            pnlContainer.Controls.Add(grpRequirements);
+            pnlContainer.Controls.Add(grpCommonEvent);
+            pnlContainer.Controls.Add(grpRegen);
+            pnlContainer.Controls.Add(grpDrops);
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Controls.Add(grpGraphics);
+            pnlContainer.Location = new System.Drawing.Point(258, 45);
+            pnlContainer.Margin = new Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new Size(853, 635);
+            pnlContainer.TabIndex = 18;
+            pnlContainer.Visible = false;
             // 
             // grpRequirements
             // 
-            this.grpRequirements.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpRequirements.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpRequirements.Controls.Add(this.lblCannotHarvest);
-            this.grpRequirements.Controls.Add(this.btnRequirements);
-            this.grpRequirements.Controls.Add(this.txtCannotHarvest);
-            this.grpRequirements.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpRequirements.Location = new System.Drawing.Point(462, 189);
-            this.grpRequirements.Margin = new System.Windows.Forms.Padding(2);
-            this.grpRequirements.Name = "grpRequirements";
-            this.grpRequirements.Padding = new System.Windows.Forms.Padding(2);
-            this.grpRequirements.Size = new System.Drawing.Size(244, 92);
-            this.grpRequirements.TabIndex = 33;
-            this.grpRequirements.TabStop = false;
-            this.grpRequirements.Text = "Requirements";
+            grpRequirements.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpRequirements.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpRequirements.Controls.Add(lblCannotHarvest);
+            grpRequirements.Controls.Add(btnRequirements);
+            grpRequirements.Controls.Add(txtCannotHarvest);
+            grpRequirements.ForeColor = System.Drawing.Color.Gainsboro;
+            grpRequirements.Location = new System.Drawing.Point(539, 218);
+            grpRequirements.Margin = new Padding(2);
+            grpRequirements.Name = "grpRequirements";
+            grpRequirements.Padding = new Padding(2);
+            grpRequirements.Size = new Size(285, 106);
+            grpRequirements.TabIndex = 33;
+            grpRequirements.TabStop = false;
+            grpRequirements.Text = "Requirements";
             // 
             // lblCannotHarvest
             // 
-            this.lblCannotHarvest.AutoSize = true;
-            this.lblCannotHarvest.Location = new System.Drawing.Point(5, 47);
-            this.lblCannotHarvest.Name = "lblCannotHarvest";
-            this.lblCannotHarvest.Size = new System.Drawing.Size(130, 13);
-            this.lblCannotHarvest.TabIndex = 54;
-            this.lblCannotHarvest.Text = "Cannot Harvest Message:";
+            lblCannotHarvest.AutoSize = true;
+            lblCannotHarvest.Location = new System.Drawing.Point(6, 54);
+            lblCannotHarvest.Margin = new Padding(4, 0, 4, 0);
+            lblCannotHarvest.Name = "lblCannotHarvest";
+            lblCannotHarvest.Size = new Size(141, 15);
+            lblCannotHarvest.TabIndex = 54;
+            lblCannotHarvest.Text = "Cannot Harvest Message:";
             // 
             // txtCannotHarvest
             // 
-            this.txtCannotHarvest.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.txtCannotHarvest.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtCannotHarvest.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.txtCannotHarvest.Location = new System.Drawing.Point(8, 63);
-            this.txtCannotHarvest.Name = "txtCannotHarvest";
-            this.txtCannotHarvest.Size = new System.Drawing.Size(225, 20);
-            this.txtCannotHarvest.TabIndex = 53;
-            this.txtCannotHarvest.TextChanged += new System.EventHandler(this.txtCannotHarvest_TextChanged);
+            txtCannotHarvest.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtCannotHarvest.BorderStyle = BorderStyle.FixedSingle;
+            txtCannotHarvest.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtCannotHarvest.Location = new System.Drawing.Point(9, 73);
+            txtCannotHarvest.Margin = new Padding(4, 3, 4, 3);
+            txtCannotHarvest.Name = "txtCannotHarvest";
+            txtCannotHarvest.Size = new Size(262, 23);
+            txtCannotHarvest.TabIndex = 53;
+            txtCannotHarvest.TextChanged += txtCannotHarvest_TextChanged;
             // 
             // grpCommonEvent
             // 
-            this.grpCommonEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpCommonEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpCommonEvent.Controls.Add(this.cmbEvent);
-            this.grpCommonEvent.Controls.Add(this.lblEvent);
-            this.grpCommonEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpCommonEvent.Location = new System.Drawing.Point(462, 116);
-            this.grpCommonEvent.Margin = new System.Windows.Forms.Padding(2);
-            this.grpCommonEvent.Name = "grpCommonEvent";
-            this.grpCommonEvent.Padding = new System.Windows.Forms.Padding(2);
-            this.grpCommonEvent.Size = new System.Drawing.Size(244, 69);
-            this.grpCommonEvent.TabIndex = 33;
-            this.grpCommonEvent.TabStop = false;
-            this.grpCommonEvent.Text = "Common Event";
+            grpCommonEvent.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpCommonEvent.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpCommonEvent.Controls.Add(cmbEvent);
+            grpCommonEvent.Controls.Add(lblEvent);
+            grpCommonEvent.ForeColor = System.Drawing.Color.Gainsboro;
+            grpCommonEvent.Location = new System.Drawing.Point(539, 134);
+            grpCommonEvent.Margin = new Padding(2);
+            grpCommonEvent.Name = "grpCommonEvent";
+            grpCommonEvent.Padding = new Padding(2);
+            grpCommonEvent.Size = new Size(285, 80);
+            grpCommonEvent.TabIndex = 33;
+            grpCommonEvent.TabStop = false;
+            grpCommonEvent.Text = "Common Event";
             // 
             // cmbEvent
             // 
-            this.cmbEvent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbEvent.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbEvent.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbEvent.DrawDropdownHoverOutline = false;
-            this.cmbEvent.DrawFocusRectangle = false;
-            this.cmbEvent.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbEvent.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbEvent.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbEvent.FormattingEnabled = true;
-            this.cmbEvent.Location = new System.Drawing.Point(8, 35);
-            this.cmbEvent.Name = "cmbEvent";
-            this.cmbEvent.Size = new System.Drawing.Size(195, 21);
-            this.cmbEvent.TabIndex = 19;
-            this.cmbEvent.Text = null;
-            this.cmbEvent.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbEvent.SelectedIndexChanged += new System.EventHandler(this.cmbEvent_SelectedIndexChanged);
+            cmbEvent.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbEvent.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbEvent.BorderStyle = ButtonBorderStyle.Solid;
+            cmbEvent.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbEvent.DrawDropdownHoverOutline = false;
+            cmbEvent.DrawFocusRectangle = false;
+            cmbEvent.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbEvent.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbEvent.FlatStyle = FlatStyle.Flat;
+            cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbEvent.FormattingEnabled = true;
+            cmbEvent.Location = new System.Drawing.Point(9, 40);
+            cmbEvent.Margin = new Padding(4, 3, 4, 3);
+            cmbEvent.Name = "cmbEvent";
+            cmbEvent.Size = new Size(227, 24);
+            cmbEvent.TabIndex = 19;
+            cmbEvent.Text = null;
+            cmbEvent.TextPadding = new Padding(2);
+            cmbEvent.SelectedIndexChanged += cmbEvent_SelectedIndexChanged;
             // 
             // lblEvent
             // 
-            this.lblEvent.AutoSize = true;
-            this.lblEvent.Location = new System.Drawing.Point(5, 18);
-            this.lblEvent.Name = "lblEvent";
-            this.lblEvent.Size = new System.Drawing.Size(38, 13);
-            this.lblEvent.TabIndex = 18;
-            this.lblEvent.Text = "Event:";
+            lblEvent.AutoSize = true;
+            lblEvent.Location = new System.Drawing.Point(6, 21);
+            lblEvent.Margin = new Padding(4, 0, 4, 0);
+            lblEvent.Name = "lblEvent";
+            lblEvent.Size = new Size(39, 15);
+            lblEvent.TabIndex = 18;
+            lblEvent.Text = "Event:";
             // 
             // grpRegen
             // 
-            this.grpRegen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpRegen.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpRegen.Controls.Add(this.nudHpRegen);
-            this.grpRegen.Controls.Add(this.lblHpRegen);
-            this.grpRegen.Controls.Add(this.lblRegenHint);
-            this.grpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpRegen.Location = new System.Drawing.Point(462, 2);
-            this.grpRegen.Margin = new System.Windows.Forms.Padding(2);
-            this.grpRegen.Name = "grpRegen";
-            this.grpRegen.Padding = new System.Windows.Forms.Padding(2);
-            this.grpRegen.Size = new System.Drawing.Size(244, 110);
-            this.grpRegen.TabIndex = 32;
-            this.grpRegen.TabStop = false;
-            this.grpRegen.Text = "Regen";
+            grpRegen.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpRegen.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpRegen.Controls.Add(nudHpRegen);
+            grpRegen.Controls.Add(lblHpRegen);
+            grpRegen.Controls.Add(lblRegenHint);
+            grpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            grpRegen.Location = new System.Drawing.Point(539, 2);
+            grpRegen.Margin = new Padding(2);
+            grpRegen.Name = "grpRegen";
+            grpRegen.Padding = new Padding(2);
+            grpRegen.Size = new Size(285, 127);
+            grpRegen.TabIndex = 32;
+            grpRegen.TabStop = false;
+            grpRegen.Text = "Regen";
             // 
             // nudHpRegen
             // 
-            this.nudHpRegen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudHpRegen.Location = new System.Drawing.Point(8, 31);
-            this.nudHpRegen.Name = "nudHpRegen";
-            this.nudHpRegen.Size = new System.Drawing.Size(86, 20);
-            this.nudHpRegen.TabIndex = 30;
-            this.nudHpRegen.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudHpRegen.ValueChanged += new System.EventHandler(this.nudHpRegen_ValueChanged);
+            nudHpRegen.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudHpRegen.ForeColor = System.Drawing.Color.Gainsboro;
+            nudHpRegen.Location = new System.Drawing.Point(9, 36);
+            nudHpRegen.Margin = new Padding(4, 3, 4, 3);
+            nudHpRegen.Name = "nudHpRegen";
+            nudHpRegen.Size = new Size(100, 23);
+            nudHpRegen.TabIndex = 30;
+            nudHpRegen.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudHpRegen.ValueChanged += nudHpRegen_ValueChanged;
             // 
             // lblHpRegen
             // 
-            this.lblHpRegen.AutoSize = true;
-            this.lblHpRegen.Location = new System.Drawing.Point(5, 17);
-            this.lblHpRegen.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblHpRegen.Name = "lblHpRegen";
-            this.lblHpRegen.Size = new System.Drawing.Size(42, 13);
-            this.lblHpRegen.TabIndex = 26;
-            this.lblHpRegen.Text = "HP: (%)";
+            lblHpRegen.AutoSize = true;
+            lblHpRegen.Location = new System.Drawing.Point(6, 20);
+            lblHpRegen.Margin = new Padding(2, 0, 2, 0);
+            lblHpRegen.Name = "lblHpRegen";
+            lblHpRegen.Size = new Size(47, 15);
+            lblHpRegen.TabIndex = 26;
+            lblHpRegen.Text = "HP: (%)";
             // 
             // lblRegenHint
             // 
-            this.lblRegenHint.Location = new System.Drawing.Point(102, 28);
-            this.lblRegenHint.Name = "lblRegenHint";
-            this.lblRegenHint.Size = new System.Drawing.Size(137, 72);
-            this.lblRegenHint.TabIndex = 0;
-            this.lblRegenHint.Text = "% of HP to restore per tick.\r\n\r\nTick timer saved in server config.json.";
+            lblRegenHint.Location = new System.Drawing.Point(119, 32);
+            lblRegenHint.Margin = new Padding(4, 0, 4, 0);
+            lblRegenHint.Name = "lblRegenHint";
+            lblRegenHint.Size = new Size(160, 83);
+            lblRegenHint.TabIndex = 0;
+            lblRegenHint.Text = "% of HP to restore per tick.\r\n\r\nTick timer saved in server config.json.";
             // 
             // grpDrops
             // 
-            this.grpDrops.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.grpDrops.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.grpDrops.Controls.Add(this.btnDropRemove);
-            this.grpDrops.Controls.Add(this.btnDropAdd);
-            this.grpDrops.Controls.Add(this.lstDrops);
-            this.grpDrops.Controls.Add(this.nudDropAmount);
-            this.grpDrops.Controls.Add(this.nudDropChance);
-            this.grpDrops.Controls.Add(this.cmbDropItem);
-            this.grpDrops.Controls.Add(this.lblDropAmount);
-            this.grpDrops.Controls.Add(this.lblDropChance);
-            this.grpDrops.Controls.Add(this.lblDropItem);
-            this.grpDrops.ForeColor = System.Drawing.Color.Gainsboro;
-            this.grpDrops.Location = new System.Drawing.Point(231, 0);
-            this.grpDrops.Name = "grpDrops";
-            this.grpDrops.Size = new System.Drawing.Size(226, 281);
-            this.grpDrops.TabIndex = 31;
-            this.grpDrops.TabStop = false;
-            this.grpDrops.Text = "Drops";
+            grpDrops.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpDrops.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpDrops.Controls.Add(nudDropMinAmount);
+            grpDrops.Controls.Add(lblDropMinAmount);
+            grpDrops.Controls.Add(btnDropRemove);
+            grpDrops.Controls.Add(btnDropAdd);
+            grpDrops.Controls.Add(lstDrops);
+            grpDrops.Controls.Add(nudDropAmount);
+            grpDrops.Controls.Add(nudDropChance);
+            grpDrops.Controls.Add(cmbDropItem);
+            grpDrops.Controls.Add(lblDropAmount);
+            grpDrops.Controls.Add(lblDropChance);
+            grpDrops.Controls.Add(lblDropItem);
+            grpDrops.ForeColor = System.Drawing.Color.Gainsboro;
+            grpDrops.Location = new System.Drawing.Point(270, 0);
+            grpDrops.Margin = new Padding(4, 3, 4, 3);
+            grpDrops.Name = "grpDrops";
+            grpDrops.Padding = new Padding(4, 3, 4, 3);
+            grpDrops.Size = new Size(264, 324);
+            grpDrops.TabIndex = 31;
+            grpDrops.TabStop = false;
+            grpDrops.Text = "Drops";
             // 
             // btnDropRemove
             // 
-            this.btnDropRemove.Location = new System.Drawing.Point(126, 252);
-            this.btnDropRemove.Name = "btnDropRemove";
-            this.btnDropRemove.Padding = new System.Windows.Forms.Padding(5);
-            this.btnDropRemove.Size = new System.Drawing.Size(75, 23);
-            this.btnDropRemove.TabIndex = 64;
-            this.btnDropRemove.Text = "Remove";
-            this.btnDropRemove.Click += new System.EventHandler(this.btnDropRemove_Click);
+            btnDropRemove.Location = new System.Drawing.Point(160, 291);
+            btnDropRemove.Margin = new Padding(4, 3, 4, 3);
+            btnDropRemove.Name = "btnDropRemove";
+            btnDropRemove.Padding = new Padding(6, 6, 6, 6);
+            btnDropRemove.Size = new Size(88, 27);
+            btnDropRemove.TabIndex = 64;
+            btnDropRemove.Text = "Remove";
+            btnDropRemove.Click += btnDropRemove_Click;
             // 
             // btnDropAdd
             // 
-            this.btnDropAdd.Location = new System.Drawing.Point(6, 252);
-            this.btnDropAdd.Name = "btnDropAdd";
-            this.btnDropAdd.Padding = new System.Windows.Forms.Padding(5);
-            this.btnDropAdd.Size = new System.Drawing.Size(75, 23);
-            this.btnDropAdd.TabIndex = 63;
-            this.btnDropAdd.Text = "Add";
-            this.btnDropAdd.Click += new System.EventHandler(this.btnDropAdd_Click);
+            btnDropAdd.Location = new System.Drawing.Point(20, 291);
+            btnDropAdd.Margin = new Padding(4, 3, 4, 3);
+            btnDropAdd.Name = "btnDropAdd";
+            btnDropAdd.Padding = new Padding(6, 6, 6, 6);
+            btnDropAdd.Size = new Size(88, 27);
+            btnDropAdd.TabIndex = 63;
+            btnDropAdd.Text = "Add";
+            btnDropAdd.Click += btnDropAdd_Click;
             // 
             // lstDrops
             // 
-            this.lstDrops.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lstDrops.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lstDrops.ForeColor = System.Drawing.Color.Gainsboro;
-            this.lstDrops.FormattingEnabled = true;
-            this.lstDrops.Location = new System.Drawing.Point(9, 19);
-            this.lstDrops.Name = "lstDrops";
-            this.lstDrops.Size = new System.Drawing.Size(192, 93);
-            this.lstDrops.TabIndex = 62;
-            this.lstDrops.SelectedIndexChanged += new System.EventHandler(this.lstDrops_SelectedIndexChanged);
+            lstDrops.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstDrops.BorderStyle = BorderStyle.FixedSingle;
+            lstDrops.ForeColor = System.Drawing.Color.Gainsboro;
+            lstDrops.FormattingEnabled = true;
+            lstDrops.ItemHeight = 15;
+            lstDrops.Location = new System.Drawing.Point(23, 22);
+            lstDrops.Margin = new Padding(4, 3, 4, 3);
+            lstDrops.Name = "lstDrops";
+            lstDrops.Size = new Size(224, 107);
+            lstDrops.TabIndex = 62;
+            lstDrops.SelectedIndexChanged += lstDrops_SelectedIndexChanged;
             // 
             // nudDropAmount
             // 
-            this.nudDropAmount.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDropAmount.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDropAmount.Location = new System.Drawing.Point(6, 173);
-            this.nudDropAmount.Maximum = new decimal(new int[] {
-            10000000,
-            0,
-            0,
-            0});
-            this.nudDropAmount.Name = "nudDropAmount";
-            this.nudDropAmount.Size = new System.Drawing.Size(195, 20);
-            this.nudDropAmount.TabIndex = 61;
-            this.nudDropAmount.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nudDropAmount.ValueChanged += new System.EventHandler(this.nudDropAmount_ValueChanged);
+            nudDropAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropAmount.Location = new System.Drawing.Point(139, 202);
+            nudDropAmount.Margin = new Padding(4, 3, 4, 3);
+            nudDropAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
+            nudDropAmount.Name = "nudDropAmount";
+            nudDropAmount.Size = new Size(108, 23);
+            nudDropAmount.TabIndex = 61;
+            nudDropAmount.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropAmount.ValueChanged += nudDropAmount_ValueChanged;
             // 
             // nudDropChance
             // 
-            this.nudDropChance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.nudDropChance.DecimalPlaces = 2;
-            this.nudDropChance.ForeColor = System.Drawing.Color.Gainsboro;
-            this.nudDropChance.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.nudDropChance.Location = new System.Drawing.Point(6, 219);
-            this.nudDropChance.Name = "nudDropChance";
-            this.nudDropChance.Size = new System.Drawing.Size(195, 20);
-            this.nudDropChance.TabIndex = 60;
-            this.nudDropChance.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudDropChance.ValueChanged += new System.EventHandler(this.nudDropChance_ValueChanged);
+            nudDropChance.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropChance.DecimalPlaces = 2;
+            nudDropChance.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropChance.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
+            nudDropChance.Location = new System.Drawing.Point(20, 253);
+            nudDropChance.Margin = new Padding(4, 3, 4, 3);
+            nudDropChance.Name = "nudDropChance";
+            nudDropChance.Size = new Size(227, 23);
+            nudDropChance.TabIndex = 60;
+            nudDropChance.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudDropChance.ValueChanged += nudDropChance_ValueChanged;
             // 
             // cmbDropItem
             // 
-            this.cmbDropItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
-            this.cmbDropItem.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-            this.cmbDropItem.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
-            this.cmbDropItem.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
-            this.cmbDropItem.DrawDropdownHoverOutline = false;
-            this.cmbDropItem.DrawFocusRectangle = false;
-            this.cmbDropItem.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.cmbDropItem.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbDropItem.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cmbDropItem.ForeColor = System.Drawing.Color.Gainsboro;
-            this.cmbDropItem.FormattingEnabled = true;
-            this.cmbDropItem.Location = new System.Drawing.Point(6, 131);
-            this.cmbDropItem.Name = "cmbDropItem";
-            this.cmbDropItem.Size = new System.Drawing.Size(195, 21);
-            this.cmbDropItem.TabIndex = 17;
-            this.cmbDropItem.Text = null;
-            this.cmbDropItem.TextPadding = new System.Windows.Forms.Padding(2);
-            this.cmbDropItem.SelectedIndexChanged += new System.EventHandler(this.cmbDropItem_SelectedIndexChanged);
+            cmbDropItem.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDropItem.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDropItem.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDropItem.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDropItem.DrawDropdownHoverOutline = false;
+            cmbDropItem.DrawFocusRectangle = false;
+            cmbDropItem.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDropItem.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDropItem.FlatStyle = FlatStyle.Flat;
+            cmbDropItem.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDropItem.FormattingEnabled = true;
+            cmbDropItem.Location = new System.Drawing.Point(20, 151);
+            cmbDropItem.Margin = new Padding(4, 3, 4, 3);
+            cmbDropItem.Name = "cmbDropItem";
+            cmbDropItem.Size = new Size(227, 24);
+            cmbDropItem.TabIndex = 17;
+            cmbDropItem.Text = null;
+            cmbDropItem.TextPadding = new Padding(2);
+            cmbDropItem.SelectedIndexChanged += cmbDropItem_SelectedIndexChanged;
             // 
             // lblDropAmount
             // 
-            this.lblDropAmount.AutoSize = true;
-            this.lblDropAmount.Location = new System.Drawing.Point(3, 157);
-            this.lblDropAmount.Name = "lblDropAmount";
-            this.lblDropAmount.Size = new System.Drawing.Size(46, 13);
-            this.lblDropAmount.TabIndex = 15;
-            this.lblDropAmount.Text = "Amount:";
+            lblDropAmount.AutoSize = true;
+            lblDropAmount.Location = new System.Drawing.Point(139, 181);
+            lblDropAmount.Margin = new Padding(4, 0, 4, 0);
+            lblDropAmount.Name = "lblDropAmount";
+            lblDropAmount.Size = new Size(80, 15);
+            lblDropAmount.TabIndex = 15;
+            lblDropAmount.Text = "Max Amount:";
             // 
             // lblDropChance
             // 
-            this.lblDropChance.AutoSize = true;
-            this.lblDropChance.Location = new System.Drawing.Point(3, 202);
-            this.lblDropChance.Name = "lblDropChance";
-            this.lblDropChance.Size = new System.Drawing.Size(64, 13);
-            this.lblDropChance.TabIndex = 13;
-            this.lblDropChance.Text = "Chance (%):";
+            lblDropChance.AutoSize = true;
+            lblDropChance.Location = new System.Drawing.Point(17, 233);
+            lblDropChance.Margin = new Padding(4, 0, 4, 0);
+            lblDropChance.Name = "lblDropChance";
+            lblDropChance.Size = new Size(71, 15);
+            lblDropChance.TabIndex = 13;
+            lblDropChance.Text = "Chance (%):";
             // 
             // lblDropItem
             // 
-            this.lblDropItem.AutoSize = true;
-            this.lblDropItem.Location = new System.Drawing.Point(3, 114);
-            this.lblDropItem.Name = "lblDropItem";
-            this.lblDropItem.Size = new System.Drawing.Size(30, 13);
-            this.lblDropItem.TabIndex = 11;
-            this.lblDropItem.Text = "Item:";
+            lblDropItem.AutoSize = true;
+            lblDropItem.Location = new System.Drawing.Point(17, 132);
+            lblDropItem.Margin = new Padding(4, 0, 4, 0);
+            lblDropItem.Name = "lblDropItem";
+            lblDropItem.Size = new Size(34, 15);
+            lblDropItem.TabIndex = 11;
+            lblDropItem.Text = "Item:";
             // 
             // btnCancel
             // 
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(760, 596);
-            this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
-            this.btnCancel.Size = new System.Drawing.Size(190, 27);
-            this.btnCancel.TabIndex = 44;
-            this.btnCancel.Text = "Cancel";
-            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(887, 688);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6, 6, 6, 6);
+            btnCancel.Size = new Size(222, 31);
+            btnCancel.TabIndex = 44;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(564, 596);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Padding = new System.Windows.Forms.Padding(5);
-            this.btnSave.Size = new System.Drawing.Size(190, 27);
-            this.btnSave.TabIndex = 41;
-            this.btnSave.Text = "Save";
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            btnSave.Location = new System.Drawing.Point(658, 688);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6, 6, 6, 6);
+            btnSave.Size = new Size(222, 31);
+            btnSave.TabIndex = 41;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
             // 
             // toolStrip
             // 
-            this.toolStrip.AutoSize = false;
-            this.toolStrip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.toolStrip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripItemNew,
-            this.toolStripSeparator1,
-            this.toolStripItemDelete,
-            this.toolStripSeparator2,
-            this.btnAlphabetical,
-            this.toolStripSeparator4,
-            this.toolStripItemCopy,
-            this.toolStripItemPaste,
-            this.toolStripSeparator3,
-            this.toolStripItemUndo});
-            this.toolStrip.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip.Name = "toolStrip";
-            this.toolStrip.Padding = new System.Windows.Forms.Padding(5, 0, 1, 0);
-            this.toolStrip.Size = new System.Drawing.Size(959, 25);
-            this.toolStrip.TabIndex = 47;
-            this.toolStrip.Text = "toolStrip1";
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(6, 0, 1, 0);
+            toolStrip.Size = new Size(1119, 29);
+            toolStrip.TabIndex = 47;
+            toolStrip.Text = "toolStrip1";
             // 
             // toolStripItemNew
             // 
-            this.toolStripItemNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemNew.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemNew.Image")));
-            this.toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemNew.Name = "toolStripItemNew";
-            this.toolStripItemNew.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemNew.Text = "New";
-            this.toolStripItemNew.Click += new System.EventHandler(this.toolStripItemNew_Click);
+            toolStripItemNew.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
             // 
             // toolStripSeparator1
             // 
-            this.toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator1.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new Size(6, 29);
             // 
             // toolStripItemDelete
             // 
-            this.toolStripItemDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemDelete.Enabled = false;
-            this.toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemDelete.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemDelete.Image")));
-            this.toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemDelete.Name = "toolStripItemDelete";
-            this.toolStripItemDelete.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemDelete.Text = "Delete";
-            this.toolStripItemDelete.Click += new System.EventHandler(this.toolStripItemDelete_Click);
+            toolStripItemDelete.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
             // 
             // toolStripSeparator2
             // 
-            this.toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator2.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new Size(6, 29);
             // 
             // btnAlphabetical
             // 
-            this.btnAlphabetical.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.btnAlphabetical.Image = ((System.Drawing.Image)(resources.GetObject("btnAlphabetical.Image")));
-            this.btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.btnAlphabetical.Name = "btnAlphabetical";
-            this.btnAlphabetical.Size = new System.Drawing.Size(23, 22);
-            this.btnAlphabetical.Text = "Order Chronologically";
-            this.btnAlphabetical.Click += new System.EventHandler(this.btnAlphabetical_Click);
+            btnAlphabetical.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new Size(23, 26);
+            btnAlphabetical.Text = "Order Chronologically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
             // 
             // toolStripSeparator4
             // 
-            this.toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator4.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new Size(6, 29);
             // 
             // toolStripItemCopy
             // 
-            this.toolStripItemCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemCopy.Enabled = false;
-            this.toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemCopy.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemCopy.Image")));
-            this.toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemCopy.Name = "toolStripItemCopy";
-            this.toolStripItemCopy.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemCopy.Text = "Copy";
-            this.toolStripItemCopy.Click += new System.EventHandler(this.toolStripItemCopy_Click);
+            toolStripItemCopy.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
             // 
             // toolStripItemPaste
             // 
-            this.toolStripItemPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemPaste.Enabled = false;
-            this.toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemPaste.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemPaste.Image")));
-            this.toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemPaste.Name = "toolStripItemPaste";
-            this.toolStripItemPaste.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemPaste.Text = "Paste";
-            this.toolStripItemPaste.Click += new System.EventHandler(this.toolStripItemPaste_Click);
+            toolStripItemPaste.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
             // 
             // toolStripSeparator3
             // 
-            this.toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator3.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new Size(6, 29);
             // 
             // toolStripItemUndo
             // 
-            this.toolStripItemUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripItemUndo.Enabled = false;
-            this.toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripItemUndo.Image = ((System.Drawing.Image)(resources.GetObject("toolStripItemUndo.Image")));
-            this.toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripItemUndo.Name = "toolStripItemUndo";
-            this.toolStripItemUndo.Size = new System.Drawing.Size(23, 22);
-            this.toolStripItemUndo.Text = "Undo";
-            this.toolStripItemUndo.Click += new System.EventHandler(this.toolStripItemUndo_Click);
+            toolStripItemUndo.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
+            // 
+            // nudDropMinAmount
+            // 
+            nudDropMinAmount.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDropMinAmount.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDropMinAmount.Location = new System.Drawing.Point(20, 202);
+            nudDropMinAmount.Margin = new Padding(4, 3, 4, 3);
+            nudDropMinAmount.Maximum = new decimal(new int[] { 10000000, 0, 0, 0 });
+            nudDropMinAmount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropMinAmount.Name = "nudDropMinAmount";
+            nudDropMinAmount.Size = new Size(108, 23);
+            nudDropMinAmount.TabIndex = 82;
+            nudDropMinAmount.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudDropMinAmount.ValueChanged += nudDropMinAmount_ValueChanged;
+            // 
+            // lblDropMinAmount
+            // 
+            lblDropMinAmount.AutoSize = true;
+            lblDropMinAmount.Location = new System.Drawing.Point(20, 180);
+            lblDropMinAmount.Margin = new Padding(4, 0, 4, 0);
+            lblDropMinAmount.Name = "lblDropMinAmount";
+            lblDropMinAmount.Size = new Size(78, 15);
+            lblDropMinAmount.TabIndex = 81;
+            lblDropMinAmount.Text = "Min Amount:";
             // 
             // FrmResource
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoSize = true;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
-            this.ClientSize = new System.Drawing.Size(959, 631);
-            this.ControlBox = false;
-            this.Controls.Add(this.toolStrip);
-            this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.grpResources);
-            this.Controls.Add(this.pnlContainer);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.KeyPreview = true;
-            this.Name = "FrmResource";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Resource Editor";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.frmResource_FormClosed);
-            this.Load += new System.EventHandler(this.frmResource_Load);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.form_KeyDown);
-            this.grpResources.ResumeLayout(false);
-            this.grpResources.PerformLayout();
-            this.grpGeneral.ResumeLayout(false);
-            this.grpGeneral.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMaxHp)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinHp)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudSpawnDuration)).EndInit();
-            this.grpGraphics.ResumeLayout(false);
-            this.grpGraphics.PerformLayout();
-            this.exhaustedGraphicContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.picEndResource)).EndInit();
-            this.initalGraphicContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.picInitialResource)).EndInit();
-            this.pnlContainer.ResumeLayout(false);
-            this.grpRequirements.ResumeLayout(false);
-            this.grpRequirements.PerformLayout();
-            this.grpCommonEvent.ResumeLayout(false);
-            this.grpCommonEvent.PerformLayout();
-            this.grpRegen.ResumeLayout(false);
-            this.grpRegen.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudHpRegen)).EndInit();
-            this.grpDrops.ResumeLayout(false);
-            this.grpDrops.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropAmount)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudDropChance)).EndInit();
-            this.toolStrip.ResumeLayout(false);
-            this.toolStrip.PerformLayout();
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            ClientSize = new Size(1119, 728);
+            ControlBox = false;
+            Controls.Add(toolStrip);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(grpResources);
+            Controls.Add(pnlContainer);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            KeyPreview = true;
+            Margin = new Padding(4, 3, 4, 3);
+            Name = "FrmResource";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Resource Editor";
+            FormClosed += frmResource_FormClosed;
+            Load += frmResource_Load;
+            KeyDown += form_KeyDown;
+            grpResources.ResumeLayout(false);
+            grpResources.PerformLayout();
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudMaxHp).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudMinHp).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpawnDuration).EndInit();
+            grpGraphics.ResumeLayout(false);
+            grpGraphics.PerformLayout();
+            exhaustedGraphicContainer.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)picEndResource).EndInit();
+            initalGraphicContainer.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)picInitialResource).EndInit();
+            pnlContainer.ResumeLayout(false);
+            grpRequirements.ResumeLayout(false);
+            grpRequirements.PerformLayout();
+            grpCommonEvent.ResumeLayout(false);
+            grpCommonEvent.PerformLayout();
+            grpRegen.ResumeLayout(false);
+            grpRegen.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudHpRegen).EndInit();
+            grpDrops.ResumeLayout(false);
+            grpDrops.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropAmount).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDropChance).EndInit();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudDropMinAmount).EndInit();
+            ResumeLayout(false);
         }
 
         #endregion
@@ -1168,5 +1202,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkGroupBox grpRequirements;
         private System.Windows.Forms.Label lblCannotHarvest;
         private DarkTextBox txtCannotHarvest;
+        private DarkNumericUpDown nudDropMinAmount;
+        private Label lblDropMinAmount;
     }
 }

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -205,6 +205,7 @@ namespace Intersect.Editor.Forms.Editors
             grpDrops.Text = Strings.ResourceEditor.drops;
             lblDropItem.Text = Strings.ResourceEditor.dropitem;
             lblDropAmount.Text = Strings.ResourceEditor.dropamount;
+            lblDropMinAmount.Text = Strings.ResourceEditor.DropMinAmount;
             lblDropChance.Text = Strings.ResourceEditor.dropchance;
             btnDropAdd.Text = Strings.ResourceEditor.dropadd;
             btnDropRemove.Text = Strings.ResourceEditor.dropremove;
@@ -300,8 +301,8 @@ namespace Intersect.Editor.Forms.Editors
                 {
                     lstDrops.Items.Add(
                         Strings.ResourceEditor.dropdisplay.ToString(
-                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
-                            mEditorItem.Drops[i].Chance
+                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].MinQuantity,
+                            mEditorItem.Drops[i].Quantity, mEditorItem.Drops[i].Chance
                         )
                     );
                 }
@@ -319,7 +320,7 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudSpawnDuration_ValueChanged(object sender, EventArgs e)
         {
-            mEditorItem.SpawnDuration = (int) nudSpawnDuration.Value;
+            mEditorItem.SpawnDuration = (int)nudSpawnDuration.Value;
         }
 
         private void cmbToolType_SelectedIndexChanged(object sender, EventArgs e)
@@ -351,7 +352,7 @@ namespace Intersect.Editor.Forms.Editors
 
                 if (File.Exists(graphic))
                 {
-                    mInitialGraphic = (Bitmap) Image.FromFile(graphic);
+                    mInitialGraphic = (Bitmap)Image.FromFile(graphic);
                     picInitialResource.Width = mInitialGraphic.Width;
                     picInitialResource.Height = mInitialGraphic.Height;
                     mInitialBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
@@ -379,7 +380,7 @@ namespace Intersect.Editor.Forms.Editors
 
                 if (File.Exists(graphic))
                 {
-                    mEndGraphic = (Bitmap) Image.FromFile(graphic);
+                    mEndGraphic = (Bitmap)Image.FromFile(graphic);
                     picEndResource.Width = mEndGraphic.Width;
                     picEndResource.Height = mEndGraphic.Height;
                     mEndBitmap = new Bitmap(picEndResource.Width, picEndResource.Height);
@@ -591,35 +592,44 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudMinHp_ValueChanged(object sender, EventArgs e)
         {
-            mEditorItem.MinHp = (int) nudMinHp.Value;
+            mEditorItem.MinHp = (int)nudMinHp.Value;
         }
 
         private void nudMaxHp_ValueChanged(object sender, EventArgs e)
         {
-            mEditorItem.MaxHp = (int) nudMaxHp.Value;
+            mEditorItem.MaxHp = (int)nudMaxHp.Value;
         }
 
         private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
-                mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+                return;
             }
 
+            mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
             UpdateDropValues(true);
         }
 
         private void nudDropAmount_ValueChanged(object sender, EventArgs e)
         {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
-
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
                 return;
             }
 
-            mEditorItem.Drops[(int) lstDrops.SelectedIndex].Quantity = (int) nudDropAmount.Value;
+            mEditorItem.Drops[lstDrops.SelectedIndex].Quantity = (int)nudDropAmount.Value;
+            UpdateDropValues(true);
+        }
+
+        private void nudDropMinAmount_ValueChanged(object sender, EventArgs e)
+        {
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
+            {
+                return;
+            }
+
+            mEditorItem.Drops[lstDrops.SelectedIndex].MinQuantity = (int)nudDropMinAmount.Value;
             UpdateDropValues(true);
         }
 
@@ -629,7 +639,8 @@ namespace Intersect.Editor.Forms.Editors
             {
                 cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
                 nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
-                nudDropChance.Value = (decimal) mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
+                nudDropMinAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].MinQuantity;
+                nudDropChance.Value = (decimal)mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
             }
         }
 
@@ -637,8 +648,9 @@ namespace Intersect.Editor.Forms.Editors
         {
             mEditorItem.Drops.Add(new Drop());
             mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int) nudDropAmount.Value;
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double) nudDropChance.Value;
+            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int)nudDropAmount.Value;
+            mEditorItem.Drops[mEditorItem.Drops.Count - 1].MinQuantity = (int)nudDropMinAmount.Value;
+            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double)nudDropChance.Value;
 
             UpdateDropValues();
         }
@@ -657,12 +669,12 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudDropChance_ValueChanged(object sender, EventArgs e)
         {
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+            if (lstDrops.SelectedIndex < 0 || lstDrops.SelectedIndex > lstDrops.Items.Count)
             {
                 return;
             }
 
-            mEditorItem.Drops[(int) lstDrops.SelectedIndex].Chance = (double) nudDropChance.Value;
+            mEditorItem.Drops[(int)lstDrops.SelectedIndex].Chance = (double)nudDropChance.Value;
             UpdateDropValues(true);
         }
 
@@ -691,8 +703,8 @@ namespace Intersect.Editor.Forms.Editors
             }
 
             mMouseDown = true;
-            mEditorItem.Initial.X = (int) Math.Floor((double) e.X / Options.TileWidth);
-            mEditorItem.Initial.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            mEditorItem.Initial.X = (int)Math.Floor((double)e.X / Options.TileWidth);
+            mEditorItem.Initial.Y = (int)Math.Floor((double)e.Y / Options.TileHeight);
             mEditorItem.Initial.Width = 0;
             mEditorItem.Initial.Height = 0;
             if (mEditorItem.Initial.X < 0)
@@ -758,8 +770,8 @@ namespace Intersect.Editor.Forms.Editors
 
             if (mMouseDown)
             {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+                var tmpX = (int)Math.Floor((double)e.X / Options.TileWidth);
+                var tmpY = (int)Math.Floor((double)e.Y / Options.TileHeight);
                 mEditorItem.Initial.Width = tmpX - mEditorItem.Initial.X;
                 mEditorItem.Initial.Height = tmpY - mEditorItem.Initial.Y;
             }
@@ -780,8 +792,8 @@ namespace Intersect.Editor.Forms.Editors
             }
 
             mMouseDown = true;
-            mEditorItem.Exhausted.X = (int) Math.Floor((double) e.X / Options.TileWidth);
-            mEditorItem.Exhausted.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            mEditorItem.Exhausted.X = (int)Math.Floor((double)e.X / Options.TileWidth);
+            mEditorItem.Exhausted.Y = (int)Math.Floor((double)e.Y / Options.TileHeight);
             mEditorItem.Exhausted.Width = 0;
             mEditorItem.Exhausted.Height = 0;
             if (mEditorItem.Exhausted.X < 0)
@@ -847,8 +859,8 @@ namespace Intersect.Editor.Forms.Editors
 
             if (mMouseDown)
             {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+                var tmpX = (int)Math.Floor((double)e.X / Options.TileWidth);
+                var tmpY = (int)Math.Floor((double)e.Y / Options.TileHeight);
                 mEditorItem.Exhausted.Width = tmpX - mEditorItem.Exhausted.X;
                 mEditorItem.Exhausted.Height = tmpY - mEditorItem.Exhausted.Y;
             }
@@ -858,7 +870,7 @@ namespace Intersect.Editor.Forms.Editors
 
         private void nudHpRegen_ValueChanged(object sender, EventArgs e)
         {
-            mEditorItem.VitalRegen = (int) nudHpRegen.Value;
+            mEditorItem.VitalRegen = (int)nudHpRegen.Value;
         }
 
         private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
@@ -889,13 +901,13 @@ namespace Intersect.Editor.Forms.Editors
             var mFolders = new List<string>();
             foreach (var itm in ResourceBase.Lookup)
             {
-                if (!string.IsNullOrEmpty(((ResourceBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((ResourceBase) itm.Value).Folder))
+                if (!string.IsNullOrEmpty(((ResourceBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((ResourceBase)itm.Value).Folder))
                 {
-                    mFolders.Add(((ResourceBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ResourceBase) itm.Value).Folder))
+                    mFolders.Add(((ResourceBase)itm.Value).Folder);
+                    if (!mKnownFolders.Contains(((ResourceBase)itm.Value).Folder))
                     {
-                        mKnownFolders.Add(((ResourceBase) itm.Value).Folder);
+                        mKnownFolders.Add(((ResourceBase)itm.Value).Folder);
                     }
                 }
             }

--- a/Intersect.Editor/Forms/Editors/frmResource.resx
+++ b/Intersect.Editor/Forms/Editors/frmResource.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4452,7 +4452,9 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dropitem = @"Item:";
 
-            public static LocalizedString dropamount = @"Amount:";
+            public static LocalizedString dropamount = @"Max Amount:";
+
+            public static LocalizedString DropMinAmount = @"Min Amount:";
 
             public static LocalizedString dropchance = @"Chance (%):";
 
@@ -4460,7 +4462,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dropremove = @"Remove";
 
-            public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
+            public static LocalizedString dropdisplay = @"{00} x{01} - {02} | {03}%";
 
             public static LocalizedString enabled = @"Enabled?";
 
@@ -4919,7 +4921,9 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dropitem = @"Item:";
 
-            public static LocalizedString dropamount = @"Amount:";
+            public static LocalizedString dropamount = @"Max Amount:";
+
+            public static LocalizedString DropMinAmount = @"Min Amount:";
 
             public static LocalizedString dropchance = @"Chance (%):";
 
@@ -4927,7 +4931,7 @@ Tick timer saved in server config.json.";
 
             public static LocalizedString dropremove = @"Remove";
 
-            public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
+            public static LocalizedString dropdisplay = @"{00} x{01} - {02} | {03}%";
 
             public static LocalizedString exhaustedgraphic = @"Exhausted Graphic:";
 

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -134,7 +134,7 @@ namespace Intersect.Server.Entities
             foreach (var drop in myBase.Drops)
             {
                 var slot = new InventorySlot(itemSlot);
-                slot.Set(new Item(drop.ItemId, drop.Quantity));
+                slot.Set(new Item(drop.ItemId, Randomization.Next(drop.MinQuantity, drop.Quantity + 1)));
                 slot.DropChance = drop.Chance;
                 Items.Add(slot);
                 itemSlot++;

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Intersect.Enums;
 using Intersect.GameObjects;
@@ -95,7 +95,7 @@ namespace Intersect.Server.Entities
                 if (Randomization.Next(1, 10001) <= drop.Chance * 100 && ItemBase.Get(drop.ItemId) != null)
                 {
                     var slot = new InventorySlot(itemSlot);
-                    slot.Set(new Item(drop.ItemId, drop.Quantity));
+                    slot.Set(new Item(drop.ItemId, Randomization.Next(drop.MinQuantity, drop.Quantity + 1)));
                     Items.Add(slot);
                     itemSlot++;
                 }

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20240607220428_RandomDrops.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20240607220428_RandomDrops.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Game
 {
     [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [Migration("20240607220428_RandomDrops")]
+    partial class RandomDrops
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20240607220428_RandomDrops.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20240607220428_RandomDrops.cs
@@ -1,0 +1,61 @@
+using Intersect.GameObjects;
+using Intersect.Server.Database;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class RandomDrops : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            using (var context = DbInterface.CreateGameContext(false))
+            {
+                foreach (var npc in context.Npcs)
+                {
+                    for (var i = 0; i < npc.Drops.Count; i++)
+                    {
+                        var drop = npc.Drops[i];
+                        npc.Drops[i] = new Drop()
+                        {
+                            Chance = drop.Chance,
+                            ItemId = drop.ItemId,
+                            Quantity = drop.Quantity,
+                            MinQuantity = 1
+                        };
+                    }
+
+                    context.Npcs.Update(npc);
+                }
+
+                foreach (var resource in context.Resources)
+                {
+                    for (var i = 0; i < resource.Drops.Count; i++)
+                    {
+                        var drop = resource.Drops[i];
+                        resource.Drops[i] = new Drop()
+                        {
+                            Chance = drop.Chance,
+                            ItemId = drop.ItemId,
+                            Quantity = drop.Quantity,
+                            MinQuantity = 1
+                        };
+                    }
+
+                    context.Resources.Update(resource);
+                }
+
+                context.SaveChanges();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
resolves #2209

The default Amount for all games now becomes MaxQuantity in the logic of this pr, but nothing has been renamed, and there is a migration that updates the npcs and resources tables to add MinQuantity. So after this pr, all games will drop a minimum of 1 - Amount when they update.

I'm also bringing the possibility of editing items that already exist in the drop list, both in the npcs and resources editor (I don't know why we didn't have this before)


https://github.com/AscensionGameDev/Intersect-Engine/assets/63019821/53e4851f-c94d-420f-8630-bae629023b36


https://github.com/AscensionGameDev/Intersect-Engine/assets/63019821/03d36584-7aa2-4987-bc22-7b835cccf7df

