### PR TITLE
fix: projectile knockback and projectile bug on seamless world

### DIFF
--- a/Intersect.Client/Entities/Projectiles/Projectile.cs
+++ b/Intersect.Client/Entities/Projectiles/Projectile.cs
@@ -372,19 +372,9 @@ namespace Intersect.Client.Entities.Projectiles
                 var map = Maps.MapInstance.Get(spawn.SpawnMapId);
                 for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
                 {
-                    if (y < 0 || y >= Options.MapHeight)
-                    {
-                        continue;
-                    }
-
                     for (var x = map.GridX - 1; x <= map.GridX + 1; x++)
                     {
-                        if (x < 0 || x >= Options.MapWidth)
-                        {
-                            continue;
-                        }
-
-                        if (x >= Globals.MapGrid.GetLength(0) || y >= Globals.MapGrid.GetLength(1))
+                        if (x < 0 || x >= Globals.MapGrid.GetLength(0) || y < 0 || y >= Globals.MapGrid.GetLength(1))
                         {
                             continue;
                         }
@@ -418,19 +408,9 @@ namespace Intersect.Client.Entities.Projectiles
                 var map = Maps.MapInstance.Get(spawn.SpawnMapId);
                 for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
                 {
-                    if (y < 0 || y >= Options.MapHeight)
-                    {
-                        continue;
-                    }
-
                     for (var x = map.GridX - 1; x <= map.GridX + 1; x++)
                     {
-                        if (x < 0 || x >= Options.MapWidth)
-                        {
-                            continue;
-                        }
-
-                        if(x >= Globals.MapGrid.GetLength(0) || y >= Globals.MapGrid.GetLength(1))
+                        if(x < 0 || x >= Globals.MapGrid.GetLength(0) || y < 0 || y >= Globals.MapGrid.GetLength(1))
                         {
                             continue;
                         }

--- a/Intersect.Server.Core/Entities/Projectile.cs
+++ b/Intersect.Server.Core/Entities/Projectile.cs
@@ -378,7 +378,7 @@ namespace Intersect.Server.Entities
                         continue;
                     }
 
-                    for (var x = map.MapGridY - 1; x <= map.MapGridX + 1; x++)
+                    for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
                     {
                         if (x == -1 || x >= grid.Width)
                         {
@@ -427,7 +427,7 @@ namespace Intersect.Server.Entities
                         continue;
                     }
 
-                    for (var x = map.MapGridY - 1; x <= map.MapGridX + 1; x++)
+                    for (var x = map.MapGridX - 1; x <= map.MapGridX + 1; x++)
                     {
                         if (x == -1 || x >= grid.Width)
                         {


### PR DESCRIPTION
maps where there are a large number of maps have errors, these errors cannot be noticed by a minimum number of maps, now fixed

Projectile knockback fixed