### PR TITLE
fix: adds missing projectile grid size checks

### DIFF
--- a/Intersect.Client/Entities/Projectiles/Projectile.cs
+++ b/Intersect.Client/Entities/Projectiles/Projectile.cs
@@ -384,6 +384,11 @@ namespace Intersect.Client.Entities.Projectiles
                             continue;
                         }
 
+                        if (x >= Globals.MapGrid.GetLength(0) || y >= Globals.MapGrid.GetLength(1))
+                        {
+                            continue;
+                        }
+
                         if (Globals.MapGrid[x, y] != Guid.Empty && Globals.MapGrid[x, y] == mLastTargetMapId)
                         {
                             var leftSide = x == map.GridX - 1;

--- a/Intersect.Server.Core/Entities/Projectile.cs
+++ b/Intersect.Server.Core/Entities/Projectile.cs
@@ -385,6 +385,11 @@ namespace Intersect.Server.Entities
                             continue;
                         }
 
+                        if (x >= grid.MapIdGrid.GetLength(0) || y >= grid.MapIdGrid.GetLength(1))
+                        {
+                            continue;
+                        }
+
                         if (grid.MapIdGrid[x, y] != Guid.Empty && grid.MapIdGrid[x, y] == mLastTargetMapId)
                         {
                             var leftSide = x == map.MapGridX - 1;
@@ -425,6 +430,11 @@ namespace Intersect.Server.Entities
                     for (var x = map.MapGridY - 1; x <= map.MapGridX + 1; x++)
                     {
                         if (x == -1 || x >= grid.Width)
+                        {
+                            continue;
+                        }
+
+                        if (x >= grid.MapIdGrid.GetLength(0) || y >= grid.MapIdGrid.GetLength(1))
                         {
                             continue;
                         }


### PR DESCRIPTION
resolves #2276 
there is a grid size check only on the client's y-axis, I added it on the x-axis too and on the server side