### PR TITLE
chore: removes unnecessary and implicit usings from intersect core

### DIFF
--- a/Intersect (Core)/Admin/Actions/WarpToLocationAction.cs
+++ b/Intersect (Core)/Admin/Actions/WarpToLocationAction.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using MessagePack;
+﻿using MessagePack;
 
 namespace Intersect.Admin.Actions
 {

--- a/Intersect (Core)/Admin/Actions/WarpToMapAction.cs
+++ b/Intersect (Core)/Admin/Actions/WarpToMapAction.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using MessagePack;
+﻿using MessagePack;
 
 namespace Intersect.Admin.Actions
 {

--- a/Intersect (Core)/AlphanumComparatorFast.cs
+++ b/Intersect (Core)/AlphanumComparatorFast.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 
 namespace Intersect
 {

--- a/Intersect (Core)/Async/AsyncValueGenerator`1.cs
+++ b/Intersect (Core)/Async/AsyncValueGenerator`1.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Intersect.Async
 {
     public partial class AsyncValueGenerator<TValue> : IDisposable

--- a/Intersect (Core)/Async/CancellableGenerator`1.cs
+++ b/Intersect (Core)/Async/CancellableGenerator`1.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-
 namespace Intersect.Async
 {
     public partial class CancellableGenerator<TValue> : IDisposable

--- a/Intersect (Core)/Collections/DatabaseObjectLookup.cs
+++ b/Intersect (Core)/Collections/DatabaseObjectLookup.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
 using System.Text;
 
 using Intersect.Logging;

--- a/Intersect (Core)/Collections/IGameObjectLookup.cs
+++ b/Intersect (Core)/Collections/IGameObjectLookup.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Models;
+﻿using Intersect.Models;
 
 namespace Intersect.Collections
 {

--- a/Intersect (Core)/Collections/ILookup.cs
+++ b/Intersect (Core)/Collections/ILookup.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Intersect.Collections
+﻿namespace Intersect.Collections
 {
 
     public interface ILookup<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>

--- a/Intersect (Core)/Collections/NamedInstanceStore.cs
+++ b/Intersect (Core)/Collections/NamedInstanceStore.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 
 namespace Intersect.Collections
 {

--- a/Intersect (Core)/Collections/ReadOnlyList.cs
+++ b/Intersect (Core)/Collections/ReadOnlyList.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 
 namespace Intersect.Collections
 {

--- a/Intersect (Core)/Collections/Sanitizer.cs
+++ b/Intersect (Core)/Collections/Sanitizer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Extensions;
+﻿using Intersect.Extensions;
 
 namespace Intersect.Collections
 {

--- a/Intersect (Core)/Collections/SingleOrList.cs
+++ b/Intersect (Core)/Collections/SingleOrList.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
 
 namespace Intersect.Collections
 {

--- a/Intersect (Core)/Color.cs
+++ b/Intersect (Core)/Color.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 using Intersect.Localization;
 using MessagePack;
 

--- a/Intersect (Core)/Compression/AssetPacker.cs
+++ b/Intersect (Core)/Compression/AssetPacker.cs
@@ -1,18 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 using Newtonsoft.Json;
-
-using Intersect.Extensions;
 
 namespace Intersect.Compression
 {
-	/// <summary>
-	/// Allows for packaging up assets and extracting them from packaged files.
-	/// </summary>
-	public sealed partial class AssetPacker : IDisposable
+    /// <summary>
+    /// Allows for packaging up assets and extracting them from packaged files.
+    /// </summary>
+    public sealed partial class AssetPacker : IDisposable
 	{
 
 		/// <summary>

--- a/Intersect (Core)/Compression/GzipCompression.cs
+++ b/Intersect (Core)/Compression/GzipCompression.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.IO.Compression;
-using System.Linq;
+﻿using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
 

--- a/Intersect (Core)/Compression/LZ4.cs
+++ b/Intersect (Core)/Compression/LZ4.cs
@@ -1,10 +1,5 @@
 ﻿using K4os.Compression.LZ4;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Compression
 {

--- a/Intersect (Core)/Config/BankOptions.cs
+++ b/Intersect (Core)/Config/BankOptions.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Intersect.Config
+﻿namespace Intersect.Config
 {
     public partial class BankOptions
     {

--- a/Intersect (Core)/Config/EquipmentOptions.cs
+++ b/Intersect (Core)/Config/EquipmentOptions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Intersect.Config
 {

--- a/Intersect (Core)/Config/Guilds/GuildOptions.cs
+++ b/Intersect (Core)/Config/Guilds/GuildOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Intersect.Config.Guilds
 {

--- a/Intersect (Core)/Config/ItemOptions.cs
+++ b/Intersect (Core)/Config/ItemOptions.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 using Newtonsoft.Json;
 
 namespace Intersect.Config

--- a/Intersect (Core)/Config/LayerOptions.cs
+++ b/Intersect (Core)/Config/LayerOptions.cs
@@ -1,10 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Config
 {

--- a/Intersect (Core)/Config/LoggingOptions.cs
+++ b/Intersect (Core)/Config/LoggingOptions.cs
@@ -1,11 +1,4 @@
 using Intersect.Logging;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Config
 {

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.IO;
-
 using Intersect.Config;
 using Intersect.Config.Guilds;
 using Intersect.Logging;

--- a/Intersect (Core)/Config/PaperdollOptions.cs
+++ b/Intersect (Core)/Config/PaperdollOptions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/Config/ProcessingOptions.cs
+++ b/Intersect (Core)/Config/ProcessingOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.Serialization;
 
 namespace Intersect.Config

--- a/Intersect (Core)/Config/QuestOptions.cs
+++ b/Intersect (Core)/Config/QuestOptions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Intersect.Config

--- a/Intersect (Core)/Config/SecurityOptions.cs
+++ b/Intersect (Core)/Config/SecurityOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Config
 {

--- a/Intersect (Core)/Configuration/ConfigurationHelper.cs
+++ b/Intersect (Core)/Configuration/ConfigurationHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 
 using Intersect.IO.Files;
 using Intersect.Logging;

--- a/Intersect (Core)/Console.cs
+++ b/Intersect (Core)/Console.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 
 using Intersect.IO;
 

--- a/Intersect (Core)/Core/ApplicationContext`2.cs
+++ b/Intersect (Core)/Core/ApplicationContext`2.cs
@@ -1,16 +1,8 @@
 using Intersect.Logging;
-using Intersect.Reflection;
 using Intersect.Threading;
-
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Intersect.Properties;
 using Intersect.Plugins.Interfaces;

--- a/Intersect (Core)/Core/ApplicationService`2.cs
+++ b/Intersect (Core)/Core/ApplicationService`2.cs
@@ -1,8 +1,6 @@
 ﻿
 using Microsoft;
 
-using System;
-
 namespace Intersect.Core
 {
     /// <summary>

--- a/Intersect (Core)/Core/ApplicationService`3.cs
+++ b/Intersect (Core)/Core/ApplicationService`3.cs
@@ -1,8 +1,6 @@
 ﻿
 using Microsoft;
 
-using System;
-
 namespace Intersect.Core
 {
     /// <summary>

--- a/Intersect (Core)/Core/ExperimentalFeatures/CommonExperiments.Core.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/CommonExperiments.Core.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 
 using Intersect.Extensions;

--- a/Intersect (Core)/Core/ExperimentalFeatures/CommonExperiments.Static.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/CommonExperiments.Static.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Intersect.Core.ExperimentalFeatures
 {

--- a/Intersect (Core)/Core/ExperimentalFeatures/ExperimentNamespace.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/ExperimentNamespace.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core.ExperimentalFeatures
+﻿namespace Intersect.Core.ExperimentalFeatures
 {
 
     [Serializable]

--- a/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlag.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlag.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Utilities;
+﻿using Intersect.Utilities;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagAlias.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagAlias.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core.ExperimentalFeatures
+﻿namespace Intersect.Core.ExperimentalFeatures
 {
 
     public partial struct ExperimentalFlagAlias : IExperimentalFlag

--- a/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagAliasAttribute.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagAliasAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core.ExperimentalFeatures
+﻿namespace Intersect.Core.ExperimentalFeatures
 {
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]

--- a/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagConverter.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/ExperimentalFlagConverter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Core.ExperimentalFeatures
 {

--- a/Intersect (Core)/Core/ExperimentalFeatures/IExperimentalFlag.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/IExperimentalFlag.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core.ExperimentalFeatures
+﻿namespace Intersect.Core.ExperimentalFeatures
 {
 
     public interface IExperimentalFlag : IEquatable<IExperimentalFlag>

--- a/Intersect (Core)/Core/ExperimentalFeatures/IFlagProvider.cs
+++ b/Intersect (Core)/Core/ExperimentalFeatures/IFlagProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core.ExperimentalFeatures
+﻿namespace Intersect.Core.ExperimentalFeatures
 {
 
     public interface IFlagProvider

--- a/Intersect (Core)/Core/IApplicationContext.cs
+++ b/Intersect (Core)/Core/IApplicationContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 using Intersect.Plugins.Interfaces;
 using Intersect.Threading;
 

--- a/Intersect (Core)/Core/IApplicationService.cs
+++ b/Intersect (Core)/Core/IApplicationService.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-
-namespace Intersect.Core
+﻿namespace Intersect.Core
 {
     /// <summary>
     /// Declares the API surface for application services.

--- a/Intersect (Core)/Core/ICommandLineOptions.cs
+++ b/Intersect (Core)/Core/ICommandLineOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Intersect.Core
+﻿namespace Intersect.Core
 {
     /// <summary>
     /// Declares the common basic command line options for all applications.

--- a/Intersect (Core)/Core/IThreadableApplicationService.cs
+++ b/Intersect (Core)/Core/IThreadableApplicationService.cs
@@ -1,7 +1,4 @@
-﻿
-using System.Threading;
-
-namespace Intersect.Core
+﻿namespace Intersect.Core
 {
     /// <summary>
     /// Declares the API surface for application services that have their own thread.

--- a/Intersect (Core)/Core/ServiceLifecycleFailureException.cs
+++ b/Intersect (Core)/Core/ServiceLifecycleFailureException.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 

--- a/Intersect (Core)/Core/ServiceLifecycleStage.cs
+++ b/Intersect (Core)/Core/ServiceLifecycleStage.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Core
+﻿namespace Intersect.Core
 {
     /// <summary>
     /// Enumeration of the different lifecycle stages for services.

--- a/Intersect (Core)/CustomColors.cs
+++ b/Intersect (Core)/CustomColors.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
 using Intersect.Logging;

--- a/Intersect (Core)/Enums/GameObjectTypeExtensions.cs
+++ b/Intersect (Core)/Enums/GameObjectTypeExtensions.cs
@@ -1,13 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using Intersect.Collections;
 using Intersect.Extensions;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Switches_and_Variables;
 using Intersect.Models;
-using MessagePack.Resolvers;
 
 namespace Intersect.Enums
 {

--- a/Intersect (Core)/Enums/MapInstanceType.cs
+++ b/Intersect (Core)/Enums/MapInstanceType.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Intersect.Enums
 {
     /// <summary>

--- a/Intersect (Core)/Enums/SpellCastFailureReason.cs
+++ b/Intersect (Core)/Enums/SpellCastFailureReason.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Intersect.Enums
+﻿namespace Intersect.Enums
 {
     public enum SpellCastFailureReason
     {

--- a/Intersect (Core)/Enums/TypewriterBehavior.cs
+++ b/Intersect (Core)/Enums/TypewriterBehavior.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Intersect.Enums
 {
     public enum TypewriterBehavior

--- a/Intersect (Core)/ErrorHandling/ExceptionInfo.cs
+++ b/Intersect (Core)/ErrorHandling/ExceptionInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Intersect.ErrorHandling

--- a/Intersect (Core)/ErrorHandling/ExceptionRepeater.cs
+++ b/Intersect (Core)/ErrorHandling/ExceptionRepeater.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace Intersect.Async
 {
     public sealed partial class ExceptionRepeater

--- a/Intersect (Core)/Extensions/ArrayExtensions.cs
+++ b/Intersect (Core)/Extensions/ArrayExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Intersect.Extensions
+﻿namespace Intersect.Extensions
 {
 
     public static partial class ArrayExtensions

--- a/Intersect (Core)/Extensions/DateTimeExtensions.cs
+++ b/Intersect (Core)/Extensions/DateTimeExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Extensions
+﻿namespace Intersect.Extensions
 {
 
     public static partial class DateTimeExtensions

--- a/Intersect (Core)/Extensions/EnumerableExtensions.cs
+++ b/Intersect (Core)/Extensions/EnumerableExtensions.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-
 namespace Intersect.Extensions
 {
 

--- a/Intersect (Core)/Extensions/GameObjectInfoAttribute.cs
+++ b/Intersect (Core)/Extensions/GameObjectInfoAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Extensions
+﻿namespace Intersect.Extensions
 {
 
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]

--- a/Intersect (Core)/Extensions/KeyValuePairExtensions.cs
+++ b/Intersect (Core)/Extensions/KeyValuePairExtensions.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Intersect.Extensions
 {
     public static partial class KeyValuePairExtensions

--- a/Intersect (Core)/Extensions/LogLevelExtensions.cs
+++ b/Intersect (Core)/Extensions/LogLevelExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Extensions
+﻿namespace Intersect.Extensions
 {
 
     public static partial class LogLevelExtensions

--- a/Intersect (Core)/Extensions/RandomExtensions.cs
+++ b/Intersect (Core)/Extensions/RandomExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using MathNet.Numerics.Random;
+﻿using MathNet.Numerics.Random;
 
 namespace Intersect.Extensions
 {

--- a/Intersect (Core)/Extensions/StringExtensions.cs
+++ b/Intersect (Core)/Extensions/StringExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 
 namespace Intersect.Extensions

--- a/Intersect (Core)/Factories/FactoryRegistry.cs
+++ b/Intersect (Core)/Factories/FactoryRegistry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 using Intersect.Logging;

--- a/Intersect (Core)/GameObjects/AnimationBase.cs
+++ b/Intersect (Core)/GameObjects/AnimationBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Models;
 

--- a/Intersect (Core)/GameObjects/Annotations/EditorBooleanAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorBooleanAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 
 using Intersect.Localization;

--- a/Intersect (Core)/GameObjects/Annotations/EditorDictionaryAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorDictionaryAttribute.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 using Intersect.Localization;
 using Intersect.Reflection;
-using MessagePack.Resolvers;
 
 #if !DEBUG
 using Intersect.Logging;

--- a/Intersect (Core)/GameObjects/Annotations/EditorDisplayAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorDisplayAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.GameObjects.Annotations
 {
     public enum EmptyBehavior

--- a/Intersect (Core)/GameObjects/Annotations/EditorEnumAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorEnumAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.GameObjects.Annotations
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/Intersect (Core)/GameObjects/Annotations/EditorFormattedAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorFormattedAttribute.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 using Intersect.Localization;

--- a/Intersect (Core)/GameObjects/Annotations/EditorLabelAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorLabelAttribute.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Reflection;
-
-using Intersect.Localization;
 
 namespace Intersect.GameObjects.Annotations
 {

--- a/Intersect (Core)/GameObjects/Annotations/EditorReferenceAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorReferenceAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reflection;
 
 using Intersect.Collections;

--- a/Intersect (Core)/GameObjects/Annotations/EditorTimeAttribute.cs
+++ b/Intersect (Core)/GameObjects/Annotations/EditorTimeAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.GameObjects.Annotations
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/Intersect (Core)/GameObjects/ClassBase.cs
+++ b/Intersect (Core)/GameObjects/ClassBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Enums;

--- a/Intersect (Core)/GameObjects/Conditions/ConditionList.cs
+++ b/Intersect (Core)/GameObjects/Conditions/ConditionList.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Intersect.GameObjects.Events;
+﻿using Intersect.GameObjects.Events;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/GameObjects/Conditions/ConditionLists.cs
+++ b/Intersect (Core)/GameObjects/Conditions/ConditionLists.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Intersect.GameObjects.Conditions

--- a/Intersect (Core)/GameObjects/Crafting/CraftBase.cs
+++ b/Intersect (Core)/GameObjects/Crafting/CraftBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Models;

--- a/Intersect (Core)/GameObjects/Crafting/CraftingTableBase.cs
+++ b/Intersect (Core)/GameObjects/Crafting/CraftingTableBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.GameObjects.Crafting;
 using Intersect.Models;

--- a/Intersect (Core)/GameObjects/Drop.cs
+++ b/Intersect (Core)/GameObjects/Drop.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.GameObjects
 {
     public partial class Drop

--- a/Intersect (Core)/GameObjects/EquipmentProperties.cs
+++ b/Intersect (Core)/GameObjects/EquipmentProperties.cs
@@ -1,9 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.Json.Serialization;
 using Intersect.Enums;
 using Intersect.GameObjects.Ranges;
-using Newtonsoft.Json;
 
 namespace Intersect.GameObjects;
 

--- a/Intersect (Core)/GameObjects/Events/Commands/EventCommands.cs
+++ b/Intersect (Core)/GameObjects/Events/Commands/EventCommands.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 using Intersect.Enums;
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/GameObjects/Events/Condition.cs
+++ b/Intersect (Core)/GameObjects/Events/Condition.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Intersect.Enums;
 
 namespace Intersect.GameObjects.Events

--- a/Intersect (Core)/GameObjects/Events/EventBase.cs
+++ b/Intersect (Core)/GameObjects/Events/EventBase.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 
 using Intersect.Models;
 

--- a/Intersect (Core)/GameObjects/Events/EventMoveRoute.cs
+++ b/Intersect (Core)/GameObjects/Events/EventMoveRoute.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.GameObjects.Events
 {

--- a/Intersect (Core)/GameObjects/Events/EventPage.cs
+++ b/Intersect (Core)/GameObjects/Events/EventPage.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using Intersect.GameObjects.Conditions;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect (Core)/GameObjects/Events/MoveRouteAction.cs
+++ b/Intersect (Core)/GameObjects/Events/MoveRouteAction.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.GameObjects.Events
+﻿namespace Intersect.GameObjects.Events
 {
     public partial class MoveRouteAction
     {

--- a/Intersect (Core)/GameObjects/Events/VariableMod.cs
+++ b/Intersect (Core)/GameObjects/Events/VariableMod.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/GameObjects/GuildVariableBase.cs
+++ b/Intersect (Core)/GameObjects/GuildVariableBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Intersect.Enums;
 using Intersect.GameObjects.Switches_and_Variables;
 

--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 
 using Intersect.Enums;
 using Intersect.GameObjects.Conditions;
@@ -13,7 +10,6 @@ using Intersect.Utilities;
 using Microsoft.EntityFrameworkCore;
 
 using Newtonsoft.Json;
-using static Intersect.GameObjects.EquipmentProperties;
 
 namespace Intersect.GameObjects
 {

--- a/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Intersect.Enums;
 using Intersect.GameObjects.Annotations;
 using Intersect.Localization;

--- a/Intersect (Core)/GameObjects/Maps/MapAutotiles.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapAutotiles.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Intersect.Logging;
+﻿using Intersect.Logging;
 
 namespace Intersect.GameObjects.Maps
 {

--- a/Intersect (Core)/GameObjects/Maps/MapBase.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Collections;
 using Intersect.Compression;
 using Intersect.Enums;

--- a/Intersect (Core)/GameObjects/Maps/MapList/MapList.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapList/MapList.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using Intersect.Collections;
 
 using Newtonsoft.Json;

--- a/Intersect (Core)/GameObjects/Maps/MapList/MapListFolder.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapList/MapListFolder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 
 namespace Intersect.GameObjects.Maps.MapList
 {

--- a/Intersect (Core)/GameObjects/Maps/MapList/MapListMap.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapList/MapListMap.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 
 namespace Intersect.GameObjects.Maps.MapList
 {

--- a/Intersect (Core)/GameObjects/Maps/MapNpcSpawn.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapNpcSpawn.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 
 namespace Intersect.GameObjects.Maps
 {

--- a/Intersect (Core)/GameObjects/Maps/MapResourceSpawn.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapResourceSpawn.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.GameObjects.Maps
+﻿namespace Intersect.GameObjects.Maps
 {
     public partial class ResourceSpawn
     {

--- a/Intersect (Core)/GameObjects/Maps/MapTile.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapTile.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.GameObjects.Maps
 {

--- a/Intersect (Core)/GameObjects/NpcBase.cs
+++ b/Intersect (Core)/GameObjects/NpcBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Enums;

--- a/Intersect (Core)/GameObjects/ProjectileBase.cs
+++ b/Intersect (Core)/GameObjects/ProjectileBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Enums;
 using Intersect.Models;

--- a/Intersect (Core)/GameObjects/QuestBase.cs
+++ b/Intersect (Core)/GameObjects/QuestBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Enums;
 using Intersect.GameObjects.Conditions;

--- a/Intersect (Core)/GameObjects/ResourceBase.cs
+++ b/Intersect (Core)/GameObjects/ResourceBase.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.GameObjects.Conditions;

--- a/Intersect (Core)/GameObjects/ShopBase.cs
+++ b/Intersect (Core)/GameObjects/ShopBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Models;
 

--- a/Intersect (Core)/GameObjects/SpellBase.cs
+++ b/Intersect (Core)/GameObjects/SpellBase.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using Intersect.Enums;
 using Intersect.GameObjects.Conditions;
 using Intersect.GameObjects.Events;

--- a/Intersect (Core)/GameObjects/Switches and Variables/IVariableBase.cs
+++ b/Intersect (Core)/GameObjects/Switches and Variables/IVariableBase.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Intersect.Enums;
 using Intersect.Models;
 

--- a/Intersect (Core)/GameObjects/Switches and Variables/PlayerVariableBase.cs
+++ b/Intersect (Core)/GameObjects/Switches and Variables/PlayerVariableBase.cs
@@ -1,6 +1,3 @@
-using System;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using Intersect.Enums;
 using Intersect.GameObjects.Switches_and_Variables;
 

--- a/Intersect (Core)/GameObjects/Switches and Variables/ServerVariableBase.cs
+++ b/Intersect (Core)/GameObjects/Switches and Variables/ServerVariableBase.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 
 using Intersect.Enums;
 using Intersect.GameObjects.Switches_and_Variables;

--- a/Intersect (Core)/GameObjects/Switches and Variables/VariableValue.cs
+++ b/Intersect (Core)/GameObjects/Switches and Variables/VariableValue.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Intersect.Enums;

--- a/Intersect (Core)/GameObjects/TilesetBase.cs
+++ b/Intersect (Core)/GameObjects/TilesetBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Models;
+﻿using Intersect.Models;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/GameObjects/TimeBase.cs
+++ b/Intersect (Core)/GameObjects/TimeBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/GameObjects/UserVariableBase.cs
+++ b/Intersect (Core)/GameObjects/UserVariableBase.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using Intersect.Enums;
 using Intersect.GameObjects.Switches_and_Variables;
 

--- a/Intersect (Core)/GameObjects/VariableDescriptor.cs
+++ b/Intersect (Core)/GameObjects/VariableDescriptor.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Intersect.Enums;
 using Intersect.GameObjects.Switches_and_Variables;
 using Intersect.Models;

--- a/Intersect (Core)/IO/ConsoleContext.cs
+++ b/Intersect (Core)/IO/ConsoleContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Threading.Tasks;
+﻿using System.Collections.Immutable;
 
 namespace Intersect.IO
 {

--- a/Intersect (Core)/IO/ConsoleWriter.cs
+++ b/Intersect (Core)/IO/ConsoleWriter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Runtime.Remoting;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace Intersect.IO
 {

--- a/Intersect (Core)/IO/Files/FileSystemHelper.cs
+++ b/Intersect (Core)/IO/Files/FileSystemHelper.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.IO;
 using System.IO.Abstractions;
 using System.Reflection;
 

--- a/Intersect (Core)/Immutability/Immutable.cs
+++ b/Intersect (Core)/Immutability/Immutable.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Immutability
+﻿namespace Intersect.Immutability
 {
 
     public partial struct Immutable<TValue>

--- a/Intersect (Core)/Localization/LocaleArgument.cs
+++ b/Intersect (Core)/Localization/LocaleArgument.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 using Newtonsoft.Json;
 

--- a/Intersect (Core)/Localization/LocaleCommand.cs
+++ b/Intersect (Core)/Localization/LocaleCommand.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Localization
 {

--- a/Intersect (Core)/Localization/LocaleCommandNamespace.cs
+++ b/Intersect (Core)/Localization/LocaleCommandNamespace.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
+﻿using System.Collections.Immutable;
 using System.Reflection;
 
 using Newtonsoft.Json;

--- a/Intersect (Core)/Localization/LocaleDescribableToken.cs
+++ b/Intersect (Core)/Localization/LocaleDescribableToken.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Localization
 {

--- a/Intersect (Core)/Localization/LocaleDictionary.cs
+++ b/Intersect (Core)/Localization/LocaleDictionary.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Intersect.Localization
 {

--- a/Intersect (Core)/Localization/LocaleNamespace.cs
+++ b/Intersect (Core)/Localization/LocaleNamespace.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Localization
+﻿namespace Intersect.Localization
 {
 
     [Serializable]

--- a/Intersect (Core)/Localization/LocaleToken.cs
+++ b/Intersect (Core)/Localization/LocaleToken.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Localization
 {

--- a/Intersect (Core)/Localization/Localized.cs
+++ b/Intersect (Core)/Localization/Localized.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.Localization
 {
 

--- a/Intersect (Core)/Localization/LocalizedString.cs
+++ b/Intersect (Core)/Localization/LocalizedString.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Localization
 {

--- a/Intersect (Core)/Logging/Formatting/DefaultFormatter.cs
+++ b/Intersect (Core)/Logging/Formatting/DefaultFormatter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 
 namespace Intersect.Logging.Formatting

--- a/Intersect (Core)/Logging/Formatting/ILogFormatter.cs
+++ b/Intersect (Core)/Logging/Formatting/ILogFormatter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Logging.Formatting
+﻿namespace Intersect.Logging.Formatting
 {
 
     public interface ILogFormatter

--- a/Intersect (Core)/Logging/Formatting/PrettyFormatter.cs
+++ b/Intersect (Core)/Logging/Formatting/PrettyFormatter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 namespace Intersect.Logging.Formatting
 {

--- a/Intersect (Core)/Logging/ILogger.cs
+++ b/Intersect (Core)/Logging/ILogger.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Logging
+﻿namespace Intersect.Logging
 {
 
     public interface ILogger

--- a/Intersect (Core)/Logging/Log.cs
+++ b/Intersect (Core)/Logging/Log.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 using Intersect.Logging.Formatting;

--- a/Intersect (Core)/Logging/LogConfiguration.cs
+++ b/Intersect (Core)/Logging/LogConfiguration.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 

--- a/Intersect (Core)/Logging/Logger.cs
+++ b/Intersect (Core)/Logging/Logger.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Intersect.Logging
 {

--- a/Intersect (Core)/Logging/MemoryDump.cs
+++ b/Intersect (Core)/Logging/MemoryDump.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 
 namespace Intersect.Logging
 {

--- a/Intersect (Core)/Logging/Output/ConciseConsoleOutput.cs
+++ b/Intersect (Core)/Logging/Output/ConciseConsoleOutput.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Intersect.Logging.Output
 {
     // TODO: Figure out what doesn't need to be duplicated between this and ConsoleOutput

--- a/Intersect (Core)/Logging/Output/ConsoleOutput.cs
+++ b/Intersect (Core)/Logging/Output/ConsoleOutput.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Logging.Output
+﻿namespace Intersect.Logging.Output
 {
 
     public partial class ConsoleOutput : ILogOutput

--- a/Intersect (Core)/Logging/Output/FileOutput.cs
+++ b/Intersect (Core)/Logging/Output/FileOutput.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 
 using Intersect.IO.Files;
 

--- a/Intersect (Core)/Logging/Output/ILogOutput.cs
+++ b/Intersect (Core)/Logging/Output/ILogOutput.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Logging.Output
+﻿namespace Intersect.Logging.Output
 {
 
     public interface ILogOutput

--- a/Intersect (Core)/Memory/IBuffer.cs
+++ b/Intersect (Core)/Memory/IBuffer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Intersect.Memory

--- a/Intersect (Core)/Memory/MemoryBuffer.cs
+++ b/Intersect (Core)/Memory/MemoryBuffer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 
 namespace Intersect.Memory
 {

--- a/Intersect (Core)/Memory/StreamWrapper.cs
+++ b/Intersect (Core)/Memory/StreamWrapper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Diagnostics;
 using System.Text;
 
 namespace Intersect.Memory

--- a/Intersect (Core)/Models/DatabaseObject.cs
+++ b/Intersect (Core)/Models/DatabaseObject.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 
 using Intersect.Collections;
 using Intersect.Enums;

--- a/Intersect (Core)/Models/IDatabaseObject.cs
+++ b/Intersect (Core)/Models/IDatabaseObject.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 
 namespace Intersect.Models
 {

--- a/Intersect (Core)/Models/IObject.cs
+++ b/Intersect (Core)/Models/IObject.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Models
+﻿namespace Intersect.Models
 {
 
     public interface IObject

--- a/Intersect (Core)/Models/LookupUtils.cs
+++ b/Intersect (Core)/Models/LookupUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 using Intersect.Enums;
 using Intersect.Logging;
 

--- a/Intersect (Core)/Models/ObjectDataDiskCache.cs
+++ b/Intersect (Core)/Models/ObjectDataDiskCache.cs
@@ -1,9 +1,6 @@
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
-using System.IO.Hashing;
-using System.Numerics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;

--- a/Intersect (Core)/Network/AbstractConnection.cs
+++ b/Intersect (Core)/Network/AbstractConnection.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 
 namespace Intersect.Network
 {

--- a/Intersect (Core)/Network/Ceras.cs
+++ b/Intersect (Core)/Network/Ceras.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-
-using Ceras;
-using Intersect.GameObjects.Maps;
+﻿using Ceras;
 using Intersect.Logging;
 
 using K4os.Compression.LZ4;

--- a/Intersect (Core)/Network/CerasPacket.cs
+++ b/Intersect (Core)/Network/CerasPacket.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 
 namespace Intersect.Network
 {

--- a/Intersect (Core)/Network/ConnectionPacket.cs
+++ b/Intersect (Core)/Network/ConnectionPacket.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using Intersect.Network.Packets;
 using Intersect.Utilities;
 

--- a/Intersect (Core)/Network/DnsUtils.cs
+++ b/Intersect (Core)/Network/DnsUtils.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
 
 namespace Intersect.Network

--- a/Intersect (Core)/Network/IConnection.cs
+++ b/Intersect (Core)/Network/IConnection.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
     public interface IConnection : IDisposable
     {

--- a/Intersect (Core)/Network/IPacket.cs
+++ b/Intersect (Core)/Network/IPacket.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 
 namespace Intersect.Network
 {

--- a/Intersect (Core)/Network/NetworkConfiguration.cs
+++ b/Intersect (Core)/Network/NetworkConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
 
     public partial class NetworkConfiguration

--- a/Intersect (Core)/Network/NetworkThread.cs
+++ b/Intersect (Core)/Network/NetworkThread.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
+﻿using System.Diagnostics;
 
 using Intersect.Logging;
 

--- a/Intersect (Core)/Network/PackedIntersectPacket.cs
+++ b/Intersect (Core)/Network/PackedIntersectPacket.cs
@@ -1,9 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Network
 {

--- a/Intersect (Core)/Network/PacketDispatcher.cs
+++ b/Intersect (Core)/Network/PacketDispatcher.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
 
     public sealed partial class PacketDispatcher

--- a/Intersect (Core)/Network/PacketHandlerAttribute.cs
+++ b/Intersect (Core)/Network/PacketHandlerAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reflection;
 using Intersect.Reflection;
 

--- a/Intersect (Core)/Network/PacketHandlerRegistry.DisposableHandler.cs
+++ b/Intersect (Core)/Network/PacketHandlerRegistry.DisposableHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
     public partial class PacketHandlerRegistry
     {

--- a/Intersect (Core)/Network/PacketHandlerRegistry.cs
+++ b/Intersect (Core)/Network/PacketHandlerRegistry.cs
@@ -1,10 +1,6 @@
 ﻿using Intersect.Collections;
 using Intersect.Logging;
 using Intersect.Reflection;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Intersect.Network

--- a/Intersect (Core)/Network/PacketLifecycle.cs
+++ b/Intersect (Core)/Network/PacketLifecycle.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
     public sealed partial class PacketLifecycle
     {

--- a/Intersect (Core)/Network/PacketQueue.cs
+++ b/Intersect (Core)/Network/PacketQueue.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-
-namespace Intersect.Network
+﻿namespace Intersect.Network
 {
 
     // TODO : Auto-stale packet deletion

--- a/Intersect (Core)/Network/PacketTypeRegistry.cs
+++ b/Intersect (Core)/Network/PacketTypeRegistry.cs
@@ -1,9 +1,5 @@
 ﻿using Intersect.Collections;
 using Intersect.Logging;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Intersect.Network

--- a/Intersect (Core)/Network/Packets/AbstractTimedPacket.cs
+++ b/Intersect (Core)/Network/Packets/AbstractTimedPacket.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using Intersect.Network.Packets.Client;
+﻿using Intersect.Network.Packets.Client;
 using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using MessagePack;

--- a/Intersect (Core)/Network/Packets/Client/AbandonQuestPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/AbandonQuestPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/ActivateEventPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/ActivateEventPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/AttackPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/AttackPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/BumpPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/BumpPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/CraftItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/CraftItemPacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/CreateCharacterPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/CreateCharacterPacket.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 using Intersect.GameObjects;
 using MessagePack;
 

--- a/Intersect (Core)/Network/Packets/Client/DeleteCharacterPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/DeleteCharacterPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/DirectionPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/DirectionPacket.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 using Intersect.Enums;
 using MessagePack;
 

--- a/Intersect (Core)/Network/Packets/Client/EventInputVariablePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/EventInputVariablePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/EventResponsePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/EventResponsePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/FadeCompletePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/FadeCompletePacket.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Client;

--- a/Intersect (Core)/Network/Packets/Client/ForgetSpellPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/ForgetSpellPacket.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Client

--- a/Intersect (Core)/Network/Packets/Client/FriendRequestResponsePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/FriendRequestResponsePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/HotbarUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/HotbarUpdatePacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/MovePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/MovePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Client

--- a/Intersect (Core)/Network/Packets/Client/PartyInvitePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PartyInvitePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/PartyInviteResponsePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PartyInviteResponsePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/PartyKickPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PartyKickPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/PickupItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PickupItemPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/PictureClosedPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PictureClosedPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/QuestResponsePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/QuestResponsePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/SelectCharacterPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/SelectCharacterPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/TradeRequestPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/TradeRequestPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/TradeRequestResponsePacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/TradeRequestResponsePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/UpdateGuildMemberPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/UpdateGuildMemberPacket.cs
@@ -1,6 +1,5 @@
 ﻿using Intersect.Enums;
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/UseItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/UseItemPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Client/UseSpellPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/UseSpellPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Client
 {

--- a/Intersect (Core)/Network/Packets/Editor/CreateMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/CreateMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/DeleteGameObjectPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/DeleteGameObjectPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Editor

--- a/Intersect (Core)/Network/Packets/Editor/EnterMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/EnterMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/LinkMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/LinkMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/MapListUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/MapListUpdatePacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Editor

--- a/Intersect (Core)/Network/Packets/Editor/MapUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/MapUpdatePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/NeedMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/NeedMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/RequestGridPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/RequestGridPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Editor/SaveGameObjectPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/SaveGameObjectPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Editor

--- a/Intersect (Core)/Network/Packets/Editor/UnlinkMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Editor/UnlinkMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Editor
 {

--- a/Intersect (Core)/Network/Packets/Server/ActionMsgPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ActionMsgPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ActionMsgPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/ActionMsgPackets.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/BagUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/BagUpdatePacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/BankUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/BankUpdatePacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/CancelCastPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/CancelCastPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/CharacterPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/CharacterPacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ChatBubblePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ChatBubblePacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EnterMapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EnterMapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/EntityAttackPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityAttackPacket.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Intersect.Enums;
 using MessagePack;
 

--- a/Intersect (Core)/Network/Packets/Server/EntityDashPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityDashPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityDiePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityDiePacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityDirectionPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityDirectionPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityLeftPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityLeftPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityMovePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityMovePacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityMovementPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityMovementPackets.cs
@@ -1,7 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
-using MessagePack;
+﻿using MessagePack;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/EntityPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/EntityPositionPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityPositionPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityStatsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityStatsPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityVitalsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityVitalsPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/EntityZDimensionPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EntityZDimensionPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/EquipmentPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EquipmentPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/EventDialogPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/EventDialogPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/FriendRequestPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/FriendRequestPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/FriendsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/FriendsPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/GameObjectPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/GameObjectPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/GuildPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/GuildPacket.cs
@@ -1,9 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/HoldPlayerPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/HoldPlayerPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/InputVariablePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/InputVariablePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/InventoryUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/InventoryUpdatePacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ItemCooldownPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ItemCooldownPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ItemProperties.cs
+++ b/Intersect (Core)/Network/Packets/Server/ItemProperties.cs
@@ -1,4 +1,3 @@
-using System;
 using Intersect.Enums;
 using MessagePack;
 

--- a/Intersect (Core)/Network/Packets/Server/MapEntityStatusPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapEntityStatusPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/MapEntityVitalsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapEntityVitalsPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/MapGridPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapGridPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/MapInstanceChangedPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapInstanceChangedPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/MapItemUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapItemUpdatePacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/MapItemsPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapItemsPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/MapPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System.IO.Hashing;
 using System.Security.Cryptography;
 using Intersect.GameObjects.Maps;
 using Intersect.Models;

--- a/Intersect (Core)/Network/Packets/Server/NpcAggressionPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/NpcAggressionPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/PartyInvitePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PartyInvitePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/PartyMemberPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PartyMemberPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/PlayAnimationPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PlayAnimationPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/PlayAnimationPackets.cs
+++ b/Intersect (Core)/Network/Packets/Server/PlayAnimationPackets.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/PlayerDeathPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PlayerDeathPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/PlayerEntityPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/PlayerEntityPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/ProjectileDeadPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ProjectileDeadPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ProjectileEntityPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ProjectileEntityPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/QuestOfferPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/QuestOfferPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/QuestProgressPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/QuestProgressPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ResourceEntityPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ResourceEntityPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/ShowPicturePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/ShowPicturePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/SpellCastPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/SpellCastPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/SpellCooldownPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/SpellCooldownPacket.cs
@@ -1,6 +1,4 @@
 ﻿using MessagePack;
-using System;
-using System.Collections.Generic;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/SpellUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/SpellUpdatePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/StatusPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/StatusPacket.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server

--- a/Intersect (Core)/Network/Packets/Server/TargetOverridePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/TargetOverridePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/TimePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/TimePacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/TradeRequestPacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/TradeRequestPacket.cs
@@ -1,5 +1,4 @@
 ﻿using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/Server/TradeUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/TradeUpdatePacket.cs
@@ -1,5 +1,4 @@
 using MessagePack;
-using System;
 
 namespace Intersect.Network.Packets.Server
 {

--- a/Intersect (Core)/Network/Packets/SlotQuantityPacket.cs
+++ b/Intersect (Core)/Network/Packets/SlotQuantityPacket.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Intersect.Collections;
+﻿using Intersect.Collections;
 using Intersect.Network.Packets.Client;
 using MessagePack;
 

--- a/Intersect (Core)/Plugins/Contexts/PluginBootstrapContext.cs
+++ b/Intersect (Core)/Plugins/Contexts/PluginBootstrapContext.cs
@@ -4,8 +4,6 @@ using Intersect.Factories;
 using Intersect.Plugins.Helpers;
 using Intersect.Plugins.Interfaces;
 using Intersect.Properties;
-
-using System;
 using System.Globalization;
 using System.Reflection;
 

--- a/Intersect (Core)/Plugins/Helpers/CommandLineHelper.cs
+++ b/Intersect (Core)/Plugins/Helpers/CommandLineHelper.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using CommandLine;
+﻿using CommandLine;
 
 using Intersect.Logging;
 using Intersect.Plugins.Interfaces;

--- a/Intersect (Core)/Plugins/Helpers/EmbeddedResourceHelper.cs
+++ b/Intersect (Core)/Plugins/Helpers/EmbeddedResourceHelper.cs
@@ -1,8 +1,4 @@
 ﻿using Intersect.Plugins.Interfaces;
-
-using System;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace Intersect.Plugins.Helpers

--- a/Intersect (Core)/Plugins/Helpers/LoggingHelper.cs
+++ b/Intersect (Core)/Plugins/Helpers/LoggingHelper.cs
@@ -1,11 +1,8 @@
 ﻿using Intersect.Logging;
 using Intersect.Logging.Output;
 using Intersect.Plugins.Interfaces;
-
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 
 namespace Intersect.Plugins.Helpers
 {

--- a/Intersect (Core)/Plugins/Helpers/PacketHelper.cs
+++ b/Intersect (Core)/Plugins/Helpers/PacketHelper.cs
@@ -2,9 +2,6 @@
 using Intersect.Network;
 using Intersect.Plugins.Interfaces;
 
-using System;
-using System.Collections.Generic;
-
 namespace Intersect.Plugins.Helpers
 {
     /// <summary>

--- a/Intersect (Core)/Plugins/IPluginEntry.cs
+++ b/Intersect (Core)/Plugins/IPluginEntry.cs
@@ -1,8 +1,6 @@
 ﻿
 using Microsoft;
 
-using System;
-
 namespace Intersect.Plugins
 {
     /// <summary>

--- a/Intersect (Core)/Plugins/IPluginService.cs
+++ b/Intersect (Core)/Plugins/IPluginService.cs
@@ -1,7 +1,4 @@
-﻿
-using System.Collections.Generic;
-
-using Intersect.Core;
+﻿using Intersect.Core;
 
 namespace Intersect.Plugins
 {

--- a/Intersect (Core)/Plugins/Interfaces/IEmbeddedResourceHelper.cs
+++ b/Intersect (Core)/Plugins/Interfaces/IEmbeddedResourceHelper.cs
@@ -1,7 +1,4 @@
-﻿using System;
-
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Intersect.Plugins.Interfaces
 {

--- a/Intersect (Core)/Plugins/Interfaces/ILoggingHelper.cs
+++ b/Intersect (Core)/Plugins/Interfaces/ILoggingHelper.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 using Intersect.Logging.Formatting;
 
 namespace Intersect.Plugins.Interfaces

--- a/Intersect (Core)/Plugins/Interfaces/IPacketHelper.cs
+++ b/Intersect (Core)/Plugins/Interfaces/IPacketHelper.cs
@@ -1,8 +1,5 @@
 ﻿using Intersect.Network;
 
-using System;
-using System.Collections.Generic;
-
 namespace Intersect.Plugins.Interfaces
 {
     /// <summary>

--- a/Intersect (Core)/Plugins/Loaders/ManifestLoader.cs
+++ b/Intersect (Core)/Plugins/Loaders/ManifestLoader.cs
@@ -3,13 +3,8 @@ using Intersect.Plugins.Interfaces;
 using Intersect.Plugins.Manifests;
 
 using Newtonsoft.Json;
-
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace Intersect.Plugins.Loaders

--- a/Intersect (Core)/Plugins/Loaders/MissingPluginEntryException.cs
+++ b/Intersect (Core)/Plugins/Loaders/MissingPluginEntryException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.Serialization;
 
 using Intersect.Extensions;

--- a/Intersect (Core)/Plugins/Loaders/PluginLoader.Assembly.cs
+++ b/Intersect (Core)/Plugins/Loaders/PluginLoader.Assembly.cs
@@ -1,7 +1,5 @@
 ﻿using Intersect.Core;
 using Intersect.Properties;
-
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 

--- a/Intersect (Core)/Plugins/Loaders/PluginLoader.Configuration.cs
+++ b/Intersect (Core)/Plugins/Loaders/PluginLoader.Configuration.cs
@@ -1,12 +1,7 @@
 ﻿using Intersect.Core;
 
 using Newtonsoft.Json;
-
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace Intersect.Plugins.Loaders

--- a/Intersect (Core)/Plugins/Loaders/PluginLoader.Discovery.cs
+++ b/Intersect (Core)/Plugins/Loaders/PluginLoader.Discovery.cs
@@ -1,10 +1,5 @@
 ﻿using Intersect.Core;
-
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 
 namespace Intersect.Plugins.Loaders
 {

--- a/Intersect (Core)/Plugins/Loaders/PluginLoader.Entry.cs
+++ b/Intersect (Core)/Plugins/Loaders/PluginLoader.Entry.cs
@@ -1,8 +1,5 @@
 ﻿using Intersect.Properties;
 using Intersect.Reflection;
-
-using System;
-using System.Linq;
 using System.Reflection;
 
 namespace Intersect.Plugins.Loaders

--- a/Intersect (Core)/Plugins/Manifests/Types/Author.cs
+++ b/Intersect (Core)/Plugins/Manifests/Types/Author.cs
@@ -1,9 +1,6 @@
 ﻿using Intersect.Utilities;
 
 using Newtonsoft.Json;
-
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 

--- a/Intersect (Core)/Plugins/Manifests/Types/Authors.cs
+++ b/Intersect (Core)/Plugins/Manifests/Types/Authors.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
 
 using Intersect.Utilities;
 

--- a/Intersect (Core)/Plugins/Plugin.PluginReference.cs
+++ b/Intersect (Core)/Plugins/Plugin.PluginReference.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Intersect.Plugins
 {

--- a/Intersect (Core)/Plugins/PluginEntry.cs
+++ b/Intersect (Core)/Plugins/PluginEntry.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Plugins
+﻿namespace Intersect.Plugins
 {
     /// <summary>
     /// Abstract class that virtually defines all of the methods declared by <see cref="IPluginEntry"/>.

--- a/Intersect (Core)/Plugins/PluginService.cs
+++ b/Intersect (Core)/Plugins/PluginService.cs
@@ -1,14 +1,9 @@
 ﻿using Intersect.Core;
 using Intersect.Factories;
 using Intersect.Plugins.Loaders;
-
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 
 namespace Intersect.Plugins
 {

--- a/Intersect (Core)/Security/ApiVisibility.cs
+++ b/Intersect (Core)/Security/ApiVisibility.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Security
+﻿namespace Intersect.Security
 {
 
     [Flags]

--- a/Intersect (Core)/Security/ApiVisibilityAttribute.cs
+++ b/Intersect (Core)/Security/ApiVisibilityAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Security
+﻿namespace Intersect.Security
 {
 
     [AttributeUsage(

--- a/Intersect (Core)/Serialization/Json/SingleOrArrayConverter.cs
+++ b/Intersect (Core)/Serialization/Json/SingleOrArrayConverter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Intersect.Serialization.Json

--- a/Intersect (Core)/Threading/ConcurrentInstance.cs
+++ b/Intersect (Core)/Threading/ConcurrentInstance.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Threading;
+﻿using System.Diagnostics;
 
 using Intersect.Logging;
 

--- a/Intersect (Core)/Threading/LockingActionQueue.cs
+++ b/Intersect (Core)/Threading/LockingActionQueue.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading;
-
-namespace Intersect.Threading
+﻿namespace Intersect.Threading
 {
 
     public partial class LockingActionQueue

--- a/Intersect (Core)/Threading/Threaded.cs
+++ b/Intersect (Core)/Threading/Threaded.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading;
-
-namespace Intersect.Threading
+﻿namespace Intersect.Threading
 {
 
     public abstract partial class Threaded : IDisposable

--- a/Intersect (Core)/Threading/Threaded`1.cs
+++ b/Intersect (Core)/Threading/Threaded`1.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Threading
+﻿namespace Intersect.Threading
 {
 
     /// <inheritdoc />

--- a/Intersect (Core)/Updater/Update.cs
+++ b/Intersect (Core)/Updater/Update.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Intersect.Updater
 {
     public partial class Update

--- a/Intersect (Core)/Updater/Updater.cs
+++ b/Intersect (Core)/Updater/Updater.cs
@@ -1,15 +1,8 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Intersect.Configuration;
 using Intersect.Logging;

--- a/Intersect (Core)/Utilities/AlphanumComparator.cs
+++ b/Intersect (Core)/Utilities/AlphanumComparator.cs
@@ -34,7 +34,6 @@
  *
  */
 
-using System;
 using System.Collections;
 using System.Text;
 

--- a/Intersect (Core)/Utilities/CSharpFeatures.cs
+++ b/Intersect (Core)/Utilities/CSharpFeatures.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
 
     public static partial class CSharpFeatures

--- a/Intersect (Core)/Utilities/DatabaseUtils.cs
+++ b/Intersect (Core)/Utilities/DatabaseUtils.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Intersect.Utilities
 {

--- a/Intersect (Core)/Utilities/ExperienceCurve.cs
+++ b/Intersect (Core)/Utilities/ExperienceCurve.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 
 using NCalc;
 

--- a/Intersect (Core)/Utilities/FieldChecking.cs
+++ b/Intersect (Core)/Utilities/FieldChecking.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Intersect.Utilities
 {

--- a/Intersect (Core)/Utilities/Formula.cs
+++ b/Intersect (Core)/Utilities/Formula.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 
 using NCalc;
 

--- a/Intersect (Core)/Utilities/GameObjectTypeUtils.cs
+++ b/Intersect (Core)/Utilities/GameObjectTypeUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
+﻿using System.Data;
 
 using Intersect.Enums;
 

--- a/Intersect (Core)/Utilities/GuidUtils.cs
+++ b/Intersect (Core)/Utilities/GuidUtils.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 
 namespace Intersect.Utilities

--- a/Intersect (Core)/Utilities/MathHelper.cs
+++ b/Intersect (Core)/Utilities/MathHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
     public static partial class MathHelper
     {

--- a/Intersect (Core)/Utilities/Nullability.cs
+++ b/Intersect (Core)/Utilities/Nullability.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
 
     public static partial class Nullability

--- a/Intersect (Core)/Utilities/Randomization.cs
+++ b/Intersect (Core)/Utilities/Randomization.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Intersect.Core;
+﻿using Intersect.Core;
 using Intersect.Enums;
 
 namespace Intersect.Utilities

--- a/Intersect (Core)/Utilities/ReflectionUtils.cs
+++ b/Intersect (Core)/Utilities/ReflectionUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 

--- a/Intersect (Core)/Utilities/Retry.cs
+++ b/Intersect (Core)/Utilities/Retry.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-
-using Intersect.Logging;
+﻿using Intersect.Logging;
 
 namespace Intersect.Utilities
 {

--- a/Intersect (Core)/Utilities/StreamUtils.cs
+++ b/Intersect (Core)/Utilities/StreamUtils.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
 
     public static partial class StreamUtils

--- a/Intersect (Core)/Utilities/TextUtils.cs
+++ b/Intersect (Core)/Utilities/TextUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
 
     public static partial class TextUtils

--- a/Intersect (Core)/Utilities/Timing.cs
+++ b/Intersect (Core)/Utilities/Timing.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Intersect.Utilities
 {

--- a/Intersect (Core)/Utilities/ValueUtils.cs
+++ b/Intersect (Core)/Utilities/ValueUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Intersect.Utilities
+﻿namespace Intersect.Utilities
 {
 
     public static partial class ValueUtils

--- a/Intersect (Core)/Utilities/VersionHelper.cs
+++ b/Intersect (Core)/Utilities/VersionHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Intersect.Utilities
 {


### PR DESCRIPTION
(side note: implicit usings were introduced with .NET 6)