### PR TITLE
chore: removes unnecessary and implicit usings from intersect editor

### DIFF
--- a/Intersect.Editor/Configuration/ToolCursor.cs
+++ b/Intersect.Editor/Configuration/ToolCursor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Intersect.Editor.General;
 
 namespace Intersect.Editor.Configuration

--- a/Intersect.Editor/Content/ContentManager.cs
+++ b/Intersect.Editor/Content/ContentManager.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Content/Texture.cs
+++ b/Intersect.Editor/Content/Texture.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.IO;
-
-using Intersect.Editor.Core;
-using Intersect.IO.Files;
+﻿using Intersect.IO.Files;
 using Intersect.Logging;
 using Intersect.Utilities;
 

--- a/Intersect.Editor/Content/TexturePacker.cs
+++ b/Intersect.Editor/Content/TexturePacker.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 
 using Intersect.Compression;
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Newtonsoft.Json.Linq;
 using Graphics = System.Drawing.Graphics;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;

--- a/Intersect.Editor/Core/Database.cs
+++ b/Intersect.Editor/Core/Database.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Drawing;
-using System.IO;
-
 using Intersect.Configuration;
 using Intersect.Editor.Configuration;
 using Mono.Data.Sqlite;

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Drawing.Imaging;
-using System.Windows.Forms;
 using Intersect.Config;
 using Intersect.Editor.Content;
 using Intersect.Editor.Entities;

--- a/Intersect.Editor/Core/Main.cs
+++ b/Intersect.Editor/Core/Main.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
-using Intersect.Editor.Content;
+﻿using Intersect.Editor.Content;
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Core/Program.cs
+++ b/Intersect.Editor/Core/Program.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
-using System.Threading;
-using System.Windows.Forms;
 
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;

--- a/Intersect.Editor/Entities/Animation.cs
+++ b/Intersect.Editor/Entities/Animation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Drawing;
-
-using Intersect.Editor.Content;
+﻿using Intersect.Editor.Content;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 

--- a/Intersect.Editor/Forms/Controls/AutoDragPanel.cs
+++ b/Intersect.Editor/Forms/Controls/AutoDragPanel.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-using Timer = System.Windows.Forms.Timer;
+﻿using Timer = System.Windows.Forms.Timer;
 
 namespace Intersect.Editor.Forms.Controls
 {

--- a/Intersect.Editor/Forms/Controls/GameObjectList.cs
+++ b/Intersect.Editor/Forms/Controls/GameObjectList.cs
@@ -1,13 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
 namespace Intersect.Editor.Forms.Controls
 {
     public partial class GameObjectList : TreeView

--- a/Intersect.Editor/Forms/Controls/LightEditorCtrl.cs
+++ b/Intersect.Editor/Forms/Controls/LightEditorCtrl.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Forms/Controls/MapAttributeTooltip.cs
+++ b/Intersect.Editor/Forms/Controls/MapAttributeTooltip.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Drawing;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Maps;
 

--- a/Intersect.Editor/Forms/Controls/MapTreeList.cs
+++ b/Intersect.Editor/Forms/Controls/MapTreeList.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 
 using Intersect.Editor.Networking;
 using Intersect.GameObjects.Maps.MapList;

--- a/Intersect.Editor/Forms/Controls/SearchableDarkTreeView.cs
+++ b/Intersect.Editor/Forms/Controls/SearchableDarkTreeView.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
-using DarkUI.Controls;
+﻿using DarkUI.Controls;
 
 using Intersect.Collections;
 using Intersect.Models;

--- a/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapEditor.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 using DarkUI.Forms;
 using Intersect.Config;
 using Intersect.Editor.Classes.Maps;

--- a/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -1,12 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
 using Intersect.Config;
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/DockingElements/frmMapList.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapList.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Intersect.Editor.General;

--- a/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;
 
 using WeifenLuo.WinFormsUI.Docking;

--- a/Intersect.Editor/Forms/Editors/EditorForm.cs
+++ b/Intersect.Editor/Forms/Editors/EditorForm.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Networking;
 using Intersect.Enums;
 using Intersect.Logging;

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Text;
-using System.Windows.Forms;
 
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CastSpellOn.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CastSpellOn.cs
@@ -1,14 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 using Intersect.GameObjects.Events.Commands;
-using Intersect.GameObjects.Events;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeGender.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeGender.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeItems.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeItems.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Enums;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeLevel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeLevel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeName.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeName.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeNameColor.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeNameColor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerColor.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerColor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerLabel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerLabel.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSpells.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSpells.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeVital.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeVital.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChatboxText.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChatboxText.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CompleteQuestTask.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CompleteQuestTask.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CreateGuild.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CreateGuild.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EndQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EndQuest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EquipItem.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EquipItem.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveExperience.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveExperience.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GotoLabel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GotoLabel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Label.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Label.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenCrafting.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenCrafting.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenShop.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenShop.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-
 using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Windows.Forms;
-
 using Intersect.Editor.Forms.Helpers;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgm.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgm.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Content;
+﻿using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgs.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgs.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Content;
+﻿using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SelfSwitch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SelfSwitch.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAccess.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAccess.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetClass.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetClass.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetGuildBankSlots.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetGuildBankSlots.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Enums;
+﻿using Intersect.Enums;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Content;
+﻿using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Windows.Forms;
-
 using Intersect.Editor.Forms.Helpers;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartCommonEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartCommonEvent.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartQuest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-
 using Intersect.Editor.Content;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
@@ -1,15 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.Editor.Utilities;
 using Intersect.Enums;
 using Intersect.Extensions;
-using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
-using Intersect.GameObjects.Switches_and_Variables;
 using Intersect.Utilities;
 using VariableMod = Intersect.Enums.VariableMod;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Wait.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Wait.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
 namespace Intersect.Editor.Forms.Editors.Events.Event_Commands

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_WaitForRouteCompletion.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_WaitForRouteCompletion.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using DarkUI.Controls;
 
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.GameObjects.Events;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteAnimationSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteAnimationSelector.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteDesigner.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteDesigner.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
-using Intersect.Editor.Localization;
+﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -1,15 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Controls;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.Forms.Editors.Events.Event_Commands;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/Forms/Editors/Quest/Quest_TaskEditor.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/Quest_TaskEditor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows.Forms;
-
-using Intersect.Editor.Forms.Editors.Events;
+﻿using Intersect.Editor.Forms.Editors.Events;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-
-using DarkUI.Forms;
+﻿using DarkUI.Forms;
 
 using Intersect.Editor.Forms.Editors.Events;
 using Intersect.Editor.General;

--- a/Intersect.Editor/Forms/Editors/frmAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/frmAnimation.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
 using System.Media;
-using System.Windows.Forms;
 
 using DarkUI.Controls;
 using DarkUI.Forms;

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -1,14 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmCommonEvent.cs
+++ b/Intersect.Editor/Forms/Editors/frmCommonEvent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
-using DarkUI.Forms;
+﻿using DarkUI.Forms;
 
 using Intersect.Editor.Forms.Editors.Events;
 using Intersect.Editor.General;

--- a/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
+++ b/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
-using DarkUI.Forms;
+﻿using DarkUI.Forms;
 
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Forms/Editors/frmCrafts.cs
+++ b/Intersect.Editor/Forms/Editors/frmCrafts.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Intersect.Editor.General;

--- a/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
+++ b/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-
-using Intersect.Editor.Forms.Editors.Events.Event_Commands;
+﻿using Intersect.Editor.Forms.Editors.Events.Event_Commands;
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Conditions;
 using Intersect.GameObjects.Events;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -1,25 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Drawing.Imaging;
-using System.Linq;
-using System.Windows.Forms;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
 using Intersect.Enums;
-using Intersect.Framework;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
-using Intersect.GameObjects.Ranges;
 using Intersect.Localization;
-using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
-using static Intersect.GameObjects.EquipmentProperties;
 using Graphics = System.Drawing.Graphics;
 
 namespace Intersect.Editor.Forms.Editors

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -1,14 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Drawing.Imaging;
-using System.Linq;
-using System.Windows.Forms;
 
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmProjectile.cs
+++ b/Intersect.Editor/Forms/Editors/frmProjectile.cs
@@ -1,12 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Controls;
 using DarkUI.Forms;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -1,14 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmShop.cs
+++ b/Intersect.Editor/Forms/Editors/frmShop.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
-using DarkUI.Forms;
+﻿using DarkUI.Forms;
 using Intersect.Editor.Content;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -1,14 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Controls;
 using DarkUI.Forms;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;

--- a/Intersect.Editor/Forms/Editors/frmTime.cs
+++ b/Intersect.Editor/Forms/Editors/frmTime.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Drawing;
-using System.Reflection;
-using System.Windows.Forms;
+﻿using System.Reflection;
 
 using DarkUI.Controls;
 

--- a/Intersect.Editor/Forms/Editors/frmVariable.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Intersect.Editor.General;

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Drawing;
-using System.Linq;
-using Intersect.Editor.Core;
-
 namespace Intersect.Editor.Forms.Helpers
 {
     using Color = System.Drawing.Color;

--- a/Intersect.Editor/Forms/frmAbout.cs
+++ b/Intersect.Editor/Forms/frmAbout.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 using Intersect.Utilities;
 

--- a/Intersect.Editor/Forms/frmLogin.cs
+++ b/Intersect.Editor/Forms/frmLogin.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Windows.Forms;
 
 using Intersect.Editor.Content;
 using Intersect.Editor.Core;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Threading;
-using System.Windows.Forms;
 
 using DarkUI.Controls;
 using DarkUI.Forms;

--- a/Intersect.Editor/Forms/frmOptions.cs
+++ b/Intersect.Editor/Forms/frmOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Windows.Forms;
+﻿using System.Globalization;
 
 using Intersect.Editor.Localization;
 

--- a/Intersect.Editor/Forms/frmProgress.cs
+++ b/Intersect.Editor/Forms/frmProgress.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 using Intersect.Editor.Localization;
 
 namespace Intersect.Editor.Forms

--- a/Intersect.Editor/Forms/frmUpdate.cs
+++ b/Intersect.Editor/Forms/frmUpdate.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
 
 using Intersect.Configuration;
 using Intersect.Editor.Content;

--- a/Intersect.Editor/Forms/frmVariableSelector.cs
+++ b/Intersect.Editor/Forms/frmVariableSelector.cs
@@ -1,18 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using Intersect.Editor.Forms.DockingElements;
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.Extensions;
-using Intersect.GameObjects;
-using Intersect.GameObjects.Annotations;
 
 namespace Intersect.Editor.Forms;
 

--- a/Intersect.Editor/Forms/frmWarpSelection.cs
+++ b/Intersect.Editor/Forms/frmWarpSelection.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Reflection;
-using System.Windows.Forms;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;

--- a/Intersect.Editor/General/Globals.cs
+++ b/Intersect.Editor/General/Globals.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-
 using Intersect.Editor.Forms;
 using Intersect.Editor.Forms.DockingElements;
 using Intersect.Editor.Forms.Editors;

--- a/Intersect.Editor/Localization/Localizer.cs
+++ b/Intersect.Editor/Localization/Localizer.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 using Intersect.GameObjects.Annotations;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 
 using Intersect.Enums;

--- a/Intersect.Editor/Maps/MapGrid.cs
+++ b/Intersect.Editor/Maps/MapGrid.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Threading;
-using System.Windows.Forms;
-
 using DarkUI.Forms;
 
 using Hjg.Pngcs;

--- a/Intersect.Editor/Maps/MapGridItem.cs
+++ b/Intersect.Editor/Maps/MapGridItem.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace Intersect.Editor.Maps
 {

--- a/Intersect.Editor/Maps/MapInstance.cs
+++ b/Intersect.Editor/Maps/MapInstance.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Text;
+﻿using System.Drawing.Imaging;
 using Intersect.Compression;
 using Intersect.Editor.Classes.Maps;
-using Intersect.Editor.Core;
 using Intersect.Editor.Entities;
 using Intersect.Editor.General;
 using Intersect.GameObjects;

--- a/Intersect.Editor/Maps/MapProperties.cs
+++ b/Intersect.Editor/Maps/MapProperties.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 using Intersect.Editor.Content;
-using Intersect.Editor.Core;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;

--- a/Intersect.Editor/Maps/MapSaveState.cs
+++ b/Intersect.Editor/Maps/MapSaveState.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace Intersect.Editor.Classes.Maps
+﻿namespace Intersect.Editor.Classes.Maps
 {
 
     public partial class MapSaveState

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.Reflection;
-using System.Windows.Forms;
 
 using Intersect.Configuration;
 using Intersect.Editor.General;
@@ -9,7 +7,6 @@ using Intersect.Logging;
 using Intersect.Network;
 using Intersect.Network.Events;
 using Intersect.Core;
-using System.Collections.Generic;
 using Intersect.Threading;
 using Intersect.Plugins.Helpers;
 using Intersect.Plugins.Interfaces;

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Windows.Forms;
-
 using Intersect.Core;
 using Intersect.Editor.Content;
 using Intersect.Editor.General;

--- a/Intersect.Editor/Networking/PacketSender.cs
+++ b/Intersect.Editor/Networking/PacketSender.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Intersect.Editor.General;
 using Intersect.Editor.Maps;
 using Intersect.Enums;


### PR DESCRIPTION
(side note: implicit usings were introduced with .NET 6)