### PR TITLE
chore: removes unnecessary and implicit usings from intersect network

### DIFF
--- a/Intersect.Network/Lidgren/LidgrenBuffer.cs
+++ b/Intersect.Network/Lidgren/LidgrenBuffer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 using Intersect.Memory;
 

--- a/Intersect.Network/Lidgren/LidgrenConnection.cs
+++ b/Intersect.Network/Lidgren/LidgrenConnection.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 
 using Intersect.Logging;
 using Intersect.Network.Packets;

--- a/Intersect.Network/Lidgren/LidgrenInterface.cs
+++ b/Intersect.Network/Lidgren/LidgrenInterface.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Net;
 using System.Security.Cryptography;
-using System.Threading;
 
 using Intersect.Logging;
 using Intersect.Memory;

--- a/Intersect.Network/LiteNetLib/AesAlgorithm.cs
+++ b/Intersect.Network/LiteNetLib/AesAlgorithm.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Security.Cryptography;
-using System.Text;
 using Intersect.Logging;
 
 namespace Intersect.Network.LiteNetLib;

--- a/Intersect.Network/LiteNetLib/LiteNetLibConnection.cs
+++ b/Intersect.Network/LiteNetLib/LiteNetLibConnection.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
-using System.Text;
 using Intersect.Logging;
 using Intersect.Memory;
 using Intersect.Network.Packets;


### PR DESCRIPTION
(side note: implicit usings were introduced with .NET 6)