### PR TITLE
enhancement: optional target window

### DIFF
--- a/Intersect (Core)/Config/CombatOptions.cs
+++ b/Intersect (Core)/Config/CombatOptions.cs
@@ -70,6 +70,11 @@
         public bool EnableTurnAroundWhileCasting = false;
 
         /// <summary>
+        /// If enabled, the target window will be shown to players whenever they target an entity
+        /// </summary>
+        public bool EnableTargetWindow = true;
+
+        /// <summary>
         /// If enabled, this makes it so a player casting a friendly spell on a hostile target instead casts the spell upon themselves
         /// </summary>
         public bool EnableAutoSelfCastFriendlySpellsWhenTargetingHostile { get; set; } = false;

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -394,7 +394,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             {
                 if (EntityWindow.IsHidden)
                 {
-                    EntityWindow.Show();
+                    Show();
                 }
             }
 
@@ -402,7 +402,7 @@ namespace Intersect.Client.Interface.Game.EntityPanel
             {
                 if (EntityWindow.IsHidden)
                 {
-                    EntityWindow.Show();
+                    Show();
                 }
 
                 if (MyEntity.IsDisposed())
@@ -1047,6 +1047,11 @@ namespace Intersect.Client.Interface.Game.EntityPanel
 
         public void Show()
         {
+            if (!Options.Instance.CombatOpts.EnableTargetWindow && !_isPlayerBox)
+            {
+                return;
+            }
+
             EntityWindow.Show();
         }
 


### PR DESCRIPTION
Adds a server combat option that if enabled (default), the target window will be shown to players whenever they target an entity

(Server Config - Combat):
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/8f637c52-b7fb-4273-850c-cbf00b7b1280)

Enabled (default):
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/f218565b-041b-49db-af56-7669b860a687)

Disabled:
![image](https://github.com/AscensionGameDev/Intersect-Engine/assets/17498701/5e12b0cc-8639-4e04-9a87-cf815410a051)

