### PR TITLE
enhancement: player, target and status window revamp

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -1649,6 +1649,14 @@ namespace Intersect.Client.Framework.Gwen.Control
         }
 
         /// <summary>
+        ///     Sets the control position based on ImagePanel
+        /// </summary>
+        public virtual void SetPosition(ImagePanel _icon)
+        {
+            SetPosition((int)_icon.LocalPosToCanvas(new Point(0, 0)).X, (int)_icon.LocalPosToCanvas(new Point(0, 0)).Y);
+        }
+
+        /// <summary>
         ///     Sets the control position.
         /// </summary>
         /// <param name="x">Target x coordinate.</param>

--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Graphics;
@@ -1651,7 +1646,7 @@ namespace Intersect.Client.Framework.Gwen.Control
         /// <summary>
         ///     Sets the control position based on ImagePanel
         /// </summary>
-        public virtual void SetPosition(ImagePanel _icon)
+        public virtual void SetPosition(Base _icon)
         {
             SetPosition((int)_icon.LocalPosToCanvas(new Point(0, 0)).X, (int)_icon.LocalPosToCanvas(new Point(0, 0)).Y);
         }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Intersect.Client.Core;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Entities.Projectiles;
@@ -457,13 +453,13 @@ namespace Intersect.Client.Entities
                     }
                     else
                     {
-                        if (Interface.Interface.GameUi.PlayerBox == null)
+                        if (Interface.Interface.GameUi.PlayerStatusWindow == null)
                         {
                             Log.Warn($"'{nameof(Interface.Interface.GameUi.PlayerBox)}' is null.");
                         }
                         else
                         {
-                            Interface.Interface.GameUi.PlayerBox.UpdateStatuses = true;
+                            Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
                         }
                     }
                 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -455,7 +455,7 @@ namespace Intersect.Client.Entities
                     {
                         if (Interface.Interface.GameUi.PlayerStatusWindow == null)
                         {
-                            Log.Warn($"'{nameof(Interface.Interface.GameUi.PlayerBox)}' is null.");
+                            Log.Warn($"'{nameof(Interface.Interface.GameUi.PlayerStatusWindow)}' is null.");
                         }
                         else
                         {

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -459,7 +459,7 @@ namespace Intersect.Client.Entities
                         }
                         else
                         {
-                            Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
+                            Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
                         }
                     }
                 }
@@ -471,7 +471,7 @@ namespace Intersect.Client.Entities
                     }
                     else
                     {
-                        Globals.Me.TargetBox.UpdateStatuses = true;
+                        Globals.Me.TargetBox.ShouldUpdateStatuses = true;
                     }
                 }
             }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -99,6 +99,8 @@ namespace Intersect.Client.Entities
 
         public EntityBox TargetBox { get; set; }
 
+        public PlayerStatusWindow StatusWindow { get; set; }
+
         public Guid TargetIndex { get; set; }
 
         TargetType IPlayer.TargetType => (TargetType)TargetType;
@@ -303,6 +305,7 @@ namespace Intersect.Client.Entities
             }
 
             TargetBox?.Update();
+            StatusWindow?.Update();
 
             // Hide our Guild window if we're not in a guild!
             if (this == Globals.Me && string.IsNullOrEmpty(Guild) && Interface.Interface.GameUi != null)

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
@@ -77,6 +77,11 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
         public virtual void SetPosition(int x, int y) => mContainer.SetPosition(x, y);
 
         /// <summary>
+        /// Sets the control position based on ImagePanel.
+        /// </summary>
+        public virtual void SetPosition(ImagePanel _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
+
+        /// <summary>
         /// Resizes the control to fit its children.
         /// </summary>
         /// <param name="width">Allow the control to resize its width.</param>

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Intersect.Client.Core;
 using Intersect.Client.Framework.Gwen.Control;
 
@@ -79,7 +77,7 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
         /// <summary>
         /// Sets the control position based on ImagePanel.
         /// </summary>
-        public virtual void SetPosition(ImagePanel _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
+        public virtual void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
 
         /// <summary>
         /// Resizes the control to fit its children.

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
@@ -168,7 +166,7 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             mContainer.MoveTo(newX, newY);
         }
 
-        public override void SetPosition(ImagePanel _icon, SpellDescriptionWindow _descriptionWindow)
+        public override void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow)
         {
             var X = _icon.LocalPosToCanvas(new Point(0, 0)).X;
             var Y = _icon.LocalPosToCanvas(new Point(0, 0)).Y;

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -167,5 +167,28 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
 
             mContainer.MoveTo(newX, newY);
         }
+
+        public override void SetPosition(ImagePanel _icon, SpellDescriptionWindow _descriptionWindow)
+        {
+            var X = _icon.LocalPosToCanvas(new Point(0, 0)).X;
+            var Y = _icon.LocalPosToCanvas(new Point(0, 0)).Y;
+
+            X = X + _descriptionWindow.Width + _icon.Height;
+            Y = Y + _icon.Height;
+
+            // Do not allow it to render outside of the screen canvas while based on the cursor position.
+            // Prevents flickering when the statusIcon is near the edge of the screen.
+            if (X > Interface.GameUi.GameCanvas.Width - _descriptionWindow.Width)
+            {
+                X = X - _descriptionWindow.Width - _icon.Height;
+            }
+
+            if (Y > Interface.GameUi.GameCanvas.Height - _descriptionWindow.Height)
+            {
+                Y = Y - _descriptionWindow.Height - _icon.Height;
+            }
+
+            _descriptionWindow.SetPosition(X, Y);
+        }
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -176,8 +176,8 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             X = X + _descriptionWindow.Width + _icon.Height;
             Y = Y + _icon.Height;
 
-            // Do not allow it to render outside of the screen canvas while based on the cursor position.
-            // Prevents flickering when the statusIcon is near the edge of the screen.
+            // Do not allow it to render outside of the screen canvas while based on the _icon position.
+            // Prevents flickering when _icon is hovered near the edge of the screen.
             if (X > Interface.GameUi.GameCanvas.Width - _descriptionWindow.Width)
             {
                 X = X - _descriptionWindow.Width - _icon.Height;

--- a/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -1,10 +1,9 @@
-using System;
-
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Utilities;
+using Intersect.Client.Framework.Gwen.Control;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows
 {
@@ -19,6 +18,15 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             GenerateComponents();
             SetupDescriptionWindow();
             SetPosition(x, y);
+        }
+
+        public SpellDescriptionWindow(Guid spellId, ImagePanel _statusIcon) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+        {
+            mSpell = SpellBase.Get(spellId);
+
+            GenerateComponents();
+            SetupDescriptionWindow();
+            SetPosition(_statusIcon, this);
         }
 
         protected void SetupDescriptionWindow()

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -90,19 +90,13 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public string[] PaperdollTextures;
 
-        //public Button PartyLabel;
-
-        public bool PlayerBox;
+        private bool _isPlayerBox;
 
         public ImagePanel ShieldBar;
 
-        //public Button TradeLabel;
-
-        public bool UpdateStatuses;
+        public bool ShouldUpdateStatuses;
 
         public bool IsHidden;
-
-        //public Button GuildLabel;
 
         // Context menu
         private Button _contextMenuButton;
@@ -118,13 +112,13 @@ namespace Intersect.Client.Interface.Game.EntityPanel
         private MenuItem _guildMenuItem;
 
         //Init
-        public EntityBox(Canvas gameCanvas, EntityType entityType, Entity myEntity, bool playerBox = false)
+        public EntityBox(Canvas gameCanvas, EntityType entityType, Entity myEntity, bool isPlayerBox = false)
         {
             MyEntity = myEntity;
             EntityType = entityType;
-            PlayerBox = playerBox;
+            _isPlayerBox = isPlayerBox;
             EntityWindow =
-                PlayerBox ? new ImagePanel(gameCanvas, "PlayerBox") : new ImagePanel(gameCanvas, "TargetBox");
+                _isPlayerBox ? new ImagePanel(gameCanvas, "PlayerBox") : new ImagePanel(gameCanvas, "TargetBox");
 
             EntityWindow.ShouldCacheToTexture = true;
 
@@ -159,7 +153,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 }
             }
 
-            if (!PlayerBox)
+            if (!_isPlayerBox)
             {
                 EventDesc = new RichLabel(EntityInfoPanel, "EventDescLabel");
             }
@@ -184,7 +178,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             ExpLbl = new Label(EntityInfoPanel, "EXPLabel");
 
             // Target context menu with basic options.
-            if (!PlayerBox)
+            if (!_isPlayerBox)
             {
                 _contextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "TargetContextMenu")
                 {
@@ -250,7 +244,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             if (MyEntity != null)
             {
                 SetupEntityElements();
-                UpdateStatuses = !PlayerBox;
+                ShouldUpdateStatuses = !_isPlayerBox;
 
                 if (EntityType == EntityType.Event)
                 {
@@ -268,7 +262,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             if (MyEntity != null)
             {
                 SetupEntityElements();
-                UpdateStatuses = !PlayerBox;
+                ShouldUpdateStatuses = !_isPlayerBox;
                 
                 if (EntityType == EntityType.Event)
                 {
@@ -286,12 +280,14 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             ExpLbl.Show();
             ExpTitle.Show();
             EntityMap.Show();
-            if (!PlayerBox)
+
+            if (!_isPlayerBox)
             {
-            TryShowGuildButton();
-            _contextMenuButton.Show();
-            EventDesc.Show();
+                TryShowGuildButton();
+                _contextMenuButton.Show();
+                EventDesc.Show();
             }
+
             MpBackground.Show();
             MpBar.Show();
             MpTitle.Show();
@@ -324,7 +320,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 case EntityType.Player:
                     if (Globals.Me != null && Globals.Me == MyEntity)
                     {
-                        if (!PlayerBox)
+                        if (!_isPlayerBox)
                         {
                             _contextMenuButton.Hide();
                             ExpBackground.Hide();
@@ -402,7 +398,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 }
             }
 
-            if (PlayerBox)
+            if (_isPlayerBox)
             {
                 if (EntityWindow.IsHidden)
                 {
@@ -440,7 +436,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             }
 
             //If player draw exp bar
-            if (PlayerBox && MyEntity == Globals.Me)
+            if (_isPlayerBox && MyEntity == Globals.Me)
             {
                 UpdateXpBar(elapsedTime);
             }
@@ -451,19 +447,17 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 {
                     _contextMenuButton.Hide();
                 }
-                else if (_contextMenuButton.IsHidden && !PlayerBox)
+                else if (_contextMenuButton.IsHidden && !_isPlayerBox)
                 {
                     TryShowGuildButton();
                     _contextMenuButton.Show();
                 }
             }
 
-            UpdateStatuses = !PlayerBox;
-
-            if (UpdateStatuses)
+            ShouldUpdateStatuses = !_isPlayerBox;
+            if (ShouldUpdateStatuses)
             {
                 SpellStatus.UpdateSpellStatus(MyEntity, EntityStatusPanel, mActiveStatuses);
-
                 EntityStatusWindow.IsHidden = mActiveStatuses.Count < 1;
 
                 foreach (var itm in mActiveStatuses)
@@ -471,7 +465,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     itm.Value.Update();
                 }
 
-                UpdateStatuses = false;
+                ShouldUpdateStatuses = false;
             }
 
             mLastUpdateTime = Timing.Global.MillisecondsUtc;
@@ -1020,16 +1014,16 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         void TryShowGuildButton()
         {
-            var show = false;
+            var shouldShow = false;
             if (MyEntity is Player plyr && MyEntity != Globals.Me && string.IsNullOrWhiteSpace(plyr.Guild))
             {
                 if (Globals.Me?.GuildRank?.Permissions?.Invite ?? false)
                 {
-                    show = true;
+                    shouldShow = true;
                 }
             }
 
-            if (show)
+            if (shouldShow)
             {
                 if (!_contextMenu.Children.Contains(_guildMenuItem))
                 {

--- a/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
@@ -6,7 +6,7 @@ using Intersect.Client.General;
 namespace Intersect.Client.Interface.Game.EntityPanel
 {
 
-    public partial class PlayerStatusWindow
+    public partial class PlayerStatusWindow : ImagePanel
     {
         private readonly Dictionary<Guid, SpellStatus> _activeStatuses = new Dictionary<Guid, SpellStatus>();
 
@@ -18,35 +18,23 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public readonly ScrollControl _playerStatusControl;
 
-        public PlayerStatusWindow(Canvas gameCanvas)
+        public PlayerStatusWindow(Canvas gameCanvas) : base(gameCanvas, "PlayerStatusWindow")
         {
             MyEntity = Globals.Me;
-
-            _playerStatusWindow = new ImagePanel(gameCanvas, "PlayerStatusWindow")
-            {
-                ShouldCacheToTexture = true
-            };
-
-            _playerStatusControl = new ScrollControl(_playerStatusWindow, "PlayerStatusControl");
-            _playerStatusWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-            Show();
+            _playerStatusControl = new ScrollControl(this, "PlayerStatusControl");
+            LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
 
         public void Update()
         {
             if (MyEntity == null || MyEntity.IsDisposed())
             {
-                if (!_playerStatusWindow.IsHidden)
+                if (!IsHidden)
                 {
                     Hide();
                 }
 
                 return;
-            }
-
-            if (_playerStatusWindow.IsHidden)
-            {
-                Show();
             }
 
             if (MyEntity.IsDisposed())
@@ -67,24 +55,12 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 UpdateStatuses = false;
             }
 
-            _playerStatusWindow.IsHidden = _activeStatuses.Count < 1;
-        }
+            IsHidden = _activeStatuses.Count < 1;
 
-        public void Show()
-        {
-            _playerStatusWindow.Show();
-        }
-
-        public void Hide()
-        {
-            _playerStatusWindow.Hide();
-        }
-
-        public void Dispose()
-        {
-            Hide();
-            Interface.GameUi.GameCanvas.RemoveChild(_playerStatusWindow, false);
-            Dispose();
+            if (!IsHidden)
+            {
+                Show();
+            }
         }
     }
 }

--- a/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
@@ -1,0 +1,90 @@
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
+
+namespace Intersect.Client.Interface.Game.EntityPanel
+{
+
+    public partial class PlayerStatusWindow
+    {
+        private readonly Dictionary<Guid, SpellStatus> _activeStatuses = new Dictionary<Guid, SpellStatus>();
+
+        public Entities.Player MyEntity;
+
+        public bool UpdateStatuses;
+
+        public readonly ImagePanel _playerStatusWindow;
+
+        public readonly ScrollControl _playerStatusControl;
+
+        public PlayerStatusWindow(Canvas gameCanvas)
+        {
+            MyEntity = Globals.Me;
+
+            _playerStatusWindow = new ImagePanel(gameCanvas, "PlayerStatusWindow")
+            {
+                ShouldCacheToTexture = true
+            };
+
+            _playerStatusControl = new ScrollControl(_playerStatusWindow, "PlayerStatusControl");
+            _playerStatusWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            Show();
+        }
+
+        public void Update()
+        {
+            if (MyEntity == null || MyEntity.IsDisposed())
+            {
+                if (!_playerStatusWindow.IsHidden)
+                {
+                    Hide();
+                }
+
+                return;
+            }
+
+            if (_playerStatusWindow.IsHidden)
+            {
+                Show();
+            }
+
+            if (MyEntity.IsDisposed())
+            {
+                Dispose();
+                return;
+            }
+
+            if (UpdateStatuses)
+            {
+                SpellStatus.UpdateSpellStatus(MyEntity, _playerStatusControl, _activeStatuses);
+
+                foreach (var itm in _activeStatuses)
+                {
+                    itm.Value.Update();
+                }
+
+                UpdateStatuses = false;
+            }
+
+            _playerStatusWindow.IsHidden = _activeStatuses.Count < 1;
+        }
+
+        public void Show()
+        {
+            _playerStatusWindow.Show();
+        }
+
+        public void Hide()
+        {
+            _playerStatusWindow.Hide();
+        }
+
+        public void Dispose()
+        {
+            Hide();
+            Interface.GameUi.GameCanvas.RemoveChild(_playerStatusWindow, false);
+            Dispose();
+        }
+    }
+}

--- a/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
@@ -1,4 +1,5 @@
 using Intersect.Client.Core;
+using Intersect.Client.Entities;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
@@ -10,9 +11,9 @@ namespace Intersect.Client.Interface.Game.EntityPanel
     {
         private readonly Dictionary<Guid, SpellStatus> _activeStatuses = new Dictionary<Guid, SpellStatus>();
 
-        public Entities.Player MyEntity;
+        public Player MyEntity;
 
-        public bool UpdateStatuses;
+        public bool ShouldUpdateStatuses;
 
         public readonly ImagePanel _playerStatusWindow;
 
@@ -43,7 +44,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                 return;
             }
 
-            if (UpdateStatuses)
+            if (ShouldUpdateStatuses)
             {
                 SpellStatus.UpdateSpellStatus(MyEntity, _playerStatusControl, _activeStatuses);
 
@@ -52,7 +53,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     itm.Value.Update();
                 }
 
-                UpdateStatuses = false;
+                ShouldUpdateStatuses = false;
             }
 
             IsHidden = _activeStatuses.Count < 1;

--- a/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
@@ -67,9 +67,11 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             _status = status;
         }
 
-        public static void UpdateSpellStatus(Entities.Entity myEntity,
+        public static void UpdateSpellStatus(
+        Entity myEntity,
         ScrollControl spellStatusControl,
-        Dictionary<Guid, SpellStatus> activeStatuses)
+        Dictionary<Guid, SpellStatus> activeStatuses
+        )
         {
             if (myEntity == null)
             {

--- a/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
@@ -59,8 +59,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             var X = _statusIcon.LocalPosToCanvas(new Point(0, 0)).X;
             var Y = _statusIcon.LocalPosToCanvas(new Point(0, 0)).Y;
 
-            _descriptionWindow = new SpellDescriptionWindow(_status.SpellId, X, Y);
-            _descriptionWindow.SetPosition(X + _descriptionWindow.Width, Y + _statusIcon.Height);
+            _descriptionWindow = new SpellDescriptionWindow(_status.SpellId, _statusIcon);
         }
 
         public void UpdateStatus(Status status)

--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -89,6 +89,8 @@ namespace Intersect.Client.Interface.Game
 
         public EntityBox PlayerBox;
 
+        public PlayerStatusWindow PlayerStatusWindow;
+
         public GameInterface(Canvas canvas) : base(canvas)
         {
             GameCanvas = canvas;
@@ -113,6 +115,7 @@ namespace Intersect.Client.Interface.Game
             Hotbar = new HotBarWindow(GameCanvas);
             PlayerBox = new EntityBox(GameCanvas, EntityType.Player, Globals.Me, true);
             PlayerBox.SetEntity(Globals.Me);
+            PlayerStatusWindow = new PlayerStatusWindow(GameCanvas);
             if (mPictureWindow == null)
             {
                 mPictureWindow = new PictureWindow(GameCanvas);
@@ -312,6 +315,7 @@ namespace Intersect.Client.Interface.Game
             Hotbar?.Update();
             EscapeMenu.Update();
             PlayerBox?.Update();
+            PlayerStatusWindow?.Update();
             mMapItemWindow.Update();
             AnnouncementWindow?.Update();
             mPictureWindow?.Update();

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -923,9 +923,6 @@ namespace Intersect.Client.Localization
             public static LocalizedString Friend = "Befriend";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FriendTip = "Send a friend request to {00}.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Level = @"Lv. {00}";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -941,13 +938,7 @@ namespace Intersect.Client.Localization
             public static LocalizedString Party = @"Party";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PartyTip = @"Invite {00} to your party.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Trade = @"Trade";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TradeTip = @"Request to trade with {00}.";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString Vital0 = @"HP:";

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -882,11 +882,11 @@ namespace Intersect.Client.Networking
                     //If its you or your target, update the entity box.
                     if (en.Id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
                     {
-                        Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
+                        Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
                     }
                     else if (en.Id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
                     {
-                        Globals.Me.TargetBox.UpdateStatuses = true;
+                        Globals.Me.TargetBox.ShouldUpdateStatuses = true;
                     }
                 }
             }
@@ -967,11 +967,11 @@ namespace Intersect.Client.Networking
                 //If its you or your target, update the entity box.
                 if (id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
                 {
-                    Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
+                    Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
                 }
                 else if (id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
                 {
-                    Globals.Me.TargetBox.UpdateStatuses = true;
+                    Globals.Me.TargetBox.ShouldUpdateStatuses = true;
                 }
             }
         }

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -880,9 +880,9 @@ namespace Intersect.Client.Networking
                 if (Interface.Interface.GameUi != null)
                 {
                     //If its you or your target, update the entity box.
-                    if (en.Id == Globals.Me.Id && Interface.Interface.GameUi.PlayerBox != null)
+                    if (en.Id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
                     {
-                        Interface.Interface.GameUi.PlayerBox.UpdateStatuses = true;
+                        Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
                     }
                     else if (en.Id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
                     {
@@ -965,9 +965,9 @@ namespace Intersect.Client.Networking
             if (Interface.Interface.GameUi != null)
             {
                 //If its you or your target, update the entity box.
-                if (id == Globals.Me.Id && Interface.Interface.GameUi.PlayerBox != null)
+                if (id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
                 {
-                    Interface.Interface.GameUi.PlayerBox.UpdateStatuses = true;
+                    Interface.Interface.GameUi.PlayerStatusWindow.UpdateStatuses = true;
                 }
                 else if (id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
                 {


### PR DESCRIPTION
- Sets the player status window free from the burdens of the PlayerBox, engine users can now edit the player's status window with it's own json file so they are not limited to edit the the status window within the playerbox anymore.
- revamps the design for player, target and status windows.
- uses drop-down menu for player options instead of buttons, saves space, more simple, same results.
- status window has been modified in order to work as a scroll controller, spell icons are placed and adapted to their window width, rows and columns, and the entire window i hidden and will show up only when there's an active status count of > 0

### Preview:

https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f003e85b-fdd3-4a54-80e7-7bbfa0b652a4

![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/e5d057d7-6a39-4170-9604-6a25c6d4e9d0) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/aa8f13c7-afeb-42ad-9410-e83ae70ddd3c) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/557e3462-871e-4f93-9f4b-281007ad6b36) ![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/9967fde1-6980-4655-8676-5437c4fa6eab)


Assets: https://github.com/AscensionGameDev/Intersect-Assets/pull/50


