### PR TITLE
chore: converts client namespaces to file-scoped namespaces

### DIFF
--- a/Intersect.Client/Core/Audio.cs
+++ b/Intersect.Client/Core/Audio.cs
@@ -7,298 +7,296 @@ using Intersect.Client.General;
 using Intersect.Logging;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+
+public static partial class Audio
 {
 
-    public static partial class Audio
+    private static string sCurrentSong = "";
+
+    private static int sFadeRate;
+
+    private static long sFadeTimer;
+
+    private static bool sFadingOut;
+
+    //Sounds
+    private static List<Sound> sGameSounds = new List<Sound>();
+
+    private static bool sIsInitialized;
+
+    private static int sQueuedFade;
+
+    private static bool sQueuedLoop;
+
+    //Music
+    private static string sQueuedMusic = "";
+
+    private static GameAudioInstance sMyMusic { get; set; }
+
+    //Init
+    public static void Init()
     {
-
-        private static string sCurrentSong = "";
-
-        private static int sFadeRate;
-
-        private static long sFadeTimer;
-
-        private static bool sFadingOut;
-
-        //Sounds
-        private static List<Sound> sGameSounds = new List<Sound>();
-
-        private static bool sIsInitialized;
-
-        private static int sQueuedFade;
-
-        private static bool sQueuedLoop;
-
-        //Music
-        private static string sQueuedMusic = "";
-
-        private static GameAudioInstance sMyMusic { get; set; }
-
-        //Init
-        public static void Init()
+        if (sIsInitialized == true)
         {
-            if (sIsInitialized == true)
-            {
-                return;
-            }
-
-            Globals.ContentManager.LoadAudio();
-            sIsInitialized = true;
+            return;
         }
 
-        public static void UpdateGlobalVolume()
-        {
-            if (sMyMusic != null)
-            {
-                sMyMusic.SetVolume(sMyMusic.GetVolume(), true);
-            }
+        Globals.ContentManager.LoadAudio();
+        sIsInitialized = true;
+    }
 
-            for (var i = 0; i < sGameSounds.Count; i++)
-            {
-                sGameSounds[i].Update();
-                if (!sGameSounds[i].Loaded)
-                {
-                    sGameSounds.RemoveAt(i);
-                }
-            }
+    public static void UpdateGlobalVolume()
+    {
+        if (sMyMusic != null)
+        {
+            sMyMusic.SetVolume(sMyMusic.GetVolume(), true);
         }
 
-        //Update
-        public static void Update()
+        for (var i = 0; i < sGameSounds.Count; i++)
         {
-            if (sMyMusic != null)
+            sGameSounds[i].Update();
+            if (!sGameSounds[i].Loaded)
             {
-                var currentTime = Timing.Global.MillisecondsUtc;
-                if (sFadeTimer != 0 && sFadeTimer < currentTime)
+                sGameSounds.RemoveAt(i);
+            }
+        }
+    }
+
+    //Update
+    public static void Update()
+    {
+        if (sMyMusic != null)
+        {
+            var currentTime = Timing.Global.MillisecondsUtc;
+            if (sFadeTimer != 0 && sFadeTimer < currentTime)
+            {
+                if (sFadingOut)
                 {
-                    if (sFadingOut)
+                    sMyMusic.SetVolume(sMyMusic.GetVolume() - 1, true);
+                    if (sMyMusic.GetVolume() <= 1)
                     {
-                        sMyMusic.SetVolume(sMyMusic.GetVolume() - 1, true);
-                        if (sMyMusic.GetVolume() <= 1)
-                        {
-                            StopMusic();
-                            PlayMusic(sQueuedMusic, 0, sQueuedFade, sQueuedLoop);
-                        }
-                        else
-                        {
-                            sFadeTimer = currentTime + sFadeRate;
-                        }
+                        StopMusic();
+                        PlayMusic(sQueuedMusic, 0, sQueuedFade, sQueuedLoop);
                     }
                     else
                     {
-                        sMyMusic.SetVolume(sMyMusic.GetVolume() + 1, true);
-                        if (sMyMusic.GetVolume() < 100)
-                        {
-                            sFadeTimer = currentTime + sFadeRate;
-                        }
-                        else
-                        {
-                            sFadeTimer = 0;
-                        }
+                        sFadeTimer = currentTime + sFadeRate;
                     }
-                }
-            }
-
-            for (var i = 0; i < sGameSounds.Count; i++)
-            {
-                sGameSounds[i].Update();
-                if (!sGameSounds[i].Loaded)
-                {
-                    sGameSounds.RemoveAt(i);
-                }
-            }
-
-            // Update our pack sound cache if we have any packs loaded.
-            if (Globals.ContentManager.SoundPacks != null)
-            {
-                Globals.ContentManager.SoundPacks.UpdateCache();
-            }
-
-            // Update our pack music cache if we have any packs loaded.
-            if (Globals.ContentManager.MusicPacks != null)
-            {
-                Globals.ContentManager.MusicPacks.UpdateCache();
-            }
-        }
-
-        //Music
-        /// <summary>
-        /// Play a music track, automatically fading out the old track with the configured values.
-        /// </summary>
-        /// <param name="filename">The song file name to start playing. A blank filename will only stop the currently playing music track.</param>
-        /// <param name="fadein">The time (in ms) it should take to fade in the new music track.</param>
-        /// <param name="fadeout">The time (in ms) it should take to fade out the current music track.</param>
-        /// <param name="loop">Determines whether the song loops once it's over or not.</param>
-        public static void PlayMusic(string filename, int fadeout = 0, int fadein = 0, bool loop = false)
-        {
-            if (string.IsNullOrWhiteSpace(filename))
-            {
-                //Entered a map with no music selected, fade out any music that's already playing.
-                StopMusic(fadeout);
-
-                return;
-            }
-
-            ClearQueue();
-
-            filename = GameContentManager.RemoveExtension(filename);
-            if (sMyMusic != null)
-            {
-                if (fadeout == 0 ||
-                    sMyMusic.State == GameAudioInstance.AudioInstanceState.Stopped ||
-                    sMyMusic.State == GameAudioInstance.AudioInstanceState.Paused ||
-                    sMyMusic.GetVolume() == 0)
-                {
-                    StopMusic();
-                    StartMusic(filename, fadein, loop);
                 }
                 else
                 {
-                    //Start fadeout
-                    if (!string.Equals(sCurrentSong, filename, StringComparison.CurrentCultureIgnoreCase) || sFadingOut)
+                    sMyMusic.SetVolume(sMyMusic.GetVolume() + 1, true);
+                    if (sMyMusic.GetVolume() < 100)
                     {
-                        StopMusic(fadeout);
-                        sQueuedMusic = filename;
-                        sQueuedFade = fadein;
-                        sQueuedLoop = loop;
+                        sFadeTimer = currentTime + sFadeRate;
+                    }
+                    else
+                    {
+                        sFadeTimer = 0;
                     }
                 }
             }
-            else
+        }
+
+        for (var i = 0; i < sGameSounds.Count; i++)
+        {
+            sGameSounds[i].Update();
+            if (!sGameSounds[i].Loaded)
             {
-                StartMusic(filename, fadein, loop);
+                sGameSounds.RemoveAt(i);
             }
         }
 
-        private static void ClearQueue()
+        // Update our pack sound cache if we have any packs loaded.
+        if (Globals.ContentManager.SoundPacks != null)
         {
-            sQueuedMusic = null;
-            sQueuedLoop = false;
-            sQueuedFade = -1;
+            Globals.ContentManager.SoundPacks.UpdateCache();
         }
 
-        /// <summary>
-        /// Start playing a new music track.
-        /// </summary>
-        /// <param name="filename">The song file name to start playing.</param>
-        /// <param name="fadein">The time (in ms) it should take to fade in the new music track.</param>
-        /// <param name="loop">Determines whether the song loops once it's over or not.</param>
-        private static void StartMusic(string filename, int fadein = 0, bool loop = false)
+        // Update our pack music cache if we have any packs loaded.
+        if (Globals.ContentManager.MusicPacks != null)
         {
-            var music = Globals.ContentManager.GetMusic(filename);
-            if (music == null)
-            {
-                return;
-            }
+            Globals.ContentManager.MusicPacks.UpdateCache();
+        }
+    }
 
-            if (sMyMusic != null)
-            {
-                Log.Warn($"Trying to start '{filename}' without properly closing '{sCurrentSong}'.");
-            }
+    //Music
+    /// <summary>
+    /// Play a music track, automatically fading out the old track with the configured values.
+    /// </summary>
+    /// <param name="filename">The song file name to start playing. A blank filename will only stop the currently playing music track.</param>
+    /// <param name="fadein">The time (in ms) it should take to fade in the new music track.</param>
+    /// <param name="fadeout">The time (in ms) it should take to fade out the current music track.</param>
+    /// <param name="loop">Determines whether the song loops once it's over or not.</param>
+    public static void PlayMusic(string filename, int fadeout = 0, int fadein = 0, bool loop = false)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            //Entered a map with no music selected, fade out any music that's already playing.
+            StopMusic(fadeout);
 
-            sMyMusic = music.CreateInstance();
-            sCurrentSong = filename;
-            sMyMusic.Play();
-            sMyMusic.SetVolume(0, true);
-            sMyMusic.IsLooping = loop;
-            sFadeRate = fadein / 100;
-            sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
-            sFadingOut = false;
+            return;
         }
 
-        /// <summary>
-        /// Stops the current playing music track.
-        /// </summary>
-        /// <param name="fadeout">The time (in ms) it should take to fade out the current music track.</param>
-        public static void StopMusic(int fadeout = 0)
-        {
-            if (sMyMusic == null)
-            {
-                return;
-            }
+        ClearQueue();
 
+        filename = GameContentManager.RemoveExtension(filename);
+        if (sMyMusic != null)
+        {
             if (fadeout == 0 ||
                 sMyMusic.State == GameAudioInstance.AudioInstanceState.Stopped ||
                 sMyMusic.State == GameAudioInstance.AudioInstanceState.Paused ||
                 sMyMusic.GetVolume() == 0)
             {
-                sCurrentSong = "";
-                sMyMusic.Stop();
-                sMyMusic.Dispose();
-                sMyMusic = null;
-                sFadeTimer = 0;
+                StopMusic();
+                StartMusic(filename, fadein, loop);
             }
             else
             {
                 //Start fadeout
-                sFadeRate = fadeout / sMyMusic.GetVolume();
-                sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
-                sFadingOut = true;
-            }
-        }
-
-        //Sounds
-        public static MapSound AddMapSound(
-            string filename,
-            int x,
-            int y,
-            Guid mapId,
-            bool loop,
-            int loopInterval,
-            int distance,
-            IEntity parent = null
-        )
-        {
-            if (sGameSounds?.Count > 128)
-            {
-                return null;
-            }
-
-            var sound = new MapSound(filename, x, y, mapId, loop, loopInterval, distance, parent);
-            sGameSounds?.Add(sound);
-
-            return sound;
-        }
-
-        public static Sound AddGameSound(string filename, bool loop)
-        {
-            if (sGameSounds?.Count > 128)
-            {
-                return null;
-            }
-
-            var sound = new Sound(filename, loop, 0);
-            sGameSounds?.Add(sound);
-
-            return sound;
-        }
-
-        public static void StopSound(IMapSound sound)
-        {
-            sound?.Stop();
-        }
-
-        public static void StopAllGameSoundsOf(string[] filenames)
-        {
-            var validSounds = sGameSounds.Where(s => filenames.Contains(s.Filename));
-            foreach (var sound in validSounds)
-            {
-                sound.Stop();
-            }
-        }
-
-        public static void StopAllSounds()
-        {
-            for (var i = 0; i < sGameSounds.Count; i++)
-            {
-                if (sGameSounds[i] != null)
+                if (!string.Equals(sCurrentSong, filename, StringComparison.CurrentCultureIgnoreCase) || sFadingOut)
                 {
-                    sGameSounds[i].Stop();
+                    StopMusic(fadeout);
+                    sQueuedMusic = filename;
+                    sQueuedFade = fadein;
+                    sQueuedLoop = loop;
                 }
             }
         }
+        else
+        {
+            StartMusic(filename, fadein, loop);
+        }
+    }
 
+    private static void ClearQueue()
+    {
+        sQueuedMusic = null;
+        sQueuedLoop = false;
+        sQueuedFade = -1;
+    }
+
+    /// <summary>
+    /// Start playing a new music track.
+    /// </summary>
+    /// <param name="filename">The song file name to start playing.</param>
+    /// <param name="fadein">The time (in ms) it should take to fade in the new music track.</param>
+    /// <param name="loop">Determines whether the song loops once it's over or not.</param>
+    private static void StartMusic(string filename, int fadein = 0, bool loop = false)
+    {
+        var music = Globals.ContentManager.GetMusic(filename);
+        if (music == null)
+        {
+            return;
+        }
+
+        if (sMyMusic != null)
+        {
+            Log.Warn($"Trying to start '{filename}' without properly closing '{sCurrentSong}'.");
+        }
+
+        sMyMusic = music.CreateInstance();
+        sCurrentSong = filename;
+        sMyMusic.Play();
+        sMyMusic.SetVolume(0, true);
+        sMyMusic.IsLooping = loop;
+        sFadeRate = fadein / 100;
+        sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
+        sFadingOut = false;
+    }
+
+    /// <summary>
+    /// Stops the current playing music track.
+    /// </summary>
+    /// <param name="fadeout">The time (in ms) it should take to fade out the current music track.</param>
+    public static void StopMusic(int fadeout = 0)
+    {
+        if (sMyMusic == null)
+        {
+            return;
+        }
+
+        if (fadeout == 0 ||
+            sMyMusic.State == GameAudioInstance.AudioInstanceState.Stopped ||
+            sMyMusic.State == GameAudioInstance.AudioInstanceState.Paused ||
+            sMyMusic.GetVolume() == 0)
+        {
+            sCurrentSong = "";
+            sMyMusic.Stop();
+            sMyMusic.Dispose();
+            sMyMusic = null;
+            sFadeTimer = 0;
+        }
+        else
+        {
+            //Start fadeout
+            sFadeRate = fadeout / sMyMusic.GetVolume();
+            sFadeTimer = Timing.Global.MillisecondsUtc + sFadeRate;
+            sFadingOut = true;
+        }
+    }
+
+    //Sounds
+    public static MapSound AddMapSound(
+        string filename,
+        int x,
+        int y,
+        Guid mapId,
+        bool loop,
+        int loopInterval,
+        int distance,
+        IEntity parent = null
+    )
+    {
+        if (sGameSounds?.Count > 128)
+        {
+            return null;
+        }
+
+        var sound = new MapSound(filename, x, y, mapId, loop, loopInterval, distance, parent);
+        sGameSounds?.Add(sound);
+
+        return sound;
+    }
+
+    public static Sound AddGameSound(string filename, bool loop)
+    {
+        if (sGameSounds?.Count > 128)
+        {
+            return null;
+        }
+
+        var sound = new Sound(filename, loop, 0);
+        sGameSounds?.Add(sound);
+
+        return sound;
+    }
+
+    public static void StopSound(IMapSound sound)
+    {
+        sound?.Stop();
+    }
+
+    public static void StopAllGameSoundsOf(string[] filenames)
+    {
+        var validSounds = sGameSounds.Where(s => filenames.Contains(s.Filename));
+        foreach (var sound in validSounds)
+        {
+            sound.Stop();
+        }
+    }
+
+    public static void StopAllSounds()
+    {
+        for (var i = 0; i < sGameSounds.Count; i++)
+        {
+            if (sGameSounds[i] != null)
+            {
+                sGameSounds[i].Stop();
+            }
+        }
     }
 
 }

--- a/Intersect.Client/Core/Bootstrapper.cs
+++ b/Intersect.Client/Core/Bootstrapper.cs
@@ -7,93 +7,91 @@ using Intersect.Plugins;
 using Intersect.Plugins.Contexts;
 using Intersect.Plugins.Helpers;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+
+internal static partial class Bootstrapper
 {
+    public static ClientContext Context { get; private set; }
 
-    internal static partial class Bootstrapper
+    public static void Start(params string[] args)
     {
-        public static ClientContext Context { get; private set; }
+        var parser = new Parser(
+            parserSettings =>
+            {
+                if (parserSettings == null)
+                {
+                    throw new ArgumentNullException(
+                        nameof(parserSettings), @"If this is null the CommandLineParser dependency is likely broken."
+                    );
+                }
 
-        public static void Start(params string[] args)
+                parserSettings.AutoHelp = true;
+                parserSettings.AutoVersion = true;
+                parserSettings.IgnoreUnknownArguments = true;
+            }
+        );
+
+        var logger = Log.Default;
+        var packetTypeRegistry = new PacketTypeRegistry(logger);
+        if (!packetTypeRegistry.TryRegisterBuiltIn())
         {
-            var parser = new Parser(
-                parserSettings =>
-                {
-                    if (parserSettings == null)
-                    {
-                        throw new ArgumentNullException(
-                            nameof(parserSettings), @"If this is null the CommandLineParser dependency is likely broken."
-                        );
-                    }
-
-                    parserSettings.AutoHelp = true;
-                    parserSettings.AutoVersion = true;
-                    parserSettings.IgnoreUnknownArguments = true;
-                }
-            );
-
-            var logger = Log.Default;
-            var packetTypeRegistry = new PacketTypeRegistry(logger);
-            if (!packetTypeRegistry.TryRegisterBuiltIn())
-            {
-                logger.Error("Failed to register built-in packets.");
-                return;
-            }
-
-            var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
-            var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
-            FactoryRegistry<IPluginBootstrapContext>.RegisterFactory(PluginBootstrapContext.CreateFactory(args, parser, packetHelper));
-
-            var commandLineOptions = parser.ParseArguments<ClientCommandLineOptions>(args)
-                .MapResult(HandleParsedArguments, HandleParserErrors);
-
-            if (!string.IsNullOrWhiteSpace(commandLineOptions.WorkingDirectory))
-            {
-                var workingDirectory = commandLineOptions.WorkingDirectory.Trim();
-                var resolvedWorkingDirectory = Path.GetFullPath(workingDirectory);
-                if (Directory.Exists(resolvedWorkingDirectory))
-                {
-                    Environment.CurrentDirectory = resolvedWorkingDirectory;
-                }
-                else
-                {
-                    Log.Warn($"Failed to set working directory to '{workingDirectory}', path does not exist: {resolvedWorkingDirectory}");
-                }
-            }
-
-            Context = new ClientContext(commandLineOptions, logger, packetHelper);
-            Context.Start();
+            logger.Error("Failed to register built-in packets.");
+            return;
         }
 
-        private static ClientCommandLineOptions HandleParsedArguments(ClientCommandLineOptions clientCommandLineOptions) =>
-            clientCommandLineOptions;
+        var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
+        var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
+        FactoryRegistry<IPluginBootstrapContext>.RegisterFactory(PluginBootstrapContext.CreateFactory(args, parser, packetHelper));
 
-        private static ClientCommandLineOptions HandleParserErrors(IEnumerable<Error> errors)
+        var commandLineOptions = parser.ParseArguments<ClientCommandLineOptions>(args)
+            .MapResult(HandleParsedArguments, HandleParserErrors);
+
+        if (!string.IsNullOrWhiteSpace(commandLineOptions.WorkingDirectory))
         {
-            var errorsAsList = errors?.ToList();
-
-            var fatalParsingError = errorsAsList?.Any(error => error?.StopsProcessing ?? false) ?? false;
-
-            var errorString = string.Join(
-                ", ", errorsAsList?.ToList().Select(error => error?.ToString()) ?? Array.Empty<string>()
-            );
-
-            var exception = new ArgumentException(
-                $@"Error parsing command line arguments, received the following errors: {errorString}"
-            );
-
-            if (fatalParsingError)
+            var workingDirectory = commandLineOptions.WorkingDirectory.Trim();
+            var resolvedWorkingDirectory = Path.GetFullPath(workingDirectory);
+            if (Directory.Exists(resolvedWorkingDirectory))
             {
-                Log.Error(exception);
+                Environment.CurrentDirectory = resolvedWorkingDirectory;
             }
             else
             {
-                Log.Warn(exception);
+                Log.Warn($"Failed to set working directory to '{workingDirectory}', path does not exist: {resolvedWorkingDirectory}");
             }
-
-            return default;
         }
 
+        Context = new ClientContext(commandLineOptions, logger, packetHelper);
+        Context.Start();
+    }
+
+    private static ClientCommandLineOptions HandleParsedArguments(ClientCommandLineOptions clientCommandLineOptions) =>
+        clientCommandLineOptions;
+
+    private static ClientCommandLineOptions HandleParserErrors(IEnumerable<Error> errors)
+    {
+        var errorsAsList = errors?.ToList();
+
+        var fatalParsingError = errorsAsList?.Any(error => error?.StopsProcessing ?? false) ?? false;
+
+        var errorString = string.Join(
+            ", ", errorsAsList?.ToList().Select(error => error?.ToString()) ?? Array.Empty<string>()
+        );
+
+        var exception = new ArgumentException(
+            $@"Error parsing command line arguments, received the following errors: {errorString}"
+        );
+
+        if (fatalParsingError)
+        {
+            Log.Error(exception);
+        }
+        else
+        {
+            Log.Warn(exception);
+        }
+
+        return default;
     }
 
 }

--- a/Intersect.Client/Core/ClientCommandLineOptions.cs
+++ b/Intersect.Client/Core/ClientCommandLineOptions.cs
@@ -3,46 +3,45 @@
 using Intersect.Client.Framework.Graphics;
 using Intersect.Core;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+internal partial struct ClientCommandLineOptions : ICommandLineOptions
 {
-    internal partial struct ClientCommandLineOptions : ICommandLineOptions
+    public ClientCommandLineOptions(
+        bool borderlessWindow,
+        int screenWidth,
+        int screenHeight,
+        string server,
+        string workingDirectory,
+        IEnumerable<string> pluginDirectories
+    )
     {
-        public ClientCommandLineOptions(
-            bool borderlessWindow,
-            int screenWidth,
-            int screenHeight,
-            string server,
-            string workingDirectory,
-            IEnumerable<string> pluginDirectories
-        )
-        {
-            BorderlessWindow = borderlessWindow;
-            ScreenWidth = screenWidth;
-            ScreenHeight = screenHeight;
-            Server = server;
-            WorkingDirectory = workingDirectory;
-            PluginDirectories = pluginDirectories?.Select(Path.GetFullPath).ToArray();
-        }
-
-        [Option("borderless", Default = false, Required = false)]
-        public bool BorderlessWindow { get; }
-
-        [Option("screen-width", Default = 0, Required = false)]
-        public int ScreenWidth { get; }
-
-        [Option("screen-height", Default = 0, Required = false)]
-        public int ScreenHeight { get; }
-
-        [Option('S', "server", Default = null, Required = false)]
-        public string Server { get; }
-
-        [Option("working-directory", Default = null, Required = false)]
-        public string WorkingDirectory { get; }
-
-        [Option('p',  "plugin-directory", Default = null, Required = false)]
-        public IEnumerable<string> PluginDirectories { get; }
-
-        public Resolution ScreenResolution => new Resolution(ScreenWidth, ScreenHeight);
-
+        BorderlessWindow = borderlessWindow;
+        ScreenWidth = screenWidth;
+        ScreenHeight = screenHeight;
+        Server = server;
+        WorkingDirectory = workingDirectory;
+        PluginDirectories = pluginDirectories?.Select(Path.GetFullPath).ToArray();
     }
+
+    [Option("borderless", Default = false, Required = false)]
+    public bool BorderlessWindow { get; }
+
+    [Option("screen-width", Default = 0, Required = false)]
+    public int ScreenWidth { get; }
+
+    [Option("screen-height", Default = 0, Required = false)]
+    public int ScreenHeight { get; }
+
+    [Option('S', "server", Default = null, Required = false)]
+    public string Server { get; }
+
+    [Option("working-directory", Default = null, Required = false)]
+    public string WorkingDirectory { get; }
+
+    [Option('p',  "plugin-directory", Default = null, Required = false)]
+    public IEnumerable<string> PluginDirectories { get; }
+
+    public Resolution ScreenResolution => new Resolution(ScreenWidth, ScreenHeight);
+
 }

--- a/Intersect.Client/Core/ClientContext.cs
+++ b/Intersect.Client/Core/ClientContext.cs
@@ -7,69 +7,68 @@ using Intersect.Plugins;
 using Intersect.Plugins.Interfaces;
 using Intersect.Reflection;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+/// <summary>
+/// Implements <see cref="IClientContext"/>.
+/// </summary>
+internal sealed partial class ClientContext : ApplicationContext<ClientContext, ClientCommandLineOptions>, IClientContext
 {
-    /// <summary>
-    /// Implements <see cref="IClientContext"/>.
-    /// </summary>
-    internal sealed partial class ClientContext : ApplicationContext<ClientContext, ClientCommandLineOptions>, IClientContext
+    internal static bool IsSinglePlayer { get; set; }
+
+    private IPlatformRunner mPlatformRunner;
+
+    internal ClientContext(ClientCommandLineOptions startupOptions, Logger logger, IPacketHelper packetHelper) : base(
+        startupOptions, logger, packetHelper
+    )
     {
-        internal static bool IsSinglePlayer { get; set; }
+        FactoryRegistry<IPluginContext>.RegisterFactory(new ClientPluginContext.Factory());
+    }
 
-        private IPlatformRunner mPlatformRunner;
+    protected override bool UsesMainThread => true;
 
-        internal ClientContext(ClientCommandLineOptions startupOptions, Logger logger, IPacketHelper packetHelper) : base(
-            startupOptions, logger, packetHelper
-        )
+    public IPlatformRunner PlatformRunner
+    {
+        get => mPlatformRunner ?? throw new ArgumentNullException(nameof(PlatformRunner));
+        private set => mPlatformRunner = value;
+    }
+
+    /// <inheritdoc />
+    protected override void InternalStart()
+    {
+        Networking.Network.PacketHandler = new PacketHandler(this, PacketHelper.HandlerRegistry);
+        PlatformRunner = typeof(ClientContext).Assembly.CreateInstanceOf<IPlatformRunner>();
+        PlatformRunner.Start(this, PostStartup);
+    }
+
+    #region Exception Handling
+
+    internal static void DispatchUnhandledException(
+        Exception exception,
+        bool isTerminating = true,
+        bool wait = false
+    )
+    {
+        var sender = Thread.CurrentThread;
+        var task = Task.Factory.StartNew(
+            () => HandleUnhandledException(sender, new UnhandledExceptionEventArgs(exception, isTerminating))
+        );
+
+        if (wait)
         {
-            FactoryRegistry<IPluginContext>.RegisterFactory(new ClientPluginContext.Factory());
+            task.Wait();
         }
+    }
 
-        protected override bool UsesMainThread => true;
+    #endregion Exception Handling
 
-        public IPlatformRunner PlatformRunner
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
         {
-            get => mPlatformRunner ?? throw new ArgumentNullException(nameof(PlatformRunner));
-            private set => mPlatformRunner = value;
-        }
-
-        /// <inheritdoc />
-        protected override void InternalStart()
-        {
-            Networking.Network.PacketHandler = new PacketHandler(this, PacketHelper.HandlerRegistry);
-            PlatformRunner = typeof(ClientContext).Assembly.CreateInstanceOf<IPlatformRunner>();
-            PlatformRunner.Start(this, PostStartup);
-        }
-
-        #region Exception Handling
-
-        internal static void DispatchUnhandledException(
-            Exception exception,
-            bool isTerminating = true,
-            bool wait = false
-        )
-        {
-            var sender = Thread.CurrentThread;
-            var task = Task.Factory.StartNew(
-                () => HandleUnhandledException(sender, new UnhandledExceptionEventArgs(exception, isTerminating))
-            );
-
-            if (wait)
-            {
-                task.Wait();
-            }
-        }
-
-        #endregion Exception Handling
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-
-            if (disposing)
-            {
-                PacketHelper.HandlerRegistry.Dispose();
-            }
+            PacketHelper.HandlerRegistry.Dispose();
         }
     }
 }

--- a/Intersect.Client/Core/Controls/ControlEnum.cs
+++ b/Intersect.Client/Core/Controls/ControlEnum.cs
@@ -1,93 +1,91 @@
-﻿namespace Intersect.Client.Core.Controls
+﻿namespace Intersect.Client.Core.Controls;
+
+
+public enum Control
 {
 
-    public enum Control
-    {
+    MoveUp,
 
-        MoveUp,
+    MoveLeft,
 
-        MoveLeft,
+    MoveDown,
 
-        MoveDown,
+    MoveRight,
 
-        MoveRight,
+    AttackInteract,
 
-        AttackInteract,
+    Block,
 
-        Block,
+    AutoTarget,
 
-        AutoTarget,
+    PickUp,
 
-        PickUp,
+    Enter,
 
-        Enter,
+    Hotkey1,
 
-        Hotkey1,
+    Hotkey2,
 
-        Hotkey2,
+    Hotkey3,
 
-        Hotkey3,
+    Hotkey4,
 
-        Hotkey4,
+    Hotkey5,
 
-        Hotkey5,
+    Hotkey6,
 
-        Hotkey6,
+    Hotkey7,
 
-        Hotkey7,
+    Hotkey8,
 
-        Hotkey8,
+    Hotkey9,
 
-        Hotkey9,
+    Hotkey0,
 
-        Hotkey0,
+    Screenshot,
 
-        Screenshot,
+    OpenMenu,
 
-        OpenMenu,
+    OpenInventory,
 
-        OpenInventory,
+    OpenQuests,
 
-        OpenQuests,
+    OpenCharacterInfo,
 
-        OpenCharacterInfo,
+    OpenParties,
 
-        OpenParties,
+    OpenSpells,
 
-        OpenSpells,
+    OpenGuild,
 
-        OpenGuild,
+    OpenFriends,
 
-        OpenFriends,
+    OpenSettings,
 
-        OpenSettings,
+    OpenDebugger,
 
-        OpenDebugger,
+    OpenAdminPanel,
 
-        OpenAdminPanel,
+    ToggleGui,
 
-        ToggleGui,
+    TurnAround,
 
-        TurnAround,
+    ToggleZoomIn,
 
-        ToggleZoomIn,
+    HoldToZoomIn,
 
-        HoldToZoomIn,
+    ToggleZoomOut,
 
-        ToggleZoomOut,
+    HoldToZoomOut,
 
-        HoldToZoomOut,
+    ToggleFullscreen,
 
-        ToggleFullscreen,
-
-        // Submit,
-        //
-        // Cancel,
-        //
-        // Previous,
-        //
-        // Next,
-
-    }
+    // Submit,
+    //
+    // Cancel,
+    //
+    // Previous,
+    //
+    // Next,
 
 }

--- a/Intersect.Client/Core/Controls/ControlMap.cs
+++ b/Intersect.Client/Core/Controls/ControlMap.cs
@@ -1,38 +1,37 @@
 using Newtonsoft.Json;
 
-namespace Intersect.Client.Core.Controls
+namespace Intersect.Client.Core.Controls;
+
+public partial class ControlMap
 {
-    public partial class ControlMap
+    public List<ControlValue> Bindings { get; }
+
+    [JsonConstructor]
+    public ControlMap(ControlValue binding, params ControlValue[] alternateBindings)
     {
-        public List<ControlValue> Bindings { get; }
+        Bindings = new List<ControlValue>(1 + (alternateBindings?.Length ?? 0)) { binding };
+        Bindings.AddRange(alternateBindings ?? Array.Empty<ControlValue>());
 
-        [JsonConstructor]
-        public ControlMap(ControlValue binding, params ControlValue[] alternateBindings)
+        if (Bindings.Count < 2)
         {
-            Bindings = new List<ControlValue>(1 + (alternateBindings?.Length ?? 0)) { binding };
-            Bindings.AddRange(alternateBindings ?? Array.Empty<ControlValue>());
-
-            if (Bindings.Count < 2)
-            {
-                Bindings.Add(ControlValue.Default);
-            }
+            Bindings.Add(ControlValue.Default);
         }
-
-        public ControlMap(ControlMap controlMap)
-        {
-            if (controlMap == default)
-            {
-                throw new ArgumentNullException(nameof(controlMap));
-            }
-
-            if (controlMap.Bindings.Count < 1)
-            {
-                throw new ArgumentException("The control map does not have at least one binding.", nameof(controlMap));
-            }
-
-            Bindings = controlMap.Bindings.Select(binding => new ControlValue(binding)).ToList();
-        }
-
-        public bool KeyDown() => Bindings.Any(button => button.IsDown() && (!button.IsMouseKey || !Interface.Interface.MouseHitGui()));
     }
+
+    public ControlMap(ControlMap controlMap)
+    {
+        if (controlMap == default)
+        {
+            throw new ArgumentNullException(nameof(controlMap));
+        }
+
+        if (controlMap.Bindings.Count < 1)
+        {
+            throw new ArgumentException("The control map does not have at least one binding.", nameof(controlMap));
+        }
+
+        Bindings = controlMap.Bindings.Select(binding => new ControlValue(binding)).ToList();
+    }
+
+    public bool KeyDown() => Bindings.Any(button => button.IsDown() && (!button.IsMouseKey || !Interface.Interface.MouseHitGui()));
 }

--- a/Intersect.Client/Core/Controls/ControlValue.cs
+++ b/Intersect.Client/Core/Controls/ControlValue.cs
@@ -3,103 +3,102 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Input;
 using Newtonsoft.Json;
 
-namespace Intersect.Client.Core.Controls
+namespace Intersect.Client.Core.Controls;
+
+public partial class ControlValue
 {
-    public partial class ControlValue
+    public static ControlValue Default => new ControlValue(Keys.None, Keys.None);
+
+    public Keys Modifier { get; set; }
+
+    public Keys Key { get; set; }
+
+    public bool IsMouseKey => Key == Keys.LButton 
+        || Key == Keys.RButton 
+        || Key == Keys.MButton 
+        || Key == Keys.XButton1 
+        || Key == Keys.XButton2;
+
+    [JsonConstructor]
+    public ControlValue(Keys modifier, Keys key)
     {
-        public static ControlValue Default => new ControlValue(Keys.None, Keys.None);
-
-        public Keys Modifier { get; set; }
-
-        public Keys Key { get; set; }
-
-        public bool IsMouseKey => Key == Keys.LButton 
-            || Key == Keys.RButton 
-            || Key == Keys.MButton 
-            || Key == Keys.XButton1 
-            || Key == Keys.XButton2;
-
-        [JsonConstructor]
-        public ControlValue(Keys modifier, Keys key)
-        {
-            Modifier = modifier;
-            Key = key;
-        }
-
-        public ControlValue(ControlValue controlValue)
-        {
-            Modifier = controlValue.Modifier;
-            Key = controlValue.Key;
-        }
-
-        public bool IsDown()
-        {
-            // Assume our modifier is clicked.
-            var modifier = true;
-
-            // Check to see if it actually is, if not disable it!
-            if (Modifier != Keys.None && !KeyDown(Modifier))
-            {
-                modifier = false;
-            }
-
-            // Check to see if our modifier and real key are pressed!
-            if (modifier)
-            {
-                if (IsMouseKey)
-                {
-                    switch (Key)
-                    {
-                        case Keys.LButton:
-                            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-                            {
-                                return true;
-                            }
-
-                            break;
-                        case Keys.RButton:
-                            if (Globals.InputManager.MouseButtonDown(MouseButtons.Right))
-                            {
-                                return true;
-                            }
-
-                            break;
-                        case Keys.MButton:
-                            if (Globals.InputManager.MouseButtonDown(MouseButtons.Middle))
-                            {
-                                return true;
-                            }
-
-                            break;
-                        case Keys.XButton1:
-                            if (Globals.InputManager.MouseButtonDown(MouseButtons.X1))
-                            {
-                                return true;
-                            }
-
-                            break;
-                        case Keys.XButton2:
-                            if (Globals.InputManager.MouseButtonDown(MouseButtons.X2))
-                            {
-                                return true;
-                            }
-
-                            break;
-                    }
-                }
-                else
-                {
-                    if (KeyDown(Key))
-                    {
-                        return true;
-                    }
-                }
-            }
-           
-            // If we get this far, clearly our buttons aren't pressed.
-            return false;
-        }
-
-        private bool KeyDown(Keys key) => Globals.InputManager.KeyDown(key);
+        Modifier = modifier;
+        Key = key;
     }
+
+    public ControlValue(ControlValue controlValue)
+    {
+        Modifier = controlValue.Modifier;
+        Key = controlValue.Key;
+    }
+
+    public bool IsDown()
+    {
+        // Assume our modifier is clicked.
+        var modifier = true;
+
+        // Check to see if it actually is, if not disable it!
+        if (Modifier != Keys.None && !KeyDown(Modifier))
+        {
+            modifier = false;
+        }
+
+        // Check to see if our modifier and real key are pressed!
+        if (modifier)
+        {
+            if (IsMouseKey)
+            {
+                switch (Key)
+                {
+                    case Keys.LButton:
+                        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case Keys.RButton:
+                        if (Globals.InputManager.MouseButtonDown(MouseButtons.Right))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case Keys.MButton:
+                        if (Globals.InputManager.MouseButtonDown(MouseButtons.Middle))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case Keys.XButton1:
+                        if (Globals.InputManager.MouseButtonDown(MouseButtons.X1))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case Keys.XButton2:
+                        if (Globals.InputManager.MouseButtonDown(MouseButtons.X2))
+                        {
+                            return true;
+                        }
+
+                        break;
+                }
+            }
+            else
+            {
+                if (KeyDown(Key))
+                {
+                    return true;
+                }
+            }
+        }
+       
+        // If we get this far, clearly our buttons aren't pressed.
+        return false;
+    }
+
+    private bool KeyDown(Keys key) => Globals.InputManager.KeyDown(key);
 }

--- a/Intersect.Client/Core/Controls/Controls.cs
+++ b/Intersect.Client/Core/Controls/Controls.cs
@@ -2,202 +2,200 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.General;
 using Newtonsoft.Json;
 
-namespace Intersect.Client.Core.Controls
+namespace Intersect.Client.Core.Controls;
+
+
+public partial class Controls
 {
 
-    public partial class Controls
+    public readonly IDictionary<Control, ControlMap> ControlMapping;
+
+    public Controls(Controls gameControls = null)
     {
+        ControlMapping = new Dictionary<Control, ControlMap>();
 
-        public readonly IDictionary<Control, ControlMap> ControlMapping;
-
-        public Controls(Controls gameControls = null)
+        if (gameControls != null)
         {
-            ControlMapping = new Dictionary<Control, ControlMap>();
-
-            if (gameControls != null)
+            foreach (var mapping in gameControls.ControlMapping)
             {
-                foreach (var mapping in gameControls.ControlMapping)
-                {
-                    CreateControlMap(mapping.Key, mapping.Value);
-                }
-            }
-            else
-            {
-                ResetDefaults();
-                foreach (Control control in Enum.GetValues(typeof(Control)))
-                {
-                    MigrateControlBindings(control);
-
-                    var name = Enum.GetName(typeof(Control), control);
-
-                    if (!ControlMapping.TryGetValue(control, out var controlMapping))
-                    {
-                        continue;
-                    }
-
-                    var bindings = controlMapping.Bindings;
-                    for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
-                    {
-                        var preferenceKey = $"{name}_binding{bindingIndex}";
-                        var preference = Globals.Database.LoadPreference(preferenceKey);
-                        if (string.IsNullOrWhiteSpace(preference))
-                        {
-                            Globals.Database.SavePreference(preferenceKey, JsonConvert.SerializeObject(bindings[bindingIndex]));
-                        }
-                        else
-                        {
-                            bindings[bindingIndex] = JsonConvert.DeserializeObject<ControlValue>(preference);
-                        }
-                    }
-                }
+                CreateControlMap(mapping.Key, mapping.Value);
             }
         }
-
-        public static Controls ActiveControls { get; set; }
-
-        public void ResetDefaults()
+        else
         {
-            CreateControlMap(Control.MoveUp, new ControlValue(Keys.None, Keys.Up), new ControlValue(Keys.None, Keys.W));
-            CreateControlMap(Control.MoveDown, new ControlValue(Keys.None, Keys.Down), new ControlValue(Keys.None, Keys.S));
-            CreateControlMap(Control.MoveLeft, new ControlValue(Keys.None, Keys.Left), new ControlValue(Keys.None, Keys.A));
-            CreateControlMap(Control.MoveRight, new ControlValue(Keys.None, Keys.Right), new ControlValue(Keys.None, Keys.D));
-            CreateControlMap(Control.AttackInteract, new ControlValue(Keys.None, Keys.E), new ControlValue(Keys.None, Keys.LButton));
-            CreateControlMap(Control.Block, new ControlValue(Keys.None, Keys.Q), new ControlValue(Keys.None, Keys.RButton));
-            CreateControlMap(Control.AutoTarget, new ControlValue(Keys.None, Keys.Tab), ControlValue.Default);
-            CreateControlMap(Control.PickUp, new ControlValue(Keys.None, Keys.Space), ControlValue.Default);
-            CreateControlMap(Control.Enter, new ControlValue(Keys.None, Keys.Enter), ControlValue.Default);
-            CreateControlMap(Control.Hotkey1, new ControlValue(Keys.None, Keys.D1), ControlValue.Default);
-            CreateControlMap(Control.Hotkey2, new ControlValue(Keys.None, Keys.D2), ControlValue.Default);
-            CreateControlMap(Control.Hotkey3, new ControlValue(Keys.None, Keys.D3), ControlValue.Default);
-            CreateControlMap(Control.Hotkey4, new ControlValue(Keys.None, Keys.D4), ControlValue.Default);
-            CreateControlMap(Control.Hotkey5, new ControlValue(Keys.None, Keys.D5), ControlValue.Default);
-            CreateControlMap(Control.Hotkey6, new ControlValue(Keys.None, Keys.D6), ControlValue.Default);
-            CreateControlMap(Control.Hotkey7, new ControlValue(Keys.None, Keys.D7), ControlValue.Default);
-            CreateControlMap(Control.Hotkey8, new ControlValue(Keys.None, Keys.D8), ControlValue.Default);
-            CreateControlMap(Control.Hotkey9, new ControlValue(Keys.None, Keys.D9), ControlValue.Default);
-            CreateControlMap(Control.Hotkey0, new ControlValue(Keys.None, Keys.D0), ControlValue.Default);
-            CreateControlMap(Control.Screenshot, new ControlValue(Keys.None, Keys.F12), ControlValue.Default);
-            CreateControlMap(Control.OpenMenu, new ControlValue(Keys.None, Keys.Escape), ControlValue.Default);
-            CreateControlMap(Control.OpenInventory, new ControlValue(Keys.None, Keys.I), ControlValue.Default);
-            CreateControlMap(Control.OpenQuests, new ControlValue(Keys.None, Keys.L), ControlValue.Default);
-            CreateControlMap(Control.OpenCharacterInfo, new ControlValue(Keys.None, Keys.C), ControlValue.Default);
-            CreateControlMap(Control.OpenParties, new ControlValue(Keys.None, Keys.P), ControlValue.Default);
-            CreateControlMap(Control.OpenSpells, new ControlValue(Keys.None, Keys.K), ControlValue.Default);
-            CreateControlMap(Control.OpenFriends, new ControlValue(Keys.None, Keys.F), ControlValue.Default);
-            CreateControlMap(Control.OpenGuild, new ControlValue(Keys.None, Keys.G), ControlValue.Default);
-            CreateControlMap(Control.OpenSettings, new ControlValue(Keys.None, Keys.O), ControlValue.Default);
-            CreateControlMap(Control.OpenDebugger, new ControlValue(Keys.None, Keys.F2), ControlValue.Default);
-            CreateControlMap(Control.OpenAdminPanel, new ControlValue(Keys.None, Keys.Insert), ControlValue.Default);
-            CreateControlMap(Control.ToggleGui, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
-            CreateControlMap(Control.TurnAround, new ControlValue(Keys.None, Keys.Control), ControlValue.Default);
-            CreateControlMap(Control.ToggleZoomIn, ControlValue.Default, ControlValue.Default);
-            CreateControlMap(Control.ToggleZoomOut, ControlValue.Default, ControlValue.Default);
-            CreateControlMap(Control.HoldToZoomIn, ControlValue.Default, ControlValue.Default);
-            CreateControlMap(Control.HoldToZoomOut, ControlValue.Default, ControlValue.Default);
-            CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.Alt, Keys.Enter), ControlValue.Default);
-            // CreateControlMap(Control.Submit, new ControlValue(Keys.None, Keys.Enter), ControlValue.Default);
-            // CreateControlMap(Control.Cancel, new ControlValue(Keys.None, Keys.Back), ControlValue.Default);
-            // CreateControlMap(Control.Next, new ControlValue(Keys.None, Keys.Tab), ControlValue.Default);
-            // CreateControlMap(Control.Previous, new ControlValue(Keys.Shift, Keys.Tab), ControlValue.Default);
-        }
-
-        private static void MigrateControlBindings(Control control)
-        {
-            var name = Enum.GetName(typeof(Control), control);
-            if (Globals.Database.HasPreference($"{name}_key1value"))
-            {
-                Globals.Database.SavePreference($"{name}_binding0", Globals.Database.LoadPreference($"{name}_key1value"));
-                Globals.Database.SavePreference($"{name}_binding1", Globals.Database.LoadPreference($"{name}_key2value"));
-                Globals.Database.DeletePreference($"{name}_key1value");
-                Globals.Database.DeletePreference($"{name}_key2value");
-            }
-            else if (Globals.Database.HasPreference($"{name}_key1"))
-            {
-                var key1 = JsonConvert.DeserializeObject<Keys>(Globals.Database.LoadPreference($"{name}_key1"));
-                var key2 = JsonConvert.DeserializeObject<Keys>(Globals.Database.LoadPreference($"{name}_key2"));
-                Globals.Database.SavePreference($"{name}_binding0", JsonConvert.SerializeObject(new ControlValue(Keys.None, key1)));
-                Globals.Database.SavePreference($"{name}_binding1", JsonConvert.SerializeObject(new ControlValue(Keys.None, key2)));
-                Globals.Database.DeletePreference($"{name}_key1");
-                Globals.Database.DeletePreference($"{name}_key2");
-            }
-        }
-
-        public void Save()
-        {
+            ResetDefaults();
             foreach (Control control in Enum.GetValues(typeof(Control)))
             {
+                MigrateControlBindings(control);
+
                 var name = Enum.GetName(typeof(Control), control);
-                var bindings = ControlMapping[control].Bindings;
+
+                if (!ControlMapping.TryGetValue(control, out var controlMapping))
+                {
+                    continue;
+                }
+
+                var bindings = controlMapping.Bindings;
                 for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
                 {
                     var preferenceKey = $"{name}_binding{bindingIndex}";
-                    Globals.Database.SavePreference(preferenceKey, JsonConvert.SerializeObject(bindings[bindingIndex]));
+                    var preference = Globals.Database.LoadPreference(preferenceKey);
+                    if (string.IsNullOrWhiteSpace(preference))
+                    {
+                        Globals.Database.SavePreference(preferenceKey, JsonConvert.SerializeObject(bindings[bindingIndex]));
+                    }
+                    else
+                    {
+                        bindings[bindingIndex] = JsonConvert.DeserializeObject<ControlValue>(preference);
+                    }
                 }
             }
         }
+    }
 
-        public static void Init()
+    public static Controls ActiveControls { get; set; }
+
+    public void ResetDefaults()
+    {
+        CreateControlMap(Control.MoveUp, new ControlValue(Keys.None, Keys.Up), new ControlValue(Keys.None, Keys.W));
+        CreateControlMap(Control.MoveDown, new ControlValue(Keys.None, Keys.Down), new ControlValue(Keys.None, Keys.S));
+        CreateControlMap(Control.MoveLeft, new ControlValue(Keys.None, Keys.Left), new ControlValue(Keys.None, Keys.A));
+        CreateControlMap(Control.MoveRight, new ControlValue(Keys.None, Keys.Right), new ControlValue(Keys.None, Keys.D));
+        CreateControlMap(Control.AttackInteract, new ControlValue(Keys.None, Keys.E), new ControlValue(Keys.None, Keys.LButton));
+        CreateControlMap(Control.Block, new ControlValue(Keys.None, Keys.Q), new ControlValue(Keys.None, Keys.RButton));
+        CreateControlMap(Control.AutoTarget, new ControlValue(Keys.None, Keys.Tab), ControlValue.Default);
+        CreateControlMap(Control.PickUp, new ControlValue(Keys.None, Keys.Space), ControlValue.Default);
+        CreateControlMap(Control.Enter, new ControlValue(Keys.None, Keys.Enter), ControlValue.Default);
+        CreateControlMap(Control.Hotkey1, new ControlValue(Keys.None, Keys.D1), ControlValue.Default);
+        CreateControlMap(Control.Hotkey2, new ControlValue(Keys.None, Keys.D2), ControlValue.Default);
+        CreateControlMap(Control.Hotkey3, new ControlValue(Keys.None, Keys.D3), ControlValue.Default);
+        CreateControlMap(Control.Hotkey4, new ControlValue(Keys.None, Keys.D4), ControlValue.Default);
+        CreateControlMap(Control.Hotkey5, new ControlValue(Keys.None, Keys.D5), ControlValue.Default);
+        CreateControlMap(Control.Hotkey6, new ControlValue(Keys.None, Keys.D6), ControlValue.Default);
+        CreateControlMap(Control.Hotkey7, new ControlValue(Keys.None, Keys.D7), ControlValue.Default);
+        CreateControlMap(Control.Hotkey8, new ControlValue(Keys.None, Keys.D8), ControlValue.Default);
+        CreateControlMap(Control.Hotkey9, new ControlValue(Keys.None, Keys.D9), ControlValue.Default);
+        CreateControlMap(Control.Hotkey0, new ControlValue(Keys.None, Keys.D0), ControlValue.Default);
+        CreateControlMap(Control.Screenshot, new ControlValue(Keys.None, Keys.F12), ControlValue.Default);
+        CreateControlMap(Control.OpenMenu, new ControlValue(Keys.None, Keys.Escape), ControlValue.Default);
+        CreateControlMap(Control.OpenInventory, new ControlValue(Keys.None, Keys.I), ControlValue.Default);
+        CreateControlMap(Control.OpenQuests, new ControlValue(Keys.None, Keys.L), ControlValue.Default);
+        CreateControlMap(Control.OpenCharacterInfo, new ControlValue(Keys.None, Keys.C), ControlValue.Default);
+        CreateControlMap(Control.OpenParties, new ControlValue(Keys.None, Keys.P), ControlValue.Default);
+        CreateControlMap(Control.OpenSpells, new ControlValue(Keys.None, Keys.K), ControlValue.Default);
+        CreateControlMap(Control.OpenFriends, new ControlValue(Keys.None, Keys.F), ControlValue.Default);
+        CreateControlMap(Control.OpenGuild, new ControlValue(Keys.None, Keys.G), ControlValue.Default);
+        CreateControlMap(Control.OpenSettings, new ControlValue(Keys.None, Keys.O), ControlValue.Default);
+        CreateControlMap(Control.OpenDebugger, new ControlValue(Keys.None, Keys.F2), ControlValue.Default);
+        CreateControlMap(Control.OpenAdminPanel, new ControlValue(Keys.None, Keys.Insert), ControlValue.Default);
+        CreateControlMap(Control.ToggleGui, new ControlValue(Keys.None, Keys.F11), ControlValue.Default);
+        CreateControlMap(Control.TurnAround, new ControlValue(Keys.None, Keys.Control), ControlValue.Default);
+        CreateControlMap(Control.ToggleZoomIn, ControlValue.Default, ControlValue.Default);
+        CreateControlMap(Control.ToggleZoomOut, ControlValue.Default, ControlValue.Default);
+        CreateControlMap(Control.HoldToZoomIn, ControlValue.Default, ControlValue.Default);
+        CreateControlMap(Control.HoldToZoomOut, ControlValue.Default, ControlValue.Default);
+        CreateControlMap(Control.ToggleFullscreen, new ControlValue(Keys.Alt, Keys.Enter), ControlValue.Default);
+        // CreateControlMap(Control.Submit, new ControlValue(Keys.None, Keys.Enter), ControlValue.Default);
+        // CreateControlMap(Control.Cancel, new ControlValue(Keys.None, Keys.Back), ControlValue.Default);
+        // CreateControlMap(Control.Next, new ControlValue(Keys.None, Keys.Tab), ControlValue.Default);
+        // CreateControlMap(Control.Previous, new ControlValue(Keys.Shift, Keys.Tab), ControlValue.Default);
+    }
+
+    private static void MigrateControlBindings(Control control)
+    {
+        var name = Enum.GetName(typeof(Control), control);
+        if (Globals.Database.HasPreference($"{name}_key1value"))
         {
-            ActiveControls = new Controls();
+            Globals.Database.SavePreference($"{name}_binding0", Globals.Database.LoadPreference($"{name}_key1value"));
+            Globals.Database.SavePreference($"{name}_binding1", Globals.Database.LoadPreference($"{name}_key2value"));
+            Globals.Database.DeletePreference($"{name}_key1value");
+            Globals.Database.DeletePreference($"{name}_key2value");
+        }
+        else if (Globals.Database.HasPreference($"{name}_key1"))
+        {
+            var key1 = JsonConvert.DeserializeObject<Keys>(Globals.Database.LoadPreference($"{name}_key1"));
+            var key2 = JsonConvert.DeserializeObject<Keys>(Globals.Database.LoadPreference($"{name}_key2"));
+            Globals.Database.SavePreference($"{name}_binding0", JsonConvert.SerializeObject(new ControlValue(Keys.None, key1)));
+            Globals.Database.SavePreference($"{name}_binding1", JsonConvert.SerializeObject(new ControlValue(Keys.None, key2)));
+            Globals.Database.DeletePreference($"{name}_key1");
+            Globals.Database.DeletePreference($"{name}_key2");
+        }
+    }
+
+    public void Save()
+    {
+        foreach (Control control in Enum.GetValues(typeof(Control)))
+        {
+            var name = Enum.GetName(typeof(Control), control);
+            var bindings = ControlMapping[control].Bindings;
+            for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
+            {
+                var preferenceKey = $"{name}_binding{bindingIndex}";
+                Globals.Database.SavePreference(preferenceKey, JsonConvert.SerializeObject(bindings[bindingIndex]));
+            }
+        }
+    }
+
+    public static void Init()
+    {
+        ActiveControls = new Controls();
+    }
+
+    public static bool KeyDown(Control control)
+    {
+        if (ActiveControls?.ControlMapping.ContainsKey(control) ?? false)
+        {
+            return ActiveControls.ControlMapping[control]?.KeyDown() ?? false;
         }
 
-        public static bool KeyDown(Control control)
-        {
-            if (ActiveControls?.ControlMapping.ContainsKey(control) ?? false)
-            {
-                return ActiveControls.ControlMapping[control]?.KeyDown() ?? false;
-            }
+        return false;
+    }
 
+    public static List<Control> GetControlsFor(Keys modifier, Keys key)
+    {
+        return Enum.GetValues(typeof(Control))
+            .Cast<Control>()
+            .Where(control => ControlHasKey(control, modifier, key))
+            .ToList();
+    }
+
+    public static bool ControlHasKey(Control control, Keys modifier, Keys key)
+    {
+        if (key == Keys.None)
+        {
             return false;
         }
 
-        public static List<Control> GetControlsFor(Keys modifier, Keys key)
+        if (!(ActiveControls?.ControlMapping.ContainsKey(control) ?? false))
         {
-            return Enum.GetValues(typeof(Control))
-                .Cast<Control>()
-                .Where(control => ControlHasKey(control, modifier, key))
-                .ToList();
+            return false;
         }
 
-        public static bool ControlHasKey(Control control, Keys modifier, Keys key)
+        var mapping = ActiveControls.ControlMapping[control];
+
+        return mapping?.Bindings.Any(binding => binding.Modifier == modifier && binding.Key == key) ?? false;
+    }
+
+    public void UpdateControl(Control control, int keyNum, Keys modifier, Keys key)
+    {
+        var mapping = ControlMapping[control];
+        if (mapping == null)
         {
-            if (key == Keys.None)
-            {
-                return false;
-            }
-
-            if (!(ActiveControls?.ControlMapping.ContainsKey(control) ?? false))
-            {
-                return false;
-            }
-
-            var mapping = ActiveControls.ControlMapping[control];
-
-            return mapping?.Bindings.Any(binding => binding.Modifier == modifier && binding.Key == key) ?? false;
+            return;
         }
 
-        public void UpdateControl(Control control, int keyNum, Keys modifier, Keys key)
-        {
-            var mapping = ControlMapping[control];
-            if (mapping == null)
-            {
-                return;
-            }
+        mapping.Bindings[keyNum].Modifier = modifier;
+        mapping.Bindings[keyNum].Key = key;
+    }
 
-            mapping.Bindings[keyNum].Modifier = modifier;
-            mapping.Bindings[keyNum].Key = key;
-        }
+    private void CreateControlMap(Control control, ControlValue binding, params ControlValue[] alternateBindings)
+    {
+        ControlMapping[control] = new ControlMap(binding, alternateBindings);
+    }
 
-        private void CreateControlMap(Control control, ControlValue binding, params ControlValue[] alternateBindings)
-        {
-            ControlMapping[control] = new ControlMap(binding, alternateBindings);
-        }
-
-        private void CreateControlMap(Control control, ControlMap controlMap)
-        {
-            ControlMapping[control] = new ControlMap(controlMap);
-        }
-
+    private void CreateControlMap(Control control, ControlMap controlMap)
+    {
+        ControlMapping[control] = new ControlMap(controlMap);
     }
 
 }

--- a/Intersect.Client/Core/Fade.cs
+++ b/Intersect.Client/Core/Fade.cs
@@ -1,101 +1,99 @@
 using Intersect.Client.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+
+public static partial class Fade
 {
 
-    public static partial class Fade
+    public enum FadeType
     {
 
-        public enum FadeType
-        {
+        None = 0,
 
-            None = 0,
+        In = 1,
 
-            In = 1,
+        Out = 2,
 
-            Out = 2,
-
-        }
-
-        private static FadeType sCurrentAction;
-
-        private static float sFadeAmt;
-
-        private static float sFadeDurationMs;
-
-        private static long sLastUpdate;
-
-        public static float Alpha => sFadeAmt * 255f;
-
-        private static bool InformServer { get; set; }
-
-        public static void FadeIn(float durationMs, bool informServer = false)
-        {
-            sFadeDurationMs = durationMs;
-            sCurrentAction = FadeType.In;
-            sFadeAmt = 1f;
-            sLastUpdate = Timing.Global.MillisecondsUtc;
-            InformServer = informServer;
-        }
-
-        public static void FadeOut(float durationMs, bool informServer = false)
-        {
-            sFadeDurationMs = durationMs;
-            sCurrentAction = FadeType.Out;
-            sFadeAmt = 0f;
-            sLastUpdate = Timing.Global.MillisecondsUtc;
-            InformServer = informServer;
-        }
-
-        public static void Cancel(bool informServer = false)
-        {
-            sCurrentAction = FadeType.None;
-            sFadeAmt = default;
-            InformServerOfCompletion(true);
-        }
-
-        public static bool DoneFading()
-        {
-            return sCurrentAction == FadeType.None;
-        }
-
-        public static void Update()
-        {
-            if (sCurrentAction == FadeType.In)
-            {
-                sFadeAmt -= (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeDurationMs;
-                if (sFadeAmt <= 0f)
-                {
-                    sCurrentAction = FadeType.None;
-                    sFadeAmt = 0f;
-
-                    InformServerOfCompletion();
-                }
-            }
-            else if (sCurrentAction == FadeType.Out)
-            {
-                sFadeAmt += (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeDurationMs;
-                if (sFadeAmt >= 1)
-                {
-                    sCurrentAction = FadeType.None;
-                    sFadeAmt = 1f;
-
-                    InformServerOfCompletion();
-                }
-            }
-
-            sLastUpdate = Timing.Global.MillisecondsUtc;
-        }
-
-        private static void InformServerOfCompletion(bool force = false)
-        {
-            if (InformServer || force)
-            {
-                InformServer = false;
-                PacketSender.SendFadeCompletePacket();
-            }
-        }
     }
 
+    private static FadeType sCurrentAction;
+
+    private static float sFadeAmt;
+
+    private static float sFadeDurationMs;
+
+    private static long sLastUpdate;
+
+    public static float Alpha => sFadeAmt * 255f;
+
+    private static bool InformServer { get; set; }
+
+    public static void FadeIn(float durationMs, bool informServer = false)
+    {
+        sFadeDurationMs = durationMs;
+        sCurrentAction = FadeType.In;
+        sFadeAmt = 1f;
+        sLastUpdate = Timing.Global.MillisecondsUtc;
+        InformServer = informServer;
+    }
+
+    public static void FadeOut(float durationMs, bool informServer = false)
+    {
+        sFadeDurationMs = durationMs;
+        sCurrentAction = FadeType.Out;
+        sFadeAmt = 0f;
+        sLastUpdate = Timing.Global.MillisecondsUtc;
+        InformServer = informServer;
+    }
+
+    public static void Cancel(bool informServer = false)
+    {
+        sCurrentAction = FadeType.None;
+        sFadeAmt = default;
+        InformServerOfCompletion(true);
+    }
+
+    public static bool DoneFading()
+    {
+        return sCurrentAction == FadeType.None;
+    }
+
+    public static void Update()
+    {
+        if (sCurrentAction == FadeType.In)
+        {
+            sFadeAmt -= (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeDurationMs;
+            if (sFadeAmt <= 0f)
+            {
+                sCurrentAction = FadeType.None;
+                sFadeAmt = 0f;
+
+                InformServerOfCompletion();
+            }
+        }
+        else if (sCurrentAction == FadeType.Out)
+        {
+            sFadeAmt += (Timing.Global.MillisecondsUtc - sLastUpdate) / sFadeDurationMs;
+            if (sFadeAmt >= 1)
+            {
+                sCurrentAction = FadeType.None;
+                sFadeAmt = 1f;
+
+                InformServerOfCompletion();
+            }
+        }
+
+        sLastUpdate = Timing.Global.MillisecondsUtc;
+    }
+
+    private static void InformServerOfCompletion(bool force = false)
+    {
+        if (InformServer || force)
+        {
+            InformServer = false;
+            PacketSender.SendFadeCompletePacket();
+        }
+    }
 }

--- a/Intersect.Client/Core/Graphics.cs
+++ b/Intersect.Client/Core/Graphics.cs
@@ -11,618 +11,637 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+
+public static partial class Graphics
 {
 
-    public static partial class Graphics
+    public static GameFont ActionMsgFont;
+
+    public static object AnimationLock = new object();
+
+    //Darkness Stuff
+    public static float BrightnessLevel;
+
+    public static GameFont ChatBubbleFont;
+
+    private static FloatRect _currentView;
+
+    public static FloatRect CurrentView
     {
-
-        public static GameFont ActionMsgFont;
-
-        public static object AnimationLock = new object();
-
-        //Darkness Stuff
-        public static float BrightnessLevel;
-
-        public static GameFont ChatBubbleFont;
-
-        private static FloatRect _currentView;
-
-        public static FloatRect CurrentView
+        get => _currentView;
+        set
         {
-            get => _currentView;
-            set
+            _currentView = value;
+            Renderer.SetView(_currentView);
+        }
+    }
+    
+    public static FloatRect WorldViewport => new FloatRect(CurrentView.Position, CurrentView.Size / (Globals.Database?.WorldZoom ?? 1));
+
+    public static GameShader DefaultShader;
+
+    //Rendering Variables
+    private static GameTexture sMenuBackground;
+
+    public static int DrawCalls;
+
+    public static int EntitiesDrawn;
+
+    public static GameFont EntityNameFont;
+
+    //Screen Values
+    public static GameFont GameFont;
+
+    public static object GfxLock = new object();
+
+    //Grid Switched
+    public static bool GridSwitched;
+
+    public static int LightsDrawn;
+
+    //Animations
+    public static List<Animation> LiveAnimations = new List<Animation>();
+
+    public static int MapsDrawn;
+
+    private static int sMenuBackgroundIndex;
+
+    private static long sMenuBackgroundInterval;
+
+    //Overlay Stuff
+    public static Color OverlayColor = Color.Transparent;
+
+    public static ColorF PlayerLightColor = ColorF.White;
+
+    //Game Renderer
+    public static GameRenderer Renderer;
+
+    //Cache the Y based rendering
+    public static HashSet<Entity>[,] RenderingEntities;
+
+    private static GameContentManager sContentManager;
+
+    private static GameRenderTexture sDarknessTexture;
+
+    private static long sFadeTimer;
+
+    private static List<LightBase> sLightQueue = new List<LightBase>();
+
+    //Player Spotlight Values
+    private static long sLightUpdate;
+
+    private static int sOldHeight;
+
+    //Resolution
+    private static int sOldWidth;
+
+    private static long sOverlayUpdate;
+
+    private static float sPlayerLightExpand;
+
+    private static float sPlayerLightIntensity = 255;
+
+    private static float sPlayerLightSize;
+
+    public static GameFont UIFont;
+
+    public static float BaseWorldScale => Options.Instance?.MapOpts?.TileScale ?? 1;
+
+    //Init Functions
+    public static void InitGraphics()
+    {
+        Renderer.Init();
+        sContentManager = Globals.ContentManager;
+        sContentManager.LoadAll();
+        GameFont = FindFont(ClientConfiguration.Instance.GameFont);
+        UIFont = FindFont(ClientConfiguration.Instance.UIFont);
+        EntityNameFont = FindFont(ClientConfiguration.Instance.EntityNameFont);
+        ChatBubbleFont = FindFont(ClientConfiguration.Instance.ChatBubbleFont);
+        ActionMsgFont = FindFont(ClientConfiguration.Instance.ActionMsgFont);
+    }
+
+    public static GameFont FindFont(string font)
+    {
+        var size = 8;
+
+        if (font.IndexOf(',') > -1)
+        {
+            var parts = font.Split(',');
+            font = parts[0];
+            int.TryParse(parts[1], out size);
+        }
+
+        return sContentManager.GetFont(font, size);
+    }
+
+    public static void InitInGame()
+    {
+        RenderingEntities = new HashSet<Entity>[6, Options.MapHeight * 5];
+        for (var z = 0; z < 6; z++)
+        {
+            for (var i = 0; i < Options.MapHeight * 5; i++)
             {
-                _currentView = value;
-                Renderer.SetView(_currentView);
+                RenderingEntities[z, i] = new HashSet<Entity>();
             }
         }
-        
-        public static FloatRect WorldViewport => new FloatRect(CurrentView.Position, CurrentView.Size / (Globals.Database?.WorldZoom ?? 1));
+    }
 
-        public static GameShader DefaultShader;
+    public static void DrawIntro()
+    {
+        var imageTex = sContentManager.GetTexture(
+            Framework.Content.TextureType.Image, ClientConfiguration.Instance.IntroImages[Globals.IntroIndex]
+        );
 
-        //Rendering Variables
-        private static GameTexture sMenuBackground;
-
-        public static int DrawCalls;
-
-        public static int EntitiesDrawn;
-
-        public static GameFont EntityNameFont;
-
-        //Screen Values
-        public static GameFont GameFont;
-
-        public static object GfxLock = new object();
-
-        //Grid Switched
-        public static bool GridSwitched;
-
-        public static int LightsDrawn;
-
-        //Animations
-        public static List<Animation> LiveAnimations = new List<Animation>();
-
-        public static int MapsDrawn;
-
-        private static int sMenuBackgroundIndex;
-
-        private static long sMenuBackgroundInterval;
-
-        //Overlay Stuff
-        public static Color OverlayColor = Color.Transparent;
-
-        public static ColorF PlayerLightColor = ColorF.White;
-
-        //Game Renderer
-        public static GameRenderer Renderer;
-
-        //Cache the Y based rendering
-        public static HashSet<Entity>[,] RenderingEntities;
-
-        private static GameContentManager sContentManager;
-
-        private static GameRenderTexture sDarknessTexture;
-
-        private static long sFadeTimer;
-
-        private static List<LightBase> sLightQueue = new List<LightBase>();
-
-        //Player Spotlight Values
-        private static long sLightUpdate;
-
-        private static int sOldHeight;
-
-        //Resolution
-        private static int sOldWidth;
-
-        private static long sOverlayUpdate;
-
-        private static float sPlayerLightExpand;
-
-        private static float sPlayerLightIntensity = 255;
-
-        private static float sPlayerLightSize;
-
-        public static GameFont UIFont;
-
-        public static float BaseWorldScale => Options.Instance?.MapOpts?.TileScale ?? 1;
-
-        //Init Functions
-        public static void InitGraphics()
+        if (imageTex != null)
         {
-            Renderer.Init();
-            sContentManager = Globals.ContentManager;
-            sContentManager.LoadAll();
-            GameFont = FindFont(ClientConfiguration.Instance.GameFont);
-            UIFont = FindFont(ClientConfiguration.Instance.UIFont);
-            EntityNameFont = FindFont(ClientConfiguration.Instance.EntityNameFont);
-            ChatBubbleFont = FindFont(ClientConfiguration.Instance.ChatBubbleFont);
-            ActionMsgFont = FindFont(ClientConfiguration.Instance.ActionMsgFont);
+            DrawFullScreenTextureFitMinimum(imageTex);
+        }
+    }
+
+    private static void DrawMenu()
+    {
+        // No background in the main menu.
+        if (ClientConfiguration.Instance.MenuBackground.Count == 0)
+        {
+            return;
         }
 
-        public static GameFont FindFont(string font)
+        // Animated background in the main menu.
+        if (ClientConfiguration.Instance.MenuBackground.Count > 1)
         {
-            var size = 8;
-
-            if (font.IndexOf(',') > -1)
-            {
-                var parts = font.Split(',');
-                font = parts[0];
-                int.TryParse(parts[1], out size);
-            }
-
-            return sContentManager.GetFont(font, size);
-        }
-
-        public static void InitInGame()
-        {
-            RenderingEntities = new HashSet<Entity>[6, Options.MapHeight * 5];
-            for (var z = 0; z < 6; z++)
-            {
-                for (var i = 0; i < Options.MapHeight * 5; i++)
-                {
-                    RenderingEntities[z, i] = new HashSet<Entity>();
-                }
-            }
-        }
-
-        public static void DrawIntro()
-        {
-            var imageTex = sContentManager.GetTexture(
-                Framework.Content.TextureType.Image, ClientConfiguration.Instance.IntroImages[Globals.IntroIndex]
+            sMenuBackground = sContentManager.GetTexture(
+                TextureType.Gui, ClientConfiguration.Instance.MenuBackground[sMenuBackgroundIndex]
             );
 
-            if (imageTex != null)
+            if (sMenuBackground == null)
             {
-                DrawFullScreenTextureFitMinimum(imageTex);
+                return;
+            }
+
+            var currentTimeMs = Timing.Global.MillisecondsUtc;
+
+            if (sMenuBackgroundInterval < currentTimeMs)
+            {
+                sMenuBackgroundIndex =
+                    (sMenuBackgroundIndex + 1) % ClientConfiguration.Instance.MenuBackground.Count;
+
+                sMenuBackgroundInterval = currentTimeMs + ClientConfiguration.Instance.MenuBackgroundFrameInterval;
             }
         }
 
-        private static void DrawMenu()
+        // Static background in the main menu.
+        else
         {
-            // No background in the main menu.
-            if (ClientConfiguration.Instance.MenuBackground.Count == 0)
+            sMenuBackground = sContentManager.GetTexture(
+                TextureType.Gui, ClientConfiguration.Instance.MenuBackground[0]
+            );
+
+            if (sMenuBackground == null)
             {
                 return;
-            }
-
-            // Animated background in the main menu.
-            if (ClientConfiguration.Instance.MenuBackground.Count > 1)
-            {
-                sMenuBackground = sContentManager.GetTexture(
-                    TextureType.Gui, ClientConfiguration.Instance.MenuBackground[sMenuBackgroundIndex]
-                );
-
-                if (sMenuBackground == null)
-                {
-                    return;
-                }
-
-                var currentTimeMs = Timing.Global.MillisecondsUtc;
-
-                if (sMenuBackgroundInterval < currentTimeMs)
-                {
-                    sMenuBackgroundIndex =
-                        (sMenuBackgroundIndex + 1) % ClientConfiguration.Instance.MenuBackground.Count;
-
-                    sMenuBackgroundInterval = currentTimeMs + ClientConfiguration.Instance.MenuBackgroundFrameInterval;
-                }
-            }
-
-            // Static background in the main menu.
-            else
-            {
-                sMenuBackground = sContentManager.GetTexture(
-                    TextureType.Gui, ClientConfiguration.Instance.MenuBackground[0]
-                );
-
-                if (sMenuBackground == null)
-                {
-                    return;
-                }
-            }
-
-            // Switch between the preferred display mode, then render the fullscreen texture.
-            switch (ClientConfiguration.Instance.MenuBackgroundDisplayMode)
-            {
-                case DisplayMode.Default:
-                    DrawFullScreenTexture(sMenuBackground);
-                    break;
-
-                case DisplayMode.Center:
-                    DrawFullScreenTextureCentered(sMenuBackground);
-                    break;
-
-                case DisplayMode.Stretch:
-                    DrawFullScreenTextureStretched(sMenuBackground);
-                    break;
-
-                case DisplayMode.FitHeight:
-                    DrawFullScreenTextureFitHeight(sMenuBackground);
-                    break;
-
-                case DisplayMode.FitWidth:
-                    DrawFullScreenTextureFitWidth(sMenuBackground);
-                    break;
-
-                case DisplayMode.Fit:
-                    DrawFullScreenTextureFitMaximum(sMenuBackground);
-                    break;
-
-                case DisplayMode.Cover:
-                    DrawFullScreenTextureFitMinimum(sMenuBackground);
-                    break;
             }
         }
 
-        public static void DrawInGame(TimeSpan deltaTime)
+        // Switch between the preferred display mode, then render the fullscreen texture.
+        switch (ClientConfiguration.Instance.MenuBackgroundDisplayMode)
         {
-            var currentMap = Globals.Me.MapInstance as MapInstance;
-            if (currentMap == null)
+            case DisplayMode.Default:
+                DrawFullScreenTexture(sMenuBackground);
+                break;
+
+            case DisplayMode.Center:
+                DrawFullScreenTextureCentered(sMenuBackground);
+                break;
+
+            case DisplayMode.Stretch:
+                DrawFullScreenTextureStretched(sMenuBackground);
+                break;
+
+            case DisplayMode.FitHeight:
+                DrawFullScreenTextureFitHeight(sMenuBackground);
+                break;
+
+            case DisplayMode.FitWidth:
+                DrawFullScreenTextureFitWidth(sMenuBackground);
+                break;
+
+            case DisplayMode.Fit:
+                DrawFullScreenTextureFitMaximum(sMenuBackground);
+                break;
+
+            case DisplayMode.Cover:
+                DrawFullScreenTextureFitMinimum(sMenuBackground);
+                break;
+        }
+    }
+
+    public static void DrawInGame(TimeSpan deltaTime)
+    {
+        var currentMap = Globals.Me.MapInstance as MapInstance;
+        if (currentMap == null)
+        {
+            return;
+        }
+
+        if (Globals.NeedsMaps)
+        {
+            return;
+        }
+
+        if (GridSwitched)
+        {
+            //Brightness
+            var brightnessTarget = (byte)(currentMap.Brightness / 100f * 255);
+            BrightnessLevel = brightnessTarget;
+            PlayerLightColor.R = currentMap.PlayerLightColor.R;
+            PlayerLightColor.G = currentMap.PlayerLightColor.G;
+            PlayerLightColor.B = currentMap.PlayerLightColor.B;
+            sPlayerLightSize = currentMap.PlayerLightSize;
+            sPlayerLightIntensity = currentMap.PlayerLightIntensity;
+            sPlayerLightExpand = currentMap.PlayerLightExpand;
+
+            //Overlay
+            OverlayColor.A = (byte)currentMap.AHue;
+            OverlayColor.R = (byte)currentMap.RHue;
+            OverlayColor.G = (byte)currentMap.GHue;
+            OverlayColor.B = (byte)currentMap.BHue;
+
+            //Fog && Panorama
+            currentMap.GridSwitched();
+            GridSwitched = false;
+        }
+
+        var animations = LiveAnimations.ToArray();
+        foreach (var animInstance in animations)
+        {
+            if (animInstance.ParentGone())
             {
-                return;
+                animInstance.Dispose();
             }
+        }
 
-            if (Globals.NeedsMaps)
+        // Clear our previous darkness texture.
+        ClearDarknessTexture();
+
+        var gridX = currentMap.GridX;
+        var gridY = currentMap.GridY;
+
+        //Draw Panoramas First...
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                return;
-            }
-
-            if (GridSwitched)
-            {
-                //Brightness
-                var brightnessTarget = (byte)(currentMap.Brightness / 100f * 255);
-                BrightnessLevel = brightnessTarget;
-                PlayerLightColor.R = currentMap.PlayerLightColor.R;
-                PlayerLightColor.G = currentMap.PlayerLightColor.G;
-                PlayerLightColor.B = currentMap.PlayerLightColor.B;
-                sPlayerLightSize = currentMap.PlayerLightSize;
-                sPlayerLightIntensity = currentMap.PlayerLightIntensity;
-                sPlayerLightExpand = currentMap.PlayerLightExpand;
-
-                //Overlay
-                OverlayColor.A = (byte)currentMap.AHue;
-                OverlayColor.R = (byte)currentMap.RHue;
-                OverlayColor.G = (byte)currentMap.GHue;
-                OverlayColor.B = (byte)currentMap.BHue;
-
-                //Fog && Panorama
-                currentMap.GridSwitched();
-                GridSwitched = false;
-            }
-
-            var animations = LiveAnimations.ToArray();
-            foreach (var animInstance in animations)
-            {
-                if (animInstance.ParentGone())
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    animInstance.Dispose();
+                    DrawMapPanorama(Globals.MapGrid[x, y]);
                 }
             }
+        }
 
-            // Clear our previous darkness texture.
-            ClearDarknessTexture();
-
-            var gridX = currentMap.GridX;
-            var gridY = currentMap.GridY;
-
-            //Draw Panoramas First...
-            for (var x = gridX - 1; x <= gridX + 1; x++)
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        DrawMapPanorama(Globals.MapGrid[x, y]);
-                    }
+                    DrawMap(Globals.MapGrid[x, y], 0);
                 }
             }
+        }
 
-            for (var x = gridX - 1; x <= gridX + 1; x++)
+        // Handle our plugin drawing.
+        Globals.OnGameDraw(DrawStates.GroundLayers, deltaTime);
+
+        foreach (var animInstance in animations)
+        {
+            animInstance.Draw(false);
+        }
+
+        // Handle our plugin drawing.
+        Globals.OnGameDraw(DrawStates.BelowPlayer, deltaTime);
+
+        for (var y = 0; y < Options.MapHeight * 5; y++)
+        {
+            for (var x = 0; x < 3; x++)
             {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                foreach (var entity in RenderingEntities[x, y])
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        DrawMap(Globals.MapGrid[x, y], 0);
-                    }
+                    // Handle our plugin drawing.
+                    Globals.OnGameDraw(DrawStates.BeforeEntity, entity, deltaTime);
+
+                    entity.Draw();
+
+                    // Handle our plugin drawing.
+                    Globals.OnGameDraw(DrawStates.AfterEntity, entity, deltaTime);
+
+                    EntitiesDrawn++;
                 }
-            }
 
-            // Handle our plugin drawing.
-            Globals.OnGameDraw(DrawStates.GroundLayers, deltaTime);
-
-            foreach (var animInstance in animations)
-            {
-                animInstance.Draw(false);
-            }
-
-            // Handle our plugin drawing.
-            Globals.OnGameDraw(DrawStates.BelowPlayer, deltaTime);
-
-            for (var y = 0; y < Options.MapHeight * 5; y++)
-            {
-                for (var x = 0; x < 3; x++)
+                if (x == 0 && y > 0 && y % Options.MapHeight == 0)
                 {
-                    foreach (var entity in RenderingEntities[x, y])
+                    for (var x1 = gridX - 1; x1 <= gridX + 1; x1++)
                     {
-                        // Handle our plugin drawing.
-                        Globals.OnGameDraw(DrawStates.BeforeEntity, entity, deltaTime);
-
-                        entity.Draw();
-
-                        // Handle our plugin drawing.
-                        Globals.OnGameDraw(DrawStates.AfterEntity, entity, deltaTime);
-
-                        EntitiesDrawn++;
-                    }
-
-                    if (x == 0 && y > 0 && y % Options.MapHeight == 0)
-                    {
-                        for (var x1 = gridX - 1; x1 <= gridX + 1; x1++)
+                        var y1 = gridY - 2 + (int)Math.Floor(y / (float)Options.MapHeight);
+                        if (x1 >= 0 &&
+                            x1 < Globals.MapGridWidth &&
+                            y1 >= 0 &&
+                            y1 < Globals.MapGridHeight &&
+                            Globals.MapGrid[x1, y1] != Guid.Empty)
                         {
-                            var y1 = gridY - 2 + (int)Math.Floor(y / (float)Options.MapHeight);
-                            if (x1 >= 0 &&
-                                x1 < Globals.MapGridWidth &&
-                                y1 >= 0 &&
-                                y1 < Globals.MapGridHeight &&
-                                Globals.MapGrid[x1, y1] != Guid.Empty)
+                            var map = MapInstance.Get(Globals.MapGrid[x1, y1]);
+                            if (map != null)
                             {
-                                var map = MapInstance.Get(Globals.MapGrid[x1, y1]);
-                                if (map != null)
-                                {
-                                    map.DrawItemsAndLights();
-                                }
+                                map.DrawItemsAndLights();
                             }
                         }
                     }
                 }
             }
+        }
 
-            foreach (var animInstance in animations)
-            {
-                animInstance.Draw(false, true);
-                animInstance.Draw(true, true);
-            }
+        foreach (var animInstance in animations)
+        {
+            animInstance.Draw(false, true);
+            animInstance.Draw(true, true);
+        }
 
-            for (var x = gridX - 1; x <= gridX + 1; x++)
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        DrawMap(Globals.MapGrid[x, y], 1);
-                    }
+                    DrawMap(Globals.MapGrid[x, y], 1);
                 }
             }
+        }
 
-            for (var y = 0; y < Options.MapHeight * 5; y++)
+        for (var y = 0; y < Options.MapHeight * 5; y++)
+        {
+            for (var x = 3; x < 6; x++)
             {
-                for (var x = 3; x < 6; x++)
+                foreach (var entity in RenderingEntities[x, y])
                 {
-                    foreach (var entity in RenderingEntities[x, y])
-                    {
-                        // Handle our plugin drawing.
-                        Globals.OnGameDraw(DrawStates.BeforeEntity, entity, deltaTime);
+                    // Handle our plugin drawing.
+                    Globals.OnGameDraw(DrawStates.BeforeEntity, entity, deltaTime);
 
-                        entity.Draw();
+                    entity.Draw();
 
-                        // Handle our plugin drawing.
-                        Globals.OnGameDraw(DrawStates.AfterEntity, entity, deltaTime);
+                    // Handle our plugin drawing.
+                    Globals.OnGameDraw(DrawStates.AfterEntity, entity, deltaTime);
 
-                        EntitiesDrawn++;
-                    }
+                    EntitiesDrawn++;
                 }
             }
+        }
 
-            // Handle our plugin drawing.
-            Globals.OnGameDraw(DrawStates.AbovePlayer, deltaTime);
+        // Handle our plugin drawing.
+        Globals.OnGameDraw(DrawStates.AbovePlayer, deltaTime);
 
-            for (var x = gridX - 1; x <= gridX + 1; x++)
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        DrawMap(Globals.MapGrid[x, y], 2);
-                    }
+                    DrawMap(Globals.MapGrid[x, y], 2);
                 }
             }
-            // Handle our plugin drawing.
-            Globals.OnGameDraw(DrawStates.FringeLayers, deltaTime);
+        }
+        // Handle our plugin drawing.
+        Globals.OnGameDraw(DrawStates.FringeLayers, deltaTime);
 
-            foreach (var animInstance in animations)
+        foreach (var animInstance in animations)
+        {
+            animInstance.Draw(true);
+        }
+
+
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                animInstance.Draw(true);
-            }
-
-
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        var map = MapInstance.Get(Globals.MapGrid[x, y]);
-                        if (map != null)
-                        {
-                            map.DrawWeather();
-                            map.DrawFog();
-                            map.DrawOverlayGraphic();
-                            map.DrawItemNames();
-                        }
-                    }
-                }
-            }
-
-            //Draw the players targets
-            Globals.Me.DrawTargets();
-
-            DrawOverlay();
-
-            // Draw lighting effects.
-            GenerateLightMap();
-            DrawDarkness();
-
-            for (var y = 0; y < Options.MapHeight * 5; y++)
-            {
-                for (var x = 0; x < 3; x++)
-                {
-                    foreach (var entity in RenderingEntities[x, y])
-                    {
-                        entity.DrawName(null);
-                        if (entity.GetType() != typeof(Event))
-                        {
-                            entity.DrawHpBar();
-                            entity.DrawCastingBar();
-                        }
-
-                        entity.DrawChatBubbles();
-                    }
-                }
-            }
-
-            for (var y = 0; y < Options.MapHeight * 5; y++)
-            {
-                for (var x = 3; x < 6; x++)
-                {
-                    foreach (var entity in RenderingEntities[x, y])
-                    {
-                        entity.DrawName(null);
-                        if (entity.GetType() != typeof(Event))
-                        {
-                            entity.DrawHpBar();
-                            entity.DrawCastingBar();
-                        }
-
-                        entity.DrawChatBubbles();
-                    }
-                }
-            }
-
-            //Draw action msg's
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
-                {
-                    if (x < 0 ||
-                        x >= Globals.MapGridWidth ||
-                        y < 0 ||
-                        y >= Globals.MapGridHeight ||
-                        Globals.MapGrid[x, y] == Guid.Empty)
-                    {
-                        continue;
-                    }
-
                     var map = MapInstance.Get(Globals.MapGrid[x, y]);
-                    map?.DrawActionMsgs();
+                    if (map != null)
+                    {
+                        map.DrawWeather();
+                        map.DrawFog();
+                        map.DrawOverlayGraphic();
+                        map.DrawItemNames();
+                    }
                 }
             }
+        }
 
-            foreach (var animInstance in animations)
+        //Draw the players targets
+        Globals.Me.DrawTargets();
+
+        DrawOverlay();
+
+        // Draw lighting effects.
+        GenerateLightMap();
+        DrawDarkness();
+
+        for (var y = 0; y < Options.MapHeight * 5; y++)
+        {
+            for (var x = 0; x < 3; x++)
             {
-                animInstance.EndDraw();
+                foreach (var entity in RenderingEntities[x, y])
+                {
+                    entity.DrawName(null);
+                    if (entity.GetType() != typeof(Event))
+                    {
+                        entity.DrawHpBar();
+                        entity.DrawCastingBar();
+                    }
+
+                    entity.DrawChatBubbles();
+                }
             }
         }
 
-        //Game Rendering
-        public static void Render(TimeSpan deltaTime, TimeSpan totalTime)
+        for (var y = 0; y < Options.MapHeight * 5; y++)
         {
-            var takingScreenshot = false;
-            if (Renderer?.ScreenshotRequests.Count > 0)
+            for (var x = 3; x < 6; x++)
             {
-                takingScreenshot = Renderer.BeginScreenshot();
-            }
+                foreach (var entity in RenderingEntities[x, y])
+                {
+                    entity.DrawName(null);
+                    if (entity.GetType() != typeof(Event))
+                    {
+                        entity.DrawHpBar();
+                        entity.DrawCastingBar();
+                    }
 
-            if (Renderer == default)
+                    entity.DrawChatBubbles();
+                }
+            }
+        }
+
+        //Draw action msg's
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                return;
+                if (x < 0 ||
+                    x >= Globals.MapGridWidth ||
+                    y < 0 ||
+                    y >= Globals.MapGridHeight ||
+                    Globals.MapGrid[x, y] == Guid.Empty)
+                {
+                    continue;
+                }
+
+                var map = MapInstance.Get(Globals.MapGrid[x, y]);
+                map?.DrawActionMsgs();
             }
+        }
 
-            Renderer.Scale = Globals.GameState == GameStates.InGame ? Globals.Database.WorldZoom : 1.0f;
+        foreach (var animInstance in animations)
+        {
+            animInstance.EndDraw();
+        }
+    }
 
-            if (!Renderer.Begin())
-            {
-                return;
-            }
+    //Game Rendering
+    public static void Render(TimeSpan deltaTime, TimeSpan totalTime)
+    {
+        var takingScreenshot = false;
+        if (Renderer?.ScreenshotRequests.Count > 0)
+        {
+            takingScreenshot = Renderer.BeginScreenshot();
+        }
 
-            if (Renderer.GetScreenWidth() != sOldWidth ||
-                Renderer.GetScreenHeight() != sOldHeight ||
-                Renderer.DisplayModeChanged())
-            {
-                sDarknessTexture = null;
-                Interface.Interface.DestroyGwen();
-                Interface.Interface.InitGwen();
-                sOldWidth = Renderer.GetScreenWidth();
-                sOldHeight = Renderer.GetScreenHeight();
-            }
+        if (Renderer == default)
+        {
+            return;
+        }
 
-            Renderer.Clear(Color.Black);
-            DrawCalls = 0;
-            MapsDrawn = 0;
-            EntitiesDrawn = 0;
-            LightsDrawn = 0;
+        Renderer.Scale = Globals.GameState == GameStates.InGame ? Globals.Database.WorldZoom : 1.0f;
 
-            UpdateView();
+        if (!Renderer.Begin())
+        {
+            return;
+        }
 
-            switch (Globals.GameState)
-            {
-                case GameStates.Intro:
-                    DrawIntro();
+        if (Renderer.GetScreenWidth() != sOldWidth ||
+            Renderer.GetScreenHeight() != sOldHeight ||
+            Renderer.DisplayModeChanged())
+        {
+            sDarknessTexture = null;
+            Interface.Interface.DestroyGwen();
+            Interface.Interface.InitGwen();
+            sOldWidth = Renderer.GetScreenWidth();
+            sOldHeight = Renderer.GetScreenHeight();
+        }
 
-                    break;
-                case GameStates.Menu:
-                    DrawMenu();
+        Renderer.Clear(Color.Black);
+        DrawCalls = 0;
+        MapsDrawn = 0;
+        EntitiesDrawn = 0;
+        LightsDrawn = 0;
 
-                    break;
-                case GameStates.Loading:
-                    break;
-                case GameStates.InGame:
-                    DrawInGame(deltaTime);
+        UpdateView();
 
-                    break;
-                case GameStates.Error:
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+        switch (Globals.GameState)
+        {
+            case GameStates.Intro:
+                DrawIntro();
 
-            Renderer.Scale = Globals.Database.UIScale;
+                break;
+            case GameStates.Menu:
+                DrawMenu();
 
-            Interface.Interface.DrawGui();
+                break;
+            case GameStates.Loading:
+                break;
+            case GameStates.InGame:
+                DrawInGame(deltaTime);
 
+                break;
+            case GameStates.Error:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        Renderer.Scale = Globals.Database.UIScale;
+
+        Interface.Interface.DrawGui();
+
+        DrawGameTexture(
+            Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1), CurrentView,
+            new Color((int)Fade.Alpha, 0, 0, 0), null, GameBlendModes.None
+        );
+
+        // Draw our mousecursor at the very end, but not when taking screenshots.
+        if (!takingScreenshot && !string.IsNullOrWhiteSpace(ClientConfiguration.Instance.MouseCursor))
+        {
+            var renderLoc = ConvertToWorldPointNoZoom(Globals.InputManager.GetMousePosition());
             DrawGameTexture(
-                Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1), CurrentView,
-                new Color((int)Fade.Alpha, 0, 0, 0), null, GameBlendModes.None
-            );
-
-            // Draw our mousecursor at the very end, but not when taking screenshots.
-            if (!takingScreenshot && !string.IsNullOrWhiteSpace(ClientConfiguration.Instance.MouseCursor))
-            {
-                var renderLoc = ConvertToWorldPointNoZoom(Globals.InputManager.GetMousePosition());
-                DrawGameTexture(
-                    Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, ClientConfiguration.Instance.MouseCursor), renderLoc.X, renderLoc.Y
-               );
-            }
-
-            Renderer.End();
-
-            if (takingScreenshot)
-            {
-                Renderer.EndScreenshot();
-            }
+                Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, ClientConfiguration.Instance.MouseCursor), renderLoc.X, renderLoc.Y
+           );
         }
 
-        private static void DrawMap(Guid mapId, int layer = 0)
-        {
-            var map = MapInstance.Get(mapId);
-            if (map == null)
-            {
-                return;
-            }
+        Renderer.End();
 
+        if (takingScreenshot)
+        {
+            Renderer.EndScreenshot();
+        }
+    }
+
+    private static void DrawMap(Guid mapId, int layer = 0)
+    {
+        var map = MapInstance.Get(mapId);
+        if (map == null)
+        {
+            return;
+        }
+
+        if (!new FloatRect(
+            map.GetX(), map.GetY(), Options.TileWidth * Options.MapWidth, Options.TileHeight * Options.MapHeight
+        ).IntersectsWith(WorldViewport))
+        {
+            return;
+        }
+
+        map.Draw(layer);
+        if (layer == 0)
+        {
+            MapsDrawn++;
+        }
+    }
+
+    private static void DrawMapPanorama(Guid mapId)
+    {
+        var map = MapInstance.Get(mapId);
+        if (map != null)
+        {
             if (!new FloatRect(
                 map.GetX(), map.GetY(), Options.TileWidth * Options.MapWidth, Options.TileHeight * Options.MapHeight
             ).IntersectsWith(WorldViewport))
@@ -630,841 +649,820 @@ namespace Intersect.Client.Core
                 return;
             }
 
-            map.Draw(layer);
-            if (layer == 0)
-            {
-                MapsDrawn++;
-            }
+            map.DrawPanorama();
         }
+    }
 
-        private static void DrawMapPanorama(Guid mapId)
+    public static void DrawOverlay()
+    {
+        var map = MapInstance.Get(Globals.Me.MapId);
+        if (map != null)
         {
-            var map = MapInstance.Get(mapId);
-            if (map != null)
+            float ecTime = Timing.Global.MillisecondsUtc - sOverlayUpdate;
+
+            if (OverlayColor.A != map.AHue ||
+                OverlayColor.R != map.RHue ||
+                OverlayColor.G != map.GHue ||
+                OverlayColor.B != map.BHue)
             {
-                if (!new FloatRect(
-                    map.GetX(), map.GetY(), Options.TileWidth * Options.MapWidth, Options.TileHeight * Options.MapHeight
-                ).IntersectsWith(WorldViewport))
+                if (OverlayColor.A < map.AHue)
                 {
-                    return;
-                }
-
-                map.DrawPanorama();
-            }
-        }
-
-        public static void DrawOverlay()
-        {
-            var map = MapInstance.Get(Globals.Me.MapId);
-            if (map != null)
-            {
-                float ecTime = Timing.Global.MillisecondsUtc - sOverlayUpdate;
-
-                if (OverlayColor.A != map.AHue ||
-                    OverlayColor.R != map.RHue ||
-                    OverlayColor.G != map.GHue ||
-                    OverlayColor.B != map.BHue)
-                {
-                    if (OverlayColor.A < map.AHue)
+                    if (OverlayColor.A + (int)(255 * ecTime / 2000f) > map.AHue)
                     {
-                        if (OverlayColor.A + (int)(255 * ecTime / 2000f) > map.AHue)
-                        {
-                            OverlayColor.A = (byte)map.AHue;
-                        }
-                        else
-                        {
-                            OverlayColor.A += (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.A > map.AHue)
-                    {
-                        if (OverlayColor.A - (int)(255 * ecTime / 2000f) < map.AHue)
-                        {
-                            OverlayColor.A = (byte)map.AHue;
-                        }
-                        else
-                        {
-                            OverlayColor.A -= (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.R < map.RHue)
-                    {
-                        if (OverlayColor.R + (int)(255 * ecTime / 2000f) > map.RHue)
-                        {
-                            OverlayColor.R = (byte)map.RHue;
-                        }
-                        else
-                        {
-                            OverlayColor.R += (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.R > map.RHue)
-                    {
-                        if (OverlayColor.R - (int)(255 * ecTime / 2000f) < map.RHue)
-                        {
-                            OverlayColor.R = (byte)map.RHue;
-                        }
-                        else
-                        {
-                            OverlayColor.R -= (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.G < map.GHue)
-                    {
-                        if (OverlayColor.G + (int)(255 * ecTime / 2000f) > map.GHue)
-                        {
-                            OverlayColor.G = (byte)map.GHue;
-                        }
-                        else
-                        {
-                            OverlayColor.G += (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.G > map.GHue)
-                    {
-                        if (OverlayColor.G - (int)(255 * ecTime / 2000f) < map.GHue)
-                        {
-                            OverlayColor.G = (byte)map.GHue;
-                        }
-                        else
-                        {
-                            OverlayColor.G -= (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.B < map.BHue)
-                    {
-                        if (OverlayColor.B + (int)(255 * ecTime / 2000f) > map.BHue)
-                        {
-                            OverlayColor.B = (byte)map.BHue;
-                        }
-                        else
-                        {
-                            OverlayColor.B += (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-
-                    if (OverlayColor.B > map.BHue)
-                    {
-                        if (OverlayColor.B - (int)(255 * ecTime / 2000f) < map.BHue)
-                        {
-                            OverlayColor.B = (byte)map.BHue;
-                        }
-                        else
-                        {
-                            OverlayColor.B -= (byte)(255 * ecTime / 2000f);
-                        }
-                    }
-                }
-            }
-
-            DrawGameTexture(Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1), CurrentView, OverlayColor, null);
-            sOverlayUpdate = Timing.Global.MillisecondsUtc;
-        }
-
-        public static FloatRect GetSourceRect(GameTexture gameTexture)
-        {
-            return gameTexture == null
-                ? new FloatRect()
-                : new FloatRect(0, 0, gameTexture.GetWidth(), gameTexture.GetHeight());
-        }
-
-        public static void DrawFullScreenTexture(GameTexture tex, float alpha = 1f)
-        {
-            var bgx = Renderer.GetScreenWidth() / 2 - tex.GetWidth() / 2;
-            var bgy = Renderer.GetScreenHeight() / 2 - tex.GetHeight() / 2;
-            var bgw = tex.GetWidth();
-            var bgh = tex.GetHeight();
-            var diff = 0;
-            if (bgw < Renderer.GetScreenWidth())
-            {
-                diff = Renderer.GetScreenWidth() - bgw;
-                bgx -= diff / 2;
-                bgw += diff;
-            }
-
-            if (bgh < Renderer.GetScreenHeight())
-            {
-                diff = Renderer.GetScreenHeight() - bgh;
-                bgy -= diff / 2;
-                bgh += diff;
-            }
-
-            DrawGameTexture(
-                tex, GetSourceRect(tex),
-                new FloatRect(bgx + Renderer.GetView().X, bgy + Renderer.GetView().Y, bgw, bgh),
-                new Color((int)(alpha * 255f), 255, 255, 255)
-            );
-        }
-
-        public static void DrawFullScreenTextureCentered(GameTexture tex, float alpha = 1f)
-        {
-            var bgx = Renderer.GetScreenWidth() / 2 - tex.GetWidth() / 2;
-            var bgy = Renderer.GetScreenHeight() / 2 - tex.GetHeight() / 2;
-            var bgw = tex.GetWidth();
-            var bgh = tex.GetHeight();
-
-            DrawGameTexture(
-                tex, GetSourceRect(tex),
-                new FloatRect(bgx + Renderer.GetView().X, bgy + Renderer.GetView().Y, bgw, bgh),
-                new Color((int)(alpha * 255f), 255, 255, 255)
-            );
-        }
-
-        public static void DrawFullScreenTextureStretched(GameTexture tex)
-        {
-            DrawGameTexture(
-                tex, GetSourceRect(tex),
-                new FloatRect(
-                    Renderer.GetView().X, Renderer.GetView().Y, Renderer.GetScreenWidth(), Renderer.GetScreenHeight()
-                ), Color.White
-            );
-        }
-
-        public static void DrawFullScreenTextureFitWidth(GameTexture tex)
-        {
-            var scale = Renderer.GetScreenWidth() / (float)tex.GetWidth();
-            var scaledHeight = tex.GetHeight() * scale;
-            var offsetY = (Renderer.GetScreenHeight() - tex.GetHeight()) / 2f;
-            DrawGameTexture(
-                tex, GetSourceRect(tex),
-                new FloatRect(
-                    Renderer.GetView().X, Renderer.GetView().Y + offsetY, Renderer.GetScreenWidth(), scaledHeight
-                ), Color.White
-            );
-        }
-
-        public static void DrawFullScreenTextureFitHeight(GameTexture tex)
-        {
-            var scale = Renderer.GetScreenHeight() / (float)tex.GetHeight();
-            var scaledWidth = tex.GetWidth() * scale;
-            var offsetX = (Renderer.GetScreenWidth() - scaledWidth) / 2f;
-            DrawGameTexture(
-                tex, GetSourceRect(tex),
-                new FloatRect(
-                    Renderer.GetView().X + offsetX, Renderer.GetView().Y, scaledWidth, Renderer.GetScreenHeight()
-                ), Color.White
-            );
-        }
-
-        public static void DrawFullScreenTextureFitMinimum(GameTexture tex)
-        {
-            if (Renderer.GetScreenWidth() > Renderer.GetScreenHeight())
-            {
-                DrawFullScreenTextureFitHeight(tex);
-            }
-            else
-            {
-                DrawFullScreenTextureFitWidth(tex);
-            }
-        }
-
-        public static void DrawFullScreenTextureFitMaximum(GameTexture tex)
-        {
-            if (Renderer.GetScreenWidth() < Renderer.GetScreenHeight())
-            {
-                DrawFullScreenTextureFitHeight(tex);
-            }
-            else
-            {
-                DrawFullScreenTextureFitWidth(tex);
-            }
-        }
-
-        private static void UpdateView()
-        {
-            var scale = Renderer.Scale;
-
-            if (Globals.GameState != GameStates.InGame || !MapInstance.TryGet(Globals.Me?.MapId ?? Guid.Empty, out var map))
-            {
-                var sw = Renderer.GetScreenWidth();
-                var sh = Renderer.GetScreenHeight();
-                var sx = 0;//sw - (sw / scale);
-                var sy = 0;//sh - (sh / scale);
-                CurrentView = new FloatRect(sx, sy, sw / scale, sh / scale);
-                return;
-            }
-
-            var mapWidth = Options.MapWidth * Options.TileWidth;
-            var mapHeight = Options.MapHeight * Options.TileHeight;
-
-            var en = Globals.Me;
-            float x = mapWidth;
-            float y = mapHeight;
-            float x1 = mapWidth * 2;
-            float y1 = mapHeight * 2;
-
-            if (map.CameraHolds[(int)Direction.Left])
-            {
-                x -= mapWidth;
-            }
-
-            if (map.CameraHolds[(int)Direction.Up])
-            {
-                y -= mapHeight;
-            }
-
-            if (map.CameraHolds[(int)Direction.Right])
-            {
-                x1 -= mapWidth;
-            }
-
-            if (map.CameraHolds[(int)Direction.Down])
-            {
-                y1 -= mapHeight;
-            }
-
-            x = map.GetX() - x;
-            y = map.GetY() - y;
-            x1 = map.GetX() + x1;
-            y1 = map.GetY() + y1;
-
-            var w = x1 - x;
-            var h = y1 - y;
-            var restrictView = new FloatRect(
-                x,
-                y,
-                w,
-                h
-            );
-            var newView = new FloatRect(
-                (int)Math.Ceiling(en.Center.X - Renderer.ScreenWidth / scale / 2f),
-                (int)Math.Ceiling(en.Center.Y - Renderer.ScreenHeight / scale / 2f),
-                Renderer.ScreenWidth / scale,
-                Renderer.ScreenHeight / scale
-            );
-
-            if (restrictView.Width >= newView.Width)
-            {
-                if (newView.Left < restrictView.Left)
-                {
-                    newView.X = restrictView.Left;
-                }
-
-                if (newView.Right > restrictView.Right)
-                {
-                    newView.X = restrictView.Right - newView.Width;
-                }
-            }
-
-            if (restrictView.Height >= newView.Height)
-            {
-                if (newView.Top < restrictView.Top)
-                {
-                    newView.Y = restrictView.Top;
-                }
-
-                if (newView.Bottom > restrictView.Bottom)
-                {
-                    newView.Y = restrictView.Bottom - newView.Height;
-                }
-            }
-
-            CurrentView = new FloatRect(
-                newView.X,
-                newView.Y,
-                newView.Width * scale,
-                newView.Height * scale
-            );
-        }
-
-        //Lighting
-        private static void ClearDarknessTexture()
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            if (sDarknessTexture == null)
-            {
-                sDarknessTexture = Renderer.CreateRenderTexture(Renderer.GetScreenWidth(), Renderer.GetScreenHeight());
-            }
-
-            sDarknessTexture.Clear(Color.Black);
-        }
-
-        private static void GenerateLightMap()
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            var map = MapInstance.Get(Globals.Me.MapId);
-            if (map == null)
-            {
-                return;
-            }
-
-            if (sDarknessTexture == null)
-            {
-                return;
-            }
-
-            var destRect = new FloatRect(new Pointf(), sDarknessTexture.Dimensions / Globals.Database.WorldZoom);
-            if (map.IsIndoors)
-            {
-                DrawGameTexture(
-                    Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                    destRect,
-                    new Color((byte)BrightnessLevel, 255, 255, 255), sDarknessTexture, GameBlendModes.Add
-                );
-            }
-            else
-            {
-                DrawGameTexture(
-                    Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                    destRect,
-                    new Color(255, 255, 255, 255), sDarknessTexture, GameBlendModes.Add
-                );
-
-                DrawGameTexture(
-                    Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                    destRect,
-                    new Color(
-                        (int)Time.GetTintColor().A, (int)Time.GetTintColor().R, (int)Time.GetTintColor().G,
-                        (int)Time.GetTintColor().B
-                    ), sDarknessTexture, GameBlendModes.None
-                );
-            }
-
-            AddLight(
-                (int)Math.Ceiling(Globals.Me.Center.X), (int)Math.Ceiling(Globals.Me.Center.Y),
-                (int)sPlayerLightSize, (byte)sPlayerLightIntensity, sPlayerLightExpand,
-                Color.FromArgb(
-                    (int)PlayerLightColor.A, (int)PlayerLightColor.R, (int)PlayerLightColor.G,
-                    (int)PlayerLightColor.B
-                )
-            );
-
-            DrawLights();
-            sDarknessTexture.End();
-        }
-
-        public static void DrawDarkness()
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            var radialShader = Globals.ContentManager.GetShader("radialgradient");
-            if (radialShader != null)
-            {
-                DrawGameTexture(
-                    sDarknessTexture,
-                    sDarknessTexture.Bounds,
-                    WorldViewport,
-                    Color.White,
-                    blendMode: GameBlendModes.Multiply
-                );
-            }
-        }
-
-        public static void AddLight(int x, int y, int size, byte intensity, float expand, Color color)
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            if (size == 0)
-            {
-                return;
-            }
-
-            sLightQueue.Add(new LightBase(0, 0, x, y, intensity, size, expand, color));
-            LightsDrawn++;
-        }
-
-        private static void DrawLights()
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            var radialShader = Globals.ContentManager.GetShader("radialgradient");
-            if (radialShader != null)
-            {
-                foreach (var light in sLightQueue.GroupBy(c => c.GetHashCode()))
-                {
-                    foreach (var l in light)
-                    {
-                        var x = l.OffsetX - ((int)CurrentView.Left + l.Size);
-                        var y = l.OffsetY - ((int)CurrentView.Top + l.Size);
-
-                        radialShader.SetColor("LightColor", new Color(l.Intensity, l.Color.R, l.Color.G, l.Color.B));
-                        radialShader.SetFloat("Expand", l.Expand / 100f);
-
-                        DrawGameTexture(
-                            Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                            new FloatRect(x, y, l.Size * 2, l.Size * 2), new Color(255, 255, 255, 255), sDarknessTexture, GameBlendModes.Add, radialShader, 0, false
-                        );
-
-                    }
-                }
-
-                sLightQueue.Clear();
-            }
-        }
-
-        public static void UpdatePlayerLight()
-        {
-            // If we're not allowed to draw lighting, exit out.
-            if (!Globals.Database.EnableLighting)
-            {
-                return;
-            }
-
-            //Draw Light Around Player
-            var map = MapInstance.Get(Globals.Me.MapId);
-            if (map != null)
-            {
-                float ecTime = Timing.Global.MillisecondsUtc - sLightUpdate;
-                var valChange = 255 * ecTime / 2000f;
-                var brightnessTarget = (byte)(map.Brightness / 100f * 255);
-                if (BrightnessLevel < brightnessTarget)
-                {
-                    if (BrightnessLevel + valChange > brightnessTarget)
-                    {
-                        BrightnessLevel = brightnessTarget;
+                        OverlayColor.A = (byte)map.AHue;
                     }
                     else
                     {
-                        BrightnessLevel += valChange;
+                        OverlayColor.A += (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                if (BrightnessLevel > brightnessTarget)
+                if (OverlayColor.A > map.AHue)
                 {
-                    if (BrightnessLevel - valChange < brightnessTarget)
+                    if (OverlayColor.A - (int)(255 * ecTime / 2000f) < map.AHue)
                     {
-                        BrightnessLevel = brightnessTarget;
+                        OverlayColor.A = (byte)map.AHue;
                     }
                     else
                     {
-                        BrightnessLevel -= valChange;
+                        OverlayColor.A -= (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                if (PlayerLightColor.R != map.PlayerLightColor.R ||
-                    PlayerLightColor.G != map.PlayerLightColor.G ||
-                    PlayerLightColor.B != map.PlayerLightColor.B)
+                if (OverlayColor.R < map.RHue)
                 {
-                    if (PlayerLightColor.R < map.PlayerLightColor.R)
+                    if (OverlayColor.R + (int)(255 * ecTime / 2000f) > map.RHue)
                     {
-                        if (PlayerLightColor.R + valChange > map.PlayerLightColor.R)
-                        {
-                            PlayerLightColor.R = map.PlayerLightColor.R;
-                        }
-                        else
-                        {
-                            PlayerLightColor.R += valChange;
-                        }
-                    }
-
-                    if (PlayerLightColor.R > map.PlayerLightColor.R)
-                    {
-                        if (PlayerLightColor.R - valChange < map.PlayerLightColor.R)
-                        {
-                            PlayerLightColor.R = map.PlayerLightColor.R;
-                        }
-                        else
-                        {
-                            PlayerLightColor.R -= valChange;
-                        }
-                    }
-
-                    if (PlayerLightColor.G < map.PlayerLightColor.G)
-                    {
-                        if (PlayerLightColor.G + valChange > map.PlayerLightColor.G)
-                        {
-                            PlayerLightColor.G = map.PlayerLightColor.G;
-                        }
-                        else
-                        {
-                            PlayerLightColor.G += valChange;
-                        }
-                    }
-
-                    if (PlayerLightColor.G > map.PlayerLightColor.G)
-                    {
-                        if (PlayerLightColor.G - valChange < map.PlayerLightColor.G)
-                        {
-                            PlayerLightColor.G = map.PlayerLightColor.G;
-                        }
-                        else
-                        {
-                            PlayerLightColor.G -= valChange;
-                        }
-                    }
-
-                    if (PlayerLightColor.B < map.PlayerLightColor.B)
-                    {
-                        if (PlayerLightColor.B + valChange > map.PlayerLightColor.B)
-                        {
-                            PlayerLightColor.B = map.PlayerLightColor.B;
-                        }
-                        else
-                        {
-                            PlayerLightColor.B += valChange;
-                        }
-                    }
-
-                    if (PlayerLightColor.B > map.PlayerLightColor.B)
-                    {
-                        if (PlayerLightColor.B - valChange < map.PlayerLightColor.B)
-                        {
-                            PlayerLightColor.B = map.PlayerLightColor.B;
-                        }
-                        else
-                        {
-                            PlayerLightColor.B -= valChange;
-                        }
-                    }
-                }
-
-                if (sPlayerLightSize != map.PlayerLightSize)
-                {
-                    if (sPlayerLightSize < map.PlayerLightSize)
-                    {
-                        if (sPlayerLightSize + 500 * ecTime / 2000f > map.PlayerLightSize)
-                        {
-                            sPlayerLightSize = map.PlayerLightSize;
-                        }
-                        else
-                        {
-                            sPlayerLightSize += 500 * ecTime / 2000f;
-                        }
-                    }
-
-                    if (sPlayerLightSize > map.PlayerLightSize)
-                    {
-                        if (sPlayerLightSize - 500 * ecTime / 2000f < map.PlayerLightSize)
-                        {
-                            sPlayerLightSize = map.PlayerLightSize;
-                        }
-                        else
-                        {
-                            sPlayerLightSize -= 500 * ecTime / 2000f;
-                        }
-                    }
-                }
-
-                if (sPlayerLightIntensity < map.PlayerLightIntensity)
-                {
-                    if (sPlayerLightIntensity + valChange > map.PlayerLightIntensity)
-                    {
-                        sPlayerLightIntensity = map.PlayerLightIntensity;
+                        OverlayColor.R = (byte)map.RHue;
                     }
                     else
                     {
-                        sPlayerLightIntensity += valChange;
+                        OverlayColor.R += (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                if (sPlayerLightIntensity > map.AHue)
+                if (OverlayColor.R > map.RHue)
                 {
-                    if (sPlayerLightIntensity - valChange < map.PlayerLightIntensity)
+                    if (OverlayColor.R - (int)(255 * ecTime / 2000f) < map.RHue)
                     {
-                        sPlayerLightIntensity = map.PlayerLightIntensity;
+                        OverlayColor.R = (byte)map.RHue;
                     }
                     else
                     {
-                        sPlayerLightIntensity -= valChange;
+                        OverlayColor.R -= (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                if (sPlayerLightExpand < map.PlayerLightExpand)
+                if (OverlayColor.G < map.GHue)
                 {
-                    if (sPlayerLightExpand + 100f * ecTime / 2000f > map.PlayerLightExpand)
+                    if (OverlayColor.G + (int)(255 * ecTime / 2000f) > map.GHue)
                     {
-                        sPlayerLightExpand = map.PlayerLightExpand;
+                        OverlayColor.G = (byte)map.GHue;
                     }
                     else
                     {
-                        sPlayerLightExpand += 100f * ecTime / 2000f;
+                        OverlayColor.G += (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                if (sPlayerLightExpand > map.PlayerLightExpand)
+                if (OverlayColor.G > map.GHue)
                 {
-                    if (sPlayerLightExpand - 100f * ecTime / 2000f < map.PlayerLightExpand)
+                    if (OverlayColor.G - (int)(255 * ecTime / 2000f) < map.GHue)
                     {
-                        sPlayerLightExpand = map.PlayerLightExpand;
+                        OverlayColor.G = (byte)map.GHue;
                     }
                     else
                     {
-                        sPlayerLightExpand -= 100f * ecTime / 2000f;
+                        OverlayColor.G -= (byte)(255 * ecTime / 2000f);
                     }
                 }
 
-                // Cap instensity between 0 and 255 so as not to overflow (as it is an alpha value)
-                sPlayerLightIntensity = (float)MathHelper.Clamp(sPlayerLightIntensity, 0f, 255f);
-                sLightUpdate = Timing.Global.MillisecondsUtc;
+                if (OverlayColor.B < map.BHue)
+                {
+                    if (OverlayColor.B + (int)(255 * ecTime / 2000f) > map.BHue)
+                    {
+                        OverlayColor.B = (byte)map.BHue;
+                    }
+                    else
+                    {
+                        OverlayColor.B += (byte)(255 * ecTime / 2000f);
+                    }
+                }
+
+                if (OverlayColor.B > map.BHue)
+                {
+                    if (OverlayColor.B - (int)(255 * ecTime / 2000f) < map.BHue)
+                    {
+                        OverlayColor.B = (byte)map.BHue;
+                    }
+                    else
+                    {
+                        OverlayColor.B -= (byte)(255 * ecTime / 2000f);
+                    }
+                }
             }
         }
 
-        //Helper Functions
-        /// <summary>
-        /// Convert a position on the screen to a position on the actual map for rendering.
-        /// </summary>
-        /// <param name="windowPoint">The point to convert.</param>
-        /// <returns>The converted point.</returns>
-        public static Pointf ConvertToWorldPoint(Pointf windowPoint)
+        DrawGameTexture(Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1), CurrentView, OverlayColor, null);
+        sOverlayUpdate = Timing.Global.MillisecondsUtc;
+    }
+
+    public static FloatRect GetSourceRect(GameTexture gameTexture)
+    {
+        return gameTexture == null
+            ? new FloatRect()
+            : new FloatRect(0, 0, gameTexture.GetWidth(), gameTexture.GetHeight());
+    }
+
+    public static void DrawFullScreenTexture(GameTexture tex, float alpha = 1f)
+    {
+        var bgx = Renderer.GetScreenWidth() / 2 - tex.GetWidth() / 2;
+        var bgy = Renderer.GetScreenHeight() / 2 - tex.GetHeight() / 2;
+        var bgw = tex.GetWidth();
+        var bgh = tex.GetHeight();
+        var diff = 0;
+        if (bgw < Renderer.GetScreenWidth())
         {
-            return new Pointf(
-                (int)Math.Floor(windowPoint.X / Globals.Database.WorldZoom + CurrentView.Left),
-                (int)Math.Floor(windowPoint.Y / Globals.Database.WorldZoom + CurrentView.Top)
-            );
+            diff = Renderer.GetScreenWidth() - bgw;
+            bgx -= diff / 2;
+            bgw += diff;
         }
 
-        /// <summary>
-        /// Converts a point in the window to its place in the world view without respecting zoom
-        /// </summary>
-        /// <param name="windowPoint">The point to convert.</param>
-        /// <returns>The converted point.</returns>
-        public static Pointf ConvertToWorldPointNoZoom(Pointf windowPoint)
+        if (bgh < Renderer.GetScreenHeight())
         {
-            return new Pointf((int)Math.Floor(windowPoint.X + CurrentView.Left), (int)Math.Floor(windowPoint.Y + CurrentView.Top));
+            diff = Renderer.GetScreenHeight() - bgh;
+            bgy -= diff / 2;
+            bgh += diff;
         }
 
-        //Rendering Functions
+        DrawGameTexture(
+            tex, GetSourceRect(tex),
+            new FloatRect(bgx + Renderer.GetView().X, bgy + Renderer.GetView().Y, bgw, bgh),
+            new Color((int)(alpha * 255f), 255, 255, 255)
+        );
+    }
 
-        /// <summary>
-        ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
-        ///     coordinates given using a specified blending mode.
-        /// </summary>
-        /// <param name="tex">The texture to draw</param>
-        /// <param name="x">X coordinate on the render target to draw to</param>
-        /// <param name="y">Y coordinate on the render target to draw to</param>
-        /// <param name="renderTarget">Where to draw to. If null it this will draw to the game screen.</param>
-        /// <param name="blendMode">Which blend mode to use when rendering</param>
-        public static void DrawGameTexture(
-            GameTexture tex,
-            float x,
-            float y,
-            GameRenderTexture renderTarget = null,
-            GameBlendModes blendMode = GameBlendModes.None,
-            GameShader shader = null,
-            float rotationDegrees = 0.0f,
-            bool drawImmediate = false
-        )
+    public static void DrawFullScreenTextureCentered(GameTexture tex, float alpha = 1f)
+    {
+        var bgx = Renderer.GetScreenWidth() / 2 - tex.GetWidth() / 2;
+        var bgy = Renderer.GetScreenHeight() / 2 - tex.GetHeight() / 2;
+        var bgw = tex.GetWidth();
+        var bgh = tex.GetHeight();
+
+        DrawGameTexture(
+            tex, GetSourceRect(tex),
+            new FloatRect(bgx + Renderer.GetView().X, bgy + Renderer.GetView().Y, bgw, bgh),
+            new Color((int)(alpha * 255f), 255, 255, 255)
+        );
+    }
+
+    public static void DrawFullScreenTextureStretched(GameTexture tex)
+    {
+        DrawGameTexture(
+            tex, GetSourceRect(tex),
+            new FloatRect(
+                Renderer.GetView().X, Renderer.GetView().Y, Renderer.GetScreenWidth(), Renderer.GetScreenHeight()
+            ), Color.White
+        );
+    }
+
+    public static void DrawFullScreenTextureFitWidth(GameTexture tex)
+    {
+        var scale = Renderer.GetScreenWidth() / (float)tex.GetWidth();
+        var scaledHeight = tex.GetHeight() * scale;
+        var offsetY = (Renderer.GetScreenHeight() - tex.GetHeight()) / 2f;
+        DrawGameTexture(
+            tex, GetSourceRect(tex),
+            new FloatRect(
+                Renderer.GetView().X, Renderer.GetView().Y + offsetY, Renderer.GetScreenWidth(), scaledHeight
+            ), Color.White
+        );
+    }
+
+    public static void DrawFullScreenTextureFitHeight(GameTexture tex)
+    {
+        var scale = Renderer.GetScreenHeight() / (float)tex.GetHeight();
+        var scaledWidth = tex.GetWidth() * scale;
+        var offsetX = (Renderer.GetScreenWidth() - scaledWidth) / 2f;
+        DrawGameTexture(
+            tex, GetSourceRect(tex),
+            new FloatRect(
+                Renderer.GetView().X + offsetX, Renderer.GetView().Y, scaledWidth, Renderer.GetScreenHeight()
+            ), Color.White
+        );
+    }
+
+    public static void DrawFullScreenTextureFitMinimum(GameTexture tex)
+    {
+        if (Renderer.GetScreenWidth() > Renderer.GetScreenHeight())
         {
-            var destRectangle = new FloatRect(x, y, tex.GetWidth(), tex.GetHeight());
-            var srcRectangle = new FloatRect(0, 0, tex.GetWidth(), tex.GetHeight());
-            DrawGameTexture(
-                tex, srcRectangle, destRectangle, Color.White, renderTarget, blendMode, shader, rotationDegrees,
-                drawImmediate
-            );
+            DrawFullScreenTextureFitHeight(tex);
+        }
+        else
+        {
+            DrawFullScreenTextureFitWidth(tex);
+        }
+    }
+
+    public static void DrawFullScreenTextureFitMaximum(GameTexture tex)
+    {
+        if (Renderer.GetScreenWidth() < Renderer.GetScreenHeight())
+        {
+            DrawFullScreenTextureFitHeight(tex);
+        }
+        else
+        {
+            DrawFullScreenTextureFitWidth(tex);
+        }
+    }
+
+    private static void UpdateView()
+    {
+        var scale = Renderer.Scale;
+
+        if (Globals.GameState != GameStates.InGame || !MapInstance.TryGet(Globals.Me?.MapId ?? Guid.Empty, out var map))
+        {
+            var sw = Renderer.GetScreenWidth();
+            var sh = Renderer.GetScreenHeight();
+            var sx = 0;//sw - (sw / scale);
+            var sy = 0;//sh - (sh / scale);
+            CurrentView = new FloatRect(sx, sy, sw / scale, sh / scale);
+            return;
         }
 
-        /// <summary>
-        ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
-        ///     coordinates given using a specified blending mode.
-        /// </summary>
-        /// <param name="tex">The texture to draw</param>
-        /// <param name="x">X coordinate on the render target to draw to</param>
-        /// <param name="y">Y coordinate on the render target to draw to</param>
-        /// <param name="renderColor">Color mask to draw with. Default is Color.White</param>
-        /// <param name="renderTarget">Where to draw to. If null it this will draw to the game screen.</param>
-        /// <param name="blendMode">Which blend mode to use when rendering</param>
-        public static void DrawGameTexture(
-            GameTexture tex,
-            float x,
-            float y,
-            Color renderColor,
-            GameRenderTexture renderTarget = null,
-            GameBlendModes blendMode = GameBlendModes.None,
-            GameShader shader = null,
-            float rotationDegrees = 0.0f,
-            bool drawImmediate = false
-        )
+        var mapWidth = Options.MapWidth * Options.TileWidth;
+        var mapHeight = Options.MapHeight * Options.TileHeight;
+
+        var en = Globals.Me;
+        float x = mapWidth;
+        float y = mapHeight;
+        float x1 = mapWidth * 2;
+        float y1 = mapHeight * 2;
+
+        if (map.CameraHolds[(int)Direction.Left])
         {
-            var destRectangle = new FloatRect(x, y, tex.GetWidth(), tex.GetHeight());
-            var srcRectangle = new FloatRect(0, 0, tex.GetWidth(), tex.GetHeight());
-            DrawGameTexture(
-                tex, srcRectangle, destRectangle, renderColor, renderTarget, blendMode, shader, rotationDegrees,
-                drawImmediate
-            );
+            x -= mapWidth;
         }
 
-        /// <summary>
-        ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
-        ///     coordinates given using a specified blending mode.
-        /// </summary>
-        /// <param name="tex">The texture to draw</param>
-        /// <param name="dx">X coordinate on the renderTarget to draw to.</param>
-        /// <param name="dy">Y coordinate on the renderTarget to draw to.</param>
-        /// <param name="sx">X coordinate on the source texture to grab from.</param>
-        /// <param name="sy">Y coordinate on the source texture to grab from.</param>
-        /// <param name="w">Width of the texture part we are rendering.</param>
-        /// <param name="h">Height of the texture part we are rendering.</param>
-        /// <param name="renderTarget">>Where to draw to. If null it this will draw to the game screen.</param>
-        /// <param name="blendMode">Which blend mode to use when rendering</param>
-        public static void DrawGameTexture(
-            GameTexture tex,
-            float dx,
-            float dy,
-            float sx,
-            float sy,
-            float w,
-            float h,
-            GameRenderTexture renderTarget = null,
-            GameBlendModes blendMode = GameBlendModes.None,
-            GameShader shader = null,
-            float rotationDegrees = 0.0f,
-            bool drawImmediate = false
-        )
+        if (map.CameraHolds[(int)Direction.Up])
         {
-            if (tex == null)
+            y -= mapHeight;
+        }
+
+        if (map.CameraHolds[(int)Direction.Right])
+        {
+            x1 -= mapWidth;
+        }
+
+        if (map.CameraHolds[(int)Direction.Down])
+        {
+            y1 -= mapHeight;
+        }
+
+        x = map.GetX() - x;
+        y = map.GetY() - y;
+        x1 = map.GetX() + x1;
+        y1 = map.GetY() + y1;
+
+        var w = x1 - x;
+        var h = y1 - y;
+        var restrictView = new FloatRect(
+            x,
+            y,
+            w,
+            h
+        );
+        var newView = new FloatRect(
+            (int)Math.Ceiling(en.Center.X - Renderer.ScreenWidth / scale / 2f),
+            (int)Math.Ceiling(en.Center.Y - Renderer.ScreenHeight / scale / 2f),
+            Renderer.ScreenWidth / scale,
+            Renderer.ScreenHeight / scale
+        );
+
+        if (restrictView.Width >= newView.Width)
+        {
+            if (newView.Left < restrictView.Left)
             {
-                return;
+                newView.X = restrictView.Left;
             }
 
-            Renderer.DrawTexture(
-                tex, sx, sy, w, h, dx, dy, w, h, Color.White, renderTarget, blendMode, shader, rotationDegrees, false,
-                drawImmediate
-            );
-        }
-
-        public static void DrawGameTexture(
-            GameTexture tex,
-            FloatRect srcRectangle,
-            FloatRect targetRect,
-            Color renderColor,
-            GameRenderTexture renderTarget = null,
-            GameBlendModes blendMode = GameBlendModes.None,
-            GameShader shader = null,
-            float rotationDegrees = 0.0f,
-            bool drawImmediate = false
-        )
-        {
-            if (tex == null)
+            if (newView.Right > restrictView.Right)
             {
-                return;
+                newView.X = restrictView.Right - newView.Width;
+            }
+        }
+
+        if (restrictView.Height >= newView.Height)
+        {
+            if (newView.Top < restrictView.Top)
+            {
+                newView.Y = restrictView.Top;
             }
 
-            Renderer.DrawTexture(
-                tex, srcRectangle.X, srcRectangle.Y, srcRectangle.Width, srcRectangle.Height, targetRect.X,
-                targetRect.Y, targetRect.Width, targetRect.Height,
-                Color.FromArgb(renderColor.A, renderColor.R, renderColor.G, renderColor.B), renderTarget, blendMode,
-                shader, rotationDegrees, false, drawImmediate
+            if (newView.Bottom > restrictView.Bottom)
+            {
+                newView.Y = restrictView.Bottom - newView.Height;
+            }
+        }
+
+        CurrentView = new FloatRect(
+            newView.X,
+            newView.Y,
+            newView.Width * scale,
+            newView.Height * scale
+        );
+    }
+
+    //Lighting
+    private static void ClearDarknessTexture()
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        if (sDarknessTexture == null)
+        {
+            sDarknessTexture = Renderer.CreateRenderTexture(Renderer.GetScreenWidth(), Renderer.GetScreenHeight());
+        }
+
+        sDarknessTexture.Clear(Color.Black);
+    }
+
+    private static void GenerateLightMap()
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        var map = MapInstance.Get(Globals.Me.MapId);
+        if (map == null)
+        {
+            return;
+        }
+
+        if (sDarknessTexture == null)
+        {
+            return;
+        }
+
+        var destRect = new FloatRect(new Pointf(), sDarknessTexture.Dimensions / Globals.Database.WorldZoom);
+        if (map.IsIndoors)
+        {
+            DrawGameTexture(
+                Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                destRect,
+                new Color((byte)BrightnessLevel, 255, 255, 255), sDarknessTexture, GameBlendModes.Add
+            );
+        }
+        else
+        {
+            DrawGameTexture(
+                Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                destRect,
+                new Color(255, 255, 255, 255), sDarknessTexture, GameBlendModes.Add
+            );
+
+            DrawGameTexture(
+                Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                destRect,
+                new Color(
+                    (int)Time.GetTintColor().A, (int)Time.GetTintColor().R, (int)Time.GetTintColor().G,
+                    (int)Time.GetTintColor().B
+                ), sDarknessTexture, GameBlendModes.None
             );
         }
 
+        AddLight(
+            (int)Math.Ceiling(Globals.Me.Center.X), (int)Math.Ceiling(Globals.Me.Center.Y),
+            (int)sPlayerLightSize, (byte)sPlayerLightIntensity, sPlayerLightExpand,
+            Color.FromArgb(
+                (int)PlayerLightColor.A, (int)PlayerLightColor.R, (int)PlayerLightColor.G,
+                (int)PlayerLightColor.B
+            )
+        );
+
+        DrawLights();
+        sDarknessTexture.End();
+    }
+
+    public static void DrawDarkness()
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        var radialShader = Globals.ContentManager.GetShader("radialgradient");
+        if (radialShader != null)
+        {
+            DrawGameTexture(
+                sDarknessTexture,
+                sDarknessTexture.Bounds,
+                WorldViewport,
+                Color.White,
+                blendMode: GameBlendModes.Multiply
+            );
+        }
+    }
+
+    public static void AddLight(int x, int y, int size, byte intensity, float expand, Color color)
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        if (size == 0)
+        {
+            return;
+        }
+
+        sLightQueue.Add(new LightBase(0, 0, x, y, intensity, size, expand, color));
+        LightsDrawn++;
+    }
+
+    private static void DrawLights()
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        var radialShader = Globals.ContentManager.GetShader("radialgradient");
+        if (radialShader != null)
+        {
+            foreach (var light in sLightQueue.GroupBy(c => c.GetHashCode()))
+            {
+                foreach (var l in light)
+                {
+                    var x = l.OffsetX - ((int)CurrentView.Left + l.Size);
+                    var y = l.OffsetY - ((int)CurrentView.Top + l.Size);
+
+                    radialShader.SetColor("LightColor", new Color(l.Intensity, l.Color.R, l.Color.G, l.Color.B));
+                    radialShader.SetFloat("Expand", l.Expand / 100f);
+
+                    DrawGameTexture(
+                        Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                        new FloatRect(x, y, l.Size * 2, l.Size * 2), new Color(255, 255, 255, 255), sDarknessTexture, GameBlendModes.Add, radialShader, 0, false
+                    );
+
+                }
+            }
+
+            sLightQueue.Clear();
+        }
+    }
+
+    public static void UpdatePlayerLight()
+    {
+        // If we're not allowed to draw lighting, exit out.
+        if (!Globals.Database.EnableLighting)
+        {
+            return;
+        }
+
+        //Draw Light Around Player
+        var map = MapInstance.Get(Globals.Me.MapId);
+        if (map != null)
+        {
+            float ecTime = Timing.Global.MillisecondsUtc - sLightUpdate;
+            var valChange = 255 * ecTime / 2000f;
+            var brightnessTarget = (byte)(map.Brightness / 100f * 255);
+            if (BrightnessLevel < brightnessTarget)
+            {
+                if (BrightnessLevel + valChange > brightnessTarget)
+                {
+                    BrightnessLevel = brightnessTarget;
+                }
+                else
+                {
+                    BrightnessLevel += valChange;
+                }
+            }
+
+            if (BrightnessLevel > brightnessTarget)
+            {
+                if (BrightnessLevel - valChange < brightnessTarget)
+                {
+                    BrightnessLevel = brightnessTarget;
+                }
+                else
+                {
+                    BrightnessLevel -= valChange;
+                }
+            }
+
+            if (PlayerLightColor.R != map.PlayerLightColor.R ||
+                PlayerLightColor.G != map.PlayerLightColor.G ||
+                PlayerLightColor.B != map.PlayerLightColor.B)
+            {
+                if (PlayerLightColor.R < map.PlayerLightColor.R)
+                {
+                    if (PlayerLightColor.R + valChange > map.PlayerLightColor.R)
+                    {
+                        PlayerLightColor.R = map.PlayerLightColor.R;
+                    }
+                    else
+                    {
+                        PlayerLightColor.R += valChange;
+                    }
+                }
+
+                if (PlayerLightColor.R > map.PlayerLightColor.R)
+                {
+                    if (PlayerLightColor.R - valChange < map.PlayerLightColor.R)
+                    {
+                        PlayerLightColor.R = map.PlayerLightColor.R;
+                    }
+                    else
+                    {
+                        PlayerLightColor.R -= valChange;
+                    }
+                }
+
+                if (PlayerLightColor.G < map.PlayerLightColor.G)
+                {
+                    if (PlayerLightColor.G + valChange > map.PlayerLightColor.G)
+                    {
+                        PlayerLightColor.G = map.PlayerLightColor.G;
+                    }
+                    else
+                    {
+                        PlayerLightColor.G += valChange;
+                    }
+                }
+
+                if (PlayerLightColor.G > map.PlayerLightColor.G)
+                {
+                    if (PlayerLightColor.G - valChange < map.PlayerLightColor.G)
+                    {
+                        PlayerLightColor.G = map.PlayerLightColor.G;
+                    }
+                    else
+                    {
+                        PlayerLightColor.G -= valChange;
+                    }
+                }
+
+                if (PlayerLightColor.B < map.PlayerLightColor.B)
+                {
+                    if (PlayerLightColor.B + valChange > map.PlayerLightColor.B)
+                    {
+                        PlayerLightColor.B = map.PlayerLightColor.B;
+                    }
+                    else
+                    {
+                        PlayerLightColor.B += valChange;
+                    }
+                }
+
+                if (PlayerLightColor.B > map.PlayerLightColor.B)
+                {
+                    if (PlayerLightColor.B - valChange < map.PlayerLightColor.B)
+                    {
+                        PlayerLightColor.B = map.PlayerLightColor.B;
+                    }
+                    else
+                    {
+                        PlayerLightColor.B -= valChange;
+                    }
+                }
+            }
+
+            if (sPlayerLightSize != map.PlayerLightSize)
+            {
+                if (sPlayerLightSize < map.PlayerLightSize)
+                {
+                    if (sPlayerLightSize + 500 * ecTime / 2000f > map.PlayerLightSize)
+                    {
+                        sPlayerLightSize = map.PlayerLightSize;
+                    }
+                    else
+                    {
+                        sPlayerLightSize += 500 * ecTime / 2000f;
+                    }
+                }
+
+                if (sPlayerLightSize > map.PlayerLightSize)
+                {
+                    if (sPlayerLightSize - 500 * ecTime / 2000f < map.PlayerLightSize)
+                    {
+                        sPlayerLightSize = map.PlayerLightSize;
+                    }
+                    else
+                    {
+                        sPlayerLightSize -= 500 * ecTime / 2000f;
+                    }
+                }
+            }
+
+            if (sPlayerLightIntensity < map.PlayerLightIntensity)
+            {
+                if (sPlayerLightIntensity + valChange > map.PlayerLightIntensity)
+                {
+                    sPlayerLightIntensity = map.PlayerLightIntensity;
+                }
+                else
+                {
+                    sPlayerLightIntensity += valChange;
+                }
+            }
+
+            if (sPlayerLightIntensity > map.AHue)
+            {
+                if (sPlayerLightIntensity - valChange < map.PlayerLightIntensity)
+                {
+                    sPlayerLightIntensity = map.PlayerLightIntensity;
+                }
+                else
+                {
+                    sPlayerLightIntensity -= valChange;
+                }
+            }
+
+            if (sPlayerLightExpand < map.PlayerLightExpand)
+            {
+                if (sPlayerLightExpand + 100f * ecTime / 2000f > map.PlayerLightExpand)
+                {
+                    sPlayerLightExpand = map.PlayerLightExpand;
+                }
+                else
+                {
+                    sPlayerLightExpand += 100f * ecTime / 2000f;
+                }
+            }
+
+            if (sPlayerLightExpand > map.PlayerLightExpand)
+            {
+                if (sPlayerLightExpand - 100f * ecTime / 2000f < map.PlayerLightExpand)
+                {
+                    sPlayerLightExpand = map.PlayerLightExpand;
+                }
+                else
+                {
+                    sPlayerLightExpand -= 100f * ecTime / 2000f;
+                }
+            }
+
+            // Cap instensity between 0 and 255 so as not to overflow (as it is an alpha value)
+            sPlayerLightIntensity = (float)MathHelper.Clamp(sPlayerLightIntensity, 0f, 255f);
+            sLightUpdate = Timing.Global.MillisecondsUtc;
+        }
+    }
+
+    //Helper Functions
+    /// <summary>
+    /// Convert a position on the screen to a position on the actual map for rendering.
+    /// </summary>
+    /// <param name="windowPoint">The point to convert.</param>
+    /// <returns>The converted point.</returns>
+    public static Pointf ConvertToWorldPoint(Pointf windowPoint)
+    {
+        return new Pointf(
+            (int)Math.Floor(windowPoint.X / Globals.Database.WorldZoom + CurrentView.Left),
+            (int)Math.Floor(windowPoint.Y / Globals.Database.WorldZoom + CurrentView.Top)
+        );
+    }
+
+    /// <summary>
+    /// Converts a point in the window to its place in the world view without respecting zoom
+    /// </summary>
+    /// <param name="windowPoint">The point to convert.</param>
+    /// <returns>The converted point.</returns>
+    public static Pointf ConvertToWorldPointNoZoom(Pointf windowPoint)
+    {
+        return new Pointf((int)Math.Floor(windowPoint.X + CurrentView.Left), (int)Math.Floor(windowPoint.Y + CurrentView.Top));
+    }
+
+    //Rendering Functions
+
+    /// <summary>
+    ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
+    ///     coordinates given using a specified blending mode.
+    /// </summary>
+    /// <param name="tex">The texture to draw</param>
+    /// <param name="x">X coordinate on the render target to draw to</param>
+    /// <param name="y">Y coordinate on the render target to draw to</param>
+    /// <param name="renderTarget">Where to draw to. If null it this will draw to the game screen.</param>
+    /// <param name="blendMode">Which blend mode to use when rendering</param>
+    public static void DrawGameTexture(
+        GameTexture tex,
+        float x,
+        float y,
+        GameRenderTexture renderTarget = null,
+        GameBlendModes blendMode = GameBlendModes.None,
+        GameShader shader = null,
+        float rotationDegrees = 0.0f,
+        bool drawImmediate = false
+    )
+    {
+        var destRectangle = new FloatRect(x, y, tex.GetWidth(), tex.GetHeight());
+        var srcRectangle = new FloatRect(0, 0, tex.GetWidth(), tex.GetHeight());
+        DrawGameTexture(
+            tex, srcRectangle, destRectangle, Color.White, renderTarget, blendMode, shader, rotationDegrees,
+            drawImmediate
+        );
+    }
+
+    /// <summary>
+    ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
+    ///     coordinates given using a specified blending mode.
+    /// </summary>
+    /// <param name="tex">The texture to draw</param>
+    /// <param name="x">X coordinate on the render target to draw to</param>
+    /// <param name="y">Y coordinate on the render target to draw to</param>
+    /// <param name="renderColor">Color mask to draw with. Default is Color.White</param>
+    /// <param name="renderTarget">Where to draw to. If null it this will draw to the game screen.</param>
+    /// <param name="blendMode">Which blend mode to use when rendering</param>
+    public static void DrawGameTexture(
+        GameTexture tex,
+        float x,
+        float y,
+        Color renderColor,
+        GameRenderTexture renderTarget = null,
+        GameBlendModes blendMode = GameBlendModes.None,
+        GameShader shader = null,
+        float rotationDegrees = 0.0f,
+        bool drawImmediate = false
+    )
+    {
+        var destRectangle = new FloatRect(x, y, tex.GetWidth(), tex.GetHeight());
+        var srcRectangle = new FloatRect(0, 0, tex.GetWidth(), tex.GetHeight());
+        DrawGameTexture(
+            tex, srcRectangle, destRectangle, renderColor, renderTarget, blendMode, shader, rotationDegrees,
+            drawImmediate
+        );
+    }
+
+    /// <summary>
+    ///     Renders a specified texture onto a RenderTexture or the GameScreen (if renderTarget is passed as null) at the
+    ///     coordinates given using a specified blending mode.
+    /// </summary>
+    /// <param name="tex">The texture to draw</param>
+    /// <param name="dx">X coordinate on the renderTarget to draw to.</param>
+    /// <param name="dy">Y coordinate on the renderTarget to draw to.</param>
+    /// <param name="sx">X coordinate on the source texture to grab from.</param>
+    /// <param name="sy">Y coordinate on the source texture to grab from.</param>
+    /// <param name="w">Width of the texture part we are rendering.</param>
+    /// <param name="h">Height of the texture part we are rendering.</param>
+    /// <param name="renderTarget">>Where to draw to. If null it this will draw to the game screen.</param>
+    /// <param name="blendMode">Which blend mode to use when rendering</param>
+    public static void DrawGameTexture(
+        GameTexture tex,
+        float dx,
+        float dy,
+        float sx,
+        float sy,
+        float w,
+        float h,
+        GameRenderTexture renderTarget = null,
+        GameBlendModes blendMode = GameBlendModes.None,
+        GameShader shader = null,
+        float rotationDegrees = 0.0f,
+        bool drawImmediate = false
+    )
+    {
+        if (tex == null)
+        {
+            return;
+        }
+
+        Renderer.DrawTexture(
+            tex, sx, sy, w, h, dx, dy, w, h, Color.White, renderTarget, blendMode, shader, rotationDegrees, false,
+            drawImmediate
+        );
+    }
+
+    public static void DrawGameTexture(
+        GameTexture tex,
+        FloatRect srcRectangle,
+        FloatRect targetRect,
+        Color renderColor,
+        GameRenderTexture renderTarget = null,
+        GameBlendModes blendMode = GameBlendModes.None,
+        GameShader shader = null,
+        float rotationDegrees = 0.0f,
+        bool drawImmediate = false
+    )
+    {
+        if (tex == null)
+        {
+            return;
+        }
+
+        Renderer.DrawTexture(
+            tex, srcRectangle.X, srcRectangle.Y, srcRectangle.Width, srcRectangle.Height, targetRect.X,
+            targetRect.Y, targetRect.Width, targetRect.Height,
+            Color.FromArgb(renderColor.A, renderColor.R, renderColor.G, renderColor.B), renderTarget, blendMode,
+            shader, rotationDegrees, false, drawImmediate
+        );
     }
 
 }

--- a/Intersect.Client/Core/IClientContext.cs
+++ b/Intersect.Client/Core/IClientContext.cs
@@ -1,15 +1,14 @@
 ﻿using Intersect.Core;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+/// <summary>
+/// Declares the API surface of client contexts.
+/// </summary>
+internal interface IClientContext : IApplicationContext<ClientCommandLineOptions>
 {
     /// <summary>
-    /// Declares the API surface of client contexts.
+    /// The platform-specific runner that initializes the actual user-visible client.
     /// </summary>
-    internal interface IClientContext : IApplicationContext<ClientCommandLineOptions>
-    {
-        /// <summary>
-        /// The platform-specific runner that initializes the actual user-visible client.
-        /// </summary>
-        IPlatformRunner PlatformRunner { get; }
-    }
+    IPlatformRunner PlatformRunner { get; }
 }

--- a/Intersect.Client/Core/IPlatformRunner.cs
+++ b/Intersect.Client/Core/IPlatformRunner.cs
@@ -1,15 +1,14 @@
-﻿namespace Intersect.Client.Core
+﻿namespace Intersect.Client.Core;
+
+/// <summary>
+/// Declares the API surface to launch instances of platform-specific (e.g. MonoGame, Unity) runners.
+/// </summary>
+internal interface IPlatformRunner
 {
     /// <summary>
-    /// Declares the API surface to launch instances of platform-specific (e.g. MonoGame, Unity) runners.
+    /// Starts the platform-specific runner for the provided context and post-startup action.
     /// </summary>
-    internal interface IPlatformRunner
-    {
-        /// <summary>
-        /// Starts the platform-specific runner for the provided context and post-startup action.
-        /// </summary>
-        /// <param name="context">the <see cref="IClientContext"/> to run for</param>
-        /// <param name="postStartupAction">the <see cref="Action"/> to do after startup</param>
-        void Start(IClientContext context, Action postStartupAction);
-    }
+    /// <param name="context">the <see cref="IClientContext"/> to run for</param>
+    /// <param name="postStartupAction">the <see cref="Action"/> to do after startup</param>
+    void Start(IClientContext context, Action postStartupAction);
 }

--- a/Intersect.Client/Core/Input.cs
+++ b/Intersect.Client/Core/Input.cs
@@ -11,525 +11,523 @@ using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+public static partial class Input
 {
-    public static partial class Input
+
+    public delegate void HandleKeyEvent(Keys modifier, Keys key);
+
+    public static HandleKeyEvent KeyDown;
+
+    public static HandleKeyEvent KeyUp;
+
+    public static HandleKeyEvent MouseDown;
+
+    public static HandleKeyEvent MouseUp;
+
+    private static void HandleZoomOut()
     {
-
-        public delegate void HandleKeyEvent(Keys modifier, Keys key);
-
-        public static HandleKeyEvent KeyDown;
-
-        public static HandleKeyEvent KeyUp;
-
-        public static HandleKeyEvent MouseDown;
-
-        public static HandleKeyEvent MouseUp;
-
-        private static void HandleZoomOut()
+        Globals.Database.WorldZoom /= 2;
+        if (Globals.Database.WorldZoom < Graphics.BaseWorldScale)
         {
-            Globals.Database.WorldZoom /= 2;
-            if (Globals.Database.WorldZoom < Graphics.BaseWorldScale)
-            {
-                Globals.Database.WorldZoom = Graphics.BaseWorldScale * 4;
-            }
-        }
-
-        private static void HandleZoomIn()
-        {
-            Globals.Database.WorldZoom *= 2;
-            if (Globals.Database.WorldZoom > Graphics.BaseWorldScale * 4)
-            {
-                Globals.Database.WorldZoom = Graphics.BaseWorldScale;
-            }
-        }
-
-        public static void OnKeyPressed(Keys modifier, Keys key)
-        {
-            if (key == Keys.None)
-            {
-                return;
-            }
-
-            var consumeKey = false;
-            bool canFocusChat = true;
-
-            KeyDown?.Invoke(modifier, key);
-            switch (key)
-            {
-                case Keys.Escape:
-                    if (Globals.GameState != GameStates.Intro)
-                    {
-                        break;
-                    }
-
-                    Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
-                    Globals.GameState = GameStates.Menu;
-
-                    return;
-
-                case Keys.Enter:
-
-                    for (int i = Interface.Interface.InputBlockingElements.Count - 1; i >= 0; i--)
-                    {
-                        try
-                        {
-                            var iBox = (InputBox)Interface.Interface.InputBlockingElements[i];
-                            if (iBox != null && !iBox.IsHidden)
-                            {
-                                iBox.okayBtn_Clicked(null, null);
-                                canFocusChat = false;
-
-                                break;
-                            }
-                        }
-                        catch { }
-
-                        try
-                        {
-                            var eventWindow = (EventWindow)Interface.Interface.InputBlockingElements[i];
-                            if (eventWindow != null && !eventWindow.IsHidden && Globals.EventDialogs.Count > 0)
-                            {
-                                eventWindow.EventResponse1_Clicked(null, null);
-                                canFocusChat = false;
-
-                                break;
-                            }
-                        }
-                        catch { }
-                    }
-
-                    break;
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.OpenMenu, modifier, key))
-            {
-                if (Globals.GameState != GameStates.InGame)
-                {
-                    return;
-                }
-
-                // First try and unfocus chat then close all UI elements, then untarget our target.. and THEN open the escape menu.
-                // Most games do this, why not this?
-                if (Interface.Interface.GameUi != null && Interface.Interface.GameUi.ChatFocussed)
-                {
-                    Interface.Interface.GameUi.UnfocusChat = true;
-                }
-                else if (Interface.Interface.GameUi != null && Interface.Interface.GameUi.CloseAllWindows())
-                {
-                    // We've closed our windows, don't do anything else. :)
-                }
-                else if (Globals.Me != null && Globals.Me.TargetIndex != Guid.Empty && !Globals.Me.Status.Any(s => s.Type == Enums.SpellEffect.Taunt))
-                {
-                    Globals.Me.ClearTarget();
-                }
-                else
-                {
-                    Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
-                }
-            }
-
-            if (Interface.Interface.HasInputFocus())
-            {
-                return;
-            }
-
-            Controls.Controls.GetControlsFor(modifier, key)
-                ?.ForEach(
-                    control =>
-                    {
-                        if (consumeKey)
-                        {
-                            return;
-                        }
-
-                        if (IsModifier(key))
-                        {
-                            return;
-                        }
-
-                        switch (control)
-                        {
-                            case Control.Screenshot:
-                                Graphics.Renderer?.RequestScreenshot();
-
-                                break;
-
-                            case Control.ToggleGui:
-                                if (Globals.GameState == GameStates.InGame)
-                                {
-                                    Interface.Interface.HideUi = !Interface.Interface.HideUi;
-                                }
-
-                                break;
-
-                            case Control.HoldToZoomIn:
-                            case Control.ToggleZoomIn:
-                            {
-                                HandleZoomIn();
-                                break;
-                            }
-
-                            case Control.HoldToZoomOut:
-                            case Control.ToggleZoomOut:
-                            {
-                                HandleZoomOut();
-                                break;
-                            }
-
-                            case Control.ToggleFullscreen:
-                            {
-                                Globals.Database.FullScreen = !Globals.Database.FullScreen;
-                                Globals.Database.SavePreferences();
-                                Graphics.Renderer.OverrideResolution = Resolution.Empty;
-                                Graphics.Renderer.Init();
-                                break;
-                            }
-
-                            case Control.OpenDebugger:
-                                MutableInterface.ToggleDebug();
-                                break;
-                        }
-
-                        switch (Globals.GameState)
-                        {
-                            case GameStates.Intro:
-                                break;
-
-                            case GameStates.Menu:
-                                break;
-
-                            case GameStates.InGame:
-                                switch (control)
-                                {
-                                    case Control.MoveUp:
-                                        break;
-
-                                    case Control.MoveLeft:
-                                        break;
-
-                                    case Control.MoveDown:
-                                        break;
-
-                                    case Control.MoveRight:
-                                        break;
-
-                                    case Control.AttackInteract:
-                                        break;
-
-                                    case Control.Block:
-                                        Globals.Me?.TryBlock();
-
-                                        break;
-
-                                    case Control.AutoTarget:
-                                        Globals.Me?.AutoTarget();
-
-                                        break;
-
-                                    case Control.PickUp:
-                                        Globals.Me?.TryPickupItem(Globals.Me.MapInstance.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X);
-
-                                        break;
-
-                                    case Control.Enter:
-                                        if (canFocusChat)
-                                        {
-                                            Interface.Interface.GameUi.FocusChat = true;
-                                            consumeKey = true;
-                                        }
-
-                                        return;
-
-                                    case Control.Hotkey1:
-                                    case Control.Hotkey2:
-                                    case Control.Hotkey3:
-                                    case Control.Hotkey4:
-                                    case Control.Hotkey5:
-                                    case Control.Hotkey6:
-                                    case Control.Hotkey7:
-                                    case Control.Hotkey8:
-                                    case Control.Hotkey9:
-                                    case Control.Hotkey0:
-                                        break;
-
-                                    case Control.OpenInventory:
-                                        Interface.Interface.GameUi?.GameMenu?.ToggleInventoryWindow();
-
-                                        break;
-
-                                    case Control.OpenQuests:
-                                        Interface.Interface.GameUi?.GameMenu?.ToggleQuestsWindow();
-
-                                        break;
-
-                                    case Control.OpenCharacterInfo:
-                                        Interface.Interface.GameUi?.GameMenu?.ToggleCharacterWindow();
-
-                                        break;
-
-                                    case Control.OpenParties:
-                                        Interface.Interface.GameUi?.GameMenu?.TogglePartyWindow();
-
-                                        break;
-
-                                    case Control.OpenSpells:
-                                        Interface.Interface.GameUi?.GameMenu?.ToggleSpellsWindow();
-
-                                        break;
-
-                                    case Control.OpenFriends:
-                                        Interface.Interface.GameUi?.GameMenu?.ToggleFriendsWindow();
-
-                                        break;
-
-                                    case Control.OpenSettings:
-                                        Interface.Interface.GameUi?.EscapeMenu?.OpenSettingsWindow();
-
-                                        break;
-
-                                    case Control.OpenAdminPanel:
-                                        PacketSender.SendOpenAdminWindow();
-
-                                        break;
-
-                                    case Control.OpenGuild:
-                                        Interface.Interface.GameUi?.GameMenu.ToggleGuildWindow();
-
-                                        break;
-                                }
-
-                                break;
-
-                            case GameStates.Loading:
-                                break;
-
-                            case GameStates.Error:
-                                break;
-
-                            default:
-                                throw new ArgumentOutOfRangeException(
-                                    nameof(Globals.GameState), Globals.GameState, null
-                                );
-                        }
-                    }
-                );
-        }
-
-        public static void OnKeyReleased(Keys modifier, Keys key)
-        {
-            KeyUp?.Invoke(modifier, key);
-            if (Interface.Interface.HasInputFocus())
-            {
-                return;
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.HoldToZoomIn, modifier, key))
-            {
-                HandleZoomOut();
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.HoldToZoomOut, modifier, key))
-            {
-                HandleZoomIn();
-            }
-
-            if (Globals.Me == null)
-            {
-                return;
-            }
-        }
-
-        public static void OnMouseDown(Keys modifier, MouseButtons btn)
-        {
-            var key = Keys.None;
-            switch (btn)
-            {
-                case MouseButtons.Left:
-                    key = Keys.LButton;
-
-                    break;
-
-                case MouseButtons.Right:
-                    key = Keys.RButton;
-
-                    break;
-
-                case MouseButtons.Middle:
-                    key = Keys.MButton;
-
-                    break;
-                case MouseButtons.X1:
-                    key = Keys.XButton1;
-
-                    break;
-                case MouseButtons.X2:
-                    key = Keys.XButton2;
-
-                    break;
-            }
-
-            MouseDown?.Invoke(modifier, key);
-            if (Interface.Interface.HasInputFocus())
-            {
-                return;
-            }
-
-            if (Globals.GameState != GameStates.InGame || Globals.Me == null)
-            {
-                return;
-            }
-
-            if (Interface.Interface.MouseHitGui())
-            {
-                return;
-            }
-
-            if (Globals.Me == null)
-            {
-                return;
-            }
-
-            if (modifier == Keys.None && btn == MouseButtons.Left && Globals.Me.TryTarget())
-            {
-                return;
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.PickUp, modifier, key))
-            {
-                if (Globals.Me.TryPickupItem(Globals.Me.MapInstance.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X, Guid.Empty, true))
-                {
-                    return;
-                }
-
-                if (!Globals.Me.IsAttacking)
-                {
-                    Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
-                }
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.Block, modifier, key))
-            {
-                if (Globals.Me.TryBlock())
-                {
-                    return;
-                }
-            }
-
-            if (key != Keys.None)
-            {
-                OnKeyPressed(modifier, key);
-            }
-        }
-
-        public static void OnMouseUp(Keys modifier, MouseButtons btn)
-        {
-            var key = Keys.LButton;
-            switch (btn)
-            {
-                case MouseButtons.Right:
-                    key = Keys.RButton;
-
-                    break;
-
-                case MouseButtons.Middle:
-                    key = Keys.MButton;
-
-                    break;
-                case MouseButtons.X1:
-                    key = Keys.XButton1;
-
-                    break;
-                case MouseButtons.X2:
-                    key = Keys.XButton2;
-
-                    break;
-            }
-
-            MouseUp?.Invoke(modifier, key);
-            if (Interface.Interface.HasInputFocus())
-            {
-                return;
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.HoldToZoomIn, modifier, key))
-            {
-                HandleZoomOut();
-            }
-
-            if (Controls.Controls.ControlHasKey(Control.HoldToZoomOut, modifier, key))
-            {
-                HandleZoomIn();
-            }
-
-            if (Globals.Me == null)
-            {
-                return;
-            }
-
-            if (btn != MouseButtons.Right)
-            {
-                return;
-            }
-
-            if (Globals.InputManager.KeyDown(Keys.Shift) != true)
-            {
-                return;
-            }
-
-            var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
-            var x = (int)mouseInWorld.X;
-            var y = (int)mouseInWorld.Y;
-
-            foreach (MapInstance map in MapInstance.Lookup.Values)
-            {
-                if (!(x >= map.GetX()) || !(x <= map.GetX() + Options.MapWidth * Options.TileWidth))
-                {
-                    continue;
-                }
-
-                if (!(y >= map.GetY()) || !(y <= map.GetY() + Options.MapHeight * Options.TileHeight))
-                {
-                    continue;
-                }
-
-                //Remove the offsets to just be dealing with pixels within the map selected
-                x -= (int) map.GetX();
-                y -= (int) map.GetY();
-
-                //transform pixel format to tile format
-                x /= Options.TileWidth;
-                y /= Options.TileHeight;
-                var mapNum = map.Id;
-
-                if (Globals.Me.TryGetRealLocation(ref x, ref y, ref mapNum))
-                {
-                    PacketSender.SendAdminAction(new WarpToLocationAction(map.Id, (byte) x, (byte) y));
-                }
-
-                return;
-            }
-        }
-
-        public static bool IsModifier(Keys key)
-        {
-            switch (key)
-            {
-                case Keys.Control:
-                case Keys.ControlKey:
-                case Keys.LControlKey:
-                case Keys.RControlKey:
-                case Keys.LShiftKey:
-                case Keys.RShiftKey:
-                case Keys.Shift:
-                case Keys.ShiftKey:
-                case Keys.Alt:
-                    return true;
-
-                default:
-                    return false;
-            }
+            Globals.Database.WorldZoom = Graphics.BaseWorldScale * 4;
         }
     }
 
+    private static void HandleZoomIn()
+    {
+        Globals.Database.WorldZoom *= 2;
+        if (Globals.Database.WorldZoom > Graphics.BaseWorldScale * 4)
+        {
+            Globals.Database.WorldZoom = Graphics.BaseWorldScale;
+        }
+    }
+
+    public static void OnKeyPressed(Keys modifier, Keys key)
+    {
+        if (key == Keys.None)
+        {
+            return;
+        }
+
+        var consumeKey = false;
+        bool canFocusChat = true;
+
+        KeyDown?.Invoke(modifier, key);
+        switch (key)
+        {
+            case Keys.Escape:
+                if (Globals.GameState != GameStates.Intro)
+                {
+                    break;
+                }
+
+                Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+                Globals.GameState = GameStates.Menu;
+
+                return;
+
+            case Keys.Enter:
+
+                for (int i = Interface.Interface.InputBlockingElements.Count - 1; i >= 0; i--)
+                {
+                    try
+                    {
+                        var iBox = (InputBox)Interface.Interface.InputBlockingElements[i];
+                        if (iBox != null && !iBox.IsHidden)
+                        {
+                            iBox.okayBtn_Clicked(null, null);
+                            canFocusChat = false;
+
+                            break;
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        var eventWindow = (EventWindow)Interface.Interface.InputBlockingElements[i];
+                        if (eventWindow != null && !eventWindow.IsHidden && Globals.EventDialogs.Count > 0)
+                        {
+                            eventWindow.EventResponse1_Clicked(null, null);
+                            canFocusChat = false;
+
+                            break;
+                        }
+                    }
+                    catch { }
+                }
+
+                break;
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.OpenMenu, modifier, key))
+        {
+            if (Globals.GameState != GameStates.InGame)
+            {
+                return;
+            }
+
+            // First try and unfocus chat then close all UI elements, then untarget our target.. and THEN open the escape menu.
+            // Most games do this, why not this?
+            if (Interface.Interface.GameUi != null && Interface.Interface.GameUi.ChatFocussed)
+            {
+                Interface.Interface.GameUi.UnfocusChat = true;
+            }
+            else if (Interface.Interface.GameUi != null && Interface.Interface.GameUi.CloseAllWindows())
+            {
+                // We've closed our windows, don't do anything else. :)
+            }
+            else if (Globals.Me != null && Globals.Me.TargetIndex != Guid.Empty && !Globals.Me.Status.Any(s => s.Type == Enums.SpellEffect.Taunt))
+            {
+                Globals.Me.ClearTarget();
+            }
+            else
+            {
+                Interface.Interface.GameUi?.EscapeMenu?.ToggleHidden();
+            }
+        }
+
+        if (Interface.Interface.HasInputFocus())
+        {
+            return;
+        }
+
+        Controls.Controls.GetControlsFor(modifier, key)
+            ?.ForEach(
+                control =>
+                {
+                    if (consumeKey)
+                    {
+                        return;
+                    }
+
+                    if (IsModifier(key))
+                    {
+                        return;
+                    }
+
+                    switch (control)
+                    {
+                        case Control.Screenshot:
+                            Graphics.Renderer?.RequestScreenshot();
+
+                            break;
+
+                        case Control.ToggleGui:
+                            if (Globals.GameState == GameStates.InGame)
+                            {
+                                Interface.Interface.HideUi = !Interface.Interface.HideUi;
+                            }
+
+                            break;
+
+                        case Control.HoldToZoomIn:
+                        case Control.ToggleZoomIn:
+                        {
+                            HandleZoomIn();
+                            break;
+                        }
+
+                        case Control.HoldToZoomOut:
+                        case Control.ToggleZoomOut:
+                        {
+                            HandleZoomOut();
+                            break;
+                        }
+
+                        case Control.ToggleFullscreen:
+                        {
+                            Globals.Database.FullScreen = !Globals.Database.FullScreen;
+                            Globals.Database.SavePreferences();
+                            Graphics.Renderer.OverrideResolution = Resolution.Empty;
+                            Graphics.Renderer.Init();
+                            break;
+                        }
+
+                        case Control.OpenDebugger:
+                            MutableInterface.ToggleDebug();
+                            break;
+                    }
+
+                    switch (Globals.GameState)
+                    {
+                        case GameStates.Intro:
+                            break;
+
+                        case GameStates.Menu:
+                            break;
+
+                        case GameStates.InGame:
+                            switch (control)
+                            {
+                                case Control.MoveUp:
+                                    break;
+
+                                case Control.MoveLeft:
+                                    break;
+
+                                case Control.MoveDown:
+                                    break;
+
+                                case Control.MoveRight:
+                                    break;
+
+                                case Control.AttackInteract:
+                                    break;
+
+                                case Control.Block:
+                                    Globals.Me?.TryBlock();
+
+                                    break;
+
+                                case Control.AutoTarget:
+                                    Globals.Me?.AutoTarget();
+
+                                    break;
+
+                                case Control.PickUp:
+                                    Globals.Me?.TryPickupItem(Globals.Me.MapInstance.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X);
+
+                                    break;
+
+                                case Control.Enter:
+                                    if (canFocusChat)
+                                    {
+                                        Interface.Interface.GameUi.FocusChat = true;
+                                        consumeKey = true;
+                                    }
+
+                                    return;
+
+                                case Control.Hotkey1:
+                                case Control.Hotkey2:
+                                case Control.Hotkey3:
+                                case Control.Hotkey4:
+                                case Control.Hotkey5:
+                                case Control.Hotkey6:
+                                case Control.Hotkey7:
+                                case Control.Hotkey8:
+                                case Control.Hotkey9:
+                                case Control.Hotkey0:
+                                    break;
+
+                                case Control.OpenInventory:
+                                    Interface.Interface.GameUi?.GameMenu?.ToggleInventoryWindow();
+
+                                    break;
+
+                                case Control.OpenQuests:
+                                    Interface.Interface.GameUi?.GameMenu?.ToggleQuestsWindow();
+
+                                    break;
+
+                                case Control.OpenCharacterInfo:
+                                    Interface.Interface.GameUi?.GameMenu?.ToggleCharacterWindow();
+
+                                    break;
+
+                                case Control.OpenParties:
+                                    Interface.Interface.GameUi?.GameMenu?.TogglePartyWindow();
+
+                                    break;
+
+                                case Control.OpenSpells:
+                                    Interface.Interface.GameUi?.GameMenu?.ToggleSpellsWindow();
+
+                                    break;
+
+                                case Control.OpenFriends:
+                                    Interface.Interface.GameUi?.GameMenu?.ToggleFriendsWindow();
+
+                                    break;
+
+                                case Control.OpenSettings:
+                                    Interface.Interface.GameUi?.EscapeMenu?.OpenSettingsWindow();
+
+                                    break;
+
+                                case Control.OpenAdminPanel:
+                                    PacketSender.SendOpenAdminWindow();
+
+                                    break;
+
+                                case Control.OpenGuild:
+                                    Interface.Interface.GameUi?.GameMenu.ToggleGuildWindow();
+
+                                    break;
+                            }
+
+                            break;
+
+                        case GameStates.Loading:
+                            break;
+
+                        case GameStates.Error:
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException(
+                                nameof(Globals.GameState), Globals.GameState, null
+                            );
+                    }
+                }
+            );
+    }
+
+    public static void OnKeyReleased(Keys modifier, Keys key)
+    {
+        KeyUp?.Invoke(modifier, key);
+        if (Interface.Interface.HasInputFocus())
+        {
+            return;
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.HoldToZoomIn, modifier, key))
+        {
+            HandleZoomOut();
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.HoldToZoomOut, modifier, key))
+        {
+            HandleZoomIn();
+        }
+
+        if (Globals.Me == null)
+        {
+            return;
+        }
+    }
+
+    public static void OnMouseDown(Keys modifier, MouseButtons btn)
+    {
+        var key = Keys.None;
+        switch (btn)
+        {
+            case MouseButtons.Left:
+                key = Keys.LButton;
+
+                break;
+
+            case MouseButtons.Right:
+                key = Keys.RButton;
+
+                break;
+
+            case MouseButtons.Middle:
+                key = Keys.MButton;
+
+                break;
+            case MouseButtons.X1:
+                key = Keys.XButton1;
+
+                break;
+            case MouseButtons.X2:
+                key = Keys.XButton2;
+
+                break;
+        }
+
+        MouseDown?.Invoke(modifier, key);
+        if (Interface.Interface.HasInputFocus())
+        {
+            return;
+        }
+
+        if (Globals.GameState != GameStates.InGame || Globals.Me == null)
+        {
+            return;
+        }
+
+        if (Interface.Interface.MouseHitGui())
+        {
+            return;
+        }
+
+        if (Globals.Me == null)
+        {
+            return;
+        }
+
+        if (modifier == Keys.None && btn == MouseButtons.Left && Globals.Me.TryTarget())
+        {
+            return;
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.PickUp, modifier, key))
+        {
+            if (Globals.Me.TryPickupItem(Globals.Me.MapInstance.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X, Guid.Empty, true))
+            {
+                return;
+            }
+
+            if (!Globals.Me.IsAttacking)
+            {
+                Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
+            }
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.Block, modifier, key))
+        {
+            if (Globals.Me.TryBlock())
+            {
+                return;
+            }
+        }
+
+        if (key != Keys.None)
+        {
+            OnKeyPressed(modifier, key);
+        }
+    }
+
+    public static void OnMouseUp(Keys modifier, MouseButtons btn)
+    {
+        var key = Keys.LButton;
+        switch (btn)
+        {
+            case MouseButtons.Right:
+                key = Keys.RButton;
+
+                break;
+
+            case MouseButtons.Middle:
+                key = Keys.MButton;
+
+                break;
+            case MouseButtons.X1:
+                key = Keys.XButton1;
+
+                break;
+            case MouseButtons.X2:
+                key = Keys.XButton2;
+
+                break;
+        }
+
+        MouseUp?.Invoke(modifier, key);
+        if (Interface.Interface.HasInputFocus())
+        {
+            return;
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.HoldToZoomIn, modifier, key))
+        {
+            HandleZoomOut();
+        }
+
+        if (Controls.Controls.ControlHasKey(Control.HoldToZoomOut, modifier, key))
+        {
+            HandleZoomIn();
+        }
+
+        if (Globals.Me == null)
+        {
+            return;
+        }
+
+        if (btn != MouseButtons.Right)
+        {
+            return;
+        }
+
+        if (Globals.InputManager.KeyDown(Keys.Shift) != true)
+        {
+            return;
+        }
+
+        var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
+        var x = (int)mouseInWorld.X;
+        var y = (int)mouseInWorld.Y;
+
+        foreach (MapInstance map in MapInstance.Lookup.Values)
+        {
+            if (!(x >= map.GetX()) || !(x <= map.GetX() + Options.MapWidth * Options.TileWidth))
+            {
+                continue;
+            }
+
+            if (!(y >= map.GetY()) || !(y <= map.GetY() + Options.MapHeight * Options.TileHeight))
+            {
+                continue;
+            }
+
+            //Remove the offsets to just be dealing with pixels within the map selected
+            x -= (int) map.GetX();
+            y -= (int) map.GetY();
+
+            //transform pixel format to tile format
+            x /= Options.TileWidth;
+            y /= Options.TileHeight;
+            var mapNum = map.Id;
+
+            if (Globals.Me.TryGetRealLocation(ref x, ref y, ref mapNum))
+            {
+                PacketSender.SendAdminAction(new WarpToLocationAction(map.Id, (byte) x, (byte) y));
+            }
+
+            return;
+        }
+    }
+
+    public static bool IsModifier(Keys key)
+    {
+        switch (key)
+        {
+            case Keys.Control:
+            case Keys.ControlKey:
+            case Keys.LControlKey:
+            case Keys.RControlKey:
+            case Keys.LShiftKey:
+            case Keys.RShiftKey:
+            case Keys.Shift:
+            case Keys.ShiftKey:
+            case Keys.Alt:
+                return true;
+
+            default:
+                return false;
+        }
+    }
 }

--- a/Intersect.Client/Core/Main.cs
+++ b/Intersect.Client/Core/Main.cs
@@ -10,391 +10,389 @@ using Intersect.Utilities;
 
 // ReSharper disable All
 
-namespace Intersect.Client.Core
+namespace Intersect.Client.Core;
+
+
+internal static partial class Main
 {
 
-    internal static partial class Main
+    private static long _animTimer;
+
+    private static bool _createdMapTextures;
+
+    private static bool _loadedTilesets;
+
+    internal static void Start(IClientContext context)
     {
+        //Load Graphics
+        Graphics.InitGraphics();
 
-        private static long _animTimer;
+        //Load Sounds
+        Audio.Init();
+        Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
 
-        private static bool _createdMapTextures;
+        //Init Network
+        Networking.Network.InitNetwork(context);
+        Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
 
-        private static bool _loadedTilesets;
-
-        internal static void Start(IClientContext context)
+        //Make Json.Net Familiar with Our Object Types
+        var id = Guid.NewGuid();
+        foreach (var val in Enum.GetValues(typeof(GameObjectType)))
         {
-            //Load Graphics
-            Graphics.InitGraphics();
-
-            //Load Sounds
-            Audio.Init();
-            Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-
-            //Init Network
-            Networking.Network.InitNetwork(context);
-            Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
-
-            //Make Json.Net Familiar with Our Object Types
-            var id = Guid.NewGuid();
-            foreach (var val in Enum.GetValues(typeof(GameObjectType)))
+            var type = ((GameObjectType) val);
+            if (type != GameObjectType.Event && type != GameObjectType.Time)
             {
-                var type = ((GameObjectType) val);
-                if (type != GameObjectType.Event && type != GameObjectType.Time)
-                {
-                    var lookup = type.GetLookup();
-                    var item = lookup.AddNew(type.GetObjectType(), id);
-                    item.Load(item.JsonData);
-                    lookup.Delete(item);
-                }
+                var lookup = type.GetLookup();
+                var item = lookup.AddNew(type.GetObjectType(), id);
+                item.Load(item.JsonData);
+                lookup.Delete(item);
             }
         }
+    }
 
-        public static void DestroyGame()
-        {
-            //Destroy Game
-            //TODO - Destroy Graphics and Networking peacefully
-            //Network.Close();
-            Interface.Interface.DestroyGwen(true);
-            Graphics.Renderer.Close();
-        }
+    public static void DestroyGame()
+    {
+        //Destroy Game
+        //TODO - Destroy Graphics and Networking peacefully
+        //Network.Close();
+        Interface.Interface.DestroyGwen(true);
+        Graphics.Renderer.Close();
+    }
 
-        public static void Update(TimeSpan deltaTime)
+    public static void Update(TimeSpan deltaTime)
+    {
+        lock (Globals.GameLock)
         {
-            lock (Globals.GameLock)
+            Networking.Network.Update();
+            Fade.Update();
+            Interface.Interface.ToggleInput(Globals.GameState != GameStates.Intro);
+
+            switch (Globals.GameState)
             {
-                Networking.Network.Update();
-                Fade.Update();
-                Interface.Interface.ToggleInput(Globals.GameState != GameStates.Intro);
+                case GameStates.Intro:
+                    ProcessIntro();
 
-                switch (Globals.GameState)
-                {
-                    case GameStates.Intro:
-                        ProcessIntro();
+                    break;
 
-                        break;
+                case GameStates.Menu:
+                    ProcessMenu();
 
-                    case GameStates.Menu:
-                        ProcessMenu();
+                    break;
 
-                        break;
+                case GameStates.Loading:
+                    ProcessLoading();
 
-                    case GameStates.Loading:
-                        ProcessLoading();
+                    break;
 
-                        break;
+                case GameStates.InGame:
+                    ProcessGame();
 
-                    case GameStates.InGame:
-                        ProcessGame();
+                    break;
 
-                        break;
+                case GameStates.Error:
+                    break;
 
-                    case GameStates.Error:
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException(
-                            nameof(Globals.GameState), $"Value {Globals.GameState} out of range."
-                        );
-                }
-
-                Globals.InputManager.Update(deltaTime);
-                Audio.Update();
-
-                Globals.OnGameUpdate(deltaTime);
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(Globals.GameState), $"Value {Globals.GameState} out of range."
+                    );
             }
+
+            Globals.InputManager.Update(deltaTime);
+            Audio.Update();
+
+            Globals.OnGameUpdate(deltaTime);
         }
+    }
 
-        private static void ProcessIntro()
+    private static void ProcessIntro()
+    {
+        if (ClientConfiguration.Instance.IntroImages.Count > 0)
         {
-            if (ClientConfiguration.Instance.IntroImages.Count > 0)
-            {
-                GameTexture imageTex = Globals.ContentManager.GetTexture(
-                    Framework.Content.TextureType.Image, ClientConfiguration.Instance.IntroImages[Globals.IntroIndex]
-                );
+            GameTexture imageTex = Globals.ContentManager.GetTexture(
+                Framework.Content.TextureType.Image, ClientConfiguration.Instance.IntroImages[Globals.IntroIndex]
+            );
 
-                if (imageTex != null)
+            if (imageTex != null)
+            {
+                if (Globals.IntroStartTime == -1)
                 {
-                    if (Globals.IntroStartTime == -1)
+                    if (Fade.DoneFading())
                     {
-                        if (Fade.DoneFading())
+                        if (Globals.IntroComing)
                         {
-                            if (Globals.IntroComing)
-                            {
-                                Globals.IntroStartTime = Timing.Global.MillisecondsUtc;
-                            }
-                            else
-                            {
-                                Globals.IntroIndex++;
-                                Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
-                                Globals.IntroComing = true;
-                            }
+                            Globals.IntroStartTime = Timing.Global.MillisecondsUtc;
                         }
-                    }
-                    else
-                    {
-                        if (Timing.Global.MillisecondsUtc > Globals.IntroStartTime + Globals.IntroDelay)
+                        else
                         {
-                            //If we have shown an image long enough, fade to black -- keep track that the image is going
-                            Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
-                            Globals.IntroStartTime = -1;
-                            Globals.IntroComing = false;
+                            Globals.IntroIndex++;
+                            Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+                            Globals.IntroComing = true;
                         }
                     }
                 }
                 else
                 {
-                    Globals.IntroIndex++;
-                }
-
-                if (Globals.IntroIndex >= ClientConfiguration.Instance.IntroImages.Count)
-                {
-                    Globals.GameState = GameStates.Menu;
+                    if (Timing.Global.MillisecondsUtc > Globals.IntroStartTime + Globals.IntroDelay)
+                    {
+                        //If we have shown an image long enough, fade to black -- keep track that the image is going
+                        Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
+                        Globals.IntroStartTime = -1;
+                        Globals.IntroComing = false;
+                    }
                 }
             }
             else
+            {
+                Globals.IntroIndex++;
+            }
+
+            if (Globals.IntroIndex >= ClientConfiguration.Instance.IntroImages.Count)
             {
                 Globals.GameState = GameStates.Menu;
             }
         }
-
-        private static void ProcessMenu()
+        else
         {
-            if (!Globals.JoiningGame)
-                return;
+            Globals.GameState = GameStates.Menu;
+        }
+    }
 
-            //if (GameGraphics.FadeAmt != 255f) return;
-            //Check if maps are loaded and ready
-            Globals.GameState = GameStates.Loading;
-            Interface.Interface.DestroyGwen();
+    private static void ProcessMenu()
+    {
+        if (!Globals.JoiningGame)
+            return;
+
+        //if (GameGraphics.FadeAmt != 255f) return;
+        //Check if maps are loaded and ready
+        Globals.GameState = GameStates.Loading;
+        Interface.Interface.DestroyGwen();
+    }
+
+    private static void ProcessLoading()
+    {
+        if (Globals.Me == null || Globals.Me.MapInstance == null)
+            return;
+
+        if (!_loadedTilesets && Globals.HasGameData)
+        {
+            Globals.ContentManager.LoadTilesets(TilesetBase.GetNameList());
+            _loadedTilesets = true;
         }
 
-        private static void ProcessLoading()
+        Audio.PlayMusic(MapInstance.Get(Globals.Me.MapId).Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
+        Globals.GameState = GameStates.InGame;
+        Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+    }
+
+    private static void ProcessGame()
+    {
+        if (Globals.ConnectionLost)
         {
-            if (Globals.Me == null || Globals.Me.MapInstance == null)
-                return;
-
-            if (!_loadedTilesets && Globals.HasGameData)
-            {
-                Globals.ContentManager.LoadTilesets(TilesetBase.GetNameList());
-                _loadedTilesets = true;
-            }
-
-            Audio.PlayMusic(MapInstance.Get(Globals.Me.MapId).Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-            Globals.GameState = GameStates.InGame;
-            Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+            Logout(false);
+            Globals.ConnectionLost = false;
+            return;
         }
 
-        private static void ProcessGame()
+        //If we are waiting on maps, lets see if we have them
+        if (Globals.NeedsMaps)
         {
-            if (Globals.ConnectionLost)
+            bool canShowWorld = true;
+            if (MapInstance.TryGet(Globals.Me.MapId, out var mapInstance))
             {
-                Logout(false);
-                Globals.ConnectionLost = false;
-                return;
-            }
-
-            //If we are waiting on maps, lets see if we have them
-            if (Globals.NeedsMaps)
-            {
-                bool canShowWorld = true;
-                if (MapInstance.TryGet(Globals.Me.MapId, out var mapInstance))
+                var gridX = mapInstance.GridX;
+                var gridY = mapInstance.GridY;
+                for (int x = gridX - 1; x <= gridX + 1; x++)
                 {
-                    var gridX = mapInstance.GridX;
-                    var gridY = mapInstance.GridY;
-                    for (int x = gridX - 1; x <= gridX + 1; x++)
+                    for (int y = gridY - 1; y <= gridY + 1; y++)
                     {
-                        for (int y = gridY - 1; y <= gridY + 1; y++)
+                        if (x >= 0 &&
+                            x < Globals.MapGridWidth &&
+                            y >= 0 &&
+                            y < Globals.MapGridHeight &&
+                            Globals.MapGrid[x, y] != Guid.Empty)
                         {
-                            if (x >= 0 &&
-                                x < Globals.MapGridWidth &&
-                                y >= 0 &&
-                                y < Globals.MapGridHeight &&
-                                Globals.MapGrid[x, y] != Guid.Empty)
+                            var map = MapInstance.Get(Globals.MapGrid[x, y]);
+                            if (map != null)
                             {
-                                var map = MapInstance.Get(Globals.MapGrid[x, y]);
-                                if (map != null)
-                                {
-                                    if (!map.IsLoaded)
-                                    {
-                                        canShowWorld = false;
-                                    }
-                                }
-                                else
+                                if (!map.IsLoaded)
                                 {
                                     canShowWorld = false;
                                 }
                             }
+                            else
+                            {
+                                canShowWorld = false;
+                            }
                         }
                     }
                 }
-                else
-                {
-                    canShowWorld = false;
-                }
-
-                canShowWorld = true;
-                if (canShowWorld)
-                {
-                    Globals.NeedsMaps = false;
-                    //Send ping to server, so it will resync time if needed as we load in
-                    PacketSender.SendPing();
-                }
             }
             else
             {
-                PacketSender.SendNeedMapForGrid();
+                canShowWorld = false;
             }
 
-            if (!Globals.NeedsMaps)
+            canShowWorld = true;
+            if (canShowWorld)
             {
-                //Update All Entities
-                foreach (var en in Globals.Entities)
+                Globals.NeedsMaps = false;
+                //Send ping to server, so it will resync time if needed as we load in
+                PacketSender.SendPing();
+            }
+        }
+        else
+        {
+            PacketSender.SendNeedMapForGrid();
+        }
+
+        if (!Globals.NeedsMaps)
+        {
+            //Update All Entities
+            foreach (var en in Globals.Entities)
+            {
+                if (en.Value == null)
+                    continue;
+
+                en.Value.Update();
+            }
+
+            for (int i = 0; i < Globals.EntitiesToDispose.Count; i++)
+            {
+                if (Globals.Entities.ContainsKey(Globals.EntitiesToDispose[i]))
                 {
-                    if (en.Value == null)
+                    if (Globals.EntitiesToDispose[i] == Globals.Me.Id)
                         continue;
 
-                    en.Value.Update();
-                }
-
-                for (int i = 0; i < Globals.EntitiesToDispose.Count; i++)
-                {
-                    if (Globals.Entities.ContainsKey(Globals.EntitiesToDispose[i]))
-                    {
-                        if (Globals.EntitiesToDispose[i] == Globals.Me.Id)
-                            continue;
-
-                        Globals.Entities[Globals.EntitiesToDispose[i]].Dispose();
-                        Globals.Entities.Remove(Globals.EntitiesToDispose[i]);
-                    }
-                }
-
-                Globals.EntitiesToDispose.Clear();
-
-                //Update Maps
-                var maps = MapInstance.Lookup.Values.ToArray();
-                foreach (MapInstance map in maps)
-                {
-                    if (map == null)
-                        continue;
-
-                    map.Update(map.InView());
+                    Globals.Entities[Globals.EntitiesToDispose[i]].Dispose();
+                    Globals.Entities.Remove(Globals.EntitiesToDispose[i]);
                 }
             }
 
-            //Update Game Animations
-            if (_animTimer < Timing.Global.MillisecondsUtc)
+            Globals.EntitiesToDispose.Clear();
+
+            //Update Maps
+            var maps = MapInstance.Lookup.Values.ToArray();
+            foreach (MapInstance map in maps)
             {
-                Globals.AnimFrame++;
-                if (Globals.AnimFrame == 3)
-                {
-                    Globals.AnimFrame = 0;
-                }
+                if (map == null)
+                    continue;
 
-                _animTimer = Timing.Global.MillisecondsUtc + 500;
+                map.Update(map.InView());
             }
-
-            //Remove Event Holds If Invalid
-            var removeHolds = new List<Guid>();
-            foreach (var hold in Globals.EventHolds)
-            {
-                //If hold.value is empty its a common event, ignore. Otherwise make sure we have the map else the hold doesnt matter
-                if (hold.Value != Guid.Empty && MapInstance.Get(hold.Value) == null)
-                {
-                    removeHolds.Add(hold.Key);
-                }
-            }
-
-            foreach (var hold in removeHolds)
-            {
-                Globals.EventHolds.Remove(hold);
-            }
-
-            Graphics.UpdatePlayerLight();
-            Time.Update();
         }
 
-        public static void JoinGame()
+        //Update Game Animations
+        if (_animTimer < Timing.Global.MillisecondsUtc)
         {
-            Globals.LoggedIn = true;
-            Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
+            Globals.AnimFrame++;
+            if (Globals.AnimFrame == 3)
+            {
+                Globals.AnimFrame = 0;
+            }
+
+            _animTimer = Timing.Global.MillisecondsUtc + 500;
         }
 
-        public static void Logout(bool characterSelect, bool skipFade = false)
+        //Remove Event Holds If Invalid
+        var removeHolds = new List<Guid>();
+        foreach (var hold in Globals.EventHolds)
         {
-            Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-            if (skipFade)
+            //If hold.value is empty its a common event, ignore. Otherwise make sure we have the map else the hold doesnt matter
+            if (hold.Value != Guid.Empty && MapInstance.Get(hold.Value) == null)
             {
-                Fade.Cancel();
-            }
-            else
-            {
-                Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
-            }
-
-            if (!ClientContext.IsSinglePlayer)
-            {
-                Globals.SoftLogout = !characterSelect;
-                PacketSender.SendLogout(characterSelect);
-            }
-
-            Globals.LoggedIn = false;
-            Globals.WaitingOnServer = false;
-            Globals.GameState = GameStates.Menu;
-            Globals.JoiningGame = false;
-            Globals.NeedsMaps = true;
-            Globals.Picture = null;
-
-            Globals.InBag = false;
-            Globals.InBank = false;
-            Globals.GameShop = null;
-            Globals.InTrade = false;
-            Globals.EventDialogs?.Clear();
-            Globals.InCraft = false;
-
-            Interface.Interface.HideUi = false;
-
-            //Dump Game Objects
-            Globals.Me = null;
-            Globals.HasGameData = false;
-            foreach (var map in MapInstance.Lookup)
-            {
-                var mp = (MapInstance) map.Value;
-                mp.Dispose(false, true);
-            }
-
-            foreach (var en in Globals.Entities.ToArray())
-            {
-                en.Value.Dispose();
-            }
-
-            MapBase.Lookup.Clear();
-            MapInstance.Lookup.Clear();
-
-            Globals.Entities.Clear();
-            Globals.MapGrid = null;
-            Globals.GridMaps.Clear();
-            Globals.EventDialogs.Clear();
-            Globals.EventHolds.Clear();
-            Globals.PendingEvents.Clear();
-
-            Interface.Interface.InitGwen();
-
-            if (ClientContext.IsSinglePlayer)
-            {
-                PacketSender.SendLogout(characterSelect);
-            }
-
-            if (skipFade)
-            {
-                Fade.Cancel();
-            }
-            else
-            {
-                Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+                removeHolds.Add(hold.Key);
             }
         }
 
+        foreach (var hold in removeHolds)
+        {
+            Globals.EventHolds.Remove(hold);
+        }
+
+        Graphics.UpdatePlayerLight();
+        Time.Update();
+    }
+
+    public static void JoinGame()
+    {
+        Globals.LoggedIn = true;
+        Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
+    }
+
+    public static void Logout(bool characterSelect, bool skipFade = false)
+    {
+        Audio.PlayMusic(ClientConfiguration.Instance.MenuMusic, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
+        if (skipFade)
+        {
+            Fade.Cancel();
+        }
+        else
+        {
+            Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
+        }
+
+        if (!ClientContext.IsSinglePlayer)
+        {
+            Globals.SoftLogout = !characterSelect;
+            PacketSender.SendLogout(characterSelect);
+        }
+
+        Globals.LoggedIn = false;
+        Globals.WaitingOnServer = false;
+        Globals.GameState = GameStates.Menu;
+        Globals.JoiningGame = false;
+        Globals.NeedsMaps = true;
+        Globals.Picture = null;
+
+        Globals.InBag = false;
+        Globals.InBank = false;
+        Globals.GameShop = null;
+        Globals.InTrade = false;
+        Globals.EventDialogs?.Clear();
+        Globals.InCraft = false;
+
+        Interface.Interface.HideUi = false;
+
+        //Dump Game Objects
+        Globals.Me = null;
+        Globals.HasGameData = false;
+        foreach (var map in MapInstance.Lookup)
+        {
+            var mp = (MapInstance) map.Value;
+            mp.Dispose(false, true);
+        }
+
+        foreach (var en in Globals.Entities.ToArray())
+        {
+            en.Value.Dispose();
+        }
+
+        MapBase.Lookup.Clear();
+        MapInstance.Lookup.Clear();
+
+        Globals.Entities.Clear();
+        Globals.MapGrid = null;
+        Globals.GridMaps.Clear();
+        Globals.EventDialogs.Clear();
+        Globals.EventHolds.Clear();
+        Globals.PendingEvents.Clear();
+
+        Interface.Interface.InitGwen();
+
+        if (ClientContext.IsSinglePlayer)
+        {
+            PacketSender.SendLogout(characterSelect);
+        }
+
+        if (skipFade)
+        {
+            Fade.Cancel();
+        }
+        else
+        {
+            Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+        }
     }
 
 }

--- a/Intersect.Client/Core/Sounds/MapSound.cs
+++ b/Intersect.Client/Core/Sounds/MapSound.cs
@@ -4,265 +4,263 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.General;
 using Intersect.Client.Maps;
 
-namespace Intersect.Client.Core.Sounds
+namespace Intersect.Client.Core.Sounds;
+
+
+public partial class MapSound : Sound, IMapSound
 {
 
-    public partial class MapSound : Sound, IMapSound
+    private int mDistance;
+
+    private IEntity mEntity;
+
+    private Guid mMapId;
+
+    private int mX;
+
+    private int mY;
+
+    public MapSound(
+        string filename,
+        int x,
+        int y,
+        Guid mapId,
+        bool loop,
+        int loopInterval,
+        int distance,
+        IEntity parent = null
+    ) : base(filename, loop, loopInterval)
     {
-
-        private int mDistance;
-
-        private IEntity mEntity;
-
-        private Guid mMapId;
-
-        private int mX;
-
-        private int mY;
-
-        public MapSound(
-            string filename,
-            int x,
-            int y,
-            Guid mapId,
-            bool loop,
-            int loopInterval,
-            int distance,
-            IEntity parent = null
-        ) : base(filename, loop, loopInterval)
+        if (string.IsNullOrEmpty(filename) || mSound == null)
         {
-            if (string.IsNullOrEmpty(filename) || mSound == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            mDistance = distance;
-            mX = x;
-            mY = y;
-            mMapId = mapId;
-            mEntity = parent;
+        mDistance = distance;
+        mX = x;
+        mY = y;
+        mMapId = mapId;
+        mEntity = parent;
+        mSound.SetVolume(0);
+    }
+
+    public void UpdatePosition(int x, int y, Guid mapId)
+    {
+        mX = x;
+        mY = y;
+        mMapId = mapId;
+    }
+
+    public override bool Update()
+    {
+        if (base.Update())
+        {
+            UpdateSoundVolume();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private void UpdateSoundVolume()
+    {
+        if (mMapId == Guid.Empty)
+        {
             mSound.SetVolume(0);
+
+            return;
         }
 
-        public void UpdatePosition(int x, int y, Guid mapId)
+        var map = MapInstance.Get(mMapId);
+        if (map == null && mEntity != Globals.Me || Globals.Me == null)
         {
-            mX = x;
-            mY = y;
-            mMapId = mapId;
+            Stop();
+
+            return;
         }
 
-        public override bool Update()
+        var sameMap = mMapId == Globals.Me.MapId;
+        var inGrid = sameMap;
+        if (!inGrid && Globals.Me.MapInstance != null)
         {
-            if (base.Update())
+            var gridX = Globals.Me.MapInstance.GridX;
+            var gridY = Globals.Me.MapInstance.GridY;
+            for (var x = gridX - 1; x <= gridX + 1; x++)
             {
-                UpdateSoundVolume();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void UpdateSoundVolume()
-        {
-            if (mMapId == Guid.Empty)
-            {
-                mSound.SetVolume(0);
-
-                return;
-            }
-
-            var map = MapInstance.Get(mMapId);
-            if (map == null && mEntity != Globals.Me || Globals.Me == null)
-            {
-                Stop();
-
-                return;
-            }
-
-            var sameMap = mMapId == Globals.Me.MapId;
-            var inGrid = sameMap;
-            if (!inGrid && Globals.Me.MapInstance != null)
-            {
-                var gridX = Globals.Me.MapInstance.GridX;
-                var gridY = Globals.Me.MapInstance.GridY;
-                for (var x = gridX - 1; x <= gridX + 1; x++)
+                for (var y = gridY - 1; y <= gridY + 1; y++)
                 {
-                    for (var y = gridY - 1; y <= gridY + 1; y++)
+                    if (x >= 0 &&
+                        x < Globals.MapGridWidth &&
+                        y >= 0 &&
+                        y < Globals.MapGridHeight &&
+                        Globals.MapGrid[x, y] != Guid.Empty)
                     {
-                        if (x >= 0 &&
-                            x < Globals.MapGridWidth &&
-                            y >= 0 &&
-                            y < Globals.MapGridHeight &&
-                            Globals.MapGrid[x, y] != Guid.Empty)
+                        if (Globals.MapGrid[x, y] == mMapId)
                         {
-                            if (Globals.MapGrid[x, y] == mMapId)
-                            {
-                                inGrid = true;
+                            inGrid = true;
 
-                                break;
-                            }
+                            break;
                         }
                     }
                 }
             }
+        }
 
-            if ((mX == -1 || mY == -1 || mDistance <= 0) && sameMap)
+        if ((mX == -1 || mY == -1 || mDistance <= 0) && sameMap)
+        {
+            mSound.SetVolume(100);
+        }
+        else
+        {
+            if (mDistance > 0 && Globals.GridMaps.Contains(mMapId))
             {
-                mSound.SetVolume(100);
+                var volume = 100 - 100 / (mDistance + 1) * CalculateSoundDistance();
+                if (volume < 0)
+                {
+                    volume = 0f;
+                }
+
+                mSound.SetVolume((int)volume);
             }
             else
             {
-                if (mDistance > 0 && Globals.GridMaps.Contains(mMapId))
-                {
-                    var volume = 100 - 100 / (mDistance + 1) * CalculateSoundDistance();
-                    if (volume < 0)
-                    {
-                        volume = 0f;
-                    }
-
-                    mSound.SetVolume((int)volume);
-                }
-                else
-                {
-                    mSound.SetVolume(0);
-                }
+                mSound.SetVolume(0);
             }
         }
+    }
 
-        private float CalculateSoundDistance()
+    private float CalculateSoundDistance()
+    {
+        var distance = 0f;
+        var playerx = 0f;
+        var playery = 0f;
+        float soundx = 0;
+        float soundy = 0;
+        var map = MapInstance.Get(mMapId);
+        var pMap = MapInstance.Get(Globals.Me.MapId);
+        if (map != null && pMap != null)
         {
-            var distance = 0f;
-            var playerx = 0f;
-            var playery = 0f;
-            float soundx = 0;
-            float soundy = 0;
-            var map = MapInstance.Get(mMapId);
-            var pMap = MapInstance.Get(Globals.Me.MapId);
-            if (map != null && pMap != null)
+            playerx = pMap.GetX() + Globals.Me.X * Options.TileWidth + (Options.TileWidth / 2);
+            playery = pMap.GetY() + Globals.Me.Y * Options.TileHeight + (Options.TileHeight / 2);
+            if (mX == -1 || mY == -1 || mDistance == -1)
             {
-                playerx = pMap.GetX() + Globals.Me.X * Options.TileWidth + (Options.TileWidth / 2);
-                playery = pMap.GetY() + Globals.Me.Y * Options.TileHeight + (Options.TileHeight / 2);
-                if (mX == -1 || mY == -1 || mDistance == -1)
-                {
-                    var player = new Point() {
-                        X = (int)playerx,
-                        Y = (int)playery
-                    };
+                var player = new Point() {
+                    X = (int)playerx,
+                    Y = (int)playery
+                };
 
-                    var mapRect = new Rectangle(
-                        (int)map.GetX(), (int)map.GetY(), Options.MapWidth * Options.TileWidth,
-                        Options.MapHeight * Options.TileHeight
-                    );
+                var mapRect = new Rectangle(
+                    (int)map.GetX(), (int)map.GetY(), Options.MapWidth * Options.TileWidth,
+                    Options.MapHeight * Options.TileHeight
+                );
 
-                    distance = DistancePointToRectangle(player, mapRect) /
-                               ((Options.TileHeight + Options.TileWidth) / 2f);
-                }
-                else
-                {
-                    soundx = map.GetX() + mX * Options.TileWidth + (Options.TileWidth / 2);
-                    soundy = map.GetY() + mY * Options.TileHeight + (Options.TileHeight / 2);
-                    distance = (float) Math.Sqrt(Math.Pow(playerx - soundx, 2) + Math.Pow(playery - soundy, 2)) /
-                               ((Options.TileHeight + Options.TileWidth) / 2f);
-                }
-            }
-
-            return distance;
-        }
-
-        //Code Courtesy of  Philip Peterson. -- Released under MIT license.
-        //Obtained, 06/27/2015 from http://wiki.unity3d.com/index.php/Distance_from_a_point_to_a_rectangle
-        public static float DistancePointToRectangle(Point point, Rectangle rect)
-        {
-            //  Calculate a distance between a point and a rectangle.
-            //  The area around/in the rectangle is defined in terms of
-            //  several regions:
-            //
-            //  O--x
-            //  |
-            //  y
-            //
-            //
-            //        I   |    II    |  III
-            //      ======+==========+======   --yMin
-            //       VIII |  IX (in) |  IV
-            //      ======+==========+======   --yMax
-            //       VII  |    VI    |   V
-            //
-            //
-            //  Note that the +y direction is down because of Unity's GUI coordinates.
-
-            if (point.X < rect.X)
-            {
-                // Region I, VIII, or VII
-                if (point.Y < rect.Y)
-                {
-                    // I
-                    point.X = point.X - rect.X;
-                    point.Y = point.Y - rect.Y;
-
-                    return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
-                }
-                else if (point.Y > rect.Y + rect.Height)
-                {
-                    // VII
-                    point.X = point.X - rect.X;
-                    point.Y = point.Y - (rect.Y + rect.Height);
-
-                    return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
-                }
-                else
-                {
-                    // VIII
-                    return rect.X - point.X;
-                }
-            }
-            else if (point.X > rect.X + rect.Width)
-            {
-                // Region III, IV, or V
-                if (point.Y < rect.Y)
-                {
-                    // III
-                    point.X = point.X - (rect.X + rect.Width);
-                    point.Y = point.Y - rect.Y;
-
-                    return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
-                }
-                else if (point.Y > rect.Y + rect.Height)
-                {
-                    // V
-                    point.X = point.X - (rect.X + rect.Width);
-                    point.Y = point.Y - (rect.Y + rect.Height);
-
-                    return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
-                }
-                else
-                {
-                    // IV
-                    return point.X - (rect.X + rect.Width);
-                }
+                distance = DistancePointToRectangle(player, mapRect) /
+                           ((Options.TileHeight + Options.TileWidth) / 2f);
             }
             else
             {
-                // Region II, IX, or VI
-                if (point.Y < rect.Y)
-                {
-                    // II
-                    return rect.Y - point.Y;
-                }
-                else if (point.Y > rect.Y + rect.Height)
-                {
-                    // VI
-                    return point.Y - (rect.Y + rect.Height);
-                }
-                else
-                {
-                    // IX
-                    return 0f;
-                }
+                soundx = map.GetX() + mX * Options.TileWidth + (Options.TileWidth / 2);
+                soundy = map.GetY() + mY * Options.TileHeight + (Options.TileHeight / 2);
+                distance = (float) Math.Sqrt(Math.Pow(playerx - soundx, 2) + Math.Pow(playery - soundy, 2)) /
+                           ((Options.TileHeight + Options.TileWidth) / 2f);
             }
         }
 
+        return distance;
+    }
+
+    //Code Courtesy of  Philip Peterson. -- Released under MIT license.
+    //Obtained, 06/27/2015 from http://wiki.unity3d.com/index.php/Distance_from_a_point_to_a_rectangle
+    public static float DistancePointToRectangle(Point point, Rectangle rect)
+    {
+        //  Calculate a distance between a point and a rectangle.
+        //  The area around/in the rectangle is defined in terms of
+        //  several regions:
+        //
+        //  O--x
+        //  |
+        //  y
+        //
+        //
+        //        I   |    II    |  III
+        //      ======+==========+======   --yMin
+        //       VIII |  IX (in) |  IV
+        //      ======+==========+======   --yMax
+        //       VII  |    VI    |   V
+        //
+        //
+        //  Note that the +y direction is down because of Unity's GUI coordinates.
+
+        if (point.X < rect.X)
+        {
+            // Region I, VIII, or VII
+            if (point.Y < rect.Y)
+            {
+                // I
+                point.X = point.X - rect.X;
+                point.Y = point.Y - rect.Y;
+
+                return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
+            }
+            else if (point.Y > rect.Y + rect.Height)
+            {
+                // VII
+                point.X = point.X - rect.X;
+                point.Y = point.Y - (rect.Y + rect.Height);
+
+                return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
+            }
+            else
+            {
+                // VIII
+                return rect.X - point.X;
+            }
+        }
+        else if (point.X > rect.X + rect.Width)
+        {
+            // Region III, IV, or V
+            if (point.Y < rect.Y)
+            {
+                // III
+                point.X = point.X - (rect.X + rect.Width);
+                point.Y = point.Y - rect.Y;
+
+                return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
+            }
+            else if (point.Y > rect.Y + rect.Height)
+            {
+                // V
+                point.X = point.X - (rect.X + rect.Width);
+                point.Y = point.Y - (rect.Y + rect.Height);
+
+                return (float)Math.Sqrt(point.X * point.X + point.Y * point.Y);
+            }
+            else
+            {
+                // IV
+                return point.X - (rect.X + rect.Width);
+            }
+        }
+        else
+        {
+            // Region II, IX, or VI
+            if (point.Y < rect.Y)
+            {
+                // II
+                return rect.Y - point.Y;
+            }
+            else if (point.Y > rect.Y + rect.Height)
+            {
+                // VI
+                return point.Y - (rect.Y + rect.Height);
+            }
+            else
+            {
+                // IX
+                return 0f;
+            }
+        }
     }
 
 }

--- a/Intersect.Client/Core/Sounds/Sound.cs
+++ b/Intersect.Client/Core/Sounds/Sound.cs
@@ -4,107 +4,105 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.General;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Core.Sounds
+namespace Intersect.Client.Core.Sounds;
+
+
+public partial class Sound : ISound
 {
 
-    public partial class Sound : ISound
+    public bool Loaded { get; set; }
+
+    protected string mFilename;
+
+    public string Filename => mFilename;
+
+    protected bool mLoop;
+
+    protected int mLoopInterval;
+
+    protected GameAudioInstance mSound;
+
+    protected float mVolume;
+
+    private long mStoppedTime = -1;
+
+    public Sound(string filename, bool loop, int loopInterval)
     {
-
-        public bool Loaded { get; set; }
-
-        protected string mFilename;
-
-        public string Filename => mFilename;
-
-        protected bool mLoop;
-
-        protected int mLoopInterval;
-
-        protected GameAudioInstance mSound;
-
-        protected float mVolume;
-
-        private long mStoppedTime = -1;
-
-        public Sound(string filename, bool loop, int loopInterval)
+        if (string.IsNullOrWhiteSpace(filename))
         {
-            if (string.IsNullOrWhiteSpace(filename))
-            {
-                return;
-            }
-
-            mFilename = GameContentManager.RemoveExtension(filename).ToLower();
-            mLoop = loop;
-            mLoopInterval = loopInterval;
-            var sound = Globals.ContentManager.GetSound(mFilename);
-            if (sound != null)
-            {
-                mSound = sound.CreateInstance();
-                mSound.IsLooping = mLoop && mLoopInterval <= 0;
-               
-                mSound.SetVolume(100);
-                mSound.Play();
-                Loaded = true;
-            }
+            return;
         }
 
-        public bool Loop
+        mFilename = GameContentManager.RemoveExtension(filename).ToLower();
+        mLoop = loop;
+        mLoopInterval = loopInterval;
+        var sound = Globals.ContentManager.GetSound(mFilename);
+        if (sound != null)
         {
-            get => mLoop;
-            set
+            mSound = sound.CreateInstance();
+            mSound.IsLooping = mLoop && mLoopInterval <= 0;
+           
+            mSound.SetVolume(100);
+            mSound.Play();
+            Loaded = true;
+        }
+    }
+
+    public bool Loop
+    {
+        get => mLoop;
+        set
+        {
+            mLoop = value;
+            if (mSound != null)
             {
-                mLoop = value;
-                if (mSound != null)
-                {
-                    mSound.IsLooping = mLoop;
-                }
+                mSound.IsLooping = mLoop;
             }
         }
+    }
 
-        public virtual bool Update()
+    public virtual bool Update()
+    {
+        if (!Loaded)
         {
-            if (!Loaded)
-            {
-                return false;
-            }
-
-            if (mLoop && mLoopInterval > 0 && mSound?.State == GameAudioInstance.AudioInstanceState.Stopped)
-            {
-                if (mStoppedTime == -1)
-                {
-                    mStoppedTime = Timing.Global.MillisecondsUtc;
-                }
-                else
-                {
-                    if (mStoppedTime + mLoopInterval < Timing.Global.MillisecondsUtc)
-                    {
-                        mSound.Play();
-                        mStoppedTime = -1;
-                    }
-                }
-                return true;
-            }
-            else if (mLoop || mSound?.State != GameAudioInstance.AudioInstanceState.Stopped)
-            {
-                return true;
-            }
-
-            Stop();
-
             return false;
         }
 
-        public virtual void Stop()
+        if (mLoop && mLoopInterval > 0 && mSound?.State == GameAudioInstance.AudioInstanceState.Stopped)
         {
-            if (!Loaded)
+            if (mStoppedTime == -1)
             {
-                return;
+                mStoppedTime = Timing.Global.MillisecondsUtc;
             }
-
-            mSound?.Dispose();
-            Loaded = false;
+            else
+            {
+                if (mStoppedTime + mLoopInterval < Timing.Global.MillisecondsUtc)
+                {
+                    mSound.Play();
+                    mStoppedTime = -1;
+                }
+            }
+            return true;
+        }
+        else if (mLoop || mSound?.State != GameAudioInstance.AudioInstanceState.Stopped)
+        {
+            return true;
         }
 
+        Stop();
+
+        return false;
+    }
+
+    public virtual void Stop()
+    {
+        if (!Loaded)
+        {
+            return;
+        }
+
+        mSound?.Dispose();
+        Loaded = false;
     }
 
 }

--- a/Intersect.Client/Entities/Animation.cs
+++ b/Intersect.Client/Entities/Animation.cs
@@ -8,481 +8,479 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class Animation : IAnimation
 {
 
-    public partial class Animation : IAnimation
+    public bool AutoRotate { get; set; }
+
+    private bool disposed = false;
+
+    public bool Hidden { get; set; }
+
+    public bool InfiniteLoop { get; set; }
+
+    private bool mDisposeNextDraw;
+
+    private int mLowerFrame;
+
+    private int mLowerLoop;
+
+    private long mLowerTimer;
+
+    private Entity mParent;
+
+    private Direction mRenderDir;
+
+    private float mRenderX;
+
+    private float mRenderY;
+
+    private bool mShowLower = true;
+
+    private bool mShowUpper = true;
+
+    private MapSound mSound;
+
+    private long mStartTime = Timing.Global.MillisecondsUtc;
+
+    private int mUpperFrame;
+
+    private int mUpperLoop;
+
+    private long mUpperTimer;
+
+    private bool mUseExternalRotation;
+
+    private float mExternalRotation;
+
+    public AnimationBase MyBase { get; set; }
+
+    public Point Size => CalculateAnimationSize();
+
+    private int mZDimension = -1;
+
+    public Animation(
+        AnimationBase animBase,
+        bool loopForever,
+        bool autoRotate = false,
+        int zDimension = -1,
+        Entity parent = null
+    )
     {
-
-        public bool AutoRotate { get; set; }
-
-        private bool disposed = false;
-
-        public bool Hidden { get; set; }
-
-        public bool InfiniteLoop { get; set; }
-
-        private bool mDisposeNextDraw;
-
-        private int mLowerFrame;
-
-        private int mLowerLoop;
-
-        private long mLowerTimer;
-
-        private Entity mParent;
-
-        private Direction mRenderDir;
-
-        private float mRenderX;
-
-        private float mRenderY;
-
-        private bool mShowLower = true;
-
-        private bool mShowUpper = true;
-
-        private MapSound mSound;
-
-        private long mStartTime = Timing.Global.MillisecondsUtc;
-
-        private int mUpperFrame;
-
-        private int mUpperLoop;
-
-        private long mUpperTimer;
-
-        private bool mUseExternalRotation;
-
-        private float mExternalRotation;
-
-        public AnimationBase MyBase { get; set; }
-
-        public Point Size => CalculateAnimationSize();
-
-        private int mZDimension = -1;
-
-        public Animation(
-            AnimationBase animBase,
-            bool loopForever,
-            bool autoRotate = false,
-            int zDimension = -1,
-            Entity parent = null
-        )
+        MyBase = animBase;
+        mParent = parent;
+        if (MyBase != null)
         {
-            MyBase = animBase;
-            mParent = parent;
-            if (MyBase != null)
-            {
-                mLowerLoop = animBase.Lower.LoopCount;
-                mUpperLoop = animBase.Upper.LoopCount;
-                mLowerTimer = Timing.Global.MillisecondsUtc + animBase.Lower.FrameSpeed;
-                mUpperTimer = Timing.Global.MillisecondsUtc + animBase.Upper.FrameSpeed;
-                InfiniteLoop = loopForever;
-                AutoRotate = autoRotate;
-                mZDimension = zDimension;
-                mSound = Audio.AddMapSound(MyBase.Sound, 0, 0, Guid.Empty, loopForever, 0, 12, parent);
-                lock (Graphics.AnimationLock)
-                {
-                    Graphics.LiveAnimations.Add(this);
-                }
-            }
-            else
-            {
-                Dispose();
-            }
-        }
-
-        public void Draw(bool upper = false, bool alternate = false)
-        {
-            if (Hidden)
-            {
-                return;
-            }
-
-            if (!upper && alternate != MyBase.Lower.AlternateRenderLayer)
-            {
-                return;
-            }
-
-            if (upper && alternate != MyBase.Upper.AlternateRenderLayer)
-            {
-                return;
-            }
-
-            var rotationDegrees = 0f;
-            var dontRotate = upper && MyBase.Upper.DisableRotations || !upper && MyBase.Lower.DisableRotations;
-
-            if (mUseExternalRotation)
-            {
-                rotationDegrees = mExternalRotation;
-            }
-
-            if ((AutoRotate || mRenderDir != Direction.None) && !dontRotate && !mUseExternalRotation)
-            {
-                switch (mRenderDir)
-                {
-                    case Direction.Up:
-                        rotationDegrees = 0f;
-
-                        break;
-                    case Direction.Down:
-                        rotationDegrees = 180f;
-
-                        break;
-                    case Direction.Left:
-                        rotationDegrees = 270f;
-
-                        break;
-                    case Direction.Right:
-                        rotationDegrees = 90f;
-
-                        break;
-                    case Direction.UpLeft:
-                        rotationDegrees = 315f;
-
-                        break;
-                    case Direction.UpRight:
-                        rotationDegrees = 45f;
-
-                        break;
-                    case Direction.DownRight:
-                        rotationDegrees = 135f;
-
-                        break;
-                    case Direction.DownLeft:
-                        rotationDegrees = 225f;
-
-                        break;
-                }
-            }
-
-            if (!upper && mShowLower && mZDimension < 1 || !upper && mShowLower && mZDimension > 0)
-            {
-                //Draw Lower
-                var tex = Globals.ContentManager.GetTexture(
-                    Framework.Content.TextureType.Animation, MyBase.Lower.Sprite
-                );
-
-                if (tex != null)
-                {
-                    if (MyBase.Lower.XFrames > 0 && MyBase.Lower.YFrames > 0)
-                    {
-                        var frameWidth = tex.GetWidth() / MyBase.Lower.XFrames;
-                        var frameHeight = tex.GetHeight() / MyBase.Lower.YFrames;
-                        Graphics.DrawGameTexture(
-                            tex,
-                            new FloatRect(
-                                mLowerFrame % MyBase.Lower.XFrames * frameWidth,
-                                (float)Math.Floor((double)mLowerFrame / MyBase.Lower.XFrames) * frameHeight,
-                                frameWidth, frameHeight
-                            ),
-                            new FloatRect(
-                                mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
-                            ), Color.White, null, GameBlendModes.None, null, rotationDegrees
-                        );
-                    }
-                }
-
-                var offsetX = MyBase.Lower.Lights[mLowerFrame].OffsetX;
-                var offsetY = MyBase.Lower.Lights[mLowerFrame].OffsetY;
-                var offset = RotatePoint(
-                    new Point(offsetX, offsetY), new Point(0, 0), rotationDegrees + 180
-                );
-
-                Graphics.AddLight(
-                    (int)mRenderX - offset.X, (int)mRenderY - offset.Y, MyBase.Lower.Lights[mLowerFrame].Size,
-                    MyBase.Lower.Lights[mLowerFrame].Intensity, MyBase.Lower.Lights[mLowerFrame].Expand,
-                    MyBase.Lower.Lights[mLowerFrame].Color
-                );
-            }
-
-            if (upper && mShowUpper && mZDimension != 0 || upper && mShowUpper && mZDimension == 0)
-            {
-                //Draw Upper
-                var tex = Globals.ContentManager.GetTexture(
-                    Framework.Content.TextureType.Animation, MyBase.Upper.Sprite
-                );
-
-                if (tex != null)
-                {
-                    if (MyBase.Upper.XFrames > 0 && MyBase.Upper.YFrames > 0)
-                    {
-                        var frameWidth = tex.GetWidth() / MyBase.Upper.XFrames;
-                        var frameHeight = tex.GetHeight() / MyBase.Upper.YFrames;
-
-                        Graphics.DrawGameTexture(
-                            tex,
-                            new FloatRect(
-                                mUpperFrame % MyBase.Upper.XFrames * frameWidth,
-                                (float)Math.Floor((double)mUpperFrame / MyBase.Upper.XFrames) * frameHeight,
-                                frameWidth, frameHeight
-                            ),
-                            new FloatRect(
-                                mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
-                            ), Color.White, null, GameBlendModes.None, null, rotationDegrees
-                        );
-                    }
-                }
-
-                var offsetX = MyBase.Upper.Lights[mUpperFrame].OffsetX;
-                var offsetY = MyBase.Upper.Lights[mUpperFrame].OffsetY;
-                var offset = RotatePoint(
-                    new Point(offsetX, offsetY), new Point(0, 0), rotationDegrees + 180
-                );
-
-                Graphics.AddLight(
-                    (int)mRenderX - offset.X, (int)mRenderY - offset.Y, MyBase.Upper.Lights[mUpperFrame].Size,
-                    MyBase.Upper.Lights[mUpperFrame].Intensity, MyBase.Upper.Lights[mUpperFrame].Expand,
-                    MyBase.Upper.Lights[mUpperFrame].Color
-                );
-            }
-        }
-
-        public void EndDraw()
-        {
-            if (mDisposeNextDraw)
-            {
-                Dispose();
-            }
-        }
-
-        static Point RotatePoint(Point pointToRotate, Point centerPoint, double angleInDegrees)
-        {
-            var angleInRadians = angleInDegrees * (Math.PI / 180);
-            var cosTheta = Math.Cos(angleInRadians);
-            var sinTheta = Math.Sin(angleInRadians);
-
-            return new Point {
-                X = (int)(cosTheta * (pointToRotate.X - centerPoint.X) -
-                           sinTheta * (pointToRotate.Y - centerPoint.Y) +
-                           centerPoint.X),
-                Y = (int)(sinTheta * (pointToRotate.X - centerPoint.X) +
-                           cosTheta * (pointToRotate.Y - centerPoint.Y) +
-                           centerPoint.Y)
-            };
-        }
-
-        public void Hide()
-        {
-            Hidden = true;
-        }
-
-        public void Show()
-        {
-            Hidden = false;
-        }
-
-        public bool ParentGone()
-        {
-            if (mParent != null && mParent.IsDisposed())
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public void Dispose()
-        {
-            if (disposed)
-            {
-                return;
-            }
-
+            mLowerLoop = animBase.Lower.LoopCount;
+            mUpperLoop = animBase.Upper.LoopCount;
+            mLowerTimer = Timing.Global.MillisecondsUtc + animBase.Lower.FrameSpeed;
+            mUpperTimer = Timing.Global.MillisecondsUtc + animBase.Upper.FrameSpeed;
+            InfiniteLoop = loopForever;
+            AutoRotate = autoRotate;
+            mZDimension = zDimension;
+            mSound = Audio.AddMapSound(MyBase.Sound, 0, 0, Guid.Empty, loopForever, 0, 12, parent);
             lock (Graphics.AnimationLock)
             {
-                if (mSound != null)
-                {
-                    mSound.Loop = false;
-                    if (!MyBase.CompleteSound)
-                    {
-                        mSound.Stop();
-                    }
-
-                    mSound = null;
-                }
-
-                Graphics.LiveAnimations.Remove(this);
-                disposed = true;
+                Graphics.LiveAnimations.Add(this);
             }
         }
-
-        public void DisposeNextDraw()
+        else
         {
-            mDisposeNextDraw = true;
+            Dispose();
+        }
+    }
+
+    public void Draw(bool upper = false, bool alternate = false)
+    {
+        if (Hidden)
+        {
+            return;
         }
 
-        public bool Disposed()
+        if (!upper && alternate != MyBase.Lower.AlternateRenderLayer)
         {
-            return disposed;
+            return;
         }
 
-        public void SetPosition(float worldX, float worldY, int mapx, int mapy, Guid mapId, Direction dir, int z = 0)
+        if (upper && alternate != MyBase.Upper.AlternateRenderLayer)
         {
-            mRenderX = worldX;
-            mRenderY = worldY;
-            if (mSound != null)
+            return;
+        }
+
+        var rotationDegrees = 0f;
+        var dontRotate = upper && MyBase.Upper.DisableRotations || !upper && MyBase.Lower.DisableRotations;
+
+        if (mUseExternalRotation)
+        {
+            rotationDegrees = mExternalRotation;
+        }
+
+        if ((AutoRotate || mRenderDir != Direction.None) && !dontRotate && !mUseExternalRotation)
+        {
+            switch (mRenderDir)
             {
-                mSound.UpdatePosition(mapx, mapy, mapId);
-            }
+                case Direction.Up:
+                    rotationDegrees = 0f;
 
-            if (dir > Direction.None)
-            {
-                mRenderDir = dir;
-            }
+                    break;
+                case Direction.Down:
+                    rotationDegrees = 180f;
 
-            mZDimension = z;
-        }
+                    break;
+                case Direction.Left:
+                    rotationDegrees = 270f;
 
-        public void Update()
-        {
-            if (disposed)
-            {
-                return;
-            }
+                    break;
+                case Direction.Right:
+                    rotationDegrees = 90f;
 
-            if (MyBase != null)
-            {
-                if (mSound != null)
-                {
-                    mSound.Update();
-                }
+                    break;
+                case Direction.UpLeft:
+                    rotationDegrees = 315f;
 
-                //Calculate Frames
-                var elapsedTime = Timing.Global.MillisecondsUtc - mStartTime;
+                    break;
+                case Direction.UpRight:
+                    rotationDegrees = 45f;
 
-                //Lower
-                if (MyBase.Lower.FrameCount > 0 && MyBase.Lower.FrameSpeed > 0)
-                {
-                    var realFrameCount = Math.Min(MyBase.Lower.FrameCount, MyBase.Lower.XFrames * MyBase.Lower.YFrames);
-                    var lowerFrame = (int)Math.Floor(elapsedTime / (float)MyBase.Lower.FrameSpeed);
-                    var lowerLoops = (int)Math.Floor(lowerFrame / (float)realFrameCount);
-                    if (lowerLoops > mLowerLoop && !InfiniteLoop)
-                    {
-                        mShowLower = false;
-                    }
-                    else
-                    {
-                        mLowerFrame = lowerFrame - lowerLoops * realFrameCount;
-                    }
-                }
+                    break;
+                case Direction.DownRight:
+                    rotationDegrees = 135f;
 
-                //Upper
-                if (MyBase.Upper.FrameCount > 0 && MyBase.Upper.FrameSpeed > 0)
-                {
-                    var realFrameCount = Math.Min(MyBase.Upper.FrameCount, MyBase.Upper.XFrames * MyBase.Upper.YFrames);
-                    var upperFrame = (int)Math.Floor(elapsedTime / (float)MyBase.Upper.FrameSpeed);
-                    var upperLoops = (int)Math.Floor(upperFrame / (float)realFrameCount);
-                    if (upperLoops > mUpperLoop && !InfiniteLoop)
-                    {
-                        mShowUpper = false;
-                    }
-                    else
-                    {
-                        mUpperFrame = upperFrame - upperLoops * realFrameCount;
-                    }
-                }
+                    break;
+                case Direction.DownLeft:
+                    rotationDegrees = 225f;
 
-                if (!mShowLower && !mShowUpper)
-                {
-                    Dispose();
-                }
+                    break;
             }
         }
 
-        public Point CalculateAnimationSize()
+        if (!upper && mShowLower && mZDimension < 1 || !upper && mShowLower && mZDimension > 0)
         {
-            var size = new Point(0, 0);
+            //Draw Lower
+            var tex = Globals.ContentManager.GetTexture(
+                Framework.Content.TextureType.Animation, MyBase.Lower.Sprite
+            );
 
-            var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Animation, MyBase.Lower.Sprite);
             if (tex != null)
             {
                 if (MyBase.Lower.XFrames > 0 && MyBase.Lower.YFrames > 0)
                 {
                     var frameWidth = tex.GetWidth() / MyBase.Lower.XFrames;
                     var frameHeight = tex.GetHeight() / MyBase.Lower.YFrames;
-                    if (frameWidth > size.X)
-                    {
-                        size.X = frameWidth;
-                    }
-
-                    if (frameHeight > size.Y)
-                    {
-                        size.Y = frameHeight;
-                    }
+                    Graphics.DrawGameTexture(
+                        tex,
+                        new FloatRect(
+                            mLowerFrame % MyBase.Lower.XFrames * frameWidth,
+                            (float)Math.Floor((double)mLowerFrame / MyBase.Lower.XFrames) * frameHeight,
+                            frameWidth, frameHeight
+                        ),
+                        new FloatRect(
+                            mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
+                        ), Color.White, null, GameBlendModes.None, null, rotationDegrees
+                    );
                 }
             }
 
-            tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Animation, MyBase.Upper.Sprite);
+            var offsetX = MyBase.Lower.Lights[mLowerFrame].OffsetX;
+            var offsetY = MyBase.Lower.Lights[mLowerFrame].OffsetY;
+            var offset = RotatePoint(
+                new Point(offsetX, offsetY), new Point(0, 0), rotationDegrees + 180
+            );
+
+            Graphics.AddLight(
+                (int)mRenderX - offset.X, (int)mRenderY - offset.Y, MyBase.Lower.Lights[mLowerFrame].Size,
+                MyBase.Lower.Lights[mLowerFrame].Intensity, MyBase.Lower.Lights[mLowerFrame].Expand,
+                MyBase.Lower.Lights[mLowerFrame].Color
+            );
+        }
+
+        if (upper && mShowUpper && mZDimension != 0 || upper && mShowUpper && mZDimension == 0)
+        {
+            //Draw Upper
+            var tex = Globals.ContentManager.GetTexture(
+                Framework.Content.TextureType.Animation, MyBase.Upper.Sprite
+            );
+
             if (tex != null)
             {
                 if (MyBase.Upper.XFrames > 0 && MyBase.Upper.YFrames > 0)
                 {
                     var frameWidth = tex.GetWidth() / MyBase.Upper.XFrames;
                     var frameHeight = tex.GetHeight() / MyBase.Upper.YFrames;
-                    if (frameWidth > size.X)
-                    {
-                        size.X = frameWidth;
-                    }
 
-                    if (frameHeight > size.Y)
-                    {
-                        size.Y = frameHeight;
-                    }
+                    Graphics.DrawGameTexture(
+                        tex,
+                        new FloatRect(
+                            mUpperFrame % MyBase.Upper.XFrames * frameWidth,
+                            (float)Math.Floor((double)mUpperFrame / MyBase.Upper.XFrames) * frameHeight,
+                            frameWidth, frameHeight
+                        ),
+                        new FloatRect(
+                            mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
+                        ), Color.White, null, GameBlendModes.None, null, rotationDegrees
+                    );
                 }
             }
 
-            foreach (var light in MyBase.Lower.Lights)
-            {
-                if (light != null)
-                {
-                    if (light.Size + Math.Abs(light.OffsetX) > size.X)
-                    {
-                        size.X = light.Size + light.OffsetX;
-                    }
+            var offsetX = MyBase.Upper.Lights[mUpperFrame].OffsetX;
+            var offsetY = MyBase.Upper.Lights[mUpperFrame].OffsetY;
+            var offset = RotatePoint(
+                new Point(offsetX, offsetY), new Point(0, 0), rotationDegrees + 180
+            );
 
-                    if (light.Size + Math.Abs(light.OffsetY) > size.Y)
-                    {
-                        size.Y = light.Size + light.OffsetY;
-                    }
-                }
-            }
+            Graphics.AddLight(
+                (int)mRenderX - offset.X, (int)mRenderY - offset.Y, MyBase.Upper.Lights[mUpperFrame].Size,
+                MyBase.Upper.Lights[mUpperFrame].Intensity, MyBase.Upper.Lights[mUpperFrame].Expand,
+                MyBase.Upper.Lights[mUpperFrame].Color
+            );
+        }
+    }
 
-            foreach (var light in MyBase.Upper.Lights)
-            {
-                if (light != null)
-                {
-                    if (light.Size + Math.Abs(light.OffsetX) > size.X)
-                    {
-                        size.X = light.Size + light.OffsetX;
-                    }
+    public void EndDraw()
+    {
+        if (mDisposeNextDraw)
+        {
+            Dispose();
+        }
+    }
 
-                    if (light.Size + Math.Abs(light.OffsetY) > size.Y)
-                    {
-                        size.Y = light.Size + light.OffsetY;
-                    }
-                }
-            }
+    static Point RotatePoint(Point pointToRotate, Point centerPoint, double angleInDegrees)
+    {
+        var angleInRadians = angleInDegrees * (Math.PI / 180);
+        var cosTheta = Math.Cos(angleInRadians);
+        var sinTheta = Math.Sin(angleInRadians);
 
-            return size;
+        return new Point {
+            X = (int)(cosTheta * (pointToRotate.X - centerPoint.X) -
+                       sinTheta * (pointToRotate.Y - centerPoint.Y) +
+                       centerPoint.X),
+            Y = (int)(sinTheta * (pointToRotate.X - centerPoint.X) +
+                       cosTheta * (pointToRotate.Y - centerPoint.Y) +
+                       centerPoint.Y)
+        };
+    }
+
+    public void Hide()
+    {
+        Hidden = true;
+    }
+
+    public void Show()
+    {
+        Hidden = false;
+    }
+
+    public bool ParentGone()
+    {
+        if (mParent != null && mParent.IsDisposed())
+        {
+            return true;
         }
 
-        public void SetDir(Direction dir)
+        return false;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        lock (Graphics.AnimationLock)
+        {
+            if (mSound != null)
+            {
+                mSound.Loop = false;
+                if (!MyBase.CompleteSound)
+                {
+                    mSound.Stop();
+                }
+
+                mSound = null;
+            }
+
+            Graphics.LiveAnimations.Remove(this);
+            disposed = true;
+        }
+    }
+
+    public void DisposeNextDraw()
+    {
+        mDisposeNextDraw = true;
+    }
+
+    public bool Disposed()
+    {
+        return disposed;
+    }
+
+    public void SetPosition(float worldX, float worldY, int mapx, int mapy, Guid mapId, Direction dir, int z = 0)
+    {
+        mRenderX = worldX;
+        mRenderY = worldY;
+        if (mSound != null)
+        {
+            mSound.UpdatePosition(mapx, mapy, mapId);
+        }
+
+        if (dir > Direction.None)
         {
             mRenderDir = dir;
         }
 
-        public void SetRotation(float angleInDegrees)
+        mZDimension = z;
+    }
+
+    public void Update()
+    {
+        if (disposed)
         {
-            mUseExternalRotation = true;
-            mExternalRotation = angleInDegrees;
+            return;
         }
 
-        public void SetRotation(bool toggle)
+        if (MyBase != null)
         {
-            mUseExternalRotation = toggle;
+            if (mSound != null)
+            {
+                mSound.Update();
+            }
+
+            //Calculate Frames
+            var elapsedTime = Timing.Global.MillisecondsUtc - mStartTime;
+
+            //Lower
+            if (MyBase.Lower.FrameCount > 0 && MyBase.Lower.FrameSpeed > 0)
+            {
+                var realFrameCount = Math.Min(MyBase.Lower.FrameCount, MyBase.Lower.XFrames * MyBase.Lower.YFrames);
+                var lowerFrame = (int)Math.Floor(elapsedTime / (float)MyBase.Lower.FrameSpeed);
+                var lowerLoops = (int)Math.Floor(lowerFrame / (float)realFrameCount);
+                if (lowerLoops > mLowerLoop && !InfiniteLoop)
+                {
+                    mShowLower = false;
+                }
+                else
+                {
+                    mLowerFrame = lowerFrame - lowerLoops * realFrameCount;
+                }
+            }
+
+            //Upper
+            if (MyBase.Upper.FrameCount > 0 && MyBase.Upper.FrameSpeed > 0)
+            {
+                var realFrameCount = Math.Min(MyBase.Upper.FrameCount, MyBase.Upper.XFrames * MyBase.Upper.YFrames);
+                var upperFrame = (int)Math.Floor(elapsedTime / (float)MyBase.Upper.FrameSpeed);
+                var upperLoops = (int)Math.Floor(upperFrame / (float)realFrameCount);
+                if (upperLoops > mUpperLoop && !InfiniteLoop)
+                {
+                    mShowUpper = false;
+                }
+                else
+                {
+                    mUpperFrame = upperFrame - upperLoops * realFrameCount;
+                }
+            }
+
+            if (!mShowLower && !mShowUpper)
+            {
+                Dispose();
+            }
         }
     }
 
+    public Point CalculateAnimationSize()
+    {
+        var size = new Point(0, 0);
+
+        var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Animation, MyBase.Lower.Sprite);
+        if (tex != null)
+        {
+            if (MyBase.Lower.XFrames > 0 && MyBase.Lower.YFrames > 0)
+            {
+                var frameWidth = tex.GetWidth() / MyBase.Lower.XFrames;
+                var frameHeight = tex.GetHeight() / MyBase.Lower.YFrames;
+                if (frameWidth > size.X)
+                {
+                    size.X = frameWidth;
+                }
+
+                if (frameHeight > size.Y)
+                {
+                    size.Y = frameHeight;
+                }
+            }
+        }
+
+        tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Animation, MyBase.Upper.Sprite);
+        if (tex != null)
+        {
+            if (MyBase.Upper.XFrames > 0 && MyBase.Upper.YFrames > 0)
+            {
+                var frameWidth = tex.GetWidth() / MyBase.Upper.XFrames;
+                var frameHeight = tex.GetHeight() / MyBase.Upper.YFrames;
+                if (frameWidth > size.X)
+                {
+                    size.X = frameWidth;
+                }
+
+                if (frameHeight > size.Y)
+                {
+                    size.Y = frameHeight;
+                }
+            }
+        }
+
+        foreach (var light in MyBase.Lower.Lights)
+        {
+            if (light != null)
+            {
+                if (light.Size + Math.Abs(light.OffsetX) > size.X)
+                {
+                    size.X = light.Size + light.OffsetX;
+                }
+
+                if (light.Size + Math.Abs(light.OffsetY) > size.Y)
+                {
+                    size.Y = light.Size + light.OffsetY;
+                }
+            }
+        }
+
+        foreach (var light in MyBase.Upper.Lights)
+        {
+            if (light != null)
+            {
+                if (light.Size + Math.Abs(light.OffsetX) > size.X)
+                {
+                    size.X = light.Size + light.OffsetX;
+                }
+
+                if (light.Size + Math.Abs(light.OffsetY) > size.Y)
+                {
+                    size.Y = light.Size + light.OffsetY;
+                }
+            }
+        }
+
+        return size;
+    }
+
+    public void SetDir(Direction dir)
+    {
+        mRenderDir = dir;
+    }
+
+    public void SetRotation(float angleInDegrees)
+    {
+        mUseExternalRotation = true;
+        mExternalRotation = angleInDegrees;
+    }
+
+    public void SetRotation(bool toggle)
+    {
+        mUseExternalRotation = toggle;
+    }
 }

--- a/Intersect.Client/Entities/ChatBubble.cs
+++ b/Intersect.Client/Entities/ChatBubble.cs
@@ -5,198 +5,196 @@ using Intersect.Client.Framework.Graphics;
 using Intersect.Client.General;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class ChatBubble
 {
 
-    public partial class ChatBubble
+    private GameTexture mBubbleTex;
+
+    private Entity mOwner;
+
+    private Color mRenderColor;
+
+    private long mRenderTimer;
+
+    private string mSourceText;
+
+    private Point[,] mTexSections;
+
+    private string[] mText;
+
+    private Rectangle mTextBounds;
+
+    private Rectangle mTextureBounds;
+
+    public ChatBubble(Entity owner, string text)
     {
-
-        private GameTexture mBubbleTex;
-
-        private Entity mOwner;
-
-        private Color mRenderColor;
-
-        private long mRenderTimer;
-
-        private string mSourceText;
-
-        private Point[,] mTexSections;
-
-        private string[] mText;
-
-        private Rectangle mTextBounds;
-
-        private Rectangle mTextureBounds;
-
-        public ChatBubble(Entity owner, string text)
+        if (string.IsNullOrEmpty(text))
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return;
-            }
-
-            mOwner = owner;
-            mSourceText = text;
-            mRenderTimer = Timing.Global.MillisecondsUtc + 5000;
-            mBubbleTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "chatbubble.png");
+            return;
         }
 
-        public bool Update()
-        {
-            if (mRenderTimer < Timing.Global.MillisecondsUtc)
-            {
-                return false;
-            }
+        mOwner = owner;
+        mSourceText = text;
+        mRenderTimer = Timing.Global.MillisecondsUtc + 5000;
+        mBubbleTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "chatbubble.png");
+    }
 
-            return true;
+    public bool Update()
+    {
+        if (mRenderTimer < Timing.Global.MillisecondsUtc)
+        {
+            return false;
         }
 
-        public float Draw(float yoffset = 0f)
+        return true;
+    }
+
+    public float Draw(float yoffset = 0f)
+    {
+        if (mText == null && mSourceText.Trim().Length > 0)
         {
-            if (mText == null && mSourceText.Trim().Length > 0)
+            mText = Interface.Interface.WrapText(mSourceText, 200, Graphics.ChatBubbleFont);
+        }
+
+        if (mText == null)
+        {
+            return 0f;
+        }
+
+        var x = (int)Math.Ceiling(mOwner.Origin.X);
+        var y = (int) Math.Ceiling(mOwner.GetLabelLocation(LabelType.ChatBubble));
+
+        if (mTextureBounds.Width == 0)
+        {
+            //Gotta Calculate Bounds
+            for (var i = (mText?.Length ?? 0) - 1; i > -1; i--)
             {
-                mText = Interface.Interface.WrapText(mSourceText, 200, Graphics.ChatBubbleFont);
+                var textSize = Graphics.Renderer.MeasureText(mText[i], Graphics.ChatBubbleFont, 1);
+                if (textSize.X > mTextureBounds.Width)
+                {
+                    mTextureBounds.Width = (int) textSize.X + 16;
+                }
+
+                mTextureBounds.Height += (int) textSize.Y + 2;
+                if (textSize.X > mTextBounds.Width)
+                {
+                    mTextBounds.Width = (int) textSize.X;
+                }
+
+                mTextBounds.Height += (int) textSize.Y + 2;
             }
 
-            if (mText == null)
+            mTextureBounds.Height += 16;
+            if (mTextureBounds.Width < 48)
             {
-                return 0f;
+                mTextureBounds.Width = 48;
             }
 
-            var x = (int)Math.Ceiling(mOwner.Origin.X);
-            var y = (int) Math.Ceiling(mOwner.GetLabelLocation(LabelType.ChatBubble));
-
-            if (mTextureBounds.Width == 0)
+            if (mTextureBounds.Height < 32)
             {
-                //Gotta Calculate Bounds
-                for (var i = (mText?.Length ?? 0) - 1; i > -1; i--)
+                mTextureBounds.Height = 32;
+            }
+
+            mTextureBounds.Width = (int) (Math.Round(mTextureBounds.Width / 8.0) * 8.0);
+            mTextureBounds.Height = (int) (Math.Round(mTextureBounds.Height / 8.0) * 8.0);
+            if (mTextureBounds.Width / 8 % 2 != 0)
+            {
+                mTextureBounds.Width += 8;
+            }
+
+            mTexSections = new Point[mTextureBounds.Width / 8, mTextureBounds.Height / 8];
+            for (var x1 = 0; x1 < mTextureBounds.Width / 8; x1++)
+            {
+                for (var y1 = 0; y1 < mTextureBounds.Height / 8; y1++)
                 {
-                    var textSize = Graphics.Renderer.MeasureText(mText[i], Graphics.ChatBubbleFont, 1);
-                    if (textSize.X > mTextureBounds.Width)
+                    if (x1 == 0)
                     {
-                        mTextureBounds.Width = (int) textSize.X + 16;
+                        mTexSections[x1, y1].X = 0;
+                    }
+                    else if (x1 == 1)
+                    {
+                        mTexSections[x1, y1].X = 1;
+                    }
+                    else if (x1 == mTextureBounds.Width / 16 - 1)
+                    {
+                        mTexSections[x1, y1].X = 3;
+                    }
+                    else if (x1 == mTextureBounds.Width / 16)
+                    {
+                        mTexSections[x1, y1].X = 4;
+                    }
+                    else if (x1 == mTextureBounds.Width / 8 - 1)
+                    {
+                        mTexSections[x1, y1].X = 7;
+                    }
+                    else if (x1 == mTextureBounds.Width / 8 - 2)
+                    {
+                        mTexSections[x1, y1].X = 6;
+                    }
+                    else
+                    {
+                        mTexSections[x1, y1].X = 2;
                     }
 
-                    mTextureBounds.Height += (int) textSize.Y + 2;
-                    if (textSize.X > mTextBounds.Width)
+                    if (y1 == 0)
                     {
-                        mTextBounds.Width = (int) textSize.X;
+                        mTexSections[x1, y1].Y = 0;
                     }
-
-                    mTextBounds.Height += (int) textSize.Y + 2;
-                }
-
-                mTextureBounds.Height += 16;
-                if (mTextureBounds.Width < 48)
-                {
-                    mTextureBounds.Width = 48;
-                }
-
-                if (mTextureBounds.Height < 32)
-                {
-                    mTextureBounds.Height = 32;
-                }
-
-                mTextureBounds.Width = (int) (Math.Round(mTextureBounds.Width / 8.0) * 8.0);
-                mTextureBounds.Height = (int) (Math.Round(mTextureBounds.Height / 8.0) * 8.0);
-                if (mTextureBounds.Width / 8 % 2 != 0)
-                {
-                    mTextureBounds.Width += 8;
-                }
-
-                mTexSections = new Point[mTextureBounds.Width / 8, mTextureBounds.Height / 8];
-                for (var x1 = 0; x1 < mTextureBounds.Width / 8; x1++)
-                {
-                    for (var y1 = 0; y1 < mTextureBounds.Height / 8; y1++)
+                    else if (y1 == 1)
                     {
-                        if (x1 == 0)
-                        {
-                            mTexSections[x1, y1].X = 0;
-                        }
-                        else if (x1 == 1)
-                        {
-                            mTexSections[x1, y1].X = 1;
-                        }
-                        else if (x1 == mTextureBounds.Width / 16 - 1)
-                        {
-                            mTexSections[x1, y1].X = 3;
-                        }
-                        else if (x1 == mTextureBounds.Width / 16)
-                        {
-                            mTexSections[x1, y1].X = 4;
-                        }
-                        else if (x1 == mTextureBounds.Width / 8 - 1)
-                        {
-                            mTexSections[x1, y1].X = 7;
-                        }
-                        else if (x1 == mTextureBounds.Width / 8 - 2)
-                        {
-                            mTexSections[x1, y1].X = 6;
-                        }
-                        else
-                        {
-                            mTexSections[x1, y1].X = 2;
-                        }
-
-                        if (y1 == 0)
-                        {
-                            mTexSections[x1, y1].Y = 0;
-                        }
-                        else if (y1 == 1)
-                        {
-                            mTexSections[x1, y1].Y = 1;
-                        }
-                        else if (y1 == mTextureBounds.Height / 8 - 1)
-                        {
-                            mTexSections[x1, y1].Y = 3;
-                        }
-                        else if (y1 == mTextureBounds.Height / 8 - 2)
-                        {
-                            mTexSections[x1, y1].Y = 2;
-                        }
-                        else
-                        {
-                            mTexSections[x1, y1].Y = 1;
-                        }
+                        mTexSections[x1, y1].Y = 1;
+                    }
+                    else if (y1 == mTextureBounds.Height / 8 - 1)
+                    {
+                        mTexSections[x1, y1].Y = 3;
+                    }
+                    else if (y1 == mTextureBounds.Height / 8 - 2)
+                    {
+                        mTexSections[x1, y1].Y = 2;
+                    }
+                    else
+                    {
+                        mTexSections[x1, y1].Y = 1;
                     }
                 }
             }
+        }
 
-            if (mBubbleTex != null)
+        if (mBubbleTex != null)
+        {
+            //Draw Background if available
+            //Draw Top Left
+            for (var x1 = 0; x1 < mTextureBounds.Width / 8; x1++)
             {
-                //Draw Background if available
-                //Draw Top Left
-                for (var x1 = 0; x1 < mTextureBounds.Width / 8; x1++)
+                for (var y1 = 0; y1 < mTextureBounds.Height / 8; y1++)
                 {
-                    for (var y1 = 0; y1 < mTextureBounds.Height / 8; y1++)
-                    {
-                        Graphics.Renderer.DrawTexture(
-                            mBubbleTex, mTexSections[x1, y1].X * 8, mTexSections[x1, y1].Y * 8, 8, 8,
-                            x - mTextureBounds.Width / 2 + x1 * 8, y - mTextureBounds.Height - yoffset + y1 * 8, 8, 8,
-                            Color.White
-                        );
-                    }
-                }
-
-                for (var i = mText.Length - 1; i > -1; i--)
-                {
-                    var textSize = Graphics.Renderer.MeasureText(mText[i], Graphics.ChatBubbleFont, 1);
-                    Graphics.Renderer.DrawString(
-                        mText[i], Graphics.ChatBubbleFont,
-                        (int) (x - mTextureBounds.Width / 2 + (mTextureBounds.Width - textSize.X) / 2f),
-                        (int) (y - mTextureBounds.Height - yoffset + 8 + i * 16), 1,
-                        Color.FromArgb(CustomColors.Chat.ChatBubbleText.ToArgb()), true, null,
-                        Color.FromArgb(CustomColors.Chat.ChatBubbleTextOutline.ToArgb())
+                    Graphics.Renderer.DrawTexture(
+                        mBubbleTex, mTexSections[x1, y1].X * 8, mTexSections[x1, y1].Y * 8, 8, 8,
+                        x - mTextureBounds.Width / 2 + x1 * 8, y - mTextureBounds.Height - yoffset + y1 * 8, 8, 8,
+                        Color.White
                     );
                 }
             }
 
-            yoffset += mTextureBounds.Height;
-
-            return yoffset;
+            for (var i = mText.Length - 1; i > -1; i--)
+            {
+                var textSize = Graphics.Renderer.MeasureText(mText[i], Graphics.ChatBubbleFont, 1);
+                Graphics.Renderer.DrawString(
+                    mText[i], Graphics.ChatBubbleFont,
+                    (int) (x - mTextureBounds.Width / 2 + (mTextureBounds.Width - textSize.X) / 2f),
+                    (int) (y - mTextureBounds.Height - yoffset + 8 + i * 16), 1,
+                    Color.FromArgb(CustomColors.Chat.ChatBubbleText.ToArgb()), true, null,
+                    Color.FromArgb(CustomColors.Chat.ChatBubbleTextOutline.ToArgb())
+                );
+            }
         }
 
+        yoffset += mTextureBounds.Height;
+
+        return yoffset;
     }
 
 }

--- a/Intersect.Client/Entities/Critter.cs
+++ b/Intersect.Client/Entities/Critter.cs
@@ -8,286 +8,285 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Maps;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+public partial class Critter : Entity
 {
-    public partial class Critter : Entity
+    private MapCritterAttribute mAttribute;
+    private long mLastMove = -1;
+
+    public Critter(MapInstance map, byte x, byte y, MapCritterAttribute att) : base(Guid.NewGuid(), null, EntityType.GlobalEntity)
     {
-        private MapCritterAttribute mAttribute;
-        private long mLastMove = -1;
+        mAttribute = att;
 
-        public Critter(MapInstance map, byte x, byte y, MapCritterAttribute att) : base(Guid.NewGuid(), null, EntityType.GlobalEntity)
+        //setup Sprite & Animation
+        Sprite = att?.Sprite;
+        var anim = AnimationBase.Get(att.AnimationId);
+        if (anim != null)
         {
-            mAttribute = att;
-
-            //setup Sprite & Animation
-            Sprite = att?.Sprite;
-            var anim = AnimationBase.Get(att.AnimationId);
-            if (anim != null)
-            {
-                var animInstance = new Animation(anim, true);
-                Animations.Add(animInstance);
-            }
-
-            //Define Location
-            MapId = map?.Id ?? default;
-            X = x;
-            Y = y;
-
-            //Determine Direction
-            if (mAttribute.Direction == 0)
-            {
-                Dir = Randomization.NextDirection();
-            }
-            else
-            {
-                Dir = (Direction)(mAttribute.Direction - 1);
-            }
-
-            //Block Players?
-            Passable = !att.BlockPlayers;
+            var animInstance = new Animation(anim, true);
+            Animations.Add(animInstance);
         }
 
-        public override bool Update()
+        //Define Location
+        MapId = map?.Id ?? default;
+        X = x;
+        Y = y;
+
+        //Determine Direction
+        if (mAttribute.Direction == 0)
         {
-            if (base.Update())
-            {
-                if (mLastMove < Timing.Global.MillisecondsUtc)
-                {
-                    switch (mAttribute.Movement)
-                    {
-                        case 0: //Move Randomly
-                            MoveRandomly();
-                            break;
-                        case 1: //Turn?
-                            Dir = Randomization.NextDirection();
-                            break;
-
-                    }
-
-                    mLastMove = Timing.Global.MillisecondsUtc + mAttribute.Frequency + Globals.Random.Next((int)(mAttribute.Frequency * .5f));
-                }
-                return true;
-            }
-            return false;
+            Dir = Randomization.NextDirection();
+        }
+        else
+        {
+            Dir = (Direction)(mAttribute.Direction - 1);
         }
 
-        private void MoveRandomly()
+        //Block Players?
+        Passable = !att.BlockPlayers;
+    }
+
+    public override bool Update()
+    {
+        if (base.Update())
         {
-            MoveDir = Randomization.NextDirection();
-            var tmpX = (sbyte)X;
-            var tmpY = (sbyte)Y;
-            IEntity blockedBy = null;
-
-            if (IsMoving || MoveTimer >= Timing.Global.MillisecondsUtc)
+            if (mLastMove < Timing.Global.MillisecondsUtc)
             {
-                return;
-            }
-
-            var deltaX = 0;
-            var deltaY = 0;
-
-            switch (MoveDir)
-            {
-                case Direction.Up:
-                    deltaX = 0;
-                    deltaY = -1;
-                    break;
-
-                case Direction.Down:
-                    deltaX = 0;
-                    deltaY = 1;
-                    break;
-
-                case Direction.Left:
-                    deltaX = -1;
-                    deltaY = 0;
-                    break;
-
-                case Direction.Right:
-                    deltaX = 1;
-                    deltaY = 0;
-                    break;
-
-                case Direction.UpLeft:
-                    deltaX = -1;
-                    deltaY = -1;
-                    break;
-
-                case Direction.UpRight:
-                    deltaX = 1;
-                    deltaY = -1;
-                    break;
-
-                case Direction.DownLeft:
-                    deltaX = -1;
-                    deltaY = 1;
-                    break;
-
-                case Direction.DownRight:
-                    deltaX = 1;
-                    deltaY = 1;
-                    break;
-            }
-
-            if (deltaX != 0 || deltaY != 0)
-            {
-                var newX = tmpX + deltaX;
-                var newY = tmpY + deltaY;
-                var isBlocked = -1 ==
-                                IsTileBlocked(
-                                    new Point(newX, newY),
-                                    Z,
-                                    MapId,
-                                    ref blockedBy,
-                                    true,
-                                    true,
-                                    mAttribute.IgnoreNpcAvoids
-                                );
-                var playerOnTile = PlayerOnTile(MapId, newX, newY);
-
-                if (isBlocked && newX >= 0 && newX < Options.MapWidth && newY >= 0 && newY < Options.MapHeight &&
-                    (!mAttribute.BlockPlayers || !playerOnTile))
+                switch (mAttribute.Movement)
                 {
-                    tmpX += (sbyte)deltaX;
-                    tmpY += (sbyte)deltaY;
-                    IsMoving = true;
-                    Dir = MoveDir;
+                    case 0: //Move Randomly
+                        MoveRandomly();
+                        break;
+                    case 1: //Turn?
+                        Dir = Randomization.NextDirection();
+                        break;
 
-                    if (deltaX == 0)
-                    {
-                        OffsetX = 0;
-                    }
-                    else
-                    {
-                        OffsetX = deltaX > 0 ? -Options.TileWidth : Options.TileWidth;
-                    }
-
-                    if (deltaY == 0)
-                    {
-                        OffsetY = 0;
-                    }
-                    else
-                    {
-                        OffsetY = deltaY > 0 ? -Options.TileHeight : Options.TileHeight;
-                    }
                 }
-            }
 
-            if (IsMoving)
-            {
-                X = (byte)tmpX;
-                Y = (byte)tmpY;
-                MoveTimer = Timing.Global.MillisecondsUtc + (long)GetMovementTime();
+                mLastMove = Timing.Global.MillisecondsUtc + mAttribute.Frequency + Globals.Random.Next((int)(mAttribute.Frequency * .5f));
             }
-            else if (MoveDir != Dir)
+            return true;
+        }
+        return false;
+    }
+
+    private void MoveRandomly()
+    {
+        MoveDir = Randomization.NextDirection();
+        var tmpX = (sbyte)X;
+        var tmpY = (sbyte)Y;
+        IEntity blockedBy = null;
+
+        if (IsMoving || MoveTimer >= Timing.Global.MillisecondsUtc)
+        {
+            return;
+        }
+
+        var deltaX = 0;
+        var deltaY = 0;
+
+        switch (MoveDir)
+        {
+            case Direction.Up:
+                deltaX = 0;
+                deltaY = -1;
+                break;
+
+            case Direction.Down:
+                deltaX = 0;
+                deltaY = 1;
+                break;
+
+            case Direction.Left:
+                deltaX = -1;
+                deltaY = 0;
+                break;
+
+            case Direction.Right:
+                deltaX = 1;
+                deltaY = 0;
+                break;
+
+            case Direction.UpLeft:
+                deltaX = -1;
+                deltaY = -1;
+                break;
+
+            case Direction.UpRight:
+                deltaX = 1;
+                deltaY = -1;
+                break;
+
+            case Direction.DownLeft:
+                deltaX = -1;
+                deltaY = 1;
+                break;
+
+            case Direction.DownRight:
+                deltaX = 1;
+                deltaY = 1;
+                break;
+        }
+
+        if (deltaX != 0 || deltaY != 0)
+        {
+            var newX = tmpX + deltaX;
+            var newY = tmpY + deltaY;
+            var isBlocked = -1 ==
+                            IsTileBlocked(
+                                new Point(newX, newY),
+                                Z,
+                                MapId,
+                                ref blockedBy,
+                                true,
+                                true,
+                                mAttribute.IgnoreNpcAvoids
+                            );
+            var playerOnTile = PlayerOnTile(MapId, newX, newY);
+
+            if (isBlocked && newX >= 0 && newX < Options.MapWidth && newY >= 0 && newY < Options.MapHeight &&
+                (!mAttribute.BlockPlayers || !playerOnTile))
             {
+                tmpX += (sbyte)deltaX;
+                tmpY += (sbyte)deltaY;
+                IsMoving = true;
                 Dir = MoveDir;
+
+                if (deltaX == 0)
+                {
+                    OffsetX = 0;
+                }
+                else
+                {
+                    OffsetX = deltaX > 0 ? -Options.TileWidth : Options.TileWidth;
+                }
+
+                if (deltaY == 0)
+                {
+                    OffsetY = 0;
+                }
+                else
+                {
+                    OffsetY = deltaY > 0 ? -Options.TileHeight : Options.TileHeight;
+                }
             }
         }
 
-        public bool PlayerOnTile(Guid mapId, int x, int y)
+        if (IsMoving)
         {
-            foreach (var en in Globals.Entities)
-            {
-                if (en.Value == null)
-                {
-                    continue;
-                }
+            X = (byte)tmpX;
+            Y = (byte)tmpY;
+            MoveTimer = Timing.Global.MillisecondsUtc + (long)GetMovementTime();
+        }
+        else if (MoveDir != Dir)
+        {
+            Dir = MoveDir;
+        }
+    }
 
-                if (en.Value.MapId == mapId &&
-                        en.Value.X == x &&
-                        en.Value.Y == y)
+    public bool PlayerOnTile(Guid mapId, int x, int y)
+    {
+        foreach (var en in Globals.Entities)
+        {
+            if (en.Value == null)
+            {
+                continue;
+            }
+
+            if (en.Value.MapId == mapId &&
+                    en.Value.X == x &&
+                    en.Value.Y == y)
+            {
+                if (en.Value is Player)
                 {
-                    if (en.Value is Player)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
-            return false;
+        }
+        return false;
+    }
+
+    public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
+    {
+        if (mAttribute.Layer == 1)
+        {
+            return base.DetermineRenderOrder(renderList, map);
         }
 
-        public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
+        renderList?.Remove(this);
+        if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
         {
-            if (mAttribute.Layer == 1)
-            {
-                return base.DetermineRenderOrder(renderList, map);
-            }
+            return null;
+        }
 
-            renderList?.Remove(this);
-            if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
+        var gridX = Globals.Me.MapInstance.GridX;
+        var gridY = Globals.Me.MapInstance.GridY;
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                return null;
-            }
-
-            var gridX = Globals.Me.MapInstance.GridX;
-            var gridY = Globals.Me.MapInstance.GridY;
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
+                    if (Globals.MapGrid[x, y] == MapId)
                     {
-                        if (Globals.MapGrid[x, y] == MapId)
+                        if (mAttribute.Layer == 0)
                         {
-                            if (mAttribute.Layer == 0)
-                            {
-                                y--;
-                            }
-
-                            if (mAttribute.Layer == 2)
-                            {
-                                y++;
-                            }
-
-                            var priority = mRenderPriority;
-                            if (Z != 0)
-                            {
-                                priority += 3;
-                            }
-
-                            HashSet<Entity> renderSet = null;
-
-                            if (y == gridY - 2)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Y];
-                            }
-                            else if (y == gridY - 1)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
-                            }
-                            else if (y == gridY)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
-                            }
-                            else if (y == gridY + 1)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 3 + Y];
-                            }
-                            else if (y == gridY + 2)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 4 + Y];
-                            }
-
-                            renderSet?.Add(this);
-                            renderList = renderSet;
-
-                            return renderList;
+                            y--;
                         }
+
+                        if (mAttribute.Layer == 2)
+                        {
+                            y++;
+                        }
+
+                        var priority = mRenderPriority;
+                        if (Z != 0)
+                        {
+                            priority += 3;
+                        }
+
+                        HashSet<Entity> renderSet = null;
+
+                        if (y == gridY - 2)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Y];
+                        }
+                        else if (y == gridY - 1)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
+                        }
+                        else if (y == gridY)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
+                        }
+                        else if (y == gridY + 1)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 3 + Y];
+                        }
+                        else if (y == gridY + 2)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 4 + Y];
+                        }
+
+                        renderSet?.Add(this);
+                        renderList = renderSet;
+
+                        return renderList;
                     }
                 }
             }
-
-            return renderList;
         }
 
-        public override float GetMovementTime()
-        {
-            return mAttribute.Speed;
-        }
+        return renderList;
+    }
+
+    public override float GetMovementTime()
+    {
+        return mAttribute.Speed;
     }
 }

--- a/Intersect.Client/Entities/Dash.cs
+++ b/Intersect.Client/Entities/Dash.cs
@@ -3,108 +3,106 @@ using Intersect.Client.Maps;
 using Intersect.Enums;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class Dash : IDash
 {
 
-    public partial class Dash : IDash
+    private Direction mChangeDirection = Direction.None;
+
+    private int mDashTime;
+
+    private Guid mEndMapId;
+
+    private byte mEndX;
+
+    private float mEndXCoord;
+
+    private byte mEndY;
+
+    private float mEndYCoord;
+
+    private long mStartTime;
+
+    private float mStartXCoord;
+
+    private float mStartYCoord;
+
+    public float OffsetX => GetXOffset();
+
+    public float OffsetY => GetYOffset();
+
+    public Dash(Entity en, Guid endMapId, byte endX, byte endY, int dashTime, Direction changeDirection = Direction.None)
     {
+        mChangeDirection = changeDirection;
+        mEndMapId = endMapId;
+        mEndX = endX;
+        mEndY = endY;
+        mDashTime = dashTime;
+    }
 
-        private Direction mChangeDirection = Direction.None;
-
-        private int mDashTime;
-
-        private Guid mEndMapId;
-
-        private byte mEndX;
-
-        private float mEndXCoord;
-
-        private byte mEndY;
-
-        private float mEndYCoord;
-
-        private long mStartTime;
-
-        private float mStartXCoord;
-
-        private float mStartYCoord;
-
-        public float OffsetX => GetXOffset();
-
-        public float OffsetY => GetYOffset();
-
-        public Dash(Entity en, Guid endMapId, byte endX, byte endY, int dashTime, Direction changeDirection = Direction.None)
+    public void Start(Entity en)
+    {
+        if (MapInstance.Get(en.MapId) == null ||
+            MapInstance.Get(mEndMapId) == null ||
+            mEndMapId == en.MapId && mEndX == en.X && mEndY == en.Y)
         {
-            mChangeDirection = changeDirection;
-            mEndMapId = endMapId;
-            mEndX = endX;
-            mEndY = endY;
-            mDashTime = dashTime;
+            en.Dashing = null;
         }
-
-        public void Start(Entity en)
+        else
         {
-            if (MapInstance.Get(en.MapId) == null ||
-                MapInstance.Get(mEndMapId) == null ||
-                mEndMapId == en.MapId && mEndX == en.X && mEndY == en.Y)
+            var startMap = MapInstance.Get(en.MapId);
+            var endMap = MapInstance.Get(mEndMapId);
+            mStartTime = Timing.Global.Milliseconds;
+            mStartXCoord = en.OffsetX;
+            mStartYCoord = en.OffsetY;
+            mEndXCoord = endMap.GetX() + mEndX * Options.TileWidth - (startMap.GetX() + en.X * Options.TileWidth);
+            mEndYCoord = endMap.GetY() + mEndY * Options.TileHeight - (startMap.GetY() + en.Y * Options.TileHeight);
+            if (mChangeDirection > Direction.None)
             {
-                en.Dashing = null;
-            }
-            else
-            {
-                var startMap = MapInstance.Get(en.MapId);
-                var endMap = MapInstance.Get(mEndMapId);
-                mStartTime = Timing.Global.Milliseconds;
-                mStartXCoord = en.OffsetX;
-                mStartYCoord = en.OffsetY;
-                mEndXCoord = endMap.GetX() + mEndX * Options.TileWidth - (startMap.GetX() + en.X * Options.TileWidth);
-                mEndYCoord = endMap.GetY() + mEndY * Options.TileHeight - (startMap.GetY() + en.Y * Options.TileHeight);
-                if (mChangeDirection > Direction.None)
-                {
-                    en.Dir = mChangeDirection;
-                }
+                en.Dir = mChangeDirection;
             }
         }
+    }
 
-        public float GetXOffset()
+    public float GetXOffset()
+    {
+        if (Timing.Global.Milliseconds > mStartTime + mDashTime)
         {
-            if (Timing.Global.Milliseconds > mStartTime + mDashTime)
-            {
-                return mEndXCoord;
-            }
-            else
-            {
-                return (mEndXCoord - mStartXCoord) * ((Timing.Global.Milliseconds - mStartTime) / (float)mDashTime);
-            }
+            return mEndXCoord;
+        }
+        else
+        {
+            return (mEndXCoord - mStartXCoord) * ((Timing.Global.Milliseconds - mStartTime) / (float)mDashTime);
+        }
+    }
+
+    public float GetYOffset()
+    {
+        if (Timing.Global.Milliseconds > mStartTime + mDashTime)
+        {
+            return mEndYCoord;
+        }
+        else
+        {
+            return (mEndYCoord - mStartYCoord) * ((Timing.Global.Milliseconds - mStartTime) / (float)mDashTime);
+        }
+    }
+
+    public bool Update(Entity en)
+    {
+        if (Timing.Global.Milliseconds > mStartTime + mDashTime)
+        {
+            en.Dashing = null;
+            en.OffsetX = 0;
+            en.OffsetY = 0;
+            en.MapId = mEndMapId;
+            en.X = mEndX;
+            en.Y = mEndY;
         }
 
-        public float GetYOffset()
-        {
-            if (Timing.Global.Milliseconds > mStartTime + mDashTime)
-            {
-                return mEndYCoord;
-            }
-            else
-            {
-                return (mEndYCoord - mStartYCoord) * ((Timing.Global.Milliseconds - mStartTime) / (float)mDashTime);
-            }
-        }
-
-        public bool Update(Entity en)
-        {
-            if (Timing.Global.Milliseconds > mStartTime + mDashTime)
-            {
-                en.Dashing = null;
-                en.OffsetX = 0;
-                en.OffsetY = 0;
-                en.MapId = mEndMapId;
-                en.X = mEndX;
-                en.Y = mEndY;
-            }
-
-            return en.Dashing != null;
-        }
-
+        return en.Dashing != null;
     }
 
 }

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -19,799 +19,789 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+public partial class Entity : IEntity
 {
-    public partial class Entity : IEntity
+    public int AnimationFrame { get; set; }
+
+    //Entity Animations
+    public List<Animation> Animations { get; set; } = new List<Animation>();
+
+    //Animation Timer (for animated sprites)
+    public long AnimationTimer { get; set; }
+
+    //Combat
+    public long AttackTimer { get; set; } = 0;
+
+    public int AttackTime { get; set; } = -1;
+
+    public long CastTime { get; set; } = 0;
+
+    //Combat Status
+    public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
+
+    public bool IsBlocking { get; set; } = false;
+
+    public bool IsCasting => CastTime > Timing.Global.Milliseconds;
+
+    public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
+
+    public bool IsDashing => Dashing != null;
+
+    //Dashing instance
+    public Dash Dashing { get; set; }
+
+    public IDash CurrentDash => Dashing as IDash;
+
+    public Queue<Dash> DashQueue { get; set; } = new Queue<Dash>();
+
+    public long DashTimer { get; set; }
+
+    public float elapsedtime { get; set; } //to be removed
+
+    private Guid[] _equipment = new Guid[Options.EquipmentSlots.Count];
+
+    public Guid[] Equipment
     {
-        public int AnimationFrame { get; set; }
-
-        //Entity Animations
-        public List<Animation> Animations { get; set; } = new List<Animation>();
-
-        //Animation Timer (for animated sprites)
-        public long AnimationTimer { get; set; }
-
-        //Combat
-        public long AttackTimer { get; set; } = 0;
-
-        public int AttackTime { get; set; } = -1;
-
-        public long CastTime { get; set; } = 0;
-
-        //Combat Status
-        public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
-
-        public bool IsBlocking { get; set; } = false;
-
-        public bool IsCasting => CastTime > Timing.Global.Milliseconds;
-
-        public bool IsTurnAroundWhileCastingDisabled => !Options.Instance.CombatOpts.EnableTurnAroundWhileCasting && IsCasting;
-
-        public bool IsDashing => Dashing != null;
-
-        //Dashing instance
-        public Dash Dashing { get; set; }
-
-        public IDash CurrentDash => Dashing as IDash;
-
-        public Queue<Dash> DashQueue { get; set; } = new Queue<Dash>();
-
-        public long DashTimer { get; set; }
-
-        public float elapsedtime { get; set; } //to be removed
-
-        private Guid[] _equipment = new Guid[Options.EquipmentSlots.Count];
-
-        public Guid[] Equipment
+        get => _equipment;
+        set
         {
-            get => _equipment;
-            set
-            {
-                if (_equipment == value)
-                {
-                    return;
-                }
-
-                _equipment = value;
-                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Weapon);
-            }
-        }
-
-        IReadOnlyList<int> IEntity.EquipmentSlots => MyEquipment.ToList();
-
-        public Animation[] EquipmentAnimations { get; set; } = new Animation[Options.EquipmentSlots.Count];
-
-        //Extras
-        public string Face { get; set; } = "";
-
-        public Label FooterLabel { get; set; }
-
-        public Gender Gender { get; set; } = Gender.Male;
-
-        public Label HeaderLabel { get; set; }
-
-        public bool IsHidden { get; set; } = false;
-
-        public bool HideName { get; set; }
-
-        //Core Values
-        public Guid Id { get; set; }
-
-        //Inventory/Spells/Equipment
-        public IItem[] Inventory { get; set; } = new IItem[Options.MaxInvItems];
-
-        IReadOnlyList<IItem> IEntity.Items => Inventory.ToList();
-
-        public bool InView { get; set; } = true;
-
-        public bool IsMoving { get; set; }
-
-        //Caching
-        public IMapInstance LatestMap { get; set; }
-
-        public int Level { get; set; } = 1;
-
-        //Vitals & Stats
-        public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        IReadOnlyList<long> IEntity.MaxVitals => MaxVital.ToList();
-
-        protected Pointf mOrigin = Pointf.Empty;
-
-        //Chat
-        private List<ChatBubble> mChatBubbles = new List<ChatBubble>();
-
-        private Direction mDir;
-
-        protected bool mDisposed;
-
-        private long mLastUpdate;
-
-        protected string mMySprite = "";
-
-        public Color Color { get; set; } = new Color(255, 255, 255, 255);
-
-        public virtual Direction MoveDir { get; set; } = Direction.None;
-
-        public long MoveTimer { get; set; }
-
-        protected byte mRenderPriority = 1;
-
-        protected string mTransformedSprite = "";
-
-        private long mWalkTimer;
-
-        public int[] MyEquipment { get; set; } = new int[Options.EquipmentSlots.Count];
-
-        public string Name { get; set; } = "";
-
-        public Color NameColor { get; set; } = null;
-
-        public float OffsetX { get; set; }
-
-        public float OffsetY { get; set; }
-
-        public bool Passable { get; set; }
-
-        //Rendering Variables
-        public HashSet<Entity> RenderList { get; set; }
-
-        private Guid _spellCast;
-
-        public Guid SpellCast
-        {
-            get => _spellCast;
-            set
-            {
-                if (value == SpellCast)
-                {
-                    return;
-                }
-
-                _spellCast = value;
-                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Cast);
-            }
-        }
-
-        public Spell[] Spells { get; set; } = new Spell[Options.MaxPlayerSkills];
-
-        IReadOnlyList<Guid> IEntity.Spells => Spells.Select(x => x.Id).ToList();
-
-        public int[] Stat { get; set; } = new int[Enum.GetValues<Stat>().Length];
-
-        IReadOnlyList<int> IEntity.Stats => Stat.ToList();
-
-        public GameTexture Texture { get; set; }
-
-        #region "Animation Textures and Timing"
-
-        public SpriteAnimations SpriteAnimation { get; set; } = SpriteAnimations.Normal;
-
-        public Dictionary<SpriteAnimations, GameTexture> AnimatedTextures { get; set; } =
-            new Dictionary<SpriteAnimations, GameTexture>();
-
-        public int SpriteFrame { get; set; } = 0;
-
-        public long SpriteFrameTimer { get; set; } = -1;
-
-        public long LastActionTime { get; set; } = -1;
-
-        public long AutoTurnToTargetTimer { get; set; } = -1;
-
-        #endregion
-
-        public EntityType Type { get; }
-
-        public NpcAggression Aggression { get; set; }
-
-        public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        IReadOnlyList<long> IEntity.Vitals => Vital.ToList();
-
-        public int WalkFrame { get; set; }
-
-        public FloatRect WorldPos { get; set; } = new FloatRect();
-
-        public bool IsHovered { get; set; }
-
-        //Location Info
-        public byte X { get; set; }
-
-        public byte Y { get; set; }
-
-        public byte Z { get; set; }
-
-        public Entity(Guid id, EntityPacket packet, EntityType entityType)
-        {
-            Id = id;
-            Type = entityType;
-            MapId = Guid.Empty;
-
-            if (Id != Guid.Empty && Type != EntityType.Event)
-            {
-                for (var i = 0; i < Options.MaxInvItems; i++)
-                {
-                    Inventory[i] = new Item();
-                }
-
-                for (var i = 0; i < Options.MaxPlayerSkills; i++)
-                {
-                    Spells[i] = new Spell();
-                }
-
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-                {
-                    Equipment[i] = Guid.Empty;
-                    MyEquipment[i] = -1;
-                }
-            }
-
-            AnimationTimer = Timing.Global.MillisecondsUtc + Globals.Random.Next(0, 500);
-
-            //TODO Remove because fixed orrrrr change the exception text
-            if (Options.EquipmentSlots.Count == 0)
-            {
-                throw new Exception("What the fuck is going on!?!?!?!?!?!");
-            }
-
-            Load(packet);
-        }
-
-        //Status effects
-        public List<IStatus> Status { get; private set; } = new List<IStatus>();
-
-        IReadOnlyList<IStatus> IEntity.Status => Status;
-
-        public Pointf Origin => LatestMap == default ? Pointf.Empty : mOrigin;
-
-        protected virtual Pointf CenterOffset => (Texture == default) ? Pointf.Empty : (Pointf.UnitY * Texture.Center.Y / Options.Instance.Sprites.Directions);
-
-        public Pointf Center => Origin - CenterOffset;
-
-        public Direction Dir
-        {
-            get => mDir;
-            set => mDir = (Direction)((int)(value + Options.Instance.MapOpts.MovementDirections) % Options.Instance.MapOpts.MovementDirections);
-        }
-
-        private Direction mLastDirection = Direction.Down;
-
-        public virtual string TransformedSprite
-        {
-            get => mTransformedSprite;
-            set
-            {
-                if (mTransformedSprite == value)
-                {
-                    return;
-                }
-
-                mTransformedSprite = value;
-
-                var textureName = string.IsNullOrEmpty(mTransformedSprite) ? mMySprite : mTransformedSprite;
-                LoadTextures(textureName);
-            }
-        }
-
-        public virtual string Sprite
-        {
-            get => mMySprite;
-            set
-            {
-                if (mMySprite == value)
-                {
-                    return;
-                }
-
-                mMySprite = value;
-                LoadTextures(mMySprite);
-            }
-        }
-
-        public virtual int SpriteFrames
-        {
-            get
-            {
-                switch (SpriteAnimation)
-                {
-                    case SpriteAnimations.Normal:
-                        return Options.Instance.Sprites.NormalFrames;
-                    case SpriteAnimations.Idle:
-                        return Options.Instance.Sprites.IdleFrames;
-                    case SpriteAnimations.Attack:
-                        return Options.Instance.Sprites.AttackFrames;
-                    case SpriteAnimations.Shoot:
-                        return Options.Instance.Sprites.ShootFrames;
-                    case SpriteAnimations.Cast:
-                        return Options.Instance.Sprites.CastFrames;
-                    case SpriteAnimations.Weapon:
-                        return Options.Instance.Sprites.WeaponFrames;
-                }
-
-                return Options.Instance.Sprites.NormalFrames;
-
-            }
-        }
-
-        public IMapInstance? MapInstance => Maps.MapInstance.Get(MapId);
-
-        public virtual Guid MapId { get; set; }
-
-        //Deserializing
-        public virtual void Load(EntityPacket packet)
-        {
-            if (packet == null)
+            if (_equipment == value)
             {
                 return;
             }
 
-            MapId = packet.MapId;
-            Name = packet.Name;
-            Sprite = packet.Sprite;
-            Color = packet.Color;
-            Face = packet.Face;
-            Level = packet.Level;
-            X = packet.X;
-            Y = packet.Y;
-            Z = packet.Z;
-            Dir = (Direction)packet.Dir;
-            Passable = packet.Passable;
-            HideName = packet.HideName;
-            IsHidden = packet.HideEntity;
-            NameColor = packet.NameColor;
-            HeaderLabel = new Label(packet.HeaderLabel.Label, packet.HeaderLabel.Color);
-            FooterLabel = new Label(packet.FooterLabel.Label, packet.FooterLabel.Color);
+            _equipment = value;
+            LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Weapon);
+        }
+    }
 
-            var animsToClear = new List<Animation>();
-            var animsToAdd = new List<AnimationBase>();
-            for (var i = 0; i < packet.Animations.Length; i++)
+    IReadOnlyList<int> IEntity.EquipmentSlots => MyEquipment.ToList();
+
+    public Animation[] EquipmentAnimations { get; set; } = new Animation[Options.EquipmentSlots.Count];
+
+    //Extras
+    public string Face { get; set; } = "";
+
+    public Label FooterLabel { get; set; }
+
+    public Gender Gender { get; set; } = Gender.Male;
+
+    public Label HeaderLabel { get; set; }
+
+    public bool IsHidden { get; set; } = false;
+
+    public bool HideName { get; set; }
+
+    //Core Values
+    public Guid Id { get; set; }
+
+    //Inventory/Spells/Equipment
+    public IItem[] Inventory { get; set; } = new IItem[Options.MaxInvItems];
+
+    IReadOnlyList<IItem> IEntity.Items => Inventory.ToList();
+
+    public bool InView { get; set; } = true;
+
+    public bool IsMoving { get; set; }
+
+    //Caching
+    public IMapInstance LatestMap { get; set; }
+
+    public int Level { get; set; } = 1;
+
+    //Vitals & Stats
+    public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    IReadOnlyList<long> IEntity.MaxVitals => MaxVital.ToList();
+
+    protected Pointf mOrigin = Pointf.Empty;
+
+    //Chat
+    private List<ChatBubble> mChatBubbles = new List<ChatBubble>();
+
+    private Direction mDir;
+
+    protected bool mDisposed;
+
+    private long mLastUpdate;
+
+    protected string mMySprite = "";
+
+    public Color Color { get; set; } = new Color(255, 255, 255, 255);
+
+    public virtual Direction MoveDir { get; set; } = Direction.None;
+
+    public long MoveTimer { get; set; }
+
+    protected byte mRenderPriority = 1;
+
+    protected string mTransformedSprite = "";
+
+    private long mWalkTimer;
+
+    public int[] MyEquipment { get; set; } = new int[Options.EquipmentSlots.Count];
+
+    public string Name { get; set; } = "";
+
+    public Color NameColor { get; set; } = null;
+
+    public float OffsetX { get; set; }
+
+    public float OffsetY { get; set; }
+
+    public bool Passable { get; set; }
+
+    //Rendering Variables
+    public HashSet<Entity> RenderList { get; set; }
+
+    private Guid _spellCast;
+
+    public Guid SpellCast
+    {
+        get => _spellCast;
+        set
+        {
+            if (value == SpellCast)
             {
-                var anim = AnimationBase.Get(packet.Animations[i]);
-                if (anim != null)
-                {
-                    animsToAdd.Add(anim);
-                }
+                return;
             }
 
-            foreach (var anim in Animations)
+            _spellCast = value;
+            LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Cast);
+        }
+    }
+
+    public Spell[] Spells { get; set; } = new Spell[Options.MaxPlayerSkills];
+
+    IReadOnlyList<Guid> IEntity.Spells => Spells.Select(x => x.Id).ToList();
+
+    public int[] Stat { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    IReadOnlyList<int> IEntity.Stats => Stat.ToList();
+
+    public GameTexture Texture { get; set; }
+
+    #region "Animation Textures and Timing"
+
+    public SpriteAnimations SpriteAnimation { get; set; } = SpriteAnimations.Normal;
+
+    public Dictionary<SpriteAnimations, GameTexture> AnimatedTextures { get; set; } =
+        new Dictionary<SpriteAnimations, GameTexture>();
+
+    public int SpriteFrame { get; set; } = 0;
+
+    public long SpriteFrameTimer { get; set; } = -1;
+
+    public long LastActionTime { get; set; } = -1;
+
+    public long AutoTurnToTargetTimer { get; set; } = -1;
+
+    #endregion
+
+    public EntityType Type { get; }
+
+    public NpcAggression Aggression { get; set; }
+
+    public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    IReadOnlyList<long> IEntity.Vitals => Vital.ToList();
+
+    public int WalkFrame { get; set; }
+
+    public FloatRect WorldPos { get; set; } = new FloatRect();
+
+    public bool IsHovered { get; set; }
+
+    //Location Info
+    public byte X { get; set; }
+
+    public byte Y { get; set; }
+
+    public byte Z { get; set; }
+
+    public Entity(Guid id, EntityPacket packet, EntityType entityType)
+    {
+        Id = id;
+        Type = entityType;
+        MapId = Guid.Empty;
+
+        if (Id != Guid.Empty && Type != EntityType.Event)
+        {
+            for (var i = 0; i < Options.MaxInvItems; i++)
             {
-                animsToClear.Add(anim);
-                if (!anim.InfiniteLoop)
+                Inventory[i] = new Item();
+            }
+
+            for (var i = 0; i < Options.MaxPlayerSkills; i++)
+            {
+                Spells[i] = new Spell();
+            }
+
+            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+            {
+                Equipment[i] = Guid.Empty;
+                MyEquipment[i] = -1;
+            }
+        }
+
+        AnimationTimer = Timing.Global.MillisecondsUtc + Globals.Random.Next(0, 500);
+
+        //TODO Remove because fixed orrrrr change the exception text
+        if (Options.EquipmentSlots.Count == 0)
+        {
+            throw new Exception("What the fuck is going on!?!?!?!?!?!");
+        }
+
+        Load(packet);
+    }
+
+    //Status effects
+    public List<IStatus> Status { get; private set; } = new List<IStatus>();
+
+    IReadOnlyList<IStatus> IEntity.Status => Status;
+
+    public Pointf Origin => LatestMap == default ? Pointf.Empty : mOrigin;
+
+    protected virtual Pointf CenterOffset => (Texture == default) ? Pointf.Empty : (Pointf.UnitY * Texture.Center.Y / Options.Instance.Sprites.Directions);
+
+    public Pointf Center => Origin - CenterOffset;
+
+    public Direction Dir
+    {
+        get => mDir;
+        set => mDir = (Direction)((int)(value + Options.Instance.MapOpts.MovementDirections) % Options.Instance.MapOpts.MovementDirections);
+    }
+
+    private Direction mLastDirection = Direction.Down;
+
+    public virtual string TransformedSprite
+    {
+        get => mTransformedSprite;
+        set
+        {
+            if (mTransformedSprite == value)
+            {
+                return;
+            }
+
+            mTransformedSprite = value;
+
+            var textureName = string.IsNullOrEmpty(mTransformedSprite) ? mMySprite : mTransformedSprite;
+            LoadTextures(textureName);
+        }
+    }
+
+    public virtual string Sprite
+    {
+        get => mMySprite;
+        set
+        {
+            if (mMySprite == value)
+            {
+                return;
+            }
+
+            mMySprite = value;
+            LoadTextures(mMySprite);
+        }
+    }
+
+    public virtual int SpriteFrames
+    {
+        get
+        {
+            switch (SpriteAnimation)
+            {
+                case SpriteAnimations.Normal:
+                    return Options.Instance.Sprites.NormalFrames;
+                case SpriteAnimations.Idle:
+                    return Options.Instance.Sprites.IdleFrames;
+                case SpriteAnimations.Attack:
+                    return Options.Instance.Sprites.AttackFrames;
+                case SpriteAnimations.Shoot:
+                    return Options.Instance.Sprites.ShootFrames;
+                case SpriteAnimations.Cast:
+                    return Options.Instance.Sprites.CastFrames;
+                case SpriteAnimations.Weapon:
+                    return Options.Instance.Sprites.WeaponFrames;
+            }
+
+            return Options.Instance.Sprites.NormalFrames;
+
+        }
+    }
+
+    public IMapInstance? MapInstance => Maps.MapInstance.Get(MapId);
+
+    public virtual Guid MapId { get; set; }
+
+    //Deserializing
+    public virtual void Load(EntityPacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        MapId = packet.MapId;
+        Name = packet.Name;
+        Sprite = packet.Sprite;
+        Color = packet.Color;
+        Face = packet.Face;
+        Level = packet.Level;
+        X = packet.X;
+        Y = packet.Y;
+        Z = packet.Z;
+        Dir = (Direction)packet.Dir;
+        Passable = packet.Passable;
+        HideName = packet.HideName;
+        IsHidden = packet.HideEntity;
+        NameColor = packet.NameColor;
+        HeaderLabel = new Label(packet.HeaderLabel.Label, packet.HeaderLabel.Color);
+        FooterLabel = new Label(packet.FooterLabel.Label, packet.FooterLabel.Color);
+
+        var animsToClear = new List<Animation>();
+        var animsToAdd = new List<AnimationBase>();
+        for (var i = 0; i < packet.Animations.Length; i++)
+        {
+            var anim = AnimationBase.Get(packet.Animations[i]);
+            if (anim != null)
+            {
+                animsToAdd.Add(anim);
+            }
+        }
+
+        foreach (var anim in Animations)
+        {
+            animsToClear.Add(anim);
+            if (!anim.InfiniteLoop)
+            {
+                animsToClear.Remove(anim);
+            }
+            else
+            {
+                foreach (var addedAnim in animsToAdd)
                 {
-                    animsToClear.Remove(anim);
+                    if (addedAnim.Id == anim.MyBase.Id)
+                    {
+                        animsToClear.Remove(anim);
+                        animsToAdd.Remove(addedAnim);
+
+                        break;
+                    }
+                }
+
+                foreach (var equipAnim in EquipmentAnimations)
+                {
+                    if (equipAnim == anim)
+                    {
+                        animsToClear.Remove(anim);
+                    }
+                }
+            }
+        }
+
+        ClearAnimations(animsToClear);
+        AddAnimations(animsToAdd);
+
+        Vital = packet.Vital;
+        MaxVital = packet.MaxVital;
+
+        //Update status effects
+        Status.Clear();
+
+        if (packet.StatusEffects == null)
+        {
+            Log.Warn($"'{nameof(packet)}.{nameof(packet.StatusEffects)}' is null.");
+        }
+        else
+        {
+            foreach (var status in packet.StatusEffects)
+            {
+                var instance = new Status(
+                    status.SpellId, status.Type, status.TransformSprite, status.TimeRemaining, status.TotalDuration
+                );
+
+                Status?.Add(instance);
+
+                if (instance.Type == SpellEffect.Shield)
+                {
+                    instance.Shield = status.VitalShields;
+                }
+            }
+        }
+
+        SortStatuses();
+        Stat = packet.Stats;
+
+        mDisposed = false;
+
+        //Status effects box update
+        if (Globals.Me == null)
+        {
+            Log.Warn($"'{nameof(Globals.Me)}' is null.");
+        }
+        else
+        {
+            if (Id == Globals.Me.Id)
+            {
+                if (Interface.Interface.GameUi == null)
+                {
+                    Log.Warn($"'{nameof(Interface.Interface.GameUi)}' is null.");
                 }
                 else
                 {
-                    foreach (var addedAnim in animsToAdd)
+                    if (Interface.Interface.GameUi.PlayerStatusWindow == null)
                     {
-                        if (addedAnim.Id == anim.MyBase.Id)
-                        {
-                            animsToClear.Remove(anim);
-                            animsToAdd.Remove(addedAnim);
-
-                            break;
-                        }
-                    }
-
-                    foreach (var equipAnim in EquipmentAnimations)
-                    {
-                        if (equipAnim == anim)
-                        {
-                            animsToClear.Remove(anim);
-                        }
-                    }
-                }
-            }
-
-            ClearAnimations(animsToClear);
-            AddAnimations(animsToAdd);
-
-            Vital = packet.Vital;
-            MaxVital = packet.MaxVital;
-
-            //Update status effects
-            Status.Clear();
-
-            if (packet.StatusEffects == null)
-            {
-                Log.Warn($"'{nameof(packet)}.{nameof(packet.StatusEffects)}' is null.");
-            }
-            else
-            {
-                foreach (var status in packet.StatusEffects)
-                {
-                    var instance = new Status(
-                        status.SpellId, status.Type, status.TransformSprite, status.TimeRemaining, status.TotalDuration
-                    );
-
-                    Status?.Add(instance);
-
-                    if (instance.Type == SpellEffect.Shield)
-                    {
-                        instance.Shield = status.VitalShields;
-                    }
-                }
-            }
-
-            SortStatuses();
-            Stat = packet.Stats;
-
-            mDisposed = false;
-
-            //Status effects box update
-            if (Globals.Me == null)
-            {
-                Log.Warn($"'{nameof(Globals.Me)}' is null.");
-            }
-            else
-            {
-                if (Id == Globals.Me.Id)
-                {
-                    if (Interface.Interface.GameUi == null)
-                    {
-                        Log.Warn($"'{nameof(Interface.Interface.GameUi)}' is null.");
+                        Log.Warn($"'{nameof(Interface.Interface.GameUi.PlayerStatusWindow)}' is null.");
                     }
                     else
                     {
-                        if (Interface.Interface.GameUi.PlayerStatusWindow == null)
-                        {
-                            Log.Warn($"'{nameof(Interface.Interface.GameUi.PlayerStatusWindow)}' is null.");
-                        }
-                        else
-                        {
-                            Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
-                        }
+                        Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
                     }
                 }
-                else if (Id != Guid.Empty && Id == Globals.Me.TargetIndex)
+            }
+            else if (Id != Guid.Empty && Id == Globals.Me.TargetIndex)
+            {
+                if (Globals.Me.TargetBox == null)
                 {
-                    if (Globals.Me.TargetBox == null)
-                    {
-                        Log.Warn($"'{nameof(Globals.Me.TargetBox)}' is null.");
-                    }
-                    else
-                    {
-                        Globals.Me.TargetBox.ShouldUpdateStatuses = true;
-                    }
+                    Log.Warn($"'{nameof(Globals.Me.TargetBox)}' is null.");
+                }
+                else
+                {
+                    Globals.Me.TargetBox.ShouldUpdateStatuses = true;
                 }
             }
         }
+    }
 
-        public void AddAnimations(List<AnimationBase> anims)
+    public void AddAnimations(List<AnimationBase> anims)
+    {
+        foreach (var anim in anims)
         {
-            foreach (var anim in anims)
-            {
-                Animations.Add(new Animation(anim, true, false, -1, this));
-            }
+            Animations.Add(new Animation(anim, true, false, -1, this));
+        }
+    }
+
+    public virtual bool IsAllyOf(Player en)
+    {
+        if (en == null || MapInstance == default || en.MapInstance == default)
+        {
+            return false;
         }
 
-        public virtual bool IsAllyOf(Player en)
+        // Resources have no allies
+        if (Type == EntityType.Resource)
         {
-            if (en == null || MapInstance == default || en.MapInstance == default)
-            {
-                return false;
-            }
+            return false;
+        }
 
-            // Resources have no allies
-            if (Type == EntityType.Resource)
-            {
-                return false;
-            }
+        // Events ONLY have allies
+        if (Type == EntityType.Event)
+        {
+            return true;
+        }
 
-            // Events ONLY have allies
-            if (Type == EntityType.Event)
-            {
-                return true;
-            }
+        // Yourself is always an ally
+        if (en.Id == Id)
+        {
+            return true;
+        }
 
-            // Yourself is always an ally
-            if (en.Id == Id)
+        return false;
+    }
+
+    public void ClearAnimations(List<Animation> anims)
+    {
+        if (anims == null)
+        {
+            anims = Animations;
+        }
+
+        if (anims.Count > 0)
+        {
+            for (var i = 0; i < anims.Count; i++)
             {
-                return true;
+                anims[i].Dispose();
+                Animations.Remove(anims[i]);
             }
+        }
+    }
+
+    public virtual bool IsDisposed()
+    {
+        return mDisposed;
+    }
+
+    public virtual void Dispose()
+    {
+        if (RenderList != null)
+        {
+            RenderList.Remove(this);
+        }
+
+        ClearAnimations(null);
+        mDisposed = true;
+    }
+
+    //Returns the amount of time required to traverse 1 tile
+    public virtual float GetMovementTime()
+    {
+        var time = 1000f / (float)(1 + Math.Log(Stat[(int)Enums.Stat.Speed]));
+        if (Dir > Direction.Right)
+        {
+            time *= MathHelper.UnitDiagonalLength;
+        }
+
+        if (IsBlocking)
+        {
+            time += time * Options.BlockingSlow;
+        }
+
+        return Math.Min(1000f, time);
+    }
+
+    public override string ToString() => Name;
+
+    //Movement Processing
+    public virtual bool Update()
+    {
+        if (mDisposed)
+        {
+            LatestMap = null;
 
             return false;
         }
 
-        public void ClearAnimations(List<Animation> anims)
+        if (LatestMap?.Id != MapId)
         {
-            if (anims == null)
-            {
-                anims = Animations;
-            }
+            LatestMap = Maps.MapInstance.Get(MapId);
+        }
 
-            if (anims.Count > 0)
+        if (LatestMap == null || !LatestMap.InView())
+        {
+            Globals.EntitiesToDispose.Add(Id);
+
+            return false;
+        }
+
+        RenderList = DetermineRenderOrder(RenderList, LatestMap);
+        if (mLastUpdate == 0)
+        {
+            mLastUpdate = Timing.Global.Milliseconds;
+        }
+
+        var ecTime = (float)(Timing.Global.Milliseconds - mLastUpdate);
+        elapsedtime = ecTime;
+        if (Dashing != null)
+        {
+            WalkFrame = Options.Instance.Sprites.NormalDashFrame; //Fix the frame whilst dashing
+        }
+        else if (mWalkTimer < Timing.Global.Milliseconds)
+        {
+            if (!IsMoving && DashQueue.Count > 0)
             {
-                for (var i = 0; i < anims.Count; i++)
+                Dashing = DashQueue.Dequeue();
+                Dashing.Start(this);
+                OffsetX = 0;
+                OffsetY = 0;
+                DashTimer = Timing.Global.Milliseconds + Options.MaxDashSpeed;
+            }
+            else
+            {
+                if (IsMoving)
                 {
-                    anims[i].Dispose();
-                    Animations.Remove(anims[i]);
-                }
-            }
-        }
-
-        public virtual bool IsDisposed()
-        {
-            return mDisposed;
-        }
-
-        public virtual void Dispose()
-        {
-            if (RenderList != null)
-            {
-                RenderList.Remove(this);
-            }
-
-            ClearAnimations(null);
-            mDisposed = true;
-        }
-
-        //Returns the amount of time required to traverse 1 tile
-        public virtual float GetMovementTime()
-        {
-            var time = 1000f / (float)(1 + Math.Log(Stat[(int)Enums.Stat.Speed]));
-            if (Dir > Direction.Right)
-            {
-                time *= MathHelper.UnitDiagonalLength;
-            }
-
-            if (IsBlocking)
-            {
-                time += time * Options.BlockingSlow;
-            }
-
-            return Math.Min(1000f, time);
-        }
-
-        public override string ToString() => Name;
-
-        //Movement Processing
-        public virtual bool Update()
-        {
-            if (mDisposed)
-            {
-                LatestMap = null;
-
-                return false;
-            }
-
-            if (LatestMap?.Id != MapId)
-            {
-                LatestMap = Maps.MapInstance.Get(MapId);
-            }
-
-            if (LatestMap == null || !LatestMap.InView())
-            {
-                Globals.EntitiesToDispose.Add(Id);
-
-                return false;
-            }
-
-            RenderList = DetermineRenderOrder(RenderList, LatestMap);
-            if (mLastUpdate == 0)
-            {
-                mLastUpdate = Timing.Global.Milliseconds;
-            }
-
-            var ecTime = (float)(Timing.Global.Milliseconds - mLastUpdate);
-            elapsedtime = ecTime;
-            if (Dashing != null)
-            {
-                WalkFrame = Options.Instance.Sprites.NormalDashFrame; //Fix the frame whilst dashing
-            }
-            else if (mWalkTimer < Timing.Global.Milliseconds)
-            {
-                if (!IsMoving && DashQueue.Count > 0)
-                {
-                    Dashing = DashQueue.Dequeue();
-                    Dashing.Start(this);
-                    OffsetX = 0;
-                    OffsetY = 0;
-                    DashTimer = Timing.Global.Milliseconds + Options.MaxDashSpeed;
+                    WalkFrame++;
+                    if (WalkFrame >= SpriteFrames)
+                    {
+                        WalkFrame = 0;
+                    }
                 }
                 else
                 {
-                    if (IsMoving)
+                    if (WalkFrame > 0 && WalkFrame / SpriteFrames < 0.7f)
                     {
-                        WalkFrame++;
-                        if (WalkFrame >= SpriteFrames)
+                        WalkFrame = SpriteFrames / 2;
+                    }
+                    else
+                    {
+                        WalkFrame = 0;
+                    }
+                }
+
+                mWalkTimer = Timing.Global.Milliseconds + Options.Instance.Sprites.MovingFrameDuration;
+            }
+        }
+
+        if (Dashing != null)
+        {
+            if (Dashing.Update(this))
+            {
+                OffsetX = Dashing.GetXOffset();
+                OffsetY = Dashing.GetYOffset();
+            }
+            else
+            {
+                OffsetX = 0;
+                OffsetY = 0;
+            }
+        }
+        else if (IsMoving)
+        {
+            var displacementTime = ecTime * Options.TileHeight / GetMovementTime();
+
+            PickLastDirection(Dir);
+
+            switch (Dir)
+            {
+                case Direction.Up:
+                    OffsetY -= displacementTime;
+                    OffsetX = 0;
+                    if (OffsetY < 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    break;
+
+                case Direction.Down:
+                    OffsetY += displacementTime;
+                    OffsetX = 0;
+                    if (OffsetY > 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    break;
+
+                case Direction.Left:
+                    OffsetX -= displacementTime;
+                    OffsetY = 0;
+                    if (OffsetX < 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+                    break;
+
+                case Direction.Right:
+                    OffsetX += displacementTime;
+                    OffsetY = 0;
+                    if (OffsetX > 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+                    break;
+                case Direction.UpLeft:
+                    OffsetY -= displacementTime;
+                    OffsetX -= displacementTime;
+                    if (OffsetY < 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    if (OffsetX < 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+                    break;
+                case Direction.UpRight:
+                    OffsetY -= displacementTime;
+                    OffsetX += displacementTime;
+                    if (OffsetY < 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    if (OffsetX > 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+                    break;
+                case Direction.DownLeft:
+                    OffsetY += displacementTime;
+                    OffsetX -= displacementTime;
+                    if (OffsetY > 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    if (OffsetX < 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+
+                    break;
+                case Direction.DownRight:
+                    OffsetY += displacementTime;
+                    OffsetX += displacementTime;
+                    if (OffsetY > 0)
+                    {
+                        OffsetY = 0;
+                    }
+
+                    if (OffsetX > 0)
+                    {
+                        OffsetX = 0;
+                    }
+
+                    break;
+            }
+
+            if (OffsetX == 0 && OffsetY == 0)
+            {
+                IsMoving = false;
+            }
+        }
+
+        //Check to see if we should start or stop equipment animations
+        if (Equipment.Length == Options.EquipmentSlots.Count)
+        {
+            for (var z = 0; z < Options.EquipmentSlots.Count; z++)
+            {
+                if (Equipment[z] != Guid.Empty && (this != Globals.Me || MyEquipment[z] < Options.MaxInvItems))
+                {
+                    var itemId = Guid.Empty;
+                    if (this == Globals.Me)
+                    {
+                        var slot = MyEquipment[z];
+                        if (slot > -1)
                         {
-                            WalkFrame = 0;
+                            itemId = Inventory[slot].ItemId;
                         }
                     }
                     else
                     {
-                        if (WalkFrame > 0 && WalkFrame / SpriteFrames < 0.7f)
-                        {
-                            WalkFrame = SpriteFrames / 2;
-                        }
-                        else
-                        {
-                            WalkFrame = 0;
-                        }
+                        itemId = Equipment[z];
                     }
 
-                    mWalkTimer = Timing.Global.Milliseconds + Options.Instance.Sprites.MovingFrameDuration;
-                }
-            }
-
-            if (Dashing != null)
-            {
-                if (Dashing.Update(this))
-                {
-                    OffsetX = Dashing.GetXOffset();
-                    OffsetY = Dashing.GetYOffset();
-                }
-                else
-                {
-                    OffsetX = 0;
-                    OffsetY = 0;
-                }
-            }
-            else if (IsMoving)
-            {
-                var displacementTime = ecTime * Options.TileHeight / GetMovementTime();
-
-                PickLastDirection(Dir);
-
-                switch (Dir)
-                {
-                    case Direction.Up:
-                        OffsetY -= displacementTime;
-                        OffsetX = 0;
-                        if (OffsetY < 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        break;
-
-                    case Direction.Down:
-                        OffsetY += displacementTime;
-                        OffsetX = 0;
-                        if (OffsetY > 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        break;
-
-                    case Direction.Left:
-                        OffsetX -= displacementTime;
-                        OffsetY = 0;
-                        if (OffsetX < 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-                        break;
-
-                    case Direction.Right:
-                        OffsetX += displacementTime;
-                        OffsetY = 0;
-                        if (OffsetX > 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-                        break;
-                    case Direction.UpLeft:
-                        OffsetY -= displacementTime;
-                        OffsetX -= displacementTime;
-                        if (OffsetY < 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        if (OffsetX < 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-                        break;
-                    case Direction.UpRight:
-                        OffsetY -= displacementTime;
-                        OffsetX += displacementTime;
-                        if (OffsetY < 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        if (OffsetX > 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-                        break;
-                    case Direction.DownLeft:
-                        OffsetY += displacementTime;
-                        OffsetX -= displacementTime;
-                        if (OffsetY > 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        if (OffsetX < 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-
-                        break;
-                    case Direction.DownRight:
-                        OffsetY += displacementTime;
-                        OffsetX += displacementTime;
-                        if (OffsetY > 0)
-                        {
-                            OffsetY = 0;
-                        }
-
-                        if (OffsetX > 0)
-                        {
-                            OffsetX = 0;
-                        }
-
-                        break;
-                }
-
-                if (OffsetX == 0 && OffsetY == 0)
-                {
-                    IsMoving = false;
-                }
-            }
-
-            //Check to see if we should start or stop equipment animations
-            if (Equipment.Length == Options.EquipmentSlots.Count)
-            {
-                for (var z = 0; z < Options.EquipmentSlots.Count; z++)
-                {
-                    if (Equipment[z] != Guid.Empty && (this != Globals.Me || MyEquipment[z] < Options.MaxInvItems))
+                    var itm = ItemBase.Get(itemId);
+                    AnimationBase anim = null;
+                    if (itm != null)
                     {
-                        var itemId = Guid.Empty;
-                        if (this == Globals.Me)
+                        anim = itm.EquipmentAnimation;
+                    }
+
+                    if (anim != null)
+                    {
+                        if (EquipmentAnimations[z] != null &&
+                            (EquipmentAnimations[z].MyBase != anim || EquipmentAnimations[z].Disposed()))
                         {
-                            var slot = MyEquipment[z];
-                            if (slot > -1)
-                            {
-                                itemId = Inventory[slot].ItemId;
-                            }
-                        }
-                        else
-                        {
-                            itemId = Equipment[z];
+                            EquipmentAnimations[z].Dispose();
+                            Animations.Remove(EquipmentAnimations[z]);
+                            EquipmentAnimations[z] = null;
                         }
 
-                        var itm = ItemBase.Get(itemId);
-                        AnimationBase anim = null;
-                        if (itm != null)
+                        if (EquipmentAnimations[z] == null)
                         {
-                            anim = itm.EquipmentAnimation;
-                        }
-
-                        if (anim != null)
-                        {
-                            if (EquipmentAnimations[z] != null &&
-                                (EquipmentAnimations[z].MyBase != anim || EquipmentAnimations[z].Disposed()))
-                            {
-                                EquipmentAnimations[z].Dispose();
-                                Animations.Remove(EquipmentAnimations[z]);
-                                EquipmentAnimations[z] = null;
-                            }
-
-                            if (EquipmentAnimations[z] == null)
-                            {
-                                EquipmentAnimations[z] = new Animation(anim, true, true, -1, this);
-                                Animations.Add(EquipmentAnimations[z]);
-                            }
-                        }
-                        else
-                        {
-                            if (EquipmentAnimations[z] != null)
-                            {
-                                EquipmentAnimations[z].Dispose();
-                                Animations.Remove(EquipmentAnimations[z]);
-                                EquipmentAnimations[z] = null;
-                            }
+                            EquipmentAnimations[z] = new Animation(anim, true, true, -1, this);
+                            Animations.Add(EquipmentAnimations[z]);
                         }
                     }
                     else
@@ -824,1148 +814,370 @@ namespace Intersect.Client.Entities
                         }
                     }
                 }
-            }
-
-            var chatbubbles = mChatBubbles.ToArray();
-            foreach (var chatbubble in chatbubbles)
-            {
-                if (!chatbubble.Update())
+                else
                 {
-                    mChatBubbles.Remove(chatbubble);
-                }
-            }
-
-            if (AnimationTimer < Timing.Global.MillisecondsUtc)
-            {
-                AnimationTimer = Timing.Global.MillisecondsUtc + 200;
-                AnimationFrame++;
-                if (AnimationFrame >= SpriteFrames)
-                {
-                    AnimationFrame = 0;
-                }
-            }
-
-            CalculateOrigin();
-
-            List<Animation> animsToRemove = null;
-            foreach (var animInstance in Animations)
-            {
-                animInstance.Update();
-
-                //If disposed mark to be removed and continue onward
-                if (animInstance.Disposed())
-                {
-                    if (animsToRemove == null)
+                    if (EquipmentAnimations[z] != null)
                     {
-                        animsToRemove = new List<Animation>();
+                        EquipmentAnimations[z].Dispose();
+                        Animations.Remove(EquipmentAnimations[z]);
+                        EquipmentAnimations[z] = null;
+                    }
+                }
+            }
+        }
+
+        var chatbubbles = mChatBubbles.ToArray();
+        foreach (var chatbubble in chatbubbles)
+        {
+            if (!chatbubble.Update())
+            {
+                mChatBubbles.Remove(chatbubble);
+            }
+        }
+
+        if (AnimationTimer < Timing.Global.MillisecondsUtc)
+        {
+            AnimationTimer = Timing.Global.MillisecondsUtc + 200;
+            AnimationFrame++;
+            if (AnimationFrame >= SpriteFrames)
+            {
+                AnimationFrame = 0;
+            }
+        }
+
+        CalculateOrigin();
+
+        List<Animation> animsToRemove = null;
+        foreach (var animInstance in Animations)
+        {
+            animInstance.Update();
+
+            //If disposed mark to be removed and continue onward
+            if (animInstance.Disposed())
+            {
+                if (animsToRemove == null)
+                {
+                    animsToRemove = new List<Animation>();
+                }
+
+                animsToRemove.Add(animInstance);
+
+                continue;
+            }
+
+            if (IsStealthed || IsHidden)
+            {
+                animInstance.Hide();
+            }
+            else
+            {
+                animInstance.Show();
+            }
+
+            var animationDirection = animInstance.AutoRotate ? Dir : default;
+            animInstance.SetPosition(
+                (int)Math.Ceiling(Center.X),
+                (int)Math.Ceiling(Center.Y),
+                X,
+                Y,
+                MapId,
+                animationDirection, Z
+            );
+        }
+
+        if (animsToRemove != null)
+        {
+            foreach (var anim in animsToRemove)
+            {
+                Animations.Remove(anim);
+            }
+        }
+
+        mLastUpdate = Timing.Global.Milliseconds;
+
+        UpdateSpriteAnimation();
+
+        return true;
+    }
+
+    public virtual int CalculateAttackTime()
+    {
+        //If this is an npc we don't know it's attack time. Luckily the server provided it!
+        if (this != Globals.Me && AttackTime > -1)
+        {
+            return AttackTime;
+        }
+
+        //Otherwise return the legacy attack speed calculation
+        return (int)(Options.MaxAttackRate +
+                      (Options.MinAttackRate - Options.MaxAttackRate) *
+                      (((float)Options.MaxStatValue - Stat[(int)Enums.Stat.Speed]) /
+                       Options.MaxStatValue));
+    }
+
+    /// <summary>
+    /// Returns whether this entity is Stealthed or not.
+    /// </summary>
+    public virtual bool IsStealthed => this != Globals.Me && Status.Any(t => t.Type == SpellEffect.Stealth);
+
+    /// <summary>
+    /// Returns whether this entity should be drawn.
+    /// </summary>
+    public virtual bool ShouldDraw => !IsHidden && (!IsStealthed || this == Globals.Me || Globals.Me.IsInMyParty(Id));
+
+    /// <summary>
+    /// Returns whether the name of this entity should be drawn.
+    /// </summary>
+    public virtual bool ShouldDrawName
+    {
+        get
+        {
+            // Return if the map instance is null or the name is empty or not set to be drawn.
+            if (MapInstance == null || string.IsNullOrWhiteSpace(Name) || HideName || !ShouldDraw)
+            {
+                return false;
+            }
+
+            // Look up the mouse position and convert it to a world point.
+            var mousePos = Graphics.ConvertToWorldPoint(Globals.InputManager.MousePosition);
+
+            // Entity is considered hovered if the mouse is over its world position and not hovering over the GUI.
+            IsHovered = WorldPos.Contains(mousePos.X, mousePos.Y) && !Interface.Interface.MouseHitGui();
+
+            // Check the type of entity and return whether its name should be drawn based on settings and conditions.
+            switch (this)
+            {
+                case Projectile _:
+                case Resource _:
+                    return false;
+
+                case Event _:
+                    return true;
+
+                case Player player:
+                    if (IsHovered)
+                    {
+                        return true;
                     }
 
-                    animsToRemove.Add(animInstance);
+                    var me = Globals.Me;
 
+                    if (Globals.Database.MyOverheadInfo && player.Id == me.Id)
+                    {
+                        return true;
+                    }
+
+                    if (Globals.Database.PlayerOverheadInfo && player.Id != me.Id)
+                    {
+                        return true;
+                    }
+
+                    if (Globals.Database.PartyMemberOverheadInfo && me.IsInMyParty(player))
+                    {
+                        return true;
+                    }
+
+                    if (Globals.Database.FriendOverheadInfo && me.IsFriend(player))
+                    {
+                        return true;
+                    }
+
+                    return Globals.Database.GuildMemberOverheadInfo && me.IsGuildMate(player);
+
+                default:
+                    return IsHovered || Globals.Database.NpcOverheadInfo;
+            }
+        }
+    }
+
+    public virtual HashSet<Entity>? DetermineRenderOrder(HashSet<Entity>? existingRenderSet, IMapInstance? map)
+    {
+        existingRenderSet?.Remove(this);
+
+        var playerMap = Globals.Me?.MapInstance;
+        if (map == default || playerMap == default)
+        {
+            return default;
+        }
+
+        var gridX = playerMap.GridX;
+        var gridY = playerMap.GridY;
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
+            {
+                if (x < 0 || x >= Globals.MapGridWidth || y < 0 || y >= Globals.MapGridHeight)
+                {
                     continue;
                 }
 
-                if (IsStealthed || IsHidden)
+                var mapIdOnGrid = Globals.MapGrid[x, y];
+                if (mapIdOnGrid != MapId)
                 {
-                    animInstance.Hide();
+                    continue;
+                }
+
+                var priority = mRenderPriority;
+                if (Z != 0)
+                {
+                    priority += 3;
+                }
+
+                HashSet<Entity>? renderSet = default;
+                int entityY;
+
+                if (y == gridY - 1)
+                {
+                    entityY = Options.MapHeight + Y;
+                }
+                else if (y == gridY)
+                {
+                    entityY = Options.MapHeight * 2 + Y;
                 }
                 else
                 {
-                    animInstance.Show();
+                    entityY = Options.MapHeight * 3 + Y;
                 }
 
-                var animationDirection = animInstance.AutoRotate ? Dir : default;
-                animInstance.SetPosition(
-                    (int)Math.Ceiling(Center.X),
-                    (int)Math.Ceiling(Center.Y),
-                    X,
-                    Y,
-                    MapId,
-                    animationDirection, Z
-                );
-            }
+                entityY = (int)Math.Floor(entityY + OffsetY / Options.TileHeight);
 
-            if (animsToRemove != null)
-            {
-                foreach (var anim in animsToRemove)
+                var renderingEntities = Graphics.RenderingEntities;
+                if (priority >= renderingEntities.GetLength(0) || entityY >= renderingEntities.GetLength(1))
                 {
-                    Animations.Remove(anim);
-                }
-            }
-
-            mLastUpdate = Timing.Global.Milliseconds;
-
-            UpdateSpriteAnimation();
-
-            return true;
-        }
-
-        public virtual int CalculateAttackTime()
-        {
-            //If this is an npc we don't know it's attack time. Luckily the server provided it!
-            if (this != Globals.Me && AttackTime > -1)
-            {
-                return AttackTime;
-            }
-
-            //Otherwise return the legacy attack speed calculation
-            return (int)(Options.MaxAttackRate +
-                          (Options.MinAttackRate - Options.MaxAttackRate) *
-                          (((float)Options.MaxStatValue - Stat[(int)Enums.Stat.Speed]) /
-                           Options.MaxStatValue));
-        }
-
-        /// <summary>
-        /// Returns whether this entity is Stealthed or not.
-        /// </summary>
-        public virtual bool IsStealthed => this != Globals.Me && Status.Any(t => t.Type == SpellEffect.Stealth);
-
-        /// <summary>
-        /// Returns whether this entity should be drawn.
-        /// </summary>
-        public virtual bool ShouldDraw => !IsHidden && (!IsStealthed || this == Globals.Me || Globals.Me.IsInMyParty(Id));
-
-        /// <summary>
-        /// Returns whether the name of this entity should be drawn.
-        /// </summary>
-        public virtual bool ShouldDrawName
-        {
-            get
-            {
-                // Return if the map instance is null or the name is empty or not set to be drawn.
-                if (MapInstance == null || string.IsNullOrWhiteSpace(Name) || HideName || !ShouldDraw)
-                {
-                    return false;
-                }
-
-                // Look up the mouse position and convert it to a world point.
-                var mousePos = Graphics.ConvertToWorldPoint(Globals.InputManager.MousePosition);
-
-                // Entity is considered hovered if the mouse is over its world position and not hovering over the GUI.
-                IsHovered = WorldPos.Contains(mousePos.X, mousePos.Y) && !Interface.Interface.MouseHitGui();
-
-                // Check the type of entity and return whether its name should be drawn based on settings and conditions.
-                switch (this)
-                {
-                    case Projectile _:
-                    case Resource _:
-                        return false;
-
-                    case Event _:
-                        return true;
-
-                    case Player player:
-                        if (IsHovered)
-                        {
-                            return true;
-                        }
-
-                        var me = Globals.Me;
-
-                        if (Globals.Database.MyOverheadInfo && player.Id == me.Id)
-                        {
-                            return true;
-                        }
-
-                        if (Globals.Database.PlayerOverheadInfo && player.Id != me.Id)
-                        {
-                            return true;
-                        }
-
-                        if (Globals.Database.PartyMemberOverheadInfo && me.IsInMyParty(player))
-                        {
-                            return true;
-                        }
-
-                        if (Globals.Database.FriendOverheadInfo && me.IsFriend(player))
-                        {
-                            return true;
-                        }
-
-                        return Globals.Database.GuildMemberOverheadInfo && me.IsGuildMate(player);
-
-                    default:
-                        return IsHovered || Globals.Database.NpcOverheadInfo;
-                }
-            }
-        }
-
-        public virtual HashSet<Entity>? DetermineRenderOrder(HashSet<Entity>? existingRenderSet, IMapInstance? map)
-        {
-            existingRenderSet?.Remove(this);
-
-            var playerMap = Globals.Me?.MapInstance;
-            if (map == default || playerMap == default)
-            {
-                return default;
-            }
-
-            var gridX = playerMap.GridX;
-            var gridY = playerMap.GridY;
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
-                {
-                    if (x < 0 || x >= Globals.MapGridWidth || y < 0 || y >= Globals.MapGridHeight)
-                    {
-                        continue;
-                    }
-
-                    var mapIdOnGrid = Globals.MapGrid[x, y];
-                    if (mapIdOnGrid != MapId)
-                    {
-                        continue;
-                    }
-
-                    var priority = mRenderPriority;
-                    if (Z != 0)
-                    {
-                        priority += 3;
-                    }
-
-                    HashSet<Entity>? renderSet = default;
-                    int entityY;
-
-                    if (y == gridY - 1)
-                    {
-                        entityY = Options.MapHeight + Y;
-                    }
-                    else if (y == gridY)
-                    {
-                        entityY = Options.MapHeight * 2 + Y;
-                    }
-                    else
-                    {
-                        entityY = Options.MapHeight * 3 + Y;
-                    }
-
-                    entityY = (int)Math.Floor(entityY + OffsetY / Options.TileHeight);
-
-                    var renderingEntities = Graphics.RenderingEntities;
-                    if (priority >= renderingEntities.GetLength(0) || entityY >= renderingEntities.GetLength(1))
-                    {
-                        return renderSet;
-                    }
-
-                    renderSet = renderingEntities[priority, entityY];
-                    renderSet.Add(this);
-
                     return renderSet;
                 }
-            }
 
-            return existingRenderSet;
+                renderSet = renderingEntities[priority, entityY];
+                renderSet.Add(this);
+
+                return renderSet;
+            }
         }
 
-        //Rendering Functions
-        public virtual void Draw()
+        return existingRenderSet;
+    }
+
+    //Rendering Functions
+    public virtual void Draw()
+    {
+        if (IsHidden)
         {
-            if (IsHidden)
+            return; //Don't draw if the entity is hidden
+        }
+
+        WorldPos.Reset();
+        var map = Maps.MapInstance.Get(MapId);
+        if (map == null || !Globals.GridMaps.Contains(MapId))
+        {
+            return;
+        }
+
+        var sprite = "";
+        // Copy the actual render color, because we'll be editing it later and don't want to overwrite it.
+        var renderColor = new Color(Color.A, Color.R, Color.G, Color.B);
+
+        string transformedSprite = "";
+
+        // Loop through the entity status list.
+        for (var n = 0; n < Status.Count; n++)
+        {
+            var status = Status[n];
+
+            switch (status.Type)
             {
-                return; //Don't draw if the entity is hidden
-            }
+                // If the entity is transformed: apply that sprite instead.
+                case SpellEffect.Transform:
+                    transformedSprite = sprite = status.Data;
+                    break;
 
-            WorldPos.Reset();
-            var map = Maps.MapInstance.Get(MapId);
-            if (map == null || !Globals.GridMaps.Contains(MapId))
-            {
-                return;
-            }
-
-            var sprite = "";
-            // Copy the actual render color, because we'll be editing it later and don't want to overwrite it.
-            var renderColor = new Color(Color.A, Color.R, Color.G, Color.B);
-
-            string transformedSprite = "";
-
-            // Loop through the entity status list.
-            for (var n = 0; n < Status.Count; n++)
-            {
-                var status = Status[n];
-
-                switch (status.Type)
-                {
-                    // If the entity is transformed: apply that sprite instead.
-                    case SpellEffect.Transform:
-                        transformedSprite = sprite = status.Data;
-                        break;
-
-                    // If entity is stealth, don't render unless the entity is the player or is within their party.
-                    case SpellEffect.Stealth:
-                        if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
-                        {
-                            return;
-                        }
-
-                        renderColor.A /= 2;
-                        break;
-                }
-            }
-
-            if (transformedSprite != TransformedSprite)
-            {
-                TransformedSprite = transformedSprite;
-            }
-
-            //Check if there is no transformed sprite set
-            if (string.IsNullOrEmpty(sprite))
-            {
-                sprite = Sprite;
-                Sprite = sprite;
-            }
-
-            if (!AnimatedTextures.TryGetValue(SpriteAnimation, out var texture))
-            {
-                texture = Texture;
-            }
-
-            if (texture == default)
-            {
-                // We don't have a texture to render, but we still want this to be targetable.
-                WorldPos = new FloatRect(
-                    map.GetX() + X * Options.TileWidth + OffsetX,
-                    map.GetY() + Y * Options.TileHeight + OffsetY,
-                    Options.TileWidth,
-                    Options.TileHeight);
-                return;
-            }
-
-            var spriteRow = PickSpriteRow(Dir);
-
-            var frameWidth = texture.GetWidth() / SpriteFrames;
-            var frameHeight = texture.GetHeight() / Options.Instance.Sprites.Directions;
-
-            var frame = SpriteFrame;
-            if (Options.AnimatedSprites.Contains(sprite.ToLower()))
-            {
-                frame = AnimationFrame;
-            }
-            else if (SpriteAnimation == SpriteAnimations.Normal)
-            {
-                frame = NormalSpriteAnimationFrame;
-            }
-
-            var srcRectangle = new FloatRect(frame * frameWidth, spriteRow * frameHeight, frameWidth, frameHeight);
-            var destRectangle = new FloatRect(
-                (int)Math.Ceiling(Origin.X - frameWidth / 2f),
-                (int)Math.Ceiling(Origin.Y - frameHeight),
-                srcRectangle.Width,
-                srcRectangle.Height
-            );
-
-            WorldPos = destRectangle;
-
-            //Order the layers of paperdolls and sprites
-            for (var z = 0; z < Options.PaperdollOrder[(int)mLastDirection].Count; z++)
-            {
-                var paperdoll = Options.PaperdollOrder[(int)mLastDirection][z];
-                var equipSlot = Options.EquipmentSlots.IndexOf(paperdoll);
-
-                //Check for player
-                if (string.Equals("Player", paperdoll, StringComparison.Ordinal))
-                {
-                    Graphics.DrawGameTexture(texture, srcRectangle, destRectangle, renderColor);
-                }
-                else if (equipSlot > -1)
-                {
-                    //Don't render the paperdolls if they have transformed.
-                    if (sprite == Sprite && Equipment.Length == Options.EquipmentSlots.Count)
+                // If entity is stealth, don't render unless the entity is the player or is within their party.
+                case SpellEffect.Stealth:
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
-                        if (Equipment[equipSlot] != Guid.Empty && this != Globals.Me ||
-                            MyEquipment[equipSlot] < Options.MaxInvItems)
-                        {
-                            var itemId = Guid.Empty;
-                            if (this == Globals.Me)
-                            {
-                                var slot = MyEquipment[equipSlot];
-                                if (slot > -1)
-                                {
-                                    itemId = Inventory[slot].ItemId;
-                                }
-                            }
-                            else
-                            {
-                                itemId = Equipment[equipSlot];
-                            }
-
-                            var item = ItemBase.Get(itemId);
-                            if (ItemBase.TryGet(itemId, out var itemDescriptor))
-                            {
-                                var itemPaperdoll = Gender == 0
-                                    ? itemDescriptor.MalePaperdoll
-                                    : itemDescriptor.FemalePaperdoll;
-                                DrawEquipment(itemPaperdoll, item.Color * renderColor);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        private int NormalSpriteAnimationFrame
-        {
-            get
-            {
-                var frame = WalkFrame;
-
-                if (IsBlocking)
-                {
-                    frame = Options.Instance.Sprites.NormalBlockFrame;
-                }
-                else if (IsCasting)
-                {
-                    frame = Options.Instance.Sprites.NormalCastFrame;
-                }
-                // Checks if the entity is attacking or not.
-                // Note: the calculation differs with IsAttacking because
-                // frames are intended to behave differently with normal sprite-sheets.
-                else if (AttackTimer - (CalculateAttackTime() / 2) > Timing.Global.Milliseconds)
-                {
-                    frame = Options.Instance.Sprites.NormalAttackFrame;
-                }
-
-                if (frame >= SpriteFrames)
-                {
-                    frame = SpriteFrames / 2;
-                }
-
-                return frame;
-            }
-        }
-
-        private int PickSpriteRow(Direction direction)
-        {
-            switch (direction)
-            {
-                case Direction.Left:
-                case Direction.DownLeft when mLastDirection == Direction.Left:
-                case Direction.UpLeft when mLastDirection == Direction.Left:
-                    return 1;
-
-                case Direction.Right:
-                case Direction.DownRight when mLastDirection == Direction.Right:
-                case Direction.UpRight when mLastDirection == Direction.Right:
-                    return 2;
-
-                case Direction.Up:
-                case Direction.UpLeft when mLastDirection != Direction.Left:
-                case Direction.UpRight when mLastDirection != Direction.Right:
-                    return 3;
-
-                case Direction.Down:
-                case Direction.DownLeft when mLastDirection != Direction.Left:
-                case Direction.DownRight when mLastDirection != Direction.Right:
-                default:
-                    return 0;
-            }
-        }
-
-        public void PickLastDirection(Direction direction)
-        {
-            switch (direction)
-            {
-                case Direction.Left:
-                case Direction.DownLeft when mLastDirection == Direction.Left:
-                case Direction.UpLeft when mLastDirection == Direction.Left:
-                    mLastDirection = Direction.Left;
-                    break;
-
-                case Direction.Right:
-                case Direction.DownRight when mLastDirection == Direction.Right:
-                case Direction.UpRight when mLastDirection == Direction.Right:
-                    mLastDirection = Direction.Right;
-                    break;
-
-                case Direction.Up:
-                case Direction.UpLeft when mLastDirection != Direction.Left:
-                case Direction.UpRight when mLastDirection != Direction.Right:
-                    mLastDirection = Direction.Up;
-                    break;
-
-                case Direction.Down:
-                case Direction.DownLeft when mLastDirection != Direction.Left:
-                case Direction.DownRight when mLastDirection != Direction.Right:
-                default:
-                    mLastDirection = Direction.Down;
-                    break;
-            }
-        }
-
-        public void DrawChatBubbles()
-        {
-            //Don't draw if the entity is hidden
-            if (IsHidden)
-            {
-                return;
-            }
-
-            //If unit is stealthed, don't render unless the entity is the player or party member.
-            if (!ShouldDraw)
-            {
-                return;
-            }
-
-            var chatbubbles = mChatBubbles.ToArray();
-            var bubbleoffset = 0f;
-            for (var i = chatbubbles.Length - 1; i > -1; i--)
-            {
-                bubbleoffset = chatbubbles[i].Draw(bubbleoffset);
-            }
-        }
-
-        /// <summary>
-        /// Draws the equipment of entities using paperdoll texture files.
-        /// </summary>
-        public virtual void DrawEquipment(string filename, Color renderColor)
-        {
-            // Get the current map.
-            var map = Maps.MapInstance.Get(MapId);
-
-            // If the map is null or hideEquipment is true: do nothing.
-            if (map == null || map.HideEquipment)
-            {
-                return;
-            }
-
-            // Paperdoll textures and Frames.
-            GameTexture paperdollTex = null;
-            var spriteFrames = SpriteFrames;
-
-            // Extract filename without it's extension.
-            var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
-
-            // Equipment's custom paperdoll texture.
-            if (SpriteAnimation == SpriteAnimations.Attack ||
-                SpriteAnimation == SpriteAnimations.Cast ||
-                SpriteAnimation == SpriteAnimations.Weapon)
-            {
-                // Extract animation name from the AnimatedTextures list.
-                var animationName = Path.GetFileNameWithoutExtension(AnimatedTextures[SpriteAnimation].Name);
-
-                // Extract the substring after the separator.
-                var separatorIndex = animationName.IndexOf('_') + 1;
-                var customAnimationName = animationName.Substring(separatorIndex);
-
-                // Try to get custom paperdoll texture.
-                var customPaperdollTex =
-                    Globals.ContentManager.GetTexture(TextureType.Paperdoll,
-                        $"{filenameNoExt}_{customAnimationName}.png");
-
-                // If custom paperdoll texture exists, use it.
-                if (customPaperdollTex != null)
-                {
-                    paperdollTex = customPaperdollTex;
-                }
-            }
-
-            // If there's no custom paperdoll: use the paperdoll texture based on the SpriteAnimation.
-            if (paperdollTex == null && !string.IsNullOrEmpty($"{SpriteAnimation}"))
-            {
-                paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll,
-                    $"{filenameNoExt}_{SpriteAnimation}.png");
-            }
-
-            // If the paperdoll texture is still null: try to get the default texture.
-            if (paperdollTex == null)
-            {
-                paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll, filename);
-                spriteFrames = Options.Instance.Sprites.NormalFrames;
-            }
-
-            // If the paperdoll texture is null at this point: do nothing.
-            if (paperdollTex == null)
-            {
-                return;
-            }
-
-            // Calculate: direction, frame width and frame height.
-            var spriteRow = PickSpriteRow(Dir);
-            var frameWidth = paperdollTex.GetWidth() / spriteFrames;
-            var frameHeight = paperdollTex.GetHeight() / Options.Instance.Sprites.Directions;
-
-            // Calculate: source and destination rectangles.
-            var frame = SpriteFrame;
-            if (SpriteAnimation == SpriteAnimations.Normal)
-            {
-                frame = NormalSpriteAnimationFrame;
-            }
-
-            var srcRectangle = new FloatRect(frame * frameWidth, spriteRow * frameHeight, frameWidth, frameHeight);
-            var destRectangle = new FloatRect(
-                (int)Math.Ceiling(Center.X - frameWidth / 2f),
-                (int)Math.Ceiling(Center.Y - frameHeight / 2f),
-                srcRectangle.Width,
-                srcRectangle.Height
-            );
-
-            // Draw the paperdoll texture using: source and destination rectangles along with the render color.
-            Graphics.DrawGameTexture(paperdollTex, srcRectangle, destRectangle, renderColor);
-        }
-
-        protected virtual void CalculateOrigin()
-        {
-            if (LatestMap == default)
-            {
-                mOrigin = default;
-                return;
-            }
-
-            mOrigin = new Pointf(
-                LatestMap.X + X * Options.TileWidth + OffsetX + Options.TileWidth / 2,
-                LatestMap.Y + Y * Options.TileHeight + OffsetY + Options.TileHeight
-            );
-        }
-
-        public virtual float GetTop(int overrideHeight = -1)
-        {
-            if (LatestMap == default)
-            {
-                return 0f;
-            }
-
-            var y = (int)Math.Ceiling(Origin.Y);
-
-            if (overrideHeight > -1)
-            {
-                y -= overrideHeight / Options.Instance.Sprites.Directions;
-            }
-            else if (Texture != null)
-            {
-                y -= Texture.Height / Options.Instance.Sprites.Directions;
-            }
-
-            return y;
-        }
-
-        public void DrawLabels(
-            string label,
-            int position,
-            Color labelColor,
-            Color textColor,
-            Color borderColor = null,
-            Color backgroundColor = null
-        )
-        {
-            // Are we supposed to hide this Label?
-            if (!ShouldDrawName || string.IsNullOrWhiteSpace(label))
-            {
-                return;
-            }
-
-            var map = MapInstance;
-            if (map == null)
-            {
-                return;
-            }
-
-            if (borderColor == null)
-            {
-                borderColor = Color.Transparent;
-            }
-
-            if (backgroundColor == null)
-            {
-                backgroundColor = Color.Transparent;
-            }
-
-            //If we have a non-transparent label color then use it, otherwise use the players name color
-            if (labelColor != null && labelColor.A != 0)
-            {
-                textColor = labelColor;
-            }
-
-            var textSize = Graphics.Renderer.MeasureText(label, Graphics.EntityNameFont, 1);
-
-            var x = (int)Math.Ceiling(Origin.X);
-            var y = position == 0 ? GetLabelLocation(LabelType.Header) : GetLabelLocation(LabelType.Footer);
-
-            if (backgroundColor != Color.Transparent)
-            {
-                Graphics.DrawGameTexture(
-                    Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                    new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y), backgroundColor
-                );
-            }
-
-            Graphics.Renderer.DrawString(
-                label, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y, 1,
-                Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
-            );
-        }
-
-        public virtual void DrawName(Color textColor, Color borderColor = null, Color backgroundColor = null)
-        {
-            // Are we really supposed to draw this name?
-            if (!ShouldDrawName)
-            {
-                return;
-            }
-
-            //Check for npc colors
-            if (textColor == null)
-            {
-                LabelColor? color;
-                switch (Aggression)
-                {
-                    case NpcAggression.Aggressive:
-                        color = CustomColors.Names.Npcs["Aggressive"];
-                        break;
-
-                    case NpcAggression.AttackWhenAttacked:
-                        color = CustomColors.Names.Npcs["AttackWhenAttacked"];
-                        break;
-
-                    case NpcAggression.AttackOnSight:
-                        color = CustomColors.Names.Npcs["AttackOnSight"];
-                        break;
-
-                    case NpcAggression.Guard:
-                        color = CustomColors.Names.Npcs["Guard"];
-                        break;
-
-                    case NpcAggression.Neutral:
-                    default:
-                        color = CustomColors.Names.Npcs["Neutral"];
-                        break;
-                }
-
-                if (color != null)
-                {
-                    textColor = color?.Name;
-                    backgroundColor = backgroundColor ?? color?.Background;
-                    borderColor = borderColor ?? color?.Outline;
-                }
-            }
-
-            if (borderColor == null)
-            {
-                borderColor = Color.Transparent;
-            }
-
-            if (backgroundColor == null)
-            {
-                backgroundColor = Color.Transparent;
-            }
-
-            var name = Name;
-            if ((this is Player && Options.Player.ShowLevelByName) || (Type == EntityType.GlobalEntity && Options.Npc.ShowLevelByName))
-            {
-                name = Strings.GameWindow.EntityNameAndLevel.ToString(Name, Level);
-            }
-
-            var textSize = Graphics.Renderer.MeasureText(name, Graphics.EntityNameFont, 1);
-
-            var x = (int)Math.Ceiling(Origin.X);
-            var y = GetLabelLocation(LabelType.Name);
-
-            if (backgroundColor != Color.Transparent)
-            {
-                Graphics.DrawGameTexture(
-                    Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                    new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y), backgroundColor
-                );
-            }
-
-            Graphics.Renderer.DrawString(
-                name, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y, 1,
-                Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
-            );
-        }
-
-        public float GetLabelLocation(LabelType type)
-        {
-            var y = GetTop() - 8;
-
-            //Need room for HP bar if not an event.
-            if (!(this is Event) && ShouldDrawHpBar)
-            {
-                y -= GetBoundingHpBarTexture().Height + 2;
-            }
-
-            switch (type)
-            {
-                case LabelType.Header:
-                    y = GetLabelLocation(LabelType.Name);
-
-                    if (string.IsNullOrWhiteSpace(HeaderLabel.Text))
-                    {
-                        break;
+                        return;
                     }
 
-                    var headerSize = Graphics.Renderer.MeasureText(HeaderLabel.Text, Graphics.EntityNameFont, 1);
-                    y -= headerSize.Y + 2;
-                    break;
-
-                case LabelType.Footer:
-                    if (string.IsNullOrWhiteSpace(FooterLabel.Text))
-                    {
-                        break;
-                    }
-
-                    var footerSize = Graphics.Renderer.MeasureText(FooterLabel.Text, Graphics.EntityNameFont, 1);
-                    y -= footerSize.Y - 6;
-                    break;
-
-                case LabelType.Name:
-                    y = GetLabelLocation(LabelType.Footer);
-                    var nameSize = Graphics.Renderer.MeasureText(Name, Graphics.EntityNameFont, 1);
-                    y -= nameSize.Y + (string.IsNullOrEmpty(FooterLabel.Text) ? -6 : 2);
-                    break;
-
-                case LabelType.ChatBubble:
-                    y = GetLabelLocation(LabelType.Guild) - 2;
-                    break;
-
-                case LabelType.Guild:
-                    if (this is Player player)
-                    {
-                        // Do we have a header? If so, slightly change the position!
-                        if (string.IsNullOrWhiteSpace(HeaderLabel.Text))
-                        {
-                            y = GetLabelLocation(LabelType.Name);
-                        }
-                        else
-                        {
-                            y = GetLabelLocation(LabelType.Header);
-                        }
-
-                        if (string.IsNullOrWhiteSpace(player.Guild))
-                        {
-                            break;
-                        }
-
-                        var guildSize = Graphics.Renderer.MeasureText(player.Guild, Graphics.EntityNameFont, 1);
-                        y -= 2 + guildSize.Y;
-                    }
+                    renderColor.A /= 2;
                     break;
             }
-
-            return y;
         }
 
-        public long GetShieldSize()
+        if (transformedSprite != TransformedSprite)
         {
-            long shieldSize = 0;
-            foreach (var status in Status)
+            TransformedSprite = transformedSprite;
+        }
+
+        //Check if there is no transformed sprite set
+        if (string.IsNullOrEmpty(sprite))
+        {
+            sprite = Sprite;
+            Sprite = sprite;
+        }
+
+        if (!AnimatedTextures.TryGetValue(SpriteAnimation, out var texture))
+        {
+            texture = Texture;
+        }
+
+        if (texture == default)
+        {
+            // We don't have a texture to render, but we still want this to be targetable.
+            WorldPos = new FloatRect(
+                map.GetX() + X * Options.TileWidth + OffsetX,
+                map.GetY() + Y * Options.TileHeight + OffsetY,
+                Options.TileWidth,
+                Options.TileHeight);
+            return;
+        }
+
+        var spriteRow = PickSpriteRow(Dir);
+
+        var frameWidth = texture.GetWidth() / SpriteFrames;
+        var frameHeight = texture.GetHeight() / Options.Instance.Sprites.Directions;
+
+        var frame = SpriteFrame;
+        if (Options.AnimatedSprites.Contains(sprite.ToLower()))
+        {
+            frame = AnimationFrame;
+        }
+        else if (SpriteAnimation == SpriteAnimations.Normal)
+        {
+            frame = NormalSpriteAnimationFrame;
+        }
+
+        var srcRectangle = new FloatRect(frame * frameWidth, spriteRow * frameHeight, frameWidth, frameHeight);
+        var destRectangle = new FloatRect(
+            (int)Math.Ceiling(Origin.X - frameWidth / 2f),
+            (int)Math.Ceiling(Origin.Y - frameHeight),
+            srcRectangle.Width,
+            srcRectangle.Height
+        );
+
+        WorldPos = destRectangle;
+
+        //Order the layers of paperdolls and sprites
+        for (var z = 0; z < Options.PaperdollOrder[(int)mLastDirection].Count; z++)
+        {
+            var paperdoll = Options.PaperdollOrder[(int)mLastDirection][z];
+            var equipSlot = Options.EquipmentSlots.IndexOf(paperdoll);
+
+            //Check for player
+            if (string.Equals("Player", paperdoll, StringComparison.Ordinal))
             {
-                if (status.Type == SpellEffect.Shield)
+                Graphics.DrawGameTexture(texture, srcRectangle, destRectangle, renderColor);
+            }
+            else if (equipSlot > -1)
+            {
+                //Don't render the paperdolls if they have transformed.
+                if (sprite == Sprite && Equipment.Length == Options.EquipmentSlots.Count)
                 {
-                    shieldSize += status.Shield[(int)Enums.Vital.Health];
-                }
-            }
-            return shieldSize;
-        }
-
-        protected virtual bool ShouldDrawHpBar
-        {
-            get
-            {
-                if (ShouldNotDrawHpBar)
-                {
-                    return false;
-                }
-
-                if (IsHovered)
-                {
-                    return true;
-                }
-
-                if (GetShieldSize() > 0)
-                {
-                    return true;
-                }
-
-                if (Vital[(int)Enums.Vital.Health] != MaxVital[(int)Enums.Vital.Health])
-                {
-                    return true;
-                }
-
-                return GetType() == typeof(Entity) && Globals.Database.NpcOverheadHpBar;
-            }
-        }
-
-        protected bool ShouldNotDrawHpBar
-        {
-            get
-            {
-                return LatestMap == default || !ShouldDraw || Vital[(int)Enums.Vital.Health] < 1;
-            }
-        }
-
-        public GameTexture GetBoundingHpBarTexture()
-        {
-            return GameTexture.GetBoundingTexture(
-                BoundsComparison.Height,
-                Globals.ContentManager.GetTexture(TextureType.Misc, "hpbackground.png"),
-                Globals.ContentManager.GetTexture(TextureType.Misc, "hpbar.png"),
-                Globals.ContentManager.GetTexture(TextureType.Misc, "shieldbar.png")
-            );
-        }
-
-        public void DrawHpBar()
-        {
-            // Are we supposed to hide this HP bar?
-            if (!ShouldDrawHpBar)
-            {
-                return;
-            }
-
-            var hpBackground = Globals.ContentManager.GetTexture(TextureType.Misc, "hpbackground.png");
-            var hpForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "hpbar.png");
-            var shieldForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "shieldbar.png");
-
-            var boundingTeture = GameTexture.GetBoundingTexture(
-                BoundsComparison.Height,
-                hpBackground,
-                hpForeground,
-                shieldForeground
-            );
-
-            var foregroundBoundingTexture = hpForeground;
-
-            // Check for shields
-            var maxVital = MaxVital[(int)Enums.Vital.Health];
-            var shieldSize = GetShieldSize();
-
-            if (shieldSize + Vital[(int)Enums.Vital.Health] > maxVital)
-            {
-                maxVital = shieldSize + Vital[(int)Enums.Vital.Health];
-            }
-
-            var hpfillRatio = (float)Vital[(int)Enums.Vital.Health] / maxVital;
-            hpfillRatio = Math.Min(1, Math.Max(0, hpfillRatio));
-
-            var hpFillWidth = (int)Math.Round(hpfillRatio * foregroundBoundingTexture.Width);
-            var shieldPixelFillRatio = (foregroundBoundingTexture.Width - hpFillWidth) / ((float)foregroundBoundingTexture.Width);
-            var shieldFillWidth = (int)Math.Floor(foregroundBoundingTexture.Width * shieldPixelFillRatio);
-
-            if (foregroundBoundingTexture.Width < hpFillWidth + shieldFillWidth)
-            {
-                hpFillWidth = Math.Max(1, foregroundBoundingTexture.Width - shieldFillWidth);
-                shieldFillWidth = Math.Max(1, foregroundBoundingTexture.Width - hpFillWidth);
-            }
-
-            if (shieldSize > 0 && shieldFillWidth < 1)
-            {
-                hpFillWidth -= 1 - shieldFillWidth;
-                shieldFillWidth = 1;
-            }
-
-            var x = (int)Math.Ceiling(Origin.X);
-            var y = (int)Math.Ceiling(Origin.Y);
-
-            var sprite = Globals.ContentManager.GetTexture(TextureType.Entity, Sprite);
-            if (sprite != null)
-            {
-                y -= sprite.Height / Options.Instance.Sprites.Directions;
-                y -= boundingTeture.Height + 2;
-            }
-
-            y += boundingTeture.Height / 2;
-
-            if (hpBackground != null)
-            {
-                Graphics.DrawGameTexture(
-                    hpBackground, new FloatRect(0, 0, hpBackground.Width, hpBackground.Height),
-                    new FloatRect(x - hpBackground.Width / 2, y - hpBackground.Height / 2, hpBackground.Width, hpBackground.Height), Color.White
-                );
-            }
-
-            if (hpForeground != null)
-            {
-                Graphics.DrawGameTexture(
-                    hpForeground,
-                    new FloatRect(0, 0, hpFillWidth, hpForeground.Height),
-                    new FloatRect(x - foregroundBoundingTexture.Width / 2, y - hpForeground.Height / 2, hpFillWidth, hpForeground.Height), Color.White
-                );
-            }
-
-            if (shieldSize > 0 && shieldForeground != null) //Check for a shield to render
-            {
-                var shieldFillRatio = shieldFillWidth / (float)foregroundBoundingTexture.Width;
-                Graphics.DrawGameTexture(
-                    shieldForeground,
-                    new FloatRect(shieldForeground.Width * (1 - shieldFillRatio), 0, shieldForeground.Width * shieldFillRatio, shieldForeground.Height),
-                    new FloatRect(x - foregroundBoundingTexture.Width / 2 + hpFillWidth, y - shieldForeground.Height / 2, shieldFillWidth, shieldForeground.Height), Color.White
-                );
-            }
-        }
-
-        public bool ShouldDrawCastingBar => ShouldDraw && IsCasting && LatestMap != default;
-
-        public void DrawCastingBar()
-        {
-            // Are we supposed to hide this cast bar?
-            if (!ShouldDrawCastingBar)
-            {
-                return;
-            }
-
-            var castingSpell = SpellBase.Get(SpellCast);
-            if (castingSpell == null)
-            {
-                return;
-            }
-
-            var castBackground = Globals.ContentManager.GetTexture(TextureType.Misc, "castbackground.png");
-            var castForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "castbar.png");
-            var boundingTexture = GameTexture.GetBoundingTexture(BoundsComparison.Height, castBackground, castForeground);
-
-            float remainingTime = CastTime - Timing.Global.Milliseconds;
-            var fillRatio = 1 - remainingTime / castingSpell.CastDuration;
-
-            var x = (int)Math.Ceiling(Origin.X);
-            var y = (int)Math.Ceiling(Origin.Y);
-
-            y += 2 + boundingTexture.Height / 2;
-
-            if (castBackground != null)
-            {
-                Graphics.DrawGameTexture(
-                    castBackground, new FloatRect(0, 0, castBackground.Width, castBackground.Height),
-                    new FloatRect(x - castBackground.Width / 2, y - castBackground.Height / 2, castBackground.Width, castBackground.Height), Color.White
-                );
-            }
-
-            if (castForeground != null)
-            {
-                Graphics.DrawGameTexture(
-                    castForeground,
-                    new FloatRect(0, 0, castForeground.GetWidth() * fillRatio, castForeground.Height),
-                    new FloatRect(x - castForeground.Width / 2, y - castForeground.Height / 2, castForeground.Width * fillRatio, castForeground.Height), Color.White
-                );
-            }
-        }
-
-        public bool ShouldDrawTarget => !(this is Projectile) && LatestMap != default;
-
-        public void DrawTarget(int priority)
-        {
-            // Should we draw the target?
-            if (!ShouldDrawTarget)
-            {
-                return;
-            }
-
-            var targetTexture = Globals.ContentManager.GetTexture(TextureType.Misc, "target.png");
-            if (targetTexture == null)
-            {
-                return;
-            }
-
-            var srcRectangle = new FloatRect(
-                priority * targetTexture.GetWidth() / 2f,
-                0,
-                targetTexture.GetWidth() / 2f,
-                targetTexture.GetHeight()
-            );
-
-            var destRectangle = new FloatRect(
-                (float)Math.Ceiling(WorldPos.X + (WorldPos.Width - targetTexture.GetWidth() / 2) / 2),
-                (float)Math.Ceiling(WorldPos.Y + (WorldPos.Height - targetTexture.GetHeight()) / 2),
-                srcRectangle.Width,
-                srcRectangle.Height
-            );
-
-            Graphics.DrawGameTexture(targetTexture, srcRectangle, destRectangle, Color.White);
-        }
-
-        public virtual bool CanBeAttacked => true;
-
-        //Chatting
-        public void AddChatBubble(string text)
-        {
-            if (string.IsNullOrEmpty(text))
-            {
-                return;
-            }
-
-            mChatBubbles.Add(new ChatBubble(this, text));
-        }
-
-        //Statuses
-        public bool StatusActive(Guid guid)
-        {
-            foreach (var status in Status)
-            {
-                if (status.SpellId == guid && status.IsActive)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public IStatus GetStatus(Guid guid)
-        {
-            foreach (var status in Status)
-            {
-                if (status.SpellId == guid && status.IsActive)
-                {
-                    return status;
-                }
-            }
-
-            return null;
-        }
-
-        public void SortStatuses()
-        {
-            //Sort Status effects by remaining time
-            Status = Status.OrderByDescending(x => x.RemainingMs).ToList();
-        }
-
-        private void UpdateSpriteAnimation()
-        {
-            //Exit if textures haven't been loaded yet
-            if (AnimatedTextures.Count == 0)
-            {
-                return;
-            }
-
-            var timingMilliseconds = Timing.Global.Milliseconds;
-            var isNotBlockingAndCasting = !IsBlocking && !IsCasting;
-
-            SpriteAnimation = SpriteAnimations.Normal;
-            if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _) &&
-                LastActionTime + Options.Instance.Sprites.IdleStartDelay < timingMilliseconds &&
-                isNotBlockingAndCasting)
-            {
-                SpriteAnimation = SpriteAnimations.Idle;
-            }
-
-            if (IsMoving && !IsAttacking && isNotBlockingAndCasting)
-            {
-                SpriteAnimation = SpriteAnimations.Normal;
-                LastActionTime = timingMilliseconds;
-            }
-
-            if (IsAttacking && isNotBlockingAndCasting)
-            {
-                // Normal sprite-sheets has their own handler for attacking frames.
-                if (AnimatedTextures.TryGetValue(SpriteAnimations.Normal, out _))
-                {
-                    return;
-                }
-
-                var timeInAttack = CalculateAttackTime() - (AttackTimer - timingMilliseconds);
-                LastActionTime = Timing.Global.Milliseconds;
-
-                if (AnimatedTextures.TryGetValue(SpriteAnimations.Attack, out _))
-                {
-                    SpriteAnimation = SpriteAnimations.Attack;
-                }
-
-                if (Options.WeaponIndex > -1 && Options.WeaponIndex < Equipment.Length)
-                {
-                    if (Equipment[Options.WeaponIndex] != Guid.Empty && this != Globals.Me ||
-                        MyEquipment[Options.WeaponIndex] < Options.MaxInvItems)
+                    if (Equipment[equipSlot] != Guid.Empty && this != Globals.Me ||
+                        MyEquipment[equipSlot] < Options.MaxInvItems)
                     {
                         var itemId = Guid.Empty;
                         if (this == Globals.Me)
                         {
-                            var slot = MyEquipment[Options.WeaponIndex];
+                            var slot = MyEquipment[equipSlot];
                             if (slot > -1)
                             {
                                 itemId = Inventory[slot].ItemId;
@@ -1973,466 +1185,1252 @@ namespace Intersect.Client.Entities
                         }
                         else
                         {
-                            itemId = Equipment[Options.WeaponIndex];
+                            itemId = Equipment[equipSlot];
                         }
 
                         var item = ItemBase.Get(itemId);
-                        if (item != null)
+                        if (ItemBase.TryGet(itemId, out var itemDescriptor))
                         {
-                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
-                            {
-                                SpriteAnimation = SpriteAnimations.Weapon;
-                            }
-
-                            if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _) &&
-                                item.ProjectileId != Guid.Empty &&
-                                item.WeaponSpriteOverride == null)
-                            {
-                                SpriteAnimation = SpriteAnimations.Shoot;
-                            }
+                            var itemPaperdoll = Gender == 0
+                                ? itemDescriptor.MalePaperdoll
+                                : itemDescriptor.FemalePaperdoll;
+                            DrawEquipment(itemPaperdoll, item.Color * renderColor);
                         }
                     }
                 }
+            }
+        }
+    }
 
-                switch (SpriteAnimation)
-                {
-                    case SpriteAnimations.Cast:
-                    case SpriteAnimations.Idle:
-                    case SpriteAnimations.Normal:
-                        break;
-                    case SpriteAnimations.Attack:
-                    case SpriteAnimations.Shoot:
-                    case SpriteAnimations.Weapon:
-                    default:
-                        SpriteFrame = (int)Math.Floor((timeInAttack / (CalculateAttackTime() / (float)SpriteFrames)));
-                        break;
-                }
+    private int NormalSpriteAnimationFrame
+    {
+        get
+        {
+            var frame = WalkFrame;
+
+            if (IsBlocking)
+            {
+                frame = Options.Instance.Sprites.NormalBlockFrame;
+            }
+            else if (IsCasting)
+            {
+                frame = Options.Instance.Sprites.NormalCastFrame;
+            }
+            // Checks if the entity is attacking or not.
+            // Note: the calculation differs with IsAttacking because
+            // frames are intended to behave differently with normal sprite-sheets.
+            else if (AttackTimer - (CalculateAttackTime() / 2) > Timing.Global.Milliseconds)
+            {
+                frame = Options.Instance.Sprites.NormalAttackFrame;
             }
 
-            if (IsCasting)
+            if (frame >= SpriteFrames)
             {
-                var spell = SpellBase.Get(SpellCast);
-                if (spell != null)
-                {
-                    var duration = spell.CastDuration;
-                    var timeInCast = duration - (CastTime - timingMilliseconds);
+                frame = SpriteFrames / 2;
+            }
 
-                    // Normal sprite-sheets has their own handler for attacking frames.
-                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Cast, out _))
+            return frame;
+        }
+    }
+
+    private int PickSpriteRow(Direction direction)
+    {
+        switch (direction)
+        {
+            case Direction.Left:
+            case Direction.DownLeft when mLastDirection == Direction.Left:
+            case Direction.UpLeft when mLastDirection == Direction.Left:
+                return 1;
+
+            case Direction.Right:
+            case Direction.DownRight when mLastDirection == Direction.Right:
+            case Direction.UpRight when mLastDirection == Direction.Right:
+                return 2;
+
+            case Direction.Up:
+            case Direction.UpLeft when mLastDirection != Direction.Left:
+            case Direction.UpRight when mLastDirection != Direction.Right:
+                return 3;
+
+            case Direction.Down:
+            case Direction.DownLeft when mLastDirection != Direction.Left:
+            case Direction.DownRight when mLastDirection != Direction.Right:
+            default:
+                return 0;
+        }
+    }
+
+    public void PickLastDirection(Direction direction)
+    {
+        switch (direction)
+        {
+            case Direction.Left:
+            case Direction.DownLeft when mLastDirection == Direction.Left:
+            case Direction.UpLeft when mLastDirection == Direction.Left:
+                mLastDirection = Direction.Left;
+                break;
+
+            case Direction.Right:
+            case Direction.DownRight when mLastDirection == Direction.Right:
+            case Direction.UpRight when mLastDirection == Direction.Right:
+                mLastDirection = Direction.Right;
+                break;
+
+            case Direction.Up:
+            case Direction.UpLeft when mLastDirection != Direction.Left:
+            case Direction.UpRight when mLastDirection != Direction.Right:
+                mLastDirection = Direction.Up;
+                break;
+
+            case Direction.Down:
+            case Direction.DownLeft when mLastDirection != Direction.Left:
+            case Direction.DownRight when mLastDirection != Direction.Right:
+            default:
+                mLastDirection = Direction.Down;
+                break;
+        }
+    }
+
+    public void DrawChatBubbles()
+    {
+        //Don't draw if the entity is hidden
+        if (IsHidden)
+        {
+            return;
+        }
+
+        //If unit is stealthed, don't render unless the entity is the player or party member.
+        if (!ShouldDraw)
+        {
+            return;
+        }
+
+        var chatbubbles = mChatBubbles.ToArray();
+        var bubbleoffset = 0f;
+        for (var i = chatbubbles.Length - 1; i > -1; i--)
+        {
+            bubbleoffset = chatbubbles[i].Draw(bubbleoffset);
+        }
+    }
+
+    /// <summary>
+    /// Draws the equipment of entities using paperdoll texture files.
+    /// </summary>
+    public virtual void DrawEquipment(string filename, Color renderColor)
+    {
+        // Get the current map.
+        var map = Maps.MapInstance.Get(MapId);
+
+        // If the map is null or hideEquipment is true: do nothing.
+        if (map == null || map.HideEquipment)
+        {
+            return;
+        }
+
+        // Paperdoll textures and Frames.
+        GameTexture paperdollTex = null;
+        var spriteFrames = SpriteFrames;
+
+        // Extract filename without it's extension.
+        var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
+
+        // Equipment's custom paperdoll texture.
+        if (SpriteAnimation == SpriteAnimations.Attack ||
+            SpriteAnimation == SpriteAnimations.Cast ||
+            SpriteAnimation == SpriteAnimations.Weapon)
+        {
+            // Extract animation name from the AnimatedTextures list.
+            var animationName = Path.GetFileNameWithoutExtension(AnimatedTextures[SpriteAnimation].Name);
+
+            // Extract the substring after the separator.
+            var separatorIndex = animationName.IndexOf('_') + 1;
+            var customAnimationName = animationName.Substring(separatorIndex);
+
+            // Try to get custom paperdoll texture.
+            var customPaperdollTex =
+                Globals.ContentManager.GetTexture(TextureType.Paperdoll,
+                    $"{filenameNoExt}_{customAnimationName}.png");
+
+            // If custom paperdoll texture exists, use it.
+            if (customPaperdollTex != null)
+            {
+                paperdollTex = customPaperdollTex;
+            }
+        }
+
+        // If there's no custom paperdoll: use the paperdoll texture based on the SpriteAnimation.
+        if (paperdollTex == null && !string.IsNullOrEmpty($"{SpriteAnimation}"))
+        {
+            paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll,
+                $"{filenameNoExt}_{SpriteAnimation}.png");
+        }
+
+        // If the paperdoll texture is still null: try to get the default texture.
+        if (paperdollTex == null)
+        {
+            paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll, filename);
+            spriteFrames = Options.Instance.Sprites.NormalFrames;
+        }
+
+        // If the paperdoll texture is null at this point: do nothing.
+        if (paperdollTex == null)
+        {
+            return;
+        }
+
+        // Calculate: direction, frame width and frame height.
+        var spriteRow = PickSpriteRow(Dir);
+        var frameWidth = paperdollTex.GetWidth() / spriteFrames;
+        var frameHeight = paperdollTex.GetHeight() / Options.Instance.Sprites.Directions;
+
+        // Calculate: source and destination rectangles.
+        var frame = SpriteFrame;
+        if (SpriteAnimation == SpriteAnimations.Normal)
+        {
+            frame = NormalSpriteAnimationFrame;
+        }
+
+        var srcRectangle = new FloatRect(frame * frameWidth, spriteRow * frameHeight, frameWidth, frameHeight);
+        var destRectangle = new FloatRect(
+            (int)Math.Ceiling(Center.X - frameWidth / 2f),
+            (int)Math.Ceiling(Center.Y - frameHeight / 2f),
+            srcRectangle.Width,
+            srcRectangle.Height
+        );
+
+        // Draw the paperdoll texture using: source and destination rectangles along with the render color.
+        Graphics.DrawGameTexture(paperdollTex, srcRectangle, destRectangle, renderColor);
+    }
+
+    protected virtual void CalculateOrigin()
+    {
+        if (LatestMap == default)
+        {
+            mOrigin = default;
+            return;
+        }
+
+        mOrigin = new Pointf(
+            LatestMap.X + X * Options.TileWidth + OffsetX + Options.TileWidth / 2,
+            LatestMap.Y + Y * Options.TileHeight + OffsetY + Options.TileHeight
+        );
+    }
+
+    public virtual float GetTop(int overrideHeight = -1)
+    {
+        if (LatestMap == default)
+        {
+            return 0f;
+        }
+
+        var y = (int)Math.Ceiling(Origin.Y);
+
+        if (overrideHeight > -1)
+        {
+            y -= overrideHeight / Options.Instance.Sprites.Directions;
+        }
+        else if (Texture != null)
+        {
+            y -= Texture.Height / Options.Instance.Sprites.Directions;
+        }
+
+        return y;
+    }
+
+    public void DrawLabels(
+        string label,
+        int position,
+        Color labelColor,
+        Color textColor,
+        Color borderColor = null,
+        Color backgroundColor = null
+    )
+    {
+        // Are we supposed to hide this Label?
+        if (!ShouldDrawName || string.IsNullOrWhiteSpace(label))
+        {
+            return;
+        }
+
+        var map = MapInstance;
+        if (map == null)
+        {
+            return;
+        }
+
+        if (borderColor == null)
+        {
+            borderColor = Color.Transparent;
+        }
+
+        if (backgroundColor == null)
+        {
+            backgroundColor = Color.Transparent;
+        }
+
+        //If we have a non-transparent label color then use it, otherwise use the players name color
+        if (labelColor != null && labelColor.A != 0)
+        {
+            textColor = labelColor;
+        }
+
+        var textSize = Graphics.Renderer.MeasureText(label, Graphics.EntityNameFont, 1);
+
+        var x = (int)Math.Ceiling(Origin.X);
+        var y = position == 0 ? GetLabelLocation(LabelType.Header) : GetLabelLocation(LabelType.Footer);
+
+        if (backgroundColor != Color.Transparent)
+        {
+            Graphics.DrawGameTexture(
+                Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y), backgroundColor
+            );
+        }
+
+        Graphics.Renderer.DrawString(
+            label, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y, 1,
+            Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
+        );
+    }
+
+    public virtual void DrawName(Color textColor, Color borderColor = null, Color backgroundColor = null)
+    {
+        // Are we really supposed to draw this name?
+        if (!ShouldDrawName)
+        {
+            return;
+        }
+
+        //Check for npc colors
+        if (textColor == null)
+        {
+            LabelColor? color;
+            switch (Aggression)
+            {
+                case NpcAggression.Aggressive:
+                    color = CustomColors.Names.Npcs["Aggressive"];
+                    break;
+
+                case NpcAggression.AttackWhenAttacked:
+                    color = CustomColors.Names.Npcs["AttackWhenAttacked"];
+                    break;
+
+                case NpcAggression.AttackOnSight:
+                    color = CustomColors.Names.Npcs["AttackOnSight"];
+                    break;
+
+                case NpcAggression.Guard:
+                    color = CustomColors.Names.Npcs["Guard"];
+                    break;
+
+                case NpcAggression.Neutral:
+                default:
+                    color = CustomColors.Names.Npcs["Neutral"];
+                    break;
+            }
+
+            if (color != null)
+            {
+                textColor = color?.Name;
+                backgroundColor = backgroundColor ?? color?.Background;
+                borderColor = borderColor ?? color?.Outline;
+            }
+        }
+
+        if (borderColor == null)
+        {
+            borderColor = Color.Transparent;
+        }
+
+        if (backgroundColor == null)
+        {
+            backgroundColor = Color.Transparent;
+        }
+
+        var name = Name;
+        if ((this is Player && Options.Player.ShowLevelByName) || (Type == EntityType.GlobalEntity && Options.Npc.ShowLevelByName))
+        {
+            name = Strings.GameWindow.EntityNameAndLevel.ToString(Name, Level);
+        }
+
+        var textSize = Graphics.Renderer.MeasureText(name, Graphics.EntityNameFont, 1);
+
+        var x = (int)Math.Ceiling(Origin.X);
+        var y = GetLabelLocation(LabelType.Name);
+
+        if (backgroundColor != Color.Transparent)
+        {
+            Graphics.DrawGameTexture(
+                Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y), backgroundColor
+            );
+        }
+
+        Graphics.Renderer.DrawString(
+            name, Graphics.EntityNameFont, x - (int)Math.Ceiling(textSize.X / 2f), (int)y, 1,
+            Color.FromArgb(textColor.ToArgb()), true, null, Color.FromArgb(borderColor.ToArgb())
+        );
+    }
+
+    public float GetLabelLocation(LabelType type)
+    {
+        var y = GetTop() - 8;
+
+        //Need room for HP bar if not an event.
+        if (!(this is Event) && ShouldDrawHpBar)
+        {
+            y -= GetBoundingHpBarTexture().Height + 2;
+        }
+
+        switch (type)
+        {
+            case LabelType.Header:
+                y = GetLabelLocation(LabelType.Name);
+
+                if (string.IsNullOrWhiteSpace(HeaderLabel.Text))
+                {
+                    break;
+                }
+
+                var headerSize = Graphics.Renderer.MeasureText(HeaderLabel.Text, Graphics.EntityNameFont, 1);
+                y -= headerSize.Y + 2;
+                break;
+
+            case LabelType.Footer:
+                if (string.IsNullOrWhiteSpace(FooterLabel.Text))
+                {
+                    break;
+                }
+
+                var footerSize = Graphics.Renderer.MeasureText(FooterLabel.Text, Graphics.EntityNameFont, 1);
+                y -= footerSize.Y - 6;
+                break;
+
+            case LabelType.Name:
+                y = GetLabelLocation(LabelType.Footer);
+                var nameSize = Graphics.Renderer.MeasureText(Name, Graphics.EntityNameFont, 1);
+                y -= nameSize.Y + (string.IsNullOrEmpty(FooterLabel.Text) ? -6 : 2);
+                break;
+
+            case LabelType.ChatBubble:
+                y = GetLabelLocation(LabelType.Guild) - 2;
+                break;
+
+            case LabelType.Guild:
+                if (this is Player player)
+                {
+                    // Do we have a header? If so, slightly change the position!
+                    if (string.IsNullOrWhiteSpace(HeaderLabel.Text))
                     {
-                        SpriteAnimation = SpriteAnimations.Cast;
+                        y = GetLabelLocation(LabelType.Name);
+                    }
+                    else
+                    {
+                        y = GetLabelLocation(LabelType.Header);
                     }
 
-                    if (spell.SpellType == SpellType.CombatSpell &&
-                        spell.Combat.TargetType == SpellTargetType.Projectile &&
-                        spell.CastSpriteOverride == null)
+                    if (string.IsNullOrWhiteSpace(player.Guild))
                     {
-                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _))
+                        break;
+                    }
+
+                    var guildSize = Graphics.Renderer.MeasureText(player.Guild, Graphics.EntityNameFont, 1);
+                    y -= 2 + guildSize.Y;
+                }
+                break;
+        }
+
+        return y;
+    }
+
+    public long GetShieldSize()
+    {
+        long shieldSize = 0;
+        foreach (var status in Status)
+        {
+            if (status.Type == SpellEffect.Shield)
+            {
+                shieldSize += status.Shield[(int)Enums.Vital.Health];
+            }
+        }
+        return shieldSize;
+    }
+
+    protected virtual bool ShouldDrawHpBar
+    {
+        get
+        {
+            if (ShouldNotDrawHpBar)
+            {
+                return false;
+            }
+
+            if (IsHovered)
+            {
+                return true;
+            }
+
+            if (GetShieldSize() > 0)
+            {
+                return true;
+            }
+
+            if (Vital[(int)Enums.Vital.Health] != MaxVital[(int)Enums.Vital.Health])
+            {
+                return true;
+            }
+
+            return GetType() == typeof(Entity) && Globals.Database.NpcOverheadHpBar;
+        }
+    }
+
+    protected bool ShouldNotDrawHpBar
+    {
+        get
+        {
+            return LatestMap == default || !ShouldDraw || Vital[(int)Enums.Vital.Health] < 1;
+        }
+    }
+
+    public GameTexture GetBoundingHpBarTexture()
+    {
+        return GameTexture.GetBoundingTexture(
+            BoundsComparison.Height,
+            Globals.ContentManager.GetTexture(TextureType.Misc, "hpbackground.png"),
+            Globals.ContentManager.GetTexture(TextureType.Misc, "hpbar.png"),
+            Globals.ContentManager.GetTexture(TextureType.Misc, "shieldbar.png")
+        );
+    }
+
+    public void DrawHpBar()
+    {
+        // Are we supposed to hide this HP bar?
+        if (!ShouldDrawHpBar)
+        {
+            return;
+        }
+
+        var hpBackground = Globals.ContentManager.GetTexture(TextureType.Misc, "hpbackground.png");
+        var hpForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "hpbar.png");
+        var shieldForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "shieldbar.png");
+
+        var boundingTeture = GameTexture.GetBoundingTexture(
+            BoundsComparison.Height,
+            hpBackground,
+            hpForeground,
+            shieldForeground
+        );
+
+        var foregroundBoundingTexture = hpForeground;
+
+        // Check for shields
+        var maxVital = MaxVital[(int)Enums.Vital.Health];
+        var shieldSize = GetShieldSize();
+
+        if (shieldSize + Vital[(int)Enums.Vital.Health] > maxVital)
+        {
+            maxVital = shieldSize + Vital[(int)Enums.Vital.Health];
+        }
+
+        var hpfillRatio = (float)Vital[(int)Enums.Vital.Health] / maxVital;
+        hpfillRatio = Math.Min(1, Math.Max(0, hpfillRatio));
+
+        var hpFillWidth = (int)Math.Round(hpfillRatio * foregroundBoundingTexture.Width);
+        var shieldPixelFillRatio = (foregroundBoundingTexture.Width - hpFillWidth) / ((float)foregroundBoundingTexture.Width);
+        var shieldFillWidth = (int)Math.Floor(foregroundBoundingTexture.Width * shieldPixelFillRatio);
+
+        if (foregroundBoundingTexture.Width < hpFillWidth + shieldFillWidth)
+        {
+            hpFillWidth = Math.Max(1, foregroundBoundingTexture.Width - shieldFillWidth);
+            shieldFillWidth = Math.Max(1, foregroundBoundingTexture.Width - hpFillWidth);
+        }
+
+        if (shieldSize > 0 && shieldFillWidth < 1)
+        {
+            hpFillWidth -= 1 - shieldFillWidth;
+            shieldFillWidth = 1;
+        }
+
+        var x = (int)Math.Ceiling(Origin.X);
+        var y = (int)Math.Ceiling(Origin.Y);
+
+        var sprite = Globals.ContentManager.GetTexture(TextureType.Entity, Sprite);
+        if (sprite != null)
+        {
+            y -= sprite.Height / Options.Instance.Sprites.Directions;
+            y -= boundingTeture.Height + 2;
+        }
+
+        y += boundingTeture.Height / 2;
+
+        if (hpBackground != null)
+        {
+            Graphics.DrawGameTexture(
+                hpBackground, new FloatRect(0, 0, hpBackground.Width, hpBackground.Height),
+                new FloatRect(x - hpBackground.Width / 2, y - hpBackground.Height / 2, hpBackground.Width, hpBackground.Height), Color.White
+            );
+        }
+
+        if (hpForeground != null)
+        {
+            Graphics.DrawGameTexture(
+                hpForeground,
+                new FloatRect(0, 0, hpFillWidth, hpForeground.Height),
+                new FloatRect(x - foregroundBoundingTexture.Width / 2, y - hpForeground.Height / 2, hpFillWidth, hpForeground.Height), Color.White
+            );
+        }
+
+        if (shieldSize > 0 && shieldForeground != null) //Check for a shield to render
+        {
+            var shieldFillRatio = shieldFillWidth / (float)foregroundBoundingTexture.Width;
+            Graphics.DrawGameTexture(
+                shieldForeground,
+                new FloatRect(shieldForeground.Width * (1 - shieldFillRatio), 0, shieldForeground.Width * shieldFillRatio, shieldForeground.Height),
+                new FloatRect(x - foregroundBoundingTexture.Width / 2 + hpFillWidth, y - shieldForeground.Height / 2, shieldFillWidth, shieldForeground.Height), Color.White
+            );
+        }
+    }
+
+    public bool ShouldDrawCastingBar => ShouldDraw && IsCasting && LatestMap != default;
+
+    public void DrawCastingBar()
+    {
+        // Are we supposed to hide this cast bar?
+        if (!ShouldDrawCastingBar)
+        {
+            return;
+        }
+
+        var castingSpell = SpellBase.Get(SpellCast);
+        if (castingSpell == null)
+        {
+            return;
+        }
+
+        var castBackground = Globals.ContentManager.GetTexture(TextureType.Misc, "castbackground.png");
+        var castForeground = Globals.ContentManager.GetTexture(TextureType.Misc, "castbar.png");
+        var boundingTexture = GameTexture.GetBoundingTexture(BoundsComparison.Height, castBackground, castForeground);
+
+        float remainingTime = CastTime - Timing.Global.Milliseconds;
+        var fillRatio = 1 - remainingTime / castingSpell.CastDuration;
+
+        var x = (int)Math.Ceiling(Origin.X);
+        var y = (int)Math.Ceiling(Origin.Y);
+
+        y += 2 + boundingTexture.Height / 2;
+
+        if (castBackground != null)
+        {
+            Graphics.DrawGameTexture(
+                castBackground, new FloatRect(0, 0, castBackground.Width, castBackground.Height),
+                new FloatRect(x - castBackground.Width / 2, y - castBackground.Height / 2, castBackground.Width, castBackground.Height), Color.White
+            );
+        }
+
+        if (castForeground != null)
+        {
+            Graphics.DrawGameTexture(
+                castForeground,
+                new FloatRect(0, 0, castForeground.GetWidth() * fillRatio, castForeground.Height),
+                new FloatRect(x - castForeground.Width / 2, y - castForeground.Height / 2, castForeground.Width * fillRatio, castForeground.Height), Color.White
+            );
+        }
+    }
+
+    public bool ShouldDrawTarget => !(this is Projectile) && LatestMap != default;
+
+    public void DrawTarget(int priority)
+    {
+        // Should we draw the target?
+        if (!ShouldDrawTarget)
+        {
+            return;
+        }
+
+        var targetTexture = Globals.ContentManager.GetTexture(TextureType.Misc, "target.png");
+        if (targetTexture == null)
+        {
+            return;
+        }
+
+        var srcRectangle = new FloatRect(
+            priority * targetTexture.GetWidth() / 2f,
+            0,
+            targetTexture.GetWidth() / 2f,
+            targetTexture.GetHeight()
+        );
+
+        var destRectangle = new FloatRect(
+            (float)Math.Ceiling(WorldPos.X + (WorldPos.Width - targetTexture.GetWidth() / 2) / 2),
+            (float)Math.Ceiling(WorldPos.Y + (WorldPos.Height - targetTexture.GetHeight()) / 2),
+            srcRectangle.Width,
+            srcRectangle.Height
+        );
+
+        Graphics.DrawGameTexture(targetTexture, srcRectangle, destRectangle, Color.White);
+    }
+
+    public virtual bool CanBeAttacked => true;
+
+    //Chatting
+    public void AddChatBubble(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        mChatBubbles.Add(new ChatBubble(this, text));
+    }
+
+    //Statuses
+    public bool StatusActive(Guid guid)
+    {
+        foreach (var status in Status)
+        {
+            if (status.SpellId == guid && status.IsActive)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public IStatus GetStatus(Guid guid)
+    {
+        foreach (var status in Status)
+        {
+            if (status.SpellId == guid && status.IsActive)
+            {
+                return status;
+            }
+        }
+
+        return null;
+    }
+
+    public void SortStatuses()
+    {
+        //Sort Status effects by remaining time
+        Status = Status.OrderByDescending(x => x.RemainingMs).ToList();
+    }
+
+    private void UpdateSpriteAnimation()
+    {
+        //Exit if textures haven't been loaded yet
+        if (AnimatedTextures.Count == 0)
+        {
+            return;
+        }
+
+        var timingMilliseconds = Timing.Global.Milliseconds;
+        var isNotBlockingAndCasting = !IsBlocking && !IsCasting;
+
+        SpriteAnimation = SpriteAnimations.Normal;
+        if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _) &&
+            LastActionTime + Options.Instance.Sprites.IdleStartDelay < timingMilliseconds &&
+            isNotBlockingAndCasting)
+        {
+            SpriteAnimation = SpriteAnimations.Idle;
+        }
+
+        if (IsMoving && !IsAttacking && isNotBlockingAndCasting)
+        {
+            SpriteAnimation = SpriteAnimations.Normal;
+            LastActionTime = timingMilliseconds;
+        }
+
+        if (IsAttacking && isNotBlockingAndCasting)
+        {
+            // Normal sprite-sheets has their own handler for attacking frames.
+            if (AnimatedTextures.TryGetValue(SpriteAnimations.Normal, out _))
+            {
+                return;
+            }
+
+            var timeInAttack = CalculateAttackTime() - (AttackTimer - timingMilliseconds);
+            LastActionTime = Timing.Global.Milliseconds;
+
+            if (AnimatedTextures.TryGetValue(SpriteAnimations.Attack, out _))
+            {
+                SpriteAnimation = SpriteAnimations.Attack;
+            }
+
+            if (Options.WeaponIndex > -1 && Options.WeaponIndex < Equipment.Length)
+            {
+                if (Equipment[Options.WeaponIndex] != Guid.Empty && this != Globals.Me ||
+                    MyEquipment[Options.WeaponIndex] < Options.MaxInvItems)
+                {
+                    var itemId = Guid.Empty;
+                    if (this == Globals.Me)
+                    {
+                        var slot = MyEquipment[Options.WeaponIndex];
+                        if (slot > -1)
+                        {
+                            itemId = Inventory[slot].ItemId;
+                        }
+                    }
+                    else
+                    {
+                        itemId = Equipment[Options.WeaponIndex];
+                    }
+
+                    var item = ItemBase.Get(itemId);
+                    if (item != null)
+                    {
+                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                        {
+                            SpriteAnimation = SpriteAnimations.Weapon;
+                        }
+
+                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _) &&
+                            item.ProjectileId != Guid.Empty &&
+                            item.WeaponSpriteOverride == null)
                         {
                             SpriteAnimation = SpriteAnimations.Shoot;
                         }
                     }
-
-                    SpriteFrame = (int)Math.Floor((timeInCast / (duration / (float)SpriteFrames)));
-                }
-
-                LastActionTime = timingMilliseconds;
-            }
-
-            if (SpriteAnimation == SpriteAnimations.Normal)
-            {
-                ResetSpriteFrame();
-            }
-            else if (SpriteAnimation == SpriteAnimations.Idle)
-            {
-                if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration < timingMilliseconds)
-                {
-                    SpriteFrame++;
-                    if (SpriteFrame >= SpriteFrames)
-                    {
-                        SpriteFrame = 0;
-                    }
-
-                    SpriteFrameTimer = timingMilliseconds;
                 }
             }
-        }
 
-        public void ResetSpriteFrame()
-        {
-            SpriteFrame = 0;
-            SpriteFrameTimer = 0;
-        }
-
-        public virtual void LoadTextures(string textureName)
-        {
-            AnimatedTextures.Clear();
-            foreach (SpriteAnimations spriteAnimation in Enum.GetValues(typeof(SpriteAnimations)))
+            switch (SpriteAnimation)
             {
-                if (spriteAnimation == SpriteAnimations.Normal)
-                {
-                    Texture = Globals.ContentManager.GetTexture(TextureType.Entity, textureName);
-                }
-                else
-                {
-                    LoadAnimationTexture(textureName, spriteAnimation);
-                }
-            }
-        }
-
-        protected virtual void LoadAnimationTexture(string textureName, SpriteAnimations spriteAnimation)
-        {
-            SpriteAnimations spriteAnimationOveride = spriteAnimation;
-            string textureOverride = default;
-
-            switch (spriteAnimation)
-            {
-                // No override for this
-                case SpriteAnimations.Normal: break;
-
-                case SpriteAnimations.Idle: break;
-                case SpriteAnimations.Attack:
-                    if (this is Player player && ClassBase.TryGet(player.Class, out var classDescriptor))
-                    {
-                        textureOverride = classDescriptor.AttackSpriteOverride;
-                    }
-                    break;
-
-                case SpriteAnimations.Shoot:
-                    {
-                        if (Equipment.Length <= Options.WeaponIndex)
-                        {
-                            break;
-                        }
-
-                        var weaponId = Equipment[Options.WeaponIndex];
-                        if (ItemBase.TryGet(weaponId, out var itemDescriptor))
-                        {
-                            textureOverride = itemDescriptor.WeaponSpriteOverride;
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(textureOverride))
-                        {
-                            spriteAnimationOveride = SpriteAnimations.Weapon;
-                        }
-                    }
-                    break;
-
                 case SpriteAnimations.Cast:
-                    if (SpellBase.TryGet(SpellCast, out var spellDescriptor))
-                    {
-                        textureOverride = spellDescriptor.CastSpriteOverride;
-                    }
+                case SpriteAnimations.Idle:
+                case SpriteAnimations.Normal:
                     break;
-
+                case SpriteAnimations.Attack:
+                case SpriteAnimations.Shoot:
                 case SpriteAnimations.Weapon:
-                    {
-                        if (Equipment.Length <= Options.WeaponIndex)
-                        {
-                            break;
-                        }
-
-                        var weaponId = Equipment[Options.WeaponIndex];
-                        if (ItemBase.TryGet(weaponId, out var itemDescriptor))
-                        {
-                            textureOverride = itemDescriptor.WeaponSpriteOverride;
-                        }
-                    }
-                    break;
-
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(spriteAnimation));
-            }
-
-            if (TryGetAnimationTexture(textureName, spriteAnimationOveride, textureOverride, out var texture))
-            {
-                AnimatedTextures[spriteAnimation] = texture;
+                    SpriteFrame = (int)Math.Floor((timeInAttack / (CalculateAttackTime() / (float)SpriteFrames)));
+                    break;
             }
         }
 
-        protected virtual bool TryGetAnimationTexture(string textureName, SpriteAnimations spriteAnimation, string textureOverride, out GameTexture texture)
+        if (IsCasting)
         {
-            var baseFilename = Path.GetFileNameWithoutExtension(textureName);
-            var extension = Path.GetExtension(textureName);
-            var animationTextureName = $"{baseFilename}_{spriteAnimation.ToString()?.ToLowerInvariant() ?? string.Empty}";
-
-            if (!string.IsNullOrWhiteSpace(textureOverride))
+            var spell = SpellBase.Get(SpellCast);
+            if (spell != null)
             {
-                animationTextureName = $"{animationTextureName}_{textureOverride}";
+                var duration = spell.CastDuration;
+                var timeInCast = duration - (CastTime - timingMilliseconds);
+
+                // Normal sprite-sheets has their own handler for attacking frames.
+                if (AnimatedTextures.TryGetValue(SpriteAnimations.Cast, out _))
+                {
+                    SpriteAnimation = SpriteAnimations.Cast;
+                }
+
+                if (spell.SpellType == SpellType.CombatSpell &&
+                    spell.Combat.TargetType == SpellTargetType.Projectile &&
+                    spell.CastSpriteOverride == null)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Shoot, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Shoot;
+                    }
+                }
+
+                SpriteFrame = (int)Math.Floor((timeInCast / (duration / (float)SpriteFrames)));
             }
 
-            texture = Globals.ContentManager.GetTexture(TextureType.Entity, $"{animationTextureName}{extension}");
-            return texture != default;
+            LastActionTime = timingMilliseconds;
         }
 
-        /// <summary>
-        /// <para>Returns the direction to a player's selected target.</para>
-        /// <para>Original logic made by Daywalkr (Middle Ages: Online), thanks for sharing!</para>
-        /// <para>Modified by Arufonsu for the Intersect Engine along with support for 8 directions when enabled.</para>
-        /// </summary>
-        /// <param name="en">entity's target</param>
-        /// <returns>direction to player's selected target</returns>
-        public Direction DirectionToTarget(Entity en)
+        if (SpriteAnimation == SpriteAnimations.Normal)
         {
-            if (en == null)
+            ResetSpriteFrame();
+        }
+        else if (SpriteAnimation == SpriteAnimations.Idle)
+        {
+            if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration < timingMilliseconds)
             {
-                return Dir;
+                SpriteFrame++;
+                if (SpriteFrame >= SpriteFrames)
+                {
+                    SpriteFrame = 0;
+                }
+
+                SpriteFrameTimer = timingMilliseconds;
             }
+        }
+    }
 
-            var originMapController = MapInstance;
-            var targetMapController = en.MapInstance;
+    public void ResetSpriteFrame()
+    {
+        SpriteFrame = 0;
+        SpriteFrameTimer = 0;
+    }
 
-            var originY = Y + originMapController.GridY * Options.MapHeight;
-            var originX = X + originMapController.GridX * Options.MapWidth;
-            var targetY = en.Y + targetMapController.GridY * Options.MapHeight;
-            var targetX = en.X + targetMapController.GridX * Options.MapWidth;
-
-            // Calculate the offset between origin and target along both of their axis.
-            var yDiff = originY - targetY;
-            var xDiff = originX - targetX;
-
-            // If Y offset is 0, direction is determined by X offset.
-            if (yDiff == 0)
+    public virtual void LoadTextures(string textureName)
+    {
+        AnimatedTextures.Clear();
+        foreach (SpriteAnimations spriteAnimation in Enum.GetValues(typeof(SpriteAnimations)))
+        {
+            if (spriteAnimation == SpriteAnimations.Normal)
             {
-                return xDiff > 0 ? Direction.Left : Direction.Right;
+                Texture = Globals.ContentManager.GetTexture(TextureType.Entity, textureName);
             }
-
-            // If X offset is 0 or If diagonal movement is disabled, direction is determined by Y offset.
-            if (xDiff == 0 || !Options.Instance.MapOpts.EnableDiagonalMovement)
+            else
             {
-                return yDiff > 0 ? Direction.Up : Direction.Down;
+                LoadAnimationTexture(textureName, spriteAnimation);
             }
+        }
+    }
 
-            // If both X and Y offset are non-zero, direction is determined by both offsets.
-            var xPositive = xDiff > 0;
-            var yPositive = yDiff > 0;
+    protected virtual void LoadAnimationTexture(string textureName, SpriteAnimations spriteAnimation)
+    {
+        SpriteAnimations spriteAnimationOveride = spriteAnimation;
+        string textureOverride = default;
 
-            if (xPositive)
-            {
-                return yPositive ? Direction.UpLeft : Direction.DownLeft;
-            }
+        switch (spriteAnimation)
+        {
+            // No override for this
+            case SpriteAnimations.Normal: break;
 
-            return yPositive ? Direction.UpRight : Direction.DownRight;
+            case SpriteAnimations.Idle: break;
+            case SpriteAnimations.Attack:
+                if (this is Player player && ClassBase.TryGet(player.Class, out var classDescriptor))
+                {
+                    textureOverride = classDescriptor.AttackSpriteOverride;
+                }
+                break;
+
+            case SpriteAnimations.Shoot:
+                {
+                    if (Equipment.Length <= Options.WeaponIndex)
+                    {
+                        break;
+                    }
+
+                    var weaponId = Equipment[Options.WeaponIndex];
+                    if (ItemBase.TryGet(weaponId, out var itemDescriptor))
+                    {
+                        textureOverride = itemDescriptor.WeaponSpriteOverride;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(textureOverride))
+                    {
+                        spriteAnimationOveride = SpriteAnimations.Weapon;
+                    }
+                }
+                break;
+
+            case SpriteAnimations.Cast:
+                if (SpellBase.TryGet(SpellCast, out var spellDescriptor))
+                {
+                    textureOverride = spellDescriptor.CastSpriteOverride;
+                }
+                break;
+
+            case SpriteAnimations.Weapon:
+                {
+                    if (Equipment.Length <= Options.WeaponIndex)
+                    {
+                        break;
+                    }
+
+                    var weaponId = Equipment[Options.WeaponIndex];
+                    if (ItemBase.TryGet(weaponId, out var itemDescriptor))
+                    {
+                        textureOverride = itemDescriptor.WeaponSpriteOverride;
+                    }
+                }
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(spriteAnimation));
         }
 
-        //Movement
-        /// <summary>
-        ///     Returns -6 if the tile is blocked by a global (non-event) entity
-        ///     Returns -5 if the tile is completely out of bounds.
-        ///     Returns -4 if a tile is blocked because of a local event.
-        ///     Returns -3 if a tile is blocked because of a Z dimension tile
-        ///     Returns -2 if a tile does not exist or is blocked by a map attribute.
-        ///     Returns -1 is a tile is passable.
-        ///     Returns any value zero or greater matching the entity index that is in the way.
-        /// </summary>
-        /// <returns></returns>
-        public int IsTileBlocked(
-            Point delta,
-            int z,
-            Guid mapId,
-            ref IEntity blockedBy,
-            bool ignoreAliveResources = true,
-            bool ignoreDeadResources = true,
-            bool ignoreNpcAvoids = true,
-            bool projectileTrigger = false
-        )
+        if (TryGetAnimationTexture(textureName, spriteAnimationOveride, textureOverride, out var texture))
         {
-            var mapInstance = Maps.MapInstance.Get(mapId);
-            if (mapInstance == null)
+            AnimatedTextures[spriteAnimation] = texture;
+        }
+    }
+
+    protected virtual bool TryGetAnimationTexture(string textureName, SpriteAnimations spriteAnimation, string textureOverride, out GameTexture texture)
+    {
+        var baseFilename = Path.GetFileNameWithoutExtension(textureName);
+        var extension = Path.GetExtension(textureName);
+        var animationTextureName = $"{baseFilename}_{spriteAnimation.ToString()?.ToLowerInvariant() ?? string.Empty}";
+
+        if (!string.IsNullOrWhiteSpace(textureOverride))
+        {
+            animationTextureName = $"{animationTextureName}_{textureOverride}";
+        }
+
+        texture = Globals.ContentManager.GetTexture(TextureType.Entity, $"{animationTextureName}{extension}");
+        return texture != default;
+    }
+
+    /// <summary>
+    /// <para>Returns the direction to a player's selected target.</para>
+    /// <para>Original logic made by Daywalkr (Middle Ages: Online), thanks for sharing!</para>
+    /// <para>Modified by Arufonsu for the Intersect Engine along with support for 8 directions when enabled.</para>
+    /// </summary>
+    /// <param name="en">entity's target</param>
+    /// <returns>direction to player's selected target</returns>
+    public Direction DirectionToTarget(Entity en)
+    {
+        if (en == null)
+        {
+            return Dir;
+        }
+
+        var originMapController = MapInstance;
+        var targetMapController = en.MapInstance;
+
+        var originY = Y + originMapController.GridY * Options.MapHeight;
+        var originX = X + originMapController.GridX * Options.MapWidth;
+        var targetY = en.Y + targetMapController.GridY * Options.MapHeight;
+        var targetX = en.X + targetMapController.GridX * Options.MapWidth;
+
+        // Calculate the offset between origin and target along both of their axis.
+        var yDiff = originY - targetY;
+        var xDiff = originX - targetX;
+
+        // If Y offset is 0, direction is determined by X offset.
+        if (yDiff == 0)
+        {
+            return xDiff > 0 ? Direction.Left : Direction.Right;
+        }
+
+        // If X offset is 0 or If diagonal movement is disabled, direction is determined by Y offset.
+        if (xDiff == 0 || !Options.Instance.MapOpts.EnableDiagonalMovement)
+        {
+            return yDiff > 0 ? Direction.Up : Direction.Down;
+        }
+
+        // If both X and Y offset are non-zero, direction is determined by both offsets.
+        var xPositive = xDiff > 0;
+        var yPositive = yDiff > 0;
+
+        if (xPositive)
+        {
+            return yPositive ? Direction.UpLeft : Direction.DownLeft;
+        }
+
+        return yPositive ? Direction.UpRight : Direction.DownRight;
+    }
+
+    //Movement
+    /// <summary>
+    ///     Returns -6 if the tile is blocked by a global (non-event) entity
+    ///     Returns -5 if the tile is completely out of bounds.
+    ///     Returns -4 if a tile is blocked because of a local event.
+    ///     Returns -3 if a tile is blocked because of a Z dimension tile
+    ///     Returns -2 if a tile does not exist or is blocked by a map attribute.
+    ///     Returns -1 is a tile is passable.
+    ///     Returns any value zero or greater matching the entity index that is in the way.
+    /// </summary>
+    /// <returns></returns>
+    public int IsTileBlocked(
+        Point delta,
+        int z,
+        Guid mapId,
+        ref IEntity blockedBy,
+        bool ignoreAliveResources = true,
+        bool ignoreDeadResources = true,
+        bool ignoreNpcAvoids = true,
+        bool projectileTrigger = false
+    )
+    {
+        var mapInstance = Maps.MapInstance.Get(mapId);
+        if (mapInstance == null)
+        {
+            return -2;
+        }
+
+        var gridX = mapInstance.GridX;
+        var gridY = mapInstance.GridY;
+        try
+        {
+            var tmpX = delta.X;
+            var tmpY = delta.Y;
+            var tmpMapId = Guid.Empty;
+            if (delta.X < 0)
+            {
+                gridX--;
+                tmpX = Options.MapWidth - delta.X * -1;
+            }
+
+            if (delta.Y < 0)
+            {
+                gridY--;
+                tmpY = Options.MapHeight - delta.Y * -1;
+            }
+
+            if (delta.X > Options.MapWidth - 1)
+            {
+                gridX++;
+                tmpX = delta.X - Options.MapWidth;
+            }
+
+            if (delta.Y > Options.MapHeight - 1)
+            {
+                gridY++;
+                tmpY = delta.Y - Options.MapHeight;
+            }
+
+            if (gridX < 0 || gridY < 0 || gridX >= Globals.MapGridWidth || gridY >= Globals.MapGridHeight)
             {
                 return -2;
             }
 
-            var gridX = mapInstance.GridX;
-            var gridY = mapInstance.GridY;
-            try
+            tmpMapId = Globals.MapGrid[gridX, gridY];
+
+            foreach (var en in Globals.Entities)
             {
-                var tmpX = delta.X;
-                var tmpY = delta.Y;
-                var tmpMapId = Guid.Empty;
-                if (delta.X < 0)
+                if (en.Value == null)
                 {
-                    gridX--;
-                    tmpX = Options.MapWidth - delta.X * -1;
+                    continue;
                 }
 
-                if (delta.Y < 0)
+                if (en.Value == Globals.Me)
                 {
-                    gridY--;
-                    tmpY = Options.MapHeight - delta.Y * -1;
+                    continue;
                 }
-
-                if (delta.X > Options.MapWidth - 1)
+                else
                 {
-                    gridX++;
-                    tmpX = delta.X - Options.MapWidth;
+                    if (en.Value.MapId == tmpMapId &&
+                        en.Value.X == tmpX &&
+                        en.Value.Y == tmpY &&
+                        en.Value.Z == Z)
+                    {
+                        if (!(en.Value is Projectile))
+                        {
+                            switch (en.Value)
+                            {
+                                case Resource resource:
+                                    var resourceBase = resource.BaseResource;
+                                    if (resourceBase != null)
+                                    {
+                                        if (projectileTrigger)
+                                        {
+                                            bool isDead = resource.IsDead;
+                                            if (!ignoreAliveResources && !isDead || !ignoreDeadResources && isDead)
+                                            {
+                                                blockedBy = en.Value;
+
+                                                return -6;
+                                            }
+
+                                            return -1;
+                                        }
+
+                                        if (resourceBase.WalkableAfter && resource.IsDead ||
+                                            resourceBase.WalkableBefore && !resource.IsDead)
+                                        {
+                                            continue;
+                                        }
+                                    }
+                                    break;
+
+                                case Player player:
+                                    //Return the entity key as this should block the player.  Only exception is if the MapZone this entity is on is passable.
+                                    var entityMap = Maps.MapInstance.Get(player.MapId);
+                                    if (Options.Instance.Passability.Passable[(int)entityMap.ZoneType])
+                                    {
+                                        continue;
+                                    }
+                                    break;
+                            }
+
+                            blockedBy = en.Value;
+
+                            return -6;
+                        }
+                    }
                 }
+            }
 
-                if (delta.Y > Options.MapHeight - 1)
-                {
-                    gridY++;
-                    tmpY = delta.Y - Options.MapHeight;
-                }
-
-                if (gridX < 0 || gridY < 0 || gridX >= Globals.MapGridWidth || gridY >= Globals.MapGridHeight)
-                {
-                    return -2;
-                }
-
-                tmpMapId = Globals.MapGrid[gridX, gridY];
-
-                foreach (var en in Globals.Entities)
+            if (Maps.MapInstance.Get(tmpMapId) != null)
+            {
+                foreach (var en in Maps.MapInstance.Get(tmpMapId).LocalEntities)
                 {
                     if (en.Value == null)
                     {
                         continue;
                     }
 
-                    if (en.Value == Globals.Me)
+                    if (en.Value.MapId == tmpMapId &&
+                        en.Value.X == tmpX &&
+                        en.Value.Y == tmpY &&
+                        en.Value.Z == Z &&
+                        !en.Value.Passable)
+                    {
+                        blockedBy = en.Value;
+
+                        return -4;
+                    }
+                }
+
+                foreach (var en in Maps.MapInstance.Get(tmpMapId).LocalCritters)
+                {
+                    if (en.Value == null)
                     {
                         continue;
                     }
-                    else
+
+                    if (en.Value.MapId == tmpMapId &&
+                        en.Value.X == tmpX &&
+                        en.Value.Y == tmpY &&
+                        en.Value.Z == Z &&
+                        !en.Value.Passable)
                     {
-                        if (en.Value.MapId == tmpMapId &&
-                            en.Value.X == tmpX &&
-                            en.Value.Y == tmpY &&
-                            en.Value.Z == Z)
-                        {
-                            if (!(en.Value is Projectile))
-                            {
-                                switch (en.Value)
-                                {
-                                    case Resource resource:
-                                        var resourceBase = resource.BaseResource;
-                                        if (resourceBase != null)
-                                        {
-                                            if (projectileTrigger)
-                                            {
-                                                bool isDead = resource.IsDead;
-                                                if (!ignoreAliveResources && !isDead || !ignoreDeadResources && isDead)
-                                                {
-                                                    blockedBy = en.Value;
+                        blockedBy = en.Value as Critter;
 
-                                                    return -6;
-                                                }
-
-                                                return -1;
-                                            }
-
-                                            if (resourceBase.WalkableAfter && resource.IsDead ||
-                                                resourceBase.WalkableBefore && !resource.IsDead)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        break;
-
-                                    case Player player:
-                                        //Return the entity key as this should block the player.  Only exception is if the MapZone this entity is on is passable.
-                                        var entityMap = Maps.MapInstance.Get(player.MapId);
-                                        if (Options.Instance.Passability.Passable[(int)entityMap.ZoneType])
-                                        {
-                                            continue;
-                                        }
-                                        break;
-                                }
-
-                                blockedBy = en.Value;
-
-                                return -6;
-                            }
-                        }
+                        return -4;
                     }
                 }
+            }
 
-                if (Maps.MapInstance.Get(tmpMapId) != null)
+            var gameMap = Maps.MapInstance.Get(Globals.MapGrid[gridX, gridY]);
+            if (gameMap != null)
+            {
+                if (gameMap.Attributes[tmpX, tmpY] != null)
                 {
-                    foreach (var en in Maps.MapInstance.Get(tmpMapId).LocalEntities)
+                    if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.Blocked || (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.Animation && ((MapAnimationAttribute)gameMap.Attributes[tmpX, tmpY]).IsBlock))
                     {
-                        if (en.Value == null)
+                        return -2;
+                    }
+                    else if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.ZDimension)
+                    {
+                        if (((MapZDimensionAttribute)gameMap.Attributes[tmpX, tmpY]).BlockedLevel - 1 == z)
                         {
-                            continue;
-                        }
-
-                        if (en.Value.MapId == tmpMapId &&
-                            en.Value.X == tmpX &&
-                            en.Value.Y == tmpY &&
-                            en.Value.Z == Z &&
-                            !en.Value.Passable)
-                        {
-                            blockedBy = en.Value;
-
-                            return -4;
+                            return -3;
                         }
                     }
-
-                    foreach (var en in Maps.MapInstance.Get(tmpMapId).LocalCritters)
+                    else if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.NpcAvoid)
                     {
-                        if (en.Value == null)
-                        {
-                            continue;
-                        }
-
-                        if (en.Value.MapId == tmpMapId &&
-                            en.Value.X == tmpX &&
-                            en.Value.Y == tmpY &&
-                            en.Value.Z == Z &&
-                            !en.Value.Passable)
-                        {
-                            blockedBy = en.Value as Critter;
-
-                            return -4;
-                        }
-                    }
-                }
-
-                var gameMap = Maps.MapInstance.Get(Globals.MapGrid[gridX, gridY]);
-                if (gameMap != null)
-                {
-                    if (gameMap.Attributes[tmpX, tmpY] != null)
-                    {
-                        if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.Blocked || (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.Animation && ((MapAnimationAttribute)gameMap.Attributes[tmpX, tmpY]).IsBlock))
+                        if (!ignoreNpcAvoids)
                         {
                             return -2;
                         }
-                        else if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.ZDimension)
-                        {
-                            if (((MapZDimensionAttribute)gameMap.Attributes[tmpX, tmpY]).BlockedLevel - 1 == z)
-                            {
-                                return -3;
-                            }
-                        }
-                        else if (gameMap.Attributes[tmpX, tmpY].Type == MapAttribute.NpcAvoid)
-                        {
-                            if (!ignoreNpcAvoids)
-                            {
-                                return -2;
-                            }
-                        }
                     }
                 }
-                else
-                {
-                    return -5;
-                }
-
-                return -1;
             }
-            catch
+            else
             {
-                return -2;
+                return -5;
             }
-        }
 
-        ~Entity()
+            return -1;
+        }
+        catch
         {
-            Dispose();
+            return -2;
         }
-
-
-
-
     }
+
+    ~Entity()
+    {
+        Dispose();
+    }
+
+
+
 
 }

--- a/Intersect.Client/Entities/Events/Dialog.cs
+++ b/Intersect.Client/Entities/Events/Dialog.cs
@@ -1,27 +1,25 @@
-﻿namespace Intersect.Client.Entities.Events
+﻿namespace Intersect.Client.Entities.Events;
+
+
+public partial class Dialog
 {
 
-    public partial class Dialog
-    {
+    public Guid EventId;
 
-        public Guid EventId;
+    public string Face = "";
 
-        public string Face = "";
+    public string Opt1 = "";
 
-        public string Opt1 = "";
+    public string Opt2 = "";
 
-        public string Opt2 = "";
+    public string Opt3 = "";
 
-        public string Opt3 = "";
+    public string Opt4 = "";
 
-        public string Opt4 = "";
+    public string Prompt = "";
 
-        public string Prompt = "";
+    public int ResponseSent;
 
-        public int ResponseSent;
-
-        public int Type;
-
-    }
+    public int Type;
 
 }

--- a/Intersect.Client/Entities/Events/Event.cs
+++ b/Intersect.Client/Entities/Events/Event.cs
@@ -9,306 +9,305 @@ using Intersect.GameObjects.Events;
 using Intersect.Logging;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Entities.Events
+namespace Intersect.Client.Entities.Events;
+
+public partial class Event : Entity
 {
-    public partial class Event : Entity
+    private bool _drawCompletedWithoutTexture = false;
+
+    public string Desc { get; set; } = string.Empty;
+
+    public bool DirectionFix { get; set; }
+
+    public bool DisablePreview { get; set; }
+
+    public string FaceGraphic { get; set; } = string.Empty;
+
+    public EventGraphic Graphic { get; set; } = new EventGraphic();
+
+    public int Layer { get; set; }
+
+    private int mOldRenderLevel { get; set; }
+
+    private MapInstance mOldRenderMap { get; set; }
+
+    private int mOldRenderY { get; set; }
+
+    public int RenderLevel { get; set; } = 1;
+
+    public bool WalkingAnim { get; set; } = true;
+
+    public EventTrigger Trigger { get; set; }
+
+    protected override Pointf CenterOffset
     {
-        private bool _drawCompletedWithoutTexture = false;
-
-        public string Desc { get; set; } = string.Empty;
-
-        public bool DirectionFix { get; set; }
-
-        public bool DisablePreview { get; set; }
-
-        public string FaceGraphic { get; set; } = string.Empty;
-
-        public EventGraphic Graphic { get; set; } = new EventGraphic();
-
-        public int Layer { get; set; }
-
-        private int mOldRenderLevel { get; set; }
-
-        private MapInstance mOldRenderMap { get; set; }
-
-        private int mOldRenderY { get; set; }
-
-        public int RenderLevel { get; set; } = 1;
-
-        public bool WalkingAnim { get; set; } = true;
-
-        public EventTrigger Trigger { get; set; }
-
-        protected override Pointf CenterOffset
-        {
-            get
-            {
-                switch (Graphic.Type)
-                {
-                    case EventGraphicType.None:
-                        return Animations.Count == 0 ? Pointf.Empty : Pointf.UnitY * Options.TileHeight / 2f;
-
-                    case EventGraphicType.Sprite:
-                        return base.CenterOffset;
-
-                    case EventGraphicType.Tileset:
-                        return Pointf.UnitY * Options.TileHeight * (Graphic.Height + 1) / 2f;
-
-                    default:
-                        Log.Error($"Unimplemented graphic type: {Graphic.Type}");
-                        return Pointf.Empty;
-                }
-            }
-        }
-
-        public Event(Guid id, EventEntityPacket packet) : base(id, packet, EntityType.Event)
-        {
-            mRenderPriority = 1;
-        }
-
-        public override void Load(EntityPacket packet)
-        {
-            if (!(packet is EventEntityPacket eventEntityPacket))
-            {
-                Log.Error($"Received invalid packet for {nameof(Event)}: {packet?.GetType()?.FullName}");
-                return;
-            }
-            DirectionFix = eventEntityPacket.DirectionFix;
-            WalkingAnim = eventEntityPacket.WalkingAnim;
-            DisablePreview = eventEntityPacket.DisablePreview;
-            Desc = eventEntityPacket.Description;
-            Graphic = eventEntityPacket.Graphic;
-            RenderLevel = eventEntityPacket.RenderLayer;
-            Trigger = eventEntityPacket.Trigger;
-
-            _drawCompletedWithoutTexture = Graphic.Type != EventGraphicType.Tileset;
-
-            base.Load(packet);
-
-            if (!string.IsNullOrEmpty(Graphic?.Filename))
-            {
-                Sprite = Graphic.Filename;
-            }
-        }
-
-        public override bool Update()
-        {
-            var success = base.Update();
-            if (!WalkingAnim)
-            {
-                WalkFrame = 0;
-            }
-
-            return success;
-        }
-
-        protected bool TryEnsureTexture(out GameTexture texture)
-        {
-            if (_drawCompletedWithoutTexture)
-            {
-                texture = Texture;
-                return texture != default;
-            }
-
-            LoadTextures(Sprite);
-            texture = Texture;
-            _drawCompletedWithoutTexture = (texture == default);
-            return !_drawCompletedWithoutTexture;
-        }
-
-        public override void Draw()
-        {
-            WorldPos.Reset();
-            if (MapInstance == default || !Globals.GridMaps.Contains(MapId) || !TryEnsureTexture(out var texture))
-            {
-                return;
-            }
-
-            FloatRect srcRectangle;
-            switch (Graphic.Type)
-            {
-                case EventGraphicType.Sprite: //Sprite
-                    base.Draw();
-                    return;
-
-                case EventGraphicType.Tileset: //Tile
-                    var width = (Graphic.Width + 1) * Options.TileWidth;
-                    var height = (Graphic.Height + 1) * Options.TileHeight;
-                    srcRectangle = new FloatRect(
-                        Graphic.X * Options.TileWidth,
-                        Graphic.Y * Options.TileHeight,
-                        width,
-                        height
-                    );
-                    break;
-
-                default:
-                    return;
-            }
-
-            var map = Maps.MapInstance.Get(MapId);
-
-            var destRectangle = new FloatRect
-            {
-                X = map.GetX() + X * Options.TileWidth + OffsetX,
-                Y = map.GetY() + Y * Options.TileHeight + OffsetY,
-                Width = Math.Max(Options.TileWidth, srcRectangle.Width),
-                Height = Math.Max(Options.TileHeight, srcRectangle.Height),
-            };
-
-            if (srcRectangle.Width > Options.TileWidth)
-            {
-                destRectangle.X -= (srcRectangle.Width - Options.TileWidth) / 2;
-            }
-
-            if (srcRectangle.Height > Options.TileHeight)
-            {
-                destRectangle.Y -= srcRectangle.Height - Options.TileHeight;
-            }
-
-            destRectangle.X = (int)Math.Ceiling(destRectangle.X);
-            destRectangle.Y = (int)Math.Ceiling(destRectangle.Y);
-
-            // Set up our targetting rectangle.
-            // If we're smaller than a tile, force the target size to a tile.
-            WorldPos = destRectangle;
-
-            Graphics.DrawGameTexture(texture, srcRectangle, destRectangle, Color.White);
-        }
-
-        public override void LoadTextures(string textureName)
+        get
         {
             switch (Graphic.Type)
             {
-                case EventGraphicType.Tileset:
-                    Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Tileset, textureName);
-                    break;
-
-                case EventGraphicType.Sprite:
-                    base.LoadTextures(textureName);
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
-        public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
-        {
-            if (RenderLevel == 1)
-            {
-                return base.DetermineRenderOrder(renderList, map);
-            }
-
-            renderList?.Remove(this);
-            if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
-            {
-                return null;
-            }
-
-            var gridX = Globals.Me.MapInstance.GridX;
-            var gridY = Globals.Me.MapInstance.GridY;
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
-                {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        if (Globals.MapGrid[x, y] != MapId)
-                        {
-                            continue;
-                        }
-
-                        if (RenderLevel == 0)
-                        {
-                            y--;
-                        }
-                        else if (RenderLevel == 2)
-                        {
-                            y++;
-                        }
-
-                        var priority = mRenderPriority;
-                        if (Z != 0)
-                        {
-                            priority += 3;
-                        }
-
-                        var maps = y - (gridY - 2);
-                        var renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * maps + Y];
-
-                        // If bugs arise from switching to the above, remove and uncomment this
-                        //HashSet<Entity> renderSet = null;
-                        //if (y == gridY - 2)
-                        //{
-                        //    renderSet = Graphics.RenderingEntities[priority, Y];
-                        //}
-                        //else if (y == gridY - 1)
-                        //{
-                        //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
-                        //}
-                        //else if (y == gridY)
-                        //{
-                        //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
-                        //}
-                        //else if (y == gridY + 1)
-                        //{
-                        //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 3 + Y];
-                        //}
-                        //else if (y == gridY + 2)
-                        //{
-                        //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 4 + Y];
-                        //}
-
-                        renderSet?.Add(this);
-                        renderList = renderSet;
-
-                        return renderList;
-                    }
-                }
-            }
-
-            return renderList;
-        }
-
-        public override float GetTop(int overrideHeight = -1)
-        {
-            float heightScale;
-            switch (Graphic.Type)
-            {
-                case EventGraphicType.Sprite:
-                    return base.GetTop(overrideHeight);
-
-                case EventGraphicType.Tileset:
-                    heightScale = Graphic.Height + 1;
-                    break;
-
                 case EventGraphicType.None:
-                    heightScale = Animations.Count > 0 ? 1 : 0.5f;
-                    break;
+                    return Animations.Count == 0 ? Pointf.Empty : Pointf.UnitY * Options.TileHeight / 2f;
+
+                case EventGraphicType.Sprite:
+                    return base.CenterOffset;
+
+                case EventGraphicType.Tileset:
+                    return Pointf.UnitY * Options.TileHeight * (Graphic.Height + 1) / 2f;
 
                 default:
-                    throw new IndexOutOfRangeException($"Unsupported {nameof(EventGraphicType)} '{Graphic.Type}'");
+                    Log.Error($"Unimplemented graphic type: {Graphic.Type}");
+                    return Pointf.Empty;
             }
-
-            var top = base.GetTop(0);
-            var offset = heightScale * Options.TileHeight;
-            return top - offset;
         }
-
-        public override void DrawName(Color textColor, Color borderColor, Color backgroundColor)
-        {
-            base.DrawName(
-                textColor: textColor ?? new Color(CustomColors.Names.Events.Name),
-                borderColor: borderColor ?? new Color(CustomColors.Names.Events.Outline),
-                backgroundColor: backgroundColor ?? new Color(CustomColors.Names.Events.Background)
-            );
-        }
-
-        ~Event() => Dispose();
     }
+
+    public Event(Guid id, EventEntityPacket packet) : base(id, packet, EntityType.Event)
+    {
+        mRenderPriority = 1;
+    }
+
+    public override void Load(EntityPacket packet)
+    {
+        if (!(packet is EventEntityPacket eventEntityPacket))
+        {
+            Log.Error($"Received invalid packet for {nameof(Event)}: {packet?.GetType()?.FullName}");
+            return;
+        }
+        DirectionFix = eventEntityPacket.DirectionFix;
+        WalkingAnim = eventEntityPacket.WalkingAnim;
+        DisablePreview = eventEntityPacket.DisablePreview;
+        Desc = eventEntityPacket.Description;
+        Graphic = eventEntityPacket.Graphic;
+        RenderLevel = eventEntityPacket.RenderLayer;
+        Trigger = eventEntityPacket.Trigger;
+
+        _drawCompletedWithoutTexture = Graphic.Type != EventGraphicType.Tileset;
+
+        base.Load(packet);
+
+        if (!string.IsNullOrEmpty(Graphic?.Filename))
+        {
+            Sprite = Graphic.Filename;
+        }
+    }
+
+    public override bool Update()
+    {
+        var success = base.Update();
+        if (!WalkingAnim)
+        {
+            WalkFrame = 0;
+        }
+
+        return success;
+    }
+
+    protected bool TryEnsureTexture(out GameTexture texture)
+    {
+        if (_drawCompletedWithoutTexture)
+        {
+            texture = Texture;
+            return texture != default;
+        }
+
+        LoadTextures(Sprite);
+        texture = Texture;
+        _drawCompletedWithoutTexture = (texture == default);
+        return !_drawCompletedWithoutTexture;
+    }
+
+    public override void Draw()
+    {
+        WorldPos.Reset();
+        if (MapInstance == default || !Globals.GridMaps.Contains(MapId) || !TryEnsureTexture(out var texture))
+        {
+            return;
+        }
+
+        FloatRect srcRectangle;
+        switch (Graphic.Type)
+        {
+            case EventGraphicType.Sprite: //Sprite
+                base.Draw();
+                return;
+
+            case EventGraphicType.Tileset: //Tile
+                var width = (Graphic.Width + 1) * Options.TileWidth;
+                var height = (Graphic.Height + 1) * Options.TileHeight;
+                srcRectangle = new FloatRect(
+                    Graphic.X * Options.TileWidth,
+                    Graphic.Y * Options.TileHeight,
+                    width,
+                    height
+                );
+                break;
+
+            default:
+                return;
+        }
+
+        var map = Maps.MapInstance.Get(MapId);
+
+        var destRectangle = new FloatRect
+        {
+            X = map.GetX() + X * Options.TileWidth + OffsetX,
+            Y = map.GetY() + Y * Options.TileHeight + OffsetY,
+            Width = Math.Max(Options.TileWidth, srcRectangle.Width),
+            Height = Math.Max(Options.TileHeight, srcRectangle.Height),
+        };
+
+        if (srcRectangle.Width > Options.TileWidth)
+        {
+            destRectangle.X -= (srcRectangle.Width - Options.TileWidth) / 2;
+        }
+
+        if (srcRectangle.Height > Options.TileHeight)
+        {
+            destRectangle.Y -= srcRectangle.Height - Options.TileHeight;
+        }
+
+        destRectangle.X = (int)Math.Ceiling(destRectangle.X);
+        destRectangle.Y = (int)Math.Ceiling(destRectangle.Y);
+
+        // Set up our targetting rectangle.
+        // If we're smaller than a tile, force the target size to a tile.
+        WorldPos = destRectangle;
+
+        Graphics.DrawGameTexture(texture, srcRectangle, destRectangle, Color.White);
+    }
+
+    public override void LoadTextures(string textureName)
+    {
+        switch (Graphic.Type)
+        {
+            case EventGraphicType.Tileset:
+                Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Tileset, textureName);
+                break;
+
+            case EventGraphicType.Sprite:
+                base.LoadTextures(textureName);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
+    {
+        if (RenderLevel == 1)
+        {
+            return base.DetermineRenderOrder(renderList, map);
+        }
+
+        renderList?.Remove(this);
+        if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
+        {
+            return null;
+        }
+
+        var gridX = Globals.Me.MapInstance.GridX;
+        var gridY = Globals.Me.MapInstance.GridY;
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
+            {
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
+                {
+                    if (Globals.MapGrid[x, y] != MapId)
+                    {
+                        continue;
+                    }
+
+                    if (RenderLevel == 0)
+                    {
+                        y--;
+                    }
+                    else if (RenderLevel == 2)
+                    {
+                        y++;
+                    }
+
+                    var priority = mRenderPriority;
+                    if (Z != 0)
+                    {
+                        priority += 3;
+                    }
+
+                    var maps = y - (gridY - 2);
+                    var renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * maps + Y];
+
+                    // If bugs arise from switching to the above, remove and uncomment this
+                    //HashSet<Entity> renderSet = null;
+                    //if (y == gridY - 2)
+                    //{
+                    //    renderSet = Graphics.RenderingEntities[priority, Y];
+                    //}
+                    //else if (y == gridY - 1)
+                    //{
+                    //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
+                    //}
+                    //else if (y == gridY)
+                    //{
+                    //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
+                    //}
+                    //else if (y == gridY + 1)
+                    //{
+                    //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 3 + Y];
+                    //}
+                    //else if (y == gridY + 2)
+                    //{
+                    //    renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 4 + Y];
+                    //}
+
+                    renderSet?.Add(this);
+                    renderList = renderSet;
+
+                    return renderList;
+                }
+            }
+        }
+
+        return renderList;
+    }
+
+    public override float GetTop(int overrideHeight = -1)
+    {
+        float heightScale;
+        switch (Graphic.Type)
+        {
+            case EventGraphicType.Sprite:
+                return base.GetTop(overrideHeight);
+
+            case EventGraphicType.Tileset:
+                heightScale = Graphic.Height + 1;
+                break;
+
+            case EventGraphicType.None:
+                heightScale = Animations.Count > 0 ? 1 : 0.5f;
+                break;
+
+            default:
+                throw new IndexOutOfRangeException($"Unsupported {nameof(EventGraphicType)} '{Graphic.Type}'");
+        }
+
+        var top = base.GetTop(0);
+        var offset = heightScale * Options.TileHeight;
+        return top - offset;
+    }
+
+    public override void DrawName(Color textColor, Color borderColor, Color backgroundColor)
+    {
+        base.DrawName(
+            textColor: textColor ?? new Color(CustomColors.Names.Events.Name),
+            borderColor: borderColor ?? new Color(CustomColors.Names.Events.Outline),
+            backgroundColor: backgroundColor ?? new Color(CustomColors.Names.Events.Background)
+        );
+    }
+
+    ~Event() => Dispose();
 }

--- a/Intersect.Client/Entities/Events/Hold.cs
+++ b/Intersect.Client/Entities/Events/Hold.cs
@@ -1,19 +1,17 @@
-﻿namespace Intersect.Client.Entities.Events
+﻿namespace Intersect.Client.Entities.Events;
+
+
+public partial class Hold
 {
 
-    public partial class Hold
+    public Guid EventId;
+
+    public Guid MapId;
+
+    public Hold(Guid eventId, Guid mapId)
     {
-
-        public Guid EventId;
-
-        public Guid MapId;
-
-        public Hold(Guid eventId, Guid mapId)
-        {
-            EventId = eventId;
-            MapId = mapId;
-        }
-
+        EventId = eventId;
+        MapId = mapId;
     }
 
 }

--- a/Intersect.Client/Entities/FriendInstance.cs
+++ b/Intersect.Client/Entities/FriendInstance.cs
@@ -1,15 +1,14 @@
 ﻿using Intersect.Client.Framework.Entities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+public partial class FriendInstance : IFriendInstance
 {
-    public partial class FriendInstance : IFriendInstance
-    {
 
-        public string Map { get; set; }
+    public string Map { get; set; }
 
-        public string Name { get; set; }
+    public string Name { get; set; }
 
-        public bool Online { get; set; } = false;
+    public bool Online { get; set; } = false;
 
-    }
 }

--- a/Intersect.Client/Entities/HotbarInstance.cs
+++ b/Intersect.Client/Entities/HotbarInstance.cs
@@ -2,21 +2,20 @@
 using Intersect.Enums;
 using Newtonsoft.Json;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+public partial class HotbarInstance : IHotbarInstance
 {
-    public partial class HotbarInstance : IHotbarInstance
+
+    public Guid BagId { get; set; } = Guid.Empty;
+
+    public Guid ItemOrSpellId { get; set; } = Guid.Empty;
+
+    public int[] PreferredStatBuffs { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    public void Load(string data)
     {
-
-        public Guid BagId { get; set; } = Guid.Empty;
-
-        public Guid ItemOrSpellId { get; set; } = Guid.Empty;
-
-        public int[] PreferredStatBuffs { get; set; } = new int[Enum.GetValues<Stat>().Length];
-
-        public void Load(string data)
-        {
-            JsonConvert.PopulateObject(data, this);
-        }
-
+        JsonConvert.PopulateObject(data, this);
     }
+
 }

--- a/Intersect.Client/Entities/PartyMember.cs
+++ b/Intersect.Client/Entities/PartyMember.cs
@@ -1,31 +1,29 @@
 ﻿using Intersect.Client.Framework.Entities;
 using Intersect.Enums;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class PartyMember : IPartyMember
 {
 
-    public partial class PartyMember : IPartyMember
+    public Guid Id { get; set; }
+
+    public int Level { get; set; }
+
+    public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    public string Name { get; set; }
+
+    public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    public PartyMember(Guid id, string name, long[] vital, long[] maxVital, int level)
     {
-
-        public Guid Id { get; set; }
-
-        public int Level { get; set; }
-
-        public long[] MaxVital { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        public string Name { get; set; }
-
-        public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        public PartyMember(Guid id, string name, long[] vital, long[] maxVital, int level)
-        {
-            Id = id;
-            Name = name;
-            Vital = vital;
-            MaxVital = maxVital;
-            Level = level;
-        }
-
+        Id = id;
+        Name = name;
+        Vital = vital;
+        MaxVital = maxVital;
+        Level = level;
     }
 
 }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -23,1923 +23,1940 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class Player : Entity, IPlayer
 {
 
-    public partial class Player : Entity, IPlayer
+    public delegate void InventoryUpdated();
+
+    private Guid _class;
+
+    public Guid Class
     {
-
-        public delegate void InventoryUpdated();
-
-        private Guid _class;
-
-        public Guid Class
+        get => _class;
+        set
         {
-            get => _class;
-            set
-            {
-                if (_class == value)
-                {
-                    return;
-                }
-
-                _class = value;
-                LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Attack);
-            }
-        }
-
-        public Access AccessLevel { get; set; }
-
-        public long Experience { get; set; } = 0;
-
-        public long ExperienceToNextLevel { get; set; } = 0;
-
-        IReadOnlyList<IFriendInstance> IPlayer.Friends => Friends;
-
-        public List<IFriendInstance> Friends { get; set; } = new();
-
-        IReadOnlyList<IHotbarInstance> IPlayer.HotbarSlots => Hotbar.ToList();
-
-        public HotbarInstance[] Hotbar { get; set; } = new HotbarInstance[Options.Instance.PlayerOpts.HotbarSlotCount];
-
-        public InventoryUpdated InventoryUpdatedDelegate { get; set; }
-
-        IReadOnlyDictionary<Guid, long> IPlayer.ItemCooldowns => ItemCooldowns;
-
-        public Dictionary<Guid, long> ItemCooldowns { get; set; } = new();
-
-        private Entity mLastBumpedEvent;
-
-        private List<IPartyMember> mParty;
-
-        private Direction _lastMoveDirection;
-
-        public override Direction MoveDir
-        {
-            get => base.MoveDir;
-            set
-            {
-                _lastMoveDirection = base.MoveDir;
-                base.MoveDir = value;
-            }
-        }
-
-        IReadOnlyDictionary<Guid, QuestProgress> IPlayer.QuestProgress => QuestProgress;
-
-        public Dictionary<Guid, QuestProgress> QuestProgress { get; set; } = new();
-
-        public Guid[] HiddenQuests { get; set; } = new Guid[0];
-
-        IReadOnlyDictionary<Guid, long> IPlayer.SpellCooldowns => SpellCooldowns;
-
-        public Dictionary<Guid, long> SpellCooldowns { get; set; } = new();
-
-        public int StatPoints { get; set; } = 0;
-
-        public EntityBox TargetBox { get; set; }
-
-        public PlayerStatusWindow StatusWindow { get; set; }
-
-        public Guid TargetIndex { get; set; }
-
-        TargetType IPlayer.TargetType => (TargetType)TargetType;
-
-        public int TargetType { get; set; }
-
-        public long CombatTimer { get; set; }
-
-        public long IsCastingCheckTimer { get; set; }
-
-        public long GlobalCooldown { get; set; }
-
-        // Target data
-        private long mlastTargetScanTime;
-
-        Guid mlastTargetScanMap = Guid.Empty;
-
-        Point mlastTargetScanLocation = new(-1, -1);
-
-        Dictionary<Entity, TargetInfo> mlastTargetList = new(); // Entity, Last Time Selected
-
-        Entity mLastEntitySelected;
-
-        private Dictionary<int, long> mLastHotbarUseTime = new();
-        private int mHotbarUseDelay = 150;
-
-        /// <summary>
-        /// Name of our guild if we are in one.
-        /// </summary>
-        public string Guild { get; set; }
-
-        string IPlayer.GuildName => Guild;
-
-        /// <summary>
-        /// Index of our rank where 0 is the leader
-        /// </summary>
-        public int Rank { get; set; }
-
-        /// <summary>
-        /// Returns whether or not we are in a guild by checking to see if we are assigned a guild name
-        /// </summary>
-        public bool IsInGuild => !string.IsNullOrWhiteSpace(Guild);
-
-        /// <summary>
-        /// Obtains our rank and permissions from the game config
-        /// </summary>
-        public GuildRank GuildRank => IsInGuild ? Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Rank, Options.Instance.Guild.Ranks.Length - 1))] : null;
-
-        /// <summary>
-        /// Contains a record of all members of this player's guild.
-        /// </summary>
-        public GuildMember[] GuildMembers = new GuildMember[0];
-
-        public Player(Guid id, PlayerEntityPacket packet) : base(id, packet, EntityType.Player)
-        {
-            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-            {
-                Hotbar[i] = new HotbarInstance();
-            }
-
-            mRenderPriority = 2;
-        }
-
-        IReadOnlyList<IPartyMember> IPlayer.PartyMembers => Party;
-
-        public List<IPartyMember> Party
-        {
-            get
-            {
-                if (mParty == null)
-                {
-                    mParty = new List<IPartyMember>();
-                }
-
-                return mParty;
-            }
-        }
-
-        public override Guid MapId
-        {
-            get => base.MapId;
-            set
-            {
-                if (value != base.MapId)
-                {
-                    var oldMap = Maps.MapInstance.Get(base.MapId);
-                    var newMap = Maps.MapInstance.Get(value);
-                    base.MapId = value;
-                    if (Globals.Me == this)
-                    {
-                        if (Maps.MapInstance.Get(Globals.Me.MapId) != null)
-                        {
-                            Audio.PlayMusic(Maps.MapInstance.Get(Globals.Me.MapId).Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-                        }
-
-                        if (newMap != null && oldMap != null)
-                        {
-                            newMap.CompareEffects(oldMap);
-                        }
-                    }
-                }
-            }
-        }
-
-        public bool IsFriend(IPlayer player)
-        {
-            return Friends.Any(
-                friend => player != null &&
-                          string.Equals(player.Name, friend.Name, StringComparison.CurrentCultureIgnoreCase));
-        }
-
-        public bool IsGuildMate(IPlayer player)
-        {
-            return GuildMembers.Any(
-                guildMate =>
-                    player != null &&
-                    string.Equals(player.Name, guildMate.Name, StringComparison.CurrentCultureIgnoreCase));
-        }
-
-        bool IPlayer.IsInParty => IsInParty();
-
-        public bool IsInParty()
-        {
-            return Party.Count > 0;
-        }
-
-        public bool IsInMyParty(IPlayer player) => player != null && IsInMyParty(player.Id);
-
-        public bool IsInMyParty(Guid id) => Party.Any(member => member.Id == id);
-
-        public bool IsInMyGuild(IPlayer player) => IsInGuild && player != null && player.GuildName == Guild;
-
-        public bool IsBusy => !(Globals.EventHolds.Count == 0 &&
-                     !Globals.MoveRouteActive &&
-                     Globals.GameShop == null &&
-                     Globals.InBank == false &&
-                     Globals.InCraft == false &&
-                     Globals.InTrade == false &&
-                     !Interface.Interface.HasInputFocus());
-
-        public override bool Update()
-        {
-
-            if (Globals.Me == this)
-            {
-                HandleInput();
-            }
-
-
-            if (!IsBusy)
-            {
-                if (this == Globals.Me && IsMoving == false)
-                {
-                    ProcessDirectionalInput();
-                }
-
-                if (Controls.KeyDown(Control.AttackInteract))
-                {
-                    if (IsCasting)
-                    {
-                        if (IsCastingCheckTimer < Timing.Global.Milliseconds &&
-                            Options.Combat.EnableCombatChatMessages)
-                        {
-                            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Combat.AttackWhileCastingDeny,
-                                CustomColors.Alerts.Declined, ChatMessageType.Combat));
-                            IsCastingCheckTimer = Timing.Global.Milliseconds + 350;
-                        }
-                    }
-                    else if (!Globals.Me.TryAttack())
-                    {
-                        if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.PlayerOpts.AllowCombatMovement))
-                        {
-                            Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
-                        }
-                    }
-                }
-
-                //Holding block button for "auto blocking"
-                if (Controls.KeyDown(Control.Block))
-                {
-                    TryBlock();
-                }
-            }
-
-            if (TargetBox == default && this == Globals.Me && Interface.Interface.GameUi != default)
-            {
-                // If for WHATEVER reason the box hasn't been created, create it.
-                TargetBox = new EntityBox(Interface.Interface.GameUi.GameCanvas, EntityType.Player, null);
-                TargetBox.Hide();
-            }
-            else if (TargetIndex != default)
-            {
-                if (!Globals.Entities.TryGetValue(TargetIndex, out var foundEntity))
-                {
-                    foundEntity = TargetBox.MyEntity?.MapInstance?.Entities.FirstOrDefault(entity => entity.Id == TargetIndex) as Entity;
-                }
-
-                if (foundEntity == default || foundEntity.IsHidden || foundEntity.IsStealthed)
-                {
-                    ClearTarget();
-                }
-            }
-
-            TargetBox?.Update();
-            StatusWindow?.Update();
-
-            // Hide our Guild window if we're not in a guild!
-            if (this == Globals.Me && string.IsNullOrEmpty(Guild) && Interface.Interface.GameUi != null)
-            {
-                Interface.Interface.GameUi.HideGuildWindow();
-            }
-
-            if (IsBlocking && !IsAttacking && !IsMoving)
-            {
-                IsBlocking = false;
-            }
-
-            var returnval = base.Update();
-
-            return returnval;
-        }
-
-        //Loading
-        public override void Load(EntityPacket packet)
-        {
-            base.Load(packet);
-            var playerPacket = (PlayerEntityPacket)packet;
-            Gender = playerPacket.Gender;
-            Class = playerPacket.ClassId;
-            AccessLevel = playerPacket.AccessLevel;
-            CombatTimer = playerPacket.CombatTimeRemaining + Timing.Global.Milliseconds;
-            Guild = playerPacket.Guild;
-            Rank = playerPacket.GuildRank;
-
-            if (playerPacket.Equipment != null)
-            {
-                if (this == Globals.Me && playerPacket.Equipment.InventorySlots != null)
-                {
-                    MyEquipment = playerPacket.Equipment.InventorySlots;
-                }
-                else if (playerPacket.Equipment.ItemIds != null)
-                {
-                    Equipment = playerPacket.Equipment.ItemIds;
-                }
-            }
-
-            if (this == Globals.Me && TargetBox == null && Interface.Interface.GameUi != null)
-            {
-                TargetBox = new EntityBox(Interface.Interface.GameUi.GameCanvas, EntityType.Player, null);
-                TargetBox.Hide();
-            }
-        }
-
-        //Item Processing
-        public void SwapItems(int fromSlotIndex, int toSlotIndex)
-        {
-            PacketSender.SendSwapInvItems(fromSlotIndex, toSlotIndex);
-            var fromSlot = Inventory[fromSlotIndex];
-            var toSlot = Inventory[toSlotIndex];
-
-            if (
-                fromSlot.ItemId == toSlot.ItemId
-                && ItemBase.TryGet(toSlot.ItemId, out var itemInSlot)
-                && itemInSlot.IsStackable
-                && fromSlot.Quantity < itemInSlot.MaxInventoryStack
-                && toSlot.Quantity < itemInSlot.MaxInventoryStack
-            )
-            {
-                var combinedQuantity = fromSlot.Quantity + toSlot.Quantity;
-                var toQuantity = Math.Min(itemInSlot.MaxInventoryStack, combinedQuantity);
-                var fromQuantity = combinedQuantity - toQuantity;
-                toSlot.Quantity = toQuantity;
-                fromSlot.Quantity = fromQuantity;
-                if (fromQuantity < 1)
-                {
-                    Inventory[fromSlotIndex].ItemId = default;
-                }
-            }
-            else
-            {
-                Inventory[fromSlotIndex] = toSlot;
-                Inventory[toSlotIndex] = fromSlot;
-            }
-        }
-
-        public void TryDropItem(int inventorySlotIndex)
-        {
-            var inventorySlot = Inventory[inventorySlotIndex];
-            if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
+            if (_class == value)
             {
                 return;
             }
 
-            var quantity = inventorySlot.Quantity;
-            var canDropMultiple = quantity > 1;
-            var inputType = canDropMultiple ? InputBox.InputType.NumericSliderInput : InputBox.InputType.YesNo;
-            var prompt = canDropMultiple ? Strings.Inventory.DropItemPrompt : Strings.Inventory.DropPrompt;
-            InputBox.Open(
-                title: Strings.Inventory.DropItemTitle,
-                prompt: prompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: inputType,
-                onSuccess: DropInputBoxOkay,
-                onCancel: default,
-                userData: inventorySlotIndex,
-                quantity: quantity,
-                maxQuantity: quantity
-            );
+            _class = value;
+            LoadAnimationTexture(string.IsNullOrWhiteSpace(TransformedSprite) ? Sprite : TransformedSprite, SpriteAnimations.Attack);
+        }
+    }
+
+    public Access AccessLevel { get; set; }
+
+    public long Experience { get; set; } = 0;
+
+    public long ExperienceToNextLevel { get; set; } = 0;
+
+    IReadOnlyList<IFriendInstance> IPlayer.Friends => Friends;
+
+    public List<IFriendInstance> Friends { get; set; } = new();
+
+    IReadOnlyList<IHotbarInstance> IPlayer.HotbarSlots => Hotbar.ToList();
+
+    public HotbarInstance[] Hotbar { get; set; } = new HotbarInstance[Options.Instance.PlayerOpts.HotbarSlotCount];
+
+    public InventoryUpdated InventoryUpdatedDelegate { get; set; }
+
+    IReadOnlyDictionary<Guid, long> IPlayer.ItemCooldowns => ItemCooldowns;
+
+    public Dictionary<Guid, long> ItemCooldowns { get; set; } = new();
+
+    private Entity mLastBumpedEvent;
+
+    private List<IPartyMember> mParty;
+
+    private Direction _lastMoveDirection;
+
+    public override Direction MoveDir
+    {
+        get => base.MoveDir;
+        set
+        {
+            _lastMoveDirection = base.MoveDir;
+            base.MoveDir = value;
+        }
+    }
+
+    IReadOnlyDictionary<Guid, QuestProgress> IPlayer.QuestProgress => QuestProgress;
+
+    public Dictionary<Guid, QuestProgress> QuestProgress { get; set; } = new();
+
+    public Guid[] HiddenQuests { get; set; } = new Guid[0];
+
+    IReadOnlyDictionary<Guid, long> IPlayer.SpellCooldowns => SpellCooldowns;
+
+    public Dictionary<Guid, long> SpellCooldowns { get; set; } = new();
+
+    public int StatPoints { get; set; } = 0;
+
+    public EntityBox TargetBox { get; set; }
+
+    public PlayerStatusWindow StatusWindow { get; set; }
+
+    public Guid TargetIndex { get; set; }
+
+    TargetType IPlayer.TargetType => (TargetType)TargetType;
+
+    public int TargetType { get; set; }
+
+    public long CombatTimer { get; set; }
+
+    public long IsCastingCheckTimer { get; set; }
+
+    public long GlobalCooldown { get; set; }
+
+    // Target data
+    private long mlastTargetScanTime;
+
+    Guid mlastTargetScanMap = Guid.Empty;
+
+    Point mlastTargetScanLocation = new(-1, -1);
+
+    Dictionary<Entity, TargetInfo> mlastTargetList = new(); // Entity, Last Time Selected
+
+    Entity mLastEntitySelected;
+
+    private Dictionary<int, long> mLastHotbarUseTime = new();
+    private int mHotbarUseDelay = 150;
+
+    /// <summary>
+    /// Name of our guild if we are in one.
+    /// </summary>
+    public string Guild { get; set; }
+
+    string IPlayer.GuildName => Guild;
+
+    /// <summary>
+    /// Index of our rank where 0 is the leader
+    /// </summary>
+    public int Rank { get; set; }
+
+    /// <summary>
+    /// Returns whether or not we are in a guild by checking to see if we are assigned a guild name
+    /// </summary>
+    public bool IsInGuild => !string.IsNullOrWhiteSpace(Guild);
+
+    /// <summary>
+    /// Obtains our rank and permissions from the game config
+    /// </summary>
+    public GuildRank GuildRank => IsInGuild ? Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Rank, Options.Instance.Guild.Ranks.Length - 1))] : null;
+
+    /// <summary>
+    /// Contains a record of all members of this player's guild.
+    /// </summary>
+    public GuildMember[] GuildMembers = new GuildMember[0];
+
+    public Player(Guid id, PlayerEntityPacket packet) : base(id, packet, EntityType.Player)
+    {
+        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+        {
+            Hotbar[i] = new HotbarInstance();
         }
 
-        private void DropInputBoxOkay(object sender, EventArgs e)
+        mRenderPriority = 2;
+    }
+
+    IReadOnlyList<IPartyMember> IPlayer.PartyMembers => Party;
+
+    public List<IPartyMember> Party
+    {
+        get
         {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
+            if (mParty == null)
             {
-                PacketSender.SendDropItem((int)((InputBox)sender).UserData, value);
+                mParty = new List<IPartyMember>();
             }
-        }
 
-        public int FindItem(Guid itemId, int itemVal = 1)
+            return mParty;
+        }
+    }
+
+    public override Guid MapId
+    {
+        get => base.MapId;
+        set
         {
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            if (value != base.MapId)
             {
-                if (Inventory[i].ItemId == itemId && Inventory[i].Quantity >= itemVal)
+                var oldMap = Maps.MapInstance.Get(base.MapId);
+                var newMap = Maps.MapInstance.Get(value);
+                base.MapId = value;
+                if (Globals.Me == this)
                 {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        private int GetQuantityOfItemIn(IEnumerable<IItem> items, Guid itemId)
-        {
-            long count = 0;
-
-            foreach (var slot in (items ?? Enumerable.Empty<IItem>()))
-            {
-                if (slot?.ItemId == itemId)
-                {
-                    count += slot.Quantity;
-                }
-            }
-
-            return (int)Math.Min(count, int.MaxValue);
-        }
-
-        public int GetQuantityOfItemInBank(Guid itemId) => GetQuantityOfItemIn(Globals.Bank, itemId);
-
-        public int GetQuantityOfItemInInventory(Guid itemId) => GetQuantityOfItemIn(Inventory, itemId);
-
-        public void TryUseItem(int index)
-        {
-            if (!IsItemOnCooldown(index) &&
-                index >= 0 && index < Globals.Me.Inventory.Length && Globals.Me.Inventory[index]?.Quantity > 0)
-            {
-                PacketSender.SendUseItem(index, TargetIndex);
-            }
-        }
-
-        public long GetItemCooldown(Guid id)
-        {
-            if (ItemCooldowns.ContainsKey(id))
-            {
-                return ItemCooldowns[id];
-            }
-
-            return 0;
-        }
-
-        public int FindHotbarItem(IHotbarInstance hotbarInstance)
-        {
-            var bestMatch = -1;
-
-            if (hotbarInstance.ItemOrSpellId != Guid.Empty)
-            {
-                for (var i = 0; i < Inventory.Length; i++)
-                {
-                    var itm = Inventory[i];
-                    if (itm != null && itm.ItemId == hotbarInstance.ItemOrSpellId)
+                    if (Maps.MapInstance.Get(Globals.Me.MapId) != null)
                     {
-                        bestMatch = i;
-                        var itemBase = ItemBase.Get(itm.ItemId);
-                        if (itemBase != null)
-                        {
-                            if (itemBase.ItemType == ItemType.Bag)
-                            {
-                                if (hotbarInstance.BagId == itm.BagId)
-                                {
-                                    break;
-                                }
-                            }
-                            else if (itemBase.ItemType == ItemType.Equipment)
-                            {
-                                if (hotbarInstance.PreferredStatBuffs != null)
-                                {
-                                    var statMatch = true;
-                                    for (var s = 0; s < hotbarInstance.PreferredStatBuffs.Length; s++)
-                                    {
-                                        if (itm.ItemProperties.StatModifiers[s] != hotbarInstance.PreferredStatBuffs[s])
-                                        {
-                                            statMatch = false;
-                                        }
-                                    }
+                        Audio.PlayMusic(Maps.MapInstance.Get(Globals.Me.MapId).Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
+                    }
 
-                                    if (statMatch)
-                                    {
-                                        break;
-                                    }
-                                }
-                            }
-                            else
+                    if (newMap != null && oldMap != null)
+                    {
+                        newMap.CompareEffects(oldMap);
+                    }
+                }
+            }
+        }
+    }
+
+    public bool IsFriend(IPlayer player)
+    {
+        return Friends.Any(
+            friend => player != null &&
+                      string.Equals(player.Name, friend.Name, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public bool IsGuildMate(IPlayer player)
+    {
+        return GuildMembers.Any(
+            guildMate =>
+                player != null &&
+                string.Equals(player.Name, guildMate.Name, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    bool IPlayer.IsInParty => IsInParty();
+
+    public bool IsInParty()
+    {
+        return Party.Count > 0;
+    }
+
+    public bool IsInMyParty(IPlayer player) => player != null && IsInMyParty(player.Id);
+
+    public bool IsInMyParty(Guid id) => Party.Any(member => member.Id == id);
+
+    public bool IsInMyGuild(IPlayer player) => IsInGuild && player != null && player.GuildName == Guild;
+
+    public bool IsBusy => !(Globals.EventHolds.Count == 0 &&
+                 !Globals.MoveRouteActive &&
+                 Globals.GameShop == null &&
+                 Globals.InBank == false &&
+                 Globals.InCraft == false &&
+                 Globals.InTrade == false &&
+                 !Interface.Interface.HasInputFocus());
+
+    public override bool Update()
+    {
+
+        if (Globals.Me == this)
+        {
+            HandleInput();
+        }
+
+
+        if (!IsBusy)
+        {
+            if (this == Globals.Me && IsMoving == false)
+            {
+                ProcessDirectionalInput();
+            }
+
+            if (Controls.KeyDown(Control.AttackInteract))
+            {
+                if (IsCasting)
+                {
+                    if (IsCastingCheckTimer < Timing.Global.Milliseconds &&
+                        Options.Combat.EnableCombatChatMessages)
+                    {
+                        ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Combat.AttackWhileCastingDeny,
+                            CustomColors.Alerts.Declined, ChatMessageType.Combat));
+                        IsCastingCheckTimer = Timing.Global.Milliseconds + 350;
+                    }
+                }
+                else if (!Globals.Me.TryAttack())
+                {
+                    if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.PlayerOpts.AllowCombatMovement))
+                    {
+                        Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
+                    }
+                }
+            }
+
+            //Holding block button for "auto blocking"
+            if (Controls.KeyDown(Control.Block))
+            {
+                TryBlock();
+            }
+        }
+
+        if (TargetBox == default && this == Globals.Me && Interface.Interface.GameUi != default)
+        {
+            // If for WHATEVER reason the box hasn't been created, create it.
+            TargetBox = new EntityBox(Interface.Interface.GameUi.GameCanvas, EntityType.Player, null);
+            TargetBox.Hide();
+        }
+        else if (TargetIndex != default)
+        {
+            if (!Globals.Entities.TryGetValue(TargetIndex, out var foundEntity))
+            {
+                foundEntity = TargetBox.MyEntity?.MapInstance?.Entities.FirstOrDefault(entity => entity.Id == TargetIndex) as Entity;
+            }
+
+            if (foundEntity == default || foundEntity.IsHidden || foundEntity.IsStealthed)
+            {
+                ClearTarget();
+            }
+        }
+
+        TargetBox?.Update();
+        StatusWindow?.Update();
+
+        // Hide our Guild window if we're not in a guild!
+        if (this == Globals.Me && string.IsNullOrEmpty(Guild) && Interface.Interface.GameUi != null)
+        {
+            Interface.Interface.GameUi.HideGuildWindow();
+        }
+
+        if (IsBlocking && !IsAttacking && !IsMoving)
+        {
+            IsBlocking = false;
+        }
+
+        var returnval = base.Update();
+
+        return returnval;
+    }
+
+    //Loading
+    public override void Load(EntityPacket packet)
+    {
+        base.Load(packet);
+        var playerPacket = (PlayerEntityPacket)packet;
+        Gender = playerPacket.Gender;
+        Class = playerPacket.ClassId;
+        AccessLevel = playerPacket.AccessLevel;
+        CombatTimer = playerPacket.CombatTimeRemaining + Timing.Global.Milliseconds;
+        Guild = playerPacket.Guild;
+        Rank = playerPacket.GuildRank;
+
+        if (playerPacket.Equipment != null)
+        {
+            if (this == Globals.Me && playerPacket.Equipment.InventorySlots != null)
+            {
+                MyEquipment = playerPacket.Equipment.InventorySlots;
+            }
+            else if (playerPacket.Equipment.ItemIds != null)
+            {
+                Equipment = playerPacket.Equipment.ItemIds;
+            }
+        }
+
+        if (this == Globals.Me && TargetBox == null && Interface.Interface.GameUi != null)
+        {
+            TargetBox = new EntityBox(Interface.Interface.GameUi.GameCanvas, EntityType.Player, null);
+            TargetBox.Hide();
+        }
+    }
+
+    //Item Processing
+    public void SwapItems(int fromSlotIndex, int toSlotIndex)
+    {
+        PacketSender.SendSwapInvItems(fromSlotIndex, toSlotIndex);
+        var fromSlot = Inventory[fromSlotIndex];
+        var toSlot = Inventory[toSlotIndex];
+
+        if (
+            fromSlot.ItemId == toSlot.ItemId
+            && ItemBase.TryGet(toSlot.ItemId, out var itemInSlot)
+            && itemInSlot.IsStackable
+            && fromSlot.Quantity < itemInSlot.MaxInventoryStack
+            && toSlot.Quantity < itemInSlot.MaxInventoryStack
+        )
+        {
+            var combinedQuantity = fromSlot.Quantity + toSlot.Quantity;
+            var toQuantity = Math.Min(itemInSlot.MaxInventoryStack, combinedQuantity);
+            var fromQuantity = combinedQuantity - toQuantity;
+            toSlot.Quantity = toQuantity;
+            fromSlot.Quantity = fromQuantity;
+            if (fromQuantity < 1)
+            {
+                Inventory[fromSlotIndex].ItemId = default;
+            }
+        }
+        else
+        {
+            Inventory[fromSlotIndex] = toSlot;
+            Inventory[toSlotIndex] = fromSlot;
+        }
+    }
+
+    public void TryDropItem(int inventorySlotIndex)
+    {
+        var inventorySlot = Inventory[inventorySlotIndex];
+        if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
+        {
+            return;
+        }
+
+        var quantity = inventorySlot.Quantity;
+        var canDropMultiple = quantity > 1;
+        var inputType = canDropMultiple ? InputBox.InputType.NumericSliderInput : InputBox.InputType.YesNo;
+        var prompt = canDropMultiple ? Strings.Inventory.DropItemPrompt : Strings.Inventory.DropPrompt;
+        InputBox.Open(
+            title: Strings.Inventory.DropItemTitle,
+            prompt: prompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: inputType,
+            onSuccess: DropInputBoxOkay,
+            onCancel: default,
+            userData: inventorySlotIndex,
+            quantity: quantity,
+            maxQuantity: quantity
+        );
+    }
+
+    private void DropInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            PacketSender.SendDropItem((int)((InputBox)sender).UserData, value);
+        }
+    }
+
+    public int FindItem(Guid itemId, int itemVal = 1)
+    {
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            if (Inventory[i].ItemId == itemId && Inventory[i].Quantity >= itemVal)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private int GetQuantityOfItemIn(IEnumerable<IItem> items, Guid itemId)
+    {
+        long count = 0;
+
+        foreach (var slot in (items ?? Enumerable.Empty<IItem>()))
+        {
+            if (slot?.ItemId == itemId)
+            {
+                count += slot.Quantity;
+            }
+        }
+
+        return (int)Math.Min(count, int.MaxValue);
+    }
+
+    public int GetQuantityOfItemInBank(Guid itemId) => GetQuantityOfItemIn(Globals.Bank, itemId);
+
+    public int GetQuantityOfItemInInventory(Guid itemId) => GetQuantityOfItemIn(Inventory, itemId);
+
+    public void TryUseItem(int index)
+    {
+        if (!IsItemOnCooldown(index) &&
+            index >= 0 && index < Globals.Me.Inventory.Length && Globals.Me.Inventory[index]?.Quantity > 0)
+        {
+            PacketSender.SendUseItem(index, TargetIndex);
+        }
+    }
+
+    public long GetItemCooldown(Guid id)
+    {
+        if (ItemCooldowns.ContainsKey(id))
+        {
+            return ItemCooldowns[id];
+        }
+
+        return 0;
+    }
+
+    public int FindHotbarItem(IHotbarInstance hotbarInstance)
+    {
+        var bestMatch = -1;
+
+        if (hotbarInstance.ItemOrSpellId != Guid.Empty)
+        {
+            for (var i = 0; i < Inventory.Length; i++)
+            {
+                var itm = Inventory[i];
+                if (itm != null && itm.ItemId == hotbarInstance.ItemOrSpellId)
+                {
+                    bestMatch = i;
+                    var itemBase = ItemBase.Get(itm.ItemId);
+                    if (itemBase != null)
+                    {
+                        if (itemBase.ItemType == ItemType.Bag)
+                        {
+                            if (hotbarInstance.BagId == itm.BagId)
                             {
                                 break;
                             }
                         }
+                        else if (itemBase.ItemType == ItemType.Equipment)
+                        {
+                            if (hotbarInstance.PreferredStatBuffs != null)
+                            {
+                                var statMatch = true;
+                                for (var s = 0; s < hotbarInstance.PreferredStatBuffs.Length; s++)
+                                {
+                                    if (itm.ItemProperties.StatModifiers[s] != hotbarInstance.PreferredStatBuffs[s])
+                                    {
+                                        statMatch = false;
+                                    }
+                                }
+
+                                if (statMatch)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
                     }
                 }
             }
-
-            return bestMatch;
         }
 
-        public bool IsEquipped(int slot)
+        return bestMatch;
+    }
+
+    public bool IsEquipped(int slot)
+    {
+        for (var i = 0; i < Options.EquipmentSlots.Count; i++)
         {
-            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+            if (MyEquipment[i] == slot)
             {
-                if (MyEquipment[i] == slot)
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool IsItemOnCooldown(int slot)
+    {
+        if (Inventory[slot] != null)
+        {
+            var itm = Inventory[slot];
+            if (itm.ItemId != Guid.Empty)
+            {
+                if (ItemCooldowns.ContainsKey(itm.ItemId) && ItemCooldowns[itm.ItemId] > Timing.Global.Milliseconds)
+                {
+                    return true;
+                }
+
+                if ((ItemBase.TryGet(itm.ItemId, out var itemBase) && !itemBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
                 {
                     return true;
                 }
             }
-
-            return false;
         }
 
-        public bool IsItemOnCooldown(int slot)
-        {
-            if (Inventory[slot] != null)
-            {
-                var itm = Inventory[slot];
-                if (itm.ItemId != Guid.Empty)
-                {
-                    if (ItemCooldowns.ContainsKey(itm.ItemId) && ItemCooldowns[itm.ItemId] > Timing.Global.Milliseconds)
-                    {
-                        return true;
-                    }
+        return false;
+    }
 
-                    if ((ItemBase.TryGet(itm.ItemId, out var itemBase) && !itemBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
-                    {
-                        return true;
-                    }
+    public long GetItemRemainingCooldown(int slot)
+    {
+        if (Inventory[slot] != null)
+        {
+            var itm = Inventory[slot];
+            if (itm.ItemId != Guid.Empty)
+            {
+                if (ItemCooldowns.ContainsKey(itm.ItemId) && ItemCooldowns[itm.ItemId] > Timing.Global.Milliseconds)
+                {
+                    return ItemCooldowns[itm.ItemId] - Timing.Global.Milliseconds;
+                }
+
+                if ((ItemBase.TryGet(itm.ItemId, out var itemBase) && !itemBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
+                {
+                    return Globals.Me.GlobalCooldown - Timing.Global.Milliseconds;
                 }
             }
-
-            return false;
         }
 
-        public long GetItemRemainingCooldown(int slot)
-        {
-            if (Inventory[slot] != null)
-            {
-                var itm = Inventory[slot];
-                if (itm.ItemId != Guid.Empty)
-                {
-                    if (ItemCooldowns.ContainsKey(itm.ItemId) && ItemCooldowns[itm.ItemId] > Timing.Global.Milliseconds)
-                    {
-                        return ItemCooldowns[itm.ItemId] - Timing.Global.Milliseconds;
-                    }
+        return 0;
+    }
 
-                    if ((ItemBase.TryGet(itm.ItemId, out var itemBase) && !itemBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
-                    {
-                        return Globals.Me.GlobalCooldown - Timing.Global.Milliseconds;
-                    }
+    public bool IsSpellOnCooldown(int slot)
+    {
+        if (Spells[slot] != null)
+        {
+            var spl = Spells[slot];
+            if (spl.Id != Guid.Empty)
+            {
+                if (SpellCooldowns.ContainsKey(spl.Id) && SpellCooldowns[spl.Id] > Timing.Global.Milliseconds)
+                {
+                    return true;
+                }
+
+                if ((SpellBase.TryGet(spl.Id, out var spellBase) && !spellBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
+                {
+                    return true;
                 }
             }
+        }
 
+        return false;
+    }
+
+    public long GetSpellRemainingCooldown(int slot)
+    {
+        if (slot < 0 || Spells.Length <= slot)
+        {
+            Log.Warn(new ArgumentOutOfRangeException(nameof(slot), slot, $@"Slot was out of the range [0,{Spells.Length}"));
             return 0;
         }
 
-        public bool IsSpellOnCooldown(int slot)
+        var spell = Spells[slot];
+        // These two can't be combined into a nullish expression because Guid is a struct
+        if (spell == default || spell.Id == Guid.Empty)
         {
-            if (Spells[slot] != null)
-            {
-                var spl = Spells[slot];
-                if (spl.Id != Guid.Empty)
-                {
-                    if (SpellCooldowns.ContainsKey(spl.Id) && SpellCooldowns[spl.Id] > Timing.Global.Milliseconds)
-                    {
-                        return true;
-                    }
-
-                    if ((SpellBase.TryGet(spl.Id, out var spellBase) && !spellBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        public long GetSpellRemainingCooldown(int slot)
-        {
-            if (slot < 0 || Spells.Length <= slot)
-            {
-                Log.Warn(new ArgumentOutOfRangeException(nameof(slot), slot, $@"Slot was out of the range [0,{Spells.Length}"));
-                return 0;
-            }
-
-            var spell = Spells[slot];
-            // These two can't be combined into a nullish expression because Guid is a struct
-            if (spell == default || spell.Id == Guid.Empty)
-            {
-                return 0;
-            }
-
-            var now = Timing.Global.Milliseconds;
-
-            if (SpellCooldowns.TryGetValue(spell.Id, out var cd) && cd > now)
-            {
-                return cd - now;
-            }
-
-            if (SpellBase.TryGet(spell.Id, out var spellBase) && !spellBase.IgnoreGlobalCooldown && Globals.Me.GlobalCooldown > now)
-            {
-                return Globals.Me.GlobalCooldown - now;
-            }
-
             return 0;
         }
 
-        public void TrySellItem(int inventorySlotIndex)
+        var now = Timing.Global.Milliseconds;
+
+        if (SpellCooldowns.TryGetValue(spell.Id, out var cd) && cd > now)
         {
-            var inventorySlot = Inventory[inventorySlotIndex];
-            if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
-            {
-                return;
-            }
-
-            var shop = Globals.GameShop;
-            var shopCanBuyItem =
-                shop.BuyingWhitelist && shop.BuyingItems.Any(buyingItem => buyingItem.ItemId == itemDescriptor.Id)
-                || !shop.BuyingWhitelist && !shop.BuyingItems.Any(buyingItem => buyingItem.ItemId == itemDescriptor.Id);
-
-            var prompt = Strings.Shop.SellPrompt;
-            var inputType = InputBox.InputType.YesNo;
-            EventHandler onSuccess = SellInputBoxOkay;
-            var userData = inventorySlotIndex;
-            var slotQuantity = inventorySlot.Quantity;
-            var maxQuantity = slotQuantity;
-
-            if (!shopCanBuyItem)
-            {
-                prompt = Strings.Shop.CannotSell;
-                inputType = InputBox.InputType.OkayOnly;
-                onSuccess = null;
-                userData = -1;
-            }
-            else if (itemDescriptor.IsStackable || slotQuantity > 1)
-            {
-                var inventoryQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
-                if (inventoryQuantity > 1)
-                {
-                    maxQuantity = inventoryQuantity;
-                    prompt = Strings.Shop.SellItemPrompt;
-                    inputType = InputBox.InputType.NumericSliderInput;
-                    onSuccess = SellItemInputBoxOkay;
-                    userData = inventorySlotIndex;
-                }
-            }
-
-            InputBox.Open(
-                title: Strings.Shop.SellItem,
-                prompt: prompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: inputType,
-                onSuccess: onSuccess,
-                onCancel: null,
-                userData: userData,
-                quantity: slotQuantity,
-                maxQuantity: maxQuantity
-            );
+            return cd - now;
         }
 
-        public void TryBuyItem(int shopSlotIndex)
+        if (SpellBase.TryGet(spell.Id, out var spellBase) && !spellBase.IgnoreGlobalCooldown && Globals.Me.GlobalCooldown > now)
         {
-            //Confirm the purchase
-            var shopSlot = Globals.GameShop.SellingItems[shopSlotIndex];
-            if (!ItemBase.TryGet(shopSlot.ItemId, out var itemDescriptor))
-            {
-                return;
-            }
-
-            var maxBuyAmount = 0;
-            if (shopSlot.CostItemQuantity < 1)
-            {
-                var emptySlots = Inventory.Count(inventorySlot => inventorySlot.ItemId == default);
-                var slotsWithItem = Inventory.Count(inventorySlot => inventorySlot.ItemId == itemDescriptor.Id);
-                var currentItemQuantity = GetQuantityOfItemInInventory(shopSlot.ItemId);
-                var stackSize = itemDescriptor.IsStackable ? itemDescriptor.MaxInventoryStack : 1;
-                var itemQuantityLimitInCurrentStacks = slotsWithItem * stackSize;
-                var partialStackEmptyQuantity = itemQuantityLimitInCurrentStacks - currentItemQuantity;
-                maxBuyAmount = emptySlots * stackSize + partialStackEmptyQuantity;
-            }
-            else
-            {
-                var currencyCount = GetQuantityOfItemInInventory(shopSlot.CostItemId);
-                maxBuyAmount = (int)Math.Floor(currencyCount / (float)shopSlot.CostItemQuantity);
-            }
-
-            // If our max buy amount is 0 or the item isn't stackable, let the server handle it
-            if (!itemDescriptor.IsStackable || maxBuyAmount == 0)
-            {
-                PacketSender.SendBuyItem(shopSlotIndex, 1);
-                return;
-            }
-
-            InputBox.Open(
-                title: Strings.Shop.BuyItem,
-                prompt: Strings.Shop.BuyItemPrompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: BuyItemInputBoxOkay,
-                onCancel: null,
-                userData: shopSlotIndex,
-                quantity: maxBuyAmount,
-                maxQuantity: maxBuyAmount
-            );
+            return Globals.Me.GlobalCooldown - now;
         }
 
-        private void BuyItemInputBoxOkay(object sender, EventArgs e)
+        return 0;
+    }
+
+    public void TrySellItem(int inventorySlotIndex)
+    {
+        var inventorySlot = Inventory[inventorySlotIndex];
+        if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
         {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
+            return;
+        }
+
+        var shop = Globals.GameShop;
+        var shopCanBuyItem =
+            shop.BuyingWhitelist && shop.BuyingItems.Any(buyingItem => buyingItem.ItemId == itemDescriptor.Id)
+            || !shop.BuyingWhitelist && !shop.BuyingItems.Any(buyingItem => buyingItem.ItemId == itemDescriptor.Id);
+
+        var prompt = Strings.Shop.SellPrompt;
+        var inputType = InputBox.InputType.YesNo;
+        EventHandler onSuccess = SellInputBoxOkay;
+        var userData = inventorySlotIndex;
+        var slotQuantity = inventorySlot.Quantity;
+        var maxQuantity = slotQuantity;
+
+        if (!shopCanBuyItem)
+        {
+            prompt = Strings.Shop.CannotSell;
+            inputType = InputBox.InputType.OkayOnly;
+            onSuccess = null;
+            userData = -1;
+        }
+        else if (itemDescriptor.IsStackable || slotQuantity > 1)
+        {
+            var inventoryQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
+            if (inventoryQuantity > 1)
             {
-                PacketSender.SendBuyItem((int)((InputBox)sender).UserData, value);
+                maxQuantity = inventoryQuantity;
+                prompt = Strings.Shop.SellItemPrompt;
+                inputType = InputBox.InputType.NumericSliderInput;
+                onSuccess = SellItemInputBoxOkay;
+                userData = inventorySlotIndex;
             }
         }
 
-        private void SellItemInputBoxOkay(object sender, EventArgs e)
+        InputBox.Open(
+            title: Strings.Shop.SellItem,
+            prompt: prompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: inputType,
+            onSuccess: onSuccess,
+            onCancel: null,
+            userData: userData,
+            quantity: slotQuantity,
+            maxQuantity: maxQuantity
+        );
+    }
+
+    public void TryBuyItem(int shopSlotIndex)
+    {
+        //Confirm the purchase
+        var shopSlot = Globals.GameShop.SellingItems[shopSlotIndex];
+        if (!ItemBase.TryGet(shopSlot.ItemId, out var itemDescriptor))
         {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                PacketSender.SendSellItem((int)((InputBox)sender).UserData, value);
-            }
+            return;
         }
 
-        private void SellInputBoxOkay(object sender, EventArgs e)
+        var maxBuyAmount = 0;
+        if (shopSlot.CostItemQuantity < 1)
         {
-            PacketSender.SendSellItem((int)((InputBox)sender).UserData, 1);
+            var emptySlots = Inventory.Count(inventorySlot => inventorySlot.ItemId == default);
+            var slotsWithItem = Inventory.Count(inventorySlot => inventorySlot.ItemId == itemDescriptor.Id);
+            var currentItemQuantity = GetQuantityOfItemInInventory(shopSlot.ItemId);
+            var stackSize = itemDescriptor.IsStackable ? itemDescriptor.MaxInventoryStack : 1;
+            var itemQuantityLimitInCurrentStacks = slotsWithItem * stackSize;
+            var partialStackEmptyQuantity = itemQuantityLimitInCurrentStacks - currentItemQuantity;
+            maxBuyAmount = emptySlots * stackSize + partialStackEmptyQuantity;
+        }
+        else
+        {
+            var currencyCount = GetQuantityOfItemInInventory(shopSlot.CostItemId);
+            maxBuyAmount = (int)Math.Floor(currencyCount / (float)shopSlot.CostItemQuantity);
         }
 
-        /// <summary>
-        /// Attempts to deposit the item from the inventory into the bank.
-        /// </summary>
-        /// <param name="inventorySlotIndex"></param>
-        /// <param name="slot"></param>
-        /// <param name="bankSlotIndex"></param>
-        /// <param name="quantityHint"></param>
-        /// <param name="skipPrompt"></param>
-        /// <returns></returns>
-        public bool TryDepositItem(
-            int inventorySlotIndex,
-            IItem? slot = null,
-            int bankSlotIndex = -1,
-            int quantityHint = -1,
-            bool skipPrompt = false
-        )
+        // If our max buy amount is 0 or the item isn't stackable, let the server handle it
+        if (!itemDescriptor.IsStackable || maxBuyAmount == 0)
         {
-            // Permission Check for Guild Bank
-            if (Globals.GuildBank && !IsGuildBankDepositAllowed())
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedDeposit.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
-                return false;
-            }
+            PacketSender.SendBuyItem(shopSlotIndex, 1);
+            return;
+        }
 
-            slot ??= Inventory[inventorySlotIndex];
-            if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
-            {
-                Log.Warn($"Tried to move item that does not exist from slot {inventorySlotIndex}: {itemDescriptor.Id}");
-                return false;
-            }
+        InputBox.Open(
+            title: Strings.Shop.BuyItem,
+            prompt: Strings.Shop.BuyItemPrompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: BuyItemInputBoxOkay,
+            onCancel: null,
+            userData: shopSlotIndex,
+            quantity: maxBuyAmount,
+            maxQuantity: maxBuyAmount
+        );
+    }
 
-            // ReSharper disable once ConvertIfStatementToSwitchStatement
-            if (quantityHint == 0)
-            {
-                Log.Warn($"Tried to move 0 of '{itemDescriptor.Name}' ({itemDescriptor.Id})");
-                return false;
-            }
+    private void BuyItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            PacketSender.SendBuyItem((int)((InputBox)sender).UserData, value);
+        }
+    }
 
-            var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxBankStack : 1;
-            var sourceQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
-            var quantity = quantityHint < 0 ? sourceQuantity : quantityHint;
+    private void SellItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            PacketSender.SendSellItem((int)((InputBox)sender).UserData, value);
+        }
+    }
 
-            var targetSlots = Globals.Bank.ToArray();
+    private void SellInputBoxOkay(object sender, EventArgs e)
+    {
+        PacketSender.SendSellItem((int)((InputBox)sender).UserData, 1);
+    }
 
-            var movableQuantity = Item.FindSpaceForItem(
-                itemDescriptor.Id,
-                itemDescriptor.ItemType,
-                maximumStack,
-                bankSlotIndex,
-                quantityHint < 0 ? sourceQuantity : quantityHint,
-                targetSlots
-            );
+    /// <summary>
+    /// Attempts to deposit the item from the inventory into the bank.
+    /// </summary>
+    /// <param name="inventorySlotIndex"></param>
+    /// <param name="slot"></param>
+    /// <param name="bankSlotIndex"></param>
+    /// <param name="quantityHint"></param>
+    /// <param name="skipPrompt"></param>
+    /// <returns></returns>
+    public bool TryDepositItem(
+        int inventorySlotIndex,
+        IItem? slot = null,
+        int bankSlotIndex = -1,
+        int quantityHint = -1,
+        bool skipPrompt = false
+    )
+    {
+        // Permission Check for Guild Bank
+        if (Globals.GuildBank && !IsGuildBankDepositAllowed())
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedDeposit.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
+            return false;
+        }
 
-            if (movableQuantity < 1)
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(
-                    Strings.Bank.NoSpace,
-                    CustomColors.Alerts.Error,
-                    ChatMessageType.Bank
-                ));
-                return false;
-            }
+        slot ??= Inventory[inventorySlotIndex];
+        if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
+        {
+            Log.Warn($"Tried to move item that does not exist from slot {inventorySlotIndex}: {itemDescriptor.Id}");
+            return false;
+        }
 
-            if (bankSlotIndex < 0 && itemDescriptor.IsStackable)
-            {
-                bankSlotIndex = Item.FindFirstPartialSlot(itemDescriptor.Id, targetSlots, maximumStack);
-            }
+        // ReSharper disable once ConvertIfStatementToSwitchStatement
+        if (quantityHint == 0)
+        {
+            Log.Warn($"Tried to move 0 of '{itemDescriptor.Name}' ({itemDescriptor.Id})");
+            return false;
+        }
 
-            if (skipPrompt)
-            {
-                PacketSender.SendDepositItem(inventorySlotIndex, movableQuantity, bankSlotIndex);
-                return true;
-            }
+        var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxBankStack : 1;
+        var sourceQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
+        var quantity = quantityHint < 0 ? sourceQuantity : quantityHint;
 
-            var maximumQuantity = movableQuantity < quantity ? movableQuantity : Item.FindSpaceForItem(
-                itemDescriptor.Id,
-                itemDescriptor.ItemType,
-                maximumStack,
-                bankSlotIndex,
-                sourceQuantity,
-                targetSlots
-            );
+        var targetSlots = Globals.Bank.ToArray();
 
-            if (maximumQuantity == 1)
-            {
-                PacketSender.SendDepositItem(inventorySlotIndex, movableQuantity, bankSlotIndex);
-                return true;
-            }
+        var movableQuantity = Item.FindSpaceForItem(
+            itemDescriptor.Id,
+            itemDescriptor.ItemType,
+            maximumStack,
+            bankSlotIndex,
+            quantityHint < 0 ? sourceQuantity : quantityHint,
+            targetSlots
+        );
 
-            InputBox.Open(
-                title: Strings.Bank.DepositItem,
-                prompt: Strings.Bank.DepositItemPrompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: DepositItemInputBoxOkay,
-                onCancel: null,
-                userData: new[] { inventorySlotIndex, bankSlotIndex },
-                quantity: movableQuantity,
-                maxQuantity: maximumQuantity
-            );
+        if (movableQuantity < 1)
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(
+                Strings.Bank.NoSpace,
+                CustomColors.Alerts.Error,
+                ChatMessageType.Bank
+            ));
+            return false;
+        }
 
+        if (bankSlotIndex < 0 && itemDescriptor.IsStackable)
+        {
+            bankSlotIndex = Item.FindFirstPartialSlot(itemDescriptor.Id, targetSlots, maximumStack);
+        }
+
+        if (skipPrompt)
+        {
+            PacketSender.SendDepositItem(inventorySlotIndex, movableQuantity, bankSlotIndex);
             return true;
         }
 
-        private bool IsGuildBankDepositAllowed()
+        var maximumQuantity = movableQuantity < quantity ? movableQuantity : Item.FindSpaceForItem(
+            itemDescriptor.Id,
+            itemDescriptor.ItemType,
+            maximumStack,
+            bankSlotIndex,
+            sourceQuantity,
+            targetSlots
+        );
+
+        if (maximumQuantity == 1)
         {
-            return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&
-                   (Globals.Me.GuildRank.Permissions.BankDeposit || Globals.Me.Rank == 0);
-        }
-
-        private void DepositItemInputBoxOkay(object sender, EventArgs e)
-        {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                var userData = (int[])((InputBox)sender).UserData;
-
-                PacketSender.SendDepositItem(userData[0], value, userData[1]);
-            }
-        }
-
-        /// <summary>
-        /// Attempts to withdraw items from the bank into the inventory.
-        /// </summary>
-        /// <param name="bankSlotIndex"></param>
-        /// <param name="slot"></param>
-        /// <param name="inventorySlotIndex"></param>
-        /// <param name="quantityHint"></param>
-        /// <param name="skipPrompt"></param>
-        /// <returns></returns>
-        public bool TryWithdrawItem(
-            int bankSlotIndex,
-            IItem? slot = null,
-            int inventorySlotIndex = -1,
-            int quantityHint = -1,
-            bool skipPrompt = false
-        )
-        {
-            // Permission Check for Guild Bank
-            if (Globals.GuildBank && !IsGuildBankWithdrawAllowed())
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedWithdraw.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
-                return false;
-            }
-
-            slot ??= Globals.Bank[bankSlotIndex];
-            if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
-            {
-                Log.Warn($"Tried to move item that does not exist from slot {bankSlotIndex}: {itemDescriptor.Id}");
-                return false;
-            }
-
-            // ReSharper disable once ConvertIfStatementToSwitchStatement
-            if (quantityHint == 0)
-            {
-                Log.Warn($"Tried to move 0 of '{itemDescriptor.Name}' ({itemDescriptor.Id})");
-                return false;
-            }
-
-            var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxInventoryStack : 1;
-            var sourceQuantity = GetQuantityOfItemInBank(itemDescriptor.Id);
-            var quantity = quantityHint < 0 ? sourceQuantity : quantityHint;
-            var targetSlots = Inventory.ToArray();
-
-            var movableQuantity = Item.FindSpaceForItem(
-                itemDescriptor.Id,
-                itemDescriptor.ItemType,
-                maximumStack,
-                bankSlotIndex,
-                quantityHint < 0 ? sourceQuantity : quantityHint,
-                targetSlots
-            );
-
-            if (movableQuantity < 1)
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(
-                    Strings.Bank.WithdrawItemNoSpace,
-                    CustomColors.Alerts.Error,
-                    ChatMessageType.Bank
-                ));
-                return false;
-            }
-
-            if (inventorySlotIndex < 0 && itemDescriptor.IsStackable)
-            {
-                inventorySlotIndex = Item.FindFirstPartialSlot(itemDescriptor.Id, targetSlots, maximumStack);
-            }
-
-            if (skipPrompt)
-            {
-                PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
-                return true;
-            }
-
-            var maximumQuantity = movableQuantity < quantity ? movableQuantity : Item.FindSpaceForItem(
-                itemDescriptor.Id,
-                itemDescriptor.ItemType,
-                maximumStack,
-                inventorySlotIndex,
-                sourceQuantity,
-                targetSlots
-            );
-
-            if (maximumQuantity == 1)
-            {
-                PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
-                return true;
-            }
-
-            InputBox.Open(
-                title: Strings.Bank.WithdrawItem,
-                prompt: Strings.Bank.WithdrawItemPrompt.ToString(itemDescriptor.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: WithdrawItemInputBoxOkay,
-                onCancel: null,
-                userData: new[] { bankSlotIndex, inventorySlotIndex },
-                quantity: movableQuantity,
-                maxQuantity: maximumQuantity
-            );
-
+            PacketSender.SendDepositItem(inventorySlotIndex, movableQuantity, bankSlotIndex);
             return true;
         }
 
-        private bool IsGuildBankWithdrawAllowed()
+        InputBox.Open(
+            title: Strings.Bank.DepositItem,
+            prompt: Strings.Bank.DepositItemPrompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: DepositItemInputBoxOkay,
+            onCancel: null,
+            userData: new[] { inventorySlotIndex, bankSlotIndex },
+            quantity: movableQuantity,
+            maxQuantity: maximumQuantity
+        );
+
+        return true;
+    }
+
+    private bool IsGuildBankDepositAllowed()
+    {
+        return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&
+               (Globals.Me.GuildRank.Permissions.BankDeposit || Globals.Me.Rank == 0);
+    }
+
+    private void DepositItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
         {
-            return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&
-                   (Globals.Me.GuildRank.Permissions.BankRetrieve || Globals.Me.Rank == 0);
+            var userData = (int[])((InputBox)sender).UserData;
+
+            PacketSender.SendDepositItem(userData[0], value, userData[1]);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to withdraw items from the bank into the inventory.
+    /// </summary>
+    /// <param name="bankSlotIndex"></param>
+    /// <param name="slot"></param>
+    /// <param name="inventorySlotIndex"></param>
+    /// <param name="quantityHint"></param>
+    /// <param name="skipPrompt"></param>
+    /// <returns></returns>
+    public bool TryWithdrawItem(
+        int bankSlotIndex,
+        IItem? slot = null,
+        int inventorySlotIndex = -1,
+        int quantityHint = -1,
+        bool skipPrompt = false
+    )
+    {
+        // Permission Check for Guild Bank
+        if (Globals.GuildBank && !IsGuildBankWithdrawAllowed())
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedWithdraw.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
+            return false;
         }
 
-        private void WithdrawItemInputBoxOkay(object sender, EventArgs e)
+        slot ??= Globals.Bank[bankSlotIndex];
+        if (!ItemBase.TryGet(slot.ItemId, out var itemDescriptor))
         {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                int[] userData = (int[])((InputBox)sender).UserData;
-                PacketSender.SendWithdrawItem(userData[0], value, userData[1]);
-            }
+            Log.Warn($"Tried to move item that does not exist from slot {bankSlotIndex}: {itemDescriptor.Id}");
+            return false;
         }
 
-        //Bag
-        public void TryStoreBagItem(int inventorySlotIndex, int bagSlotIndex)
+        // ReSharper disable once ConvertIfStatementToSwitchStatement
+        if (quantityHint == 0)
         {
-            var inventorySlot = Inventory[inventorySlotIndex];
-            if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
-            {
-                return;
-            }
+            Log.Warn($"Tried to move 0 of '{itemDescriptor.Name}' ({itemDescriptor.Id})");
+            return false;
+        }
 
-            int[] userData = new int[2] { inventorySlotIndex, bagSlotIndex };
+        var maximumStack = itemDescriptor.Stackable ? itemDescriptor.MaxInventoryStack : 1;
+        var sourceQuantity = GetQuantityOfItemInBank(itemDescriptor.Id);
+        var quantity = quantityHint < 0 ? sourceQuantity : quantityHint;
+        var targetSlots = Inventory.ToArray();
 
-            var quantity = inventorySlot.Quantity;
-            var maxQuantity = quantity;
+        var movableQuantity = Item.FindSpaceForItem(
+            itemDescriptor.Id,
+            itemDescriptor.ItemType,
+            maximumStack,
+            bankSlotIndex,
+            quantityHint < 0 ? sourceQuantity : quantityHint,
+            targetSlots
+        );
 
-            // TODO: Refactor server bagging logic to allow transferring quantities from the entire inventory and not just the slot
-            //if (itemDescriptor.IsStackable)
-            //{
-            //    maxQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
-            //}
+        if (movableQuantity < 1)
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(
+                Strings.Bank.WithdrawItemNoSpace,
+                CustomColors.Alerts.Error,
+                ChatMessageType.Bank
+            ));
+            return false;
+        }
 
-            if (maxQuantity < 2)
-            {
-                PacketSender.SendStoreBagItem(inventorySlotIndex, 1, bagSlotIndex);
-                return;
-            }
+        if (inventorySlotIndex < 0 && itemDescriptor.IsStackable)
+        {
+            inventorySlotIndex = Item.FindFirstPartialSlot(itemDescriptor.Id, targetSlots, maximumStack);
+        }
 
+        if (skipPrompt)
+        {
+            PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
+            return true;
+        }
+
+        var maximumQuantity = movableQuantity < quantity ? movableQuantity : Item.FindSpaceForItem(
+            itemDescriptor.Id,
+            itemDescriptor.ItemType,
+            maximumStack,
+            inventorySlotIndex,
+            sourceQuantity,
+            targetSlots
+        );
+
+        if (maximumQuantity == 1)
+        {
+            PacketSender.SendWithdrawItem(bankSlotIndex, movableQuantity, inventorySlotIndex);
+            return true;
+        }
+
+        InputBox.Open(
+            title: Strings.Bank.WithdrawItem,
+            prompt: Strings.Bank.WithdrawItemPrompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: WithdrawItemInputBoxOkay,
+            onCancel: null,
+            userData: new[] { bankSlotIndex, inventorySlotIndex },
+            quantity: movableQuantity,
+            maxQuantity: maximumQuantity
+        );
+
+        return true;
+    }
+
+    private bool IsGuildBankWithdrawAllowed()
+    {
+        return !string.IsNullOrWhiteSpace(Globals.Me.Guild) &&
+               (Globals.Me.GuildRank.Permissions.BankRetrieve || Globals.Me.Rank == 0);
+    }
+
+    private void WithdrawItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            int[] userData = (int[])((InputBox)sender).UserData;
+            PacketSender.SendWithdrawItem(userData[0], value, userData[1]);
+        }
+    }
+
+    //Bag
+    public void TryStoreBagItem(int inventorySlotIndex, int bagSlotIndex)
+    {
+        var inventorySlot = Inventory[inventorySlotIndex];
+        if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
+        {
+            return;
+        }
+
+        int[] userData = new int[2] { inventorySlotIndex, bagSlotIndex };
+
+        var quantity = inventorySlot.Quantity;
+        var maxQuantity = quantity;
+
+        // TODO: Refactor server bagging logic to allow transferring quantities from the entire inventory and not just the slot
+        //if (itemDescriptor.IsStackable)
+        //{
+        //    maxQuantity = GetQuantityOfItemInInventory(itemDescriptor.Id);
+        //}
+
+        if (maxQuantity < 2)
+        {
+            PacketSender.SendStoreBagItem(inventorySlotIndex, 1, bagSlotIndex);
+            return;
+        }
+
+        InputBox.Open(
+            title: Strings.Bags.StoreItem,
+            prompt: Strings.Bags.StoreItemPrompt.ToString(itemDescriptor.Name), true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: StoreBagItemInputBoxOkay,
+            onCancel: null,
+            userData: userData,
+            quantity: quantity,
+            maxQuantity: maxQuantity
+        );
+    }
+
+    private void StoreBagItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            int[] userData = (int[])((InputBox)sender).UserData;
+            PacketSender.SendStoreBagItem(userData[0], value, userData[1]);
+        }
+    }
+
+    public void TryRetreiveBagItem(int bagSlotIndex, int inventorySlotIndex)
+    {
+        var bagSlot = Globals.Bag[bagSlotIndex];
+        if (bagSlot == default)
+        {
+            return;
+        }
+
+        if (!ItemBase.TryGet(bagSlot.ItemId, out var itemDescriptor))
+        {
+            return;
+        }
+
+        var userData = new int[2] { bagSlotIndex, inventorySlotIndex };
+
+        var quantity = bagSlot.Quantity;
+        var maxQuantity = quantity;
+
+        // TODO: Refactor server bagging logic to allow transferring quantities from the entire inventory and not just the slot
+        //if (itemDescriptor.IsStackable)
+        //{
+        //    maxQuantity = GetQuantityOfItemInBag(itemDescriptor.Id);
+        //}
+
+        if (maxQuantity < 2)
+        {
+            PacketSender.SendRetrieveBagItem(bagSlotIndex, 1, inventorySlotIndex);
+            return;
+        }
+
+        InputBox.Open(
+            title: Strings.Bags.RetrieveItem,
+            prompt: Strings.Bags.RetrieveItemPrompt.ToString(itemDescriptor.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: RetreiveBagItemInputBoxOkay,
+            onCancel: null,
+            userData: userData,
+            quantity: quantity,
+            maxQuantity: maxQuantity
+        );
+    }
+
+    private void RetreiveBagItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            int[] userData = (int[])((InputBox)sender).UserData;
+            PacketSender.SendRetrieveBagItem(userData[0], value, userData[1]);
+        }
+    }
+
+    //Trade
+    public void TryTradeItem(int index)
+    {
+        var slot = Inventory[index];
+        var quantity = slot.Quantity;
+        var tradingItem = ItemBase.Get(slot.ItemId);
+        if (tradingItem == null)
+        {
+            return;
+        }
+
+        if (quantity == 1)
+        {
+            PacketSender.SendOfferTradeItem(index, 1);
+            return;
+        }
+
+        InputBox.Open(
+            title: Strings.Trading.OfferItem,
+            prompt: Strings.Trading.OfferItemPrompt.ToString(tradingItem.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: TradeItemInputBoxOkay,
+            onCancel: null,
+            userData: index,
+            quantity: quantity,
+            maxQuantity: quantity
+        );
+    }
+
+    private void TradeItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            PacketSender.SendOfferTradeItem((int)((InputBox)sender).UserData, value);
+        }
+    }
+
+    public void TryRevokeItem(int index)
+    {
+        var slot = Globals.Trade[0, index];
+        var quantity = slot.Quantity;
+        var revokedItem = ItemBase.Get(slot.ItemId);
+        if (revokedItem == null)
+        {
+            return;
+        }
+
+        if (quantity == 1)
+        {
+            PacketSender.SendRevokeTradeItem(index, 1);
+            return;
+        }
+
+        InputBox.Open(
+            title: Strings.Trading.RevokeItem,
+            prompt: Strings.Trading.RevokeItemPrompt.ToString(revokedItem.Name),
+            modal: true,
+            inputType: InputBox.InputType.NumericSliderInput,
+            onSuccess: RevokeItemInputBoxOkay,
+            onCancel: null,
+            userData: index,
+            quantity: quantity,
+            maxQuantity: quantity
+        );
+    }
+
+    private void RevokeItemInputBoxOkay(object sender, EventArgs e)
+    {
+        var value = (int)Math.Round(((InputBox)sender).Value);
+        if (value > 0)
+        {
+            PacketSender.SendRevokeTradeItem((int)((InputBox)sender).UserData, value);
+        }
+    }
+
+    //Spell Processing
+    public void SwapSpells(int fromSpellIndex, int toSpellIndex)
+    {
+        PacketSender.SendSwapSpells(fromSpellIndex, toSpellIndex);
+        var tmpInstance = Spells[toSpellIndex];
+        Spells[toSpellIndex] = Spells[fromSpellIndex];
+        Spells[fromSpellIndex] = tmpInstance;
+    }
+
+    public void TryForgetSpell(int spellIndex)
+    {
+        var spellSlot = Spells[spellIndex];
+        if (SpellBase.TryGet(spellSlot.Id, out var spellDescriptor))
+        {
             InputBox.Open(
-                title: Strings.Bags.StoreItem,
-                prompt: Strings.Bags.StoreItemPrompt.ToString(itemDescriptor.Name), true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: StoreBagItemInputBoxOkay,
-                onCancel: null,
-                userData: userData,
-                quantity: quantity,
-                maxQuantity: maxQuantity
-            );
-        }
-
-        private void StoreBagItemInputBoxOkay(object sender, EventArgs e)
-        {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                int[] userData = (int[])((InputBox)sender).UserData;
-                PacketSender.SendStoreBagItem(userData[0], value, userData[1]);
-            }
-        }
-
-        public void TryRetreiveBagItem(int bagSlotIndex, int inventorySlotIndex)
-        {
-            var bagSlot = Globals.Bag[bagSlotIndex];
-            if (bagSlot == default)
-            {
-                return;
-            }
-
-            if (!ItemBase.TryGet(bagSlot.ItemId, out var itemDescriptor))
-            {
-                return;
-            }
-
-            var userData = new int[2] { bagSlotIndex, inventorySlotIndex };
-
-            var quantity = bagSlot.Quantity;
-            var maxQuantity = quantity;
-
-            // TODO: Refactor server bagging logic to allow transferring quantities from the entire inventory and not just the slot
-            //if (itemDescriptor.IsStackable)
-            //{
-            //    maxQuantity = GetQuantityOfItemInBag(itemDescriptor.Id);
-            //}
-
-            if (maxQuantity < 2)
-            {
-                PacketSender.SendRetrieveBagItem(bagSlotIndex, 1, inventorySlotIndex);
-                return;
-            }
-
-            InputBox.Open(
-                title: Strings.Bags.RetrieveItem,
-                prompt: Strings.Bags.RetrieveItemPrompt.ToString(itemDescriptor.Name),
+                title: Strings.Spells.ForgetSpell,
+                prompt: Strings.Spells.ForgetSpellPrompt.ToString(spellDescriptor.Name),
                 modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: RetreiveBagItemInputBoxOkay,
+                inputType: InputBox.InputType.YesNo,
+                onSuccess: ForgetSpellInputBoxOkay,
                 onCancel: null,
-                userData: userData,
-                quantity: quantity,
-                maxQuantity: maxQuantity
+                userData: spellIndex
             );
         }
+    }
 
-        private void RetreiveBagItemInputBoxOkay(object sender, EventArgs e)
-        {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                int[] userData = (int[])((InputBox)sender).UserData;
-                PacketSender.SendRetrieveBagItem(userData[0], value, userData[1]);
-            }
-        }
+    private void ForgetSpellInputBoxOkay(object sender, EventArgs e)
+    {
+        PacketSender.SendForgetSpell((int)((InputBox)sender).UserData);
+    }
 
-        //Trade
-        public void TryTradeItem(int index)
+    public void TryUseSpell(int index)
+    {
+        if (Spells[index].Id != Guid.Empty &&
+            (GetSpellRemainingCooldown(index) < Timing.Global.Milliseconds))
         {
-            var slot = Inventory[index];
-            var quantity = slot.Quantity;
-            var tradingItem = ItemBase.Get(slot.ItemId);
-            if (tradingItem == null)
+            var spellBase = SpellBase.Get(Spells[index].Id);
+
+            if (spellBase.CastDuration > 0 && (Options.Instance.CombatOpts.MovementCancelsCast && Globals.Me.IsMoving))
             {
                 return;
             }
 
-            if (quantity == 1)
+            PacketSender.SendUseSpell(index, TargetIndex);
+        }
+    }
+
+    public long GetSpellCooldown(Guid id)
+    {
+        if (SpellCooldowns.TryGetValue(id, out var cd) && cd > Timing.Global.Milliseconds)
+        {
+            return cd;
+        }
+
+        if ((SpellBase.TryGet(id, out var spellBase) && !spellBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
+        {
+            return Globals.Me.GlobalCooldown;
+        }
+
+        return 0;
+    }
+
+    public void TryUseSpell(Guid spellId)
+    {
+        if (spellId == Guid.Empty)
+        {
+            return;
+        }
+
+        for (var i = 0; i < Spells.Length; i++)
+        {
+            if (Spells[i].Id == spellId)
             {
-                PacketSender.SendOfferTradeItem(index, 1);
+                TryUseSpell(i);
+
                 return;
             }
-
-            InputBox.Open(
-                title: Strings.Trading.OfferItem,
-                prompt: Strings.Trading.OfferItemPrompt.ToString(tradingItem.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: TradeItemInputBoxOkay,
-                onCancel: null,
-                userData: index,
-                quantity: quantity,
-                maxQuantity: quantity
-            );
         }
+    }
 
-        private void TradeItemInputBoxOkay(object sender, EventArgs e)
+    public int FindHotbarSpell(IHotbarInstance hotbarInstance)
+    {
+        if (hotbarInstance.ItemOrSpellId != Guid.Empty && SpellBase.Get(hotbarInstance.ItemOrSpellId) != null)
         {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                PacketSender.SendOfferTradeItem((int)((InputBox)sender).UserData, value);
-            }
-        }
-
-        public void TryRevokeItem(int index)
-        {
-            var slot = Globals.Trade[0, index];
-            var quantity = slot.Quantity;
-            var revokedItem = ItemBase.Get(slot.ItemId);
-            if (revokedItem == null)
-            {
-                return;
-            }
-
-            if (quantity == 1)
-            {
-                PacketSender.SendRevokeTradeItem(index, 1);
-                return;
-            }
-
-            InputBox.Open(
-                title: Strings.Trading.RevokeItem,
-                prompt: Strings.Trading.RevokeItemPrompt.ToString(revokedItem.Name),
-                modal: true,
-                inputType: InputBox.InputType.NumericSliderInput,
-                onSuccess: RevokeItemInputBoxOkay,
-                onCancel: null,
-                userData: index,
-                quantity: quantity,
-                maxQuantity: quantity
-            );
-        }
-
-        private void RevokeItemInputBoxOkay(object sender, EventArgs e)
-        {
-            var value = (int)Math.Round(((InputBox)sender).Value);
-            if (value > 0)
-            {
-                PacketSender.SendRevokeTradeItem((int)((InputBox)sender).UserData, value);
-            }
-        }
-
-        //Spell Processing
-        public void SwapSpells(int fromSpellIndex, int toSpellIndex)
-        {
-            PacketSender.SendSwapSpells(fromSpellIndex, toSpellIndex);
-            var tmpInstance = Spells[toSpellIndex];
-            Spells[toSpellIndex] = Spells[fromSpellIndex];
-            Spells[fromSpellIndex] = tmpInstance;
-        }
-
-        public void TryForgetSpell(int spellIndex)
-        {
-            var spellSlot = Spells[spellIndex];
-            if (SpellBase.TryGet(spellSlot.Id, out var spellDescriptor))
-            {
-                InputBox.Open(
-                    title: Strings.Spells.ForgetSpell,
-                    prompt: Strings.Spells.ForgetSpellPrompt.ToString(spellDescriptor.Name),
-                    modal: true,
-                    inputType: InputBox.InputType.YesNo,
-                    onSuccess: ForgetSpellInputBoxOkay,
-                    onCancel: null,
-                    userData: spellIndex
-                );
-            }
-        }
-
-        private void ForgetSpellInputBoxOkay(object sender, EventArgs e)
-        {
-            PacketSender.SendForgetSpell((int)((InputBox)sender).UserData);
-        }
-
-        public void TryUseSpell(int index)
-        {
-            if (Spells[index].Id != Guid.Empty &&
-                (GetSpellRemainingCooldown(index) < Timing.Global.Milliseconds))
-            {
-                var spellBase = SpellBase.Get(Spells[index].Id);
-
-                if (spellBase.CastDuration > 0 && (Options.Instance.CombatOpts.MovementCancelsCast && Globals.Me.IsMoving))
-                {
-                    return;
-                }
-
-                PacketSender.SendUseSpell(index, TargetIndex);
-            }
-        }
-
-        public long GetSpellCooldown(Guid id)
-        {
-            if (SpellCooldowns.TryGetValue(id, out var cd) && cd > Timing.Global.Milliseconds)
-            {
-                return cd;
-            }
-
-            if ((SpellBase.TryGet(id, out var spellBase) && !spellBase.IgnoreGlobalCooldown) && Globals.Me.GlobalCooldown > Timing.Global.Milliseconds)
-            {
-                return Globals.Me.GlobalCooldown;
-            }
-
-            return 0;
-        }
-
-        public void TryUseSpell(Guid spellId)
-        {
-            if (spellId == Guid.Empty)
-            {
-                return;
-            }
-
             for (var i = 0; i < Spells.Length; i++)
             {
-                if (Spells[i].Id == spellId)
+                if (Spells[i].Id == hotbarInstance.ItemOrSpellId)
                 {
-                    TryUseSpell(i);
-
-                    return;
+                    return i;
                 }
             }
         }
 
-        public int FindHotbarSpell(IHotbarInstance hotbarInstance)
+        return -1;
+    }
+
+    //Hotbar Processing
+    public void AddToHotbar(int hotbarSlot, sbyte itemType, int itemSlot)
+    {
+        Hotbar[hotbarSlot].ItemOrSpellId = Guid.Empty;
+        Hotbar[hotbarSlot].PreferredStatBuffs = new int[Enum.GetValues<Stat>().Length];
+        if (itemType == 0)
         {
-            if (hotbarInstance.ItemOrSpellId != Guid.Empty && SpellBase.Get(hotbarInstance.ItemOrSpellId) != null)
+            var item = Inventory[itemSlot];
+            if (item != null)
             {
-                for (var i = 0; i < Spells.Length; i++)
+                Hotbar[hotbarSlot].ItemOrSpellId = item.ItemId;
+                Hotbar[hotbarSlot].PreferredStatBuffs = item.ItemProperties.StatModifiers;
+            }
+        }
+        else if (itemType == 1)
+        {
+            var spell = Spells[itemSlot];
+            if (spell != null)
+            {
+                Hotbar[hotbarSlot].ItemOrSpellId = spell.Id;
+            }
+        }
+
+        PacketSender.SendHotbarUpdate(hotbarSlot, itemType, itemSlot);
+    }
+
+    public void HotbarSwap(int index, int swapIndex)
+    {
+        var itemId = Hotbar[index].ItemOrSpellId;
+        var bagId = Hotbar[index].BagId;
+        var stats = Hotbar[index].PreferredStatBuffs;
+
+        Hotbar[index].ItemOrSpellId = Hotbar[swapIndex].ItemOrSpellId;
+        Hotbar[index].BagId = Hotbar[swapIndex].BagId;
+        Hotbar[index].PreferredStatBuffs = Hotbar[swapIndex].PreferredStatBuffs;
+
+        Hotbar[swapIndex].ItemOrSpellId = itemId;
+        Hotbar[swapIndex].BagId = bagId;
+        Hotbar[swapIndex].PreferredStatBuffs = stats;
+
+        PacketSender.SendHotbarSwap(index, swapIndex);
+    }
+
+    // Change the dimension if the player is on a gateway
+    private void TryToChangeDimension()
+    {
+        if (X < Options.MapWidth && X >= 0)
+        {
+            if (Y < Options.MapHeight && Y >= 0)
+            {
+                if (Maps.MapInstance.Get(MapId) != null && Maps.MapInstance.Get(MapId).Attributes[X, Y] != null)
                 {
-                    if (Spells[i].Id == hotbarInstance.ItemOrSpellId)
+                    if (Maps.MapInstance.Get(MapId).Attributes[X, Y].Type == MapAttribute.ZDimension)
                     {
-                        return i;
-                    }
-                }
-            }
-
-            return -1;
-        }
-
-        //Hotbar Processing
-        public void AddToHotbar(int hotbarSlot, sbyte itemType, int itemSlot)
-        {
-            Hotbar[hotbarSlot].ItemOrSpellId = Guid.Empty;
-            Hotbar[hotbarSlot].PreferredStatBuffs = new int[Enum.GetValues<Stat>().Length];
-            if (itemType == 0)
-            {
-                var item = Inventory[itemSlot];
-                if (item != null)
-                {
-                    Hotbar[hotbarSlot].ItemOrSpellId = item.ItemId;
-                    Hotbar[hotbarSlot].PreferredStatBuffs = item.ItemProperties.StatModifiers;
-                }
-            }
-            else if (itemType == 1)
-            {
-                var spell = Spells[itemSlot];
-                if (spell != null)
-                {
-                    Hotbar[hotbarSlot].ItemOrSpellId = spell.Id;
-                }
-            }
-
-            PacketSender.SendHotbarUpdate(hotbarSlot, itemType, itemSlot);
-        }
-
-        public void HotbarSwap(int index, int swapIndex)
-        {
-            var itemId = Hotbar[index].ItemOrSpellId;
-            var bagId = Hotbar[index].BagId;
-            var stats = Hotbar[index].PreferredStatBuffs;
-
-            Hotbar[index].ItemOrSpellId = Hotbar[swapIndex].ItemOrSpellId;
-            Hotbar[index].BagId = Hotbar[swapIndex].BagId;
-            Hotbar[index].PreferredStatBuffs = Hotbar[swapIndex].PreferredStatBuffs;
-
-            Hotbar[swapIndex].ItemOrSpellId = itemId;
-            Hotbar[swapIndex].BagId = bagId;
-            Hotbar[swapIndex].PreferredStatBuffs = stats;
-
-            PacketSender.SendHotbarSwap(index, swapIndex);
-        }
-
-        // Change the dimension if the player is on a gateway
-        private void TryToChangeDimension()
-        {
-            if (X < Options.MapWidth && X >= 0)
-            {
-                if (Y < Options.MapHeight && Y >= 0)
-                {
-                    if (Maps.MapInstance.Get(MapId) != null && Maps.MapInstance.Get(MapId).Attributes[X, Y] != null)
-                    {
-                        if (Maps.MapInstance.Get(MapId).Attributes[X, Y].Type == MapAttribute.ZDimension)
+                        if (((MapZDimensionAttribute)Maps.MapInstance.Get(MapId).Attributes[X, Y]).GatewayTo > 0)
                         {
-                            if (((MapZDimensionAttribute)Maps.MapInstance.Get(MapId).Attributes[X, Y]).GatewayTo > 0)
-                            {
-                                Z = (byte)(((MapZDimensionAttribute)Maps.MapInstance.Get(MapId).Attributes[X, Y])
-                                            .GatewayTo -
-                                            1);
-                            }
+                            Z = (byte)(((MapZDimensionAttribute)Maps.MapInstance.Get(MapId).Attributes[X, Y])
+                                        .GatewayTo -
+                                        1);
                         }
                     }
                 }
             }
         }
+    }
 
-        //Input Handling
-        private void HandleInput()
+    //Input Handling
+    private void HandleInput()
+    {
+        var inputX = 0;
+        var inputY = 0;
+
+        if (Interface.Interface.HasInputFocus())
         {
-            var inputX = 0;
-            var inputY = 0;
+            return;
+        }
 
-            if (Interface.Interface.HasInputFocus())
+        if (Controls.KeyDown(Control.MoveUp))
+        {
+            inputY += 1;
+        }
+
+        if (Controls.KeyDown(Control.MoveDown))
+        {
+            inputY -= 1;
+        }
+
+        if (Controls.KeyDown(Control.MoveLeft))
+        {
+            inputX -= 1;
+        }
+
+        if (Controls.KeyDown(Control.MoveRight))
+        {
+            inputX += 1;
+        }
+
+        Direction inputDirection;
+        if (inputX == 0 && inputY == 0)
+        {
+            inputDirection = Direction.None;
+        }
+        else
+        {
+            var diagonalMovement = inputX != 0 && Options.Instance.MapOpts.EnableDiagonalMovement;
+            var inputXDirection = Math.Sign(inputX) switch
             {
-                return;
+                < 0 => Direction.Left,
+                > 0 => Direction.Right,
+                _ => Direction.None,
+            };
+            var inputYDirection = Math.Sign(inputY) switch
+            {
+                < 0 => Direction.Down,
+                > 0 => Direction.Up,
+                _ => Direction.None,
+            };
+
+            if (diagonalMovement)
+            {
+                inputDirection = inputYDirection switch
+                {
+                    Direction.Down => inputXDirection switch
+                    {
+                        Direction.Left => Direction.DownLeft,
+                        Direction.Right => Direction.DownRight,
+                        _ => inputYDirection,
+                    },
+                    Direction.Up => inputXDirection switch
+                    {
+                        Direction.Left => Direction.UpLeft,
+                        Direction.Right => Direction.UpRight,
+                        _ => inputYDirection,
+                    },
+                    _ => inputXDirection,
+                };
             }
-
-            if (Controls.KeyDown(Control.MoveUp))
+            else if (inputYDirection != Direction.None)
             {
-                inputY += 1;
-            }
-
-            if (Controls.KeyDown(Control.MoveDown))
-            {
-                inputY -= 1;
-            }
-
-            if (Controls.KeyDown(Control.MoveLeft))
-            {
-                inputX -= 1;
-            }
-
-            if (Controls.KeyDown(Control.MoveRight))
-            {
-                inputX += 1;
-            }
-
-            Direction inputDirection;
-            if (inputX == 0 && inputY == 0)
-            {
-                inputDirection = Direction.None;
+                inputDirection = inputYDirection;
             }
             else
             {
-                var diagonalMovement = inputX != 0 && Options.Instance.MapOpts.EnableDiagonalMovement;
-                var inputXDirection = Math.Sign(inputX) switch
-                {
-                    < 0 => Direction.Left,
-                    > 0 => Direction.Right,
-                    _ => Direction.None,
-                };
-                var inputYDirection = Math.Sign(inputY) switch
-                {
-                    < 0 => Direction.Down,
-                    > 0 => Direction.Up,
-                    _ => Direction.None,
-                };
-
-                if (diagonalMovement)
-                {
-                    inputDirection = inputYDirection switch
-                    {
-                        Direction.Down => inputXDirection switch
-                        {
-                            Direction.Left => Direction.DownLeft,
-                            Direction.Right => Direction.DownRight,
-                            _ => inputYDirection,
-                        },
-                        Direction.Up => inputXDirection switch
-                        {
-                            Direction.Left => Direction.UpLeft,
-                            Direction.Right => Direction.UpRight,
-                            _ => inputYDirection,
-                        },
-                        _ => inputXDirection,
-                    };
-                }
-                else if (inputYDirection != Direction.None)
-                {
-                    inputDirection = inputYDirection;
-                }
-                else
-                {
-                    inputDirection = inputXDirection;
-                }
-            }
-
-            Globals.Me.MoveDir = inputDirection;
-
-            TurnAround();
-
-            var castInput = -1;
-            for (var barSlot = 0; barSlot < Options.Instance.PlayerOpts.HotbarSlotCount; barSlot++)
-            {
-                if (!mLastHotbarUseTime.ContainsKey(barSlot))
-                {
-                    mLastHotbarUseTime.Add(barSlot, 0);
-                }
-
-                if (Controls.KeyDown((Control)barSlot + (int)Control.Hotkey1))
-                {
-                    castInput = barSlot;
-                }
-            }
-
-            if (castInput != -1)
-            {
-                if (0 <= castInput && castInput < Interface.Interface.GameUi?.Hotbar?.Items?.Count && mLastHotbarUseTime[castInput] < Timing.Global.Milliseconds)
-                {
-                    Interface.Interface.GameUi?.Hotbar?.Items?[castInput]?.Activate();
-                    mLastHotbarUseTime[castInput] = Timing.Global.Milliseconds + mHotbarUseDelay;
-                }
+                inputDirection = inputXDirection;
             }
         }
 
-        protected int GetDistanceTo(IEntity target)
+        Globals.Me.MoveDir = inputDirection;
+
+        TurnAround();
+
+        var castInput = -1;
+        for (var barSlot = 0; barSlot < Options.Instance.PlayerOpts.HotbarSlotCount; barSlot++)
         {
-            if (target != null)
+            if (!mLastHotbarUseTime.ContainsKey(barSlot))
             {
-                var myMap = Maps.MapInstance.Get(MapId);
-                var targetMap = Maps.MapInstance.Get(target.MapId);
-                if (myMap != null && targetMap != null)
-                {
-                    //Calculate World Tile of Me
-                    var x1 = X + myMap.GridX * Options.MapWidth;
-                    var y1 = Y + myMap.GridY * Options.MapHeight;
-
-                    //Calculate world tile of target
-                    var x2 = target.X + targetMap.GridX * Options.MapWidth;
-                    var y2 = target.Y + targetMap.GridY * Options.MapHeight;
-
-                    return (int)Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
-                }
+                mLastHotbarUseTime.Add(barSlot, 0);
             }
 
-            //Something is null.. return a value that is out of range :)
-            return 9999;
+            if (Controls.KeyDown((Control)barSlot + (int)Control.Hotkey1))
+            {
+                castInput = barSlot;
+            }
         }
 
-        public void AutoTarget()
+        if (castInput != -1)
         {
-            //Check for taunt status if so don't allow to change target
-            for (var i = 0; i < Status.Count; i++)
+            if (0 <= castInput && castInput < Interface.Interface.GameUi?.Hotbar?.Items?.Count && mLastHotbarUseTime[castInput] < Timing.Global.Milliseconds)
             {
-                if (Status[i].Type == SpellEffect.Taunt)
-                {
-                    return;
-                }
+                Interface.Interface.GameUi?.Hotbar?.Items?[castInput]?.Activate();
+                mLastHotbarUseTime[castInput] = Timing.Global.Milliseconds + mHotbarUseDelay;
             }
+        }
+    }
 
-            // Do we need to account for players?
-            // Depends on what type of map we're currently on.
-            if (Globals.Me.MapInstance == null)
+    protected int GetDistanceTo(IEntity target)
+    {
+        if (target != null)
+        {
+            var myMap = Maps.MapInstance.Get(MapId);
+            var targetMap = Maps.MapInstance.Get(target.MapId);
+            if (myMap != null && targetMap != null)
+            {
+                //Calculate World Tile of Me
+                var x1 = X + myMap.GridX * Options.MapWidth;
+                var y1 = Y + myMap.GridY * Options.MapHeight;
+
+                //Calculate world tile of target
+                var x2 = target.X + targetMap.GridX * Options.MapWidth;
+                var y2 = target.Y + targetMap.GridY * Options.MapHeight;
+
+                return (int)Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
+            }
+        }
+
+        //Something is null.. return a value that is out of range :)
+        return 9999;
+    }
+
+    public void AutoTarget()
+    {
+        //Check for taunt status if so don't allow to change target
+        for (var i = 0; i < Status.Count; i++)
+        {
+            if (Status[i].Type == SpellEffect.Taunt)
             {
                 return;
             }
-            var currentMap = Globals.Me.MapInstance as MapInstance;
-            var canTargetPlayers = currentMap.ZoneType != MapZone.Safe;
+        }
 
-            // Build a list of Entities to select from with positions if our list is either old, we've moved or changed maps somehow.
-            if (
-                mlastTargetScanTime < Timing.Global.Milliseconds ||
-                mlastTargetScanMap != Globals.Me.MapId ||
-                mlastTargetScanLocation != new Point(X, Y)
-                )
+        // Do we need to account for players?
+        // Depends on what type of map we're currently on.
+        if (Globals.Me.MapInstance == null)
+        {
+            return;
+        }
+        var currentMap = Globals.Me.MapInstance as MapInstance;
+        var canTargetPlayers = currentMap.ZoneType != MapZone.Safe;
+
+        // Build a list of Entities to select from with positions if our list is either old, we've moved or changed maps somehow.
+        if (
+            mlastTargetScanTime < Timing.Global.Milliseconds ||
+            mlastTargetScanMap != Globals.Me.MapId ||
+            mlastTargetScanLocation != new Point(X, Y)
+            )
+        {
+            // Add new items to our list!
+            foreach (var en in Globals.Entities)
             {
-                // Add new items to our list!
-                foreach (var en in Globals.Entities)
-                {
-                    // Check if this is a valid entity.
-                    if (en.Value == null)
-                    {
-                        continue;
-                    }
-
-                    // Don't allow us to auto target ourselves.
-                    if (en.Value == Globals.Me)
-                    {
-                        continue;
-                    }
-
-                    // Check if the entity has stealth status
-                    if (en.Value.IsHidden || (en.Value.IsStealthed && !Globals.Me.IsInMyParty(en.Value.Id)))
-                    {
-                        continue;
-                    }
-
-                    // Check if we are allowed to target players here, if we're not and this is a player then skip!
-                    // If we are, check to see if they're our party or nation member, then exclude them. We're friendly happy people here.
-                    if (!canTargetPlayers && en.Value.Type == EntityType.Player)
-                    {
-                        continue;
-                    }
-
-                    if (canTargetPlayers && en.Value.Type == EntityType.Player)
-                    {
-                        var player = en.Value as Player;
-                        if (IsInMyParty(player))
-                        {
-                            continue;
-                        }
-                    }
-
-                    if (en.Value.Type == EntityType.GlobalEntity || en.Value.Type == EntityType.Player)
-                    {
-                        // Already in our list?
-                        if (mlastTargetList.ContainsKey(en.Value))
-                        {
-                            mlastTargetList[en.Value].DistanceTo = GetDistanceTo(en.Value);
-                        }
-                        else
-                        {
-                            // Add entity with blank time. Never been selected.
-                            mlastTargetList.Add(en.Value, new TargetInfo { DistanceTo = GetDistanceTo(en.Value), LastTimeSelected = 0 });
-                        }
-                    }
-                }
-
-                // Remove old items.
-                var toRemove = mlastTargetList.Where(en => !Globals.Entities.ContainsValue(en.Key)).ToArray();
-                foreach (var en in toRemove)
-                {
-                    mlastTargetList.Remove(en.Key);
-                }
-
-                // Skip scanning for another second or so.. And set up other values.
-                mlastTargetScanTime = Timing.Global.Milliseconds + 300;
-                mlastTargetScanMap = MapId;
-                mlastTargetScanLocation = new Point(X, Y);
-            }
-
-            // Find valid entities.
-            var validEntities = mlastTargetList.ToArray();
-
-            // Reduce the number of targets down to what is in our allowed range.
-            validEntities = validEntities.Where(en => en.Value.DistanceTo <= Options.Combat.MaxPlayerAutoTargetRadius).ToArray();
-
-            int currentDistance = 9999;
-            long currentTime = Timing.Global.Milliseconds;
-            Entity currentEntity = mLastEntitySelected;
-            foreach (var entity in validEntities)
-            {
-                if (currentEntity == entity.Key)
+                // Check if this is a valid entity.
+                if (en.Value == null)
                 {
                     continue;
                 }
 
-                // if distance is the same
-                if (entity.Value.DistanceTo == currentDistance)
+                // Don't allow us to auto target ourselves.
+                if (en.Value == Globals.Me)
                 {
-                    if (entity.Value.LastTimeSelected < currentTime)
-                    {
-                        currentTime = entity.Value.LastTimeSelected;
-                        currentDistance = entity.Value.DistanceTo;
-                        currentEntity = entity.Key;
-                    }
+                    continue;
                 }
-                else if (entity.Value.DistanceTo < currentDistance)
+
+                // Check if the entity has stealth status
+                if (en.Value.IsHidden || (en.Value.IsStealthed && !Globals.Me.IsInMyParty(en.Value.Id)))
                 {
-                    if (entity.Value.LastTimeSelected < currentTime || entity.Value.LastTimeSelected == currentTime)
-                    {
-                        currentTime = entity.Value.LastTimeSelected;
-                        currentDistance = entity.Value.DistanceTo;
-                        currentEntity = entity.Key;
-                    }
+                    continue;
                 }
-            }
 
-            // We didn't target anything? Can we default to closest?
-            if (currentEntity == null)
-            {
-                currentEntity = validEntities.Where(x => x.Value.DistanceTo == validEntities.Min(y => y.Value.DistanceTo)).FirstOrDefault().Key;
-
-                // Also reset our target times so we can start auto targetting again.
-                foreach (var entity in mlastTargetList)
+                // Check if we are allowed to target players here, if we're not and this is a player then skip!
+                // If we are, check to see if they're our party or nation member, then exclude them. We're friendly happy people here.
+                if (!canTargetPlayers && en.Value.Type == EntityType.Player)
                 {
-                    entity.Value.LastTimeSelected = 0;
+                    continue;
                 }
-            }
 
-            if (currentEntity == null)
-            {
-                mLastEntitySelected = null;
-                return;
-            }
-
-            if(!Globals.Entities.TryGetValue(currentEntity.Id, out var targetedEntity))
-            {
-                return;
-            }
-
-            if (mlastTargetList.TryGetValue(targetedEntity, out var lastTarget))
-            {
-                lastTarget.LastTimeSelected = Timing.Global.Milliseconds;
-            }
-            mLastEntitySelected = targetedEntity;
-
-            if (TargetIndex != targetedEntity.Id)
-            {
-                SetTargetBox(targetedEntity);
-                TargetIndex = targetedEntity.Id;
-                TargetType = 0;
-            }
-        }
-
-        private void SetTargetBox(Entity en)
-        {
-            if (en == null)
-            {
-                TargetBox?.SetEntity(null);
-                TargetBox?.Hide();
-                PacketSender.SendTarget(Guid.Empty);
-                return;
-            }
-
-            if (en is Player)
-            {
-                TargetBox?.SetEntity(en, EntityType.Player);
-            }
-            else if (en is Event)
-            {
-                TargetBox?.SetEntity(en, EntityType.Event);
-            }
-            else
-            {
-                TargetBox?.SetEntity(en, EntityType.GlobalEntity);
-            }
-
-            TargetBox?.Show();
-            PacketSender.SendTarget(en.Id);
-        }
-
-        private void AutoTurnToTarget(Entity en)
-        {
-            if (en == this)
-            {
-                return;
-            }
-
-            if (!Globals.Database.AutoTurnToTarget)
-            {
-                return;
-            }
-
-            if (!Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
-            {
-                return;
-            }
-
-            if (Controls.KeyDown(Control.TurnAround))
-            {
-                return;
-            }
-
-            if (IsTurnAroundWhileCastingDisabled)
-            {
-                return;
-            }
-
-            var directionToTarget = DirectionToTarget(en);
-
-            if (IsMoving || Dir == MoveDir || Dir == directionToTarget)
-            {
-                AutoTurnToTargetTimer = Timing.Global.Milliseconds + Options.Instance.PlayerOpts.AutoTurnToTargetDelay;
-                return;
-            }
-
-            if (AutoTurnToTargetTimer > Timing.Global.Milliseconds)
-            {
-                return;
-            }
-
-            if (Options.Instance.PlayerOpts.AutoTurnToTargetIgnoresEntitiesBehind &&
-                IsTargetAtOppositeDirection(Dir, directionToTarget))
-            {
-                return;
-            }
-
-            MoveDir = Direction.None;
-            Dir = directionToTarget;
-            PacketSender.SendDirection(Dir);
-            PickLastDirection(Dir);
-        }
-
-        public bool TryBlock()
-        {
-            var shieldIndex = Options.ShieldIndex;
-            var myShieldIndex = MyEquipment[shieldIndex];
-
-            // Return false if character is attacking, or blocking or if they don't have a shield equipped.
-            if (IsAttacking || IsBlocking || shieldIndex < 0 || myShieldIndex < 0)
-            {
-                return false;
-            }
-
-            // Return false if the shield item descriptor could not be retrieved.
-            if (!ItemBase.TryGet(Inventory[myShieldIndex].ItemId, out _))
-            {
-                return false;
-            }
-
-            IsBlocking = true;
-            PacketSender.SendBlock(IsBlocking);
-            return IsBlocking;
-        }
-
-        public bool TryAttack()
-        {
-            if (IsAttacking || IsBlocking || (IsMoving && !Options.Instance.PlayerOpts.AllowCombatMovement))
-            {
-                return false;
-            }
-
-            int x = Globals.Me.X;
-            int y = Globals.Me.Y;
-            var map = Globals.Me.MapId;
-
-            switch (Globals.Me.Dir)
-            {
-                case Direction.Up:
-                    y--;
-                    break;
-
-                case Direction.Down:
-                    y++;
-                    break;
-
-                case Direction.Left:
-                    x--;
-                    break;
-
-                case Direction.Right:
-                    x++;
-                    break;
-
-                case Direction.UpLeft:
-                    y--;
-                    x--;
-                    break;
-
-                case Direction.UpRight:
-                    y--;
-                    x++;
-                    break;
-
-                case Direction.DownRight:
-                    y++;
-                    x++;
-                    break;
-
-                case Direction.DownLeft:
-                    y++;
-                    x--;
-                    break;
-            }
-
-            if (TryGetRealLocation(ref x, ref y, ref map))
-            {
-                // Iterate through all entities
-                foreach (var en in Globals.Entities)
+                if (canTargetPlayers && en.Value.Type == EntityType.Player)
                 {
-                    // Skip if the entity is null or is not within the player's map.
-                    if (en.Value?.MapId != map)
+                    var player = en.Value as Player;
+                    if (IsInMyParty(player))
                     {
                         continue;
                     }
-
-                    // Skip if the entity is the current player.
-                    if (en.Value == Globals.Me)
-                    {
-                        continue;
-                    }
-
-                    // Skip if the entity can't be attacked.
-                    if (!en.Value.CanBeAttacked)
-                    {
-                        continue;
-                    }
-
-                    if (en.Value.X != x || en.Value.Y != y)
-                    {
-                        continue;
-                    }
-
-                    // Attack the entity.
-                    PacketSender.SendAttack(en.Key);
-                    AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
-
-                    return true;
                 }
-            }
 
-            foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
-            {
-                foreach (var en in eventMap.LocalEntities)
+                if (en.Value.Type == EntityType.GlobalEntity || en.Value.Type == EntityType.Player)
                 {
-                    if (en.Value == null)
+                    // Already in our list?
+                    if (mlastTargetList.ContainsKey(en.Value))
                     {
-                        continue;
+                        mlastTargetList[en.Value].DistanceTo = GetDistanceTo(en.Value);
                     }
-
-                    if (en.Value.MapId == map && en.Value.X == x && en.Value.Y == y)
+                    else
                     {
-                        if (en.Value is Event evt && evt.Trigger == EventTrigger.ActionButton)
-                        {
-                            //Talk to Event
-                            PacketSender.SendActivateEvent(en.Key);
-                            AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
-
-                            return true;
-                        }
+                        // Add entity with blank time. Never been selected.
+                        mlastTargetList.Add(en.Value, new TargetInfo { DistanceTo = GetDistanceTo(en.Value), LastTimeSelected = 0 });
                     }
                 }
             }
 
-            //Projectile/empty swing for animations
-            PacketSender.SendAttack(Guid.Empty);
-            AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
+            // Remove old items.
+            var toRemove = mlastTargetList.Where(en => !Globals.Entities.ContainsValue(en.Key)).ToArray();
+            foreach (var en in toRemove)
+            {
+                mlastTargetList.Remove(en.Key);
+            }
 
-            return true;
+            // Skip scanning for another second or so.. And set up other values.
+            mlastTargetScanTime = Timing.Global.Milliseconds + 300;
+            mlastTargetScanMap = MapId;
+            mlastTargetScanLocation = new Point(X, Y);
         }
 
-        public bool TryGetRealLocation(ref int x, ref int y, ref Guid mapId)
+        // Find valid entities.
+        var validEntities = mlastTargetList.ToArray();
+
+        // Reduce the number of targets down to what is in our allowed range.
+        validEntities = validEntities.Where(en => en.Value.DistanceTo <= Options.Combat.MaxPlayerAutoTargetRadius).ToArray();
+
+        int currentDistance = 9999;
+        long currentTime = Timing.Global.Milliseconds;
+        Entity currentEntity = mLastEntitySelected;
+        foreach (var entity in validEntities)
         {
-            var tmpX = x;
-            var tmpY = y;
-            var tmpI = -1;
-            if (Maps.MapInstance.Get(mapId) != null)
+            if (currentEntity == entity.Key)
             {
-                var gridX = Maps.MapInstance.Get(mapId).GridX;
-                var gridY = Maps.MapInstance.Get(mapId).GridY;
+                continue;
+            }
 
-                if (x < 0)
+            // if distance is the same
+            if (entity.Value.DistanceTo == currentDistance)
+            {
+                if (entity.Value.LastTimeSelected < currentTime)
                 {
-                    tmpX = Options.MapWidth - x * -1;
-                    gridX--;
+                    currentTime = entity.Value.LastTimeSelected;
+                    currentDistance = entity.Value.DistanceTo;
+                    currentEntity = entity.Key;
+                }
+            }
+            else if (entity.Value.DistanceTo < currentDistance)
+            {
+                if (entity.Value.LastTimeSelected < currentTime || entity.Value.LastTimeSelected == currentTime)
+                {
+                    currentTime = entity.Value.LastTimeSelected;
+                    currentDistance = entity.Value.DistanceTo;
+                    currentEntity = entity.Key;
+                }
+            }
+        }
+
+        // We didn't target anything? Can we default to closest?
+        if (currentEntity == null)
+        {
+            currentEntity = validEntities.Where(x => x.Value.DistanceTo == validEntities.Min(y => y.Value.DistanceTo)).FirstOrDefault().Key;
+
+            // Also reset our target times so we can start auto targetting again.
+            foreach (var entity in mlastTargetList)
+            {
+                entity.Value.LastTimeSelected = 0;
+            }
+        }
+
+        if (currentEntity == null)
+        {
+            mLastEntitySelected = null;
+            return;
+        }
+
+        if(!Globals.Entities.TryGetValue(currentEntity.Id, out var targetedEntity))
+        {
+            return;
+        }
+
+        if (mlastTargetList.TryGetValue(targetedEntity, out var lastTarget))
+        {
+            lastTarget.LastTimeSelected = Timing.Global.Milliseconds;
+        }
+        mLastEntitySelected = targetedEntity;
+
+        if (TargetIndex != targetedEntity.Id)
+        {
+            SetTargetBox(targetedEntity);
+            TargetIndex = targetedEntity.Id;
+            TargetType = 0;
+        }
+    }
+
+    private void SetTargetBox(Entity en)
+    {
+        if (en == null)
+        {
+            TargetBox?.SetEntity(null);
+            TargetBox?.Hide();
+            PacketSender.SendTarget(Guid.Empty);
+            return;
+        }
+
+        if (en is Player)
+        {
+            TargetBox?.SetEntity(en, EntityType.Player);
+        }
+        else if (en is Event)
+        {
+            TargetBox?.SetEntity(en, EntityType.Event);
+        }
+        else
+        {
+            TargetBox?.SetEntity(en, EntityType.GlobalEntity);
+        }
+
+        TargetBox?.Show();
+        PacketSender.SendTarget(en.Id);
+    }
+
+    private void AutoTurnToTarget(Entity en)
+    {
+        if (en == this)
+        {
+            return;
+        }
+
+        if (!Globals.Database.AutoTurnToTarget)
+        {
+            return;
+        }
+
+        if (!Options.Instance.PlayerOpts.EnableAutoTurnToTarget)
+        {
+            return;
+        }
+
+        if (Controls.KeyDown(Control.TurnAround))
+        {
+            return;
+        }
+
+        if (IsTurnAroundWhileCastingDisabled)
+        {
+            return;
+        }
+
+        var directionToTarget = DirectionToTarget(en);
+
+        if (IsMoving || Dir == MoveDir || Dir == directionToTarget)
+        {
+            AutoTurnToTargetTimer = Timing.Global.Milliseconds + Options.Instance.PlayerOpts.AutoTurnToTargetDelay;
+            return;
+        }
+
+        if (AutoTurnToTargetTimer > Timing.Global.Milliseconds)
+        {
+            return;
+        }
+
+        if (Options.Instance.PlayerOpts.AutoTurnToTargetIgnoresEntitiesBehind &&
+            IsTargetAtOppositeDirection(Dir, directionToTarget))
+        {
+            return;
+        }
+
+        MoveDir = Direction.None;
+        Dir = directionToTarget;
+        PacketSender.SendDirection(Dir);
+        PickLastDirection(Dir);
+    }
+
+    public bool TryBlock()
+    {
+        var shieldIndex = Options.ShieldIndex;
+        var myShieldIndex = MyEquipment[shieldIndex];
+
+        // Return false if character is attacking, or blocking or if they don't have a shield equipped.
+        if (IsAttacking || IsBlocking || shieldIndex < 0 || myShieldIndex < 0)
+        {
+            return false;
+        }
+
+        // Return false if the shield item descriptor could not be retrieved.
+        if (!ItemBase.TryGet(Inventory[myShieldIndex].ItemId, out _))
+        {
+            return false;
+        }
+
+        IsBlocking = true;
+        PacketSender.SendBlock(IsBlocking);
+        return IsBlocking;
+    }
+
+    public bool TryAttack()
+    {
+        if (IsAttacking || IsBlocking || (IsMoving && !Options.Instance.PlayerOpts.AllowCombatMovement))
+        {
+            return false;
+        }
+
+        int x = Globals.Me.X;
+        int y = Globals.Me.Y;
+        var map = Globals.Me.MapId;
+
+        switch (Globals.Me.Dir)
+        {
+            case Direction.Up:
+                y--;
+                break;
+
+            case Direction.Down:
+                y++;
+                break;
+
+            case Direction.Left:
+                x--;
+                break;
+
+            case Direction.Right:
+                x++;
+                break;
+
+            case Direction.UpLeft:
+                y--;
+                x--;
+                break;
+
+            case Direction.UpRight:
+                y--;
+                x++;
+                break;
+
+            case Direction.DownRight:
+                y++;
+                x++;
+                break;
+
+            case Direction.DownLeft:
+                y++;
+                x--;
+                break;
+        }
+
+        if (TryGetRealLocation(ref x, ref y, ref map))
+        {
+            // Iterate through all entities
+            foreach (var en in Globals.Entities)
+            {
+                // Skip if the entity is null or is not within the player's map.
+                if (en.Value?.MapId != map)
+                {
+                    continue;
                 }
 
-                if (y < 0)
+                // Skip if the entity is the current player.
+                if (en.Value == Globals.Me)
                 {
-                    tmpY = Options.MapHeight - y * -1;
-                    gridY--;
+                    continue;
                 }
 
-                if (y > Options.MapHeight - 1)
+                // Skip if the entity can't be attacked.
+                if (!en.Value.CanBeAttacked)
                 {
-                    tmpY = y - Options.MapHeight;
-                    gridY++;
+                    continue;
                 }
 
-                if (x > Options.MapWidth - 1)
+                if (en.Value.X != x || en.Value.Y != y)
                 {
-                    tmpX = x - Options.MapWidth;
-                    gridX++;
+                    continue;
                 }
 
-                if (gridX >= 0 && gridX < Globals.MapGridWidth && gridY >= 0 && gridY < Globals.MapGridHeight)
+                // Attack the entity.
+                PacketSender.SendAttack(en.Key);
+                AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
+
+                return true;
+            }
+        }
+
+        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
+        {
+            foreach (var en in eventMap.LocalEntities)
+            {
+                if (en.Value == null)
                 {
-                    if (Maps.MapInstance.Get(Globals.MapGrid[gridX, gridY]) != null)
+                    continue;
+                }
+
+                if (en.Value.MapId == map && en.Value.X == x && en.Value.Y == y)
+                {
+                    if (en.Value is Event evt && evt.Trigger == EventTrigger.ActionButton)
                     {
-                        x = (byte)tmpX;
-                        y = (byte)tmpY;
-                        mapId = Globals.MapGrid[gridX, gridY];
+                        //Talk to Event
+                        PacketSender.SendActivateEvent(en.Key);
+                        AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
 
                         return true;
                     }
                 }
             }
-
-            return false;
         }
 
-        public bool TryTarget()
+        //Projectile/empty swing for animations
+        PacketSender.SendAttack(Guid.Empty);
+        AttackTimer = Timing.Global.Milliseconds + CalculateAttackTime();
+
+        return true;
+    }
+
+    public bool TryGetRealLocation(ref int x, ref int y, ref Guid mapId)
+    {
+        var tmpX = x;
+        var tmpY = y;
+        var tmpI = -1;
+        if (Maps.MapInstance.Get(mapId) != null)
         {
-            //Check for taunt status if so don't allow to change target
-            for (var i = 0; i < Status.Count; i++)
+            var gridX = Maps.MapInstance.Get(mapId).GridX;
+            var gridY = Maps.MapInstance.Get(mapId).GridY;
+
+            if (x < 0)
             {
-                if (Status[i].Type == SpellEffect.Taunt)
-                {
-                    return false;
-                }
+                tmpX = Options.MapWidth - x * -1;
+                gridX--;
             }
 
-            var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
-            var x = (int)mouseInWorld.X;
-            var y = (int)mouseInWorld.Y;
-            var targetRect = new FloatRect(x - 8, y - 8, 16, 16); //Adjust to allow more/less error
-
-            IEntity bestMatch = null;
-            var bestAreaMatch = 0f;
-
-
-            foreach (MapInstance map in Maps.MapInstance.Lookup.Values)
+            if (y < 0)
             {
-                if (x >= map.GetX() && x <= map.GetX() + Options.MapWidth * Options.TileWidth)
+                tmpY = Options.MapHeight - y * -1;
+                gridY--;
+            }
+
+            if (y > Options.MapHeight - 1)
+            {
+                tmpY = y - Options.MapHeight;
+                gridY++;
+            }
+
+            if (x > Options.MapWidth - 1)
+            {
+                tmpX = x - Options.MapWidth;
+                gridX++;
+            }
+
+            if (gridX >= 0 && gridX < Globals.MapGridWidth && gridY >= 0 && gridY < Globals.MapGridHeight)
+            {
+                if (Maps.MapInstance.Get(Globals.MapGrid[gridX, gridY]) != null)
                 {
-                    if (y >= map.GetY() && y <= map.GetY() + Options.MapHeight * Options.TileHeight)
+                    x = (byte)tmpX;
+                    y = (byte)tmpY;
+                    mapId = Globals.MapGrid[gridX, gridY];
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public bool TryTarget()
+    {
+        //Check for taunt status if so don't allow to change target
+        for (var i = 0; i < Status.Count; i++)
+        {
+            if (Status[i].Type == SpellEffect.Taunt)
+            {
+                return false;
+            }
+        }
+
+        var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
+        var x = (int)mouseInWorld.X;
+        var y = (int)mouseInWorld.Y;
+        var targetRect = new FloatRect(x - 8, y - 8, 16, 16); //Adjust to allow more/less error
+
+        IEntity bestMatch = null;
+        var bestAreaMatch = 0f;
+
+
+        foreach (MapInstance map in Maps.MapInstance.Lookup.Values)
+        {
+            if (x >= map.GetX() && x <= map.GetX() + Options.MapWidth * Options.TileWidth)
+            {
+                if (y >= map.GetY() && y <= map.GetY() + Options.MapHeight * Options.TileHeight)
+                {
+                    //Remove the offsets to just be dealing with pixels within the map selected
+                    x -= (int)map.GetX();
+                    y -= (int)map.GetY();
+
+                    //transform pixel format to tile format
+                    x /= Options.TileWidth;
+                    y /= Options.TileHeight;
+                    var mapId = map.Id;
+
+                    if (TryGetRealLocation(ref x, ref y, ref mapId))
                     {
-                        //Remove the offsets to just be dealing with pixels within the map selected
-                        x -= (int)map.GetX();
-                        y -= (int)map.GetY();
-
-                        //transform pixel format to tile format
-                        x /= Options.TileWidth;
-                        y /= Options.TileHeight;
-                        var mapId = map.Id;
-
-                        if (TryGetRealLocation(ref x, ref y, ref mapId))
+                        foreach (var en in Globals.Entities)
                         {
-                            foreach (var en in Globals.Entities)
+                            if (en.Value == null || en.Value.MapId != mapId || en.Value is Projectile || en.Value is Resource || (en.Value.IsStealthed && !Globals.Me.IsInMyParty(en.Value.Id)))
                             {
-                                if (en.Value == null || en.Value.MapId != mapId || en.Value is Projectile || en.Value is Resource || (en.Value.IsStealthed && !Globals.Me.IsInMyParty(en.Value.Id)))
+                                continue;
+                            }
+
+                            var intersectRect = FloatRect.Intersect(en.Value.WorldPos, targetRect);
+                            if (intersectRect.Width * intersectRect.Height > bestAreaMatch)
+                            {
+                                bestAreaMatch = intersectRect.Width * intersectRect.Height;
+                                bestMatch = en.Value;
+                            }
+                        }
+
+                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
+                        {
+                            foreach (var en in eventMap.LocalEntities)
+                            {
+                                if (en.Value == null || en.Value.MapId != mapId || ((Event)en.Value).DisablePreview)
                                 {
                                     continue;
                                 }
@@ -1951,626 +1968,652 @@ namespace Intersect.Client.Entities
                                     bestMatch = en.Value;
                                 }
                             }
-
-                            foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
-                            {
-                                foreach (var en in eventMap.LocalEntities)
-                                {
-                                    if (en.Value == null || en.Value.MapId != mapId || ((Event)en.Value).DisablePreview)
-                                    {
-                                        continue;
-                                    }
-
-                                    var intersectRect = FloatRect.Intersect(en.Value.WorldPos, targetRect);
-                                    if (intersectRect.Width * intersectRect.Height > bestAreaMatch)
-                                    {
-                                        bestAreaMatch = intersectRect.Width * intersectRect.Height;
-                                        bestMatch = en.Value;
-                                    }
-                                }
-                            }
-
-                            if (bestMatch != null && bestMatch.Id != TargetIndex)
-                            {
-                                var targetType = bestMatch is Event ? 1 : 0;
-
-
-                                SetTargetBox(bestMatch as Entity);
-
-                                if (bestMatch is Player)
-                                {
-                                    //Select in admin window if open
-                                    if (Interface.Interface.GameUi.AdminWindowOpen())
-                                    {
-                                        Interface.Interface.GameUi.AdminWindowSelectName(bestMatch.Name);
-                                    }
-                                }
-
-                                TargetType = targetType;
-                                TargetIndex = bestMatch.Id;
-
-                                return true;
-                            }
-
-                            if (!Globals.Database.StickyTarget)
-                            {
-                                // We've clicked off of our target and are allowed to clear it!
-                                return ClearTarget();
-                            }
                         }
 
-                        return false;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        public bool TryTarget(IEntity entity, bool force = false)
-        {
-            //Check for taunt status if so don't allow to change target
-            for (var i = 0; i < Status.Count; i++)
-            {
-                if (Status[i].Type == SpellEffect.Taunt && !force)
-                {
-                    return false;
-                }
-            }
-
-            if (entity == null)
-            {
-                return false;
-            }
-
-            // Are we already targetting this?
-            if (TargetBox != null && TargetBox.MyEntity == entity)
-            {
-                return true;
-            }
-
-            var targetType = entity is Event ? 1 : 0;
-
-            if (entity is Player)
-            {
-                //Select in admin window if open
-                if (Interface.Interface.GameUi.AdminWindowOpen())
-                {
-                    Interface.Interface.GameUi.AdminWindowSelectName(entity.Name);
-                }
-            }
-
-            if (TargetIndex != entity.Id)
-            {
-                SetTargetBox(entity as Entity);
-                TargetType = targetType;
-                TargetIndex = entity.Id;
-            }
-
-            return true;
-
-        }
-
-        public bool ClearTarget()
-        {
-            SetTargetBox(null);
-
-            if (TargetIndex == default && TargetType == -1)
-            {
-                return false;
-            }
-
-            TargetIndex = Guid.Empty;
-            TargetType = -1;
-            return true;
-        }
-
-        /// <summary>
-        /// Attempts to pick up an item at the specified location.
-        /// </summary>
-        /// <param name="mapId">The Id of the map we are trying to loot from.</param>
-        /// <param name="x">The X location on the current map.</param>
-        /// <param name="y">The Y location on the current map.</param>
-        /// <param name="uniqueId">The Unique Id of the specific item we want to pick up, leave <see cref="Guid.Empty"/> to not specificy an item and pick up the first thing we can find.</param>
-        /// <param name="firstOnly">Defines whether we only want to pick up the first item we can find when true, or all items when false.</param>
-        /// <returns></returns>
-        public bool TryPickupItem(Guid mapId, int tileIndex, Guid uniqueId = new(), bool firstOnly = false)
-        {
-            var map = Maps.MapInstance.Get(mapId);
-            if (map == null || tileIndex < 0 || tileIndex >= Options.MapWidth * Options.MapHeight)
-            {
-                return false;
-            }
-
-            // Are we trying to pick up anything in particular, or everything?
-            if (uniqueId != Guid.Empty || firstOnly)
-            {
-                if (!map.MapItems.ContainsKey(tileIndex) || map.MapItems[tileIndex].Count < 1)
-                {
-                    return false;
-                }
-
-                foreach (var item in map.MapItems[tileIndex])
-                {
-                    // Check if we are trying to pick up a specific item, and if this is the one.
-                    if (uniqueId != Guid.Empty && item.Id != uniqueId)
-                    {
-                        continue;
-                    }
-
-                    PacketSender.SendPickupItem(mapId, tileIndex, item.Id);
-
-                    return true;
-                }
-            }
-            else
-            {
-                // Let the server worry about what we can and can not pick up.
-                PacketSender.SendPickupItem(mapId, tileIndex, uniqueId);
-
-                return true;
-            }
-
-            return false;
-        }
-
-        //Forumlas
-        public long GetNextLevelExperience()
-        {
-            return ExperienceToNextLevel;
-        }
-
-        public override int CalculateAttackTime()
-        {
-            ItemBase weapon = null;
-            var attackTime = base.CalculateAttackTime();
-
-            var cls = ClassBase.Get(Class);
-            if (cls != null && cls.AttackSpeedModifier == 1) //Static
-            {
-                attackTime = cls.AttackSpeedValue;
-            }
-
-            if (this == Globals.Me)
-            {
-                if (Options.WeaponIndex > -1 &&
-                    Options.WeaponIndex < Equipment.Length &&
-                    MyEquipment[Options.WeaponIndex] >= 0)
-                {
-                    weapon = ItemBase.Get(Inventory[MyEquipment[Options.WeaponIndex]].ItemId);
-                }
-            }
-            else
-            {
-                if (Options.WeaponIndex > -1 &&
-                    Options.WeaponIndex < Equipment.Length &&
-                    Equipment[Options.WeaponIndex] != Guid.Empty)
-                {
-                    weapon = ItemBase.Get(Equipment[Options.WeaponIndex]);
-                }
-            }
-
-            if (weapon != null)
-            {
-                if (weapon.AttackSpeedModifier == 1) // Static
-                {
-                    attackTime = weapon.AttackSpeedValue;
-                }
-                else if (weapon.AttackSpeedModifier == 2) //Percentage
-                {
-                    attackTime = (int)(attackTime * (100f / weapon.AttackSpeedValue));
-                }
-            }
-
-            return attackTime;
-        }
-
-        /// <summary>
-        /// Calculate the attack time for the player as if they have a specified speed stat.
-        /// </summary>
-        /// <param name="speed"></param>
-        /// <returns></returns>
-        public virtual int CalculateAttackTime(int speed)
-        {
-            return (int)(Options.MaxAttackRate +
-                          (Options.MinAttackRate - Options.MaxAttackRate) *
-                          (((float)Options.MaxStatValue - speed) /
-                           Options.MaxStatValue));
-        }
-
-        //Movement Processing
-        private void ProcessDirectionalInput()
-        {
-            //Check if player is crafting
-            if (Globals.InCraft)
-            {
-                return;
-            }
-
-            //check if player is stunned or snared, if so don't let them move.
-            for (var n = 0; n < Status.Count; n++)
-            {
-                if (Status[n].Type == SpellEffect.Stun ||
-                    Status[n].Type == SpellEffect.Snare ||
-                    Status[n].Type == SpellEffect.Sleep)
-                {
-                    return;
-                }
-            }
-
-            //Check if the player is dashing, if so don't let them move.
-            if (Dashing != null || DashQueue.Count > 0 || DashTimer > Timing.Global.Milliseconds)
-            {
-                return;
-            }
-
-            if (IsAttacking && !Options.Instance.PlayerOpts.AllowCombatMovement)
-            {
-                return;
-            }
-
-            Point position = new(X, Y);
-            IEntity blockedBy = null;
-
-            if (MoveDir <= Direction.None || Globals.EventDialogs.Count != 0)
-            {
-                return;
-            }
-
-            //Try to move if able and not casting spells.
-            if (IsMoving || MoveTimer >= Timing.Global.Milliseconds ||
-                (!Options.Combat.MovementCancelsCast && IsCasting))
-            {
-                return;
-            }
-
-            if (Options.Combat.MovementCancelsCast)
-            {
-                CastTime = 0;
-            }
-
-            var dir = Dir;
-            var moveDir = MoveDir;
-
-            var enableCrossingDiagonalBlocks = Options.Instance.MapOpts.EnableCrossingDiagonalBlocks;
-
-            if (moveDir != Direction.None)
-            {
-                List<Direction> possibleDirections = new(4) { moveDir };
-                if (dir.IsAdjacent(moveDir))
-                {
-                    System.Console.WriteLine($"{dir} is adjacent to {moveDir}");
-                    possibleDirections.Add(dir);
-                }
-
-                if (moveDir.IsDiagonal())
-                {
-                    possibleDirections.AddRange(moveDir.GetComponentDirections());
-                }
-
-                foreach (var possibleDirection in possibleDirections)
-                {
-                    var delta = possibleDirection.GetDeltaPoint();
-                    var target = position + delta;
-                    if (IsTileBlocked(target, Z, MapId, ref blockedBy) != -1)
-                    {
-                        continue;
-                    }
-
-                    if (!enableCrossingDiagonalBlocks && possibleDirection.IsDiagonal())
-                    {
-                        if (possibleDirection.GetComponentDirections()
-                            .Select(componentDirection => componentDirection.GetDeltaPoint() + position)
-                            .All(componentTarget => IsTileBlocked(componentTarget, Z, MapId, ref blockedBy) != -1))
+                        if (bestMatch != null && bestMatch.Id != TargetIndex)
                         {
-                            continue;
+                            var targetType = bestMatch is Event ? 1 : 0;
+
+
+                            SetTargetBox(bestMatch as Entity);
+
+                            if (bestMatch is Player)
+                            {
+                                //Select in admin window if open
+                                if (Interface.Interface.GameUi.AdminWindowOpen())
+                                {
+                                    Interface.Interface.GameUi.AdminWindowSelectName(bestMatch.Name);
+                                }
+                            }
+
+                            TargetType = targetType;
+                            TargetIndex = bestMatch.Id;
+
+                            return true;
+                        }
+
+                        if (!Globals.Database.StickyTarget)
+                        {
+                            // We've clicked off of our target and are allowed to clear it!
+                            return ClearTarget();
                         }
                     }
 
-                    position.X += delta.X;
-                    position.Y += delta.Y;
-                    IsMoving = true;
-                    Dir = possibleDirection;
-
-                    if (delta.X == 0)
-                    {
-                        OffsetX = 0;
-                    }
-                    else
-                    {
-                        OffsetX = delta.X > 0 ? -Options.TileWidth : Options.TileWidth;
-                    }
-
-                    if (delta.Y == 0)
-                    {
-                        OffsetY = 0;
-                    }
-                    else
-                    {
-                        OffsetY = delta.Y > 0 ? -Options.TileHeight : Options.TileHeight;
-                    }
-
-                    break;
+                    return false;
                 }
             }
+        }
 
-            if (blockedBy != mLastBumpedEvent)
+        return false;
+    }
+
+    public bool TryTarget(IEntity entity, bool force = false)
+    {
+        //Check for taunt status if so don't allow to change target
+        for (var i = 0; i < Status.Count; i++)
+        {
+            if (Status[i].Type == SpellEffect.Taunt && !force)
             {
-                mLastBumpedEvent = null;
+                return false;
+            }
+        }
+
+        if (entity == null)
+        {
+            return false;
+        }
+
+        // Are we already targetting this?
+        if (TargetBox != null && TargetBox.MyEntity == entity)
+        {
+            return true;
+        }
+
+        var targetType = entity is Event ? 1 : 0;
+
+        if (entity is Player)
+        {
+            //Select in admin window if open
+            if (Interface.Interface.GameUi.AdminWindowOpen())
+            {
+                Interface.Interface.GameUi.AdminWindowSelectName(entity.Name);
+            }
+        }
+
+        if (TargetIndex != entity.Id)
+        {
+            SetTargetBox(entity as Entity);
+            TargetType = targetType;
+            TargetIndex = entity.Id;
+        }
+
+        return true;
+
+    }
+
+    public bool ClearTarget()
+    {
+        SetTargetBox(null);
+
+        if (TargetIndex == default && TargetType == -1)
+        {
+            return false;
+        }
+
+        TargetIndex = Guid.Empty;
+        TargetType = -1;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to pick up an item at the specified location.
+    /// </summary>
+    /// <param name="mapId">The Id of the map we are trying to loot from.</param>
+    /// <param name="x">The X location on the current map.</param>
+    /// <param name="y">The Y location on the current map.</param>
+    /// <param name="uniqueId">The Unique Id of the specific item we want to pick up, leave <see cref="Guid.Empty"/> to not specificy an item and pick up the first thing we can find.</param>
+    /// <param name="firstOnly">Defines whether we only want to pick up the first item we can find when true, or all items when false.</param>
+    /// <returns></returns>
+    public bool TryPickupItem(Guid mapId, int tileIndex, Guid uniqueId = new(), bool firstOnly = false)
+    {
+        var map = Maps.MapInstance.Get(mapId);
+        if (map == null || tileIndex < 0 || tileIndex >= Options.MapWidth * Options.MapHeight)
+        {
+            return false;
+        }
+
+        // Are we trying to pick up anything in particular, or everything?
+        if (uniqueId != Guid.Empty || firstOnly)
+        {
+            if (!map.MapItems.ContainsKey(tileIndex) || map.MapItems[tileIndex].Count < 1)
+            {
+                return false;
             }
 
-            if (IsMoving)
+            foreach (var item in map.MapItems[tileIndex])
             {
-                if (position.X < 0 || position.Y < 0 || position.X > Options.MapWidth - 1 || position.Y > Options.MapHeight - 1)
+                // Check if we are trying to pick up a specific item, and if this is the one.
+                if (uniqueId != Guid.Empty && item.Id != uniqueId)
                 {
-                    var gridX = Maps.MapInstance.Get(Globals.Me.MapId).GridX;
-                    var gridY = Maps.MapInstance.Get(Globals.Me.MapId).GridY;
-                    if (position.X < 0)
-                    {
-                        gridX--;
-                        X = (byte)(Options.MapWidth - 1);
-                    }
-                    else if (position.X >= Options.MapWidth)
-                    {
-                        X = 0;
-                        gridX++;
-                    }
-                    else
-                    {
-                        X = (byte)position.X;
-                    }
+                    continue;
+                }
 
-                    if (position.Y < 0)
-                    {
-                        gridY--;
-                        Y = (byte)(Options.MapHeight - 1);
-                    }
-                    else if (position.Y >= Options.MapHeight)
-                    {
-                        Y = 0;
-                        gridY++;
-                    }
-                    else
-                    {
-                        Y = (byte)position.Y;
-                    }
+                PacketSender.SendPickupItem(mapId, tileIndex, item.Id);
 
-                    if (MapId != Globals.MapGrid[gridX, gridY])
+                return true;
+            }
+        }
+        else
+        {
+            // Let the server worry about what we can and can not pick up.
+            PacketSender.SendPickupItem(mapId, tileIndex, uniqueId);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    //Forumlas
+    public long GetNextLevelExperience()
+    {
+        return ExperienceToNextLevel;
+    }
+
+    public override int CalculateAttackTime()
+    {
+        ItemBase weapon = null;
+        var attackTime = base.CalculateAttackTime();
+
+        var cls = ClassBase.Get(Class);
+        if (cls != null && cls.AttackSpeedModifier == 1) //Static
+        {
+            attackTime = cls.AttackSpeedValue;
+        }
+
+        if (this == Globals.Me)
+        {
+            if (Options.WeaponIndex > -1 &&
+                Options.WeaponIndex < Equipment.Length &&
+                MyEquipment[Options.WeaponIndex] >= 0)
+            {
+                weapon = ItemBase.Get(Inventory[MyEquipment[Options.WeaponIndex]].ItemId);
+            }
+        }
+        else
+        {
+            if (Options.WeaponIndex > -1 &&
+                Options.WeaponIndex < Equipment.Length &&
+                Equipment[Options.WeaponIndex] != Guid.Empty)
+            {
+                weapon = ItemBase.Get(Equipment[Options.WeaponIndex]);
+            }
+        }
+
+        if (weapon != null)
+        {
+            if (weapon.AttackSpeedModifier == 1) // Static
+            {
+                attackTime = weapon.AttackSpeedValue;
+            }
+            else if (weapon.AttackSpeedModifier == 2) //Percentage
+            {
+                attackTime = (int)(attackTime * (100f / weapon.AttackSpeedValue));
+            }
+        }
+
+        return attackTime;
+    }
+
+    /// <summary>
+    /// Calculate the attack time for the player as if they have a specified speed stat.
+    /// </summary>
+    /// <param name="speed"></param>
+    /// <returns></returns>
+    public virtual int CalculateAttackTime(int speed)
+    {
+        return (int)(Options.MaxAttackRate +
+                      (Options.MinAttackRate - Options.MaxAttackRate) *
+                      (((float)Options.MaxStatValue - speed) /
+                       Options.MaxStatValue));
+    }
+
+    //Movement Processing
+    private void ProcessDirectionalInput()
+    {
+        //Check if player is crafting
+        if (Globals.InCraft)
+        {
+            return;
+        }
+
+        //check if player is stunned or snared, if so don't let them move.
+        for (var n = 0; n < Status.Count; n++)
+        {
+            if (Status[n].Type == SpellEffect.Stun ||
+                Status[n].Type == SpellEffect.Snare ||
+                Status[n].Type == SpellEffect.Sleep)
+            {
+                return;
+            }
+        }
+
+        //Check if the player is dashing, if so don't let them move.
+        if (Dashing != null || DashQueue.Count > 0 || DashTimer > Timing.Global.Milliseconds)
+        {
+            return;
+        }
+
+        if (IsAttacking && !Options.Instance.PlayerOpts.AllowCombatMovement)
+        {
+            return;
+        }
+
+        Point position = new(X, Y);
+        IEntity blockedBy = null;
+
+        if (MoveDir <= Direction.None || Globals.EventDialogs.Count != 0)
+        {
+            return;
+        }
+
+        //Try to move if able and not casting spells.
+        if (IsMoving || MoveTimer >= Timing.Global.Milliseconds ||
+            (!Options.Combat.MovementCancelsCast && IsCasting))
+        {
+            return;
+        }
+
+        if (Options.Combat.MovementCancelsCast)
+        {
+            CastTime = 0;
+        }
+
+        var dir = Dir;
+        var moveDir = MoveDir;
+
+        var enableCrossingDiagonalBlocks = Options.Instance.MapOpts.EnableCrossingDiagonalBlocks;
+
+        if (moveDir != Direction.None)
+        {
+            List<Direction> possibleDirections = new(4) { moveDir };
+            if (dir.IsAdjacent(moveDir))
+            {
+                System.Console.WriteLine($"{dir} is adjacent to {moveDir}");
+                possibleDirections.Add(dir);
+            }
+
+            if (moveDir.IsDiagonal())
+            {
+                possibleDirections.AddRange(moveDir.GetComponentDirections());
+            }
+
+            foreach (var possibleDirection in possibleDirections)
+            {
+                var delta = possibleDirection.GetDeltaPoint();
+                var target = position + delta;
+                if (IsTileBlocked(target, Z, MapId, ref blockedBy) != -1)
+                {
+                    continue;
+                }
+
+                if (!enableCrossingDiagonalBlocks && possibleDirection.IsDiagonal())
+                {
+                    if (possibleDirection.GetComponentDirections()
+                        .Select(componentDirection => componentDirection.GetDeltaPoint() + position)
+                        .All(componentTarget => IsTileBlocked(componentTarget, Z, MapId, ref blockedBy) != -1))
                     {
-                        MapId = Globals.MapGrid[gridX, gridY];
-                        FetchNewMaps();
+                        continue;
                     }
+                }
+
+                position.X += delta.X;
+                position.Y += delta.Y;
+                IsMoving = true;
+                Dir = possibleDirection;
+
+                if (delta.X == 0)
+                {
+                    OffsetX = 0;
+                }
+                else
+                {
+                    OffsetX = delta.X > 0 ? -Options.TileWidth : Options.TileWidth;
+                }
+
+                if (delta.Y == 0)
+                {
+                    OffsetY = 0;
+                }
+                else
+                {
+                    OffsetY = delta.Y > 0 ? -Options.TileHeight : Options.TileHeight;
+                }
+
+                break;
+            }
+        }
+
+        if (blockedBy != mLastBumpedEvent)
+        {
+            mLastBumpedEvent = null;
+        }
+
+        if (IsMoving)
+        {
+            if (position.X < 0 || position.Y < 0 || position.X > Options.MapWidth - 1 || position.Y > Options.MapHeight - 1)
+            {
+                var gridX = Maps.MapInstance.Get(Globals.Me.MapId).GridX;
+                var gridY = Maps.MapInstance.Get(Globals.Me.MapId).GridY;
+                if (position.X < 0)
+                {
+                    gridX--;
+                    X = (byte)(Options.MapWidth - 1);
+                }
+                else if (position.X >= Options.MapWidth)
+                {
+                    X = 0;
+                    gridX++;
                 }
                 else
                 {
                     X = (byte)position.X;
+                }
+
+                if (position.Y < 0)
+                {
+                    gridY--;
+                    Y = (byte)(Options.MapHeight - 1);
+                }
+                else if (position.Y >= Options.MapHeight)
+                {
+                    Y = 0;
+                    gridY++;
+                }
+                else
+                {
                     Y = (byte)position.Y;
                 }
 
-                TryToChangeDimension();
-                PacketSender.SendMove();
-                MoveTimer = (Timing.Global.Milliseconds) + (long)GetMovementTime();
+                if (MapId != Globals.MapGrid[gridX, gridY])
+                {
+                    MapId = Globals.MapGrid[gridX, gridY];
+                    FetchNewMaps();
+                }
             }
             else
             {
-                if (MoveDir != Dir)
-                {
-                    Dir = MoveDir;
-                    PacketSender.SendDirection(Dir);
-                    PickLastDirection(Dir);
-                }
+                X = (byte)position.X;
+                Y = (byte)position.Y;
+            }
 
-                if (blockedBy != null && mLastBumpedEvent != blockedBy && blockedBy is Event)
-                {
-                    PacketSender.SendBumpEvent(blockedBy.MapId, blockedBy.Id);
-                    mLastBumpedEvent = blockedBy as Entity;
-                }
+            TryToChangeDimension();
+            PacketSender.SendMove();
+            MoveTimer = (Timing.Global.Milliseconds) + (long)GetMovementTime();
+        }
+        else
+        {
+            if (MoveDir != Dir)
+            {
+                Dir = MoveDir;
+                PacketSender.SendDirection(Dir);
+                PickLastDirection(Dir);
+            }
+
+            if (blockedBy != null && mLastBumpedEvent != blockedBy && blockedBy is Event)
+            {
+                PacketSender.SendBumpEvent(blockedBy.MapId, blockedBy.Id);
+                mLastBumpedEvent = blockedBy as Entity;
             }
         }
+    }
 
-        public void FetchNewMaps()
+    public void FetchNewMaps()
+    {
+        if (Globals.MapGridWidth == 0 || Globals.MapGridHeight == 0)
         {
-            if (Globals.MapGridWidth == 0 || Globals.MapGridHeight == 0)
+            return;
+        }
+
+        PacketSender.SendNeedMapForGrid();
+    }
+
+    public override void DrawEquipment(string filename, Color renderColor)
+    {
+        //check if player is stunned or snared, if so don't let them move.
+        for (var n = 0; n < Status.Count; n++)
+        {
+            if (Status[n].Type == SpellEffect.Transform)
             {
                 return;
             }
-
-            PacketSender.SendNeedMapForGrid();
         }
 
-        public override void DrawEquipment(string filename, Color renderColor)
-        {
-            //check if player is stunned or snared, if so don't let them move.
-            for (var n = 0; n < Status.Count; n++)
-            {
-                if (Status[n].Type == SpellEffect.Transform)
-                {
-                    return;
-                }
-            }
+        base.DrawEquipment(filename, renderColor);
+    }
 
-            base.DrawEquipment(filename, renderColor);
+    //Override of the original function, used for rendering the color of a player based on rank
+    public override void DrawName(Color textColor, Color borderColor, Color backgroundColor)
+    {
+        if (textColor == null)
+        {
+            switch (AccessLevel)
+            {
+                case Access.Moderator:
+                    textColor = CustomColors.Names.Players["Moderator"].Name;
+                    borderColor = CustomColors.Names.Players["Moderator"].Outline;
+                    backgroundColor = CustomColors.Names.Players["Moderator"].Background;
+                    break;
+
+                case Access.Admin:
+                    textColor = CustomColors.Names.Players["Admin"].Name;
+                    borderColor = CustomColors.Names.Players["Admin"].Outline;
+                    backgroundColor = CustomColors.Names.Players["Admin"].Background;
+                    break;
+
+                case Access.None:
+                default:
+                    textColor = CustomColors.Names.Players["Normal"].Name;
+                    borderColor = CustomColors.Names.Players["Normal"].Outline;
+                    backgroundColor = CustomColors.Names.Players["Normal"].Background;
+                    break;
+            }
         }
 
-        //Override of the original function, used for rendering the color of a player based on rank
-        public override void DrawName(Color textColor, Color borderColor, Color backgroundColor)
+        var customColorOverride = NameColor;
+        if (customColorOverride != null)
         {
-            if (textColor == null)
+            //We don't want to override the default colors if the color is transparent!
+            if (customColorOverride.A != 0)
             {
-                switch (AccessLevel)
-                {
-                    case Access.Moderator:
-                        textColor = CustomColors.Names.Players["Moderator"].Name;
-                        borderColor = CustomColors.Names.Players["Moderator"].Outline;
-                        backgroundColor = CustomColors.Names.Players["Moderator"].Background;
-                        break;
-
-                    case Access.Admin:
-                        textColor = CustomColors.Names.Players["Admin"].Name;
-                        borderColor = CustomColors.Names.Players["Admin"].Outline;
-                        backgroundColor = CustomColors.Names.Players["Admin"].Background;
-                        break;
-
-                    case Access.None:
-                    default:
-                        textColor = CustomColors.Names.Players["Normal"].Name;
-                        borderColor = CustomColors.Names.Players["Normal"].Outline;
-                        backgroundColor = CustomColors.Names.Players["Normal"].Background;
-                        break;
-                }
+                textColor = customColorOverride;
             }
-
-            var customColorOverride = NameColor;
-            if (customColorOverride != null)
-            {
-                //We don't want to override the default colors if the color is transparent!
-                if (customColorOverride.A != 0)
-                {
-                    textColor = customColorOverride;
-                }
-            }
-
-            if (Globals.Me.Id != Id)
-            {
-                // Party member names
-                if (Globals.Me.IsInMyParty(this) && CustomColors.Names.Players.TryGetValue(nameof(Party), out var partyColors))
-                {
-                    textColor = partyColors.Name;
-                    borderColor = partyColors.Outline;
-                    backgroundColor = partyColors.Background;
-                }
-                // Guildies
-                else if (Globals.Me.IsInGuild && Guild == Globals.Me.Guild && CustomColors.Names.Players.TryGetValue(nameof(Guild), out var guildColors))
-                {
-                    textColor = guildColors.Name;
-                    borderColor = guildColors.Outline;
-                    backgroundColor = guildColors.Background;
-                }
-
-                // Enemies in PvP
-                if (!Globals.Me.IsAllyOf(this) && Globals.Me.MapInstance.ZoneType != MapZone.Safe && CustomColors.Names.Players.TryGetValue("Hostile", out var hostileColors))
-                {
-                    textColor = hostileColors.Name;
-                    borderColor = hostileColors.Outline;
-                    backgroundColor = hostileColors.Background;
-                }
-            }
-
-            DrawNameAndLabels(textColor, borderColor, backgroundColor);
         }
 
-        public override bool IsAllyOf(Player en)
+        if (Globals.Me.Id != Id)
         {
-            if (base.IsAllyOf(en)) 
+            // Party member names
+            if (Globals.Me.IsInMyParty(this) && CustomColors.Names.Players.TryGetValue(nameof(Party), out var partyColors))
+            {
+                textColor = partyColors.Name;
+                borderColor = partyColors.Outline;
+                backgroundColor = partyColors.Background;
+            }
+            // Guildies
+            else if (Globals.Me.IsInGuild && Guild == Globals.Me.Guild && CustomColors.Names.Players.TryGetValue(nameof(Guild), out var guildColors))
+            {
+                textColor = guildColors.Name;
+                borderColor = guildColors.Outline;
+                backgroundColor = guildColors.Background;
+            }
+
+            // Enemies in PvP
+            if (!Globals.Me.IsAllyOf(this) && Globals.Me.MapInstance.ZoneType != MapZone.Safe && CustomColors.Names.Players.TryGetValue("Hostile", out var hostileColors))
+            {
+                textColor = hostileColors.Name;
+                borderColor = hostileColors.Outline;
+                backgroundColor = hostileColors.Background;
+            }
+        }
+
+        DrawNameAndLabels(textColor, borderColor, backgroundColor);
+    }
+
+    public override bool IsAllyOf(Player en)
+    {
+        if (base.IsAllyOf(en)) 
+        {
+            return true;
+        }
+
+        return IsInMyParty(en) || IsInMyGuild(en) || en.MapInstance.ZoneType == MapZone.Safe;
+    }
+
+    private void DrawNameAndLabels(Color textColor, Color borderColor, Color backgroundColor)
+    {
+        base.DrawName(textColor, borderColor, backgroundColor);
+        DrawLabels(HeaderLabel.Text, 0, HeaderLabel.Color, textColor, borderColor, backgroundColor);
+        DrawLabels(FooterLabel.Text, 1, FooterLabel.Color, textColor, borderColor, backgroundColor);
+        DrawGuildName(textColor, borderColor, backgroundColor);
+    }
+
+    public virtual void DrawGuildName(Color textColor, Color? borderColor = default, Color? backgroundColor = default)
+    {
+        var guildLabel = Guild?.Trim();
+        if (!ShouldDrawName || string.IsNullOrWhiteSpace(guildLabel) || !Options.Instance.Guild.ShowGuildNameTagsOverMembers)
+        {
+            return;
+        }
+
+        if (IsStealthed && !IsInMyParty(Globals.Me))
+        {
+            // Do not render if the party is stealthed and not in the local player's party
+            return;
+        }
+
+        if (MapInstance == default)
+        {
+            return;
+        }
+
+        var textSize = Graphics.Renderer.MeasureText(guildLabel, Graphics.EntityNameFont, 1);
+
+        var x = (int)Math.Ceiling(Origin.X);
+        var y = GetLabelLocation(LabelType.Guild);
+
+        backgroundColor ??= Color.Transparent;
+        if (backgroundColor != Color.Transparent)
+        {
+            Graphics.DrawGameTexture(
+                Graphics.Renderer.GetWhiteTexture(),
+                new FloatRect(0, 0, 1, 1),
+                new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y),
+                backgroundColor
+            );
+        }
+
+        borderColor ??= Color.Transparent;
+        Graphics.Renderer.DrawString(
+            guildLabel,
+            Graphics.EntityNameFont,
+            x - (int)Math.Ceiling(textSize.X / 2f),
+            (int)y,
+            1,
+            Color.FromArgb(textColor.ToArgb()),
+            true,
+            default,
+            Color.FromArgb(borderColor.ToArgb())
+        );
+    }
+
+    protected override bool ShouldDrawHpBar
+    {
+        get
+        {
+            if (ShouldNotDrawHpBar)
+            {
+                return false;
+            }
+
+            if (IsHovered)
             {
                 return true;
             }
 
-            return IsInMyParty(en) || IsInMyGuild(en) || en.MapInstance.ZoneType == MapZone.Safe;
+            var me = Globals.Me;
+
+            if (Globals.Database.MyOverheadHpBar && Id == me.Id)
+            {
+                return true;
+            }
+
+            if (Globals.Database.PlayerOverheadHpBar && Id != me.Id)
+            {
+                return true;
+            }
+
+            if (Globals.Database.PartyMemberOverheadHpBar && me.IsInMyParty(this))
+            {
+                return true;
+            }
+
+            if (Globals.Database.FriendOverheadHpBar && me.IsFriend(this))
+            {
+                return true;
+            }
+
+            return Globals.Database.GuildMemberOverheadHpBar && me.IsGuildMate(this);
+        }
+    }
+
+    public void DrawTargets()
+    {
+        foreach (var en in Globals.Entities)
+        {
+            if (en.Value == null)
+            {
+                continue;
+            }
+
+            if (en.Value.IsHidden)
+            {
+                continue;
+            }
+
+            if (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player)))
+            {
+                continue;
+            }
+
+            if (en.Value is Projectile || en.Value is Resource)
+            {
+                continue;
+            }
+
+            if (TargetType != 0 || TargetIndex != en.Value.Id)
+            {
+                continue;
+            }
+
+            en.Value.DrawTarget((int)Enums.TargetType.Selected);
+            AutoTurnToTarget(en.Value);
         }
 
-        private void DrawNameAndLabels(Color textColor, Color borderColor, Color backgroundColor)
+        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
         {
-            base.DrawName(textColor, borderColor, backgroundColor);
-            DrawLabels(HeaderLabel.Text, 0, HeaderLabel.Color, textColor, borderColor, backgroundColor);
-            DrawLabels(FooterLabel.Text, 1, FooterLabel.Color, textColor, borderColor, backgroundColor);
-            DrawGuildName(textColor, borderColor, backgroundColor);
-        }
-
-        public virtual void DrawGuildName(Color textColor, Color? borderColor = default, Color? backgroundColor = default)
-        {
-            var guildLabel = Guild?.Trim();
-            if (!ShouldDrawName || string.IsNullOrWhiteSpace(guildLabel) || !Options.Instance.Guild.ShowGuildNameTagsOverMembers)
-            {
-                return;
-            }
-
-            if (IsStealthed && !IsInMyParty(Globals.Me))
-            {
-                // Do not render if the party is stealthed and not in the local player's party
-                return;
-            }
-
-            if (MapInstance == default)
-            {
-                return;
-            }
-
-            var textSize = Graphics.Renderer.MeasureText(guildLabel, Graphics.EntityNameFont, 1);
-
-            var x = (int)Math.Ceiling(Origin.X);
-            var y = GetLabelLocation(LabelType.Guild);
-
-            backgroundColor ??= Color.Transparent;
-            if (backgroundColor != Color.Transparent)
-            {
-                Graphics.DrawGameTexture(
-                    Graphics.Renderer.GetWhiteTexture(),
-                    new FloatRect(0, 0, 1, 1),
-                    new FloatRect(x - textSize.X / 2f - 4, y, textSize.X + 8, textSize.Y),
-                    backgroundColor
-                );
-            }
-
-            borderColor ??= Color.Transparent;
-            Graphics.Renderer.DrawString(
-                guildLabel,
-                Graphics.EntityNameFont,
-                x - (int)Math.Ceiling(textSize.X / 2f),
-                (int)y,
-                1,
-                Color.FromArgb(textColor.ToArgb()),
-                true,
-                default,
-                Color.FromArgb(borderColor.ToArgb())
-            );
-        }
-
-        protected override bool ShouldDrawHpBar
-        {
-            get
-            {
-                if (ShouldNotDrawHpBar)
-                {
-                    return false;
-                }
-
-                if (IsHovered)
-                {
-                    return true;
-                }
-
-                var me = Globals.Me;
-
-                if (Globals.Database.MyOverheadHpBar && Id == me.Id)
-                {
-                    return true;
-                }
-
-                if (Globals.Database.PlayerOverheadHpBar && Id != me.Id)
-                {
-                    return true;
-                }
-
-                if (Globals.Database.PartyMemberOverheadHpBar && me.IsInMyParty(this))
-                {
-                    return true;
-                }
-
-                if (Globals.Database.FriendOverheadHpBar && me.IsFriend(this))
-                {
-                    return true;
-                }
-
-                return Globals.Database.GuildMemberOverheadHpBar && me.IsGuildMate(this);
-            }
-        }
-
-        public void DrawTargets()
-        {
-            foreach (var en in Globals.Entities)
+            foreach (var en in eventMap.LocalEntities)
             {
                 if (en.Value == null)
+                {
+                    continue;
+                }
+
+                if (en.Value.MapId != eventMap.Id)
+                {
+                    continue;
+                }
+
+                if (en.Value is Event eventEntity && eventEntity.DisablePreview)
                 {
                     continue;
                 }
@@ -2585,12 +2628,7 @@ namespace Intersect.Client.Entities
                     continue;
                 }
 
-                if (en.Value is Projectile || en.Value is Resource)
-                {
-                    continue;
-                }
-
-                if (TargetType != 0 || TargetIndex != en.Value.Id)
+                if (TargetType != 1 || TargetIndex != en.Value.Id)
                 {
                     continue;
                 }
@@ -2598,59 +2636,46 @@ namespace Intersect.Client.Entities
                 en.Value.DrawTarget((int)Enums.TargetType.Selected);
                 AutoTurnToTarget(en.Value);
             }
+        }
 
-            foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
+        if (!Interface.Interface.MouseHitGui())
+        {
+            var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
+            foreach (MapInstance map in Maps.MapInstance.Lookup.Values)
             {
-                foreach (var en in eventMap.LocalEntities)
+                if (mouseInWorld.X >= map.GetX() && mouseInWorld.X <= map.GetX() + Options.MapWidth * Options.TileWidth)
                 {
-                    if (en.Value == null)
+                    if (mouseInWorld.Y >= map.GetY() &&
+                        mouseInWorld.Y <= map.GetY() + Options.MapHeight * Options.TileHeight)
                     {
-                        continue;
-                    }
+                        var mapId = map.Id;
 
-                    if (en.Value.MapId != eventMap.Id)
-                    {
-                        continue;
-                    }
-
-                    if (en.Value is Event eventEntity && eventEntity.DisablePreview)
-                    {
-                        continue;
-                    }
-
-                    if (en.Value.IsHidden)
-                    {
-                        continue;
-                    }
-
-                    if (en.Value.IsStealthed && (!(en.Value is Player player) || !Globals.Me.IsInMyParty(player)))
-                    {
-                        continue;
-                    }
-
-                    if (TargetType != 1 || TargetIndex != en.Value.Id)
-                    {
-                        continue;
-                    }
-
-                    en.Value.DrawTarget((int)Enums.TargetType.Selected);
-                    AutoTurnToTarget(en.Value);
-                }
-            }
-
-            if (!Interface.Interface.MouseHitGui())
-            {
-                var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
-                foreach (MapInstance map in Maps.MapInstance.Lookup.Values)
-                {
-                    if (mouseInWorld.X >= map.GetX() && mouseInWorld.X <= map.GetX() + Options.MapWidth * Options.TileWidth)
-                    {
-                        if (mouseInWorld.Y >= map.GetY() &&
-                            mouseInWorld.Y <= map.GetY() + Options.MapHeight * Options.TileHeight)
+                        foreach (var en in Globals.Entities)
                         {
-                            var mapId = map.Id;
+                            if (en.Value == null)
+                            {
+                                continue;
+                            }
 
-                            foreach (var en in Globals.Entities)
+                            if (en.Value.MapId == mapId &&
+                                !en.Value.HideName &&
+                                (!en.Value.IsStealthed ||
+                                 en.Value is Player player && Globals.Me.IsInMyParty(player)) &&
+                                en.Value.WorldPos.Contains(mouseInWorld.X, mouseInWorld.Y))
+                            {
+                                if (!(en.Value is Projectile || en.Value is Resource))
+                                {
+                                    if (TargetType != 0 || TargetIndex != en.Value.Id)
+                                    {
+                                        en.Value.DrawTarget((int)Enums.TargetType.Hover);
+                                    }
+                                }
+                            }
+                        }
+
+                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
+                        {
+                            foreach (var en in eventMap.LocalEntities)
                             {
                                 if (en.Value == null)
                                 {
@@ -2658,144 +2683,117 @@ namespace Intersect.Client.Entities
                                 }
 
                                 if (en.Value.MapId == mapId &&
-                                    !en.Value.HideName &&
+                                    !(en.Value as Event).DisablePreview &&
+                                    !en.Value.IsHidden &&
                                     (!en.Value.IsStealthed ||
                                      en.Value is Player player && Globals.Me.IsInMyParty(player)) &&
                                     en.Value.WorldPos.Contains(mouseInWorld.X, mouseInWorld.Y))
                                 {
-                                    if (!(en.Value is Projectile || en.Value is Resource))
+                                    if (TargetType != 1 || TargetIndex != en.Value.Id)
                                     {
-                                        if (TargetType != 0 || TargetIndex != en.Value.Id)
-                                        {
-                                            en.Value.DrawTarget((int)Enums.TargetType.Hover);
-                                        }
+                                        en.Value.DrawTarget((int)Enums.TargetType.Hover);
                                     }
                                 }
                             }
-
-                            foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values)
-                            {
-                                foreach (var en in eventMap.LocalEntities)
-                                {
-                                    if (en.Value == null)
-                                    {
-                                        continue;
-                                    }
-
-                                    if (en.Value.MapId == mapId &&
-                                        !(en.Value as Event).DisablePreview &&
-                                        !en.Value.IsHidden &&
-                                        (!en.Value.IsStealthed ||
-                                         en.Value is Player player && Globals.Me.IsInMyParty(player)) &&
-                                        en.Value.WorldPos.Contains(mouseInWorld.X, mouseInWorld.Y))
-                                    {
-                                        if (TargetType != 1 || TargetIndex != en.Value.Id)
-                                        {
-                                            en.Value.DrawTarget((int)Enums.TargetType.Hover);
-                                        }
-                                    }
-                                }
-                            }
-
-                            break;
                         }
+
+                        break;
                     }
                 }
             }
         }
+    }
 
-        private class TargetInfo
+    private class TargetInfo
+    {
+        public long LastTimeSelected;
+
+        public int DistanceTo;
+    }
+
+    private void TurnAround()
+    {
+        // If players hold the 'TurnAround' Control Key and tap to any direction, they will turn on their own axis.
+        for (var direction = 0; direction < Options.Instance.MapOpts.MovementDirections; direction++)
         {
-            public long LastTimeSelected;
-
-            public int DistanceTo;
-        }
-
-        private void TurnAround()
-        {
-            // If players hold the 'TurnAround' Control Key and tap to any direction, they will turn on their own axis.
-            for (var direction = 0; direction < Options.Instance.MapOpts.MovementDirections; direction++)
+            if (!Controls.KeyDown(Control.TurnAround) || direction != (int)Globals.Me.MoveDir || IsTurnAroundWhileCastingDisabled)
             {
-                if (!Controls.KeyDown(Control.TurnAround) || direction != (int)Globals.Me.MoveDir || IsTurnAroundWhileCastingDisabled)
-                {
-                    continue;
-                }
-
-                // Turn around and hold the player in place if the requested direction is different from the current one.
-                if (!Globals.Me.IsMoving && Dir != Globals.Me.MoveDir)
-                {
-                    Dir = Globals.Me.MoveDir;
-                    PacketSender.SendDirection(Dir);
-                    Globals.Me.MoveDir = Direction.None;
-                    PickLastDirection(Dir);
-                }
-
-                // Hold the player in place if the requested direction is the same as the current one.
-                if (!Globals.Me.IsMoving && Dir == Globals.Me.MoveDir)
-                {
-                    Globals.Me.MoveDir = Direction.None;
-                }
-            }
-        }
-        
-        // Checks if the target is at the opposite direction of the current player's direction.
-        // The comparison also takes into account whether diagonal movement is enabled or not.
-        private static bool IsTargetAtOppositeDirection(Direction currentDir, Direction targetDir)
-        {
-            if (Options.Instance.MapOpts.EnableDiagonalMovement)
-            {
-                // If diagonal movement is disabled, check opposite directions on 4 directions.
-                switch (currentDir)
-                {
-                    case Direction.Up:
-                        return targetDir == Direction.Down || targetDir == Direction.DownLeft ||
-                               targetDir == Direction.DownRight;
-
-                    case Direction.Down:
-                        return targetDir == Direction.Up || targetDir == Direction.UpLeft ||
-                               targetDir == Direction.UpRight;
-
-                    case Direction.Left:
-                        return targetDir == Direction.Right || targetDir == Direction.UpRight ||
-                               targetDir == Direction.DownRight;
-
-                    case Direction.Right:
-                        return targetDir == Direction.Left || targetDir == Direction.UpLeft ||
-                               targetDir == Direction.DownLeft;
-
-                    default:
-                        if (!Options.Instance.MapOpts.EnableDiagonalMovement)
-                        {
-                            return false;
-                        }
-
-                        break;
-                }
+                continue;
             }
 
-            // If diagonal movement is enabled, check opposite directions on 8 directions.
-            switch (currentDir)
+            // Turn around and hold the player in place if the requested direction is different from the current one.
+            if (!Globals.Me.IsMoving && Dir != Globals.Me.MoveDir)
             {
-                case Direction.UpLeft:
-                    return targetDir == Direction.DownRight || targetDir == Direction.Right ||
-                           targetDir == Direction.Down;
+                Dir = Globals.Me.MoveDir;
+                PacketSender.SendDirection(Dir);
+                Globals.Me.MoveDir = Direction.None;
+                PickLastDirection(Dir);
+            }
 
-                case Direction.UpRight:
-                    return targetDir == Direction.DownLeft || targetDir == Direction.Left ||
-                           targetDir == Direction.Down;
-
-                case Direction.DownLeft:
-                    return targetDir == Direction.UpRight || targetDir == Direction.Right || 
-                           targetDir == Direction.Up;
-
-                case Direction.DownRight:
-                    return targetDir == Direction.UpLeft || targetDir == Direction.Left || 
-                           targetDir == Direction.Up;
-
-                default:
-                    return false;
+            // Hold the player in place if the requested direction is the same as the current one.
+            if (!Globals.Me.IsMoving && Dir == Globals.Me.MoveDir)
+            {
+                Globals.Me.MoveDir = Direction.None;
             }
         }
     }
+    
+    // Checks if the target is at the opposite direction of the current player's direction.
+    // The comparison also takes into account whether diagonal movement is enabled or not.
+    private static bool IsTargetAtOppositeDirection(Direction currentDir, Direction targetDir)
+    {
+        if (Options.Instance.MapOpts.EnableDiagonalMovement)
+        {
+            // If diagonal movement is disabled, check opposite directions on 4 directions.
+            switch (currentDir)
+            {
+                case Direction.Up:
+                    return targetDir == Direction.Down || targetDir == Direction.DownLeft ||
+                           targetDir == Direction.DownRight;
 
+                case Direction.Down:
+                    return targetDir == Direction.Up || targetDir == Direction.UpLeft ||
+                           targetDir == Direction.UpRight;
+
+                case Direction.Left:
+                    return targetDir == Direction.Right || targetDir == Direction.UpRight ||
+                           targetDir == Direction.DownRight;
+
+                case Direction.Right:
+                    return targetDir == Direction.Left || targetDir == Direction.UpLeft ||
+                           targetDir == Direction.DownLeft;
+
+                default:
+                    if (!Options.Instance.MapOpts.EnableDiagonalMovement)
+                    {
+                        return false;
+                    }
+
+                    break;
+            }
+        }
+
+        // If diagonal movement is enabled, check opposite directions on 8 directions.
+        switch (currentDir)
+        {
+            case Direction.UpLeft:
+                return targetDir == Direction.DownRight || targetDir == Direction.Right ||
+                       targetDir == Direction.Down;
+
+            case Direction.UpRight:
+                return targetDir == Direction.DownLeft || targetDir == Direction.Left ||
+                       targetDir == Direction.Down;
+
+            case Direction.DownLeft:
+                return targetDir == Direction.UpRight || targetDir == Direction.Right || 
+                       targetDir == Direction.Up;
+
+            case Direction.DownRight:
+                return targetDir == Direction.UpLeft || targetDir == Direction.Left || 
+                       targetDir == Direction.Up;
+
+            default:
+                return false;
+        }
+    }
 }

--- a/Intersect.Client/Entities/Projectiles/Projectile.cs
+++ b/Intersect.Client/Entities/Projectiles/Projectile.cs
@@ -7,758 +7,756 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Client.Entities.Projectiles
+namespace Intersect.Client.Entities.Projectiles;
+
+
+public partial class Projectile : Entity
 {
 
-    public partial class Projectile : Entity
+    private bool _isDisposing;
+
+    private bool _isLoaded;
+
+    private readonly object _lock = new object();
+
+    private ProjectileBase _myBase;
+
+    private Guid _owner;
+
+    private int _quantity;
+
+    private int _spawnCount;
+
+    private int _spawnedAmount;
+
+    private long _spawnTime;
+
+    private int _totalSpawns;
+
+    private Guid _projectileId;
+
+    // Individual Spawns
+    private ProjectileSpawns[] _spawns;
+
+    private Guid _targetId;
+
+    private int _lastTargetX = -1;
+
+    private int _lastTargetY = -1;
+
+    private Guid _lastTargetMapId = Guid.Empty;
+
+    /// <summary>
+    /// The constructor for the inherated projectile class
+    /// </summary>
+    public Projectile(Guid id, ProjectileEntityPacket packet) : base(id, packet, EntityType.Projectile)
     {
+        Vital[(int)Enums.Vital.Health] = 1;
+        MaxVital[(int)Enums.Vital.Health] = 1;
+        HideName = true;
+        Passable = true;
+        IsMoving = true;
+    }
 
-        private bool _isDisposing;
-
-        private bool _isLoaded;
-
-        private readonly object _lock = new object();
-
-        private ProjectileBase _myBase;
-
-        private Guid _owner;
-
-        private int _quantity;
-
-        private int _spawnCount;
-
-        private int _spawnedAmount;
-
-        private long _spawnTime;
-
-        private int _totalSpawns;
-
-        private Guid _projectileId;
-
-        // Individual Spawns
-        private ProjectileSpawns[] _spawns;
-
-        private Guid _targetId;
-
-        private int _lastTargetX = -1;
-
-        private int _lastTargetY = -1;
-
-        private Guid _lastTargetMapId = Guid.Empty;
-
-        /// <summary>
-        /// The constructor for the inherated projectile class
-        /// </summary>
-        public Projectile(Guid id, ProjectileEntityPacket packet) : base(id, packet, EntityType.Projectile)
+    public override void Load(EntityPacket packet)
+    {
+        if (_isLoaded)
         {
-            Vital[(int)Enums.Vital.Health] = 1;
-            MaxVital[(int)Enums.Vital.Health] = 1;
-            HideName = true;
-            Passable = true;
-            IsMoving = true;
+            return;
         }
 
-        public override void Load(EntityPacket packet)
+        base.Load(packet);
+        var pkt = (ProjectileEntityPacket)packet;
+        _projectileId = pkt.ProjectileId;
+        Dir = (Direction)pkt.ProjectileDirection;
+        _targetId = pkt.TargetId;
+        _owner = pkt.OwnerId;
+        _myBase = ProjectileBase.Get(_projectileId);
+        if (_myBase != null)
         {
-            if (_isLoaded)
-            {
-                return;
-            }
-
-            base.Load(packet);
-            var pkt = (ProjectileEntityPacket)packet;
-            _projectileId = pkt.ProjectileId;
-            Dir = (Direction)pkt.ProjectileDirection;
-            _targetId = pkt.TargetId;
-            _owner = pkt.OwnerId;
-            _myBase = ProjectileBase.Get(_projectileId);
-            if (_myBase != null)
-            {
-                for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
-                {
-                    for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
-                    {
-                        for (var d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
-                        {
-                            if (_myBase.SpawnLocations[x, y].Directions[d] == true)
-                            {
-                                _totalSpawns++;
-                            }
-                        }
-                    }
-                }
-
-                _totalSpawns *= _myBase.Quantity;
-            }
-
-            _spawns = new ProjectileSpawns[_totalSpawns];
-            _isLoaded = true;
-        }
-
-        /// <summary>
-        /// Disposes of the resources used by this instance, preventing any further use.
-        /// </summary>
-        public override void Dispose()
-        {
-            if (!_isDisposing)
-            {
-                lock (_lock)
-                {
-                    _isDisposing = true;
-
-                    // Perform a final update if no projectiles have been spawned.
-                    if (_spawnedAmount == 0)
-                    {
-                        Update();
-                    }
-
-                    if (_spawns != null)
-                    {
-                        foreach (var s in _spawns)
-                        {
-                            s?.Anim?.DisposeNextDraw();
-                        }
-                    }
-
-                    GC.SuppressFinalize(this);
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public override bool CanBeAttacked
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Determines the appropriate animation data index for the current spawn wave of the projectile.
-        /// This method iterates through the available animations defined in the projectile's base configuration,
-        /// selecting the one whose spawn range encompasses the current quantity of spawns.
-        /// </summary>
-        /// <returns>The index of the animation data to use for the current spawn wave.</returns>
-        private int FindSpawnAnimationData()
-        {
-            var start = 0;
-            for (var i = 0; i < _myBase.Animations.Count; i++)
-            {
-                var end = _myBase.Animations[i].SpawnRange;
-                if (_quantity >= start && _quantity < end)
-                {
-                    return i;
-                }
-
-                start = end;
-            }
-
-            // If no suitable animation is found (e.g., developer(s) fucked up the animation ranges), default to the last animation.
-            // This serves as a fallback to prevent crashes or undefined behavior in case of misconfiguration.
-            return _myBase.Animations.Count - 1;
-        }
-
-        /// <summary>
-        /// Adds projectile spawns based on predefined spawn locations and directions.
-        /// </summary>
-        private void AddProjectileSpawns()
-        {
-            var spawn = FindSpawnAnimationData();
-            var animBase = AnimationBase.Get(_myBase.Animations[spawn].AnimationId);
-
             for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
             {
                 for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
                 {
                     for (var d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
                     {
-                        // Check if the current direction is enabled for spawning at this location.
                         if (_myBase.SpawnLocations[x, y].Directions[d] == true)
                         {
-                            // Calculate the spawn position and direction for the new projectile
-                            var s = new ProjectileSpawns(
-                                FindProjectileRotationDir(Dir, (Direction)d),
-                                (byte)(X + FindProjectileRotation(Dir, x - 2, y - 2, true)),
-                                (byte)(Y + FindProjectileRotation(Dir, x - 2, y - 2, false)), Z, MapId, animBase,
-                                _myBase.Animations[spawn].AutoRotate, _myBase, this
-                            );
-
-                            _spawns[_spawnedAmount] = s;
-                            if (Collided(_spawnedAmount))
-                            {
-                                TryRemoveSpawn(_spawnedAmount);
-                                _spawnCount--;
-                            }
-
-                            // Add the new spawn to the array and increment counters
-                            _spawnedAmount++;
-                            _spawnCount++;
+                            _totalSpawns++;
                         }
                     }
                 }
             }
 
-            // Increment the quantity of projectiles spawned and update the spawn time based on the delay
-            _quantity++;
-            _spawnTime = Timing.Global.Milliseconds + _myBase.Delay;
+            _totalSpawns *= _myBase.Quantity;
         }
 
-        /// <summary>
-        /// Finds the projectile rotation value based on the direction, position and the axis.
-        /// </summary>
-        /// <param name="direction">The direction of the projectile.</param>
-        /// <param name="x">The x-coordinate value.</param>
-        /// <param name="y">The y-coordinate value.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The rotation value for the specified axis based on the direction.</returns>
-        private static int FindProjectileRotation(Direction direction, int x, int y, bool isXAxis)
+        _spawns = new ProjectileSpawns[_totalSpawns];
+        _isLoaded = true;
+    }
+
+    /// <summary>
+    /// Disposes of the resources used by this instance, preventing any further use.
+    /// </summary>
+    public override void Dispose()
+    {
+        if (!_isDisposing)
         {
-            if (isXAxis)
-            {
-                return direction switch
-                {
-                    Direction.Up => x,
-                    Direction.Down => -x,
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => y,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => -y,
-                    _ => x,
-                };
-            }
-            else
-            {
-                return direction switch
-                {
-                    Direction.Up => y,
-                    Direction.Down => -y,
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => -x,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => x,
-                    _ => y,
-                };
-            }
-        }
-
-        private static Direction FindProjectileRotationDir(Direction entityDir, Direction projectionDir) =>
-            (Direction)ProjectileBase.ProjectileRotationDir[(int)entityDir * ProjectileBase.MAX_PROJECTILE_DIRECTIONS + (int)projectionDir];
-
-        /// <summary>
-        /// Calculates the projectile range based on the given direction, range, and axis.
-        /// </summary>
-        /// <param name="direction">The direction of the projectile.</param>
-        /// <param name="range">The range of the projectile.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The calculated range value.</returns>
-        private static float GetRange(Direction direction, float range, bool isXAxis)
-        {
-            if (isXAxis)
-            {
-                return direction switch
-                {
-                    Direction.Left or Direction.UpLeft or Direction.DownLeft => -range,
-                    Direction.Right or Direction.UpRight or Direction.DownRight => range,
-                    _ => 0,
-                };
-            }
-            else
-            {
-                return direction switch
-                {
-                    Direction.Up or Direction.UpLeft or Direction.UpRight => -range,
-                    Direction.Down or Direction.DownLeft or Direction.DownRight => range,
-                    _ => 0,
-                };
-            }
-        }
-
-        /// <summary>
-        /// Gets the displacement of the projectile during projection
-        /// </summary>
-        /// <returns>The displacement from the co-ordinates if placed on a Options.TileHeight grid.</returns>
-        private float GetDisplacement(long spawnTime)
-        {
-            var elapsedTime = Timing.Global.Milliseconds - spawnTime;
-            var displacementPercent = elapsedTime / (float)_myBase.Speed;
-            var calculatedDisplacement = displacementPercent * Options.TileHeight * _myBase.Range;
-
-            // Ensure displacement does not exceed the maximum range of the projectile
-            var maxDisplacement = Options.TileHeight * _myBase.Range;
-            return Math.Min(calculatedDisplacement, maxDisplacement);
-        }
-
-        /// <summary>
-        /// Overwrite updating the offsets for projectile movement.
-        /// </summary>
-        public override bool Update()
-        {
-            if (_myBase == null)
-            {
-                return false;
-            }
-
             lock (_lock)
             {
-                var map = MapId;
-                var y = Y;
+                _isDisposing = true;
 
-                if (!_isDisposing && _quantity < _myBase.Quantity && _spawnTime < Timing.Global.Milliseconds)
+                // Perform a final update if no projectiles have been spawned.
+                if (_spawnedAmount == 0)
                 {
-                    AddProjectileSpawns();
+                    Update();
                 }
 
-                if (IsMoving)
+                if (_spawns != null)
                 {
-                    for (var s = 0; s < _spawnedAmount; s++)
+                    foreach (var s in _spawns)
                     {
-                        var spawn = _spawns[s];
-                        
-                        if (spawn != null && Maps.MapInstance.Get(spawn.SpawnMapId) != null)
-                        {
-                            if (_targetId != Guid.Empty && _targetId != _owner && Globals.Entities.ContainsKey(_targetId) && (_myBase.HomingBehavior || _myBase.DirectShotBehavior))
-                            {
-                                var target = Globals.Entities[_targetId];
-                                _lastTargetX = target.X;
-                                _lastTargetY = target.Y;
-                                _lastTargetMapId = target.MapId;
-
-                                spawn.OffsetX = GetProjectileLerping(spawn, true);
-                                spawn.OffsetY = GetProjectileLerping(spawn, false);
-                                SetProjectileRotation(spawn);
-
-                                if (_myBase.DirectShotBehavior)
-                                {
-                                    _targetId = Guid.Empty;
-                                }
-                            }
-                            else if (_lastTargetX != -1 && _lastTargetY != -1)
-                            {
-                                spawn.OffsetX = GetProjectileLerping(spawn, true);
-                                spawn.OffsetY = GetProjectileLerping(spawn, false);
-                                SetProjectileRotation(spawn);
-                            }
-                            else
-                            {
-                                spawn.OffsetX = GetRange(spawn.Dir, GetDisplacement(spawn.SpawnTime), true);
-                                spawn.OffsetY = GetRange(spawn.Dir, GetDisplacement(spawn.SpawnTime), false);
-                                spawn.Anim.SetRotation(false);
-                            }
-
-                            var spawnMapId = Maps.MapInstance.Get(spawn.SpawnMapId);
-                            var spawnX = spawnMapId.GetX() + spawn.SpawnX * Options.TileWidth + spawn.OffsetX + Options.TileWidth / 2;
-                            var spawnY = spawnMapId.GetY() + spawn.SpawnY * Options.TileHeight + spawn.OffsetY + Options.TileHeight / 2;
-                            var spawnDirection = spawn.AutoRotate ? spawn.Dir : Direction.Up;
-
-                            spawn.Anim.SetPosition(spawnX, spawnY, X, Y, MapId, spawnDirection, spawn.Z);
-                            spawn.Anim.Update();
-                        }
+                        s?.Anim?.DisposeNextDraw();
                     }
                 }
 
-                CheckForCollision();
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool CanBeAttacked
+    {
+        get
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines the appropriate animation data index for the current spawn wave of the projectile.
+    /// This method iterates through the available animations defined in the projectile's base configuration,
+    /// selecting the one whose spawn range encompasses the current quantity of spawns.
+    /// </summary>
+    /// <returns>The index of the animation data to use for the current spawn wave.</returns>
+    private int FindSpawnAnimationData()
+    {
+        var start = 0;
+        for (var i = 0; i < _myBase.Animations.Count; i++)
+        {
+            var end = _myBase.Animations[i].SpawnRange;
+            if (_quantity >= start && _quantity < end)
+            {
+                return i;
             }
 
-            return true;
+            start = end;
         }
 
-        /// <summary>
-        /// Calculates the offset for the projectile spawn position based on the target map and spawn location.
-        /// </summary>
-        /// <param name="spawn">The projectile spawn information.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The calculated offset value.</returns>
-        private float GetProjectileOffset(ProjectileSpawns spawn, bool isXAxis)
+        // If no suitable animation is found (e.g., developer(s) fucked up the animation ranges), default to the last animation.
+        // This serves as a fallback to prevent crashes or undefined behavior in case of misconfiguration.
+        return _myBase.Animations.Count - 1;
+    }
+
+    /// <summary>
+    /// Adds projectile spawns based on predefined spawn locations and directions.
+    /// </summary>
+    private void AddProjectileSpawns()
+    {
+        var spawn = FindSpawnAnimationData();
+        var animBase = AnimationBase.Get(_myBase.Animations[spawn].AnimationId);
+
+        for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
         {
-            if (_lastTargetMapId == Guid.Empty || _lastTargetMapId == spawn.SpawnMapId || !Maps.MapInstance.TryGet(spawn.SpawnMapId, out var map))
+            for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
             {
-                return isXAxis ? _lastTargetX - spawn.SpawnX : _lastTargetY - spawn.SpawnY;
+                for (var d = 0; d < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; d++)
+                {
+                    // Check if the current direction is enabled for spawning at this location.
+                    if (_myBase.SpawnLocations[x, y].Directions[d] == true)
+                    {
+                        // Calculate the spawn position and direction for the new projectile
+                        var s = new ProjectileSpawns(
+                            FindProjectileRotationDir(Dir, (Direction)d),
+                            (byte)(X + FindProjectileRotation(Dir, x - 2, y - 2, true)),
+                            (byte)(Y + FindProjectileRotation(Dir, x - 2, y - 2, false)), Z, MapId, animBase,
+                            _myBase.Animations[spawn].AutoRotate, _myBase, this
+                        );
+
+                        _spawns[_spawnedAmount] = s;
+                        if (Collided(_spawnedAmount))
+                        {
+                            TryRemoveSpawn(_spawnedAmount);
+                            _spawnCount--;
+                        }
+
+                        // Add the new spawn to the array and increment counters
+                        _spawnedAmount++;
+                        _spawnCount++;
+                    }
+                }
+            }
+        }
+
+        // Increment the quantity of projectiles spawned and update the spawn time based on the delay
+        _quantity++;
+        _spawnTime = Timing.Global.Milliseconds + _myBase.Delay;
+    }
+
+    /// <summary>
+    /// Finds the projectile rotation value based on the direction, position and the axis.
+    /// </summary>
+    /// <param name="direction">The direction of the projectile.</param>
+    /// <param name="x">The x-coordinate value.</param>
+    /// <param name="y">The y-coordinate value.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The rotation value for the specified axis based on the direction.</returns>
+    private static int FindProjectileRotation(Direction direction, int x, int y, bool isXAxis)
+    {
+        if (isXAxis)
+        {
+            return direction switch
+            {
+                Direction.Up => x,
+                Direction.Down => -x,
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => y,
+                Direction.Right or Direction.UpRight or Direction.DownRight => -y,
+                _ => x,
+            };
+        }
+        else
+        {
+            return direction switch
+            {
+                Direction.Up => y,
+                Direction.Down => -y,
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => -x,
+                Direction.Right or Direction.UpRight or Direction.DownRight => x,
+                _ => y,
+            };
+        }
+    }
+
+    private static Direction FindProjectileRotationDir(Direction entityDir, Direction projectionDir) =>
+        (Direction)ProjectileBase.ProjectileRotationDir[(int)entityDir * ProjectileBase.MAX_PROJECTILE_DIRECTIONS + (int)projectionDir];
+
+    /// <summary>
+    /// Calculates the projectile range based on the given direction, range, and axis.
+    /// </summary>
+    /// <param name="direction">The direction of the projectile.</param>
+    /// <param name="range">The range of the projectile.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The calculated range value.</returns>
+    private static float GetRange(Direction direction, float range, bool isXAxis)
+    {
+        if (isXAxis)
+        {
+            return direction switch
+            {
+                Direction.Left or Direction.UpLeft or Direction.DownLeft => -range,
+                Direction.Right or Direction.UpRight or Direction.DownRight => range,
+                _ => 0,
+            };
+        }
+        else
+        {
+            return direction switch
+            {
+                Direction.Up or Direction.UpLeft or Direction.UpRight => -range,
+                Direction.Down or Direction.DownLeft or Direction.DownRight => range,
+                _ => 0,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Gets the displacement of the projectile during projection
+    /// </summary>
+    /// <returns>The displacement from the co-ordinates if placed on a Options.TileHeight grid.</returns>
+    private float GetDisplacement(long spawnTime)
+    {
+        var elapsedTime = Timing.Global.Milliseconds - spawnTime;
+        var displacementPercent = elapsedTime / (float)_myBase.Speed;
+        var calculatedDisplacement = displacementPercent * Options.TileHeight * _myBase.Range;
+
+        // Ensure displacement does not exceed the maximum range of the projectile
+        var maxDisplacement = Options.TileHeight * _myBase.Range;
+        return Math.Min(calculatedDisplacement, maxDisplacement);
+    }
+
+    /// <summary>
+    /// Overwrite updating the offsets for projectile movement.
+    /// </summary>
+    public override bool Update()
+    {
+        if (_myBase == null)
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            var map = MapId;
+            var y = Y;
+
+            if (!_isDisposing && _quantity < _myBase.Quantity && _spawnTime < Timing.Global.Milliseconds)
+            {
+                AddProjectileSpawns();
             }
 
-            for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
+            if (IsMoving)
             {
-                for (var x = map.GridX - 1; x <= map.GridX + 1; x++)
+                for (var s = 0; s < _spawnedAmount; s++)
                 {
-                    if (x < 0 || x >= Globals.MapGrid.GetLength(0) || y < 0 || y >= Globals.MapGrid.GetLength(1))
+                    var spawn = _spawns[s];
+                    
+                    if (spawn != null && Maps.MapInstance.Get(spawn.SpawnMapId) != null)
                     {
-                        continue;
-                    }
-
-                    if (Globals.MapGrid[x, y] != _lastTargetMapId || Globals.MapGrid[x, y] == Guid.Empty)
-                    {
-                        continue;
-                    }
-
-                    if (isXAxis) // Horizontal (X) calculation
-                    {
-                        var leftSide = x == map.GridX - 1;
-                        var rightSide = x == map.GridX + 1;
-
-                        if (leftSide)
+                        if (_targetId != Guid.Empty && _targetId != _owner && Globals.Entities.ContainsKey(_targetId) && (_myBase.HomingBehavior || _myBase.DirectShotBehavior))
                         {
-                            return _lastTargetX - Options.MapWidth - spawn.SpawnX;
+                            var target = Globals.Entities[_targetId];
+                            _lastTargetX = target.X;
+                            _lastTargetY = target.Y;
+                            _lastTargetMapId = target.MapId;
+
+                            spawn.OffsetX = GetProjectileLerping(spawn, true);
+                            spawn.OffsetY = GetProjectileLerping(spawn, false);
+                            SetProjectileRotation(spawn);
+
+                            if (_myBase.DirectShotBehavior)
+                            {
+                                _targetId = Guid.Empty;
+                            }
+                        }
+                        else if (_lastTargetX != -1 && _lastTargetY != -1)
+                        {
+                            spawn.OffsetX = GetProjectileLerping(spawn, true);
+                            spawn.OffsetY = GetProjectileLerping(spawn, false);
+                            SetProjectileRotation(spawn);
+                        }
+                        else
+                        {
+                            spawn.OffsetX = GetRange(spawn.Dir, GetDisplacement(spawn.SpawnTime), true);
+                            spawn.OffsetY = GetRange(spawn.Dir, GetDisplacement(spawn.SpawnTime), false);
+                            spawn.Anim.SetRotation(false);
                         }
 
-                        if (rightSide)
-                        {
-                            return _lastTargetX + Options.MapWidth - spawn.SpawnX;
-                        }
-                    }
-                    else // Vertical (Y) calculation
-                    {
-                        var topSide = y == map.GridY + 1;
-                        var bottomSide = y == map.GridY - 1;
+                        var spawnMapId = Maps.MapInstance.Get(spawn.SpawnMapId);
+                        var spawnX = spawnMapId.GetX() + spawn.SpawnX * Options.TileWidth + spawn.OffsetX + Options.TileWidth / 2;
+                        var spawnY = spawnMapId.GetY() + spawn.SpawnY * Options.TileHeight + spawn.OffsetY + Options.TileHeight / 2;
+                        var spawnDirection = spawn.AutoRotate ? spawn.Dir : Direction.Up;
 
-                        if (topSide)
-                        {
-                            return _lastTargetY + Options.MapHeight - spawn.SpawnY;
-                        }
-
-                        if (bottomSide)
-                        {
-                            return _lastTargetY - Options.MapHeight - spawn.SpawnY;
-                        }
+                        spawn.Anim.SetPosition(spawnX, spawnY, X, Y, MapId, spawnDirection, spawn.Z);
+                        spawn.Anim.Update();
                     }
                 }
             }
 
+            CheckForCollision();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Calculates the offset for the projectile spawn position based on the target map and spawn location.
+    /// </summary>
+    /// <param name="spawn">The projectile spawn information.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The calculated offset value.</returns>
+    private float GetProjectileOffset(ProjectileSpawns spawn, bool isXAxis)
+    {
+        if (_lastTargetMapId == Guid.Empty || _lastTargetMapId == spawn.SpawnMapId || !Maps.MapInstance.TryGet(spawn.SpawnMapId, out var map))
+        {
             return isXAxis ? _lastTargetX - spawn.SpawnX : _lastTargetY - spawn.SpawnY;
         }
 
-        /// <summary>
-        /// Calculates the interpolated (lerped) position value for a projectile along the X or Y axis.
-        /// </summary>
-        /// <param name="spawn">The spawn information of the projectile, including its initial position and spawn time.</param>
-        /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
-        /// <returns>The interpolated position value for the projectile on the specified axis, taking into account the projectile's travel direction, speed, and elapsed time since spawning.</returns>
-        /// <remarks>
-        /// This method determines the projectile's current position by interpolating between its initial offset and its desired position at the current time.
-        /// It calculates the direction and magnitude of the projectile's movement, normalizes this to obtain a unit vector in the direction of movement,
-        /// and then applies linear interpolation based on the elapsed time since the projectile was spawned.
-        /// The interpolation factor is clamped to ensure that the projectile does not overshoot its target position.
-        /// </remarks>
-        private float GetProjectileLerping(ProjectileSpawns spawn, bool isXAxis)
+        for (var y = map.GridY - 1; y <= map.GridY + 1; y++)
         {
-            var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
-            var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
-            if (distance == 0) return 0;
-
-            var valueToLerp = (isXAxis ? directionX : directionY) / distance;
-            var offset = isXAxis ? spawn.OffsetX : spawn.OffsetY;
-            var desiredValue = GetDisplacement(spawn.SpawnTime + Options.Instance.Processing.ProjectileUpdateInterval) * valueToLerp;
-            var totalDuration = (float)_myBase.Range * (_myBase.Speed / Options.TileHeight);
-            var elapsedTime = Timing.Global.Milliseconds - spawn.SpawnTime;
-            var lerpFactor = Utilities.MathHelper.Clamp(elapsedTime / totalDuration, 0f, 1f);
-
-            // Dynamically calculated lerp factor
-            return (1 - lerpFactor) * offset + lerpFactor * desiredValue;
-        }
-
-        /// <summary>
-        /// Sets the rotation of a projectile based on its spawn information.
-        /// </summary>
-        /// <param name="spawn">The spawn information of the projectile, including its current animation state and position.</param>
-        /// <remarks>
-        /// This method calculates the angle between the projectile's current position and its target,
-        /// converting the angle from radians to degrees and adjusting it by 90 degrees to align with the game's coordinate system.
-        /// The calculated angle is then applied to the projectile's animation state to visually orient the projectile towards its target.
-        /// </remarks>
-        private void SetProjectileRotation(ProjectileSpawns spawn)
-        {
-            var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
-            var angle = (float)(Math.Atan2(directionY, directionX) * (180.0 / Math.PI) + 90);
-            spawn.Anim.SetRotation(angle);
-        }
-
-        /// <summary>
-        /// Checks for collision of the projectile with other entities or map boundaries.
-        /// </summary>
-        public void CheckForCollision()
-        {
-            if (_spawnCount == 0 && _quantity > _myBase.Quantity)
+            for (var x = map.GridX - 1; x <= map.GridX + 1; x++)
             {
-                Globals.Entities[Id].Dispose();
-                return;
-            }
-
-            for (var i = 0; i < _spawnedAmount && i < _spawns.Length; i++)
-            {
-                var projectileSpawn = _spawns[i];
-                if (projectileSpawn == null || Timing.Global.Milliseconds <= projectileSpawn.TransmissionTimer)
+                if (x < 0 || x >= Globals.MapGrid.GetLength(0) || y < 0 || y >= Globals.MapGrid.GetLength(1))
                 {
                     continue;
                 }
 
-                if (!Maps.MapInstance.TryGet(projectileSpawn.MapId, out var spawnMap))
+                if (Globals.MapGrid[x, y] != _lastTargetMapId || Globals.MapGrid[x, y] == Guid.Empty)
                 {
                     continue;
                 }
 
-                float newx = projectileSpawn.X;
-                float newy = projectileSpawn.Y;
-
-                if (_myBase.HomingBehavior || _myBase.DirectShotBehavior)
+                if (isXAxis) // Horizontal (X) calculation
                 {
-                    if (_targetId != Guid.Empty && _targetId != _owner || _lastTargetX != -1 && _lastTargetY != -1 && _lastTargetMapId != Guid.Empty)
+                    var leftSide = x == map.GridX - 1;
+                    var rightSide = x == map.GridX + 1;
+
+                    if (leftSide)
                     {
-                        var (deltaX, deltaY) = (GetProjectileOffset(projectileSpawn, true), GetProjectileOffset(projectileSpawn, false));
-                        float distance = MathF.Sqrt(deltaX * deltaX + deltaY * deltaY);
-                        float xFactor = deltaX / distance;
-                        float yFactor = deltaY / distance;
-                        newx += xFactor;
-                        newy += yFactor;
+                        return _lastTargetX - Options.MapWidth - spawn.SpawnX;
+                    }
+
+                    if (rightSide)
+                    {
+                        return _lastTargetX + Options.MapWidth - spawn.SpawnX;
                     }
                 }
-                else
+                else // Vertical (Y) calculation
                 {
-                    newx += GetRange(projectileSpawn.Dir, 1, true);
-                    newy += GetRange(projectileSpawn.Dir, 1, false);
-                }
+                    var topSide = y == map.GridY + 1;
+                    var bottomSide = y == map.GridY - 1;
 
-                AdjustPositionOnMapBoundaries(ref newx, ref newy, ref spawnMap);
-
-                projectileSpawn.X = (int)newx;
-                projectileSpawn.Y = (int)newy;
-                projectileSpawn.MapId = spawnMap.Id;
-                projectileSpawn.Distance++;
-                projectileSpawn.TransmissionTimer = Timing.Global.MillisecondsOffset + (long)(_myBase.Speed / (float)_myBase.Range);
-
-                var killSpawn = Collided(i) || projectileSpawn.Distance >= _myBase.Range ||
-                                newx < 0 || newx >= Options.MapWidth || newy < 0 ||
-                                newy >= Options.MapHeight;
-
-                // Check for map boundaries and remove the spawn if it goes out of bounds.
-                if (killSpawn)
-                {
-                    TryRemoveSpawn(i);
-                    _spawnCount--;
-
-                    continue;
-                }
-
-                // Check for Z-Dimension
-                if (!killSpawn && spawnMap.Attributes != null &&
-                    projectileSpawn.X >= 0 && projectileSpawn.Y >= 0 && projectileSpawn.X < spawnMap.Attributes.GetLength(0) &&
-                    projectileSpawn.Y < spawnMap.Attributes.GetLength(1))
-                {
-                    var attribute = spawnMap.Attributes[projectileSpawn.X, projectileSpawn.Y];
-
-                    if (attribute != null && attribute.Type == MapAttribute.ZDimension)
+                    if (topSide)
                     {
-                        var zDimensionAttribute = (MapZDimensionAttribute)attribute;
-
-                        // If the Z dimension attribute specifies a blocked level that matches the projectile's current Z level,
-                        // mark the projectile for destruction.
-                        if (zDimensionAttribute.BlockedLevel > 0 && projectileSpawn.Z == zDimensionAttribute.BlockedLevel - 1)
-                        {
-                            killSpawn = true;
-                        }
-
-                        // If the Z dimension attribute specifies a gateway to another level,
-                        // adjust the projectile's Z level to the specified gateway level.
-                        if (zDimensionAttribute.GatewayTo > 0)
-                        {
-                            projectileSpawn.Z = zDimensionAttribute.GatewayTo - 1;
-                        }
+                        return _lastTargetY + Options.MapHeight - spawn.SpawnY;
                     }
-                }
 
-                if (killSpawn)
-                {
-                    TryRemoveSpawn(i);
-                    _spawnCount--;
+                    if (bottomSide)
+                    {
+                        return _lastTargetY - Options.MapHeight - spawn.SpawnY;
+                    }
                 }
             }
         }
 
-        /// <summary>
-        /// Adjusts the position of a projectile on the map boundaries, potentially changing its map instance.
-        /// </summary>
-        /// <param name="newx">The new x-coordinate of the projectile.</param>
-        /// <param name="newy">The new y-coordinate of the projectile.</param>
-        /// <param name="spawnMap">The map instance where the projectile is spawned. This may be updated if the projectile crosses map boundaries.</param>
-        /// <remarks>
-        /// This method checks if the projectile crosses the boundaries of its current map. If it does, it attempts to move the projectile
-        /// to the adjacent map in the direction it crossed the boundary. This includes handling corner cases where the projectile crosses
-        /// at the corners of the map, potentially moving it diagonally to a new map. The new position of the projectile is adjusted to
-        /// visually reflect its entry point into the adjacent map.
-        /// </remarks>
-        private static void AdjustPositionOnMapBoundaries(ref float newx, ref float newy, ref Maps.MapInstance spawnMap)
+        return isXAxis ? _lastTargetX - spawn.SpawnX : _lastTargetY - spawn.SpawnY;
+    }
+
+    /// <summary>
+    /// Calculates the interpolated (lerped) position value for a projectile along the X or Y axis.
+    /// </summary>
+    /// <param name="spawn">The spawn information of the projectile, including its initial position and spawn time.</param>
+    /// <param name="isXAxis">True for horizontal (X-axis), false for vertical (Y-axis) calculation.</param>
+    /// <returns>The interpolated position value for the projectile on the specified axis, taking into account the projectile's travel direction, speed, and elapsed time since spawning.</returns>
+    /// <remarks>
+    /// This method determines the projectile's current position by interpolating between its initial offset and its desired position at the current time.
+    /// It calculates the direction and magnitude of the projectile's movement, normalizes this to obtain a unit vector in the direction of movement,
+    /// and then applies linear interpolation based on the elapsed time since the projectile was spawned.
+    /// The interpolation factor is clamped to ensure that the projectile does not overshoot its target position.
+    /// </remarks>
+    private float GetProjectileLerping(ProjectileSpawns spawn, bool isXAxis)
+    {
+        var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
+        var distance = MathF.Sqrt(directionX * directionX + directionY * directionY);
+        if (distance == 0) return 0;
+
+        var valueToLerp = (isXAxis ? directionX : directionY) / distance;
+        var offset = isXAxis ? spawn.OffsetX : spawn.OffsetY;
+        var desiredValue = GetDisplacement(spawn.SpawnTime + Options.Instance.Processing.ProjectileUpdateInterval) * valueToLerp;
+        var totalDuration = (float)_myBase.Range * (_myBase.Speed / Options.TileHeight);
+        var elapsedTime = Timing.Global.Milliseconds - spawn.SpawnTime;
+        var lerpFactor = Utilities.MathHelper.Clamp(elapsedTime / totalDuration, 0f, 1f);
+
+        // Dynamically calculated lerp factor
+        return (1 - lerpFactor) * offset + lerpFactor * desiredValue;
+    }
+
+    /// <summary>
+    /// Sets the rotation of a projectile based on its spawn information.
+    /// </summary>
+    /// <param name="spawn">The spawn information of the projectile, including its current animation state and position.</param>
+    /// <remarks>
+    /// This method calculates the angle between the projectile's current position and its target,
+    /// converting the angle from radians to degrees and adjusting it by 90 degrees to align with the game's coordinate system.
+    /// The calculated angle is then applied to the projectile's animation state to visually orient the projectile towards its target.
+    /// </remarks>
+    private void SetProjectileRotation(ProjectileSpawns spawn)
+    {
+        var (directionX, directionY) = (GetProjectileOffset(spawn, true), GetProjectileOffset(spawn, false));
+        var angle = (float)(Math.Atan2(directionY, directionX) * (180.0 / Math.PI) + 90);
+        spawn.Anim.SetRotation(angle);
+    }
+
+    /// <summary>
+    /// Checks for collision of the projectile with other entities or map boundaries.
+    /// </summary>
+    public void CheckForCollision()
+    {
+        if (_spawnCount == 0 && _quantity > _myBase.Quantity)
         {
-            int MapWidth = Options.MapWidth;
-            int MapHeight = Options.MapHeight;
-
-            // Determine if the projectile crosses any of the map boundaries.
-            bool crossesLeftBoundary = MathF.Floor(newx) < 0;
-            bool crossesRightBoundary = MathF.Ceiling(newx) > MapWidth - 1;
-            bool crossesTopBoundary = MathF.Floor(newy) < 0;
-            bool crossesBottomBoundary = MathF.Ceiling(newy) > MapHeight - 1;
-
-            // Handle corner cases: crossing boundaries at the corners of the map.
-            if (crossesLeftBoundary && crossesTopBoundary)
-            {
-                // Move to the map diagonally up-left if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap) &&
-                    Maps.MapInstance.TryGet(upMap.Left, out var upLeftMap))
-                {
-                    spawnMap = upLeftMap;
-                    newx = MapWidth - 1;
-                    newy = MapHeight - 1;
-                }
-            }
-            else if (crossesRightBoundary && crossesTopBoundary)
-            {
-                // Move to the map diagonally up-right if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap) &&
-                    Maps.MapInstance.TryGet(upMap.Right, out var upRightMap))
-                {
-                    spawnMap = upRightMap;
-                    newx = 0;
-                    newy = MapHeight - 1;
-                }
-            }
-            else if (crossesLeftBoundary && crossesBottomBoundary)
-            {
-                // Move to the map diagonally down-left if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap) &&
-                    Maps.MapInstance.TryGet(downMap.Left, out var downLeftMap))
-                {
-                    spawnMap = downLeftMap;
-                    newx = MapWidth - 1;
-                    newy = 0;
-                }
-            }
-            else if (crossesRightBoundary && crossesBottomBoundary)
-            {
-                // Move to the map diagonally down-right if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap) &&
-                    Maps.MapInstance.TryGet(downMap.Right, out var downRightMap))
-                {
-                    spawnMap = downRightMap;
-                    newx = 0;
-                    newy = 0;
-                }
-            }
-            // Handle cases where the projectile crosses one boundary.
-            else if (crossesLeftBoundary)
-            {
-                // Move to the map on the left if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Left, out var leftMap))
-                {
-                    spawnMap = leftMap;
-                    newx = MapWidth - 1;
-                }
-            }
-            else if (crossesRightBoundary)
-            {
-                // Move to the map on the right if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Right, out var rightMap))
-                {
-                    spawnMap = rightMap;
-                    newx = 0;
-                }
-            }
-            else if (crossesTopBoundary)
-            {
-                // Move to the map above if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap))
-                {
-                    spawnMap = upMap;
-                    newy = MapHeight - 1;
-                }
-            }
-            else if (crossesBottomBoundary)
-            {
-                // Move to the map below if possible.
-                if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap))
-                {
-                    spawnMap = downMap;
-                    newy = 0;
-                }
-            }
+            Globals.Entities[Id].Dispose();
+            return;
         }
 
-        /// <summary>
-        /// Determines if a projectile spawn has collided with an entity, resource, or map block.
-        /// </summary>
-        /// <param name="i">The index of the projectile spawn in the _spawns array.</param>
-        /// <returns>True if the projectile spawn has collided and should be destroyed; otherwise, false.</returns>
-        private bool Collided(int i)
+        for (var i = 0; i < _spawnedAmount && i < _spawns.Length; i++)
         {
-            var killSpawn = false;
-            IEntity? blockedBy = default;
-            var spawn = _spawns[i];
-
-            // Check if the tile at the projectile's location is blocked.
-            var tileBlocked = Globals.Me.IsTileBlocked(
-                delta: new Point(spawn.X, spawn.Y),
-                z: Z,
-                mapId: spawn.MapId,
-                blockedBy: ref blockedBy,
-                ignoreAliveResources: spawn.ProjectileBase.IgnoreActiveResources,
-                ignoreDeadResources: spawn.ProjectileBase.IgnoreExhaustedResources,
-                ignoreNpcAvoids: true,
-                projectileTrigger: true
-            );
-
-            switch (tileBlocked)
+            var projectileSpawn = _spawns[i];
+            if (projectileSpawn == null || Timing.Global.Milliseconds <= projectileSpawn.TransmissionTimer)
             {
-                case -1: // No collision detected
-                    return killSpawn;
-                case -6: // Collision with an entity other than the owner
-                    if (blockedBy != default && blockedBy.Id != _owner && Globals.Entities.ContainsKey(blockedBy.Id))
-                    {
-                        if (blockedBy is Resource)
-                        {
-                            killSpawn = true;
-                        }
-                    }
-                    break;
-                case -2: // Collision with a map block
-                    if (!spawn.ProjectileBase.IgnoreMapBlocks)
+                continue;
+            }
+
+            if (!Maps.MapInstance.TryGet(projectileSpawn.MapId, out var spawnMap))
+            {
+                continue;
+            }
+
+            float newx = projectileSpawn.X;
+            float newy = projectileSpawn.Y;
+
+            if (_myBase.HomingBehavior || _myBase.DirectShotBehavior)
+            {
+                if (_targetId != Guid.Empty && _targetId != _owner || _lastTargetX != -1 && _lastTargetY != -1 && _lastTargetMapId != Guid.Empty)
+                {
+                    var (deltaX, deltaY) = (GetProjectileOffset(projectileSpawn, true), GetProjectileOffset(projectileSpawn, false));
+                    float distance = MathF.Sqrt(deltaX * deltaX + deltaY * deltaY);
+                    float xFactor = deltaX / distance;
+                    float yFactor = deltaY / distance;
+                    newx += xFactor;
+                    newy += yFactor;
+                }
+            }
+            else
+            {
+                newx += GetRange(projectileSpawn.Dir, 1, true);
+                newy += GetRange(projectileSpawn.Dir, 1, false);
+            }
+
+            AdjustPositionOnMapBoundaries(ref newx, ref newy, ref spawnMap);
+
+            projectileSpawn.X = (int)newx;
+            projectileSpawn.Y = (int)newy;
+            projectileSpawn.MapId = spawnMap.Id;
+            projectileSpawn.Distance++;
+            projectileSpawn.TransmissionTimer = Timing.Global.MillisecondsOffset + (long)(_myBase.Speed / (float)_myBase.Range);
+
+            var killSpawn = Collided(i) || projectileSpawn.Distance >= _myBase.Range ||
+                            newx < 0 || newx >= Options.MapWidth || newy < 0 ||
+                            newy >= Options.MapHeight;
+
+            // Check for map boundaries and remove the spawn if it goes out of bounds.
+            if (killSpawn)
+            {
+                TryRemoveSpawn(i);
+                _spawnCount--;
+
+                continue;
+            }
+
+            // Check for Z-Dimension
+            if (!killSpawn && spawnMap.Attributes != null &&
+                projectileSpawn.X >= 0 && projectileSpawn.Y >= 0 && projectileSpawn.X < spawnMap.Attributes.GetLength(0) &&
+                projectileSpawn.Y < spawnMap.Attributes.GetLength(1))
+            {
+                var attribute = spawnMap.Attributes[projectileSpawn.X, projectileSpawn.Y];
+
+                if (attribute != null && attribute.Type == MapAttribute.ZDimension)
+                {
+                    var zDimensionAttribute = (MapZDimensionAttribute)attribute;
+
+                    // If the Z dimension attribute specifies a blocked level that matches the projectile's current Z level,
+                    // mark the projectile for destruction.
+                    if (zDimensionAttribute.BlockedLevel > 0 && projectileSpawn.Z == zDimensionAttribute.BlockedLevel - 1)
                     {
                         killSpawn = true;
                     }
-                    break;
-                case -3: // Collision with a Z-dimension block
-                    if (!spawn.ProjectileBase.IgnoreZDimension)
+
+                    // If the Z dimension attribute specifies a gateway to another level,
+                    // adjust the projectile's Z level to the specified gateway level.
+                    if (zDimensionAttribute.GatewayTo > 0)
+                    {
+                        projectileSpawn.Z = zDimensionAttribute.GatewayTo - 1;
+                    }
+                }
+            }
+
+            if (killSpawn)
+            {
+                TryRemoveSpawn(i);
+                _spawnCount--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adjusts the position of a projectile on the map boundaries, potentially changing its map instance.
+    /// </summary>
+    /// <param name="newx">The new x-coordinate of the projectile.</param>
+    /// <param name="newy">The new y-coordinate of the projectile.</param>
+    /// <param name="spawnMap">The map instance where the projectile is spawned. This may be updated if the projectile crosses map boundaries.</param>
+    /// <remarks>
+    /// This method checks if the projectile crosses the boundaries of its current map. If it does, it attempts to move the projectile
+    /// to the adjacent map in the direction it crossed the boundary. This includes handling corner cases where the projectile crosses
+    /// at the corners of the map, potentially moving it diagonally to a new map. The new position of the projectile is adjusted to
+    /// visually reflect its entry point into the adjacent map.
+    /// </remarks>
+    private static void AdjustPositionOnMapBoundaries(ref float newx, ref float newy, ref Maps.MapInstance spawnMap)
+    {
+        int MapWidth = Options.MapWidth;
+        int MapHeight = Options.MapHeight;
+
+        // Determine if the projectile crosses any of the map boundaries.
+        bool crossesLeftBoundary = MathF.Floor(newx) < 0;
+        bool crossesRightBoundary = MathF.Ceiling(newx) > MapWidth - 1;
+        bool crossesTopBoundary = MathF.Floor(newy) < 0;
+        bool crossesBottomBoundary = MathF.Ceiling(newy) > MapHeight - 1;
+
+        // Handle corner cases: crossing boundaries at the corners of the map.
+        if (crossesLeftBoundary && crossesTopBoundary)
+        {
+            // Move to the map diagonally up-left if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap) &&
+                Maps.MapInstance.TryGet(upMap.Left, out var upLeftMap))
+            {
+                spawnMap = upLeftMap;
+                newx = MapWidth - 1;
+                newy = MapHeight - 1;
+            }
+        }
+        else if (crossesRightBoundary && crossesTopBoundary)
+        {
+            // Move to the map diagonally up-right if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap) &&
+                Maps.MapInstance.TryGet(upMap.Right, out var upRightMap))
+            {
+                spawnMap = upRightMap;
+                newx = 0;
+                newy = MapHeight - 1;
+            }
+        }
+        else if (crossesLeftBoundary && crossesBottomBoundary)
+        {
+            // Move to the map diagonally down-left if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap) &&
+                Maps.MapInstance.TryGet(downMap.Left, out var downLeftMap))
+            {
+                spawnMap = downLeftMap;
+                newx = MapWidth - 1;
+                newy = 0;
+            }
+        }
+        else if (crossesRightBoundary && crossesBottomBoundary)
+        {
+            // Move to the map diagonally down-right if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap) &&
+                Maps.MapInstance.TryGet(downMap.Right, out var downRightMap))
+            {
+                spawnMap = downRightMap;
+                newx = 0;
+                newy = 0;
+            }
+        }
+        // Handle cases where the projectile crosses one boundary.
+        else if (crossesLeftBoundary)
+        {
+            // Move to the map on the left if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Left, out var leftMap))
+            {
+                spawnMap = leftMap;
+                newx = MapWidth - 1;
+            }
+        }
+        else if (crossesRightBoundary)
+        {
+            // Move to the map on the right if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Right, out var rightMap))
+            {
+                spawnMap = rightMap;
+                newx = 0;
+            }
+        }
+        else if (crossesTopBoundary)
+        {
+            // Move to the map above if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Up, out var upMap))
+            {
+                spawnMap = upMap;
+                newy = MapHeight - 1;
+            }
+        }
+        else if (crossesBottomBoundary)
+        {
+            // Move to the map below if possible.
+            if (Maps.MapInstance.TryGet(spawnMap.Down, out var downMap))
+            {
+                spawnMap = downMap;
+                newy = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines if a projectile spawn has collided with an entity, resource, or map block.
+    /// </summary>
+    /// <param name="i">The index of the projectile spawn in the _spawns array.</param>
+    /// <returns>True if the projectile spawn has collided and should be destroyed; otherwise, false.</returns>
+    private bool Collided(int i)
+    {
+        var killSpawn = false;
+        IEntity? blockedBy = default;
+        var spawn = _spawns[i];
+
+        // Check if the tile at the projectile's location is blocked.
+        var tileBlocked = Globals.Me.IsTileBlocked(
+            delta: new Point(spawn.X, spawn.Y),
+            z: Z,
+            mapId: spawn.MapId,
+            blockedBy: ref blockedBy,
+            ignoreAliveResources: spawn.ProjectileBase.IgnoreActiveResources,
+            ignoreDeadResources: spawn.ProjectileBase.IgnoreExhaustedResources,
+            ignoreNpcAvoids: true,
+            projectileTrigger: true
+        );
+
+        switch (tileBlocked)
+        {
+            case -1: // No collision detected
+                return killSpawn;
+            case -6: // Collision with an entity other than the owner
+                if (blockedBy != default && blockedBy.Id != _owner && Globals.Entities.ContainsKey(blockedBy.Id))
+                {
+                    if (blockedBy is Resource)
                     {
                         killSpawn = true;
                     }
-                    break;
-                case -5: // Collision with an unspecified block type or out of map bounds
+                }
+                break;
+            case -2: // Collision with a map block
+                if (!spawn.ProjectileBase.IgnoreMapBlocks)
+                {
                     killSpawn = true;
-                    break;
-            }
-
-            return killSpawn;
+                }
+                break;
+            case -3: // Collision with a Z-dimension block
+                if (!spawn.ProjectileBase.IgnoreZDimension)
+                {
+                    killSpawn = true;
+                }
+                break;
+            case -5: // Collision with an unspecified block type or out of map bounds
+                killSpawn = true;
+                break;
         }
 
-        /// <summary>
-        /// Rendering all of the individual projectiles from a singular spawn to a map.
-        /// </summary>
-        public override void Draw()
+        return killSpawn;
+    }
+
+    /// <summary>
+    /// Rendering all of the individual projectiles from a singular spawn to a map.
+    /// </summary>
+    public override void Draw()
+    {
+        if (Maps.MapInstance.Get(MapId) == null || !Globals.GridMaps.Contains(MapId))
         {
-            if (Maps.MapInstance.Get(MapId) == null || !Globals.GridMaps.Contains(MapId))
-            {
-                return;
-            }
+            return;
         }
+    }
 
-        public void SpawnDead(int spawnIndex)
+    public void SpawnDead(int spawnIndex)
+    {
+        if (spawnIndex < _spawnedAmount && _spawns[spawnIndex] != null)
         {
-            if (spawnIndex < _spawnedAmount && _spawns[spawnIndex] != null)
-            {
-                TryRemoveSpawn(spawnIndex);
-            }
+            TryRemoveSpawn(spawnIndex);
         }
+    }
 
-        private void TryRemoveSpawn(int spawnIndex)
+    private void TryRemoveSpawn(int spawnIndex)
+    {
+        if (spawnIndex < _spawnedAmount && _spawns[spawnIndex] != null)
         {
-            if (spawnIndex < _spawnedAmount && _spawns[spawnIndex] != null)
-            {
-                _spawns[spawnIndex].Dispose();
-                _spawns[spawnIndex] = null;
-            }
+            _spawns[spawnIndex].Dispose();
+            _spawns[spawnIndex] = null;
         }
-
     }
 
 }

--- a/Intersect.Client/Entities/Projectiles/ProjectileSpawns.cs
+++ b/Intersect.Client/Entities/Projectiles/ProjectileSpawns.cs
@@ -2,76 +2,74 @@
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities.Projectiles
+namespace Intersect.Client.Entities.Projectiles;
+
+
+public partial class ProjectileSpawns
 {
 
-    public partial class ProjectileSpawns
+    public Animation Anim;
+
+    public bool AutoRotate;
+
+    public Direction Dir;
+
+    public int Distance;
+
+    public Guid MapId;
+
+    //Clientside variables
+    public float OffsetX;
+
+    public float OffsetY;
+
+    public ProjectileBase ProjectileBase;
+
+    public Guid SpawnMapId;
+
+    public long SpawnTime = Timing.Global.Milliseconds;
+
+    public int SpawnX;
+
+    public int SpawnY;
+
+    public long TransmissionTimer = Timing.Global.Milliseconds;
+
+    public int X;
+
+    public int Y;
+
+    public int Z;
+
+    public ProjectileSpawns(
+        Direction dir,
+        int x,
+        int y,
+        int z,
+        Guid mapId,
+        AnimationBase animBase,
+        bool autoRotate,
+        ProjectileBase projectileBase,
+        Entity parent
+    )
     {
+        X = x;
+        Y = y;
+        SpawnX = X;
+        SpawnY = Y;
+        Z = z;
+        MapId = mapId;
+        SpawnMapId = MapId;
+        Dir = dir;
+        Anim = new Animation(animBase, true, autoRotate, Z, parent);
+        AutoRotate = autoRotate;
+        ProjectileBase = projectileBase;
+        TransmissionTimer = Timing.Global.Milliseconds + (ProjectileBase.Speed / ProjectileBase.Range);
+    }
 
-        public Animation Anim;
-
-        public bool AutoRotate;
-
-        public Direction Dir;
-
-        public int Distance;
-
-        public Guid MapId;
-
-        //Clientside variables
-        public float OffsetX;
-
-        public float OffsetY;
-
-        public ProjectileBase ProjectileBase;
-
-        public Guid SpawnMapId;
-
-        public long SpawnTime = Timing.Global.Milliseconds;
-
-        public int SpawnX;
-
-        public int SpawnY;
-
-        public long TransmissionTimer = Timing.Global.Milliseconds;
-
-        public int X;
-
-        public int Y;
-
-        public int Z;
-
-        public ProjectileSpawns(
-            Direction dir,
-            int x,
-            int y,
-            int z,
-            Guid mapId,
-            AnimationBase animBase,
-            bool autoRotate,
-            ProjectileBase projectileBase,
-            Entity parent
-        )
-        {
-            X = x;
-            Y = y;
-            SpawnX = X;
-            SpawnY = Y;
-            Z = z;
-            MapId = mapId;
-            SpawnMapId = MapId;
-            Dir = dir;
-            Anim = new Animation(animBase, true, autoRotate, Z, parent);
-            AutoRotate = autoRotate;
-            ProjectileBase = projectileBase;
-            TransmissionTimer = Timing.Global.Milliseconds + (ProjectileBase.Speed / ProjectileBase.Range);
-        }
-
-        public void Dispose()
-        {
-            Anim.DisposeNextDraw();
-        }
-
+    public void Dispose()
+    {
+        Anim.DisposeNextDraw();
     }
 
 }

--- a/Intersect.Client/Entities/Resource.cs
+++ b/Intersect.Client/Entities/Resource.cs
@@ -8,289 +8,287 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class Resource : Entity, IResource
 {
 
-    public partial class Resource : Entity, IResource
+    private bool _waitingForTilesets;
+
+    public ResourceBase BaseResource { get; set; }
+
+    bool IResource.IsDepleted => IsDead;
+
+    public bool IsDead { get; set; }
+
+    FloatRect mDestRectangle = FloatRect.Empty;
+
+    private bool mHasRenderBounds;
+
+    FloatRect mSrcRectangle = FloatRect.Empty;
+
+    public Resource(Guid id, ResourceEntityPacket packet) : base(id, packet, EntityType.Resource)
     {
+        mRenderPriority = 0;
+    }
 
-        private bool _waitingForTilesets;
-
-        public ResourceBase BaseResource { get; set; }
-
-        bool IResource.IsDepleted => IsDead;
-
-        public bool IsDead { get; set; }
-
-        FloatRect mDestRectangle = FloatRect.Empty;
-
-        private bool mHasRenderBounds;
-
-        FloatRect mSrcRectangle = FloatRect.Empty;
-
-        public Resource(Guid id, ResourceEntityPacket packet) : base(id, packet, EntityType.Resource)
+    public override string Sprite
+    {
+        get => mMySprite;
+        set
         {
-            mRenderPriority = 0;
-        }
-
-        public override string Sprite
-        {
-            get => mMySprite;
-            set
+            if (BaseResource == null)
             {
-                if (BaseResource == null)
-                {
-                    return;
-                }
+                return;
+            }
 
-                mMySprite = value;
-                if (IsDead && BaseResource.Exhausted.GraphicFromTileset ||
-                    !IsDead && BaseResource.Initial.GraphicFromTileset)
+            mMySprite = value;
+            if (IsDead && BaseResource.Exhausted.GraphicFromTileset ||
+                !IsDead && BaseResource.Initial.GraphicFromTileset)
+            {
+                if (GameContentManager.Current.TilesetsLoaded)
                 {
-                    if (GameContentManager.Current.TilesetsLoaded)
-                    {
-                        Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Tileset, mMySprite);
-                    }
-                    else
-                    {
-                        _waitingForTilesets = true;
-                    }
+                    Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Tileset, mMySprite);
                 }
                 else
                 {
-                    Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Resource, mMySprite);
+                    _waitingForTilesets = true;
                 }
-
-                mHasRenderBounds = false;
-            }
-        }
-
-        public override void Load(EntityPacket packet)
-        {
-            base.Load(packet);
-            var pkt = (ResourceEntityPacket) packet;
-            IsDead = pkt.IsDead;
-            var baseId = pkt.ResourceId;
-            BaseResource = ResourceBase.Get(baseId);
-            HideName = true;
-            if (IsDead)
-            {
-                Sprite = BaseResource?.Exhausted.Graphic;
             }
             else
             {
-                Sprite = BaseResource?.Initial.Graphic;
+                Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Resource, mMySprite);
+            }
+
+            mHasRenderBounds = false;
+        }
+    }
+
+    public override void Load(EntityPacket packet)
+    {
+        base.Load(packet);
+        var pkt = (ResourceEntityPacket) packet;
+        IsDead = pkt.IsDead;
+        var baseId = pkt.ResourceId;
+        BaseResource = ResourceBase.Get(baseId);
+        HideName = true;
+        if (IsDead)
+        {
+            Sprite = BaseResource?.Exhausted.Graphic;
+        }
+        else
+        {
+            Sprite = BaseResource?.Initial.Graphic;
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (RenderList != null)
+        {
+            RenderList.Remove(this);
+            RenderList = null;
+        }
+
+        ClearAnimations(null);
+        mDisposed = true;
+    }
+
+    public override bool Update()
+    {
+        if (mDisposed)
+        {
+            LatestMap = null;
+
+            return false;
+        }
+        else
+        {
+            var map = Maps.MapInstance.Get(MapId);
+            LatestMap = map;
+            if (map == null || !map.InView())
+            {
+                Globals.EntitiesToDispose.Add(Id);
+
+                return false;
             }
         }
 
-        public override void Dispose()
+        if (!mHasRenderBounds)
+        {
+            CalculateRenderBounds();
+        }
+
+        if (!Graphics.WorldViewport.IntersectsWith(mDestRectangle))
         {
             if (RenderList != null)
             {
                 RenderList.Remove(this);
-                RenderList = null;
             }
 
-            ClearAnimations(null);
-            mDisposed = true;
+            return true;
         }
 
-        public override bool Update()
+        var result = base.Update();
+        if (!result)
         {
-            if (mDisposed)
+            if (RenderList != null)
             {
-                LatestMap = null;
-
-                return false;
+                RenderList.Remove(this);
             }
-            else
-            {
-                var map = Maps.MapInstance.Get(MapId);
-                LatestMap = map;
-                if (map == null || !map.InView())
-                {
-                    Globals.EntitiesToDispose.Add(Id);
-
-                    return false;
-                }
-            }
-
-            if (!mHasRenderBounds)
-            {
-                CalculateRenderBounds();
-            }
-
-            if (!Graphics.WorldViewport.IntersectsWith(mDestRectangle))
-            {
-                if (RenderList != null)
-                {
-                    RenderList.Remove(this);
-                }
-
-                return true;
-            }
-
-            var result = base.Update();
-            if (!result)
-            {
-                if (RenderList != null)
-                {
-                    RenderList.Remove(this);
-                }
-            }
-
-            return result;
         }
 
-        /// <inheritdoc />
-        public override bool CanBeAttacked => !IsDead;
+        return result;
+    }
 
-        public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
+    /// <inheritdoc />
+    public override bool CanBeAttacked => !IsDead;
+
+    public override HashSet<Entity> DetermineRenderOrder(HashSet<Entity> renderList, IMapInstance map)
+    {
+        if (IsDead && !BaseResource.Exhausted.RenderBelowEntities)
         {
-            if (IsDead && !BaseResource.Exhausted.RenderBelowEntities)
-            {
-                return base.DetermineRenderOrder(renderList, map);
-            }
+            return base.DetermineRenderOrder(renderList, map);
+        }
 
-            if (!IsDead && !BaseResource.Initial.RenderBelowEntities)
-            {
-                return base.DetermineRenderOrder(renderList, map);
-            }
+        if (!IsDead && !BaseResource.Initial.RenderBelowEntities)
+        {
+            return base.DetermineRenderOrder(renderList, map);
+        }
 
-            //Otherwise we are alive or dead and we want to render below players/npcs
-            if (renderList != null)
-            {
-                renderList.Remove(this);
-            }
+        //Otherwise we are alive or dead and we want to render below players/npcs
+        if (renderList != null)
+        {
+            renderList.Remove(this);
+        }
 
-            if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
-            {
-                return null;
-            }
+        if (map == null || Globals.Me == null || Globals.Me.MapInstance == null)
+        {
+            return null;
+        }
 
-            var gridX = Globals.Me.MapInstance.GridX;
-            var gridY = Globals.Me.MapInstance.GridY;
-            for (var x = gridX - 1; x <= gridX + 1; x++)
+        var gridX = Globals.Me.MapInstance.GridX;
+        var gridY = Globals.Me.MapInstance.GridY;
+        for (var x = gridX - 1; x <= gridX + 1; x++)
+        {
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
+                if (x >= 0 &&
+                    x < Globals.MapGridWidth &&
+                    y >= 0 &&
+                    y < Globals.MapGridHeight &&
+                    Globals.MapGrid[x, y] != Guid.Empty)
                 {
-                    if (x >= 0 &&
-                        x < Globals.MapGridWidth &&
-                        y >= 0 &&
-                        y < Globals.MapGridHeight &&
-                        Globals.MapGrid[x, y] != Guid.Empty)
+                    if (Globals.MapGrid[x, y] == MapId)
                     {
-                        if (Globals.MapGrid[x, y] == MapId)
+                        var priority = mRenderPriority;
+                        if (Z != 0)
                         {
-                            var priority = mRenderPriority;
-                            if (Z != 0)
-                            {
-                                priority += 3;
-                            }
-
-                            HashSet<Entity> renderSet;
-
-                            if (y == gridY - 1)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Y];
-                            }
-                            else if (y == gridY)
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
-                            }
-                            else
-                            {
-                                renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
-                            }
-
-                            renderSet.Add(this);
-                            renderList = renderSet;
-
-                            return renderList;
-
+                            priority += 3;
                         }
+
+                        HashSet<Entity> renderSet;
+
+                        if (y == gridY - 1)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Y];
+                        }
+                        else if (y == gridY)
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight + Y];
+                        }
+                        else
+                        {
+                            renderSet = Graphics.RenderingEntities[priority, Options.MapHeight * 2 + Y];
+                        }
+
+                        renderSet.Add(this);
+                        renderList = renderSet;
+
+                        return renderList;
+
                     }
                 }
             }
-
-            return renderList;
         }
 
-        private void CalculateRenderBounds()
+        return renderList;
+    }
+
+    private void CalculateRenderBounds()
+    {
+        var map = MapInstance;
+        if (map == null)
         {
-            var map = MapInstance;
-            if (map == null)
-            {
-                return;
-            }
-
-            if (_waitingForTilesets && !GameContentManager.Current.TilesetsLoaded)
-            {
-                return;
-            }
-
-            if (_waitingForTilesets && GameContentManager.Current.TilesetsLoaded)
-            {
-                _waitingForTilesets = false;
-                Sprite = Sprite;
-            }
-
-            if (Texture != null)
-            {
-                mSrcRectangle.X = 0;
-                mSrcRectangle.Y = 0;
-                if (IsDead && BaseResource.Exhausted.GraphicFromTileset)
-                {
-                    mSrcRectangle.X = BaseResource.Exhausted.X * Options.TileWidth;
-                    mSrcRectangle.Y = BaseResource.Exhausted.Y * Options.TileHeight;
-                    mSrcRectangle.Width = (BaseResource.Exhausted.Width + 1) * Options.TileWidth;
-                    mSrcRectangle.Height = (BaseResource.Exhausted.Height + 1) * Options.TileHeight;
-                }
-                else if (!IsDead && BaseResource.Initial.GraphicFromTileset)
-                {
-                    mSrcRectangle.X = BaseResource.Initial.X * Options.TileWidth;
-                    mSrcRectangle.Y = BaseResource.Initial.Y * Options.TileHeight;
-                    mSrcRectangle.Width = (BaseResource.Initial.Width + 1) * Options.TileWidth;
-                    mSrcRectangle.Height = (BaseResource.Initial.Height + 1) * Options.TileHeight;
-                }
-                else
-                {
-                    mSrcRectangle.Width = Texture.GetWidth();
-                    mSrcRectangle.Height = Texture.GetHeight();
-                }
-
-                mDestRectangle.Width = mSrcRectangle.Width;
-                mDestRectangle.Height = mSrcRectangle.Height;
-                mDestRectangle.Y = (int) (map.Y + Y * Options.TileHeight + OffsetY);
-                mDestRectangle.X = (int) (map.X + X * Options.TileWidth + OffsetX);
-                if (mSrcRectangle.Height > Options.TileHeight)
-                {
-                    mDestRectangle.Y -= mSrcRectangle.Height - Options.TileHeight;
-                }
-
-                if (mSrcRectangle.Width > Options.TileWidth)
-                {
-                    mDestRectangle.X -= (mSrcRectangle.Width - Options.TileWidth) / 2;
-                }
-
-                mHasRenderBounds = true;
-            }
+            return;
         }
 
-        //Rendering Resources
-        public override void Draw()
+        if (_waitingForTilesets && !GameContentManager.Current.TilesetsLoaded)
         {
-            if (MapInstance == null)
-            {
-                return;
-            }
-
-            if (Texture != null)
-            {
-                Graphics.DrawGameTexture(Texture, mSrcRectangle, mDestRectangle, Intersect.Color.White);
-            }
+            return;
         }
 
+        if (_waitingForTilesets && GameContentManager.Current.TilesetsLoaded)
+        {
+            _waitingForTilesets = false;
+            Sprite = Sprite;
+        }
+
+        if (Texture != null)
+        {
+            mSrcRectangle.X = 0;
+            mSrcRectangle.Y = 0;
+            if (IsDead && BaseResource.Exhausted.GraphicFromTileset)
+            {
+                mSrcRectangle.X = BaseResource.Exhausted.X * Options.TileWidth;
+                mSrcRectangle.Y = BaseResource.Exhausted.Y * Options.TileHeight;
+                mSrcRectangle.Width = (BaseResource.Exhausted.Width + 1) * Options.TileWidth;
+                mSrcRectangle.Height = (BaseResource.Exhausted.Height + 1) * Options.TileHeight;
+            }
+            else if (!IsDead && BaseResource.Initial.GraphicFromTileset)
+            {
+                mSrcRectangle.X = BaseResource.Initial.X * Options.TileWidth;
+                mSrcRectangle.Y = BaseResource.Initial.Y * Options.TileHeight;
+                mSrcRectangle.Width = (BaseResource.Initial.Width + 1) * Options.TileWidth;
+                mSrcRectangle.Height = (BaseResource.Initial.Height + 1) * Options.TileHeight;
+            }
+            else
+            {
+                mSrcRectangle.Width = Texture.GetWidth();
+                mSrcRectangle.Height = Texture.GetHeight();
+            }
+
+            mDestRectangle.Width = mSrcRectangle.Width;
+            mDestRectangle.Height = mSrcRectangle.Height;
+            mDestRectangle.Y = (int) (map.Y + Y * Options.TileHeight + OffsetY);
+            mDestRectangle.X = (int) (map.X + X * Options.TileWidth + OffsetX);
+            if (mSrcRectangle.Height > Options.TileHeight)
+            {
+                mDestRectangle.Y -= mSrcRectangle.Height - Options.TileHeight;
+            }
+
+            if (mSrcRectangle.Width > Options.TileWidth)
+            {
+                mDestRectangle.X -= (mSrcRectangle.Width - Options.TileWidth) / 2;
+            }
+
+            mHasRenderBounds = true;
+        }
+    }
+
+    //Rendering Resources
+    public override void Draw()
+    {
+        if (MapInstance == null)
+        {
+            return;
+        }
+
+        if (Texture != null)
+        {
+            Graphics.DrawGameTexture(Texture, mSrcRectangle, mDestRectangle, Intersect.Color.White);
+        }
     }
 
 }

--- a/Intersect.Client/Entities/Status.cs
+++ b/Intersect.Client/Entities/Status.cs
@@ -2,40 +2,38 @@
 using Intersect.Enums;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Entities
+namespace Intersect.Client.Entities;
+
+
+public partial class Status : IStatus
 {
 
-    public partial class Status : IStatus
+    public string Data { get; set; } = "";
+
+    public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    public Guid SpellId { get; set; }
+
+    public long TimeRecevied { get; set; } = 0;
+
+    public long TimeRemaining { get; set; } = 0;
+
+    public long TotalDuration { get; set; } = 1;
+
+    public SpellEffect Type { get; set; }
+
+    public Status(Guid spellId, SpellEffect type, string data, long timeRemaining, long totalDuration)
     {
-
-        public string Data { get; set; } = "";
-
-        public long[] Shield { get; set; } = new long[Enum.GetValues<Vital>().Length];
-
-        public Guid SpellId { get; set; }
-
-        public long TimeRecevied { get; set; } = 0;
-
-        public long TimeRemaining { get; set; } = 0;
-
-        public long TotalDuration { get; set; } = 1;
-
-        public SpellEffect Type { get; set; }
-
-        public Status(Guid spellId, SpellEffect type, string data, long timeRemaining, long totalDuration)
-        {
-            SpellId = spellId;
-            Type = type;
-            Data = data;
-            TimeRemaining = timeRemaining;
-            TotalDuration = totalDuration;
-            TimeRecevied = Timing.Global.Milliseconds;
-        }
-
-        public bool IsActive => RemainingMs > 0;
-
-        public long RemainingMs => TimeRemaining - (Timing.Global.Milliseconds - TimeRecevied);
-
+        SpellId = spellId;
+        Type = type;
+        Data = data;
+        TimeRemaining = timeRemaining;
+        TotalDuration = totalDuration;
+        TimeRecevied = Timing.Global.Milliseconds;
     }
+
+    public bool IsActive => RemainingMs > 0;
+
+    public long RemainingMs => TimeRemaining - (Timing.Global.Milliseconds - TimeRecevied);
 
 }

--- a/Intersect.Client/General/Globals.cs
+++ b/Intersect.Client/General/Globals.cs
@@ -13,232 +13,230 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.General
+namespace Intersect.Client.General;
+
+
+public static partial class Globals
 {
 
-    public static partial class Globals
+    //Only need 1 table, and that is the one we see at a given moment in time.
+    public static CraftingTableBase ActiveCraftingTable;
+
+    public static int AnimFrame = 0;
+
+    //Bag
+    public static Item[] Bag = null;
+
+    //Bank
+    public static Item[] Bank;
+    public static bool GuildBank;
+    public static int BankSlots;
+
+    public static bool ConnectionLost;
+
+    /// <summary>
+    /// This is used to prevent the client from showing unnecessary disconnect messages
+    /// </summary>
+    public static bool SoftLogout;
+
+    //Game Systems
+    public static GameContentManager ContentManager;
+
+    public static int CurrentMap = -1;
+
+    public static GameDatabase Database;
+
+    //Entities and stuff
+    //public static List<Entity> Entities = new List<Entity>();
+    public static Dictionary<Guid, Entity> Entities = new Dictionary<Guid, Entity>();
+
+    public static List<Guid> EntitiesToDispose = new List<Guid>();
+
+    //Control Objects
+    public static List<Dialog> EventDialogs = new List<Dialog>();
+
+    public static Dictionary<Guid, Guid> EventHolds = new Dictionary<Guid, Guid>();
+
+    //Game Lock
+    public static object GameLock = new object();
+
+    //Game Shop
+    //Only need 1 shop, and that is the one we see at a given moment in time.
+    public static ShopBase GameShop;
+
+    //Crucial game variables
+
+    internal static List<IClientLifecycleHelper> ClientLifecycleHelpers { get; } =
+        new List<IClientLifecycleHelper>();
+
+    internal static void OnLifecycleChangeState()
     {
+        ClientLifecycleHelpers.ForEach(
+            clientLifecycleHelper => clientLifecycleHelper?.OnLifecycleChangeState(GameState)
+        );
+    }
 
-        //Only need 1 table, and that is the one we see at a given moment in time.
-        public static CraftingTableBase ActiveCraftingTable;
+    internal static void OnGameUpdate(TimeSpan deltaTime)
+    {
+        // Gather all known entities before passing them on to the plugins!
+        // The global entity list is incomplete and lacks events.
+        var knownEntities = new Dictionary<Guid, IEntity>();
 
-        public static int AnimFrame = 0;
-
-        //Bag
-        public static Item[] Bag = null;
-
-        //Bank
-        public static Item[] Bank;
-        public static bool GuildBank;
-        public static int BankSlots;
-
-        public static bool ConnectionLost;
-
-        /// <summary>
-        /// This is used to prevent the client from showing unnecessary disconnect messages
-        /// </summary>
-        public static bool SoftLogout;
-
-        //Game Systems
-        public static GameContentManager ContentManager;
-
-        public static int CurrentMap = -1;
-
-        public static GameDatabase Database;
-
-        //Entities and stuff
-        //public static List<Entity> Entities = new List<Entity>();
-        public static Dictionary<Guid, Entity> Entities = new Dictionary<Guid, Entity>();
-
-        public static List<Guid> EntitiesToDispose = new List<Guid>();
-
-        //Control Objects
-        public static List<Dialog> EventDialogs = new List<Dialog>();
-
-        public static Dictionary<Guid, Guid> EventHolds = new Dictionary<Guid, Guid>();
-
-        //Game Lock
-        public static object GameLock = new object();
-
-        //Game Shop
-        //Only need 1 shop, and that is the one we see at a given moment in time.
-        public static ShopBase GameShop;
-
-        //Crucial game variables
-
-        internal static List<IClientLifecycleHelper> ClientLifecycleHelpers { get; } =
-            new List<IClientLifecycleHelper>();
-
-        internal static void OnLifecycleChangeState()
+        if (Entities != null)
         {
-            ClientLifecycleHelpers.ForEach(
-                clientLifecycleHelper => clientLifecycleHelper?.OnLifecycleChangeState(GameState)
-            );
-        }
-
-        internal static void OnGameUpdate(TimeSpan deltaTime)
-        {
-            // Gather all known entities before passing them on to the plugins!
-            // The global entity list is incomplete and lacks events.
-            var knownEntities = new Dictionary<Guid, IEntity>();
-
-            if (Entities != null)
+            foreach (var en in Entities)
             {
-                foreach (var en in Entities)
+                if (!knownEntities.ContainsKey(en.Key))
                 {
-                    if (!knownEntities.ContainsKey(en.Key))
-                    {
-                        knownEntities.Add(en.Key, en.Value);
-                    }
+                    knownEntities.Add(en.Key, en.Value);
                 }
             }
-            
-            if (MapGrid != null)
+        }
+        
+        if (MapGrid != null)
+        {
+            for (var x = 0; x < MapGridWidth; x++)
             {
-                for (var x = 0; x < MapGridWidth; x++)
+                for (var y = 0; y < MapGridHeight; y++)
                 {
-                    for (var y = 0; y < MapGridHeight; y++)
+                    var map = MapInstance.Get(MapGrid[x, y]);
+                    if (map != null)
                     {
-                        var map = MapInstance.Get(MapGrid[x, y]);
-                        if (map != null)
+                        foreach (var en in map.LocalEntities)
                         {
-                            foreach (var en in map.LocalEntities)
+                            if (!knownEntities.ContainsKey(en.Key))
                             {
-                                if (!knownEntities.ContainsKey(en.Key))
-                                {
-                                    knownEntities.Add(en.Key, en.Value);
-                                }
+                                knownEntities.Add(en.Key, en.Value);
                             }
                         }
                     }
                 }
             }
-            
-            ClientLifecycleHelpers.ForEach(
-                clientLifecycleHelper => clientLifecycleHelper?.OnGameUpdate(GameState, Globals.Me, knownEntities, deltaTime)
-            );
         }
+        
+        ClientLifecycleHelpers.ForEach(
+            clientLifecycleHelper => clientLifecycleHelper?.OnGameUpdate(GameState, Globals.Me, knownEntities, deltaTime)
+        );
+    }
 
-        internal static void OnGameDraw(DrawStates state, TimeSpan deltaTime)
+    internal static void OnGameDraw(DrawStates state, TimeSpan deltaTime)
+    {
+        ClientLifecycleHelpers.ForEach(
+           clientLifecycleHelper => clientLifecycleHelper?.OnGameDraw(state, deltaTime)
+       );
+    }
+
+    internal static void OnGameDraw(DrawStates state, IEntity entity, TimeSpan deltaTime)
+    {
+        ClientLifecycleHelpers.ForEach(
+           clientLifecycleHelper => clientLifecycleHelper?.OnGameDraw(state, entity, deltaTime)
+       );
+    }
+
+    private static GameStates mGameState = GameStates.Intro;
+
+    /// <see cref="GameStates" />
+    public static GameStates GameState
+    {
+        get => mGameState;
+        set
         {
-            ClientLifecycleHelpers.ForEach(
-               clientLifecycleHelper => clientLifecycleHelper?.OnGameDraw(state, deltaTime)
-           );
+            mGameState = value;
+            OnLifecycleChangeState();
         }
+    }
 
-        internal static void OnGameDraw(DrawStates state, IEntity entity, TimeSpan deltaTime)
+    public static List<Guid> GridMaps = new List<Guid>();
+
+    public static bool HasGameData = false;
+
+    public static bool InBag = false;
+
+    public static bool InBank = false;
+
+    //Crafting station
+    public static bool InCraft = false;
+
+    public static bool InShop => GameShop != null;
+
+    public static bool InTrade = false;
+
+    public static bool CanCloseInventory => !(InBag || InBank || InCraft || InShop || InTrade);
+
+    public static GameInput InputManager;
+
+    public static bool IntroComing = true;
+
+    public static long IntroDelay = 2000;
+
+    //Engine Progression
+    public static int IntroIndex = 0;
+
+    public static long IntroStartTime = -1;
+
+    public static bool IsRunning = true;
+
+    public static bool JoiningGame = false;
+
+    public static bool LoggedIn = false;
+
+    //Map/Chunk Array
+    public static Guid[,] MapGrid;
+
+    public static long MapGridHeight;
+
+    public static long MapGridWidth;
+
+    //Local player information
+    public static Player Me;
+
+    public static bool MoveRouteActive = false;
+
+    public static bool NeedsMaps = true;
+
+    //Event Guid and the Map its associated with
+    public static Dictionary<Guid, Dictionary<Guid, EventEntityPacket>> PendingEvents =
+        new Dictionary<Guid, Dictionary<Guid, EventEntityPacket>>();
+
+    //Event Show Pictures
+    public static ShowPicturePacket Picture;
+
+    public static List<Guid> QuestOffers = new List<Guid>();
+
+    public static Random Random = new Random();
+
+    public static GameSystem System;
+
+    //Trading (Only 2 people can trade at once)
+    public static Item[,] Trade;
+
+    //Scene management
+    private static bool _waitingOnServer;
+
+    public static bool WaitingOnServer
+    {
+        get => _waitingOnServer;
+        set => _waitingOnServer = value;
+    }
+
+    public static Entity GetEntity(Guid id, EntityType type)
+    {
+        if (Entities.ContainsKey(id))
         {
-            ClientLifecycleHelpers.ForEach(
-               clientLifecycleHelper => clientLifecycleHelper?.OnGameDraw(state, entity, deltaTime)
-           );
-        }
+            var entity = Entities[id];
 
-        private static GameStates mGameState = GameStates.Intro;
-
-        /// <see cref="GameStates" />
-        public static GameStates GameState
-        {
-            get => mGameState;
-            set
+            if (!entity.IsDisposed() && entity.Type == type)
             {
-                mGameState = value;
-                OnLifecycleChangeState();
-            }
-        }
+                EntitiesToDispose.Remove(entity.Id);
 
-        public static List<Guid> GridMaps = new List<Guid>();
-
-        public static bool HasGameData = false;
-
-        public static bool InBag = false;
-
-        public static bool InBank = false;
-
-        //Crafting station
-        public static bool InCraft = false;
-
-        public static bool InShop => GameShop != null;
-
-        public static bool InTrade = false;
-
-        public static bool CanCloseInventory => !(InBag || InBank || InCraft || InShop || InTrade);
-
-        public static GameInput InputManager;
-
-        public static bool IntroComing = true;
-
-        public static long IntroDelay = 2000;
-
-        //Engine Progression
-        public static int IntroIndex = 0;
-
-        public static long IntroStartTime = -1;
-
-        public static bool IsRunning = true;
-
-        public static bool JoiningGame = false;
-
-        public static bool LoggedIn = false;
-
-        //Map/Chunk Array
-        public static Guid[,] MapGrid;
-
-        public static long MapGridHeight;
-
-        public static long MapGridWidth;
-
-        //Local player information
-        public static Player Me;
-
-        public static bool MoveRouteActive = false;
-
-        public static bool NeedsMaps = true;
-
-        //Event Guid and the Map its associated with
-        public static Dictionary<Guid, Dictionary<Guid, EventEntityPacket>> PendingEvents =
-            new Dictionary<Guid, Dictionary<Guid, EventEntityPacket>>();
-
-        //Event Show Pictures
-        public static ShowPicturePacket Picture;
-
-        public static List<Guid> QuestOffers = new List<Guid>();
-
-        public static Random Random = new Random();
-
-        public static GameSystem System;
-
-        //Trading (Only 2 people can trade at once)
-        public static Item[,] Trade;
-
-        //Scene management
-        private static bool _waitingOnServer;
-
-        public static bool WaitingOnServer
-        {
-            get => _waitingOnServer;
-            set => _waitingOnServer = value;
-        }
-
-        public static Entity GetEntity(Guid id, EntityType type)
-        {
-            if (Entities.ContainsKey(id))
-            {
-                var entity = Entities[id];
-
-                if (!entity.IsDisposed() && entity.Type == type)
-                {
-                    EntitiesToDispose.Remove(entity.Id);
-
-                    return entity;
-                }
-
-                entity.Dispose();
-                Entities.Remove(id);
+                return entity;
             }
 
-            return default;
+            entity.Dispose();
+            Entities.Remove(id);
         }
 
+        return default;
     }
 
 }

--- a/Intersect.Client/General/Time.cs
+++ b/Intersect.Client/General/Time.cs
@@ -1,89 +1,87 @@
 ﻿using Intersect.Utilities;
 
-namespace Intersect.Client.General
+namespace Intersect.Client.General;
+
+
+public static partial class Time
 {
 
-    public static partial class Time
+    private static long sColorUpdate;
+
+    private static ColorF sCurrentColor = ColorF.White;
+
+    private static float sRate = 1f;
+
+    private static DateTime sServerTime = DateTime.Now;
+
+    private static Color sTargetColor = Color.Transparent;
+
+    private static long sUpdateTime;
+
+    public static void LoadTime(DateTime timeUpdate, Color clr, float rate)
     {
+        sServerTime = timeUpdate;
+        sTargetColor = clr;
+        sUpdateTime = 0;
+        sRate = rate;
+    }
 
-        private static long sColorUpdate;
-
-        private static ColorF sCurrentColor = ColorF.White;
-
-        private static float sRate = 1f;
-
-        private static DateTime sServerTime = DateTime.Now;
-
-        private static Color sTargetColor = Color.Transparent;
-
-        private static long sUpdateTime;
-
-        public static void LoadTime(DateTime timeUpdate, Color clr, float rate)
+    public static void Update()
+    {
+        if (sUpdateTime < Timing.Global.Milliseconds)
         {
-            sServerTime = timeUpdate;
-            sTargetColor = clr;
-            sUpdateTime = 0;
-            sRate = rate;
+            var ts = new TimeSpan(0, 0, 0, 0, (int) (1000 * sRate));
+            sServerTime = sServerTime.Add(ts);
+            sUpdateTime = Timing.Global.Milliseconds + 1000;
         }
 
-        public static void Update()
+        float ecTime = Timing.Global.MillisecondsUtc - sColorUpdate;
+        var valChange = 255 * ecTime / 10000f;
+        sCurrentColor.A = LerpVal(sCurrentColor.A, sTargetColor.A, valChange);
+        sCurrentColor.R = LerpVal(sCurrentColor.R, sTargetColor.R, valChange);
+        sCurrentColor.G = LerpVal(sCurrentColor.G, sTargetColor.G, valChange);
+        sCurrentColor.B = LerpVal(sCurrentColor.B, sTargetColor.B, valChange);
+
+        sColorUpdate = Timing.Global.MillisecondsUtc;
+    }
+
+    private static float LerpVal(float val, float target, float amt)
+    {
+        if (val < target)
         {
-            if (sUpdateTime < Timing.Global.Milliseconds)
+            if (val + amt > target)
             {
-                var ts = new TimeSpan(0, 0, 0, 0, (int) (1000 * sRate));
-                sServerTime = sServerTime.Add(ts);
-                sUpdateTime = Timing.Global.Milliseconds + 1000;
+                val = target;
             }
-
-            float ecTime = Timing.Global.MillisecondsUtc - sColorUpdate;
-            var valChange = 255 * ecTime / 10000f;
-            sCurrentColor.A = LerpVal(sCurrentColor.A, sTargetColor.A, valChange);
-            sCurrentColor.R = LerpVal(sCurrentColor.R, sTargetColor.R, valChange);
-            sCurrentColor.G = LerpVal(sCurrentColor.G, sTargetColor.G, valChange);
-            sCurrentColor.B = LerpVal(sCurrentColor.B, sTargetColor.B, valChange);
-
-            sColorUpdate = Timing.Global.MillisecondsUtc;
-        }
-
-        private static float LerpVal(float val, float target, float amt)
-        {
-            if (val < target)
+            else
             {
-                if (val + amt > target)
-                {
-                    val = target;
-                }
-                else
-                {
-                    val += amt;
-                }
+                val += amt;
             }
+        }
 
-            if (val > target)
+        if (val > target)
+        {
+            if (val - amt < target)
             {
-                if (val - amt < target)
-                {
-                    val = target;
-                }
-                else
-                {
-                    val -= amt;
-                }
+                val = target;
             }
-
-            return val;
+            else
+            {
+                val -= amt;
+            }
         }
 
-        public static string GetTime()
-        {
-            return sServerTime.ToString("h:mm:ss tt");
-        }
+        return val;
+    }
 
-        public static ColorF GetTintColor()
-        {
-            return sCurrentColor;
-        }
+    public static string GetTime()
+    {
+        return sServerTime.ToString("h:mm:ss tt");
+    }
 
+    public static ColorF GetTintColor()
+    {
+        return sCurrentColor;
     }
 
 }

--- a/Intersect.Client/Interface/Debugging/DebugWindow.cs
+++ b/Intersect.Client/Interface/Debugging/DebugWindow.cs
@@ -10,282 +10,281 @@ using Intersect.Extensions;
 
 using static Intersect.Client.Framework.File_Management.GameContentManager;
 
-namespace Intersect.Client.Interface.Debugging
+namespace Intersect.Client.Interface.Debugging;
+
+internal sealed partial class DebugWindow : Window
 {
-    internal sealed partial class DebugWindow : Window
+    private readonly List<IDisposable> _disposables;
+    private bool _wasParentDrawDebugOutlinesEnabled;
+    private bool _drawDebugOutlinesEnabled;
+
+    public DebugWindow(Base parent) : base(parent, Strings.Debug.Title, false, nameof(DebugWindow))
     {
-        private readonly List<IDisposable> _disposables;
-        private bool _wasParentDrawDebugOutlinesEnabled;
-        private bool _drawDebugOutlinesEnabled;
+        _disposables = new List<IDisposable>();
 
-        public DebugWindow(Base parent) : base(parent, Strings.Debug.Title, false, nameof(DebugWindow))
+        DisableResizing();
+
+        IsHidden = true;
+    }
+
+    private LabeledCheckBox CheckboxDrawDebugOutlines { get; set; }
+
+    private LabeledCheckBox CheckboxEnableLayoutHotReloading { get; set; }
+
+    private Button ButtonShutdownServer { get; set; }
+
+    private Button ButtonShutdownServerAndExit { get; set; }
+
+    private Table TableDebugStats { get; set; }
+
+    protected override void EnsureInitialized()
+    {
+        CheckboxDrawDebugOutlines = CreateCheckboxDrawDebugOutlines();
+        CheckboxEnableLayoutHotReloading = CreateCheckboxEnableLayoutHotReloading();
+        ButtonShutdownServer = CreateButtonShutdownServer();
+        ButtonShutdownServerAndExit = CreateButtonShutdownServerAndExit();
+        TableDebugStats = CreateTableDebugStats();
+
+        LoadJsonUi(UI.Debug, Graphics.Renderer.GetResolutionString());
+    }
+
+    protected override void OnAttached(Base parent)
+    {
+        base.OnAttached(parent);
+
+        Root.DrawDebugOutlines = _drawDebugOutlinesEnabled;
+    }
+
+    protected override void OnAttaching(Base newParent)
+    {
+        base.OnAttaching(newParent);
+        _wasParentDrawDebugOutlinesEnabled = newParent.DrawDebugOutlines;
+    }
+
+    protected override void OnDetached()
+    {
+        base.OnDetached();
+    }
+
+    protected override void OnDetaching(Base oldParent)
+    {
+        base.OnDetaching(oldParent);
+        oldParent.DrawDebugOutlines = _wasParentDrawDebugOutlinesEnabled;
+    }
+
+    public override void Dispose()
+    {
+        foreach (var disposable in _disposables)
         {
-            _disposables = new List<IDisposable>();
-
-            DisableResizing();
-
-            IsHidden = true;
+            disposable?.Dispose();
         }
 
-        private LabeledCheckBox CheckboxDrawDebugOutlines { get; set; }
+        base.Dispose();
+    }
 
-        private LabeledCheckBox CheckboxEnableLayoutHotReloading { get; set; }
-
-        private Button ButtonShutdownServer { get; set; }
-
-        private Button ButtonShutdownServerAndExit { get; set; }
-
-        private Table TableDebugStats { get; set; }
-
-        protected override void EnsureInitialized()
+    private LabeledCheckBox CreateCheckboxDrawDebugOutlines()
+    {
+        var checkbox = new LabeledCheckBox(this, nameof(CheckboxDrawDebugOutlines))
         {
-            CheckboxDrawDebugOutlines = CreateCheckboxDrawDebugOutlines();
-            CheckboxEnableLayoutHotReloading = CreateCheckboxEnableLayoutHotReloading();
-            ButtonShutdownServer = CreateButtonShutdownServer();
-            ButtonShutdownServerAndExit = CreateButtonShutdownServerAndExit();
-            TableDebugStats = CreateTableDebugStats();
+            IsChecked = Root?.DrawDebugOutlines ?? false,
+            Text = Strings.Debug.DrawDebugOutlines,
+        };
 
-            LoadJsonUi(UI.Debug, Graphics.Renderer.GetResolutionString());
-        }
-
-        protected override void OnAttached(Base parent)
+        checkbox.CheckChanged += (sender, args) =>
         {
-            base.OnAttached(parent);
-
-            Root.DrawDebugOutlines = _drawDebugOutlinesEnabled;
-        }
-
-        protected override void OnAttaching(Base newParent)
-        {
-            base.OnAttaching(newParent);
-            _wasParentDrawDebugOutlinesEnabled = newParent.DrawDebugOutlines;
-        }
-
-        protected override void OnDetached()
-        {
-            base.OnDetached();
-        }
-
-        protected override void OnDetaching(Base oldParent)
-        {
-            base.OnDetaching(oldParent);
-            oldParent.DrawDebugOutlines = _wasParentDrawDebugOutlinesEnabled;
-        }
-
-        public override void Dispose()
-        {
-            foreach (var disposable in _disposables)
+            _drawDebugOutlinesEnabled = checkbox.IsChecked;
+            if (Root != default)
             {
-                disposable?.Dispose();
+                Root.DrawDebugOutlines = _drawDebugOutlinesEnabled;
+            }
+        };
+
+        return checkbox;
+    }
+
+    private LabeledCheckBox CreateCheckboxEnableLayoutHotReloading()
+    {
+        var checkbox = new LabeledCheckBox(this, nameof(CheckboxEnableLayoutHotReloading))
+        {
+            IsChecked = Globals.ContentManager.ContentWatcher.Enabled,
+            Text = Strings.Debug.EnableLayoutHotReloading,
+        };
+
+        checkbox.CheckChanged += (sender, args) =>
+        {
+            Globals.ContentManager.ContentWatcher.Enabled = checkbox.IsChecked;
+        };
+
+        checkbox.SetToolTipText(Strings.Internals.ExperimentalFeatureTooltip);
+        checkbox.ToolTipFont = Skin.DefaultFont;
+
+        return checkbox;
+    }
+
+    private Button CreateButtonShutdownServer()
+    {
+        var button = new Button(this, nameof(ButtonShutdownServer))
+        {
+            IsHidden = true,
+            Text = Strings.Debug.ShutdownServer,
+        };
+
+        button.Clicked += (sender, args) =>
+        {
+            // TODO: Implement
+        };
+
+        return button;
+    }
+
+    private Button CreateButtonShutdownServerAndExit()
+    {
+        var button = new Button(this, nameof(ButtonShutdownServerAndExit))
+        {
+            IsHidden = true,
+            Text = Strings.Debug.ShutdownServerAndExit,
+        };
+
+        button.Clicked += (sender, args) =>
+        {
+            // TODO: Implement
+        };
+
+        return button;
+    }
+
+    private Table CreateTableDebugStats()
+    {
+        var table = new Table(this, nameof(TableDebugStats))
+        {
+            ColumnCount = 2,
+        };
+
+        var fpsProvider = new ValueTableCellDataProvider<int>(() => Graphics.Renderer.GetFps());
+        table.AddRow(Strings.Debug.Fps).Listen(fpsProvider, 1);
+        _disposables.Add(fpsProvider.Generator.Start());
+
+        var pingProvider = new ValueTableCellDataProvider<int>(() => Networking.Network.Ping);
+        table.AddRow(Strings.Debug.Ping).Listen(pingProvider, 1);
+        _disposables.Add(pingProvider.Generator.Start());
+
+        var drawCallsProvider = new ValueTableCellDataProvider<int>(() => Graphics.DrawCalls);
+        table.AddRow(Strings.Debug.Draws).Listen(drawCallsProvider, 1);
+        _disposables.Add(drawCallsProvider.Generator.Start());
+
+        var mapNameProvider = new ValueTableCellDataProvider<string>(() =>
+        {
+            var mapId = Globals.Me?.MapId ?? default;
+
+            if (mapId == default)
+            {
+                return Strings.Internals.NotApplicable;
             }
 
-            base.Dispose();
-        }
+            return MapInstance.Get(mapId)?.Name ?? Strings.Internals.NotApplicable;
+        });
+        table.AddRow(Strings.Debug.Map).Listen(mapNameProvider, 1);
+        _disposables.Add(mapNameProvider.Generator.Start());
 
-        private LabeledCheckBox CreateCheckboxDrawDebugOutlines()
+        var coordinateXProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.X ?? -1);
+        table.AddRow(Strings.Internals.CoordinateX).Listen(coordinateXProvider, 1);
+        _disposables.Add(coordinateXProvider.Generator.Start());
+
+        var coordinateYProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.Y ?? -1);
+        table.AddRow(Strings.Internals.CoordinateY).Listen(coordinateYProvider, 1);
+        _disposables.Add(coordinateYProvider.Generator.Start());
+
+        var coordinateZProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.Z ?? -1);
+        table.AddRow(Strings.Internals.CoordinateZ).Listen(coordinateZProvider, 1);
+        _disposables.Add(coordinateZProvider.Generator.Start());
+
+        var knownEntitiesProvider = new ValueTableCellDataProvider<int>(() => Graphics.DrawCalls);
+        table.AddRow(Strings.Debug.KnownEntities).Listen(knownEntitiesProvider, 1);
+        _disposables.Add(knownEntitiesProvider.Generator.Start());
+
+        var knownMapsProvider = new ValueTableCellDataProvider<int>(() => MapInstance.Lookup.Count);
+        table.AddRow(Strings.Debug.KnownMaps).Listen(knownMapsProvider, 1);
+        _disposables.Add(knownMapsProvider.Generator.Start());
+
+        var mapsDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.MapsDrawn);
+        table.AddRow(Strings.Debug.MapsDrawn).Listen(mapsDrawnProvider, 1);
+        _disposables.Add(mapsDrawnProvider.Generator.Start());
+
+        var entitiesDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.EntitiesDrawn);
+        table.AddRow(Strings.Debug.EntitiesDrawn).Listen(entitiesDrawnProvider, 1);
+        _disposables.Add(entitiesDrawnProvider.Generator.Start());
+
+        var lightsDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.LightsDrawn);
+        table.AddRow(Strings.Debug.LightsDrawn).Listen(lightsDrawnProvider, 1);
+        _disposables.Add(lightsDrawnProvider.Generator.Start());
+
+        var timeProvider = new ValueTableCellDataProvider<string>(() => Time.GetTime());
+        table.AddRow(Strings.Debug.Time).Listen(timeProvider, 1);
+        _disposables.Add(timeProvider.Generator.Start());
+
+        var interfaceObjectsProvider = new ValueTableCellDataProvider<int>((cancellationToken) =>
         {
-            var checkbox = new LabeledCheckBox(this, nameof(CheckboxDrawDebugOutlines))
+            try
             {
-                IsChecked = Root?.DrawDebugOutlines ?? false,
-                Text = Strings.Debug.DrawDebugOutlines,
-            };
-
-            checkbox.CheckChanged += (sender, args) =>
-            {
-                _drawDebugOutlinesEnabled = checkbox.IsChecked;
-                if (Root != default)
-                {
-                    Root.DrawDebugOutlines = _drawDebugOutlinesEnabled;
-                }
-            };
-
-            return checkbox;
-        }
-
-        private LabeledCheckBox CreateCheckboxEnableLayoutHotReloading()
-        {
-            var checkbox = new LabeledCheckBox(this, nameof(CheckboxEnableLayoutHotReloading))
-            {
-                IsChecked = Globals.ContentManager.ContentWatcher.Enabled,
-                Text = Strings.Debug.EnableLayoutHotReloading,
-            };
-
-            checkbox.CheckChanged += (sender, args) =>
-            {
-                Globals.ContentManager.ContentWatcher.Enabled = checkbox.IsChecked;
-            };
-
-            checkbox.SetToolTipText(Strings.Internals.ExperimentalFeatureTooltip);
-            checkbox.ToolTipFont = Skin.DefaultFont;
-
-            return checkbox;
-        }
-
-        private Button CreateButtonShutdownServer()
-        {
-            var button = new Button(this, nameof(ButtonShutdownServer))
-            {
-                IsHidden = true,
-                Text = Strings.Debug.ShutdownServer,
-            };
-
-            button.Clicked += (sender, args) =>
-            {
-                // TODO: Implement
-            };
-
-            return button;
-        }
-
-        private Button CreateButtonShutdownServerAndExit()
-        {
-            var button = new Button(this, nameof(ButtonShutdownServerAndExit))
-            {
-                IsHidden = true,
-                Text = Strings.Debug.ShutdownServerAndExit,
-            };
-
-            button.Clicked += (sender, args) =>
-            {
-                // TODO: Implement
-            };
-
-            return button;
-        }
-
-        private Table CreateTableDebugStats()
-        {
-            var table = new Table(this, nameof(TableDebugStats))
-            {
-                ColumnCount = 2,
-            };
-
-            var fpsProvider = new ValueTableCellDataProvider<int>(() => Graphics.Renderer.GetFps());
-            table.AddRow(Strings.Debug.Fps).Listen(fpsProvider, 1);
-            _disposables.Add(fpsProvider.Generator.Start());
-
-            var pingProvider = new ValueTableCellDataProvider<int>(() => Networking.Network.Ping);
-            table.AddRow(Strings.Debug.Ping).Listen(pingProvider, 1);
-            _disposables.Add(pingProvider.Generator.Start());
-
-            var drawCallsProvider = new ValueTableCellDataProvider<int>(() => Graphics.DrawCalls);
-            table.AddRow(Strings.Debug.Draws).Listen(drawCallsProvider, 1);
-            _disposables.Add(drawCallsProvider.Generator.Start());
-
-            var mapNameProvider = new ValueTableCellDataProvider<string>(() =>
-            {
-                var mapId = Globals.Me?.MapId ?? default;
-
-                if (mapId == default)
-                {
-                    return Strings.Internals.NotApplicable;
-                }
-
-                return MapInstance.Get(mapId)?.Name ?? Strings.Internals.NotApplicable;
-            });
-            table.AddRow(Strings.Debug.Map).Listen(mapNameProvider, 1);
-            _disposables.Add(mapNameProvider.Generator.Start());
-
-            var coordinateXProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.X ?? -1);
-            table.AddRow(Strings.Internals.CoordinateX).Listen(coordinateXProvider, 1);
-            _disposables.Add(coordinateXProvider.Generator.Start());
-
-            var coordinateYProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.Y ?? -1);
-            table.AddRow(Strings.Internals.CoordinateY).Listen(coordinateYProvider, 1);
-            _disposables.Add(coordinateYProvider.Generator.Start());
-
-            var coordinateZProvider = new ValueTableCellDataProvider<int>(() => Globals.Me?.Z ?? -1);
-            table.AddRow(Strings.Internals.CoordinateZ).Listen(coordinateZProvider, 1);
-            _disposables.Add(coordinateZProvider.Generator.Start());
-
-            var knownEntitiesProvider = new ValueTableCellDataProvider<int>(() => Graphics.DrawCalls);
-            table.AddRow(Strings.Debug.KnownEntities).Listen(knownEntitiesProvider, 1);
-            _disposables.Add(knownEntitiesProvider.Generator.Start());
-
-            var knownMapsProvider = new ValueTableCellDataProvider<int>(() => MapInstance.Lookup.Count);
-            table.AddRow(Strings.Debug.KnownMaps).Listen(knownMapsProvider, 1);
-            _disposables.Add(knownMapsProvider.Generator.Start());
-
-            var mapsDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.MapsDrawn);
-            table.AddRow(Strings.Debug.MapsDrawn).Listen(mapsDrawnProvider, 1);
-            _disposables.Add(mapsDrawnProvider.Generator.Start());
-
-            var entitiesDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.EntitiesDrawn);
-            table.AddRow(Strings.Debug.EntitiesDrawn).Listen(entitiesDrawnProvider, 1);
-            _disposables.Add(entitiesDrawnProvider.Generator.Start());
-
-            var lightsDrawnProvider = new ValueTableCellDataProvider<int>(() => Graphics.LightsDrawn);
-            table.AddRow(Strings.Debug.LightsDrawn).Listen(lightsDrawnProvider, 1);
-            _disposables.Add(lightsDrawnProvider.Generator.Start());
-
-            var timeProvider = new ValueTableCellDataProvider<string>(() => Time.GetTime());
-            table.AddRow(Strings.Debug.Time).Listen(timeProvider, 1);
-            _disposables.Add(timeProvider.Generator.Start());
-
-            var interfaceObjectsProvider = new ValueTableCellDataProvider<int>((cancellationToken) =>
-            {
-                try
-                {
-                    return Interface.CurrentInterface?.Children.ToArray().SelectManyRecursive(
-                        x => x.Children.ToArray(),
-                        cancellationToken
-                    ).ToArray().Length ?? 0;
-                }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (InvalidOperationException)
-                {
-                    return 0;
-                }
-            });
-            table.AddRow(Strings.Debug.InterfaceObjects).Listen(interfaceObjectsProvider, 1);
-            _disposables.Add(interfaceObjectsProvider.Generator.Start());
-
-            _ = table.AddRow(Strings.Debug.ControlUnderCursor, 1);
-
-            var controlUnderCursorProvider = new ControlUnderCursorProvider();
-            table.AddRow(Strings.Internals.Type).Listen(controlUnderCursorProvider, 0);
-            table.AddRow(Strings.Internals.Name).Listen(controlUnderCursorProvider, 1);
-            table.AddRow(Strings.Internals.LocalItem.ToString(Strings.Internals.Bounds)).Listen(controlUnderCursorProvider, 2);
-            table.AddRow(Strings.Internals.GlobalItem.ToString(Strings.Internals.Bounds)).Listen(controlUnderCursorProvider, 3);
-            table.AddRow(Strings.Internals.Color).Listen(controlUnderCursorProvider, 4);
-            table.AddRow(Strings.Internals.ColorOverride).Listen(controlUnderCursorProvider, 5);
-            _disposables.Add(controlUnderCursorProvider.Generator.Start());
-
-            return table;
-        }
-
-        private partial class ControlUnderCursorProvider : ITableDataProvider
-        {
-            public ControlUnderCursorProvider()
-            {
-                Generator = new CancellableGenerator<Base>(CreateControlUnderCursorGenerator);
+                return Interface.CurrentInterface?.Children.ToArray().SelectManyRecursive(
+                    x => x.Children.ToArray(),
+                    cancellationToken
+                ).ToArray().Length ?? 0;
             }
-
-            public event TableDataChangedEventHandler DataChanged;
-
-            public CancellableGenerator<Base> Generator { get; }
-
-            public void Start()
+            catch (ObjectDisposedException)
             {
-                _ = Generator.Start();
+                throw;
             }
-
-            private AsyncValueGenerator<Base> CreateControlUnderCursorGenerator(CancellationToken cancellationToken)
+            catch (InvalidOperationException)
             {
-                return new AsyncValueGenerator<Base>(() => Task.Delay(100).ContinueWith((completedTask) => Interface.FindControlAtCursor(), TaskScheduler.Current), (component) =>
-                {
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(0, 1, default, component?.GetType().Name ?? Strings.Internals.NotApplicable));
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(1, 1, default, component?.CanonicalName ?? string.Empty));
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(2, 1, default, component?.Bounds.ToString() ?? string.Empty));
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(3, 1, default, component?.BoundsGlobal.ToString() ?? string.Empty));
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(4, 1, default, (component as IColorableText)?.TextColor ?? string.Empty));
-                    DataChanged?.Invoke(this, new TableDataChangedEventArgs(5, 1, default, (component as IColorableText)?.TextColorOverride ?? string.Empty));
-
-                }, cancellationToken);
+                return 0;
             }
+        });
+        table.AddRow(Strings.Debug.InterfaceObjects).Listen(interfaceObjectsProvider, 1);
+        _disposables.Add(interfaceObjectsProvider.Generator.Start());
+
+        _ = table.AddRow(Strings.Debug.ControlUnderCursor, 1);
+
+        var controlUnderCursorProvider = new ControlUnderCursorProvider();
+        table.AddRow(Strings.Internals.Type).Listen(controlUnderCursorProvider, 0);
+        table.AddRow(Strings.Internals.Name).Listen(controlUnderCursorProvider, 1);
+        table.AddRow(Strings.Internals.LocalItem.ToString(Strings.Internals.Bounds)).Listen(controlUnderCursorProvider, 2);
+        table.AddRow(Strings.Internals.GlobalItem.ToString(Strings.Internals.Bounds)).Listen(controlUnderCursorProvider, 3);
+        table.AddRow(Strings.Internals.Color).Listen(controlUnderCursorProvider, 4);
+        table.AddRow(Strings.Internals.ColorOverride).Listen(controlUnderCursorProvider, 5);
+        _disposables.Add(controlUnderCursorProvider.Generator.Start());
+
+        return table;
+    }
+
+    private partial class ControlUnderCursorProvider : ITableDataProvider
+    {
+        public ControlUnderCursorProvider()
+        {
+            Generator = new CancellableGenerator<Base>(CreateControlUnderCursorGenerator);
+        }
+
+        public event TableDataChangedEventHandler DataChanged;
+
+        public CancellableGenerator<Base> Generator { get; }
+
+        public void Start()
+        {
+            _ = Generator.Start();
+        }
+
+        private AsyncValueGenerator<Base> CreateControlUnderCursorGenerator(CancellationToken cancellationToken)
+        {
+            return new AsyncValueGenerator<Base>(() => Task.Delay(100).ContinueWith((completedTask) => Interface.FindControlAtCursor(), TaskScheduler.Current), (component) =>
+            {
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(0, 1, default, component?.GetType().Name ?? Strings.Internals.NotApplicable));
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(1, 1, default, component?.CanonicalName ?? string.Empty));
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(2, 1, default, component?.Bounds.ToString() ?? string.Empty));
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(3, 1, default, component?.BoundsGlobal.ToString() ?? string.Empty));
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(4, 1, default, (component as IColorableText)?.TextColor ?? string.Empty));
+                DataChanged?.Invoke(this, new TableDataChangedEventArgs(5, 1, default, (component as IColorableText)?.TextColorOverride ?? string.Empty));
+
+            }, cancellationToken);
         }
     }
 }

--- a/Intersect.Client/Interface/Game/AdminWindow.cs
+++ b/Intersect.Client/Interface/Game/AdminWindow.cs
@@ -9,445 +9,444 @@ using Intersect.Client.Networking;
 using Intersect.GameObjects.Maps.MapList;
 using static Intersect.Client.Framework.File_Management.GameContentManager;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+partial class AdminWindow
 {
 
-    partial class AdminWindow
+    //Graphics
+    public ImagePanel PanelFace;
+    
+    public ImagePanel FacePanel;
+
+    private ComboBox DropdownAccess;
+
+    private Label LabelAccess;
+
+    //Controls
+    private WindowControl mAdminWindow;
+
+    private Button ButtonBan;
+
+    //Windows
+    BanMuteBox mBanMuteWindow;
+
+    private CheckBox CheckboxChronological;
+
+    private ComboBox DropdownFace;
+
+    private Label LabelFace;
+
+    //Player Mod Buttons
+    private Button ButtonKick;
+
+    private Button ButtonKill;
+
+    private Label LabelChronological;
+
+    private TreeControl mMapList;
+
+    private Label LabelMapList;
+
+    private Button ButtonMute;
+
+    //Player Mod Labels
+    private Label LabelName;
+
+    //Player Mod Textboxes
+    private TextBox TextboxName;
+
+    private Button ButtonSetFace;
+
+    private Button ButtonSetPower;
+
+    private Button ButtonSetSprite;
+
+    private ComboBox DropdownSprite;
+
+    private Label LabelSprite;
+
+    private Button ButtonUnban;
+
+    private Button ButtonUnmute;
+
+    private Button ButtonWarpMeTo;
+
+    private Button ButtonWarpToMe;
+    
+    private Button ButtonOverworldReturn;
+
+    public ImagePanel PanelSprite;
+
+    public ImagePanel SpritePanel;
+
+    //Init
+    public AdminWindow(Base gameCanvas)
     {
+        mAdminWindow = new WindowControl(gameCanvas, Strings.Admin.Title, false, nameof(AdminWindow));
+        mAdminWindow.SetPosition(
+            (Graphics.Renderer.ScreenWidth - mAdminWindow.Width) / 2,
+            (Graphics.Renderer.ScreenHeight - mAdminWindow.Height) / 2
+        );
+        mAdminWindow.DisableResizing();
+        mAdminWindow.Margin = Margin.Zero;
+        mAdminWindow.Padding = Padding.Zero;
 
-        //Graphics
-        public ImagePanel PanelFace;
-        
-        public ImagePanel FacePanel;
+        LabelName = new Label(mAdminWindow, nameof(LabelName));
+        LabelName.Text = Strings.Admin.Name;
+        TextboxName = new TextBox(mAdminWindow, nameof(TextboxName));
+        Interface.FocusElements.Add(TextboxName);
 
-        private ComboBox DropdownAccess;
+        LabelAccess = new Label(mAdminWindow, nameof(LabelAccess));
+        LabelAccess.Text = Strings.Admin.Access;
+        DropdownAccess = new ComboBox(mAdminWindow, nameof(DropdownAccess));
+        DropdownAccess.AddItem(Strings.Admin.Access0).UserData = "None";
+        DropdownAccess.AddItem(Strings.Admin.Access1).UserData = "Moderator";
+        DropdownAccess.AddItem(Strings.Admin.Access2).UserData = "Admin";
+        ButtonSetPower = new Button(mAdminWindow, nameof(ButtonSetPower)) { Text = Strings.Admin.SetPower };
+        ButtonSetPower.Clicked += _setPowerButton_Clicked;
 
-        private Label LabelAccess;
+        ButtonWarpToMe = new Button(mAdminWindow, nameof(ButtonWarpToMe));
+        ButtonWarpToMe.Text = Strings.Admin.Warp2Me;
+        ButtonWarpToMe.Clicked += _warpToMeButton_Clicked;
 
-        //Controls
-        private WindowControl mAdminWindow;
+        ButtonWarpMeTo = new Button(mAdminWindow, nameof(ButtonWarpMeTo));
+        ButtonWarpMeTo.Text = Strings.Admin.WarpMe2;
+        ButtonWarpMeTo.Clicked += _warpMeToButton_Clicked;
 
-        private Button ButtonBan;
+        ButtonOverworldReturn = new Button(mAdminWindow, nameof(ButtonOverworldReturn));
+        ButtonOverworldReturn.Text = Strings.Admin.OverworldReturn;
+        ButtonOverworldReturn.Clicked += _overWorldReturn_Clicked;
 
-        //Windows
-        BanMuteBox mBanMuteWindow;
+        ButtonKick = new Button(mAdminWindow, nameof(ButtonKick));
+        ButtonKick.Text = Strings.Admin.Kick;
+        ButtonKick.Clicked += _kickButton_Clicked;
 
-        private CheckBox CheckboxChronological;
+        ButtonKill = new Button(mAdminWindow, nameof(ButtonKill));
+        ButtonKill.Text = Strings.Admin.Kill;
+        ButtonKill.Clicked += _killButton_Clicked;
 
-        private ComboBox DropdownFace;
+        ButtonBan = new Button(mAdminWindow, nameof(ButtonBan));
+        ButtonBan.Text = Strings.Admin.Ban;
+        ButtonBan.Clicked += _banButton_Clicked;
 
-        private Label LabelFace;
+        ButtonUnban = new Button(mAdminWindow, nameof(ButtonUnban));
+        ButtonUnban.Text = Strings.Admin.Unban;
+        ButtonUnban.Clicked += _unbanButton_Clicked;
 
-        //Player Mod Buttons
-        private Button ButtonKick;
+        ButtonMute = new Button(mAdminWindow, nameof(ButtonMute));
+        ButtonMute.Text = Strings.Admin.Mute;
+        ButtonMute.Clicked += _muteButton_Clicked;
 
-        private Button ButtonKill;
+        ButtonUnmute = new Button(mAdminWindow, nameof(ButtonUnmute));
+        ButtonUnmute.Text = Strings.Admin.Unmute;
+        ButtonUnmute.Clicked += _unmuteButton_Clicked;
 
-        private Label LabelChronological;
-
-        private TreeControl mMapList;
-
-        private Label LabelMapList;
-
-        private Button ButtonMute;
-
-        //Player Mod Labels
-        private Label LabelName;
-
-        //Player Mod Textboxes
-        private TextBox TextboxName;
-
-        private Button ButtonSetFace;
-
-        private Button ButtonSetPower;
-
-        private Button ButtonSetSprite;
-
-        private ComboBox DropdownSprite;
-
-        private Label LabelSprite;
-
-        private Button ButtonUnban;
-
-        private Button ButtonUnmute;
-
-        private Button ButtonWarpMeTo;
-
-        private Button ButtonWarpToMe;
-        
-        private Button ButtonOverworldReturn;
-
-        public ImagePanel PanelSprite;
-
-        public ImagePanel SpritePanel;
-
-        //Init
-        public AdminWindow(Base gameCanvas)
+        LabelSprite = new Label(mAdminWindow, nameof(LabelSprite));
+        LabelSprite.Text = Strings.Admin.Sprite;
+        DropdownSprite = new ComboBox(mAdminWindow, nameof(DropdownSprite));
+        DropdownSprite.AddItem(Strings.Admin.None);
+        var sprites = Globals.ContentManager.GetTextureNames(Framework.Content.TextureType.Entity);
+        Array.Sort(sprites, new AlphanumComparatorFast());
+        foreach (var sprite in sprites)
         {
-            mAdminWindow = new WindowControl(gameCanvas, Strings.Admin.Title, false, nameof(AdminWindow));
-            mAdminWindow.SetPosition(
-                (Graphics.Renderer.ScreenWidth - mAdminWindow.Width) / 2,
-                (Graphics.Renderer.ScreenHeight - mAdminWindow.Height) / 2
+            DropdownSprite.AddItem(sprite);
+        }
+        DropdownSprite.ItemSelected += _spriteDropdown_ItemSelected;
+        ButtonSetSprite = new Button(mAdminWindow, nameof(ButtonSetSprite));
+        ButtonSetSprite.Text = Strings.Admin.SetSprite;
+        ButtonSetSprite.Clicked += _setSpriteButton_Clicked;
+        PanelSprite = new ImagePanel(mAdminWindow, nameof(PanelSprite));
+        SpritePanel = new ImagePanel(PanelSprite);
+
+        LabelFace = new Label(mAdminWindow, nameof(LabelFace));
+        LabelFace.Text = Strings.Admin.Face;
+        DropdownFace = new ComboBox(mAdminWindow, nameof(DropdownFace));
+        DropdownFace.AddItem(Strings.Admin.None);
+        var faces = Globals.ContentManager.GetTextureNames(Framework.Content.TextureType.Face);
+        Array.Sort(faces, new AlphanumComparatorFast());
+        foreach (var face in faces)
+        {
+            DropdownFace.AddItem(face);
+        }
+        DropdownFace.ItemSelected += _faceDropdown_ItemSelected;
+        ButtonSetFace = new Button(mAdminWindow, nameof(ButtonSetFace));
+        ButtonSetFace.Text = Strings.Admin.SetFace;
+        ButtonSetFace.Clicked += _setFaceButton_Clicked;
+        PanelFace = new ImagePanel(mAdminWindow, nameof(PanelFace));
+        FacePanel = new ImagePanel(PanelFace);
+
+        LabelMapList = new Label(mAdminWindow, nameof(LabelMapList)) { Text = Strings.Admin.MapList };
+        CheckboxChronological = new CheckBox(mAdminWindow, nameof(CheckboxChronological));
+        CheckboxChronological.SetToolTipText(Strings.Admin.ChronologicalTip);
+        CheckboxChronological.CheckChanged += _chkChronological_CheckChanged;
+        LabelChronological = new Label(mAdminWindow, nameof(LabelChronological))
+        {
+            Text = Strings.Admin.Chronological
+        };
+        CreateMapList();
+        mAdminWindow.LoadJsonUi(UI.InGame, Graphics.Renderer.GetResolutionString(), true);
+        UpdateMapList();
+    }
+
+    private void _spriteDropdown_ItemSelected(Base sender, ItemSelectedEventArgs arguments)
+    {
+        SpritePanel.Texture = Globals.ContentManager.GetTexture(
+            Framework.Content.TextureType.Entity, DropdownSprite.Text);
+
+        if (SpritePanel.Texture == null)
+        {
+            return;
+        }
+
+        var textFrameWidth = SpritePanel.Texture.Width / Options.Instance.Sprites.NormalFrames;
+        var textFrameHeight = SpritePanel.Texture.Height / Options.Instance.Sprites.Directions;
+        SpritePanel.SetTextureRect(0, 0, textFrameWidth, textFrameHeight);
+        SpritePanel.SetSize(Math.Min(textFrameWidth, 46), Math.Min(textFrameHeight, 46));
+        Align.Center(SpritePanel);
+    }
+
+    private void _faceDropdown_ItemSelected(Base sender, ItemSelectedEventArgs arguments)
+    {
+        FacePanel.Texture = Globals.ContentManager.GetTexture(
+            Framework.Content.TextureType.Face, DropdownFace.Text);
+
+        if (FacePanel.Texture == null)
+        {
+            return;
+        }
+
+        var textFrameWidth = FacePanel.Texture.Width;
+        var textFrameHeight = FacePanel.Texture.Height;
+        FacePanel.SetTextureRect(0, 0, textFrameWidth, textFrameHeight);
+        FacePanel.SetSize(Math.Min(textFrameWidth, 46), Math.Min(textFrameHeight, 46));
+        Align.Center(FacePanel);
+    }
+
+    //Methods
+    public void SetName(string name)
+    {
+        TextboxName.Text = name;
+    }
+
+    private void CreateMapList()
+    {
+        mMapList = new TreeControl(mAdminWindow);
+        mMapList.SetPosition(4f, 330);
+        mMapList.Width = mAdminWindow.Width - 8;
+        mMapList.Height = 80;
+        mMapList.RenderColor = Color.FromArgb(255, 255, 255, 255);
+        mMapList.MaximumSize = new Point(4096, 999999);
+    }
+
+    public void UpdateMapList()
+    {
+        mMapList.Dispose();
+        CreateMapList();
+        AddMapListToTree(MapList.List, null);
+    }
+
+    private void AddMapListToTree(MapList mapList, TreeNode parent)
+    {
+        TreeNode tmpNode;
+        if (CheckboxChronological.IsChecked)
+        {
+            for (var i = MapList.OrderedMaps.Count - 1; i >= 0; i--)
+            {
+                tmpNode = mMapList.AddNode(MapList.OrderedMaps[i].Name);
+                tmpNode.UserData = MapList.OrderedMaps[i].MapId;
+                tmpNode.DoubleClicked += tmpNode_DoubleClicked;
+                tmpNode.Clicked += tmpNode_DoubleClicked;
+            }
+        }
+        else
+        {
+            foreach (var item in mapList.Items)
+            {
+                switch (item)
+                {
+                    case MapListFolder folder:
+                        tmpNode = parent?.AddNode(item.Name) ?? mMapList.AddNode(item.Name);
+                        tmpNode.UserData = folder;
+                        AddMapListToTree(folder.Children, tmpNode);
+                        break;
+                    case MapListMap map:
+                        tmpNode = parent?.AddNode(item.Name) ?? mMapList.AddNode(item.Name);
+                        tmpNode.UserData = map.MapId;
+                        tmpNode.DoubleClicked += tmpNode_DoubleClicked;
+                        tmpNode.Clicked += tmpNode_DoubleClicked;
+                        break;
+                }
+            }
+        }
+    }
+
+    void _kickButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new KickAction(TextboxName.Text));
+        }
+    }
+
+    void _killButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new KillAction(TextboxName.Text));
+        }
+    }
+
+    void _warpToMeButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new WarpToMeAction(TextboxName.Text));
+        }
+    }
+
+    void _warpMeToButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new WarpMeToAction(TextboxName.Text));
+        }
+    }
+
+    void _overWorldReturn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (!string.IsNullOrEmpty(TextboxName.Text))
+        {
+            PacketSender.SendAdminAction(new ReturnToOverworldAction(TextboxName.Text));
+        }
+    }
+
+    void _muteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            mBanMuteWindow = new BanMuteBox(Strings.Admin.MuteCaption.ToString(TextboxName.Text),
+                Strings.Admin.MutePrompt.ToString(TextboxName.Text), true, MuteUser);
+        }
+    }
+
+    void MuteUser(object sender, EventArgs e)
+    {
+        PacketSender.SendAdminAction(new MuteAction(TextboxName.Text, mBanMuteWindow.GetDuration(),
+            mBanMuteWindow.GetReason(), mBanMuteWindow.BanIp()));
+
+        mBanMuteWindow.Dispose();
+    }
+
+    void BanUser(object sender, EventArgs e)
+    {
+        PacketSender.SendAdminAction(new BanAction(TextboxName.Text, mBanMuteWindow.GetDuration(),
+            mBanMuteWindow.GetReason(), mBanMuteWindow.BanIp()));
+
+        mBanMuteWindow.Dispose();
+    }
+
+    void _banButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (string.IsNullOrWhiteSpace(TextboxName.Text))
+        {
+            return;
+        }
+
+        var name = TextboxName.Text.Trim();
+
+        if (string.Equals(name, Globals.Me.Name, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return;
+        }
+
+        mBanMuteWindow = new BanMuteBox(Strings.Admin.BanCaption.ToString(name),
+            Strings.Admin.BanPrompt.ToString(TextboxName.Text), true, BanUser);
+    }
+
+    private void _setFaceButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new SetFaceAction(TextboxName.Text, DropdownFace.Text));
+        }
+    }
+
+    void _unmuteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            new InputBox(Strings.Admin.UnmuteCaption.ToString(TextboxName.Text),
+                Strings.Admin.UnmutePrompt.ToString(TextboxName.Text), true, InputBox.InputType.YesNo, UnmuteUser,
+                null, -1);
+        }
+    }
+
+    void _unbanButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            new InputBox(Strings.Admin.UnbanCaption.ToString(TextboxName.Text),
+                Strings.Admin.UnbanPrompt.ToString(TextboxName.Text), true, InputBox.InputType.YesNo, UnbanUser,
+                null, -1);
+        }
+    }
+
+    void UnmuteUser(object sender, EventArgs e)
+    {
+        PacketSender.SendAdminAction(new UnmuteAction(TextboxName.Text));
+    }
+
+    void UnbanUser(object sender, EventArgs e)
+    {
+        PacketSender.SendAdminAction(new UnbanAction(TextboxName.Text));
+    }
+
+    void _setSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(new SetSpriteAction(TextboxName.Text, DropdownSprite.Text));
+        }
+    }
+
+    void _setPowerButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (TextboxName.Text.Trim().Length > 0)
+        {
+            PacketSender.SendAdminAction(
+                new SetAccessAction(TextboxName.Text, DropdownAccess.SelectedItem.UserData.ToString())
             );
-            mAdminWindow.DisableResizing();
-            mAdminWindow.Margin = Margin.Zero;
-            mAdminWindow.Padding = Padding.Zero;
-
-            LabelName = new Label(mAdminWindow, nameof(LabelName));
-            LabelName.Text = Strings.Admin.Name;
-            TextboxName = new TextBox(mAdminWindow, nameof(TextboxName));
-            Interface.FocusElements.Add(TextboxName);
-
-            LabelAccess = new Label(mAdminWindow, nameof(LabelAccess));
-            LabelAccess.Text = Strings.Admin.Access;
-            DropdownAccess = new ComboBox(mAdminWindow, nameof(DropdownAccess));
-            DropdownAccess.AddItem(Strings.Admin.Access0).UserData = "None";
-            DropdownAccess.AddItem(Strings.Admin.Access1).UserData = "Moderator";
-            DropdownAccess.AddItem(Strings.Admin.Access2).UserData = "Admin";
-            ButtonSetPower = new Button(mAdminWindow, nameof(ButtonSetPower)) { Text = Strings.Admin.SetPower };
-            ButtonSetPower.Clicked += _setPowerButton_Clicked;
-
-            ButtonWarpToMe = new Button(mAdminWindow, nameof(ButtonWarpToMe));
-            ButtonWarpToMe.Text = Strings.Admin.Warp2Me;
-            ButtonWarpToMe.Clicked += _warpToMeButton_Clicked;
-
-            ButtonWarpMeTo = new Button(mAdminWindow, nameof(ButtonWarpMeTo));
-            ButtonWarpMeTo.Text = Strings.Admin.WarpMe2;
-            ButtonWarpMeTo.Clicked += _warpMeToButton_Clicked;
-
-            ButtonOverworldReturn = new Button(mAdminWindow, nameof(ButtonOverworldReturn));
-            ButtonOverworldReturn.Text = Strings.Admin.OverworldReturn;
-            ButtonOverworldReturn.Clicked += _overWorldReturn_Clicked;
-
-            ButtonKick = new Button(mAdminWindow, nameof(ButtonKick));
-            ButtonKick.Text = Strings.Admin.Kick;
-            ButtonKick.Clicked += _kickButton_Clicked;
-
-            ButtonKill = new Button(mAdminWindow, nameof(ButtonKill));
-            ButtonKill.Text = Strings.Admin.Kill;
-            ButtonKill.Clicked += _killButton_Clicked;
-
-            ButtonBan = new Button(mAdminWindow, nameof(ButtonBan));
-            ButtonBan.Text = Strings.Admin.Ban;
-            ButtonBan.Clicked += _banButton_Clicked;
-
-            ButtonUnban = new Button(mAdminWindow, nameof(ButtonUnban));
-            ButtonUnban.Text = Strings.Admin.Unban;
-            ButtonUnban.Clicked += _unbanButton_Clicked;
-
-            ButtonMute = new Button(mAdminWindow, nameof(ButtonMute));
-            ButtonMute.Text = Strings.Admin.Mute;
-            ButtonMute.Clicked += _muteButton_Clicked;
-
-            ButtonUnmute = new Button(mAdminWindow, nameof(ButtonUnmute));
-            ButtonUnmute.Text = Strings.Admin.Unmute;
-            ButtonUnmute.Clicked += _unmuteButton_Clicked;
-
-            LabelSprite = new Label(mAdminWindow, nameof(LabelSprite));
-            LabelSprite.Text = Strings.Admin.Sprite;
-            DropdownSprite = new ComboBox(mAdminWindow, nameof(DropdownSprite));
-            DropdownSprite.AddItem(Strings.Admin.None);
-            var sprites = Globals.ContentManager.GetTextureNames(Framework.Content.TextureType.Entity);
-            Array.Sort(sprites, new AlphanumComparatorFast());
-            foreach (var sprite in sprites)
-            {
-                DropdownSprite.AddItem(sprite);
-            }
-            DropdownSprite.ItemSelected += _spriteDropdown_ItemSelected;
-            ButtonSetSprite = new Button(mAdminWindow, nameof(ButtonSetSprite));
-            ButtonSetSprite.Text = Strings.Admin.SetSprite;
-            ButtonSetSprite.Clicked += _setSpriteButton_Clicked;
-            PanelSprite = new ImagePanel(mAdminWindow, nameof(PanelSprite));
-            SpritePanel = new ImagePanel(PanelSprite);
-
-            LabelFace = new Label(mAdminWindow, nameof(LabelFace));
-            LabelFace.Text = Strings.Admin.Face;
-            DropdownFace = new ComboBox(mAdminWindow, nameof(DropdownFace));
-            DropdownFace.AddItem(Strings.Admin.None);
-            var faces = Globals.ContentManager.GetTextureNames(Framework.Content.TextureType.Face);
-            Array.Sort(faces, new AlphanumComparatorFast());
-            foreach (var face in faces)
-            {
-                DropdownFace.AddItem(face);
-            }
-            DropdownFace.ItemSelected += _faceDropdown_ItemSelected;
-            ButtonSetFace = new Button(mAdminWindow, nameof(ButtonSetFace));
-            ButtonSetFace.Text = Strings.Admin.SetFace;
-            ButtonSetFace.Clicked += _setFaceButton_Clicked;
-            PanelFace = new ImagePanel(mAdminWindow, nameof(PanelFace));
-            FacePanel = new ImagePanel(PanelFace);
-
-            LabelMapList = new Label(mAdminWindow, nameof(LabelMapList)) { Text = Strings.Admin.MapList };
-            CheckboxChronological = new CheckBox(mAdminWindow, nameof(CheckboxChronological));
-            CheckboxChronological.SetToolTipText(Strings.Admin.ChronologicalTip);
-            CheckboxChronological.CheckChanged += _chkChronological_CheckChanged;
-            LabelChronological = new Label(mAdminWindow, nameof(LabelChronological))
-            {
-                Text = Strings.Admin.Chronological
-            };
-            CreateMapList();
-            mAdminWindow.LoadJsonUi(UI.InGame, Graphics.Renderer.GetResolutionString(), true);
-            UpdateMapList();
         }
+    }
 
-        private void _spriteDropdown_ItemSelected(Base sender, ItemSelectedEventArgs arguments)
-        {
-            SpritePanel.Texture = Globals.ContentManager.GetTexture(
-                Framework.Content.TextureType.Entity, DropdownSprite.Text);
+    void _chkChronological_CheckChanged(Base sender, EventArgs arguments)
+    {
+        UpdateMapList();
+    }
 
-            if (SpritePanel.Texture == null)
-            {
-                return;
-            }
+    static void tmpNode_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendAdminAction(new WarpToMapAction((Guid) ((TreeNode) sender).UserData));
+    }
 
-            var textFrameWidth = SpritePanel.Texture.Width / Options.Instance.Sprites.NormalFrames;
-            var textFrameHeight = SpritePanel.Texture.Height / Options.Instance.Sprites.Directions;
-            SpritePanel.SetTextureRect(0, 0, textFrameWidth, textFrameHeight);
-            SpritePanel.SetSize(Math.Min(textFrameWidth, 46), Math.Min(textFrameHeight, 46));
-            Align.Center(SpritePanel);
-        }
+    public void Update()
+    {
+    }
 
-        private void _faceDropdown_ItemSelected(Base sender, ItemSelectedEventArgs arguments)
-        {
-            FacePanel.Texture = Globals.ContentManager.GetTexture(
-                Framework.Content.TextureType.Face, DropdownFace.Text);
+    public void Show()
+    {
+        mAdminWindow.IsHidden = false;
+    }
 
-            if (FacePanel.Texture == null)
-            {
-                return;
-            }
+    public bool IsVisible()
+    {
+        return !mAdminWindow.IsHidden;
+    }
 
-            var textFrameWidth = FacePanel.Texture.Width;
-            var textFrameHeight = FacePanel.Texture.Height;
-            FacePanel.SetTextureRect(0, 0, textFrameWidth, textFrameHeight);
-            FacePanel.SetSize(Math.Min(textFrameWidth, 46), Math.Min(textFrameHeight, 46));
-            Align.Center(FacePanel);
-        }
-
-        //Methods
-        public void SetName(string name)
-        {
-            TextboxName.Text = name;
-        }
-
-        private void CreateMapList()
-        {
-            mMapList = new TreeControl(mAdminWindow);
-            mMapList.SetPosition(4f, 330);
-            mMapList.Width = mAdminWindow.Width - 8;
-            mMapList.Height = 80;
-            mMapList.RenderColor = Color.FromArgb(255, 255, 255, 255);
-            mMapList.MaximumSize = new Point(4096, 999999);
-        }
-
-        public void UpdateMapList()
-        {
-            mMapList.Dispose();
-            CreateMapList();
-            AddMapListToTree(MapList.List, null);
-        }
-
-        private void AddMapListToTree(MapList mapList, TreeNode parent)
-        {
-            TreeNode tmpNode;
-            if (CheckboxChronological.IsChecked)
-            {
-                for (var i = MapList.OrderedMaps.Count - 1; i >= 0; i--)
-                {
-                    tmpNode = mMapList.AddNode(MapList.OrderedMaps[i].Name);
-                    tmpNode.UserData = MapList.OrderedMaps[i].MapId;
-                    tmpNode.DoubleClicked += tmpNode_DoubleClicked;
-                    tmpNode.Clicked += tmpNode_DoubleClicked;
-                }
-            }
-            else
-            {
-                foreach (var item in mapList.Items)
-                {
-                    switch (item)
-                    {
-                        case MapListFolder folder:
-                            tmpNode = parent?.AddNode(item.Name) ?? mMapList.AddNode(item.Name);
-                            tmpNode.UserData = folder;
-                            AddMapListToTree(folder.Children, tmpNode);
-                            break;
-                        case MapListMap map:
-                            tmpNode = parent?.AddNode(item.Name) ?? mMapList.AddNode(item.Name);
-                            tmpNode.UserData = map.MapId;
-                            tmpNode.DoubleClicked += tmpNode_DoubleClicked;
-                            tmpNode.Clicked += tmpNode_DoubleClicked;
-                            break;
-                    }
-                }
-            }
-        }
-
-        void _kickButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new KickAction(TextboxName.Text));
-            }
-        }
-
-        void _killButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new KillAction(TextboxName.Text));
-            }
-        }
-
-        void _warpToMeButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new WarpToMeAction(TextboxName.Text));
-            }
-        }
-
-        void _warpMeToButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new WarpMeToAction(TextboxName.Text));
-            }
-        }
-
-        void _overWorldReturn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (!string.IsNullOrEmpty(TextboxName.Text))
-            {
-                PacketSender.SendAdminAction(new ReturnToOverworldAction(TextboxName.Text));
-            }
-        }
-
-        void _muteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                mBanMuteWindow = new BanMuteBox(Strings.Admin.MuteCaption.ToString(TextboxName.Text),
-                    Strings.Admin.MutePrompt.ToString(TextboxName.Text), true, MuteUser);
-            }
-        }
-
-        void MuteUser(object sender, EventArgs e)
-        {
-            PacketSender.SendAdminAction(new MuteAction(TextboxName.Text, mBanMuteWindow.GetDuration(),
-                mBanMuteWindow.GetReason(), mBanMuteWindow.BanIp()));
-
-            mBanMuteWindow.Dispose();
-        }
-
-        void BanUser(object sender, EventArgs e)
-        {
-            PacketSender.SendAdminAction(new BanAction(TextboxName.Text, mBanMuteWindow.GetDuration(),
-                mBanMuteWindow.GetReason(), mBanMuteWindow.BanIp()));
-
-            mBanMuteWindow.Dispose();
-        }
-
-        void _banButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (string.IsNullOrWhiteSpace(TextboxName.Text))
-            {
-                return;
-            }
-
-            var name = TextboxName.Text.Trim();
-
-            if (string.Equals(name, Globals.Me.Name, StringComparison.CurrentCultureIgnoreCase))
-            {
-                return;
-            }
-
-            mBanMuteWindow = new BanMuteBox(Strings.Admin.BanCaption.ToString(name),
-                Strings.Admin.BanPrompt.ToString(TextboxName.Text), true, BanUser);
-        }
-
-        private void _setFaceButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new SetFaceAction(TextboxName.Text, DropdownFace.Text));
-            }
-        }
-
-        void _unmuteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                new InputBox(Strings.Admin.UnmuteCaption.ToString(TextboxName.Text),
-                    Strings.Admin.UnmutePrompt.ToString(TextboxName.Text), true, InputBox.InputType.YesNo, UnmuteUser,
-                    null, -1);
-            }
-        }
-
-        void _unbanButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                new InputBox(Strings.Admin.UnbanCaption.ToString(TextboxName.Text),
-                    Strings.Admin.UnbanPrompt.ToString(TextboxName.Text), true, InputBox.InputType.YesNo, UnbanUser,
-                    null, -1);
-            }
-        }
-
-        void UnmuteUser(object sender, EventArgs e)
-        {
-            PacketSender.SendAdminAction(new UnmuteAction(TextboxName.Text));
-        }
-
-        void UnbanUser(object sender, EventArgs e)
-        {
-            PacketSender.SendAdminAction(new UnbanAction(TextboxName.Text));
-        }
-
-        void _setSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(new SetSpriteAction(TextboxName.Text, DropdownSprite.Text));
-            }
-        }
-
-        void _setPowerButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (TextboxName.Text.Trim().Length > 0)
-            {
-                PacketSender.SendAdminAction(
-                    new SetAccessAction(TextboxName.Text, DropdownAccess.SelectedItem.UserData.ToString())
-                );
-            }
-        }
-
-        void _chkChronological_CheckChanged(Base sender, EventArgs arguments)
-        {
-            UpdateMapList();
-        }
-
-        static void tmpNode_DoubleClicked(Base sender, ClickedEventArgs arguments)
-        {
-            PacketSender.SendAdminAction(new WarpToMapAction((Guid) ((TreeNode) sender).UserData));
-        }
-
-        public void Update()
-        {
-        }
-
-        public void Show()
-        {
-            mAdminWindow.IsHidden = false;
-        }
-
-        public bool IsVisible()
-        {
-            return !mAdminWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mAdminWindow.IsHidden = true;
-        }
+    public void Hide()
+    {
+        mAdminWindow.IsHidden = true;
     }
 }

--- a/Intersect.Client/Interface/Game/AnnouncementWindow.cs
+++ b/Intersect.Client/Interface/Game/AnnouncementWindow.cs
@@ -4,93 +4,91 @@ using Intersect.Client.Framework.Gwen.Control;
 
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+/// <summary>
+/// The GUI class for the Announcement Window that can pop up on-screen during gameplay.
+/// </summary>
+public partial class AnnouncementWindow
 {
+
+    //Controls
+    private Canvas mGameCanvas;
+
+    private ImagePanel mPicture;
+
+    private Label mLabel;
+
+    private string mLabelText;
+
+    private long mDisplayUntil = 0;
+
     /// <summary>
-    /// The GUI class for the Announcement Window that can pop up on-screen during gameplay.
+    /// Indicates whether the control is hidden.
     /// </summary>
-    public partial class AnnouncementWindow
+    public bool IsHidden
     {
+        get { return mPicture.IsHidden; }
+        set { mPicture.IsHidden = value; }
+    }
 
-        //Controls
-        private Canvas mGameCanvas;
+    /// <summary>
+    /// Create a new instance of the <see cref="AnnouncementWindow"/> class.
+    /// </summary>
+    /// <param name="gameCanvas">The <see cref="Canvas"/> to render this control on.</param>
+    public AnnouncementWindow(Canvas gameCanvas)
+    {
+       mGameCanvas = gameCanvas;
+       mPicture = new ImagePanel(gameCanvas, "AnnouncementWindow");
+       mLabel = new Label(mPicture, "AnnouncementLabel");
+    
+       mPicture.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        private ImagePanel mPicture;
-
-        private Label mLabel;
-
-        private string mLabelText;
-
-        private long mDisplayUntil = 0;
-
-        /// <summary>
-        /// Indicates whether the control is hidden.
-        /// </summary>
-        public bool IsHidden
+    /// <summary>
+    /// Update this control..
+    /// </summary>
+    public void Update()
+    {
+        // Only update when we're visible to the user.
+        if (!mPicture.IsHidden)
         {
-            get { return mPicture.IsHidden; }
-            set { mPicture.IsHidden = value; }
-        }
+            mLabel.Text = mLabelText;
 
-        /// <summary>
-        /// Create a new instance of the <see cref="AnnouncementWindow"/> class.
-        /// </summary>
-        /// <param name="gameCanvas">The <see cref="Canvas"/> to render this control on.</param>
-        public AnnouncementWindow(Canvas gameCanvas)
-        {
-           mGameCanvas = gameCanvas;
-           mPicture = new ImagePanel(gameCanvas, "AnnouncementWindow");
-           mLabel = new Label(mPicture, "AnnouncementLabel");
-        
-           mPicture.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-        }
-
-        /// <summary>
-        /// Update this control..
-        /// </summary>
-        public void Update()
-        {
-            // Only update when we're visible to the user.
-            if (!mPicture.IsHidden)
+            // Are we still supposed to be visible?
+            if (Timing.Global.Milliseconds > mDisplayUntil)
             {
-                mLabel.Text = mLabelText;
-
-                // Are we still supposed to be visible?
-                if (Timing.Global.Milliseconds > mDisplayUntil)
-                {
-                    Hide();
-                }
+                Hide();
             }
         }
+    }
 
-        /// <summary>
-        /// Display an announcement.
-        /// </summary>
-        /// <param name="announcementText">The text to display.</param>
-        /// <param name="displayTime">The time for which to display the announcement.</param>
-        public void ShowAnnouncement(string announcementText, long displayTime)
-        {
-            mLabelText = announcementText;
-            mDisplayUntil = Timing.Global.Milliseconds + displayTime;
-            Show();
-        }
+    /// <summary>
+    /// Display an announcement.
+    /// </summary>
+    /// <param name="announcementText">The text to display.</param>
+    /// <param name="displayTime">The time for which to display the announcement.</param>
+    public void ShowAnnouncement(string announcementText, long displayTime)
+    {
+        mLabelText = announcementText;
+        mDisplayUntil = Timing.Global.Milliseconds + displayTime;
+        Show();
+    }
 
-        /// <summary>
-        /// Hides the control.
-        /// </summary>
-        public void Hide()
-        {
-            mPicture.Hide();
-        }
+    /// <summary>
+    /// Hides the control.
+    /// </summary>
+    public void Hide()
+    {
+        mPicture.Hide();
+    }
 
-        /// <summary>
-        /// Shows the control.
-        /// </summary>
-        public void Show()
-        {
-            mPicture.Show();
-        }
-
+    /// <summary>
+    /// Shows the control.
+    /// </summary>
+    public void Show()
+    {
+        mPicture.Show();
     }
 
 }

--- a/Intersect.Client/Interface/Game/Bag/BagItem.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagItem.cs
@@ -10,164 +10,156 @@ using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Bag
+namespace Intersect.Client.Interface.Game.Bag;
+
+
+public partial class BagItem
 {
 
-    public partial class BagItem
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public ImagePanel Container;
+
+    public bool IsDragging;
+
+    //Drag/Drop References
+    private BagWindow mBagWindow;
+
+    //Dragging
+    private bool mCanDrag;
+
+    private long mClickTime;
+
+    private Guid mCurrentItemId;
+
+    private ItemDescriptionWindow mDescWindow;
+
+    private Draggable mDragIcon;
+
+    //Mouse Event Variables
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    //Slot info
+    private int mMySlot;
+
+    public ImagePanel Pnl;
+
+    public BagItem(BagWindow bagWindow, int index)
     {
+        mBagWindow = bagWindow;
+        mMySlot = index;
+    }
 
-        private static int sItemXPadding = 4;
+    public void Setup()
+    {
+        Pnl = new ImagePanel(Container, "BagItemIcon");
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+        Pnl.RightClicked += Pnl_RightClicked;
+        Pnl.DoubleClicked += Pnl_DoubleClicked;
+        Pnl.Clicked += pnl_Clicked;
+    }
 
-        private static int sItemYPadding = 4;
-
-        public ImagePanel Container;
-
-        public bool IsDragging;
-
-        //Drag/Drop References
-        private BagWindow mBagWindow;
-
-        //Dragging
-        private bool mCanDrag;
-
-        private long mClickTime;
-
-        private Guid mCurrentItemId;
-
-        private ItemDescriptionWindow mDescWindow;
-
-        private Draggable mDragIcon;
-
-        //Mouse Event Variables
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        //Slot info
-        private int mMySlot;
-
-        public ImagePanel Pnl;
-
-        public BagItem(BagWindow bagWindow, int index)
+    private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (ClientConfiguration.Instance.EnableContextMenus)
         {
-            mBagWindow = bagWindow;
-            mMySlot = index;
+            mBagWindow.OpenContextMenu(mMySlot);
+        }
+        else
+        {
+            Pnl_DoubleClicked(sender, arguments);
+        }    
+    }
+
+    private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.InBag)
+        {
+            Globals.Me.TryRetreiveBagItem(mMySlot, -1);
+        }
+    }
+
+    void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mClickTime = Timing.Global.MillisecondsUtc + 500;
+    }
+
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        public void Setup()
+        mMouseOver = true;
+        mCanDrag = true;
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            Pnl = new ImagePanel(Container, "BagItemIcon");
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-            Pnl.RightClicked += Pnl_RightClicked;
-            Pnl.DoubleClicked += Pnl_DoubleClicked;
-            Pnl.Clicked += pnl_Clicked;
+            mCanDrag = false;
+
+            return;
         }
 
-        private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+        if (mDescWindow != null)
         {
-            if (ClientConfiguration.Instance.EnableContextMenus)
-            {
-                mBagWindow.OpenContextMenu(mMySlot);
-            }
-            else
-            {
-                Pnl_DoubleClicked(sender, arguments);
-            }    
+            mDescWindow.Dispose();
+            mDescWindow = null;
         }
 
-        private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
+        if (Globals.Bag[mMySlot]?.Base != null)
         {
-            if (Globals.InBag)
-            {
-                Globals.Me.TryRetreiveBagItem(mMySlot, -1);
-            }
+            mDescWindow = new ItemDescriptionWindow(
+                Globals.Bag[mMySlot].Base, Globals.Bag[mMySlot].Quantity, mBagWindow.X, mBagWindow.Y,
+                Globals.Bag[mMySlot].ItemProperties
+            );
         }
+    }
 
-        void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            mClickTime = Timing.Global.MillisecondsUtc + 500;
-        }
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
 
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
+        return rect;
+    }
+
+    public void Update()
+    {
+        if (Globals.Bag[mMySlot].ItemId != mCurrentItemId)
         {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
-            if (mDescWindow != null)
+            mCurrentItemId = Globals.Bag[mMySlot].ItemId;
+            var item = ItemBase.Get(Globals.Bag[mMySlot].ItemId);
+            if (item != null)
             {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-        }
-
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
-        {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
-
-            mMouseOver = true;
-            mCanDrag = true;
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                mCanDrag = false;
-
-                return;
-            }
-
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-
-            if (Globals.Bag[mMySlot]?.Base != null)
-            {
-                mDescWindow = new ItemDescriptionWindow(
-                    Globals.Bag[mMySlot].Base, Globals.Bag[mMySlot].Quantity, mBagWindow.X, mBagWindow.Y,
-                    Globals.Bag[mMySlot].ItemProperties
-                );
-            }
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
-
-            return rect;
-        }
-
-        public void Update()
-        {
-            if (Globals.Bag[mMySlot].ItemId != mCurrentItemId)
-            {
-                mCurrentItemId = Globals.Bag[mMySlot].ItemId;
-                var item = ItemBase.Get(Globals.Bag[mMySlot].ItemId);
-                if (item != null)
+                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+                if (itemTex != null)
                 {
-                    var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-                    if (itemTex != null)
-                    {
-                        Pnl.Texture = itemTex;
-                        Pnl.RenderColor = item.Color;
-                    }
-                    else
-                    {
-                        if (Pnl.Texture != null)
-                        {
-                            Pnl.Texture = null;
-                        }
-                    }
+                    Pnl.Texture = itemTex;
+                    Pnl.RenderColor = item.Color;
                 }
                 else
                 {
@@ -177,80 +169,120 @@ namespace Intersect.Client.Interface.Game.Bag
                     }
                 }
             }
-
-            if (!IsDragging)
+            else
             {
-                if (mMouseOver)
+                if (Pnl.Texture != null)
                 {
-                    if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                    Pnl.Texture = null;
+                }
+            }
+        }
+
+        if (!IsDragging)
+        {
+            if (mMouseOver)
+            {
+                if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                {
+                    mCanDrag = true;
+                    mMouseX = -1;
+                    mMouseY = -1;
+                    if (Timing.Global.MillisecondsUtc < mClickTime)
                     {
-                        mCanDrag = true;
-                        mMouseX = -1;
-                        mMouseY = -1;
-                        if (Timing.Global.MillisecondsUtc < mClickTime)
-                        {
-                            mClickTime = 0;
-                        }
+                        mClickTime = 0;
                     }
-                    else
+                }
+                else
+                {
+                    if (mCanDrag && Draggable.Active == null)
                     {
-                        if (mCanDrag && Draggable.Active == null)
+                        if (mMouseX == -1 || mMouseY == -1)
                         {
-                            if (mMouseX == -1 || mMouseY == -1)
-                            {
-                                mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
-                                mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
-                            }
-                            else
-                            {
-                                var xdiff = mMouseX -
-                                            (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
+                            mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
+                            mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
+                        }
+                        else
+                        {
+                            var xdiff = mMouseX -
+                                        (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
 
-                                var ydiff = mMouseY -
-                                            (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
+                            var ydiff = mMouseY -
+                                        (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
 
-                                if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
-                                {
-                                    IsDragging = true;
-                                    mDragIcon = new Draggable(
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
-                                    );
-                                }
+                            if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
+                            {
+                                IsDragging = true;
+                                mDragIcon = new Draggable(
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
+                                );
                             }
                         }
                     }
                 }
             }
-            else
+        }
+        else
+        {
+            if (mDragIcon.Update())
             {
-                if (mDragIcon.Update())
+                //Drug the item and now we stopped
+                IsDragging = false;
+                var dragRect = new FloatRect(
+                    mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
+                    sItemYPadding / 2 + 32
+                );
+
+                float bestIntersect = 0;
+                var bestIntersectIndex = -1;
+
+                //So we picked up an item and then dropped it. Lets see where we dropped it to.
+                //Check inventory first.
+                if (mBagWindow.RenderBounds().IntersectsWith(dragRect))
                 {
-                    //Drug the item and now we stopped
-                    IsDragging = false;
-                    var dragRect = new FloatRect(
-                        mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
-                        sItemYPadding / 2 + 32
-                    );
-
-                    float bestIntersect = 0;
-                    var bestIntersectIndex = -1;
-
-                    //So we picked up an item and then dropped it. Lets see where we dropped it to.
-                    //Check inventory first.
-                    if (mBagWindow.RenderBounds().IntersectsWith(dragRect))
+                    for (var i = 0; i < Globals.Bag.Length; i++)
                     {
-                        for (var i = 0; i < Globals.Bag.Length; i++)
+                        if (mBagWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
                         {
-                            if (mBagWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
+                            if (FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Width *
+                                FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Height >
+                                bestIntersect)
                             {
-                                if (FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Width *
-                                    FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Height >
+                                bestIntersect =
+                                    FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Width *
+                                    FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Height;
+
+                                bestIntersectIndex = i;
+                            }
+                        }
+                    }
+
+                    if (bestIntersectIndex > -1)
+                    {
+                        if (mMySlot != bestIntersectIndex)
+                        {
+                            //Try to swap....
+                            PacketSender.SendMoveBagItems(mMySlot, bestIntersectIndex);
+                        }
+                    }
+                }
+                else
+                {
+                    var invWindow = Interface.GameUi.GameMenu.GetInventoryWindow();
+
+                    if (invWindow.RenderBounds().IntersectsWith(dragRect))
+                    {
+                        for (var i = 0; i < Options.MaxInvItems; i++)
+                        {
+                            if (invWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
+                            {
+                                if (FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
+                                    FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height >
                                     bestIntersect)
                                 {
                                     bestIntersect =
-                                        FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Width *
-                                        FloatRect.Intersect(mBagWindow.Items[i].RenderBounds(), dragRect).Height;
+                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
+                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height;
 
                                     bestIntersectIndex = i;
                                 }
@@ -259,48 +291,14 @@ namespace Intersect.Client.Interface.Game.Bag
 
                         if (bestIntersectIndex > -1)
                         {
-                            if (mMySlot != bestIntersectIndex)
-                            {
-                                //Try to swap....
-                                PacketSender.SendMoveBagItems(mMySlot, bestIntersectIndex);
-                            }
+                            Globals.Me.TryRetreiveBagItem(mMySlot, bestIntersectIndex);
                         }
                     }
-                    else
-                    {
-                        var invWindow = Interface.GameUi.GameMenu.GetInventoryWindow();
-
-                        if (invWindow.RenderBounds().IntersectsWith(dragRect))
-                        {
-                            for (var i = 0; i < Options.MaxInvItems; i++)
-                            {
-                                if (invWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
-                                {
-                                    if (FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
-                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height >
-                                        bestIntersect)
-                                    {
-                                        bestIntersect =
-                                            FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
-                                            FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height;
-
-                                        bestIntersectIndex = i;
-                                    }
-                                }
-                            }
-
-                            if (bestIntersectIndex > -1)
-                            {
-                                Globals.Me.TryRetreiveBagItem(mMySlot, bestIntersectIndex);
-                            }
-                        }
-                    }
-
-                    mDragIcon.Dispose();
                 }
+
+                mDragIcon.Dispose();
             }
         }
-
     }
 
 }

--- a/Intersect.Client/Interface/Game/Bag/BagWindow.cs
+++ b/Intersect.Client/Interface/Game/Bag/BagWindow.cs
@@ -6,189 +6,187 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Bag
+namespace Intersect.Client.Interface.Game.Bag;
+
+
+public partial class BagWindow
 {
 
-    public partial class BagWindow
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public List<BagItem> Items = new List<BagItem>();
+
+    //Controls
+    private WindowControl mBagWindow;
+
+    private ScrollControl mItemContainer;
+
+    private List<Label> mValues = new List<Label>();
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mWithdrawContextItem;
+
+    //Init
+    public BagWindow(Canvas gameCanvas)
     {
+        mBagWindow = new WindowControl(gameCanvas, Strings.Bags.Title, false, "BagWindow");
+        mBagWindow.DisableResizing();
+        Interface.InputBlockingElements.Add(mBagWindow);
 
-        private static int sItemXPadding = 4;
+        mItemContainer = new ScrollControl(mBagWindow, "ItemContainer");
+        mItemContainer.EnableScroll(false, true);
 
-        private static int sItemYPadding = 4;
+        mBagWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        public List<BagItem> Items = new List<BagItem>();
+        InitItemContainer();
 
-        //Controls
-        private WindowControl mBagWindow;
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "BagContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mWithdrawContextItem = mContextMenu.AddItem(Strings.BagContextMenu.Withdraw);
+        mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        private ScrollControl mItemContainer;
+    public void OpenContextMenu(int slot)
+    {
+        var item = ItemBase.Get(Globals.Bag[slot].ItemId);
 
-        private List<Label> mValues = new List<Label>();
-
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mWithdrawContextItem;
-
-        //Init
-        public BagWindow(Canvas gameCanvas)
+        // No point showing a menu for blank space.
+        if (item == null)
         {
-            mBagWindow = new WindowControl(gameCanvas, Strings.Bags.Title, false, "BagWindow");
-            mBagWindow.DisableResizing();
-            Interface.InputBlockingElements.Add(mBagWindow);
-
-            mItemContainer = new ScrollControl(mBagWindow, "ItemContainer");
-            mItemContainer.EnableScroll(false, true);
-
-            mBagWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            InitItemContainer();
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "BagContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mWithdrawContextItem = mContextMenu.AddItem(Strings.BagContextMenu.Withdraw);
-            mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            return;
         }
 
-        public void OpenContextMenu(int slot)
-        {
-            var item = ItemBase.Get(Globals.Bag[slot].ItemId);
+        mWithdrawContextItem.SetText(Strings.BagContextMenu.Withdraw.ToString(item.Name));
 
-            // No point showing a menu for blank space.
-            if (item == null)
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = slot;
+
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+    }
+
+    private void MWithdrawContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        if (Globals.InBag)
+        {
+            var slot = (int) sender.Parent.UserData;
+            Globals.Me.TryRetreiveBagItem(slot, -1);
+        }
+    }
+
+    //Location
+    //Location
+    public int X => mBagWindow.X;
+
+    public int Y => mBagWindow.Y;
+
+    public void Close()
+    {
+        mContextMenu?.Close();
+        mBagWindow.Close();
+    }
+
+    public bool IsVisible()
+    {
+        return !mBagWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mBagWindow.IsHidden = true;
+    }
+
+    public void Update()
+    {
+        if (mBagWindow.IsHidden == true || Globals.Bag == null)
+        {
+            return;
+        }
+
+        for (var i = 0; i < Globals.Bag.Length; i++)
+        {
+            if (Globals.Bag[i] != null && Globals.Bag[i].ItemId != Guid.Empty)
             {
-                return;
-            }
-
-            mWithdrawContextItem.SetText(Strings.BagContextMenu.Withdraw.ToString(item.Name));
-
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = slot;
-
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
-        }
-
-        private void MWithdrawContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
-        {
-            if (Globals.InBag)
-            {
-                var slot = (int) sender.Parent.UserData;
-                Globals.Me.TryRetreiveBagItem(slot, -1);
-            }
-        }
-
-        //Location
-        //Location
-        public int X => mBagWindow.X;
-
-        public int Y => mBagWindow.Y;
-
-        public void Close()
-        {
-            mContextMenu?.Close();
-            mBagWindow.Close();
-        }
-
-        public bool IsVisible()
-        {
-            return !mBagWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mBagWindow.IsHidden = true;
-        }
-
-        public void Update()
-        {
-            if (mBagWindow.IsHidden == true || Globals.Bag == null)
-            {
-                return;
-            }
-
-            for (var i = 0; i < Globals.Bag.Length; i++)
-            {
-                if (Globals.Bag[i] != null && Globals.Bag[i].ItemId != Guid.Empty)
+                var item = ItemBase.Get(Globals.Bag[i].ItemId);
+                if (item != null)
                 {
-                    var item = ItemBase.Get(Globals.Bag[i].ItemId);
-                    if (item != null)
+                    Items[i].Pnl.IsHidden = false;
+
+                    if (item.IsStackable)
                     {
-                        Items[i].Pnl.IsHidden = false;
-
-                        if (item.IsStackable)
-                        {
-                            mValues[i].IsHidden = Globals.Bag[i].Quantity <= 1;
-                            mValues[i].Text = Strings.FormatQuantityAbbreviated(Globals.Bag[i].Quantity);
-                        }
-                        else
-                        {
-                            mValues[i].IsHidden = true;
-                        }
-
-                        if (Items[i].IsDragging)
-                        {
-                            Items[i].Pnl.IsHidden = true;
-                            mValues[i].IsHidden = true;
-                        }
-
-                        Items[i].Update();
+                        mValues[i].IsHidden = Globals.Bag[i].Quantity <= 1;
+                        mValues[i].Text = Strings.FormatQuantityAbbreviated(Globals.Bag[i].Quantity);
                     }
-                }
-                else
-                {
-                    Items[i].Pnl.IsHidden = true;
-                    mValues[i].IsHidden = true;
+                    else
+                    {
+                        mValues[i].IsHidden = true;
+                    }
+
+                    if (Items[i].IsDragging)
+                    {
+                        Items[i].Pnl.IsHidden = true;
+                        mValues[i].IsHidden = true;
+                    }
+
+                    Items[i].Update();
                 }
             }
-        }
-
-        private void InitItemContainer()
-        {
-            for (var i = 0; i < Globals.Bag.Length; i++)
+            else
             {
-                Items.Add(new BagItem(this, i));
-                Items[i].Container = new ImagePanel(mItemContainer, "BagItem");
-                Items[i].Setup();
-
-                mValues.Add(new Label(Items[i].Container, "BagItemValue"));
-                mValues[i].Text = "";
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
+                Items[i].Pnl.IsHidden = true;
+                mValues[i].IsHidden = true;
             }
         }
+    }
 
-        public FloatRect RenderBounds()
+    private void InitItemContainer()
+    {
+        for (var i = 0; i < Globals.Bag.Length; i++)
         {
-            var rect = new FloatRect()
-            {
-                X = mBagWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
-                Y = mBagWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
-                Width = mBagWindow.Width + sItemXPadding,
-                Height = mBagWindow.Height + sItemYPadding
-            };
+            Items.Add(new BagItem(this, i));
+            Items[i].Container = new ImagePanel(mItemContainer, "BagItem");
+            Items[i].Setup();
 
-            return rect;
+            mValues.Add(new Label(Items[i].Container, "BagItemValue"));
+            mValues[i].Text = "";
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
         }
+    }
 
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = mBagWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
+            Y = mBagWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
+            Width = mBagWindow.Width + sItemXPadding,
+            Height = mBagWindow.Height + sItemYPadding
+        };
+
+        return rect;
     }
 
 }

--- a/Intersect.Client/Interface/Game/BanMuteBox.cs
+++ b/Intersect.Client/Interface/Game/BanMuteBox.cs
@@ -4,178 +4,176 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Localization;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class BanMuteBox
 {
 
-    public partial class BanMuteBox
+    private ComboBox mDurationBox;
+
+    private Label mDurationLabel;
+
+    private CheckBox mIpCheckbox;
+
+    private Label mIpLabel;
+
+    private WindowControl mMyWindow;
+
+    private TextBox mReasonBox;
+
+    private Label mReasonLabel;
+
+    private TextBoxNumeric mTextbox;
+
+    public BanMuteBox(string title, string prompt, bool modal, EventHandler okayClicked)
     {
+        OkayEventHandler = okayClicked;
 
-        private ComboBox mDurationBox;
+        mMyWindow = new WindowControl(Interface.GameUi.GameCanvas, title, modal);
+        mMyWindow.SetSize(400, 150);
+        mMyWindow.SetPosition(
+            Graphics.Renderer.GetScreenWidth() / 2 - mMyWindow.Width / 2,
+            Graphics.Renderer.GetScreenHeight() / 2 - mMyWindow.Height / 2
+        );
+        mMyWindow.SetTextColor(Color.White, WindowControl.ControlState.Active);
 
-        private Label mDurationLabel;
+        mMyWindow.IsClosable = false;
+        mMyWindow.DisableResizing();
+        mMyWindow.Margin = Margin.Zero;
+        mMyWindow.Padding = Padding.Zero;
+        Interface.InputBlockingElements.Add(mMyWindow);
 
-        private CheckBox mIpCheckbox;
+        var promptLabel = new Label(mMyWindow);
+        promptLabel.SetText(prompt);
+        promptLabel.SetPosition(mMyWindow.Width / 2 - promptLabel.Width / 2, 8);
+        promptLabel.TextColor = Color.White;
 
-        private Label mIpLabel;
+        var y = promptLabel.Y + promptLabel.Height + 8;
 
-        private WindowControl mMyWindow;
-
-        private TextBox mReasonBox;
-
-        private Label mReasonLabel;
-
-        private TextBoxNumeric mTextbox;
-
-        public BanMuteBox(string title, string prompt, bool modal, EventHandler okayClicked)
+        mReasonLabel = new Label(mMyWindow)
         {
-            OkayEventHandler = okayClicked;
+            Text = Strings.BanMute.Reason
+        };
+        mReasonLabel.SetPosition(32, y);
+        mReasonLabel.TextColor = Color.White;
+        
+        mReasonBox = new TextBox(mMyWindow);
+        mReasonBox.SetBounds(90, y - 3, 220, 22);
+        Interface.FocusElements.Add(mReasonBox);
+        y = mReasonBox.Bottom + 6;
 
-            mMyWindow = new WindowControl(Interface.GameUi.GameCanvas, title, modal);
-            mMyWindow.SetSize(400, 150);
-            mMyWindow.SetPosition(
-                Graphics.Renderer.GetScreenWidth() / 2 - mMyWindow.Width / 2,
-                Graphics.Renderer.GetScreenHeight() / 2 - mMyWindow.Height / 2
-            );
-            mMyWindow.SetTextColor(Color.White, WindowControl.ControlState.Active);
+        mDurationLabel = new Label(mMyWindow) { Text = Strings.BanMute.Duration };
+        mDurationLabel.SetPosition(32, y);
+        mDurationLabel.TextColor = Color.White;
+        
+        mDurationBox = new ComboBox(mMyWindow);
+        mDurationBox.SetMenuBackgroundColor(Color.FromArgb(242, 27,36,49));
+        mDurationBox.SetBounds(90, y - 3, 120, 22);
+        mDurationBox.AddItem(Strings.BanMute.OneDay).UserData = "1 day";
+        mDurationBox.AddItem(Strings.BanMute.TwoDays).UserData = "2 days";
+        mDurationBox.AddItem(Strings.BanMute.ThreeDays).UserData = "3 days";
+        mDurationBox.AddItem(Strings.BanMute.FourDays).UserData = "4 days";
+        mDurationBox.AddItem(Strings.BanMute.FiveDays).UserData = "5 days";
+        mDurationBox.AddItem(Strings.BanMute.OneWeek).UserData = "1 week";
+        mDurationBox.AddItem(Strings.BanMute.TwoWeeks).UserData = "2 weeks";
+        mDurationBox.AddItem(Strings.BanMute.OneMonth).UserData = "1 month";
+        mDurationBox.AddItem(Strings.BanMute.TwoMonths).UserData = "2 months";
+        mDurationBox.AddItem(Strings.BanMute.SixMonths).UserData = "6 months";
+        mDurationBox.AddItem(Strings.BanMute.OneYear).UserData = "1 year";
+        mDurationBox.AddItem(Strings.BanMute.Forever).UserData = "Indefinitely";
+        
+        mDurationBox.SetTextColor(Color.White, Label.ControlState.Normal);
+        mDurationBox.SetTextColor(Color.White, Label.ControlState.Hovered);
 
-            mMyWindow.IsClosable = false;
-            mMyWindow.DisableResizing();
-            mMyWindow.Margin = Margin.Zero;
-            mMyWindow.Padding = Padding.Zero;
-            Interface.InputBlockingElements.Add(mMyWindow);
+        mIpLabel = new Label(mMyWindow)
+        {
+            Text = Strings.BanMute.IncludeIp
+        };
 
-            var promptLabel = new Label(mMyWindow);
-            promptLabel.SetText(prompt);
-            promptLabel.SetPosition(mMyWindow.Width / 2 - promptLabel.Width / 2, 8);
-            promptLabel.TextColor = Color.White;
+        mIpLabel.SetPosition(235, y);
+        mIpLabel.TextColor = Color.White;
 
-            var y = promptLabel.Y + promptLabel.Height + 8;
+        mIpCheckbox = new CheckBox(mMyWindow);
+        mIpCheckbox.SetSize(22, 22);
+        mIpCheckbox.SetPosition(310 - mIpCheckbox.Width, y - 2);
 
-            mReasonLabel = new Label(mMyWindow)
-            {
-                Text = Strings.BanMute.Reason
-            };
-            mReasonLabel.SetPosition(32, y);
-            mReasonLabel.TextColor = Color.White;
-            
-            mReasonBox = new TextBox(mMyWindow);
-            mReasonBox.SetBounds(90, y - 3, 220, 22);
-            Interface.FocusElements.Add(mReasonBox);
-            y = mReasonBox.Bottom + 6;
+        var okayBtn = new Button(mMyWindow);
+        okayBtn.SetSize(86, 22);
+        okayBtn.SetTextColor(Color.White, Label.ControlState.Normal);
+        okayBtn.SetTextColor(Color.White, Label.ControlState.Clicked);
+        okayBtn.SetText(Strings.BanMute.Okay);
+        okayBtn.SetPosition(mMyWindow.Width / 2 - 188 / 2, 90);
+        okayBtn.Clicked += okayBtn_Clicked;
 
-            mDurationLabel = new Label(mMyWindow) { Text = Strings.BanMute.Duration };
-            mDurationLabel.SetPosition(32, y);
-            mDurationLabel.TextColor = Color.White;
-            
-            mDurationBox = new ComboBox(mMyWindow);
-            mDurationBox.SetMenuBackgroundColor(Color.FromArgb(242, 27,36,49));
-            mDurationBox.SetBounds(90, y - 3, 120, 22);
-            mDurationBox.AddItem(Strings.BanMute.OneDay).UserData = "1 day";
-            mDurationBox.AddItem(Strings.BanMute.TwoDays).UserData = "2 days";
-            mDurationBox.AddItem(Strings.BanMute.ThreeDays).UserData = "3 days";
-            mDurationBox.AddItem(Strings.BanMute.FourDays).UserData = "4 days";
-            mDurationBox.AddItem(Strings.BanMute.FiveDays).UserData = "5 days";
-            mDurationBox.AddItem(Strings.BanMute.OneWeek).UserData = "1 week";
-            mDurationBox.AddItem(Strings.BanMute.TwoWeeks).UserData = "2 weeks";
-            mDurationBox.AddItem(Strings.BanMute.OneMonth).UserData = "1 month";
-            mDurationBox.AddItem(Strings.BanMute.TwoMonths).UserData = "2 months";
-            mDurationBox.AddItem(Strings.BanMute.SixMonths).UserData = "6 months";
-            mDurationBox.AddItem(Strings.BanMute.OneYear).UserData = "1 year";
-            mDurationBox.AddItem(Strings.BanMute.Forever).UserData = "Indefinitely";
-            
-            mDurationBox.SetTextColor(Color.White, Label.ControlState.Normal);
-            mDurationBox.SetTextColor(Color.White, Label.ControlState.Hovered);
+        var cancelBtn = new Button(mMyWindow);
+        cancelBtn.SetTextColor(Color.White, Label.ControlState.Normal);
+        cancelBtn.SetTextColor(Color.White, Label.ControlState.Clicked);
+        cancelBtn.SetSize(86, 22);
+        cancelBtn.SetText(Strings.BanMute.Cancel);
+        cancelBtn.Clicked += CancelBtn_Clicked;
+        cancelBtn.SetPosition(mMyWindow.Width / 2 - 188 / 2 + 86 + 16, 90);
+    }
 
-            mIpLabel = new Label(mMyWindow)
-            {
-                Text = Strings.BanMute.IncludeIp
-            };
+    private event EventHandler OkayEventHandler;
 
-            mIpLabel.SetPosition(235, y);
-            mIpLabel.TextColor = Color.White;
+    private void CancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Dispose();
+    }
 
-            mIpCheckbox = new CheckBox(mMyWindow);
-            mIpCheckbox.SetSize(22, 22);
-            mIpCheckbox.SetPosition(310 - mIpCheckbox.Width, y - 2);
+    void okayBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        OkayEventHandler?.Invoke(this, EventArgs.Empty);
+        mMyWindow.Close();
+    }
 
-            var okayBtn = new Button(mMyWindow);
-            okayBtn.SetSize(86, 22);
-            okayBtn.SetTextColor(Color.White, Label.ControlState.Normal);
-            okayBtn.SetTextColor(Color.White, Label.ControlState.Clicked);
-            okayBtn.SetText(Strings.BanMute.Okay);
-            okayBtn.SetPosition(mMyWindow.Width / 2 - 188 / 2, 90);
-            okayBtn.Clicked += okayBtn_Clicked;
+    public void Dispose()
+    {
+        mMyWindow.Close();
+        Interface.GameUi.GameCanvas.RemoveChild(mMyWindow, false);
+        mMyWindow.Dispose();
+    }
 
-            var cancelBtn = new Button(mMyWindow);
-            cancelBtn.SetTextColor(Color.White, Label.ControlState.Normal);
-            cancelBtn.SetTextColor(Color.White, Label.ControlState.Clicked);
-            cancelBtn.SetSize(86, 22);
-            cancelBtn.SetText(Strings.BanMute.Cancel);
-            cancelBtn.Clicked += CancelBtn_Clicked;
-            cancelBtn.SetPosition(mMyWindow.Width / 2 - 188 / 2 + 86 + 16, 90);
+    public int GetDuration() //days by default
+    {
+        switch (mDurationBox.SelectedItem.UserData.ToString())
+        {
+            case "1 day":
+                return 1;
+            case "2 days":
+                return 2;
+            case "3 days":
+                return 3;
+            case "5 days":
+                return 5;
+            case "1 week":
+                return 7;
+            case "2 weeks":
+                return 14;
+            case "1 month":
+                return 30;
+            case "2 months":
+                return 60;
+            case "6 months":
+                return 180;
+            case "1 year":
+                return 365;
+            case "Indefinitely":
+                return 999999;
         }
 
-        private event EventHandler OkayEventHandler;
+        return 1;
+    }
 
-        private void CancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Dispose();
-        }
+    public string GetReason()
+    {
+        return mReasonBox.Text;
+    }
 
-        void okayBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            OkayEventHandler?.Invoke(this, EventArgs.Empty);
-            mMyWindow.Close();
-        }
-
-        public void Dispose()
-        {
-            mMyWindow.Close();
-            Interface.GameUi.GameCanvas.RemoveChild(mMyWindow, false);
-            mMyWindow.Dispose();
-        }
-
-        public int GetDuration() //days by default
-        {
-            switch (mDurationBox.SelectedItem.UserData.ToString())
-            {
-                case "1 day":
-                    return 1;
-                case "2 days":
-                    return 2;
-                case "3 days":
-                    return 3;
-                case "5 days":
-                    return 5;
-                case "1 week":
-                    return 7;
-                case "2 weeks":
-                    return 14;
-                case "1 month":
-                    return 30;
-                case "2 months":
-                    return 60;
-                case "6 months":
-                    return 180;
-                case "1 year":
-                    return 365;
-                case "Indefinitely":
-                    return 999999;
-            }
-
-            return 1;
-        }
-
-        public string GetReason()
-        {
-            return mReasonBox.Text;
-        }
-
-        public bool BanIp()
-        {
-            return mIpCheckbox.IsChecked;
-        }
-
+    public bool BanIp()
+    {
+        return mIpCheckbox.IsChecked;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankItem.cs
@@ -13,180 +13,172 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Bank
+namespace Intersect.Client.Interface.Game.Bank;
+
+
+public partial class BankItem
 {
 
-    public partial class BankItem
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public ImagePanel Container;
+
+    public bool IsDragging;
+
+    //Drag/Drop References
+    private BankWindow mBankWindow;
+
+    //Dragging
+    private bool mCanDrag;
+
+    private long mClickTime;
+
+    private Guid mCurrentItemId;
+
+    private ItemDescriptionWindow mDescWindow;
+
+    private Draggable mDragIcon;
+
+    //Mouse Event Variables
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    //Slot info
+    private int mMySlot;
+
+    public ImagePanel Pnl;
+
+    public BankItem(BankWindow bankWindow, int index)
     {
+        mBankWindow = bankWindow;
+        mMySlot = index;
+    }
 
-        private static int sItemXPadding = 4;
+    public void Setup()
+    {
+        Pnl = new ImagePanel(Container, "BankItemIcon");
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+        Pnl.RightClicked += Pnl_RightClicked;
+        Pnl.DoubleClicked += Pnl_DoubleClicked;
+        Pnl.Clicked += pnl_Clicked;
+    }
 
-        private static int sItemYPadding = 4;
-
-        public ImagePanel Container;
-
-        public bool IsDragging;
-
-        //Drag/Drop References
-        private BankWindow mBankWindow;
-
-        //Dragging
-        private bool mCanDrag;
-
-        private long mClickTime;
-
-        private Guid mCurrentItemId;
-
-        private ItemDescriptionWindow mDescWindow;
-
-        private Draggable mDragIcon;
-
-        //Mouse Event Variables
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        //Slot info
-        private int mMySlot;
-
-        public ImagePanel Pnl;
-
-        public BankItem(BankWindow bankWindow, int index)
+    private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (ClientConfiguration.Instance.EnableContextMenus)
         {
-            mBankWindow = bankWindow;
-            mMySlot = index;
+            mBankWindow.OpenContextMenu(mMySlot);
         }
-
-        public void Setup()
+        else
         {
-            Pnl = new ImagePanel(Container, "BankItemIcon");
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-            Pnl.RightClicked += Pnl_RightClicked;
-            Pnl.DoubleClicked += Pnl_DoubleClicked;
-            Pnl.Clicked += pnl_Clicked;
+            Pnl_DoubleClicked(sender, arguments);
         }
+    }
 
-        private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.InBank)
         {
-            if (ClientConfiguration.Instance.EnableContextMenus)
+            if (Globals.InputManager.KeyDown(Keys.Shift))
             {
-                mBankWindow.OpenContextMenu(mMySlot);
+                Globals.Me.TryWithdrawItem(
+                    mMySlot,
+                    skipPrompt: true
+                );
             }
             else
             {
-                Pnl_DoubleClicked(sender, arguments);
-            }
-        }
-
-        private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.InBank)
-            {
-                if (Globals.InputManager.KeyDown(Keys.Shift))
-                {
-                    Globals.Me.TryWithdrawItem(
-                        mMySlot,
-                        skipPrompt: true
-                    );
-                }
-                else
-                {
-                    var slot = Globals.Bank[mMySlot];
-                    Globals.Me.TryWithdrawItem(
-                        mMySlot,
-                        slot,
-                        quantityHint: slot.Quantity,
-                        skipPrompt: false
-                    );
-                }
-            }
-        }
-
-        void pnl_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mClickTime = Timing.Global.MillisecondsUtc + 500;
-        }
-
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
-        {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-        }
-
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
-        {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
-
-            mMouseOver = true;
-            mCanDrag = true;
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                mCanDrag = false;
-
-                return;
-            }
-
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-
-            if (Globals.Bank[mMySlot]?.Base != null)
-            {
-                mDescWindow = new ItemDescriptionWindow(
-                    Globals.Bank[mMySlot].Base, Globals.Bank[mMySlot].Quantity, mBankWindow.X, mBankWindow.Y,
-                    Globals.Bank[mMySlot].ItemProperties
+                var slot = Globals.Bank[mMySlot];
+                Globals.Me.TryWithdrawItem(
+                    mMySlot,
+                    slot,
+                    quantityHint: slot.Quantity,
+                    skipPrompt: false
                 );
             }
         }
+    }
 
-        public FloatRect RenderBounds()
+    void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mClickTime = Timing.Global.MillisecondsUtc + 500;
+    }
+
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (mDescWindow != null)
         {
-            var rect = new FloatRect()
-            {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+    }
 
-            return rect;
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        public void Update()
+        mMouseOver = true;
+        mCanDrag = true;
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            if (Globals.Bank[mMySlot].ItemId != mCurrentItemId)
+            mCanDrag = false;
+
+            return;
+        }
+
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+
+        if (Globals.Bank[mMySlot]?.Base != null)
+        {
+            mDescWindow = new ItemDescriptionWindow(
+                Globals.Bank[mMySlot].Base, Globals.Bank[mMySlot].Quantity, mBankWindow.X, mBankWindow.Y,
+                Globals.Bank[mMySlot].ItemProperties
+            );
+        }
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
+
+        return rect;
+    }
+
+    public void Update()
+    {
+        if (Globals.Bank[mMySlot].ItemId != mCurrentItemId)
+        {
+            mCurrentItemId = Globals.Bank[mMySlot].ItemId;
+            var item = ItemBase.Get(Globals.Bank[mMySlot].ItemId);
+            if (item != null)
             {
-                mCurrentItemId = Globals.Bank[mMySlot].ItemId;
-                var item = ItemBase.Get(Globals.Bank[mMySlot].ItemId);
-                if (item != null)
+                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+                if (itemTex != null)
                 {
-                    var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-                    if (itemTex != null)
-                    {
-                        Pnl.Texture = itemTex;
-                        Pnl.RenderColor = item.Color;
-                    }
-                    else
-                    {
-                        if (Pnl.Texture != null)
-                        {
-                            Pnl.Texture = null;
-                        }
-                    }
+                    Pnl.Texture = itemTex;
+                    Pnl.RenderColor = item.Color;
                 }
                 else
                 {
@@ -196,81 +188,137 @@ namespace Intersect.Client.Interface.Game.Bank
                     }
                 }
             }
-
-            if (!IsDragging)
+            else
             {
-                if (mMouseOver)
+                if (Pnl.Texture != null)
                 {
-                    if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                    Pnl.Texture = null;
+                }
+            }
+        }
+
+        if (!IsDragging)
+        {
+            if (mMouseOver)
+            {
+                if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                {
+                    mCanDrag = true;
+                    mMouseX = -1;
+                    mMouseY = -1;
+                    if (Timing.Global.MillisecondsUtc < mClickTime)
                     {
-                        mCanDrag = true;
-                        mMouseX = -1;
-                        mMouseY = -1;
-                        if (Timing.Global.MillisecondsUtc < mClickTime)
-                        {
-                            //Globals.Me.TryUseItem(_mySlot);
-                            mClickTime = 0;
-                        }
+                        //Globals.Me.TryUseItem(_mySlot);
+                        mClickTime = 0;
                     }
-                    else
+                }
+                else
+                {
+                    if (mCanDrag && Draggable.Active == null)
                     {
-                        if (mCanDrag && Draggable.Active == null)
+                        if (mMouseX == -1 || mMouseY == -1)
                         {
-                            if (mMouseX == -1 || mMouseY == -1)
-                            {
-                                mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
-                                mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
-                            }
-                            else
-                            {
-                                var xdiff = mMouseX -
-                                            (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
+                            mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
+                            mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
+                        }
+                        else
+                        {
+                            var xdiff = mMouseX -
+                                        (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
 
-                                var ydiff = mMouseY -
-                                            (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
+                            var ydiff = mMouseY -
+                                        (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
 
-                                if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
-                                {
-                                    IsDragging = true;
-                                    mDragIcon = new Draggable(
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
-                                    );
-                                }
+                            if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
+                            {
+                                IsDragging = true;
+                                mDragIcon = new Draggable(
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
+                                );
                             }
                         }
                     }
                 }
             }
-            else
+        }
+        else
+        {
+            if (mDragIcon.Update())
             {
-                if (mDragIcon.Update())
+                //Drug the item and now we stopped
+                IsDragging = false;
+                var dragRect = new FloatRect(
+                    mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
+                    sItemYPadding / 2 + 32
+                );
+
+                float bestIntersect = 0;
+                var bestIntersectIndex = -1;
+
+                //So we picked up an item and then dropped it. Lets see where we dropped it to.
+                //Check inventory first.
+                if (mBankWindow.RenderBounds().IntersectsWith(dragRect))
                 {
-                    //Drug the item and now we stopped
-                    IsDragging = false;
-                    var dragRect = new FloatRect(
-                        mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
-                        sItemYPadding / 2 + 32
-                    );
-
-                    float bestIntersect = 0;
-                    var bestIntersectIndex = -1;
-
-                    //So we picked up an item and then dropped it. Lets see where we dropped it to.
-                    //Check inventory first.
-                    if (mBankWindow.RenderBounds().IntersectsWith(dragRect))
+                    for (var i = 0; i < Globals.BankSlots; i++)
                     {
-                        for (var i = 0; i < Globals.BankSlots; i++)
+                        if (mBankWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
                         {
-                            if (mBankWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
+                            if (FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Width *
+                                FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Height >
+                                bestIntersect)
                             {
-                                if (FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Width *
-                                    FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Height >
+                                bestIntersect =
+                                    FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Width *
+                                    FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Height;
+
+                                bestIntersectIndex = i;
+                            }
+                        }
+                    }
+
+                    if (bestIntersectIndex > -1)
+                    {
+                        if (mMySlot != bestIntersectIndex)
+                        {
+                            var allowed = true;
+
+                            //Permission Check
+                            if (Globals.GuildBank)
+                            {
+                                var rank = Globals.Me.GuildRank;
+                                if (string.IsNullOrWhiteSpace(Globals.Me.Guild) || (!rank.Permissions.BankDeposit && Globals.Me.Rank != 0))
+                                {
+                                    ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedSwap.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
+                                    allowed = false;
+                                }
+                            }
+
+                            if (allowed)
+                            {
+                                PacketSender.SendMoveBankItems(mMySlot, bestIntersectIndex);
+                            }
+
+                            //Globals.Me.SwapItems(bestIntersectIndex, _mySlot);
+                        }
+                    }
+                }
+                else
+                {
+                    var invWindow = Interface.GameUi.GameMenu.GetInventoryWindow();
+                    if (invWindow.RenderBounds().IntersectsWith(dragRect))
+                    {
+                        for (var i = 0; i < Globals.Me.Inventory.Length; i++)
+                        {
+                            if (invWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
+                            {
+                                if (FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
+                                    FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height >
                                     bestIntersect)
                                 {
                                     bestIntersect =
-                                        FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Width *
-                                        FloatRect.Intersect(mBankWindow.Items[i].RenderBounds(), dragRect).Height;
+                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
+                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height;
 
                                     bestIntersectIndex = i;
                                 }
@@ -279,70 +327,20 @@ namespace Intersect.Client.Interface.Game.Bank
 
                         if (bestIntersectIndex > -1)
                         {
-                            if (mMySlot != bestIntersectIndex)
-                            {
-                                var allowed = true;
-
-                                //Permission Check
-                                if (Globals.GuildBank)
-                                {
-                                    var rank = Globals.Me.GuildRank;
-                                    if (string.IsNullOrWhiteSpace(Globals.Me.Guild) || (!rank.Permissions.BankDeposit && Globals.Me.Rank != 0))
-                                    {
-                                        ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotAllowedSwap.ToString(Globals.Me.Guild), CustomColors.Alerts.Error, ChatMessageType.Bank));
-                                        allowed = false;
-                                    }
-                                }
-
-                                if (allowed)
-                                {
-                                    PacketSender.SendMoveBankItems(mMySlot, bestIntersectIndex);
-                                }
-
-                                //Globals.Me.SwapItems(bestIntersectIndex, _mySlot);
-                            }
+                            var slot = Globals.Bank[mMySlot];
+                            Globals.Me.TryWithdrawItem(
+                                mMySlot,
+                                inventorySlotIndex: bestIntersectIndex,
+                                quantityHint: slot.Quantity,
+                                skipPrompt: true
+                            );
                         }
                     }
-                    else
-                    {
-                        var invWindow = Interface.GameUi.GameMenu.GetInventoryWindow();
-                        if (invWindow.RenderBounds().IntersectsWith(dragRect))
-                        {
-                            for (var i = 0; i < Globals.Me.Inventory.Length; i++)
-                            {
-                                if (invWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
-                                {
-                                    if (FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
-                                        FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height >
-                                        bestIntersect)
-                                    {
-                                        bestIntersect =
-                                            FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Width *
-                                            FloatRect.Intersect(invWindow.Items[i].RenderBounds(), dragRect).Height;
-
-                                        bestIntersectIndex = i;
-                                    }
-                                }
-                            }
-
-                            if (bestIntersectIndex > -1)
-                            {
-                                var slot = Globals.Bank[mMySlot];
-                                Globals.Me.TryWithdrawItem(
-                                    mMySlot,
-                                    inventorySlotIndex: bestIntersectIndex,
-                                    quantityHint: slot.Quantity,
-                                    skipPrompt: true
-                                );
-                            }
-                        }
-                    }
-
-                    mDragIcon.Dispose();
                 }
+
+                mDragIcon.Dispose();
             }
         }
-
     }
 
 }

--- a/Intersect.Client/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client/Interface/Game/Bank/BankWindow.cs
@@ -6,249 +6,247 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Bank
+namespace Intersect.Client.Interface.Game.Bank;
+
+
+public partial class BankWindow
 {
 
-    public partial class BankWindow
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public List<BankItem> Items = new List<BankItem>();
+
+    //Controls
+    private WindowControl mBankWindow;
+
+    private ScrollControl mItemContainer;
+
+    private List<Label> mValues = new List<Label>();
+
+    //Location
+    public int X;
+
+    public int Y;
+
+    private bool mOpen;
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mWithdrawContextItem;
+
+    //Init
+    public BankWindow(Canvas gameCanvas)
     {
+        // Create a new window to display the contents of the bank.
+        mBankWindow = new WindowControl(gameCanvas,
+            Globals.GuildBank
+                ? Strings.Guilds.Bank.ToString(Globals.Me?.Guild)
+                : Strings.Bank.Title.ToString(),
+            false, "BankWindow");
 
-        private static int sItemXPadding = 4;
+        // Disable resizing and add to the list of input-blocking elements.
+        mBankWindow.DisableResizing();
+        Interface.InputBlockingElements.Add(mBankWindow);
 
-        private static int sItemYPadding = 4;
+        // Create a new scroll control for the items in the bank.
+        mItemContainer = new ScrollControl(mBankWindow, "ItemContainer");
+        mItemContainer.EnableScroll(false, true);
 
-        public List<BankItem> Items = new List<BankItem>();
+        // Initialize the bank window and item container.
+        mBankWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        InitItemContainer();
 
-        //Controls
-        private WindowControl mBankWindow;
+        // Create a context menu for the bank items.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "BankContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
 
-        private ScrollControl mItemContainer;
+        // Clear the children of the context menu and add a "Withdraw" option.
+        mContextMenu.Children.Clear();
+        mWithdrawContextItem = mContextMenu.AddItem(Strings.BankContextMenu.Withdraw);
+        mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        private List<Label> mValues = new List<Label>();
+        // Close the window.
+        Close();
+    }
 
-        //Location
-        public int X;
+    public void OpenContextMenu(int slot)
+    {
+        var item = ItemBase.Get(Globals.Bank[slot].ItemId);
 
-        public int Y;
-
-        private bool mOpen;
-
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mWithdrawContextItem;
-
-        //Init
-        public BankWindow(Canvas gameCanvas)
+        // No point showing a menu for blank space.
+        if (item == null)
         {
-            // Create a new window to display the contents of the bank.
-            mBankWindow = new WindowControl(gameCanvas,
-                Globals.GuildBank
-                    ? Strings.Guilds.Bank.ToString(Globals.Me?.Guild)
-                    : Strings.Bank.Title.ToString(),
-                false, "BankWindow");
-
-            // Disable resizing and add to the list of input-blocking elements.
-            mBankWindow.DisableResizing();
-            Interface.InputBlockingElements.Add(mBankWindow);
-
-            // Create a new scroll control for the items in the bank.
-            mItemContainer = new ScrollControl(mBankWindow, "ItemContainer");
-            mItemContainer.EnableScroll(false, true);
-
-            // Initialize the bank window and item container.
-            mBankWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-            InitItemContainer();
-
-            // Create a context menu for the bank items.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "BankContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-
-            // Clear the children of the context menu and add a "Withdraw" option.
-            mContextMenu.Children.Clear();
-            mWithdrawContextItem = mContextMenu.AddItem(Strings.BankContextMenu.Withdraw);
-            mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            // Close the window.
-            Close();
+            return;
         }
 
-        public void OpenContextMenu(int slot)
-        {
-            var item = ItemBase.Get(Globals.Bank[slot].ItemId);
+        mWithdrawContextItem.SetText(Strings.BankContextMenu.Withdraw.ToString(item.Name));
 
-            // No point showing a menu for blank space.
-            if (item == null)
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = slot;
+
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+    }
+
+    private void MWithdrawContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int)sender.Parent.UserData;
+        Globals.Me.TryWithdrawItem(slot);
+    }
+
+    public void Close()
+    {
+        mBankWindow.IsHidden = true;
+        mOpen = false;
+        mContextMenu?.Close();
+    }
+
+    public void Open()
+    {
+        // Hide unavailable bank slots
+        var currentBankSlots = Math.Max(0, Globals.BankSlots);
+        // For any slot beyond the current bank's maximum slots
+        for (var i = currentBankSlots; i < Options.Instance.Bank.MaxSlots; i++)
+        {
+            var bankItem = Items[i];
+            var bankLabel = mValues[i];
+
+            bankItem.Container.Hide();
+            bankLabel.Hide();
+
+            // Position this invisible BankItem at 0,0 so the scrollbar doesn't think we have more slots than we do
+            SetItemPosition(i);
+        }
+
+        mBankWindow.IsHidden = false;
+        mOpen = true;
+    }
+
+    public bool IsVisible()
+    {
+        return !mBankWindow.IsHidden;
+    }
+
+    public void Update()
+    {
+        if (mBankWindow.IsHidden)
+        {
+            if (mOpen)
             {
-                return;
+                Interface.GameUi.NotifyCloseBank();
             }
 
-            mWithdrawContextItem.SetText(Strings.BankContextMenu.Withdraw.ToString(item.Name));
-
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = slot;
-
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
+            return;
         }
 
-        private void MWithdrawContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+        X = mBankWindow.X;
+        Y = mBankWindow.Y;
+        for (var i = 0; i < Math.Min(Globals.BankSlots, Options.Instance.Bank.MaxSlots); i++)
         {
-            var slot = (int)sender.Parent.UserData;
-            Globals.Me.TryWithdrawItem(slot);
-        }
+            var bankItem = Items[i];
+            var bankLabel = mValues[i];
+            var globalBankItem = Globals.Bank[i];
 
-        public void Close()
-        {
-            mBankWindow.IsHidden = true;
-            mOpen = false;
-            mContextMenu?.Close();
-        }
-
-        public void Open()
-        {
-            // Hide unavailable bank slots
-            var currentBankSlots = Math.Max(0, Globals.BankSlots);
-            // For any slot beyond the current bank's maximum slots
-            for (var i = currentBankSlots; i < Options.Instance.Bank.MaxSlots; i++)
+            bankItem.Container.Show();
+            SetItemPosition(i);
+            if (globalBankItem != null && globalBankItem.ItemId != Guid.Empty)
             {
-                var bankItem = Items[i];
-                var bankLabel = mValues[i];
-
-                bankItem.Container.Hide();
-                bankLabel.Hide();
-
-                // Position this invisible BankItem at 0,0 so the scrollbar doesn't think we have more slots than we do
-                SetItemPosition(i);
-            }
-
-            mBankWindow.IsHidden = false;
-            mOpen = true;
-        }
-
-        public bool IsVisible()
-        {
-            return !mBankWindow.IsHidden;
-        }
-
-        public void Update()
-        {
-            if (mBankWindow.IsHidden)
-            {
-                if (mOpen)
+                var item = ItemBase.Get(globalBankItem.ItemId);
+                if (item != null)
                 {
-                    Interface.GameUi.NotifyCloseBank();
-                }
-
-                return;
-            }
-
-            X = mBankWindow.X;
-            Y = mBankWindow.Y;
-            for (var i = 0; i < Math.Min(Globals.BankSlots, Options.Instance.Bank.MaxSlots); i++)
-            {
-                var bankItem = Items[i];
-                var bankLabel = mValues[i];
-                var globalBankItem = Globals.Bank[i];
-
-                bankItem.Container.Show();
-                SetItemPosition(i);
-                if (globalBankItem != null && globalBankItem.ItemId != Guid.Empty)
-                {
-                    var item = ItemBase.Get(globalBankItem.ItemId);
-                    if (item != null)
+                    bankItem.Pnl.IsHidden = false;
+                    if (item.IsStackable)
                     {
-                        bankItem.Pnl.IsHidden = false;
-                        if (item.IsStackable)
-                        {
-                            bankLabel.IsHidden = globalBankItem.Quantity <= 1;
-                            bankLabel.Text = Strings.FormatQuantityAbbreviated(globalBankItem.Quantity);
-                        }
-                        else
-                        {
-                            bankLabel.IsHidden = true;
-                        }
-
-                        if (bankItem.IsDragging)
-                        {
-                            bankItem.Pnl.IsHidden = true;
-                            bankLabel.IsHidden = true;
-                        }
-
-                        bankItem.Update();
+                        bankLabel.IsHidden = globalBankItem.Quantity <= 1;
+                        bankLabel.Text = Strings.FormatQuantityAbbreviated(globalBankItem.Quantity);
                     }
+                    else
+                    {
+                        bankLabel.IsHidden = true;
+                    }
+
+                    if (bankItem.IsDragging)
+                    {
+                        bankItem.Pnl.IsHidden = true;
+                        bankLabel.IsHidden = true;
+                    }
+
+                    bankItem.Update();
                 }
-                else
-                {
-                    bankItem.Pnl.IsHidden = true;
-                    bankLabel.IsHidden = true;
-                }
+            }
+            else
+            {
+                bankItem.Pnl.IsHidden = true;
+                bankLabel.IsHidden = true;
             }
         }
+    }
 
-        private void InitItemContainer()
+    private void InitItemContainer()
+    {
+        for (var slotIndex = 0; slotIndex < Options.Instance.Bank.MaxSlots; slotIndex++)
         {
-            for (var slotIndex = 0; slotIndex < Options.Instance.Bank.MaxSlots; slotIndex++)
-            {
-                var bankItem = new BankItem(this, slotIndex);
+            var bankItem = new BankItem(this, slotIndex);
 
-                bankItem.Container = new ImagePanel(mItemContainer, "BankItem");
-                bankItem.Setup();
+            bankItem.Container = new ImagePanel(mItemContainer, "BankItem");
+            bankItem.Setup();
 
-                var bankLabel = new Label(bankItem.Container, "BankItemValue");
-                bankLabel.Text = "";
+            var bankLabel = new Label(bankItem.Container, "BankItemValue");
+            bankLabel.Text = "";
 
-                bankItem.Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-                
-                Items.Add(bankItem);
-                mValues.Add(bankLabel);
-            }
+            bankItem.Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            
+            Items.Add(bankItem);
+            mValues.Add(bankLabel);
+        }
+    }
+
+    /// <summary>
+    /// Sets the item's position based on whether it's hidden or not
+    /// </summary>
+    /// <param name="i">Index of the item slot</param>
+    private void SetItemPosition(int i)
+    {
+        var item = Items[i];
+
+        // If the item is hidden, the player doesn't have that slot unlocked - move it to the top so that the scrollbar doesn't lie to the player
+        if (item.Container.IsHidden)
+        {
+            item.Container.SetPosition(0, 0);
+            return;
         }
 
-        /// <summary>
-        /// Sets the item's position based on whether it's hidden or not
-        /// </summary>
-        /// <param name="i">Index of the item slot</param>
-        private void SetItemPosition(int i)
+        var xPadding = item.Container.Margin.Left + item.Container.Margin.Right;
+        var yPadding = item.Container.Margin.Top + item.Container.Margin.Bottom;
+
+        item.Container.SetPosition(
+            i %
+            (mItemContainer.Width / (item.Container.Width + xPadding)) *
+            (item.Container.Width + xPadding) +
+            xPadding,
+            i /
+            (mItemContainer.Width / (item.Container.Width + xPadding)) *
+            (item.Container.Height + yPadding) +
+            yPadding
+        );
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            var item = Items[i];
+            X = mBankWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
+            Y = mBankWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
+            Width = mBankWindow.Width + sItemXPadding,
+            Height = mBankWindow.Height + sItemYPadding
+        };
 
-            // If the item is hidden, the player doesn't have that slot unlocked - move it to the top so that the scrollbar doesn't lie to the player
-            if (item.Container.IsHidden)
-            {
-                item.Container.SetPosition(0, 0);
-                return;
-            }
-
-            var xPadding = item.Container.Margin.Left + item.Container.Margin.Right;
-            var yPadding = item.Container.Margin.Top + item.Container.Margin.Bottom;
-
-            item.Container.SetPosition(
-                i %
-                (mItemContainer.Width / (item.Container.Width + xPadding)) *
-                (item.Container.Width + xPadding) +
-                xPadding,
-                i /
-                (mItemContainer.Width / (item.Container.Width + xPadding)) *
-                (item.Container.Height + yPadding) +
-                yPadding
-            );
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = mBankWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
-                Y = mBankWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
-                Width = mBankWindow.Width + sItemXPadding,
-                Height = mBankWindow.Height + sItemYPadding
-            };
-
-            return rect;
-        }
-
+        return rect;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client/Interface/Game/Character/CharacterWindow.cs
@@ -10,512 +10,510 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Interface.Game.Character
+namespace Intersect.Client.Interface.Game.Character;
+
+
+public partial class CharacterWindow
 {
 
-    public partial class CharacterWindow
+    //Equipment List
+    public List<EquipmentItem> Items = new List<EquipmentItem>();
+
+    Label mAbilityPwrLabel;
+
+    Button mAddAbilityPwrBtn;
+
+    Button mAddAttackBtn;
+
+    Button mAddDefenseBtn;
+
+    Button mAddMagicResistBtn;
+
+    Button mAddSpeedBtn;
+
+    //Stats
+    Label mAttackLabel;
+
+    private ImagePanel mCharacterContainer;
+
+    private Label mCharacterLevelAndClass;
+
+    private Label mCharacterName;
+
+    private ImagePanel mCharacterPortrait;
+
+    private string mCharacterPortraitImg = "";
+
+    //Controls
+    private WindowControl mCharacterWindow;
+
+    private string mCurrentSprite = "";
+
+    Label mDefenseLabel;
+
+    private ItemProperties mItemProperties = null;
+
+    Label mMagicRstLabel;
+
+    Label mPointsLabel;
+
+    Label mSpeedLabel;
+
+    public ImagePanel[] PaperdollPanels;
+
+    public string[] PaperdollTextures;
+
+    //Location
+    public int X;
+
+    public int Y;
+
+    //Extra Buffs
+    ClassBase mPlayer;
+
+    Label mHpRegen;
+
+    long HpRegenAmount;
+
+    Label mManaRegen;
+
+    long ManaRegenAmount;
+
+    Label mLifeSteal;
+
+    int LifeStealAmount = 0;
+
+    Label mAttackSpeed;
+
+    Label mExtraExp;
+
+    int ExtraExpAmount = 0;
+
+    Label mLuck;
+
+    int LuckAmount = 0;
+
+    Label mTenacity;
+
+    int TenacityAmount = 0;
+
+    Label mCooldownReduction;
+
+    int CooldownAmount = 0;
+
+    Label mManaSteal;
+
+    int ManaStealAmount = 0;
+
+    //Init
+    public CharacterWindow(Canvas gameCanvas)
     {
+        mCharacterWindow = new WindowControl(gameCanvas, Strings.Character.Title, false, "CharacterWindow");
+        mCharacterWindow.DisableResizing();
 
-        //Equipment List
-        public List<EquipmentItem> Items = new List<EquipmentItem>();
+        mCharacterName = new Label(mCharacterWindow, "CharacterNameLabel");
+        mCharacterName.SetTextColor(Color.White, Label.ControlState.Normal);
 
-        Label mAbilityPwrLabel;
+        mCharacterLevelAndClass = new Label(mCharacterWindow, "ChatacterInfoLabel");
+        mCharacterLevelAndClass.SetText("");
 
-        Button mAddAbilityPwrBtn;
+        mCharacterContainer = new ImagePanel(mCharacterWindow, "CharacterContainer");
 
-        Button mAddAttackBtn;
+        mCharacterPortrait = new ImagePanel(mCharacterContainer);
 
-        Button mAddDefenseBtn;
-
-        Button mAddMagicResistBtn;
-
-        Button mAddSpeedBtn;
-
-        //Stats
-        Label mAttackLabel;
-
-        private ImagePanel mCharacterContainer;
-
-        private Label mCharacterLevelAndClass;
-
-        private Label mCharacterName;
-
-        private ImagePanel mCharacterPortrait;
-
-        private string mCharacterPortraitImg = "";
-
-        //Controls
-        private WindowControl mCharacterWindow;
-
-        private string mCurrentSprite = "";
-
-        Label mDefenseLabel;
-
-        private ItemProperties mItemProperties = null;
-
-        Label mMagicRstLabel;
-
-        Label mPointsLabel;
-
-        Label mSpeedLabel;
-
-        public ImagePanel[] PaperdollPanels;
-
-        public string[] PaperdollTextures;
-
-        //Location
-        public int X;
-
-        public int Y;
-
-        //Extra Buffs
-        ClassBase mPlayer;
-
-        Label mHpRegen;
-
-        long HpRegenAmount;
-
-        Label mManaRegen;
-
-        long ManaRegenAmount;
-
-        Label mLifeSteal;
-
-        int LifeStealAmount = 0;
-
-        Label mAttackSpeed;
-
-        Label mExtraExp;
-
-        int ExtraExpAmount = 0;
-
-        Label mLuck;
-
-        int LuckAmount = 0;
-
-        Label mTenacity;
-
-        int TenacityAmount = 0;
-
-        Label mCooldownReduction;
-
-        int CooldownAmount = 0;
-
-        Label mManaSteal;
-
-        int ManaStealAmount = 0;
-
-        //Init
-        public CharacterWindow(Canvas gameCanvas)
+        PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count + 1];
+        PaperdollTextures = new string[Options.EquipmentSlots.Count + 1];
+        for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
         {
-            mCharacterWindow = new WindowControl(gameCanvas, Strings.Character.Title, false, "CharacterWindow");
-            mCharacterWindow.DisableResizing();
-
-            mCharacterName = new Label(mCharacterWindow, "CharacterNameLabel");
-            mCharacterName.SetTextColor(Color.White, Label.ControlState.Normal);
-
-            mCharacterLevelAndClass = new Label(mCharacterWindow, "ChatacterInfoLabel");
-            mCharacterLevelAndClass.SetText("");
-
-            mCharacterContainer = new ImagePanel(mCharacterWindow, "CharacterContainer");
-
-            mCharacterPortrait = new ImagePanel(mCharacterContainer);
-
-            PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count + 1];
-            PaperdollTextures = new string[Options.EquipmentSlots.Count + 1];
-            for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
-            {
-                PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
-                PaperdollTextures[i] = "";
-                PaperdollPanels[i].Hide();
-            }
-
-            var equipmentLabel = new Label(mCharacterWindow, "EquipmentLabel");
-            equipmentLabel.SetText(Strings.Character.Equipment);
-
-            var statsLabel = new Label(mCharacterWindow, "StatsLabel");
-            statsLabel.SetText(Strings.Character.Stats);
-
-            mAttackLabel = new Label(mCharacterWindow, "AttackLabel");
-
-            mAddAttackBtn = new Button(mCharacterWindow, "IncreaseAttackButton");
-            mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
-
-            mDefenseLabel = new Label(mCharacterWindow, "DefenseLabel");
-            mAddDefenseBtn = new Button(mCharacterWindow, "IncreaseDefenseButton");
-            mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
-
-            mSpeedLabel = new Label(mCharacterWindow, "SpeedLabel");
-            mAddSpeedBtn = new Button(mCharacterWindow, "IncreaseSpeedButton");
-            mAddSpeedBtn.Clicked += _addSpeedBtn_Clicked;
-
-            mAbilityPwrLabel = new Label(mCharacterWindow, "AbilityPowerLabel");
-            mAddAbilityPwrBtn = new Button(mCharacterWindow, "IncreaseAbilityPowerButton");
-            mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
-
-            mMagicRstLabel = new Label(mCharacterWindow, "MagicResistLabel");
-            mAddMagicResistBtn = new Button(mCharacterWindow, "IncreaseMagicResistButton");
-            mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
-
-            mPointsLabel = new Label(mCharacterWindow, "PointsLabel");
-
-            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-            {
-                Items.Add(new EquipmentItem(i, mCharacterWindow));
-                Items[i].Pnl = new ImagePanel(mCharacterWindow, "EquipmentItem" + i);
-                Items[i].Setup();
-            }
-
-            var extraBuffsLabel = new Label(mCharacterWindow, "ExtraBuffsLabel");
-            extraBuffsLabel.SetText(Strings.Character.ExtraBuffs);
-
-            mHpRegen = new Label(mCharacterWindow, "HpRegen");
-            mManaRegen = new Label(mCharacterWindow, "ManaRegen");
-            mLifeSteal = new Label(mCharacterWindow, "Lifesteal");
-            mAttackSpeed = new Label(mCharacterWindow, "AttackSpeed");
-            mExtraExp = new Label(mCharacterWindow, "ExtraExp");
-            mLuck = new Label(mCharacterWindow, "Luck");
-            mTenacity = new Label(mCharacterWindow, "Tenacity");
-            mCooldownReduction = new Label(mCharacterWindow, "CooldownReduction");
-            mManaSteal = new Label(mCharacterWindow, "Manasteal");
-
-            mCharacterWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
+            PaperdollTextures[i] = "";
+            PaperdollPanels[i].Hide();
         }
 
-        //Update Button Event Handlers
-        void _addMagicResistBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        var equipmentLabel = new Label(mCharacterWindow, "EquipmentLabel");
+        equipmentLabel.SetText(Strings.Character.Equipment);
+
+        var statsLabel = new Label(mCharacterWindow, "StatsLabel");
+        statsLabel.SetText(Strings.Character.Stats);
+
+        mAttackLabel = new Label(mCharacterWindow, "AttackLabel");
+
+        mAddAttackBtn = new Button(mCharacterWindow, "IncreaseAttackButton");
+        mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
+
+        mDefenseLabel = new Label(mCharacterWindow, "DefenseLabel");
+        mAddDefenseBtn = new Button(mCharacterWindow, "IncreaseDefenseButton");
+        mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
+
+        mSpeedLabel = new Label(mCharacterWindow, "SpeedLabel");
+        mAddSpeedBtn = new Button(mCharacterWindow, "IncreaseSpeedButton");
+        mAddSpeedBtn.Clicked += _addSpeedBtn_Clicked;
+
+        mAbilityPwrLabel = new Label(mCharacterWindow, "AbilityPowerLabel");
+        mAddAbilityPwrBtn = new Button(mCharacterWindow, "IncreaseAbilityPowerButton");
+        mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
+
+        mMagicRstLabel = new Label(mCharacterWindow, "MagicResistLabel");
+        mAddMagicResistBtn = new Button(mCharacterWindow, "IncreaseMagicResistButton");
+        mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
+
+        mPointsLabel = new Label(mCharacterWindow, "PointsLabel");
+
+        for (var i = 0; i < Options.EquipmentSlots.Count; i++)
         {
-            PacketSender.SendUpgradeStat((int) Stat.MagicResist);
+            Items.Add(new EquipmentItem(i, mCharacterWindow));
+            Items[i].Pnl = new ImagePanel(mCharacterWindow, "EquipmentItem" + i);
+            Items[i].Setup();
         }
 
-        void _addAbilityPwrBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        var extraBuffsLabel = new Label(mCharacterWindow, "ExtraBuffsLabel");
+        extraBuffsLabel.SetText(Strings.Character.ExtraBuffs);
+
+        mHpRegen = new Label(mCharacterWindow, "HpRegen");
+        mManaRegen = new Label(mCharacterWindow, "ManaRegen");
+        mLifeSteal = new Label(mCharacterWindow, "Lifesteal");
+        mAttackSpeed = new Label(mCharacterWindow, "AttackSpeed");
+        mExtraExp = new Label(mCharacterWindow, "ExtraExp");
+        mLuck = new Label(mCharacterWindow, "Luck");
+        mTenacity = new Label(mCharacterWindow, "Tenacity");
+        mCooldownReduction = new Label(mCharacterWindow, "CooldownReduction");
+        mManaSteal = new Label(mCharacterWindow, "Manasteal");
+
+        mCharacterWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+
+    //Update Button Event Handlers
+    void _addMagicResistBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendUpgradeStat((int) Stat.MagicResist);
+    }
+
+    void _addAbilityPwrBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendUpgradeStat((int) Stat.AbilityPower);
+    }
+
+    void _addSpeedBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendUpgradeStat((int) Stat.Speed);
+    }
+
+    void _addDefenseBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendUpgradeStat((int) Stat.Defense);
+    }
+
+    void _addAttackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        PacketSender.SendUpgradeStat((int) Stat.Attack);
+    }
+
+    //Methods
+    public void Update()
+    {
+        if (mCharacterWindow.IsHidden)
         {
-            PacketSender.SendUpgradeStat((int) Stat.AbilityPower);
+            return;
         }
 
-        void _addSpeedBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            PacketSender.SendUpgradeStat((int) Stat.Speed);
-        }
+        mCharacterName.Text = Globals.Me.Name;
+        mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(
+            Globals.Me.Level, ClassBase.GetName(Globals.Me.Class)
+        );
 
-        void _addDefenseBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            PacketSender.SendUpgradeStat((int) Stat.Defense);
-        }
+        //Load Portrait
+        //UNCOMMENT THIS LINE IF YOU'D RATHER HAVE A FACE HERE GameTexture faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, Globals.Me.Face);
+        var entityTex = Globals.ContentManager.GetTexture(
+            Framework.Content.TextureType.Entity, Globals.Me.Sprite
+        );
 
-        void _addAttackBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            PacketSender.SendUpgradeStat((int) Stat.Attack);
-        }
-
-        //Methods
-        public void Update()
-        {
-            if (mCharacterWindow.IsHidden)
-            {
-                return;
-            }
-
-            mCharacterName.Text = Globals.Me.Name;
-            mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(
-                Globals.Me.Level, ClassBase.GetName(Globals.Me.Class)
-            );
-
-            //Load Portrait
-            //UNCOMMENT THIS LINE IF YOU'D RATHER HAVE A FACE HERE GameTexture faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, Globals.Me.Face);
-            var entityTex = Globals.ContentManager.GetTexture(
-                Framework.Content.TextureType.Entity, Globals.Me.Sprite
-            );
-
-            /* UNCOMMENT THIS BLOCK IF YOU"D RATHER HAVE A FACE HERE if (Globals.Me.Face != "" && Globals.Me.Face != _currentSprite && faceTex != null)
+        /* UNCOMMENT THIS BLOCK IF YOU"D RATHER HAVE A FACE HERE if (Globals.Me.Face != "" && Globals.Me.Face != _currentSprite && faceTex != null)
+         {
+             _characterPortrait.Texture = faceTex;
+             _characterPortrait.SetTextureRect(0, 0, faceTex.GetWidth(), faceTex.GetHeight());
+             _characterPortrait.SizeToContents();
+             Align.Center(_characterPortrait);
+             _characterPortrait.IsHidden = false;
+             for (int i = 0; i < Options.EquipmentSlots.Count; i++)
              {
-                 _characterPortrait.Texture = faceTex;
-                 _characterPortrait.SetTextureRect(0, 0, faceTex.GetWidth(), faceTex.GetHeight());
-                 _characterPortrait.SizeToContents();
-                 Align.Center(_characterPortrait);
-                 _characterPortrait.IsHidden = false;
-                 for (int i = 0; i < Options.EquipmentSlots.Count; i++)
-                 {
-                     _paperdollPanels[i].Hide();
-                 }
+                 _paperdollPanels[i].Hide();
              }
-             else */
-            if (!string.IsNullOrWhiteSpace(Globals.Me.Sprite) && Globals.Me.Sprite != mCurrentSprite && entityTex != null)
+         }
+         else */
+        if (!string.IsNullOrWhiteSpace(Globals.Me.Sprite) && Globals.Me.Sprite != mCurrentSprite && entityTex != null)
+        {
+            for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
             {
-                for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+                var paperdoll = "";
+                if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1)
                 {
-                    var paperdoll = "";
-                    if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1)
+                    var equipment = Globals.Me.MyEquipment;
+                    if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
+                        equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
+                        Options.MaxInvItems)
                     {
-                        var equipment = Globals.Me.MyEquipment;
-                        if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] > -1 &&
-                            equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] <
-                            Options.MaxInvItems)
-                        {
-                            var itemNum = Globals.Me
-                                .Inventory[equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])]]
-                                .ItemId;
+                        var itemNum = Globals.Me
+                            .Inventory[equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])]]
+                            .ItemId;
 
-                            if (ItemBase.TryGet(itemNum, out var itemDescriptor))
-                            {
-                                paperdoll = Globals.Me.Gender == 0
-                                    ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
-                                PaperdollPanels[z].RenderColor = itemDescriptor.Color;
-                            }
+                        if (ItemBase.TryGet(itemNum, out var itemDescriptor))
+                        {
+                            paperdoll = Globals.Me.Gender == 0
+                                ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                            PaperdollPanels[z].RenderColor = itemDescriptor.Color;
                         }
                     }
-                    else if (Options.PaperdollOrder[1][z] == "Player")
-                    {
-                        PaperdollPanels[z].Show();
-                        PaperdollPanels[z].Texture = entityTex;
-                        PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SizeToContents();
-                        PaperdollPanels[z].RenderColor = Globals.Me.Color;
-                        Align.Center(PaperdollPanels[z]);
-                    }
-
-                    if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[z]) && Options.PaperdollOrder[1][z] != "Player")
-                    {
-                        PaperdollPanels[z].Texture = null;
-                        PaperdollPanels[z].Hide();
-                        PaperdollTextures[z] = "";
-                    }
-                    else if (paperdoll != "" && paperdoll != PaperdollTextures[z])
-                    {
-                        var paperdollTex = Globals.ContentManager.GetTexture(
-                            Framework.Content.TextureType.Paperdoll, paperdoll
-                        );
-
-                        PaperdollPanels[z].Texture = paperdollTex;
-                        if (paperdollTex != null)
-                        {
-                            PaperdollPanels[z]
-                                .SetTextureRect(
-                                    0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            PaperdollPanels[z]
-                                .SetSize(
-                                    PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            PaperdollPanels[z]
-                                .SetPosition(
-                                    mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
-                                    mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
-                                );
-                        }
-
-                        PaperdollPanels[z].Show();
-                        PaperdollTextures[z] = paperdoll;
-                    }
                 }
-            }
-            else if (Globals.Me.Sprite != mCurrentSprite && Globals.Me.Face != mCurrentSprite)
-            {
-                mCharacterPortrait.IsHidden = true;
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+                else if (Options.PaperdollOrder[1][z] == "Player")
                 {
-                    PaperdollPanels[i].Hide();
+                    PaperdollPanels[z].Show();
+                    PaperdollPanels[z].Texture = entityTex;
+                    PaperdollPanels[z].SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
+                    PaperdollPanels[z].SizeToContents();
+                    PaperdollPanels[z].RenderColor = Globals.Me.Color;
+                    Align.Center(PaperdollPanels[z]);
                 }
-            }
 
-            mAttackLabel.SetText(
-                Strings.Character.Stat0.ToString(Strings.Combat.Stat0, Globals.Me.Stat[(int) Stat.Attack])
-            );
-
-            mDefenseLabel.SetText(
-                Strings.Character.Stat2.ToString(Strings.Combat.Stat2, Globals.Me.Stat[(int) Stat.Defense])
-            );
-
-            mSpeedLabel.SetText(
-                Strings.Character.Stat4.ToString(Strings.Combat.Stat4, Globals.Me.Stat[(int) Stat.Speed])
-            );
-
-            mAbilityPwrLabel.SetText(
-                Strings.Character.Stat1.ToString(Strings.Combat.Stat1, Globals.Me.Stat[(int) Stat.AbilityPower])
-            );
-
-            mMagicRstLabel.SetText(
-                Strings.Character.Stat3.ToString(Strings.Combat.Stat3, Globals.Me.Stat[(int) Stat.MagicResist])
-            );
-
-            mPointsLabel.SetText(Strings.Character.Points.ToString(Globals.Me.StatPoints));
-            mAddAbilityPwrBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                         Globals.Me.Stat[(int) Stat.AbilityPower] == Options.MaxStatValue;
-
-            mAddAttackBtn.IsHidden =
-                Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stat.Attack] == Options.MaxStatValue;
-
-            mAddDefenseBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                      Globals.Me.Stat[(int) Stat.Defense] == Options.MaxStatValue;
-
-            mAddMagicResistBtn.IsHidden = Globals.Me.StatPoints == 0 ||
-                                          Globals.Me.Stat[(int) Stat.MagicResist] == Options.MaxStatValue;
-
-            mAddSpeedBtn.IsHidden =
-                Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stat.Speed] == Options.MaxStatValue;
-
-            UpdateExtraBuffs();
-
-            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
-            {
-                if (Globals.Me.MyEquipment[i] > -1 && Globals.Me.MyEquipment[i] < Options.MaxInvItems)
+                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[z]) && Options.PaperdollOrder[1][z] != "Player")
                 {
-                    if (Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId != Guid.Empty)
+                    PaperdollPanels[z].Texture = null;
+                    PaperdollPanels[z].Hide();
+                    PaperdollTextures[z] = "";
+                }
+                else if (paperdoll != "" && paperdoll != PaperdollTextures[z])
+                {
+                    var paperdollTex = Globals.ContentManager.GetTexture(
+                        Framework.Content.TextureType.Paperdoll, paperdoll
+                    );
+
+                    PaperdollPanels[z].Texture = paperdollTex;
+                    if (paperdollTex != null)
                     {
-                        Items[i]
-                            .Update(
-                                Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId,
-                                Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemProperties
+                        PaperdollPanels[z]
+                            .SetTextureRect(
+                                0, 0, PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
                             );
 
-                        UpdateExtraBuffs(Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId);
+                        PaperdollPanels[z]
+                            .SetSize(
+                                PaperdollPanels[z].Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                PaperdollPanels[z].Texture.GetHeight() / Options.Instance.Sprites.Directions
+                            );
+
+                        PaperdollPanels[z]
+                            .SetPosition(
+                                mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
+                                mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
+                            );
                     }
-                    else
-                    {
-                        Items[i].Update(Guid.Empty, mItemProperties);
-                    }
+
+                    PaperdollPanels[z].Show();
+                    PaperdollTextures[z] = paperdoll;
+                }
+            }
+        }
+        else if (Globals.Me.Sprite != mCurrentSprite && Globals.Me.Face != mCurrentSprite)
+        {
+            mCharacterPortrait.IsHidden = true;
+            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+            {
+                PaperdollPanels[i].Hide();
+            }
+        }
+
+        mAttackLabel.SetText(
+            Strings.Character.Stat0.ToString(Strings.Combat.Stat0, Globals.Me.Stat[(int) Stat.Attack])
+        );
+
+        mDefenseLabel.SetText(
+            Strings.Character.Stat2.ToString(Strings.Combat.Stat2, Globals.Me.Stat[(int) Stat.Defense])
+        );
+
+        mSpeedLabel.SetText(
+            Strings.Character.Stat4.ToString(Strings.Combat.Stat4, Globals.Me.Stat[(int) Stat.Speed])
+        );
+
+        mAbilityPwrLabel.SetText(
+            Strings.Character.Stat1.ToString(Strings.Combat.Stat1, Globals.Me.Stat[(int) Stat.AbilityPower])
+        );
+
+        mMagicRstLabel.SetText(
+            Strings.Character.Stat3.ToString(Strings.Combat.Stat3, Globals.Me.Stat[(int) Stat.MagicResist])
+        );
+
+        mPointsLabel.SetText(Strings.Character.Points.ToString(Globals.Me.StatPoints));
+        mAddAbilityPwrBtn.IsHidden = Globals.Me.StatPoints == 0 ||
+                                     Globals.Me.Stat[(int) Stat.AbilityPower] == Options.MaxStatValue;
+
+        mAddAttackBtn.IsHidden =
+            Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stat.Attack] == Options.MaxStatValue;
+
+        mAddDefenseBtn.IsHidden = Globals.Me.StatPoints == 0 ||
+                                  Globals.Me.Stat[(int) Stat.Defense] == Options.MaxStatValue;
+
+        mAddMagicResistBtn.IsHidden = Globals.Me.StatPoints == 0 ||
+                                      Globals.Me.Stat[(int) Stat.MagicResist] == Options.MaxStatValue;
+
+        mAddSpeedBtn.IsHidden =
+            Globals.Me.StatPoints == 0 || Globals.Me.Stat[(int) Stat.Speed] == Options.MaxStatValue;
+
+        UpdateExtraBuffs();
+
+        for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+        {
+            if (Globals.Me.MyEquipment[i] > -1 && Globals.Me.MyEquipment[i] < Options.MaxInvItems)
+            {
+                if (Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId != Guid.Empty)
+                {
+                    Items[i]
+                        .Update(
+                            Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId,
+                            Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemProperties
+                        );
+
+                    UpdateExtraBuffs(Globals.Me.Inventory[Globals.Me.MyEquipment[i]].ItemId);
                 }
                 else
                 {
                     Items[i].Update(Guid.Empty, mItemProperties);
                 }
             }
+            else
+            {
+                Items[i].Update(Guid.Empty, mItemProperties);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Update Extra Buffs Effects like hp/mana regen and items effect types
+    /// </summary>
+    public void UpdateExtraBuffs()
+    {
+        mPlayer = ClassBase.Get(Globals.Me?.Class ?? Guid.Empty);
+
+        //Getting HP and Mana Regen
+        if (mPlayer != null)
+        {
+            HpRegenAmount = mPlayer.VitalRegen[0];
+            mHpRegen.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
+            ManaRegenAmount = mPlayer.VitalRegen[1];
+            mManaRegen.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
         }
 
-        /// <summary>
-        /// Update Extra Buffs Effects like hp/mana regen and items effect types
-        /// </summary>
-        public void UpdateExtraBuffs()
+        CooldownAmount = 0;
+        LifeStealAmount = 0;
+        TenacityAmount = 0;
+        LuckAmount = 0;
+        ExtraExpAmount = 0;
+        ManaStealAmount = 0;
+
+        mLifeSteal.SetText(Strings.Character.Lifesteal.ToString(0));
+        mExtraExp.SetText(Strings.Character.ExtraExp.ToString(0));
+        mLuck.SetText(Strings.Character.Luck.ToString(0));
+        mTenacity.SetText(Strings.Character.Tenacity.ToString(0));
+        mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(0));
+        mManaSteal.SetText(Strings.Character.Manasteal.ToString(0));
+
+        mAttackSpeed.SetText(Strings.Character.AttackSpeed.ToString(Globals.Me.CalculateAttackTime() / 1000f));
+    }
+
+    /// <summary>
+    /// Update Extra Buffs Effects like hp/mana regen and items effect types
+    /// </summary>
+    /// <param name="itemId">Id of item to update extra buffs</param>
+    public void UpdateExtraBuffs(Guid itemId)
+    {
+        var item = ItemBase.Get(itemId);
+
+        if (item == null)
         {
-            mPlayer = ClassBase.Get(Globals.Me?.Class ?? Guid.Empty);
-
-            //Getting HP and Mana Regen
-            if (mPlayer != null)
-            {
-                HpRegenAmount = mPlayer.VitalRegen[0];
-                mHpRegen.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
-                ManaRegenAmount = mPlayer.VitalRegen[1];
-                mManaRegen.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
-            }
-
-            CooldownAmount = 0;
-            LifeStealAmount = 0;
-            TenacityAmount = 0;
-            LuckAmount = 0;
-            ExtraExpAmount = 0;
-            ManaStealAmount = 0;
-
-            mLifeSteal.SetText(Strings.Character.Lifesteal.ToString(0));
-            mExtraExp.SetText(Strings.Character.ExtraExp.ToString(0));
-            mLuck.SetText(Strings.Character.Luck.ToString(0));
-            mTenacity.SetText(Strings.Character.Tenacity.ToString(0));
-            mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(0));
-            mManaSteal.SetText(Strings.Character.Manasteal.ToString(0));
-
-            mAttackSpeed.SetText(Strings.Character.AttackSpeed.ToString(Globals.Me.CalculateAttackTime() / 1000f));
+            return;
         }
 
-        /// <summary>
-        /// Update Extra Buffs Effects like hp/mana regen and items effect types
-        /// </summary>
-        /// <param name="itemId">Id of item to update extra buffs</param>
-        public void UpdateExtraBuffs(Guid itemId)
+        //Getting HP and Mana Regen
+        if (item.VitalsRegen[0] != 0)
         {
-            var item = ItemBase.Get(itemId);
+            HpRegenAmount += item.VitalsRegen[0];
+            mHpRegen?.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
+        }
 
-            if (item == null)
-            {
-                return;
-            }
+        if (item.VitalsRegen[1] != 0)
+        {
+            ManaRegenAmount += item.VitalsRegen[1];
+            mManaRegen?.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
+        }
 
-            //Getting HP and Mana Regen
-            if (item.VitalsRegen[0] != 0)
+        //Getting extra buffs
+        if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.Percentage > 0) != default)
+        {
+            foreach(var effect in item.Effects)
             {
-                HpRegenAmount += item.VitalsRegen[0];
-                mHpRegen?.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
-            }
-
-            if (item.VitalsRegen[1] != 0)
-            {
-                ManaRegenAmount += item.VitalsRegen[1];
-                mManaRegen?.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
-            }
-
-            //Getting extra buffs
-            if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.Percentage > 0) != default)
-            {
-                foreach(var effect in item.Effects)
+                if (effect.Percentage <= 0)
                 {
-                    if (effect.Percentage <= 0)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    switch (effect.Type)
-                    {
-                        case ItemEffect.CooldownReduction:
-                            CooldownAmount += effect.Percentage;
-                            mCooldownReduction?.SetText(Strings.Character.CooldownReduction.ToString(CooldownAmount));
+                switch (effect.Type)
+                {
+                    case ItemEffect.CooldownReduction:
+                        CooldownAmount += effect.Percentage;
+                        mCooldownReduction?.SetText(Strings.Character.CooldownReduction.ToString(CooldownAmount));
 
-                            break;
-                        case ItemEffect.Lifesteal:
-                            LifeStealAmount += effect.Percentage;
-                            mLifeSteal?.SetText(Strings.Character.Lifesteal.ToString(LifeStealAmount));
+                        break;
+                    case ItemEffect.Lifesteal:
+                        LifeStealAmount += effect.Percentage;
+                        mLifeSteal?.SetText(Strings.Character.Lifesteal.ToString(LifeStealAmount));
 
-                            break;
-                        case ItemEffect.Tenacity:
-                            TenacityAmount += effect.Percentage;
-                            mTenacity?.SetText(Strings.Character.Tenacity.ToString(TenacityAmount));
+                        break;
+                    case ItemEffect.Tenacity:
+                        TenacityAmount += effect.Percentage;
+                        mTenacity?.SetText(Strings.Character.Tenacity.ToString(TenacityAmount));
 
-                            break;
-                        case ItemEffect.Luck:
-                            LuckAmount += effect.Percentage;
-                            mLuck?.SetText(Strings.Character.Luck.ToString(LuckAmount));
+                        break;
+                    case ItemEffect.Luck:
+                        LuckAmount += effect.Percentage;
+                        mLuck?.SetText(Strings.Character.Luck.ToString(LuckAmount));
 
-                            break;
-                        case ItemEffect.EXP:
-                            ExtraExpAmount += effect.Percentage;
-                            mExtraExp?.SetText(Strings.Character.ExtraExp.ToString(ExtraExpAmount));
+                        break;
+                    case ItemEffect.EXP:
+                        ExtraExpAmount += effect.Percentage;
+                        mExtraExp?.SetText(Strings.Character.ExtraExp.ToString(ExtraExpAmount));
 
-                            break;
-                        case ItemEffect.Manasteal:
-                            ManaStealAmount += effect.Percentage;
-                            mManaSteal?.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
+                        break;
+                    case ItemEffect.Manasteal:
+                        ManaStealAmount += effect.Percentage;
+                        mManaSteal?.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
 
-                            break;
-                    }
+                        break;
                 }
             }
         }
+    }
 
-        /// <summary>
-        /// Show the window
-        /// </summary>
-        public void Show()
-        {
-            mCharacterWindow.IsHidden = false;
-        }
+    /// <summary>
+    /// Show the window
+    /// </summary>
+    public void Show()
+    {
+        mCharacterWindow.IsHidden = false;
+    }
 
-        /// <summary>
-        /// </summary>
-        /// <returns>Returns if window is visible</returns>
-        public bool IsVisible()
-        {
-            return !mCharacterWindow.IsHidden;
-        }
+    /// <summary>
+    /// </summary>
+    /// <returns>Returns if window is visible</returns>
+    public bool IsVisible()
+    {
+        return !mCharacterWindow.IsHidden;
+    }
 
-        /// <summary>
-        /// Hide the window
-        /// </summary>
-        public void Hide()
-        {
-            mCharacterWindow.IsHidden = true;
-        }
-
+    /// <summary>
+    /// Hide the window
+    /// </summary>
+    public void Hide()
+    {
+        mCharacterWindow.IsHidden = true;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client/Interface/Game/Character/EquipmentItem.cs
@@ -10,145 +10,143 @@ using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Interface.Game.Character
+namespace Intersect.Client.Interface.Game.Character;
+
+
+public partial class EquipmentItem
 {
 
-    public partial class EquipmentItem
+    public ImagePanel ContentPanel;
+
+    private WindowControl mCharacterWindow;
+
+    private Guid mCurrentItemId;
+
+    private ItemDescriptionWindow mDescWindow;
+
+    private ItemProperties mItemProperties = null;
+
+    private bool mTexLoaded;
+
+    private int mYindex;
+
+    public ImagePanel Pnl;
+
+    public EquipmentItem(int index, WindowControl characterWindow)
     {
+        mYindex = index;
+        mCharacterWindow = characterWindow;
+    }
 
-        public ImagePanel ContentPanel;
+    public void Setup()
+    {
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+        Pnl.RightClicked += pnl_RightClicked;
 
-        private WindowControl mCharacterWindow;
+        ContentPanel = new ImagePanel(Pnl, "EquipmentIcon");
+        ContentPanel.MouseInputEnabled = false;
+        Pnl.SetToolTipText(Options.EquipmentSlots[mYindex]);
+    }
 
-        private Guid mCurrentItemId;
-
-        private ItemDescriptionWindow mDescWindow;
-
-        private ItemProperties mItemProperties = null;
-
-        private bool mTexLoaded;
-
-        private int mYindex;
-
-        public ImagePanel Pnl;
-
-        public EquipmentItem(int index, WindowControl characterWindow)
+    void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (ClientConfiguration.Instance.EnableContextMenus)
         {
-            mYindex = index;
-            mCharacterWindow = characterWindow;
-        }
-
-        public void Setup()
-        {
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-            Pnl.RightClicked += pnl_RightClicked;
-
-            ContentPanel = new ImagePanel(Pnl, "EquipmentIcon");
-            ContentPanel.MouseInputEnabled = false;
-            Pnl.SetToolTipText(Options.EquipmentSlots[mYindex]);
-        }
-
-        void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (ClientConfiguration.Instance.EnableContextMenus)
+            var window = Interface.GameUi.GameMenu.GetInventoryWindow();
+            if (window != null)
             {
-                var window = Interface.GameUi.GameMenu.GetInventoryWindow();
-                if (window != null)
+                var invSlot = Globals.Me.MyEquipment[mYindex];
+                if (invSlot >= 0 && invSlot < Options.MaxInvItems)
                 {
-                    var invSlot = Globals.Me.MyEquipment[mYindex];
-                    if (invSlot >= 0 && invSlot < Options.MaxInvItems)
-                    {
-                        window.OpenContextMenu(invSlot);
-                    }
+                    window.OpenContextMenu(invSlot);
                 }
             }
-            else
-            {
-                PacketSender.SendUnequipItem(mYindex);
-            }
-            
+        }
+        else
+        {
+            PacketSender.SendUnequipItem(mYindex);
+        }
+        
+    }
+
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
+            return;
         }
 
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
+        if (mDescWindow != null)
         {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
 
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                return;
-            }
+        var item = ItemBase.Get(mCurrentItemId);
+        if (item == null)
+        {
+            return;
+        }
 
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
+        mDescWindow = new ItemDescriptionWindow(item, 1, mCharacterWindow.X, mCharacterWindow.Y, mItemProperties, item.Name);
+    }
 
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
+
+        return rect;
+    }
+
+    public void Update(Guid currentItemId, ItemProperties itemProperties)
+    {
+        if (currentItemId != mCurrentItemId || !mTexLoaded)
+        {
+            mCurrentItemId = currentItemId;
+            mItemProperties = itemProperties;
             var item = ItemBase.Get(mCurrentItemId);
-            if (item == null)
+            if (item != null)
             {
-                return;
-            }
-
-            mDescWindow = new ItemDescriptionWindow(item, 1, mCharacterWindow.X, mCharacterWindow.Y, mItemProperties, item.Name);
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
-
-            return rect;
-        }
-
-        public void Update(Guid currentItemId, ItemProperties itemProperties)
-        {
-            if (currentItemId != mCurrentItemId || !mTexLoaded)
-            {
-                mCurrentItemId = currentItemId;
-                mItemProperties = itemProperties;
-                var item = ItemBase.Get(mCurrentItemId);
-                if (item != null)
+                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+                if (itemTex != null)
                 {
-                    var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-                    if (itemTex != null)
-                    {
-                        ContentPanel.Show();
-                        ContentPanel.Texture = itemTex;
-                        ContentPanel.RenderColor = item.Color;
-                    }
-                    else
-                    {
-                        ContentPanel.Hide();
-                    }
+                    ContentPanel.Show();
+                    ContentPanel.Texture = itemTex;
+                    ContentPanel.RenderColor = item.Color;
                 }
                 else
                 {
                     ContentPanel.Hide();
                 }
-
-                mTexLoaded = true;
             }
-        }
+            else
+            {
+                ContentPanel.Hide();
+            }
 
+            mTexLoaded = true;
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client/Interface/Game/Chat/Chatbox.cs
@@ -14,492 +14,346 @@ using Intersect.Enums;
 using Intersect.Localization;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Chat
+namespace Intersect.Client.Interface.Game.Chat;
+
+
+public partial class Chatbox
 {
 
-    public partial class Chatbox
+    private ComboBox mChannelCombobox;
+
+    private Label mChannelLabel;
+
+    private ImagePanel mChatbar;
+
+    private TextBox mChatboxInput;
+
+    private ListBox mChatboxMessages;
+
+    private ScrollBar mChatboxScrollBar;
+
+    private Button mChatboxSendButton;
+
+    private Button _chatboxToggleLogButton;
+
+    private Button _chatboxClearLogButton;
+
+    private readonly GameTexture _chatboxTexture;
+
+    private Label mChatboxText;
+
+    private Label mChatboxTitle;
+
+    /// <summary>
+    /// A dictionary of all chat tab buttons based on the <see cref="ChatboxTab"/> enum.
+    /// </summary>
+    private Dictionary<ChatboxTab, Button> mTabButtons = new Dictionary<ChatboxTab, Button>();
+
+    //Window Controls
+    private ImagePanel mChatboxWindow;
+
+    private GameInterface mGameUi;
+
+    private long mLastChatTime = -1;
+
+    private int mMessageIndex;
+
+    private bool mReceivedMessage;
+
+    /// <summary>
+    /// Defines which chat tab we are currently looking at.
+    /// </summary>
+    private ChatboxTab mCurrentTab = ChatboxTab.All;
+
+    /// <summary>
+    /// The last tab that was looked at before switching around, if a switch was made at all.
+    /// </summary>
+    private ChatboxTab mLastTab = ChatboxTab.All;
+
+    /// <summary>
+    /// Keep track of what chat channel we were chatting in on certain tabs so we can remember this when switching back to them.
+    /// </summary>
+    private Dictionary<ChatboxTab, int> mLastChatChannel = new Dictionary<ChatboxTab, int>() {
+        { ChatboxTab.All, 0 },
+        { ChatboxTab.System, 0 },
+    };
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mPMContextItem;
+
+    private MenuItem mFriendInviteContextItem;
+
+    private MenuItem mPartyInviteContextItem;
+
+    private MenuItem mGuildInviteContextItem;
+
+    //Init
+    public Chatbox(Canvas gameCanvas, GameInterface gameUi)
     {
+        mGameUi = gameUi;
 
-        private ComboBox mChannelCombobox;
-
-        private Label mChannelLabel;
-
-        private ImagePanel mChatbar;
-
-        private TextBox mChatboxInput;
-
-        private ListBox mChatboxMessages;
-
-        private ScrollBar mChatboxScrollBar;
-
-        private Button mChatboxSendButton;
-
-        private Button _chatboxToggleLogButton;
-
-        private Button _chatboxClearLogButton;
-
-        private readonly GameTexture _chatboxTexture;
-
-        private Label mChatboxText;
-
-        private Label mChatboxTitle;
-
-        /// <summary>
-        /// A dictionary of all chat tab buttons based on the <see cref="ChatboxTab"/> enum.
-        /// </summary>
-        private Dictionary<ChatboxTab, Button> mTabButtons = new Dictionary<ChatboxTab, Button>();
-
-        //Window Controls
-        private ImagePanel mChatboxWindow;
-
-        private GameInterface mGameUi;
-
-        private long mLastChatTime = -1;
-
-        private int mMessageIndex;
-
-        private bool mReceivedMessage;
-
-        /// <summary>
-        /// Defines which chat tab we are currently looking at.
-        /// </summary>
-        private ChatboxTab mCurrentTab = ChatboxTab.All;
-
-        /// <summary>
-        /// The last tab that was looked at before switching around, if a switch was made at all.
-        /// </summary>
-        private ChatboxTab mLastTab = ChatboxTab.All;
-
-        /// <summary>
-        /// Keep track of what chat channel we were chatting in on certain tabs so we can remember this when switching back to them.
-        /// </summary>
-        private Dictionary<ChatboxTab, int> mLastChatChannel = new Dictionary<ChatboxTab, int>() {
-            { ChatboxTab.All, 0 },
-            { ChatboxTab.System, 0 },
-        };
-
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mPMContextItem;
-
-        private MenuItem mFriendInviteContextItem;
-
-        private MenuItem mPartyInviteContextItem;
-
-        private MenuItem mGuildInviteContextItem;
-
-        //Init
-        public Chatbox(Canvas gameCanvas, GameInterface gameUi)
-        {
-            mGameUi = gameUi;
-
-            //Chatbox Window
-            mChatboxWindow = new ImagePanel(gameCanvas, "ChatboxWindow");
-            mChatboxMessages = new ListBox(mChatboxWindow, "MessageList");
-            mChatboxMessages.EnableScroll(false, true);
-            mChatboxWindow.ShouldCacheToTexture = true;
-
-            mChatboxTitle = new Label(mChatboxWindow, "ChatboxTitle");
-            mChatboxTitle.Text = Strings.Chatbox.Title;
-            mChatboxTitle.IsHidden = true;
-
-            // Generate tab butons.
-            for (var btn = 0; btn < (int)ChatboxTab.Count; btn++)
-            {
-                mTabButtons.Add((ChatboxTab)btn, new Button(mChatboxWindow, $"{(ChatboxTab)btn}TabButton"));
-                // Do we have a localized string for this chat tab? If not assign none as the text.
-                LocalizedString name;
-                mTabButtons[(ChatboxTab)btn].Text = Strings.Chatbox.ChatTabButtons.TryGetValue((ChatboxTab)btn, out name) ? name : Strings.General.None;
-                mTabButtons[(ChatboxTab)btn].Clicked += TabButtonClicked;
-                // We'll be using the user data to determine which tab we've clicked later.
-                mTabButtons[(ChatboxTab)btn].UserData = (ChatboxTab)btn;
-            }
-
-            mChatbar = new ImagePanel(mChatboxWindow, "Chatbar");
-            mChatbar.IsHidden = true;
-
-            mChatboxInput = new TextBox(mChatboxWindow, "ChatboxInputField");
-            mChatboxInput.SubmitPressed += ChatboxInput_SubmitPressed;
-            mChatboxInput.Text = GetDefaultInputText();
-            mChatboxInput.Clicked += ChatboxInput_Clicked;
-            mChatboxInput.IsTabable = false;
-            mChatboxInput.SetMaxLength(Options.MaxChatLength);
-            Interface.FocusElements.Add(mChatboxInput);
-
-            mChannelLabel = new Label(mChatboxWindow, "ChannelLabel");
-            mChannelLabel.Text = Strings.Chatbox.Channel;
-            mChannelLabel.IsHidden = true;
-
-            mChannelCombobox = new ComboBox(mChatboxWindow, "ChatChannelCombobox");
-            for (var i = 0; i < 4; i++)
-            {
-                var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.Channels[i]);
-                menuItem.UserData = i;
-                menuItem.Selected += MenuItem_Selected;
-            }
-
-            //Add admin channel only if power > 0.
-            if (Globals.Me.Type > 0)
-            {
-                var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.ChannelAdmin);
-                menuItem.UserData = 4;
-                menuItem.Selected += MenuItem_Selected;
-            }
-
-            mChatboxText = new Label(mChatboxWindow);
-            mChatboxText.Name = "ChatboxText";
-            mChatboxText.Font = mChatboxWindow.Parent.Skin.DefaultFont;
-
-            mChatboxSendButton = new Button(mChatboxWindow, "ChatboxSendButton");
-            mChatboxSendButton.Text = Strings.Chatbox.Send;
-            mChatboxSendButton.Clicked += ChatboxSendBtn_Clicked;
-
-            _chatboxToggleLogButton = new Button(mChatboxWindow, "ChatboxToggleLogButton");
-            _chatboxToggleLogButton.SetToolTipText(Strings.Chatbox.ToggleLogButtonToolTip);
-            _chatboxToggleLogButton.Clicked += ChatboxToggleLogBtn_Clicked;
-
-            _chatboxClearLogButton = new Button(mChatboxWindow, "ChatboxClearLogButton");
-            _chatboxClearLogButton.SetToolTipText(Strings.Chatbox.ClearLogButtonToolTip);
-            _chatboxClearLogButton.Clicked += ChatboxClearLogBtn_Clicked;
-
-            mChatboxWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            _chatboxTexture = mChatboxWindow.Texture; // store chatbox texture here so we can re-use it later.
-            mChatboxText.IsHidden = true;
-
-            // Disable this to start, since this is the default tab we open the client on.
-            mTabButtons[ChatboxTab.All].Disable();
-
-            // Platform check, are we capable of copy/pasting on this machine?
-            if (GameClipboard.Instance == null || !GameClipboard.Instance.IsEnabled)
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.UnableToCopy, CustomColors.Alerts.Error, ChatMessageType.Error));
-            }
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "ChatContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mPMContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.PM);
-            mPMContextItem.Clicked += MPMContextItem_Clicked;
-            mFriendInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.FriendInvite);
-            mFriendInviteContextItem.Clicked += MFriendInviteContextItem_Clicked;
-            mPartyInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.PartyInvite);
-            mPartyInviteContextItem.Clicked += MPartyInviteContextItem_Clicked;
-            mGuildInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.GuildInvite);
-            mGuildInviteContextItem.Clicked += MGuildInviteContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-        }
-
-        public void OpenContextMenu(string name)
-        {
-            // Clear out the old options.
-            mContextMenu.RemoveChild(mPMContextItem, false);
-            mContextMenu.RemoveChild(mFriendInviteContextItem, false);
-            mContextMenu.RemoveChild(mPartyInviteContextItem, false);
-            mContextMenu.RemoveChild(mGuildInviteContextItem, false);
-            mContextMenu.Children.Clear();
-
-            // No point showing a menu for blank space.
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return;
-            }
-
-            // Add our PM option!
-            mContextMenu.AddChild(mPMContextItem);
-            mPMContextItem.SetText(Strings.ChatContextMenu.PM.ToString(name));
-
-            // If we do not already have this player on our friendlist, add a request button!
-            if (!Globals.Me.Friends.Any(f => f.Name == name))
-            {
-                mContextMenu.AddChild(mFriendInviteContextItem);
-                mFriendInviteContextItem.SetText(Strings.ChatContextMenu.FriendInvite.ToString(name));
-            }
-
-            // Are we in a party, the leader and is this player not yet in our party?
-            if ((Globals.Me.IsInParty() && Globals.Me.Party[0].Id == Globals.Me.Id && !Globals.Me.Party.Any(p => p.Name == name)) || !Globals.Me.IsInParty())
-            {
-                mContextMenu.AddChild(mPartyInviteContextItem);
-                mPartyInviteContextItem.SetText(Strings.ChatContextMenu.PartyInvite.ToString(name));
-            }
-
-            // Are we in a guild, able to invite players and are they not yet in our guild?
-            if (Globals.Me.IsInGuild && Globals.Me.GuildRank.Permissions.Invite && !Globals.Me.GuildMembers.Any(g => g.Name == name))
-            {
-                mContextMenu.AddChild(mGuildInviteContextItem);
-                mGuildInviteContextItem.SetText(Strings.ChatContextMenu.GuildInvite.ToString(name));
-            }
-
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = name;
-
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
-        }
-
-        private void MGuildInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var name = (string)sender.Parent.UserData;
-            PacketSender.SendInviteGuild(name);
-        }
-
-        private void MPartyInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var name = (string)sender.Parent.UserData;
-            PacketSender.SendPartyInvite(name);
-        }
-
-        private void MFriendInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var name = (string)sender.Parent.UserData;
-            PacketSender.SendAddFriend(name);
-        }
-
-        private void MPMContextItem_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var name = (string)sender.Parent.UserData;
-            SetChatboxText($"/pm {name} ");
-        }
-
-        /// <summary>
-        /// Handle logic after a chat channel menu item is selected.
-        /// </summary>
-        private void MenuItem_Selected(Base sender, ItemSelectedEventArgs arguments)
-        {
-            // If we're on the two generic tabs, remember which channel we're trying to type in so we can switch back to this channel when we decide to swap between tabs.
-            if ((mCurrentTab == ChatboxTab.All || mCurrentTab == ChatboxTab.System))
-            {
-                mLastChatChannel[mCurrentTab] = (int)sender.UserData;
-            }
-        }
-
-        /// <summary>
-        /// Enables all the chat tab buttons.
-        /// </summary>
-        private void EnableChatTabs()
-        {
-            for (var btn = 0; btn < (int)ChatboxTab.Count; btn++)
-            {
-                mTabButtons[(ChatboxTab)btn].Enable();
-            }
-
-        }
-
-        /// <summary>
-        /// Handles the click event of a chat tab button.
-        /// </summary>
-        /// <param name="sender">The button that was clicked.</param>
-        /// <param name="arguments">The arguments passed by the event.</param>
-        private void TabButtonClicked(Base sender, ClickedEventArgs arguments)
-        {
-            // Enable all buttons again!
-            EnableChatTabs();
-
-            // Disable the clicked button to fake our tab being selected and set our selected chat tab.
-            sender.Disable();
-            var tab = (ChatboxTab)sender.UserData;
-            mCurrentTab = tab;
-
-            // Change the default channel we're trying to chat in based on the tab we've just selected.
-            SetChannelToTab(tab);
-        }
-
-        /// <summary>
-        /// Sets the selected chat channel to type in by default to the channel corresponding to the provided tab.
-        /// </summary>
-        /// <param name="tab">The tab to use for reference as to which channel we want to speak in.</param>
-        private void SetChannelToTab(ChatboxTab tab)
-        {
-            switch (tab)
-            {
-                case ChatboxTab.System:
-                case ChatboxTab.All:
-                    mChannelCombobox.SelectByUserData(mLastChatChannel[tab]);
-                    break;
-
-                case ChatboxTab.Local:
-                    mChannelCombobox.SelectByUserData(0);
-                    break;
-
-                case ChatboxTab.Global:
-                    mChannelCombobox.SelectByUserData(1);
-                    break;
-
-                case ChatboxTab.Party:
-                    mChannelCombobox.SelectByUserData(2);
-                    break;
-
-                case ChatboxTab.Guild:
-                    mChannelCombobox.SelectByUserData(3);
-                    break;
-
-                default:
-                    // remain unchanged.
-                    break;
-            }
-        }
-
-        //Update
-        public void Update()
-        {
-            var vScrollBar = mChatboxMessages.GetVerticalScrollBar();
-            var scrollAmount = vScrollBar.ScrollAmount;
-            var scrollBarVisible = vScrollBar.ContentSize > mChatboxMessages.Height;
-            var scrollToBottom = vScrollBar.ScrollAmount == 1 || !scrollBarVisible;
-
-            // Did the tab change recently? If so, we need to reset a few things to make it work...
-            if (mLastTab != mCurrentTab)
-            {
-                mChatboxMessages.Clear();
-                mChatboxMessages.GetHorizontalScrollBar().SetScrollAmount(0);
-                mMessageIndex = 0;
-                mReceivedMessage = true;
-                mLastTab = mCurrentTab;
-            }
-
-            var msgs = ChatboxMsg.GetMessages(mCurrentTab);
-            for (var i = mMessageIndex; i < msgs.Count; i++)
-            {
-                var msg = msgs[i];
-                var myText = Interface.WrapText(
-                    msg.Message, mChatboxMessages.Width - vScrollBar.Width - 8,
-                    mChatboxText.Font
-                );
-
-                foreach (var t in myText)
-                {
-                    var rw = mChatboxMessages.AddRow(t.Trim());
-                    rw.SetTextFont(mChatboxText.Font);
-                    rw.SetTextColor(msg.Color);
-                    rw.ShouldDrawBackground = false;
-                    rw.UserData = msg.Target;
-                    rw.Clicked += ChatboxRow_Clicked;
-                    rw.RightClicked += ChatboxRow_RightClicked;
-                    mReceivedMessage = true;
-
-                    while (mChatboxMessages.RowCount > ClientConfiguration.Instance.ChatLines)
-                    {
-                        mChatboxMessages.RemoveRow(0);
-                    }
-                }
-
-                mMessageIndex++;
-            }
-
-
-            if (mReceivedMessage)
-            {
-                mChatboxMessages.InnerPanel.SizeToChildren(false, true);
-                mChatboxMessages.UpdateScrollBars();
-                if (!scrollToBottom)
-                {
-                    vScrollBar.SetScrollAmount(scrollAmount);
-                }
-                else
-                {
-                    vScrollBar.SetScrollAmount(1);
-                }
-                mReceivedMessage = false;
-            }
-        }
-
-        private void ChatboxRow_RightClicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rw = (ListBoxRow)sender;
-            var target = (string)rw.UserData;
-
-            if (!string.IsNullOrWhiteSpace(target) && target != Globals.Me.Name)
-            {
-                if (ClientConfiguration.Instance.EnableContextMenus)
-                {
-                    OpenContextMenu(target);
-                }
-                else
-                {
-                    SetChatboxText($"/pm {target} ");
-                }
-
-            }
-        }
-
-        public void SetChatboxText(string msg)
-        {
-            mChatboxInput.Text = msg;
-            mChatboxInput.Focus();
-            mChatboxInput.CursorEnd = mChatboxInput.Text.Length;
-            mChatboxInput.CursorPos = mChatboxInput.Text.Length;
-        }
-
-        private void ChatboxRow_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rw = (ListBoxRow)sender;
-            var target = (string)rw.UserData;
-            if (!string.IsNullOrWhiteSpace(target))
-            {
-                if (mGameUi.AdminWindowOpen())
-                {
-                    mGameUi.AdminWindowSelectName(target);
-                }
-            }
-        }
-
-        //Extra Methods
-        public void Focus()
-        {
-            if (!mChatboxInput.HasFocus)
-            {
-                mChatboxInput.Text = string.Empty;
-                mChatboxInput.Focus();
-                if (Globals.Database.AutoToggleChatLog)
-                {
-                    ShowChatLog();
-                }
-            }
-        }
-
-        public bool HasFocus => mChatboxInput.HasFocus;
-
-        public void UnFocus()
-        {
-            // Just focus something else if we need to unfocus.
-            if (mChatboxInput.HasFocus)
-            {
-                mChatboxInput.Text = GetDefaultInputText();
-                mChatboxMessages.Focus();
-                if (Globals.Database.AutoToggleChatLog)
-                {
-                    HideChatLog();
-                }
-            }
-        }
-
-        //Input Handlers
         //Chatbox Window
-        void ChatboxInput_Clicked(Base sender, ClickedEventArgs arguments)
+        mChatboxWindow = new ImagePanel(gameCanvas, "ChatboxWindow");
+        mChatboxMessages = new ListBox(mChatboxWindow, "MessageList");
+        mChatboxMessages.EnableScroll(false, true);
+        mChatboxWindow.ShouldCacheToTexture = true;
+
+        mChatboxTitle = new Label(mChatboxWindow, "ChatboxTitle");
+        mChatboxTitle.Text = Strings.Chatbox.Title;
+        mChatboxTitle.IsHidden = true;
+
+        // Generate tab butons.
+        for (var btn = 0; btn < (int)ChatboxTab.Count; btn++)
         {
-            if (mChatboxInput.Text == GetDefaultInputText())
-            {
-                mChatboxInput.Text = "";
-            }
+            mTabButtons.Add((ChatboxTab)btn, new Button(mChatboxWindow, $"{(ChatboxTab)btn}TabButton"));
+            // Do we have a localized string for this chat tab? If not assign none as the text.
+            LocalizedString name;
+            mTabButtons[(ChatboxTab)btn].Text = Strings.Chatbox.ChatTabButtons.TryGetValue((ChatboxTab)btn, out name) ? name : Strings.General.None;
+            mTabButtons[(ChatboxTab)btn].Clicked += TabButtonClicked;
+            // We'll be using the user data to determine which tab we've clicked later.
+            mTabButtons[(ChatboxTab)btn].UserData = (ChatboxTab)btn;
         }
 
-        void ChatboxInput_SubmitPressed(Base sender, EventArgs arguments)
+        mChatbar = new ImagePanel(mChatboxWindow, "Chatbar");
+        mChatbar.IsHidden = true;
+
+        mChatboxInput = new TextBox(mChatboxWindow, "ChatboxInputField");
+        mChatboxInput.SubmitPressed += ChatboxInput_SubmitPressed;
+        mChatboxInput.Text = GetDefaultInputText();
+        mChatboxInput.Clicked += ChatboxInput_Clicked;
+        mChatboxInput.IsTabable = false;
+        mChatboxInput.SetMaxLength(Options.MaxChatLength);
+        Interface.FocusElements.Add(mChatboxInput);
+
+        mChannelLabel = new Label(mChatboxWindow, "ChannelLabel");
+        mChannelLabel.Text = Strings.Chatbox.Channel;
+        mChannelLabel.IsHidden = true;
+
+        mChannelCombobox = new ComboBox(mChatboxWindow, "ChatChannelCombobox");
+        for (var i = 0; i < 4; i++)
         {
-            TrySendMessage();
+            var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.Channels[i]);
+            menuItem.UserData = i;
+            menuItem.Selected += MenuItem_Selected;
         }
 
-        void ChatboxSendBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        //Add admin channel only if power > 0.
+        if (Globals.Me.Type > 0)
         {
-            TrySendMessage();
+            var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.ChannelAdmin);
+            menuItem.UserData = 4;
+            menuItem.Selected += MenuItem_Selected;
         }
 
-        void ChatboxClearLogBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        mChatboxText = new Label(mChatboxWindow);
+        mChatboxText.Name = "ChatboxText";
+        mChatboxText.Font = mChatboxWindow.Parent.Skin.DefaultFont;
+
+        mChatboxSendButton = new Button(mChatboxWindow, "ChatboxSendButton");
+        mChatboxSendButton.Text = Strings.Chatbox.Send;
+        mChatboxSendButton.Clicked += ChatboxSendBtn_Clicked;
+
+        _chatboxToggleLogButton = new Button(mChatboxWindow, "ChatboxToggleLogButton");
+        _chatboxToggleLogButton.SetToolTipText(Strings.Chatbox.ToggleLogButtonToolTip);
+        _chatboxToggleLogButton.Clicked += ChatboxToggleLogBtn_Clicked;
+
+        _chatboxClearLogButton = new Button(mChatboxWindow, "ChatboxClearLogButton");
+        _chatboxClearLogButton.SetToolTipText(Strings.Chatbox.ClearLogButtonToolTip);
+        _chatboxClearLogButton.Clicked += ChatboxClearLogBtn_Clicked;
+
+        mChatboxWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        _chatboxTexture = mChatboxWindow.Texture; // store chatbox texture here so we can re-use it later.
+        mChatboxText.IsHidden = true;
+
+        // Disable this to start, since this is the default tab we open the client on.
+        mTabButtons[ChatboxTab.All].Disable();
+
+        // Platform check, are we capable of copy/pasting on this machine?
+        if (GameClipboard.Instance == null || !GameClipboard.Instance.IsEnabled)
         {
-            ChatboxMsg.ClearMessages();
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.UnableToCopy, CustomColors.Alerts.Error, ChatMessageType.Error));
+        }
+
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "ChatContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mPMContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.PM);
+        mPMContextItem.Clicked += MPMContextItem_Clicked;
+        mFriendInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.FriendInvite);
+        mFriendInviteContextItem.Clicked += MFriendInviteContextItem_Clicked;
+        mPartyInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.PartyInvite);
+        mPartyInviteContextItem.Clicked += MPartyInviteContextItem_Clicked;
+        mGuildInviteContextItem = mContextMenu.AddItem(Strings.ChatContextMenu.GuildInvite);
+        mGuildInviteContextItem.Clicked += MGuildInviteContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+
+    public void OpenContextMenu(string name)
+    {
+        // Clear out the old options.
+        mContextMenu.RemoveChild(mPMContextItem, false);
+        mContextMenu.RemoveChild(mFriendInviteContextItem, false);
+        mContextMenu.RemoveChild(mPartyInviteContextItem, false);
+        mContextMenu.RemoveChild(mGuildInviteContextItem, false);
+        mContextMenu.Children.Clear();
+
+        // No point showing a menu for blank space.
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        // Add our PM option!
+        mContextMenu.AddChild(mPMContextItem);
+        mPMContextItem.SetText(Strings.ChatContextMenu.PM.ToString(name));
+
+        // If we do not already have this player on our friendlist, add a request button!
+        if (!Globals.Me.Friends.Any(f => f.Name == name))
+        {
+            mContextMenu.AddChild(mFriendInviteContextItem);
+            mFriendInviteContextItem.SetText(Strings.ChatContextMenu.FriendInvite.ToString(name));
+        }
+
+        // Are we in a party, the leader and is this player not yet in our party?
+        if ((Globals.Me.IsInParty() && Globals.Me.Party[0].Id == Globals.Me.Id && !Globals.Me.Party.Any(p => p.Name == name)) || !Globals.Me.IsInParty())
+        {
+            mContextMenu.AddChild(mPartyInviteContextItem);
+            mPartyInviteContextItem.SetText(Strings.ChatContextMenu.PartyInvite.ToString(name));
+        }
+
+        // Are we in a guild, able to invite players and are they not yet in our guild?
+        if (Globals.Me.IsInGuild && Globals.Me.GuildRank.Permissions.Invite && !Globals.Me.GuildMembers.Any(g => g.Name == name))
+        {
+            mContextMenu.AddChild(mGuildInviteContextItem);
+            mGuildInviteContextItem.SetText(Strings.ChatContextMenu.GuildInvite.ToString(name));
+        }
+
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = name;
+
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+    }
+
+    private void MGuildInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var name = (string)sender.Parent.UserData;
+        PacketSender.SendInviteGuild(name);
+    }
+
+    private void MPartyInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var name = (string)sender.Parent.UserData;
+        PacketSender.SendPartyInvite(name);
+    }
+
+    private void MFriendInviteContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var name = (string)sender.Parent.UserData;
+        PacketSender.SendAddFriend(name);
+    }
+
+    private void MPMContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var name = (string)sender.Parent.UserData;
+        SetChatboxText($"/pm {name} ");
+    }
+
+    /// <summary>
+    /// Handle logic after a chat channel menu item is selected.
+    /// </summary>
+    private void MenuItem_Selected(Base sender, ItemSelectedEventArgs arguments)
+    {
+        // If we're on the two generic tabs, remember which channel we're trying to type in so we can switch back to this channel when we decide to swap between tabs.
+        if ((mCurrentTab == ChatboxTab.All || mCurrentTab == ChatboxTab.System))
+        {
+            mLastChatChannel[mCurrentTab] = (int)sender.UserData;
+        }
+    }
+
+    /// <summary>
+    /// Enables all the chat tab buttons.
+    /// </summary>
+    private void EnableChatTabs()
+    {
+        for (var btn = 0; btn < (int)ChatboxTab.Count; btn++)
+        {
+            mTabButtons[(ChatboxTab)btn].Enable();
+        }
+
+    }
+
+    /// <summary>
+    /// Handles the click event of a chat tab button.
+    /// </summary>
+    /// <param name="sender">The button that was clicked.</param>
+    /// <param name="arguments">The arguments passed by the event.</param>
+    private void TabButtonClicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Enable all buttons again!
+        EnableChatTabs();
+
+        // Disable the clicked button to fake our tab being selected and set our selected chat tab.
+        sender.Disable();
+        var tab = (ChatboxTab)sender.UserData;
+        mCurrentTab = tab;
+
+        // Change the default channel we're trying to chat in based on the tab we've just selected.
+        SetChannelToTab(tab);
+    }
+
+    /// <summary>
+    /// Sets the selected chat channel to type in by default to the channel corresponding to the provided tab.
+    /// </summary>
+    /// <param name="tab">The tab to use for reference as to which channel we want to speak in.</param>
+    private void SetChannelToTab(ChatboxTab tab)
+    {
+        switch (tab)
+        {
+            case ChatboxTab.System:
+            case ChatboxTab.All:
+                mChannelCombobox.SelectByUserData(mLastChatChannel[tab]);
+                break;
+
+            case ChatboxTab.Local:
+                mChannelCombobox.SelectByUserData(0);
+                break;
+
+            case ChatboxTab.Global:
+                mChannelCombobox.SelectByUserData(1);
+                break;
+
+            case ChatboxTab.Party:
+                mChannelCombobox.SelectByUserData(2);
+                break;
+
+            case ChatboxTab.Guild:
+                mChannelCombobox.SelectByUserData(3);
+                break;
+
+            default:
+                // remain unchanged.
+                break;
+        }
+    }
+
+    //Update
+    public void Update()
+    {
+        var vScrollBar = mChatboxMessages.GetVerticalScrollBar();
+        var scrollAmount = vScrollBar.ScrollAmount;
+        var scrollBarVisible = vScrollBar.ContentSize > mChatboxMessages.Height;
+        var scrollToBottom = vScrollBar.ScrollAmount == 1 || !scrollBarVisible;
+
+        // Did the tab change recently? If so, we need to reset a few things to make it work...
+        if (mLastTab != mCurrentTab)
+        {
             mChatboxMessages.Clear();
             mChatboxMessages.GetHorizontalScrollBar().SetScrollAmount(0);
             mMessageIndex = 0;
@@ -507,99 +361,243 @@ namespace Intersect.Client.Interface.Game.Chat
             mLastTab = mCurrentTab;
         }
 
-        void ChatboxToggleLogBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        var msgs = ChatboxMsg.GetMessages(mCurrentTab);
+        for (var i = mMessageIndex; i < msgs.Count; i++)
         {
-            if (mChatboxWindow.Texture != null)
+            var msg = msgs[i];
+            var myText = Interface.WrapText(
+                msg.Message, mChatboxMessages.Width - vScrollBar.Width - 8,
+                mChatboxText.Font
+            );
+
+            foreach (var t in myText)
             {
-                HideChatLog();
+                var rw = mChatboxMessages.AddRow(t.Trim());
+                rw.SetTextFont(mChatboxText.Font);
+                rw.SetTextColor(msg.Color);
+                rw.ShouldDrawBackground = false;
+                rw.UserData = msg.Target;
+                rw.Clicked += ChatboxRow_Clicked;
+                rw.RightClicked += ChatboxRow_RightClicked;
+                mReceivedMessage = true;
+
+                while (mChatboxMessages.RowCount > ClientConfiguration.Instance.ChatLines)
+                {
+                    mChatboxMessages.RemoveRow(0);
+                }
+            }
+
+            mMessageIndex++;
+        }
+
+
+        if (mReceivedMessage)
+        {
+            mChatboxMessages.InnerPanel.SizeToChildren(false, true);
+            mChatboxMessages.UpdateScrollBars();
+            if (!scrollToBottom)
+            {
+                vScrollBar.SetScrollAmount(scrollAmount);
             }
             else
+            {
+                vScrollBar.SetScrollAmount(1);
+            }
+            mReceivedMessage = false;
+        }
+    }
+
+    private void ChatboxRow_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rw = (ListBoxRow)sender;
+        var target = (string)rw.UserData;
+
+        if (!string.IsNullOrWhiteSpace(target) && target != Globals.Me.Name)
+        {
+            if (ClientConfiguration.Instance.EnableContextMenus)
+            {
+                OpenContextMenu(target);
+            }
+            else
+            {
+                SetChatboxText($"/pm {target} ");
+            }
+
+        }
+    }
+
+    public void SetChatboxText(string msg)
+    {
+        mChatboxInput.Text = msg;
+        mChatboxInput.Focus();
+        mChatboxInput.CursorEnd = mChatboxInput.Text.Length;
+        mChatboxInput.CursorPos = mChatboxInput.Text.Length;
+    }
+
+    private void ChatboxRow_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rw = (ListBoxRow)sender;
+        var target = (string)rw.UserData;
+        if (!string.IsNullOrWhiteSpace(target))
+        {
+            if (mGameUi.AdminWindowOpen())
+            {
+                mGameUi.AdminWindowSelectName(target);
+            }
+        }
+    }
+
+    //Extra Methods
+    public void Focus()
+    {
+        if (!mChatboxInput.HasFocus)
+        {
+            mChatboxInput.Text = string.Empty;
+            mChatboxInput.Focus();
+            if (Globals.Database.AutoToggleChatLog)
             {
                 ShowChatLog();
             }
         }
+    }
 
-        private void ShowChatLog()
+    public bool HasFocus => mChatboxInput.HasFocus;
+
+    public void UnFocus()
+    {
+        // Just focus something else if we need to unfocus.
+        if (mChatboxInput.HasFocus)
         {
-            mTabButtons[ChatboxTab.All].Show();
-            mTabButtons[ChatboxTab.Local].Show();
-            mTabButtons[ChatboxTab.Party].Show();
-            mTabButtons[ChatboxTab.Guild].Show();
-            mTabButtons[ChatboxTab.Global].Show();
-            mTabButtons[ChatboxTab.System].Show();
-            mChatboxMessages.Show();
-            mChatboxWindow.Texture = _chatboxTexture;
+            mChatboxInput.Text = GetDefaultInputText();
+            mChatboxMessages.Focus();
+            if (Globals.Database.AutoToggleChatLog)
+            {
+                HideChatLog();
+            }
+        }
+    }
+
+    //Input Handlers
+    //Chatbox Window
+    void ChatboxInput_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (mChatboxInput.Text == GetDefaultInputText())
+        {
+            mChatboxInput.Text = "";
+        }
+    }
+
+    void ChatboxInput_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TrySendMessage();
+    }
+
+    void ChatboxSendBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        TrySendMessage();
+    }
+
+    void ChatboxClearLogBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ChatboxMsg.ClearMessages();
+        mChatboxMessages.Clear();
+        mChatboxMessages.GetHorizontalScrollBar().SetScrollAmount(0);
+        mMessageIndex = 0;
+        mReceivedMessage = true;
+        mLastTab = mCurrentTab;
+    }
+
+    void ChatboxToggleLogBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (mChatboxWindow.Texture != null)
+        {
+            HideChatLog();
+        }
+        else
+        {
+            ShowChatLog();
+        }
+    }
+
+    private void ShowChatLog()
+    {
+        mTabButtons[ChatboxTab.All].Show();
+        mTabButtons[ChatboxTab.Local].Show();
+        mTabButtons[ChatboxTab.Party].Show();
+        mTabButtons[ChatboxTab.Guild].Show();
+        mTabButtons[ChatboxTab.Global].Show();
+        mTabButtons[ChatboxTab.System].Show();
+        mChatboxMessages.Show();
+        mChatboxWindow.Texture = _chatboxTexture;
+    }
+
+    private void HideChatLog()
+    {
+        mTabButtons[ChatboxTab.All].Hide();
+        mTabButtons[ChatboxTab.Local].Hide();
+        mTabButtons[ChatboxTab.Party].Hide();
+        mTabButtons[ChatboxTab.Guild].Hide();
+        mTabButtons[ChatboxTab.Global].Hide();
+        mTabButtons[ChatboxTab.System].Hide();
+        mChatboxMessages.Hide();
+        mChatboxWindow.Texture = null;
+    }
+
+    void TrySendMessage()
+    {
+        var msg = mChatboxInput.Text.Trim();
+
+        if (string.IsNullOrWhiteSpace(msg) || string.Equals(msg, GetDefaultInputText(), StringComparison.Ordinal))
+        {
+            mChatboxInput.Text = GetDefaultInputText();
+
+            return;
         }
 
-        private void HideChatLog()
+        if (mLastChatTime > Timing.Global.MillisecondsUtc)
         {
-            mTabButtons[ChatboxTab.All].Hide();
-            mTabButtons[ChatboxTab.Local].Hide();
-            mTabButtons[ChatboxTab.Party].Hide();
-            mTabButtons[ChatboxTab.Guild].Hide();
-            mTabButtons[ChatboxTab.Global].Hide();
-            mTabButtons[ChatboxTab.System].Hide();
-            mChatboxMessages.Hide();
-            mChatboxWindow.Texture = null;
-        }
-
-        void TrySendMessage()
-        {
-            var msg = mChatboxInput.Text.Trim();
-
-            if (string.IsNullOrWhiteSpace(msg) || string.Equals(msg, GetDefaultInputText(), StringComparison.Ordinal))
-            {
-                mChatboxInput.Text = GetDefaultInputText();
-
-                return;
-            }
-
-            if (mLastChatTime > Timing.Global.MillisecondsUtc)
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.TooFast, Color.Red, ChatMessageType.Error));
-                mLastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
-
-                return;
-            }
-
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Chatbox.TooFast, Color.Red, ChatMessageType.Error));
             mLastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
 
-            PacketSender.SendChatMsg(
-                msg, byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString())
-            );
-
-            mChatboxInput.Text = GetDefaultInputText();
+            return;
         }
 
-        string GetDefaultInputText()
+        mLastChatTime = Timing.Global.MillisecondsUtc + Options.MinChatInterval;
+
+        PacketSender.SendChatMsg(
+            msg, byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString())
+        );
+
+        mChatboxInput.Text = GetDefaultInputText();
+    }
+
+    string GetDefaultInputText()
+    {
+        var key1 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[0];
+        var key2 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[1];
+        if (key1.Key == Keys.None && key2.Key != Keys.None)
         {
-            var key1 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[0];
-            var key2 = Controls.ActiveControls.ControlMapping[Control.Enter].Bindings[1];
-            if (key1.Key == Keys.None && key2.Key != Keys.None)
-            {
-                return Strings.Chatbox.EnterChat1.ToString(
-                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key2.Key).ToLower()]
-                );
-            }
-
-            if (key1.Key != Keys.None && key2.Key == Keys.None)
-            {
-                return Strings.Chatbox.EnterChat1.ToString(
-                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key1.Key).ToLower()]
-                );
-            }
-
-            if (key1.Key != Keys.None && key2.Key != Keys.None)
-            {
-                return Strings.Chatbox.EnterChat2.ToString(
-                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key1.Key).ToLower()],
-                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key2.Key).ToLower()]
-                );
-            }
-
-            return Strings.Chatbox.EnterChat;
+            return Strings.Chatbox.EnterChat1.ToString(
+                Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key2.Key).ToLower()]
+            );
         }
 
+        if (key1.Key != Keys.None && key2.Key == Keys.None)
+        {
+            return Strings.Chatbox.EnterChat1.ToString(
+                Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key1.Key).ToLower()]
+            );
+        }
+
+        if (key1.Key != Keys.None && key2.Key != Keys.None)
+        {
+            return Strings.Chatbox.EnterChat2.ToString(
+                Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key1.Key).ToLower()],
+                Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), key2.Key).ToLower()]
+            );
+        }
+
+        return Strings.Chatbox.EnterChat;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Chat/ChatboxMsg.cs
+++ b/Intersect.Client/Interface/Game/Chat/ChatboxMsg.cs
@@ -1,125 +1,123 @@
 ﻿using Intersect.Enums;
 
-namespace Intersect.Client.Interface.Game.Chat
+namespace Intersect.Client.Interface.Game.Chat;
+
+
+public partial class ChatboxMsg
 {
 
-    public partial class ChatboxMsg
+    private static List<ChatboxMsg> sGameMessages = new List<ChatboxMsg>();
+
+    // TODO: Move to a configuration file to make this player configurable?
+    /// <summary>
+    /// Contains the configuration of which message types to display in each chat tab.
+    /// </summary>
+    private static Dictionary<ChatboxTab, ChatMessageType[]> sTabMessageTypes = new Dictionary<ChatboxTab, ChatMessageType[]>() {
+        // All has ALL tabs unlocked, so really we don't have to worry about that one.
+        { ChatboxTab.Local, new ChatMessageType[] { ChatMessageType.Local, ChatMessageType.PM, ChatMessageType.Admin } },
+        { ChatboxTab.Party, new ChatMessageType[] { ChatMessageType.Party, ChatMessageType.PM, ChatMessageType.Admin } },
+        { ChatboxTab.Global, new ChatMessageType[] { ChatMessageType.Global, ChatMessageType.PM, ChatMessageType.Admin } },
+        { ChatboxTab.Guild, new ChatMessageType[] { ChatMessageType.Guild, ChatMessageType.PM, ChatMessageType.Admin } },
+        { ChatboxTab.System, new ChatMessageType[] { 
+            ChatMessageType.Experience, ChatMessageType.Loot, ChatMessageType.Inventory, ChatMessageType.Bank, 
+            ChatMessageType.Combat, ChatMessageType.Quest, ChatMessageType.Crafting, ChatMessageType.Trading, 
+            ChatMessageType.Friend, ChatMessageType.Spells, ChatMessageType.Notice, ChatMessageType.Error,
+            ChatMessageType.Admin } },
+    };
+
+    private string mMsg = "";
+
+    private Color mMsgColor;
+
+    private string mTarget = "";
+
+    private ChatMessageType mType;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="ChatboxMsg"/> class.
+    /// </summary>
+    /// <param name="msg">The message to add.</param>
+    /// <param name="clr">The color of the message.</param>
+    /// <param name="type">The type of the message.</param>
+    /// <param name="target">The target of the message.</param>
+    public ChatboxMsg(string msg, Color clr, ChatMessageType type, string target = "")
     {
-
-        private static List<ChatboxMsg> sGameMessages = new List<ChatboxMsg>();
-
-        // TODO: Move to a configuration file to make this player configurable?
-        /// <summary>
-        /// Contains the configuration of which message types to display in each chat tab.
-        /// </summary>
-        private static Dictionary<ChatboxTab, ChatMessageType[]> sTabMessageTypes = new Dictionary<ChatboxTab, ChatMessageType[]>() {
-            // All has ALL tabs unlocked, so really we don't have to worry about that one.
-            { ChatboxTab.Local, new ChatMessageType[] { ChatMessageType.Local, ChatMessageType.PM, ChatMessageType.Admin } },
-            { ChatboxTab.Party, new ChatMessageType[] { ChatMessageType.Party, ChatMessageType.PM, ChatMessageType.Admin } },
-            { ChatboxTab.Global, new ChatMessageType[] { ChatMessageType.Global, ChatMessageType.PM, ChatMessageType.Admin } },
-            { ChatboxTab.Guild, new ChatMessageType[] { ChatMessageType.Guild, ChatMessageType.PM, ChatMessageType.Admin } },
-            { ChatboxTab.System, new ChatMessageType[] { 
-                ChatMessageType.Experience, ChatMessageType.Loot, ChatMessageType.Inventory, ChatMessageType.Bank, 
-                ChatMessageType.Combat, ChatMessageType.Quest, ChatMessageType.Crafting, ChatMessageType.Trading, 
-                ChatMessageType.Friend, ChatMessageType.Spells, ChatMessageType.Notice, ChatMessageType.Error,
-                ChatMessageType.Admin } },
-        };
-
-        private string mMsg = "";
-
-        private Color mMsgColor;
-
-        private string mTarget = "";
-
-        private ChatMessageType mType;
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="ChatboxMsg"/> class.
-        /// </summary>
-        /// <param name="msg">The message to add.</param>
-        /// <param name="clr">The color of the message.</param>
-        /// <param name="type">The type of the message.</param>
-        /// <param name="target">The target of the message.</param>
-        public ChatboxMsg(string msg, Color clr, ChatMessageType type, string target = "")
-        {
-            mMsg = msg;
-            mMsgColor = clr;
-            mTarget = target;
-            mType = type;
-        }
-
-        /// <summary>
-        /// The contents of this message.
-        /// </summary>
-        public string Message => mMsg;
-
-        /// <summary>
-        /// The color of this message.
-        /// </summary>
-        public Color Color => mMsgColor;
-
-        // The target of this message.
-        public string Target => mTarget;
-
-        /// <summary>
-        /// The type of this message.
-        /// </summary>
-        public ChatMessageType Type => mType;
-
-        /// <summary>
-        /// Adds a new chat message to the stored list.
-        /// </summary>
-        /// <param name="msg">The message to add.</param>
-        public static void AddMessage(ChatboxMsg msg)
-        {
-            sGameMessages.Add(msg);
-        }
-
-        /// <summary>
-        /// Retrieves all chat messages.
-        /// </summary>
-        /// <returns>Returns a list of chat messages.</returns>
-        public static List<ChatboxMsg> GetMessages()
-        {
-            return sGameMessages;
-        }
-
-        /// <summary>
-        /// Retrieves all messages that should be displayed in the provided tab.
-        /// </summary>
-        /// <param name="tab">The tab for which to retrieve all messages.</param>
-        /// <returns>Returns a list of chat messages.</returns>
-        public static List<ChatboxMsg> GetMessages(ChatboxTab tab)
-        {
-            var output = new List<ChatboxMsg>();
-
-            // Are we looking for all messages?
-            if (tab == ChatboxTab.All)
-            {
-                output = GetMessages();
-            }
-            else
-            {
-                // No, sort them out! Select what we want to display in this tab.
-                foreach (var message in sGameMessages)
-                {
-                    if (sTabMessageTypes[tab].Contains(message.Type))
-                    {
-                        output.Add(message);
-                    }
-                }
-            }
-
-            return output;
-        }
-
-        /// <summary>
-        /// Clears all stored messages.
-        /// </summary>
-        public static void ClearMessages()
-        {
-            sGameMessages.Clear();
-        }
+        mMsg = msg;
+        mMsgColor = clr;
+        mTarget = target;
+        mType = type;
     }
 
+    /// <summary>
+    /// The contents of this message.
+    /// </summary>
+    public string Message => mMsg;
+
+    /// <summary>
+    /// The color of this message.
+    /// </summary>
+    public Color Color => mMsgColor;
+
+    // The target of this message.
+    public string Target => mTarget;
+
+    /// <summary>
+    /// The type of this message.
+    /// </summary>
+    public ChatMessageType Type => mType;
+
+    /// <summary>
+    /// Adds a new chat message to the stored list.
+    /// </summary>
+    /// <param name="msg">The message to add.</param>
+    public static void AddMessage(ChatboxMsg msg)
+    {
+        sGameMessages.Add(msg);
+    }
+
+    /// <summary>
+    /// Retrieves all chat messages.
+    /// </summary>
+    /// <returns>Returns a list of chat messages.</returns>
+    public static List<ChatboxMsg> GetMessages()
+    {
+        return sGameMessages;
+    }
+
+    /// <summary>
+    /// Retrieves all messages that should be displayed in the provided tab.
+    /// </summary>
+    /// <param name="tab">The tab for which to retrieve all messages.</param>
+    /// <returns>Returns a list of chat messages.</returns>
+    public static List<ChatboxMsg> GetMessages(ChatboxTab tab)
+    {
+        var output = new List<ChatboxMsg>();
+
+        // Are we looking for all messages?
+        if (tab == ChatboxTab.All)
+        {
+            output = GetMessages();
+        }
+        else
+        {
+            // No, sort them out! Select what we want to display in this tab.
+            foreach (var message in sGameMessages)
+            {
+                if (sTabMessageTypes[tab].Contains(message.Type))
+                {
+                    output.Add(message);
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Clears all stored messages.
+    /// </summary>
+    public static void ClearMessages()
+    {
+        sGameMessages.Clear();
+    }
 }

--- a/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client/Interface/Game/Crafting/CraftingWindow.cs
@@ -10,273 +10,266 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Crafting
+namespace Intersect.Client.Interface.Game.Crafting;
+
+
+public partial class CraftingWindow
 {
+    private ImagePanel mBar;
 
-    public partial class CraftingWindow
+    private ImagePanel mBarContainer;
+
+    private long mBarTimer;
+
+    private RecipeItem mCombinedItem;
+
+    private Label mCombinedValue;
+
+    private Button mCraft;
+
+    private Button mCraftAll;
+
+    private Guid mAutoCraftId = Guid.Empty;
+
+    private int mRemainingCrafts = 0;
+
+    private Guid mCraftId;
+
+    //Controls
+    private WindowControl mCraftWindow;
+
+    private bool mInitialized = false;
+
+    private ScrollControl mItemContainer;
+
+    private List<RecipeItem> mItems = new List<RecipeItem>();
+
+    private Label mLblIngredients;
+
+    private Label mLblProduct;
+
+    private Label mLblRecipes;
+
+    private Label mLblCraftingChance;
+
+    private Label mLblDestroyMaterialsChance;
+
+    private Label mLblCraftingTime;
+
+    //Objects
+    private ListBox mRecipes;
+
+    private List<Label> mValues = new List<Label>();
+
+    //Location
+    public int X => mCraftWindow.X;
+
+    public int Y => mCraftWindow.Y;
+
+    public bool IsCrafting => mRemainingCrafts > 0;
+
+    private bool mJournalMode { get; set; }
+
+    public CraftingWindow(Canvas gameCanvas, bool journalMode)
     {
-        private ImagePanel mBar;
+        mCraftWindow = new WindowControl(gameCanvas, Globals.ActiveCraftingTable.Name, false, "CraftingWindow");
+        mCraftWindow.DisableResizing();
 
-        private ImagePanel mBarContainer;
+        mItemContainer = new ScrollControl(mCraftWindow, "IngredientsContainer");
 
-        private long mBarTimer;
+        mJournalMode = journalMode;
 
-        private RecipeItem mCombinedItem;
+        //Labels
+        mLblRecipes = new Label(mCraftWindow, "RecipesTitle");
+        mLblRecipes.Text = Strings.Crafting.Recipes;
 
-        private Label mCombinedValue;
+        mLblIngredients = new Label(mCraftWindow, "IngredientsTitle");
+        mLblIngredients.Text = Strings.Crafting.Ingredients;
 
-        private Button mCraft;
+        mLblProduct = new Label(mCraftWindow, "ProductLabel");
+        mLblProduct.Text = Strings.Crafting.Product;
 
-        private Button mCraftAll;
+        mLblCraftingChance = new Label(mCraftWindow, "ProductChanceLabel");
+        mLblCraftingChance.Text = Strings.Crafting.CraftChance.ToString(0);
 
-        private Guid mAutoCraftId = Guid.Empty;
+        mLblDestroyMaterialsChance = new Label(mCraftWindow, "DestroyMaterialsChanceLabel");
+        mLblDestroyMaterialsChance.Text = Strings.Crafting.DestroyMaterialsChance.ToString(0);
 
-        private int mRemainingCrafts = 0;
+        mLblCraftingTime = new Label(mCraftWindow, "CraftingTimeLabel");
+        mLblCraftingTime.Text = Strings.Crafting.CraftingTime.ToString(0);
 
-        private Guid mCraftId;
+        //Recepie list
+        mRecipes = new ListBox(mCraftWindow, "RecipesList");
 
-        //Controls
-        private WindowControl mCraftWindow;
+        //Progress Bar
+        mBarContainer = new ImagePanel(mCraftWindow, "ProgressBarContainer");
+        mBar = new ImagePanel(mBarContainer, "ProgressBar");
 
-        private bool mInitialized = false;
+        //Load the craft button
+        mCraft = new Button(mCraftWindow, "CraftButton");
+        mCraft.SetText(Strings.Crafting.Craft);
+        mCraft.Clicked += craft_Clicked;
 
-        private ScrollControl mItemContainer;
+        //Craft all button
+        mCraftAll = new Button(mCraftWindow, "CraftAllButton");
+        mCraftAll.SetText(Strings.Crafting.CraftAll.ToString(1));
+        mCraftAll.Clicked += craftAll_Clicked;
 
-        private List<RecipeItem> mItems = new List<RecipeItem>();
+        mCraftWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        private Label mLblIngredients;
-
-        private Label mLblProduct;
-
-        private Label mLblRecipes;
-
-        private Label mLblCraftingChance;
-
-        private Label mLblDestroyMaterialsChance;
-
-        private Label mLblCraftingTime;
-
-        //Objects
-        private ListBox mRecipes;
-
-        private List<Label> mValues = new List<Label>();
-
-        //Location
-        public int X => mCraftWindow.X;
-
-        public int Y => mCraftWindow.Y;
-
-        public bool IsCrafting => mRemainingCrafts > 0;
-
-        private bool mJournalMode { get; set; }
-
-        public CraftingWindow(Canvas gameCanvas, bool journalMode)
+        if (mJournalMode)
         {
-            mCraftWindow = new WindowControl(gameCanvas, Globals.ActiveCraftingTable.Name, false, "CraftingWindow");
-            mCraftWindow.DisableResizing();
-
-            mItemContainer = new ScrollControl(mCraftWindow, "IngredientsContainer");
-
-            mJournalMode = journalMode;
-
-            //Labels
-            mLblRecipes = new Label(mCraftWindow, "RecipesTitle");
-            mLblRecipes.Text = Strings.Crafting.Recipes;
-
-            mLblIngredients = new Label(mCraftWindow, "IngredientsTitle");
-            mLblIngredients.Text = Strings.Crafting.Ingredients;
-
-            mLblProduct = new Label(mCraftWindow, "ProductLabel");
-            mLblProduct.Text = Strings.Crafting.Product;
-
-            mLblCraftingChance = new Label(mCraftWindow, "ProductChanceLabel");
-            mLblCraftingChance.Text = Strings.Crafting.CraftChance.ToString(0);
-
-            mLblDestroyMaterialsChance = new Label(mCraftWindow, "DestroyMaterialsChanceLabel");
-            mLblDestroyMaterialsChance.Text = Strings.Crafting.DestroyMaterialsChance.ToString(0);
-
-            mLblCraftingTime = new Label(mCraftWindow, "CraftingTimeLabel");
-            mLblCraftingTime.Text = Strings.Crafting.CraftingTime.ToString(0);
-
-            //Recepie list
-            mRecipes = new ListBox(mCraftWindow, "RecipesList");
-
-            //Progress Bar
-            mBarContainer = new ImagePanel(mCraftWindow, "ProgressBarContainer");
-            mBar = new ImagePanel(mBarContainer, "ProgressBar");
-
-            //Load the craft button
-            mCraft = new Button(mCraftWindow, "CraftButton");
-            mCraft.SetText(Strings.Crafting.Craft);
-            mCraft.Clicked += craft_Clicked;
-
-            //Craft all button
-            mCraftAll = new Button(mCraftWindow, "CraftAllButton");
-            mCraftAll.SetText(Strings.Crafting.CraftAll.ToString(1));
-            mCraftAll.Clicked += craftAll_Clicked;
-
-            mCraftWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            if (mJournalMode)
-            {
-                mCraft.Hide();
-                mCraftAll.Hide();
-            }
-
-            Interface.InputBlockingElements.Add(mCraftWindow);
-
-            Globals.Me.InventoryUpdatedDelegate = () =>
-            {
-                //Refresh crafting window items
-                LoadCraftItems(mCraftId);
-            };
+            mCraft.Hide();
+            mCraftAll.Hide();
         }
 
-        private void LoadCraftItems(Guid id)
+        Interface.InputBlockingElements.Add(mCraftWindow);
+
+        Globals.Me.InventoryUpdatedDelegate = () =>
         {
-            //Combined item
-            mCraftId = id;
-            if (mCombinedItem != null)
-            {
-                mCraftWindow.Children.Remove(mCombinedItem.Container);
-            }
+            //Refresh crafting window items
+            LoadCraftItems(mCraftId);
+        };
+    }
 
+    private void LoadCraftItems(Guid id)
+    {
+        //Combined item
+        mCraftId = id;
+        if (mCombinedItem != null)
+        {
+            mCraftWindow.Children.Remove(mCombinedItem.Container);
+        }
+
+        //Clear the old item description box
+        if (mCombinedItem != null && mCombinedItem.DescWindow != null)
+        {
+            mCombinedItem.DescWindow.Dispose();
+        }
+
+        if (!Globals.ActiveCraftingTable.Crafts.Contains(id))
+        {
+            return;
+        }
+
+        var craft = Globals.ActiveCraftingTable.Crafts.Get(id);
+
+        if (craft == null)
+        {
+            return;
+        }
+
+        mCombinedItem = new RecipeItem(this, new CraftIngredient(craft.ItemId, 0))
+        {
+            Container = new ImagePanel(mCraftWindow, "CraftedItem")
+        };
+
+        mCombinedItem.Setup("CraftedItemIcon");
+        mCombinedValue = new Label(mCombinedItem.Container, "CraftedItemQuantity");
+
+        mCombinedItem.Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        mCombinedItem.LoadItem();
+        mCombinedValue.Show();
+        var quantity = Math.Max(craft.Quantity, 1);
+        var itm = ItemBase.Get(craft.ItemId);
+        if (itm == null || !itm.IsStackable)
+        {
+            quantity = 1;
+        }
+
+        mCombinedValue.Text = quantity.ToString();
+
+        for (var i = 0; i < mItems.Count; i++)
+        {
             //Clear the old item description box
-            if (mCombinedItem != null && mCombinedItem.DescWindow != null)
+            if (mItems[i].DescWindow != null)
             {
-                mCombinedItem.DescWindow.Dispose();
+                mItems[i].DescWindow.Dispose();
             }
 
-            if (!Globals.ActiveCraftingTable.Crafts.Contains(id))
+            mItemContainer.RemoveChild(mItems[i].Container, true);
+        }
+
+        mItems.Clear();
+        mValues.Clear();
+
+        //Quickly Look through the inventory and create a catalog of what items we have, and how many
+        var itemdict = new Dictionary<Guid, int>();
+        foreach (var item in Globals.Me.Inventory)
+        {
+            if (item != null)
             {
-                return;
-            }
-
-            var craft = Globals.ActiveCraftingTable.Crafts.Get(id);
-
-            if (craft == null)
-            {
-                return;
-            }
-
-            mCombinedItem = new RecipeItem(this, new CraftIngredient(craft.ItemId, 0))
-            {
-                Container = new ImagePanel(mCraftWindow, "CraftedItem")
-            };
-
-            mCombinedItem.Setup("CraftedItemIcon");
-            mCombinedValue = new Label(mCombinedItem.Container, "CraftedItemQuantity");
-
-            mCombinedItem.Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            mCombinedItem.LoadItem();
-            mCombinedValue.Show();
-            var quantity = Math.Max(craft.Quantity, 1);
-            var itm = ItemBase.Get(craft.ItemId);
-            if (itm == null || !itm.IsStackable)
-            {
-                quantity = 1;
-            }
-
-            mCombinedValue.Text = quantity.ToString();
-
-            for (var i = 0; i < mItems.Count; i++)
-            {
-                //Clear the old item description box
-                if (mItems[i].DescWindow != null)
+                if (itemdict.ContainsKey(item.ItemId))
                 {
-                    mItems[i].DescWindow.Dispose();
+                    itemdict[item.ItemId] += item.Quantity;
                 }
+                else
+                {
+                    itemdict.Add(item.ItemId, item.Quantity);
+                }
+            }
+        }
 
-                mItemContainer.RemoveChild(mItems[i].Container, true);
+        var craftableQuantity = -1;
+
+        for (var i = 0; i < craft.Ingredients.Count; i++)
+        {
+            mItems.Add(new RecipeItem(this, craft.Ingredients[i]));
+            mItems[i].Container = new ImagePanel(mItemContainer, "CraftingIngredient");
+            mItems[i].Setup("IngredientItemIcon");
+
+            var lblTemp = new Label(mItems[i].Container, "IngredientItemValue");
+
+            var onHand = 0;
+            if (itemdict.ContainsKey(craft.Ingredients[i].ItemId))
+            {
+                onHand = itemdict[craft.Ingredients[i].ItemId];
             }
 
-            mItems.Clear();
-            mValues.Clear();
+            lblTemp.Text = onHand + "/" + craft.Ingredients[i].Quantity;
 
-            //Quickly Look through the inventory and create a catalog of what items we have, and how many
-            var itemdict = new Dictionary<Guid, int>();
-            foreach (var item in Globals.Me.Inventory)
+            var possibleToCraft = (int)Math.Floor(onHand / (double)craft.Ingredients[i].Quantity);
+
+            if (craftableQuantity == -1 || possibleToCraft < craftableQuantity)
             {
-                if (item != null)
+                craftableQuantity = possibleToCraft;
+            }
+
+            mValues.Add(lblTemp);
+
+            mItems[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            mItems[i].LoadItem();
+
+            var xPadding = mItems[i].Container.Margin.Left + mItems[i].Container.Margin.Right;
+            var yPadding = mItems[i].Container.Margin.Top + mItems[i].Container.Margin.Bottom;
+
+            var sizeFactor = (mItemContainer.Width - mItemContainer.GetVerticalScrollBar().Width) /
+                             (mItems[i].Container.Width + xPadding);
+
+            mItems[i].Container.SetPosition(
+                i % sizeFactor * (mItems[i].Container.Width + xPadding) + xPadding,
+                i / sizeFactor * (mItems[i].Container.Height + yPadding) + yPadding
+            );
+        }
+
+        //Show crafting time and chances
+        mLblCraftingTime.Text = Strings.Crafting.CraftingTime.ToString(craft.Time / 1000.0);
+        mLblCraftingChance.Text = Strings.Crafting.CraftChance.ToString(craft.FailureChance);
+        mLblDestroyMaterialsChance.Text = Strings.Crafting.DestroyMaterialsChance.ToString(craft.ItemLossChance);
+
+        //If crafting & we no longer have the items for the craft then stop!
+        if (IsCrafting)
+        {
+            var cancraft = true;
+            foreach (var c in CraftBase.Get(mCraftId).Ingredients)
+            {
+                if (itemdict.ContainsKey(c.ItemId))
                 {
-                    if (itemdict.ContainsKey(item.ItemId))
+                    if (itemdict[c.ItemId] >= c.Quantity)
                     {
-                        itemdict[item.ItemId] += item.Quantity;
-                    }
-                    else
-                    {
-                        itemdict.Add(item.ItemId, item.Quantity);
-                    }
-                }
-            }
-
-            var craftableQuantity = -1;
-
-            for (var i = 0; i < craft.Ingredients.Count; i++)
-            {
-                mItems.Add(new RecipeItem(this, craft.Ingredients[i]));
-                mItems[i].Container = new ImagePanel(mItemContainer, "CraftingIngredient");
-                mItems[i].Setup("IngredientItemIcon");
-
-                var lblTemp = new Label(mItems[i].Container, "IngredientItemValue");
-
-                var onHand = 0;
-                if (itemdict.ContainsKey(craft.Ingredients[i].ItemId))
-                {
-                    onHand = itemdict[craft.Ingredients[i].ItemId];
-                }
-
-                lblTemp.Text = onHand + "/" + craft.Ingredients[i].Quantity;
-
-                var possibleToCraft = (int)Math.Floor(onHand / (double)craft.Ingredients[i].Quantity);
-
-                if (craftableQuantity == -1 || possibleToCraft < craftableQuantity)
-                {
-                    craftableQuantity = possibleToCraft;
-                }
-
-                mValues.Add(lblTemp);
-
-                mItems[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                mItems[i].LoadItem();
-
-                var xPadding = mItems[i].Container.Margin.Left + mItems[i].Container.Margin.Right;
-                var yPadding = mItems[i].Container.Margin.Top + mItems[i].Container.Margin.Bottom;
-
-                var sizeFactor = (mItemContainer.Width - mItemContainer.GetVerticalScrollBar().Width) /
-                                 (mItems[i].Container.Width + xPadding);
-
-                mItems[i].Container.SetPosition(
-                    i % sizeFactor * (mItems[i].Container.Width + xPadding) + xPadding,
-                    i / sizeFactor * (mItems[i].Container.Height + yPadding) + yPadding
-                );
-            }
-
-            //Show crafting time and chances
-            mLblCraftingTime.Text = Strings.Crafting.CraftingTime.ToString(craft.Time / 1000.0);
-            mLblCraftingChance.Text = Strings.Crafting.CraftChance.ToString(craft.FailureChance);
-            mLblDestroyMaterialsChance.Text = Strings.Crafting.DestroyMaterialsChance.ToString(craft.ItemLossChance);
-
-            //If crafting & we no longer have the items for the craft then stop!
-            if (IsCrafting)
-            {
-                var cancraft = true;
-                foreach (var c in CraftBase.Get(mCraftId).Ingredients)
-                {
-                    if (itemdict.ContainsKey(c.ItemId))
-                    {
-                        if (itemdict[c.ItemId] >= c.Quantity)
-                        {
-                            itemdict[c.ItemId] -= c.Quantity;
-                        }
-                        else
-                        {
-                            cancraft = false;
-
-                            break;
-                        }
+                        itemdict[c.ItemId] -= c.Quantity;
                     }
                     else
                     {
@@ -285,237 +278,242 @@ namespace Intersect.Client.Interface.Game.Crafting
                         break;
                     }
                 }
-
-                if (!cancraft)
+                else
                 {
-                    mRemainingCrafts = 0;
-                    mCraftWindow.IsClosable = true;
-                    mBar.Width = 0;
-                    ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.IncorrectResources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
+                    cancraft = false;
 
-                    return;
+                    break;
                 }
             }
 
-            mCraftAll.IsHidden = mJournalMode || craftableQuantity < 2;
-            if (!mCraftAll.IsHidden)
+            if (!cancraft)
             {
-                mCraftAll.SetText(Strings.Crafting.CraftAll.ToString(craftableQuantity));
-                mCraftAll.UserData = craftableQuantity;
-                mCraftAll.IsDisabled = IsCrafting;
-            }
-        }
-
-        public void Close()
-        {
-            if (IsCrafting == false)
-            {
-                mCraftWindow.Close();
-            }
-        }
-
-        public bool IsVisible()
-        {
-            return !mCraftWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            if (IsCrafting == false)
-            {
-                mCraftWindow.IsHidden = true;
-            }
-        }
-
-        //Load new recepie
-        void tmpNode_DoubleClicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (IsCrafting == false)
-            {
-                LoadCraftItems((Guid) ((ListBoxRow) sender).UserData);
-            }
-        }
-
-        bool CanCraft()
-        {
-            //This shouldn't be client side :(
-            //Quickly Look through the inventory and create a catalog of what items we have, and how many
-            var availableItemQuantities = new Dictionary<Guid, int>();
-            foreach (var item in Globals.Me.Inventory)
-            {
-                if (item != null)
-                {
-                    if (availableItemQuantities.ContainsKey(item.ItemId))
-                    {
-                        availableItemQuantities[item.ItemId] += item.Quantity;
-                    }
-                    else
-                    {
-                        availableItemQuantities.Add(item.ItemId, item.Quantity);
-                    }
-                }
-            }
-
-            var craftDescriptor = CraftBase.Get(mCraftId);
-            var canCraft = craftDescriptor?.Ingredients != null;
-
-            if (canCraft)
-            {
-                foreach (var ingredient in craftDescriptor.Ingredients)
-                {
-                    if (!availableItemQuantities.TryGetValue(ingredient.ItemId, out var availableQuantity))
-                    {
-                        canCraft = false;
-
-                        break;
-                    }
-
-                    if (availableQuantity < ingredient.Quantity)
-                    {
-                        canCraft = false;
-
-                        break;
-                    }
-
-                    availableItemQuantities[ingredient.ItemId] -= ingredient.Quantity;
-                }
-            }
-
-            return canCraft;
-        }
-
-        void DoCraft(int count)
-        {
-            if (IsCrafting)
-            {
-                PacketSender.SendCraftItem(default, default);
                 mRemainingCrafts = 0;
                 mCraftWindow.IsClosable = true;
                 mBar.Width = 0;
-                mAutoCraftId = default;
-
-                LoadCraftItems(mCraftId);
-
-                return;
-            }
-
-            if (CanCraft())
-            {
-                mRemainingCrafts = count;
-                mBarTimer = Timing.Global.Milliseconds;
-                PacketSender.SendCraftItem(mCraftId, count);
-                mCraftWindow.IsClosable = false;
-                mCraftAll.IsDisabled = true;
-
-                return;
-            }
-
-            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.IncorrectResources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
-        }
-
-        //Craft the item
-        void craft_Clicked(Base sender, ClickedEventArgs arguments) => DoCraft(1);
-
-        //Craft all the items
-        void craftAll_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (CanCraft())
-            {
-                DoCraft((int)mCraftAll.UserData);
-                mAutoCraftId = mCraftId;
-                mCraftAll.Disable();
-            }
-            else
-            {
                 ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.IncorrectResources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
+
+                return;
             }
         }
 
-        //Update the crafting bar
-        public void Update()
+        mCraftAll.IsHidden = mJournalMode || craftableQuantity < 2;
+        if (!mCraftAll.IsHidden)
         {
-            if (!mInitialized)
+            mCraftAll.SetText(Strings.Crafting.CraftAll.ToString(craftableQuantity));
+            mCraftAll.UserData = craftableQuantity;
+            mCraftAll.IsDisabled = IsCrafting;
+        }
+    }
+
+    public void Close()
+    {
+        if (IsCrafting == false)
+        {
+            mCraftWindow.Close();
+        }
+    }
+
+    public bool IsVisible()
+    {
+        return !mCraftWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        if (IsCrafting == false)
+        {
+            mCraftWindow.IsHidden = true;
+        }
+    }
+
+    //Load new recepie
+    void tmpNode_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (IsCrafting == false)
+        {
+            LoadCraftItems((Guid) ((ListBoxRow) sender).UserData);
+        }
+    }
+
+    bool CanCraft()
+    {
+        //This shouldn't be client side :(
+        //Quickly Look through the inventory and create a catalog of what items we have, and how many
+        var availableItemQuantities = new Dictionary<Guid, int>();
+        foreach (var item in Globals.Me.Inventory)
+        {
+            if (item != null)
             {
-                for (var i = 0; i < Globals.ActiveCraftingTable?.Crafts?.Count; ++i)
+                if (availableItemQuantities.ContainsKey(item.ItemId))
                 {
-                    var activeCraft = CraftBase.Get(Globals.ActiveCraftingTable.Crafts[i]);
-                    if (activeCraft == null)
-                    {
-                        continue;
-                    }
-
-                    var tmpRow = mRecipes?.AddRow(i + 1 + ") " + activeCraft.Name);
-                    if (tmpRow == null)
-                    {
-                        continue;
-                    }
-
-                    tmpRow.UserData = Globals.ActiveCraftingTable.Crafts[i];
-                    tmpRow.DoubleClicked += tmpNode_DoubleClicked;
-                    tmpRow.Clicked += tmpNode_DoubleClicked;
-                }
-
-                //Load the craft data
-                if (Globals.ActiveCraftingTable?.Crafts?.Count > 0)
-                {
-                    LoadCraftItems(Globals.ActiveCraftingTable.Crafts[0]);
-                }
-
-                mInitialized = true;
-            }
-
-            if (IsCrafting)
-            {
-                mCraft.SetText(Strings.Crafting.CraftStop);
-            }
-            else
-            {
-                mCraft.SetText(Strings.Crafting.Craft);
-                mBar.Width = 0;
-                return;
-            }
-
-            var craft = CraftBase.Get(mCraftId);
-            if (craft == null)
-            {
-                return;
-            }
-
-            var delta = Timing.Global.Milliseconds - mBarTimer;
-            if (delta > craft.Time)
-            {
-                delta = craft.Time;
-                mRemainingCrafts--;
-                if (mRemainingCrafts < 1)
-                {
-                    if (mCraftWindow != null)
-                    {
-                        mCraftWindow.IsClosable = true;
-                    }
-
-                    mBar.Width = 0;
+                    availableItemQuantities[item.ItemId] += item.Quantity;
                 }
                 else
                 {
-                    mBarTimer = Timing.Global.Milliseconds;
+                    availableItemQuantities.Add(item.ItemId, item.Quantity);
                 }
             }
-
-            var ratio = craft.Time == 0 ? 0 : Convert.ToDecimal(delta) / Convert.ToDecimal(craft.Time);
-            var width = ratio * mBarContainer?.Width ?? 0;
-
-            if (mBar == null)
-            {
-                return;
-            }
-
-            mBar.SetTextureRect(
-                0, 0, Convert.ToInt32(ratio * mBar.Texture?.GetWidth() ?? 0), mBar.Texture?.GetHeight() ?? 0
-            );
-
-            mBar.Width = Convert.ToInt32(width);
         }
 
+        var craftDescriptor = CraftBase.Get(mCraftId);
+        var canCraft = craftDescriptor?.Ingredients != null;
+
+        if (canCraft)
+        {
+            foreach (var ingredient in craftDescriptor.Ingredients)
+            {
+                if (!availableItemQuantities.TryGetValue(ingredient.ItemId, out var availableQuantity))
+                {
+                    canCraft = false;
+
+                    break;
+                }
+
+                if (availableQuantity < ingredient.Quantity)
+                {
+                    canCraft = false;
+
+                    break;
+                }
+
+                availableItemQuantities[ingredient.ItemId] -= ingredient.Quantity;
+            }
+        }
+
+        return canCraft;
+    }
+
+    void DoCraft(int count)
+    {
+        if (IsCrafting)
+        {
+            PacketSender.SendCraftItem(default, default);
+            mRemainingCrafts = 0;
+            mCraftWindow.IsClosable = true;
+            mBar.Width = 0;
+            mAutoCraftId = default;
+
+            LoadCraftItems(mCraftId);
+
+            return;
+        }
+
+        if (CanCraft())
+        {
+            mRemainingCrafts = count;
+            mBarTimer = Timing.Global.Milliseconds;
+            PacketSender.SendCraftItem(mCraftId, count);
+            mCraftWindow.IsClosable = false;
+            mCraftAll.IsDisabled = true;
+
+            return;
+        }
+
+        ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.IncorrectResources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
+    }
+
+    //Craft the item
+    void craft_Clicked(Base sender, ClickedEventArgs arguments) => DoCraft(1);
+
+    //Craft all the items
+    void craftAll_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (CanCraft())
+        {
+            DoCraft((int)mCraftAll.UserData);
+            mAutoCraftId = mCraftId;
+            mCraftAll.Disable();
+        }
+        else
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Crafting.IncorrectResources, CustomColors.Alerts.Error, Enums.ChatMessageType.Crafting));
+        }
+    }
+
+    //Update the crafting bar
+    public void Update()
+    {
+        if (!mInitialized)
+        {
+            for (var i = 0; i < Globals.ActiveCraftingTable?.Crafts?.Count; ++i)
+            {
+                var activeCraft = CraftBase.Get(Globals.ActiveCraftingTable.Crafts[i]);
+                if (activeCraft == null)
+                {
+                    continue;
+                }
+
+                var tmpRow = mRecipes?.AddRow(i + 1 + ") " + activeCraft.Name);
+                if (tmpRow == null)
+                {
+                    continue;
+                }
+
+                tmpRow.UserData = Globals.ActiveCraftingTable.Crafts[i];
+                tmpRow.DoubleClicked += tmpNode_DoubleClicked;
+                tmpRow.Clicked += tmpNode_DoubleClicked;
+            }
+
+            //Load the craft data
+            if (Globals.ActiveCraftingTable?.Crafts?.Count > 0)
+            {
+                LoadCraftItems(Globals.ActiveCraftingTable.Crafts[0]);
+            }
+
+            mInitialized = true;
+        }
+
+        if (IsCrafting)
+        {
+            mCraft.SetText(Strings.Crafting.CraftStop);
+        }
+        else
+        {
+            mCraft.SetText(Strings.Crafting.Craft);
+            mBar.Width = 0;
+            return;
+        }
+
+        var craft = CraftBase.Get(mCraftId);
+        if (craft == null)
+        {
+            return;
+        }
+
+        var delta = Timing.Global.Milliseconds - mBarTimer;
+        if (delta > craft.Time)
+        {
+            delta = craft.Time;
+            mRemainingCrafts--;
+            if (mRemainingCrafts < 1)
+            {
+                if (mCraftWindow != null)
+                {
+                    mCraftWindow.IsClosable = true;
+                }
+
+                mBar.Width = 0;
+            }
+            else
+            {
+                mBarTimer = Timing.Global.Milliseconds;
+            }
+        }
+
+        var ratio = craft.Time == 0 ? 0 : Convert.ToDecimal(delta) / Convert.ToDecimal(craft.Time);
+        var width = ratio * mBarContainer?.Width ?? 0;
+
+        if (mBar == null)
+        {
+            return;
+        }
+
+        mBar.SetTextureRect(
+            0, 0, Convert.ToInt32(ratio * mBar.Texture?.GetWidth() ?? 0), mBar.Texture?.GetHeight() ?? 0
+        );
+
+        mBar.Width = Convert.ToInt32(width);
     }
 
 }

--- a/Intersect.Client/Interface/Game/Crafting/RecipeItem.cs
+++ b/Intersect.Client/Interface/Game/Crafting/RecipeItem.cs
@@ -6,70 +6,62 @@ using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
 
-namespace Intersect.Client.Interface.Game.Crafting
+namespace Intersect.Client.Interface.Game.Crafting;
+
+
+public partial class RecipeItem
 {
 
-    public partial class RecipeItem
+    public ImagePanel Container;
+
+    public ItemDescriptionWindow DescWindow;
+
+    public bool IsDragging;
+
+    //Dragging
+    private bool mCanDrag;
+
+    //References
+    private CraftingWindow mCraftingWindow;
+
+    private Draggable mDragIcon;
+
+    //Slot info
+    CraftIngredient mIngredient;
+
+    //Mouse Event Variables
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    public ImagePanel Pnl;
+
+    public RecipeItem(CraftingWindow craftingWindow, CraftIngredient ingredient)
     {
+        mCraftingWindow = craftingWindow;
+        mIngredient = ingredient;
+    }
 
-        public ImagePanel Container;
+    public void Setup(string name)
+    {
+        Pnl = new ImagePanel(Container, name);
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+    }
 
-        public ItemDescriptionWindow DescWindow;
+    public void LoadItem()
+    {
+        var item = ItemBase.Get(mIngredient.ItemId);
 
-        public bool IsDragging;
-
-        //Dragging
-        private bool mCanDrag;
-
-        //References
-        private CraftingWindow mCraftingWindow;
-
-        private Draggable mDragIcon;
-
-        //Slot info
-        CraftIngredient mIngredient;
-
-        //Mouse Event Variables
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        public ImagePanel Pnl;
-
-        public RecipeItem(CraftingWindow craftingWindow, CraftIngredient ingredient)
+        if (item != null)
         {
-            mCraftingWindow = craftingWindow;
-            mIngredient = ingredient;
-        }
-
-        public void Setup(string name)
-        {
-            Pnl = new ImagePanel(Container, name);
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-        }
-
-        public void LoadItem()
-        {
-            var item = ItemBase.Get(mIngredient.ItemId);
-
-            if (item != null)
+            var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+            if (itemTex != null)
             {
-                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-                if (itemTex != null)
-                {
-                    Pnl.Texture = itemTex;
-                    Pnl.RenderColor = item.Color;
-                }
-                else
-                {
-                    if (Pnl.Texture != null)
-                    {
-                        Pnl.Texture = null;
-                    }
-                }
+                Pnl.Texture = itemTex;
+                Pnl.RenderColor = item.Color;
             }
             else
             {
@@ -79,49 +71,55 @@ namespace Intersect.Client.Interface.Game.Crafting
                 }
             }
         }
-
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
+        else
         {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
-            if (DescWindow != null)
+            if (Pnl.Texture != null)
             {
-                DescWindow.Dispose();
-                DescWindow = null;
+                Pnl.Texture = null;
             }
         }
+    }
 
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (DescWindow != null)
         {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
+            DescWindow.Dispose();
+            DescWindow = null;
+        }
+    }
 
-            mMouseOver = true;
-            mCanDrag = true;
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                mCanDrag = false;
-
-                return;
-            }
-
-            if (DescWindow != null)
-            {
-                DescWindow.Dispose();
-                DescWindow = null;
-            }
-
-            if (mIngredient != null && ItemBase.TryGet(mIngredient.ItemId, out var itemDescriptor))
-            {
-                DescWindow = new ItemDescriptionWindow(
-                    itemDescriptor, mIngredient.Quantity, mCraftingWindow.X, mCraftingWindow.Y, null
-                );
-            }
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
+        mMouseOver = true;
+        mCanDrag = true;
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+        {
+            mCanDrag = false;
+
+            return;
+        }
+
+        if (DescWindow != null)
+        {
+            DescWindow.Dispose();
+            DescWindow = null;
+        }
+
+        if (mIngredient != null && ItemBase.TryGet(mIngredient.ItemId, out var itemDescriptor))
+        {
+            DescWindow = new ItemDescriptionWindow(
+                itemDescriptor, mIngredient.Quantity, mCraftingWindow.X, mCraftingWindow.Y, null
+            );
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/ComponentBase.cs
@@ -1,115 +1,114 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class ComponentBase : IDisposable
 {
-    public partial class ComponentBase : IDisposable
+    protected Base mParent;
+
+    protected string mName;
+
+    protected ImagePanel mContainer;
+
+    public ComponentBase(Base parent, string name = "")
     {
-        protected Base mParent;
+        mParent = parent;
+        mName = name;
+    }
 
-        protected string mName;
+    protected virtual void GenerateComponents()
+    {
+        mContainer = new ImagePanel(mParent, mName);
+    }
 
-        protected ImagePanel mContainer;
+    /// <summary>
+    /// The name of this control.
+    /// </summary>
+    public string Name { get { return mName; } }
 
-        public ComponentBase(Base parent, string name = "")
+    /// <summary>
+    /// The base container of this control.
+    /// </summary>
+    public ImagePanel Container => mContainer;
+
+    /// <summary>
+    /// Is this component current visible?
+    /// </summary>
+    public bool IsVisible => mContainer.IsVisible;
+
+    /// <summary>
+    /// The current X location of the control.
+    /// </summary>
+    public int X => mContainer.X;
+
+    /// <summary>
+    /// The current Y location of the control.
+    /// </summary>
+    public int Y => mContainer.Y;
+
+    /// <summary>
+    /// The current width of the control.
+    /// </summary>
+    public int Width => mContainer.Width;
+
+    /// <summary>
+    /// The current Height of the control.
+    /// </summary>
+    public int Height => mContainer.Height;
+
+    /// <summary>
+    /// Hide the control.
+    /// </summary>
+    public void Hide() => mContainer.Hide();
+
+    /// <summary>
+    /// Show the control.
+    /// </summary>
+    public void Show() => mContainer.Show();
+
+    /// <summary>
+    /// Sets the control position.
+    /// </summary>
+    /// <param name="x">The X position to move the control to.</param>
+    /// <param name="y">The Y position to move the control to.</param>
+    public virtual void SetPosition(int x, int y) => mContainer.SetPosition(x, y);
+
+    /// <summary>
+    /// Sets the control position based on ImagePanel.
+    /// </summary>
+    public virtual void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
+
+    /// <summary>
+    /// Resizes the control to fit its children.
+    /// </summary>
+    /// <param name="width">Allow the control to resize its width.</param>
+    /// <param name="height">Allow the control to resize its height.</param>
+    public void SizeToChildren(bool width = true, bool height = true) => mContainer.SizeToChildren(width, height);
+
+    /// <summary>
+    /// Dispose of the object.
+    /// </summary>
+    public virtual void Dispose()
+    {
+        if(!mParent.Children.Contains(mContainer))
         {
-            mParent = parent;
-            mName = name;
+            return;
         }
 
-        protected virtual void GenerateComponents()
-        {
-            mContainer = new ImagePanel(mParent, mName);
-        }
+        mParent.RemoveChild(mContainer, true);
+    }
 
-        /// <summary>
-        /// The name of this control.
-        /// </summary>
-        public string Name { get { return mName; } }
+    /// <summary>
+    /// Load the Json layout of the current component.
+    /// </summary>
+    public void LoadLayout() => mContainer.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        /// <summary>
-        /// The base container of this control.
-        /// </summary>
-        public ImagePanel Container => mContainer;
-
-        /// <summary>
-        /// Is this component current visible?
-        /// </summary>
-        public bool IsVisible => mContainer.IsVisible;
-
-        /// <summary>
-        /// The current X location of the control.
-        /// </summary>
-        public int X => mContainer.X;
-
-        /// <summary>
-        /// The current Y location of the control.
-        /// </summary>
-        public int Y => mContainer.Y;
-
-        /// <summary>
-        /// The current width of the control.
-        /// </summary>
-        public int Width => mContainer.Width;
-
-        /// <summary>
-        /// The current Height of the control.
-        /// </summary>
-        public int Height => mContainer.Height;
-
-        /// <summary>
-        /// Hide the control.
-        /// </summary>
-        public void Hide() => mContainer.Hide();
-
-        /// <summary>
-        /// Show the control.
-        /// </summary>
-        public void Show() => mContainer.Show();
-
-        /// <summary>
-        /// Sets the control position.
-        /// </summary>
-        /// <param name="x">The X position to move the control to.</param>
-        /// <param name="y">The Y position to move the control to.</param>
-        public virtual void SetPosition(int x, int y) => mContainer.SetPosition(x, y);
-
-        /// <summary>
-        /// Sets the control position based on ImagePanel.
-        /// </summary>
-        public virtual void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow) => mContainer.SetPosition(_icon);
-
-        /// <summary>
-        /// Resizes the control to fit its children.
-        /// </summary>
-        /// <param name="width">Allow the control to resize its width.</param>
-        /// <param name="height">Allow the control to resize its height.</param>
-        public void SizeToChildren(bool width = true, bool height = true) => mContainer.SizeToChildren(width, height);
-
-        /// <summary>
-        /// Dispose of the object.
-        /// </summary>
-        public virtual void Dispose()
-        {
-            if(!mParent.Children.Contains(mContainer))
-            {
-                return;
-            }
-
-            mParent.RemoveChild(mContainer, true);
-        }
-
-        /// <summary>
-        /// Load the Json layout of the current component.
-        /// </summary>
-        public void LoadLayout() => mContainer.LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-        /// <summary>
-        /// Corrects the width of the component compared to the parent size.
-        /// </summary>
-        public virtual void CorrectWidth()
-        {
-            mContainer.SetSize(mParent.InnerWidth, mContainer.InnerHeight);
-        }
+    /// <summary>
+    /// Corrects the width of the component compared to the parent size.
+    /// </summary>
+    public virtual void CorrectWidth()
+    {
+        mContainer.SetSize(mParent.InnerWidth, mContainer.InnerHeight);
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/DescriptionComponent.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/DescriptionComponent.cs
@@ -1,50 +1,49 @@
 ﻿using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class DescriptionComponent : ComponentBase
 {
-    public partial class DescriptionComponent : ComponentBase
+    protected RichLabel mDescription;
+
+    public DescriptionComponent(Base parent, string name) : base(parent, name)
     {
-        protected RichLabel mDescription;
+        GenerateComponents();
+    }
 
-        public DescriptionComponent(Base parent, string name) : base(parent, name)
-        {
-            GenerateComponents();
-        }
+    protected override void GenerateComponents()
+    {
+        base.GenerateComponents();
 
-        protected override void GenerateComponents()
-        {
-            base.GenerateComponents();
+        mDescription = new RichLabel(mContainer, "Description");
+    }
 
-            mDescription = new RichLabel(mContainer, "Description");
-        }
+    /// <summary>
+    /// Add text to the description with the provided <see cref="Color"/>.
+    /// </summary>
+    /// <param name="description">The description to place on this component.</param>
+    /// <param name="color">The <see cref="Color"/> the description text should render with.</param>
+    public void AddText(string description, Color color)
+    {
+        mDescription.AddText(description, color);
+        mDescription.SizeToChildren(false, true);
+        mContainer.SizeToChildren(false, true);
+    }
 
-        /// <summary>
-        /// Add text to the description with the provided <see cref="Color"/>.
-        /// </summary>
-        /// <param name="description">The description to place on this component.</param>
-        /// <param name="color">The <see cref="Color"/> the description text should render with.</param>
-        public void AddText(string description, Color color)
-        {
-            mDescription.AddText(description, color);
-            mDescription.SizeToChildren(false, true);
-            mContainer.SizeToChildren(false, true);
-        }
+    /// <summary>
+    /// Adds a line break to the description.
+    /// </summary>
+    public void AddLineBreak() => mDescription.AddLineBreak();
 
-        /// <summary>
-        /// Adds a line break to the description.
-        /// </summary>
-        public void AddLineBreak() => mDescription.AddLineBreak();
+    /// <inheritdoc/>
+    public override void CorrectWidth()
+    {
+        base.CorrectWidth();
+        var margins = mDescription.Margin;
 
-        /// <inheritdoc/>
-        public override void CorrectWidth()
-        {
-            base.CorrectWidth();
-            var margins = mDescription.Margin;
-
-            mDescription.SetSize(mContainer.InnerWidth - margins.Right, mContainer.InnerHeight);
-            mDescription.SizeToChildren(false, true);
-            mDescription.SetSize(mDescription.Width, mDescription.Height + margins.Bottom);
-            mContainer.SizeToChildren(false, true);
-        }
+        mDescription.SetSize(mContainer.InnerWidth - margins.Right, mContainer.InnerHeight);
+        mDescription.SizeToChildren(false, true);
+        mDescription.SetSize(mDescription.Width, mDescription.Height + margins.Bottom);
+        mContainer.SizeToChildren(false, true);
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/DividerComponent.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/DividerComponent.cs
@@ -1,12 +1,11 @@
 ﻿using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class DividerComponent : ComponentBase
 {
-    public partial class DividerComponent : ComponentBase
+    public DividerComponent(Base parent, string name) : base(parent, name)
     {
-        public DividerComponent(Base parent, string name) : base(parent, name)
-        {
-            GenerateComponents();
-        }
+        GenerateComponents();
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/HeaderComponent.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/HeaderComponent.cs
@@ -2,80 +2,79 @@
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class HeaderComponent : ComponentBase
 {
-    public partial class HeaderComponent : ComponentBase
+    protected ImagePanel mIconContainer;
+
+    protected ImagePanel mIcon;
+
+    protected Label mTitle;
+
+    protected Label mSubtitle;
+
+    protected Label mDescription;
+
+    public HeaderComponent(Base parent, string name) : base(parent, name)
     {
-        protected ImagePanel mIconContainer;
+        GenerateComponents();
+    }
 
-        protected ImagePanel mIcon;
+    protected override void GenerateComponents()
+    {
+        base.GenerateComponents();
 
-        protected Label mTitle;
+        mIconContainer = new ImagePanel(mContainer, "IconContainer");
+        mIcon = new ImagePanel(mIconContainer, "Icon");
+        mTitle = new Label(mContainer, "Title");
+        mSubtitle = new Label(mContainer, "Subtitle");
+        mDescription = new Label(mContainer, "Description");
+    }
 
-        protected Label mSubtitle;
+    /// <summary>
+    /// Set the icon on this header.
+    /// </summary>
+    /// <param name="texture">The <see cref="GameTexture"/> to use for display purposes.</param>
+    /// <param name="color">The <see cref="Color"/> to use to display the texture.</param>
+    public void SetIcon(GameTexture texture, Color color)
+    {
+        mIcon.Texture = texture;
+        mIcon.RenderColor = color;
+        mIcon.SizeToContents();
+        Align.Center(mIcon);
+    }
 
-        protected Label mDescription;
+    /// <summary>
+    /// Set the title on this header.
+    /// </summary>
+    /// <param name="title">The title text to use.</param>
+    /// <param name="color">The <see cref="Color"/> to use to display this title.</param>
+    public void SetTitle(string title, Color color)
+    {
+        mTitle.SetText(title);
+        mTitle.SetTextColor(color, Label.ControlState.Normal);
+    }
 
-        public HeaderComponent(Base parent, string name) : base(parent, name)
-        {
-            GenerateComponents();
-        }
+    /// <summary>
+    /// Set the subtitle on this header.
+    /// </summary>
+    /// <param name="subtitle">The subtitle text to use.</param>
+    /// <param name="color">The <see cref="Color"/> to use to display this subtitle.</param>
+    public void SetSubtitle(string subtitle, Color color)
+    {
+        mSubtitle.SetText(subtitle);
+        mSubtitle.SetTextColor(color, Label.ControlState.Normal);
+    }
 
-        protected override void GenerateComponents()
-        {
-            base.GenerateComponents();
-
-            mIconContainer = new ImagePanel(mContainer, "IconContainer");
-            mIcon = new ImagePanel(mIconContainer, "Icon");
-            mTitle = new Label(mContainer, "Title");
-            mSubtitle = new Label(mContainer, "Subtitle");
-            mDescription = new Label(mContainer, "Description");
-        }
-
-        /// <summary>
-        /// Set the icon on this header.
-        /// </summary>
-        /// <param name="texture">The <see cref="GameTexture"/> to use for display purposes.</param>
-        /// <param name="color">The <see cref="Color"/> to use to display the texture.</param>
-        public void SetIcon(GameTexture texture, Color color)
-        {
-            mIcon.Texture = texture;
-            mIcon.RenderColor = color;
-            mIcon.SizeToContents();
-            Align.Center(mIcon);
-        }
-
-        /// <summary>
-        /// Set the title on this header.
-        /// </summary>
-        /// <param name="title">The title text to use.</param>
-        /// <param name="color">The <see cref="Color"/> to use to display this title.</param>
-        public void SetTitle(string title, Color color)
-        {
-            mTitle.SetText(title);
-            mTitle.SetTextColor(color, Label.ControlState.Normal);
-        }
-
-        /// <summary>
-        /// Set the subtitle on this header.
-        /// </summary>
-        /// <param name="subtitle">The subtitle text to use.</param>
-        /// <param name="color">The <see cref="Color"/> to use to display this subtitle.</param>
-        public void SetSubtitle(string subtitle, Color color)
-        {
-            mSubtitle.SetText(subtitle);
-            mSubtitle.SetTextColor(color, Label.ControlState.Normal);
-        }
-
-        /// <summary>
-        /// Set the description on this header.
-        /// </summary>
-        /// <param name="description">The description text to use.</param>
-        /// <param name="color">The <see cref="Color"/> to use to display this description.</param>
-        public void SetDescription(string description, Color color)
-        {
-            mDescription.SetText(description);
-            mDescription.SetTextColor(color, Label.ControlState.Normal);
-        }
+    /// <summary>
+    /// Set the description on this header.
+    /// </summary>
+    /// <param name="description">The description text to use.</param>
+    /// <param name="color">The <see cref="Color"/> to use to display this description.</param>
+    public void SetDescription(string description, Color color)
+    {
+        mDescription.SetText(description);
+        mDescription.SetTextColor(color, Label.ControlState.Normal);
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
@@ -2,129 +2,128 @@
 
 using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows.Components
+namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
+
+public partial class RowContainerComponent : ComponentBase
 {
-    public partial class RowContainerComponent : ComponentBase
+    protected KeyValueRowComponent mKeyValueRow;
+
+    protected JObject KeyValueRowLayout;
+
+    private int mComponentY = 0;
+
+    public RowContainerComponent(Base parent, string name) : base(parent, name)
     {
-        protected KeyValueRowComponent mKeyValueRow;
-
-        protected JObject KeyValueRowLayout;
-
-        private int mComponentY = 0;
-
-        public RowContainerComponent(Base parent, string name) : base(parent, name)
-        {
-            GenerateComponents();
-            LoadLayout();
-            GetLayoutTemplates();
-            DestroyLayoutComponents();
-        }
-
-        protected override void GenerateComponents()
-        {
-            base.GenerateComponents();
-
-            mKeyValueRow = new KeyValueRowComponent(mContainer);
-        }
-
-        private void GetLayoutTemplates()
-        {
-            KeyValueRowLayout = mKeyValueRow.GetJson();
-        }
-
-        private void DestroyLayoutComponents()
-        {
-            mKeyValueRow.Dispose();
-        }
-
-        private void PositionComponent(ComponentBase component)
-        {
-            component.SetPosition(component.X, mComponentY);
-            mComponentY += component.Height;
-        }
-
-        /// <inheritdoc/>
-        public override void CorrectWidth()
-        {
-            base.CorrectWidth();
-            var margins = mContainer.Margin;
-
-            mContainer.SetSize(mContainer.Width, mContainer.Height + margins.Bottom);
-        }
-
-        /// <summary>
-        /// Add a new <see cref="KeyValueRowComponent"/> row to the container.
-        /// </summary>
-        /// <param name="key">The key to display.</param>
-        /// <param name="value">The value to display.</param>
-        /// <returns>Returns a new instance of <see cref="KeyValueRowComponent"/> with the provided settings.</returns>
-        public KeyValueRowComponent AddKeyValueRow(string key, string value)
-        {
-            var row = new KeyValueRowComponent(mContainer, key, value);
-
-            // Since we're pulling some trickery here, catch any errors doing this ourselves and log them.
-            try
-            {
-                row.LoadJson(KeyValueRowLayout);
-            }
-            catch (Exception ex)
-            {
-                Logging.Log.Error(ex, $"An error occured while loading KeyvalueRowComponent Json for {mName}");
-            }
-
-            row.SizeToChildren(true, false);
-            PositionComponent(row);
-            return row;
-        }
+        GenerateComponents();
+        LoadLayout();
+        GetLayoutTemplates();
+        DestroyLayoutComponents();
     }
 
-    public partial class KeyValueRowComponent : ComponentBase
+    protected override void GenerateComponents()
     {
-        protected Label mKeyLabel;
+        base.GenerateComponents();
 
-        protected Label mValueLabel;
-
-        public KeyValueRowComponent(Base parent) : this(parent, string.Empty, string.Empty)
-        {
-        }
-
-        public KeyValueRowComponent(Base parent, string key, string value) : base(parent, "KeyValueRow")
-        {
-            GenerateComponents();
-            mKeyLabel.SetText(key);
-            mValueLabel.SetText(value);
-        }
-
-        protected override void GenerateComponents()
-        {
-            base.GenerateComponents();
-
-            mKeyLabel = new Label(mContainer, "Key");
-            mValueLabel = new Label(mContainer, "Value");
-        }
-
-        /// <summary>
-        /// Set the <see cref="Color"/> of the key text.
-        /// </summary>
-        /// <param name="color">The <see cref="Color"/> to draw the key text in.</param>
-        public void SetKeyTextColor(Color color) => mKeyLabel.SetTextColor(color, Label.ControlState.Normal);
-
-        /// <summary>
-        /// Set the <see cref="Color"/> of the value text.
-        /// </summary>
-        /// <param name="color">The <see cref="Color"/> to draw the value text in.</param>
-        public void SetValueTextColor(Color color) => mValueLabel.SetTextColor(color, Label.ControlState.Normal);
-
-        /// <summary>
-        /// Get the Json layout of the current component.
-        /// </summary>
-        /// <returns>Returns a <see cref="JObject"/> containing the layout of the current component.</returns>
-        public JObject GetJson() => mContainer.GetJson();
-
-        /// <summary>
-        /// Set the Json layout of the current component.
-        /// </summary>
-        /// <param name="json">The new layout to apply to this component in <see cref="JObject"/> format.</param>
-        public void LoadJson(JObject json) => mContainer.LoadJson(json);
+        mKeyValueRow = new KeyValueRowComponent(mContainer);
     }
+
+    private void GetLayoutTemplates()
+    {
+        KeyValueRowLayout = mKeyValueRow.GetJson();
+    }
+
+    private void DestroyLayoutComponents()
+    {
+        mKeyValueRow.Dispose();
+    }
+
+    private void PositionComponent(ComponentBase component)
+    {
+        component.SetPosition(component.X, mComponentY);
+        mComponentY += component.Height;
+    }
+
+    /// <inheritdoc/>
+    public override void CorrectWidth()
+    {
+        base.CorrectWidth();
+        var margins = mContainer.Margin;
+
+        mContainer.SetSize(mContainer.Width, mContainer.Height + margins.Bottom);
+    }
+
+    /// <summary>
+    /// Add a new <see cref="KeyValueRowComponent"/> row to the container.
+    /// </summary>
+    /// <param name="key">The key to display.</param>
+    /// <param name="value">The value to display.</param>
+    /// <returns>Returns a new instance of <see cref="KeyValueRowComponent"/> with the provided settings.</returns>
+    public KeyValueRowComponent AddKeyValueRow(string key, string value)
+    {
+        var row = new KeyValueRowComponent(mContainer, key, value);
+
+        // Since we're pulling some trickery here, catch any errors doing this ourselves and log them.
+        try
+        {
+            row.LoadJson(KeyValueRowLayout);
+        }
+        catch (Exception ex)
+        {
+            Logging.Log.Error(ex, $"An error occured while loading KeyvalueRowComponent Json for {mName}");
+        }
+
+        row.SizeToChildren(true, false);
+        PositionComponent(row);
+        return row;
+    }
+}
+
+public partial class KeyValueRowComponent : ComponentBase
+{
+    protected Label mKeyLabel;
+
+    protected Label mValueLabel;
+
+    public KeyValueRowComponent(Base parent) : this(parent, string.Empty, string.Empty)
+    {
+    }
+
+    public KeyValueRowComponent(Base parent, string key, string value) : base(parent, "KeyValueRow")
+    {
+        GenerateComponents();
+        mKeyLabel.SetText(key);
+        mValueLabel.SetText(value);
+    }
+
+    protected override void GenerateComponents()
+    {
+        base.GenerateComponents();
+
+        mKeyLabel = new Label(mContainer, "Key");
+        mValueLabel = new Label(mContainer, "Value");
+    }
+
+    /// <summary>
+    /// Set the <see cref="Color"/> of the key text.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to draw the key text in.</param>
+    public void SetKeyTextColor(Color color) => mKeyLabel.SetTextColor(color, Label.ControlState.Normal);
+
+    /// <summary>
+    /// Set the <see cref="Color"/> of the value text.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to draw the value text in.</param>
+    public void SetValueTextColor(Color color) => mValueLabel.SetTextColor(color, Label.ControlState.Normal);
+
+    /// <summary>
+    /// Get the Json layout of the current component.
+    /// </summary>
+    /// <returns>Returns a <see cref="JObject"/> containing the layout of the current component.</returns>
+    public JObject GetJson() => mContainer.GetJson();
+
+    /// <summary>
+    /// Set the Json layout of the current component.
+    /// </summary>
+    /// <param name="json">The new layout to apply to this component in <see cref="JObject"/> format.</param>
+    public void LoadJson(JObject json) => mContainer.LoadJson(json);
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -1,192 +1,191 @@
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows
+namespace Intersect.Client.Interface.Game.DescriptionWindows;
+
+public partial class DescriptionWindowBase : ComponentBase
 {
-    public partial class DescriptionWindowBase : ComponentBase
+    // Track current Y height for placing components.
+    private int mComponentY = 0;
+
+    // Our internal list of components.
+    private List<ComponentBase> mComponents;
+
+    private bool mCenterOnPosition;
+
+    public DescriptionWindowBase(Base parent, string name, bool centerOnPosition = false) : base(parent, name)
     {
-        // Track current Y height for placing components.
-        private int mComponentY = 0;
+        // Set up our internal component list we use for re-ordering.
+        mComponents = new List<ComponentBase>();
 
-        // Our internal list of components.
-        private List<ComponentBase> mComponents;
+        // Set up whether we should center on our desired position.
+        mCenterOnPosition = centerOnPosition;
 
-        private bool mCenterOnPosition;
+        GenerateComponents();
+    }
 
-        public DescriptionWindowBase(Base parent, string name, bool centerOnPosition = false) : base(parent, name)
+    protected override void GenerateComponents()
+    {
+        base.GenerateComponents();
+
+        // Load layout prior to adding components so we can retrieve padding information.
+        LoadLayout();
+    }
+
+    /// <summary>
+    /// Adds a <see cref="HeaderComponent"/> to the current window.
+    /// </summary>
+    /// <param name="name">The name of the component.</param>
+    /// <param name="loadLayout">Should we load the layour json file automatically?</param>
+    /// <returns>Returns a new instance of the <see cref="HeaderComponent"/> class</returns>
+    public HeaderComponent AddHeader(string name = "DescriptionWindowHeader", bool loadLayout = true)
+    {
+        var component = new HeaderComponent(mContainer, name);
+        if (loadLayout)
         {
-            // Set up our internal component list we use for re-ordering.
-            mComponents = new List<ComponentBase>();
+            component.LoadLayout();
+        }
+        mComponents.Add(component);
+        return component;
+    }
 
-            // Set up whether we should center on our desired position.
-            mCenterOnPosition = centerOnPosition;
+    /// <summary>
+    /// Adds a <see cref="DividerComponent"/> to the current window.
+    /// </summary>
+    /// <param name="name">The name of the component.</param>
+    /// <param name="loadLayout">Should we load the layour json file automatically?</param>
+    /// <returns>Returns a new instance of the <see cref="DividerComponent"/> class</returns>
+    public DividerComponent AddDivider(string name = "DescriptionWindowDivider", bool loadLayout = true)
+    {
+        var component = new DividerComponent(mContainer, name);
+        if (loadLayout)
+        {
+            component.LoadLayout();
+        }
+        mComponents.Add(component);
+        return component;
+    }
 
-            GenerateComponents();
+    /// <summary>
+    /// Adds a <see cref="DescriptionComponent"/> to the current window.
+    /// </summary>
+    /// <param name="name">The name of the component.</param>
+    /// <param name="loadLayout">Should we load the layour json file automatically?</param>
+    /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
+    public DescriptionComponent AddDescription(string name = "DescriptionWindowDescription", bool loadLayout = true)
+    {
+        var component = new DescriptionComponent(mContainer, name);
+        if (loadLayout)
+        {
+            component.LoadLayout();
+        }
+        mComponents.Add(component);
+        return component;
+    }
+
+    /// <summary>
+    /// Adds a <see cref="RowContainerComponent"/> to the current window.
+    /// </summary>
+    /// <param name="name">The name of the component.</param>
+    /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
+    public RowContainerComponent AddRowContainer(string name = "DescriptionWindowRowContainer")
+    {
+        var component = new RowContainerComponent(mContainer, name);
+        mComponents.Add(component);
+        return component;
+    }
+
+    /// <summary>
+    /// Positions a component correctly on the current window.
+    /// </summary>
+    /// <param name="component">The <see cref="ComponentBase"/> to place.</param>
+    private void PositionComponent(ComponentBase component)
+    {
+        if (component == null)
+        {
+            return;
         }
 
-        protected override void GenerateComponents()
-        {
-            base.GenerateComponents();
+        component.SetPosition(component.X, mComponentY);
+        mComponentY += component.Height;
+    }
 
-            // Load layout prior to adding components so we can retrieve padding information.
-            LoadLayout();
+    /// <summary>
+    /// Position and resize all components properly for display.
+    /// </summary>
+    protected void FinalizeWindow()
+    {
+        // Reset our componentY so we start from scratch!
+        mComponentY = 0;
+
+        // Correctly set our container width to the largest child start with, this way our other child components will have a width to work with.
+        mContainer.SizeToChildren(true, false);
+
+        // Resize and relocate our components to properly display on our window.
+        foreach (var component in mComponents)
+        {
+            component.CorrectWidth();
+            PositionComponent(component);
         }
 
-        /// <summary>
-        /// Adds a <see cref="HeaderComponent"/> to the current window.
-        /// </summary>
-        /// <param name="name">The name of the component.</param>
-        /// <param name="loadLayout">Should we load the layour json file automatically?</param>
-        /// <returns>Returns a new instance of the <see cref="HeaderComponent"/> class</returns>
-        public HeaderComponent AddHeader(string name = "DescriptionWindowHeader", bool loadLayout = true)
+        // Correctly set our container height so we display everything.
+        mContainer.SizeToChildren(false, true);
+    }
+
+    /// <inheritdoc/>
+    public override void SetPosition(int x, int y)
+    {
+        var newX = x - mContainer.Width - mContainer.Padding.Right;
+        var newY = y + mContainer.Padding.Top;
+
+        // Center on the desired position if requested.
+        if (mCenterOnPosition)
         {
-            var component = new HeaderComponent(mContainer, name);
-            if (loadLayout)
-            {
-                component.LoadLayout();
-            }
-            mComponents.Add(component);
-            return component;
+            newX += (mContainer.Width - mContainer.Padding.Right) / 2;
+        }
+        
+        // Do not allow it to render outside of the screen canvas.
+        if (newX < 0)
+        {
+            newX = 0;
+        }
+        else if (newX > mContainer.Canvas.Width - mContainer.Width)
+        {
+            newX = mContainer.Canvas.Width - mContainer.Width;
         }
 
-        /// <summary>
-        /// Adds a <see cref="DividerComponent"/> to the current window.
-        /// </summary>
-        /// <param name="name">The name of the component.</param>
-        /// <param name="loadLayout">Should we load the layour json file automatically?</param>
-        /// <returns>Returns a new instance of the <see cref="DividerComponent"/> class</returns>
-        public DividerComponent AddDivider(string name = "DescriptionWindowDivider", bool loadLayout = true)
+        if (newY < 0)
         {
-            var component = new DividerComponent(mContainer, name);
-            if (loadLayout)
-            {
-                component.LoadLayout();
-            }
-            mComponents.Add(component);
-            return component;
+            newY = 0;
+        }
+        else if (newY > mContainer.Canvas.Height - mContainer.Height)
+        {
+            newY = mContainer.Canvas.Height - mContainer.Height;
         }
 
-        /// <summary>
-        /// Adds a <see cref="DescriptionComponent"/> to the current window.
-        /// </summary>
-        /// <param name="name">The name of the component.</param>
-        /// <param name="loadLayout">Should we load the layour json file automatically?</param>
-        /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
-        public DescriptionComponent AddDescription(string name = "DescriptionWindowDescription", bool loadLayout = true)
+        mContainer.MoveTo(newX, newY);
+    }
+
+    public override void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow)
+    {
+        var X = _icon.LocalPosToCanvas(new Point(0, 0)).X;
+        var Y = _icon.LocalPosToCanvas(new Point(0, 0)).Y;
+
+        X = X + _descriptionWindow.Width + _icon.Height;
+        Y = Y + _icon.Height;
+
+        // Do not allow it to render outside of the screen canvas while based on the _icon position.
+        // Prevents flickering when _icon is hovered near the edge of the screen.
+        if (X > Interface.GameUi.GameCanvas.Width - _descriptionWindow.Width)
         {
-            var component = new DescriptionComponent(mContainer, name);
-            if (loadLayout)
-            {
-                component.LoadLayout();
-            }
-            mComponents.Add(component);
-            return component;
+            X = X - _descriptionWindow.Width - _icon.Height;
         }
 
-        /// <summary>
-        /// Adds a <see cref="RowContainerComponent"/> to the current window.
-        /// </summary>
-        /// <param name="name">The name of the component.</param>
-        /// <returns>Returns a new instance of the <see cref="DescriptionComponent"/> class</returns>
-        public RowContainerComponent AddRowContainer(string name = "DescriptionWindowRowContainer")
+        if (Y > Interface.GameUi.GameCanvas.Height - _descriptionWindow.Height)
         {
-            var component = new RowContainerComponent(mContainer, name);
-            mComponents.Add(component);
-            return component;
+            Y = Y - _descriptionWindow.Height - _icon.Height;
         }
 
-        /// <summary>
-        /// Positions a component correctly on the current window.
-        /// </summary>
-        /// <param name="component">The <see cref="ComponentBase"/> to place.</param>
-        private void PositionComponent(ComponentBase component)
-        {
-            if (component == null)
-            {
-                return;
-            }
-
-            component.SetPosition(component.X, mComponentY);
-            mComponentY += component.Height;
-        }
-
-        /// <summary>
-        /// Position and resize all components properly for display.
-        /// </summary>
-        protected void FinalizeWindow()
-        {
-            // Reset our componentY so we start from scratch!
-            mComponentY = 0;
-
-            // Correctly set our container width to the largest child start with, this way our other child components will have a width to work with.
-            mContainer.SizeToChildren(true, false);
-
-            // Resize and relocate our components to properly display on our window.
-            foreach (var component in mComponents)
-            {
-                component.CorrectWidth();
-                PositionComponent(component);
-            }
-
-            // Correctly set our container height so we display everything.
-            mContainer.SizeToChildren(false, true);
-        }
-
-        /// <inheritdoc/>
-        public override void SetPosition(int x, int y)
-        {
-            var newX = x - mContainer.Width - mContainer.Padding.Right;
-            var newY = y + mContainer.Padding.Top;
-
-            // Center on the desired position if requested.
-            if (mCenterOnPosition)
-            {
-                newX += (mContainer.Width - mContainer.Padding.Right) / 2;
-            }
-            
-            // Do not allow it to render outside of the screen canvas.
-            if (newX < 0)
-            {
-                newX = 0;
-            }
-            else if (newX > mContainer.Canvas.Width - mContainer.Width)
-            {
-                newX = mContainer.Canvas.Width - mContainer.Width;
-            }
-
-            if (newY < 0)
-            {
-                newY = 0;
-            }
-            else if (newY > mContainer.Canvas.Height - mContainer.Height)
-            {
-                newY = mContainer.Canvas.Height - mContainer.Height;
-            }
-
-            mContainer.MoveTo(newX, newY);
-        }
-
-        public override void SetPosition(Base _icon, SpellDescriptionWindow _descriptionWindow)
-        {
-            var X = _icon.LocalPosToCanvas(new Point(0, 0)).X;
-            var Y = _icon.LocalPosToCanvas(new Point(0, 0)).Y;
-
-            X = X + _descriptionWindow.Width + _icon.Height;
-            Y = Y + _icon.Height;
-
-            // Do not allow it to render outside of the screen canvas while based on the _icon position.
-            // Prevents flickering when _icon is hovered near the edge of the screen.
-            if (X > Interface.GameUi.GameCanvas.Width - _descriptionWindow.Width)
-            {
-                X = X - _descriptionWindow.Width - _icon.Height;
-            }
-
-            if (Y > Interface.GameUi.GameCanvas.Height - _descriptionWindow.Height)
-            {
-                Y = Y - _descriptionWindow.Height - _icon.Height;
-            }
-
-            _descriptionWindow.SetPosition(X, Y);
-        }
+        _descriptionWindow.SetPosition(X, Y);
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -6,201 +6,480 @@ using Intersect.Logging;
 using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows
+namespace Intersect.Client.Interface.Game.DescriptionWindows;
+
+public partial class ItemDescriptionWindow : DescriptionWindowBase
 {
-    public partial class ItemDescriptionWindow : DescriptionWindowBase
+    protected ItemBase mItem;
+
+    protected int mAmount;
+
+    protected ItemProperties mItemProperties;
+
+    protected string mTitleOverride;
+
+    protected string mValueLabel;
+
+    protected SpellDescriptionWindow mSpellDescWindow;
+
+    public ItemDescriptionWindow(
+        ItemBase item,
+        int amount,
+        int x,
+        int y,
+        ItemProperties itemProperties,
+        string titleOverride = "",
+        string valueLabel = "",
+        bool centerOnPosition = false
+    ) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
     {
-        protected ItemBase mItem;
+        mItem = item;
+        mAmount = amount;
+        mItemProperties = itemProperties;
+        mTitleOverride = titleOverride;
+        mValueLabel = valueLabel;
 
-        protected int mAmount;
+        GenerateComponents();
+        SetupDescriptionWindow();
+        SetPosition(x, y);
 
-        protected ItemProperties mItemProperties;
-
-        protected string mTitleOverride;
-
-        protected string mValueLabel;
-
-        protected SpellDescriptionWindow mSpellDescWindow;
-
-        public ItemDescriptionWindow(
-            ItemBase item,
-            int amount,
-            int x,
-            int y,
-            ItemProperties itemProperties,
-            string titleOverride = "",
-            string valueLabel = "",
-            bool centerOnPosition = false
-        ) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
+        // If a spell, also display the spell description!
+        if (mItem.ItemType == ItemType.Spell)
         {
-            mItem = item;
-            mAmount = amount;
-            mItemProperties = itemProperties;
-            mTitleOverride = titleOverride;
-            mValueLabel = valueLabel;
+            mSpellDescWindow = new SpellDescriptionWindow(mItem.SpellId, x, mContainer.Bottom);
+        }
+    }
 
-            GenerateComponents();
-            SetupDescriptionWindow();
-            SetPosition(x, y);
-
-            // If a spell, also display the spell description!
-            if (mItem.ItemType == ItemType.Spell)
-            {
-                mSpellDescWindow = new SpellDescriptionWindow(mItem.SpellId, x, mContainer.Bottom);
-            }
+    protected void SetupDescriptionWindow()
+    {
+        if (mItem == null)
+        {
+            return;
         }
 
-        protected void SetupDescriptionWindow()
+        // Set up our header information.
+        SetupHeader();
+
+        // Set up our item limit information.
+        SetupItemLimits();
+
+        // if we have a description, set that up.
+        if (!string.IsNullOrWhiteSpace(mItem.Description))
         {
-            if (mItem == null)
-            {
-                return;
-            }
-
-            // Set up our header information.
-            SetupHeader();
-
-            // Set up our item limit information.
-            SetupItemLimits();
-
-            // if we have a description, set that up.
-            if (!string.IsNullOrWhiteSpace(mItem.Description))
-            {
-                SetupDescription();
-            }
-
-            // Set up information depending on the item type.
-            switch (mItem.ItemType)
-            {
-                case ItemType.Equipment:
-                    SetupEquipmentInfo();
-                    break;
-
-                case ItemType.Consumable:
-                    SetupConsumableInfo();
-                    break;
-
-                case ItemType.Spell:
-                    SetupSpellInfo();
-                    break;
-
-                case ItemType.Bag:
-                    SetupBagInfo();
-                    break;
-            }
-
-            // Set up additional information such as amounts and shop values.
-            SetupExtraInfo();
-
-            // Resize the container, correct the display and position our window.
-            FinalizeWindow();
+            SetupDescription();
         }
 
-        protected void SetupHeader()
+        // Set up information depending on the item type.
+        switch (mItem.ItemType)
         {
-            // Create our header, but do not load our layout yet since we're adding components manually.
-            var header = AddHeader();
+            case ItemType.Equipment:
+                SetupEquipmentInfo();
+                break;
 
-            // Set up the icon, if we can load it.
-            var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, mItem.Icon);
-            if (tex != null)
-            {
-                header.SetIcon(tex, mItem.Color);
-            }
+            case ItemType.Consumable:
+                SetupConsumableInfo();
+                break;
 
-            // Set up the header as the item name.
-            CustomColors.Items.Rarities.TryGetValue(mItem.Rarity, out var rarityColor);
-            var name = !string.IsNullOrWhiteSpace(mTitleOverride) ? mTitleOverride : mItem.Name;
-            header.SetTitle(name, rarityColor ?? Color.White);
+            case ItemType.Spell:
+                SetupSpellInfo();
+                break;
 
-            // Set up the description telling us what type of item this is.
-            // if equipment, also list what kind.
-            Strings.ItemDescription.ItemTypes.TryGetValue((int)mItem.ItemType, out var typeDesc);
-            if (mItem.ItemType == ItemType.Equipment)
-            {
-                var equipSlot = Options.Equipment.Slots[mItem.EquipmentSlot];
-                var extraInfo = equipSlot;
-                if (mItem.EquipmentSlot == Options.WeaponIndex && mItem.TwoHanded)
-                {
-                    extraInfo = $"{Strings.ItemDescription.TwoHand} {equipSlot}";
-                }
-                header.SetSubtitle($"{typeDesc} - {extraInfo}", Color.White);
-            }
-            else
-            {
-                header.SetSubtitle(typeDesc, Color.White);
-            }
-
-            // Set up the item rarity label.
-            try
-            {
-                var rarityName = Options.Instance.Items.RarityTiers[mItem.Rarity];
-                _ = Strings.ItemDescription.Rarity.TryGetValue(rarityName, out var rarityLabel);
-                header.SetDescription(rarityLabel, rarityColor ?? Color.White);
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-
-            header.SizeToChildren(true, false);
+            case ItemType.Bag:
+                SetupBagInfo();
+                break;
         }
 
-        protected void SetupItemLimits()
+        // Set up additional information such as amounts and shop values.
+        SetupExtraInfo();
+
+        // Resize the container, correct the display and position our window.
+        FinalizeWindow();
+    }
+
+    protected void SetupHeader()
+    {
+        // Create our header, but do not load our layout yet since we're adding components manually.
+        var header = AddHeader();
+
+        // Set up the icon, if we can load it.
+        var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, mItem.Icon);
+        if (tex != null)
         {
-            // Gather up what limitations apply to this item.
-            var limits = new List<string>();
-            if (!mItem.CanBank)
-            {
-                limits.Add(Strings.ItemDescription.Banked);
-            }
-            if (!mItem.CanGuildBank)
-            {
-                limits.Add(Strings.ItemDescription.GuildBanked);
-            }
-            if (!mItem.CanBag)
-            {
-                limits.Add(Strings.ItemDescription.Bagged);
-            }
-            if (!mItem.CanTrade)
-            {
-                limits.Add(Strings.ItemDescription.Traded);
-            }
-            if (!mItem.CanDrop)
-            {
-                limits.Add(Strings.ItemDescription.Dropped);
-            }
-            if (!mItem.CanSell)
-            {
-                limits.Add(Strings.ItemDescription.Sold);
-            }
-
-            // Do we have any limitations? If so, generate a display for it.
-            if (limits.Count > 0)
-            {
-                // Add a divider.
-                AddDivider();
-
-                // Add the actual description.
-                var description = AddDescription();
-
-                // Commbine our lovely limitations to a single line and display them.
-                description.AddText(Strings.ItemDescription.ItemLimits.ToString(string.Join(", ", limits)), Color.White);
-            }
+            header.SetIcon(tex, mItem.Color);
         }
 
-        protected void SetupDescription()
+        // Set up the header as the item name.
+        CustomColors.Items.Rarities.TryGetValue(mItem.Rarity, out var rarityColor);
+        var name = !string.IsNullOrWhiteSpace(mTitleOverride) ? mTitleOverride : mItem.Name;
+        header.SetTitle(name, rarityColor ?? Color.White);
+
+        // Set up the description telling us what type of item this is.
+        // if equipment, also list what kind.
+        Strings.ItemDescription.ItemTypes.TryGetValue((int)mItem.ItemType, out var typeDesc);
+        if (mItem.ItemType == ItemType.Equipment)
+        {
+            var equipSlot = Options.Equipment.Slots[mItem.EquipmentSlot];
+            var extraInfo = equipSlot;
+            if (mItem.EquipmentSlot == Options.WeaponIndex && mItem.TwoHanded)
+            {
+                extraInfo = $"{Strings.ItemDescription.TwoHand} {equipSlot}";
+            }
+            header.SetSubtitle($"{typeDesc} - {extraInfo}", Color.White);
+        }
+        else
+        {
+            header.SetSubtitle(typeDesc, Color.White);
+        }
+
+        // Set up the item rarity label.
+        try
+        {
+            var rarityName = Options.Instance.Items.RarityTiers[mItem.Rarity];
+            _ = Strings.ItemDescription.Rarity.TryGetValue(rarityName, out var rarityLabel);
+            header.SetDescription(rarityLabel, rarityColor ?? Color.White);
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+
+        header.SizeToChildren(true, false);
+    }
+
+    protected void SetupItemLimits()
+    {
+        // Gather up what limitations apply to this item.
+        var limits = new List<string>();
+        if (!mItem.CanBank)
+        {
+            limits.Add(Strings.ItemDescription.Banked);
+        }
+        if (!mItem.CanGuildBank)
+        {
+            limits.Add(Strings.ItemDescription.GuildBanked);
+        }
+        if (!mItem.CanBag)
+        {
+            limits.Add(Strings.ItemDescription.Bagged);
+        }
+        if (!mItem.CanTrade)
+        {
+            limits.Add(Strings.ItemDescription.Traded);
+        }
+        if (!mItem.CanDrop)
+        {
+            limits.Add(Strings.ItemDescription.Dropped);
+        }
+        if (!mItem.CanSell)
+        {
+            limits.Add(Strings.ItemDescription.Sold);
+        }
+
+        // Do we have any limitations? If so, generate a display for it.
+        if (limits.Count > 0)
         {
             // Add a divider.
             AddDivider();
 
             // Add the actual description.
             var description = AddDescription();
-            description.AddText(Strings.ItemDescription.Description.ToString(mItem.Description), Color.White);
+
+            // Commbine our lovely limitations to a single line and display them.
+            description.AddText(Strings.ItemDescription.ItemLimits.ToString(string.Join(", ", limits)), Color.White);
+        }
+    }
+
+    protected void SetupDescription()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add the actual description.
+        var description = AddDescription();
+        description.AddText(Strings.ItemDescription.Description.ToString(mItem.Description), Color.White);
+    }
+
+    protected void SetupEquipmentInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Is this a weapon?
+        if (mItem.EquipmentSlot == Options.WeaponIndex)
+        {
+            // Base Damage:
+            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, mItem.Damage.ToString());
+
+            // Damage Type:
+            Strings.ItemDescription.DamageTypes.TryGetValue(mItem.DamageType, out var damageType);
+            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamageType, damageType);
+
+            if (mItem.Scaling > 0)
+            {
+                Strings.ItemDescription.Stats.TryGetValue(mItem.ScalingStat, out var stat);
+                rows.AddKeyValueRow(Strings.ItemDescription.ScalingStat, stat);
+                rows.AddKeyValueRow(Strings.ItemDescription.ScalingPercentage, Strings.ItemDescription.Percentage.ToString(mItem.Scaling));
+            }
+
+            // Crit Chance
+            if (mItem.CritChance > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(mItem.CritChance));
+                rows.AddKeyValueRow(Strings.ItemDescription.CritMultiplier, Strings.ItemDescription.Multiplier.ToString(mItem.CritMultiplier));
+            }
+
+            // Attack Speed
+            // Are we supposed to change our attack time based on a modifier?
+            if (mItem.AttackSpeedModifier == 0)
+            {
+                // No modifier, assuming base attack rate? We have to calculate the speed stat manually here though..!
+                var speed = Globals.Me.Stat[(int)Stat.Speed];
+
+                // Remove currently equipped weapon stats.. We want to create a fair display!
+                var weaponSlot = Globals.Me.MyEquipment[Options.WeaponIndex];
+                if (weaponSlot != -1)
+                {
+                    var randomStats = Globals.Me.Inventory[weaponSlot].ItemProperties.StatModifiers;
+                    var weapon = ItemBase.Get(Globals.Me.Inventory[weaponSlot].ItemId);
+                    if (weapon != null && randomStats != null)
+                    {
+                        speed = (int)Math.Round(speed / ((100 + weapon.PercentageStatsGiven[(int)Stat.Speed]) / 100f));
+                        speed -= weapon.StatsGiven[(int)Stat.Speed];
+                        speed -= randomStats[(int)Stat.Speed];
+                    }
+                }
+
+                // Add current item's speed stats!
+                if (mItemProperties?.StatModifiers != default)
+                {
+                    speed += mItem.StatsGiven[(int)Stat.Speed];
+                    speed += mItemProperties.StatModifiers[(int)Stat.Speed];
+                    speed += (int)Math.Floor(speed * (mItem.PercentageStatsGiven[(int)Stat.Speed] / 100f));
+                }
+
+                // Display the actual speed this weapon would have based off of our calculated speed stat.
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(Globals.Me.CalculateAttackTime(speed)).WithSuffix());
+            }
+            else if (mItem.AttackSpeedModifier == 1)
+            {
+                // Static, so this weapon's attack speed.
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(mItem.AttackSpeedValue).WithSuffix());
+            }
+            else if (mItem.AttackSpeedModifier == 2)
+            {
+                // Percentage based.
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, Strings.ItemDescription.Percentage.ToString(mItem.AttackSpeedValue));
+            }
         }
 
-        protected void SetupEquipmentInfo()
+        //Blocking options
+        if (mItem.EquipmentSlot == Options.ShieldIndex)
+        {
+            if (mItem.BlockChance > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockChance, Strings.ItemDescription.Percentage.ToString(mItem.BlockChance));
+            }
+
+            if (mItem.BlockAmount > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockAmount, Strings.ItemDescription.Percentage.ToString(mItem.BlockAmount));
+            }
+
+            if (mItem.BlockAbsorption > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.BlockAbsorption, Strings.ItemDescription.Percentage.ToString(mItem.BlockAbsorption));
+            }
+        }
+
+        // Vitals
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            if (mItem.VitalsGiven[i] != 0 && mItem.PercentageVitalsGiven[i] != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.VitalsGiven[i], mItem.PercentageVitalsGiven[i]));
+            }
+            else if (mItem.VitalsGiven[i] != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], mItem.VitalsGiven[i].ToString());
+            }
+            else if (mItem.PercentageVitalsGiven[i] != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageVitalsGiven[i]));
+            }
+        }
+
+        // Vitals Regen
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            if (mItem.VitalsRegen[i] != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.VitalsRegen[i], Strings.ItemDescription.Percentage.ToString(mItem.VitalsRegen[i]));
+            }
+        }
+
+        // Stats
+        var statModifiers = mItemProperties?.StatModifiers;
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
+            if (statModifiers != default || mItem.StatRanges?.Length == 0 || (mItem.StatRanges != default && mItem.StatRanges[i].LowRange == 0 && mItem.StatRanges[i].HighRange == 0))
+            {
+                var flatStat = mItem.StatsGiven[i];
+                if (statModifiers != default)
+                {
+                    flatStat += statModifiers[i];
+                }
+
+                if (flatStat != 0 && mItem.PercentageStatsGiven[i] != 0)
+                {
+                    rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.RegularAndPercentage.ToString(flatStat, mItem.PercentageStatsGiven[i]));
+                }
+                else if (flatStat != 0)
+                {
+                    rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], flatStat.ToString());
+                }
+                else if (mItem.PercentageStatsGiven[i] != 0)
+                {
+                    rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageStatsGiven[i]));
+                }
+            }
+            // We do not have item properties and have growing stats! So don't display a finished stat but a range instead.
+            else
+            {
+                if (mItem.TryGetRangeFor((Stat)i, out var range))
+                {
+                    var statGiven = mItem.StatsGiven[i];
+                    var percentageStatGiven = mItem.PercentageStatsGiven[i];
+                    var statLow = statGiven + range.LowRange;
+                    var statHigh = statGiven + range.HighRange;
+
+                    var statMessage = Strings.ItemDescription.StatGrowthRange.ToString(statLow, statHigh);
+
+                    if (percentageStatGiven != 0)
+                    {
+                        statMessage = Strings.ItemDescription.RegularAndPercentage.ToString(statMessage, percentageStatGiven);
+                    }
+                    rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], statMessage);
+                }
+        }
+    }
+
+        // Bonus Effect
+        foreach (var effect in mItem.Effects)
+        {
+            if (effect.Type != ItemEffect.None && effect.Percentage != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.BonusEffects[(int)effect.Type], Strings.ItemDescription.Percentage.ToString(effect.Percentage));
+            }
+        }
+
+        // Resize the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupConsumableInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Consumable data.
+        if (mItem.Consumable != null)
+        {
+            if (mItem.Consumable.Value > 0 && mItem.Consumable.Percentage > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.Consumable.Value, mItem.Consumable.Percentage));
+            }
+            else if (mItem.Consumable.Value > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], mItem.Consumable.Value.ToString());
+            }
+            else if (mItem.Consumable.Percentage > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.Percentage.ToString(mItem.Consumable.Percentage));
+            }
+        }
+
+        // Resize and position the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupSpellInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Spell data.
+        if (mItem.Spell != null)
+        {
+            if (mItem.QuickCast)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.CastSpell.ToString(mItem.Spell.Name), string.Empty);
+            }
+            else
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.TeachSpell.ToString(mItem.Spell.Name), string.Empty);
+            }
+
+            if (mItem.SingleUse)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.SingleUse, string.Empty);
+            }
+        }
+
+        // Resize and position the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupBagInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Bag data.
+        rows.AddKeyValueRow(Strings.ItemDescription.BagSlots, mItem.SlotCount.ToString());
+
+        // Resize and position the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupExtraInfo()
+    {
+        // Our list of data to add, should we need to.
+        var data = new List<Tuple<string, string>>();
+
+        // Display our amount, but only if we are stackable and have more than one.
+        if (mItem.IsStackable && mAmount > 1)
+        {
+            data.Add(new Tuple<string, string>(Strings.ItemDescription.Amount, mAmount.ToString("N0").Replace(",", Strings.Numbers.Comma)));
+        }
+
+        // Display item drop chance if configured.
+        if (mItem.DropChanceOnDeath > 0)
+        {
+            data.Add(new Tuple<string, string>(Strings.ItemDescription.DropOnDeath, Strings.ItemDescription.Percentage.ToString(mItem.DropChanceOnDeath)));
+        }
+
+        // Display shop value if we have one.
+        if (!string.IsNullOrWhiteSpace(mValueLabel))
+        {
+            data.Add(new Tuple<string, string>(mValueLabel, string.Empty));
+        }
+
+        // Do we have any data to display? If so, generate the element and add the data to it.
+        if (data.Count > 0)
         {
             // Add a divider.
             AddDivider();
@@ -208,300 +487,20 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             // Add a row component.
             var rows = AddRowContainer();
 
-            // Is this a weapon?
-            if (mItem.EquipmentSlot == Options.WeaponIndex)
+            foreach (var item in data)
             {
-                // Base Damage:
-                rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, mItem.Damage.ToString());
-
-                // Damage Type:
-                Strings.ItemDescription.DamageTypes.TryGetValue(mItem.DamageType, out var damageType);
-                rows.AddKeyValueRow(Strings.ItemDescription.BaseDamageType, damageType);
-
-                if (mItem.Scaling > 0)
-                {
-                    Strings.ItemDescription.Stats.TryGetValue(mItem.ScalingStat, out var stat);
-                    rows.AddKeyValueRow(Strings.ItemDescription.ScalingStat, stat);
-                    rows.AddKeyValueRow(Strings.ItemDescription.ScalingPercentage, Strings.ItemDescription.Percentage.ToString(mItem.Scaling));
-                }
-
-                // Crit Chance
-                if (mItem.CritChance > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(mItem.CritChance));
-                    rows.AddKeyValueRow(Strings.ItemDescription.CritMultiplier, Strings.ItemDescription.Multiplier.ToString(mItem.CritMultiplier));
-                }
-
-                // Attack Speed
-                // Are we supposed to change our attack time based on a modifier?
-                if (mItem.AttackSpeedModifier == 0)
-                {
-                    // No modifier, assuming base attack rate? We have to calculate the speed stat manually here though..!
-                    var speed = Globals.Me.Stat[(int)Stat.Speed];
-
-                    // Remove currently equipped weapon stats.. We want to create a fair display!
-                    var weaponSlot = Globals.Me.MyEquipment[Options.WeaponIndex];
-                    if (weaponSlot != -1)
-                    {
-                        var randomStats = Globals.Me.Inventory[weaponSlot].ItemProperties.StatModifiers;
-                        var weapon = ItemBase.Get(Globals.Me.Inventory[weaponSlot].ItemId);
-                        if (weapon != null && randomStats != null)
-                        {
-                            speed = (int)Math.Round(speed / ((100 + weapon.PercentageStatsGiven[(int)Stat.Speed]) / 100f));
-                            speed -= weapon.StatsGiven[(int)Stat.Speed];
-                            speed -= randomStats[(int)Stat.Speed];
-                        }
-                    }
-
-                    // Add current item's speed stats!
-                    if (mItemProperties?.StatModifiers != default)
-                    {
-                        speed += mItem.StatsGiven[(int)Stat.Speed];
-                        speed += mItemProperties.StatModifiers[(int)Stat.Speed];
-                        speed += (int)Math.Floor(speed * (mItem.PercentageStatsGiven[(int)Stat.Speed] / 100f));
-                    }
-
-                    // Display the actual speed this weapon would have based off of our calculated speed stat.
-                    rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(Globals.Me.CalculateAttackTime(speed)).WithSuffix());
-                }
-                else if (mItem.AttackSpeedModifier == 1)
-                {
-                    // Static, so this weapon's attack speed.
-                    rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(mItem.AttackSpeedValue).WithSuffix());
-                }
-                else if (mItem.AttackSpeedModifier == 2)
-                {
-                    // Percentage based.
-                    rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, Strings.ItemDescription.Percentage.ToString(mItem.AttackSpeedValue));
-                }
-            }
-
-            //Blocking options
-            if (mItem.EquipmentSlot == Options.ShieldIndex)
-            {
-                if (mItem.BlockChance > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.BlockChance, Strings.ItemDescription.Percentage.ToString(mItem.BlockChance));
-                }
-
-                if (mItem.BlockAmount > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.BlockAmount, Strings.ItemDescription.Percentage.ToString(mItem.BlockAmount));
-                }
-
-                if (mItem.BlockAbsorption > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.BlockAbsorption, Strings.ItemDescription.Percentage.ToString(mItem.BlockAbsorption));
-                }
-            }
-
-            // Vitals
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                if (mItem.VitalsGiven[i] != 0 && mItem.PercentageVitalsGiven[i] != 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.VitalsGiven[i], mItem.PercentageVitalsGiven[i]));
-                }
-                else if (mItem.VitalsGiven[i] != 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], mItem.VitalsGiven[i].ToString());
-                }
-                else if (mItem.PercentageVitalsGiven[i] != 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.Vitals[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageVitalsGiven[i]));
-                }
-            }
-
-            // Vitals Regen
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                if (mItem.VitalsRegen[i] != 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.VitalsRegen[i], Strings.ItemDescription.Percentage.ToString(mItem.VitalsRegen[i]));
-                }
-            }
-
-            // Stats
-            var statModifiers = mItemProperties?.StatModifiers;
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                // Do we have item properties, if so this is a finished item. Otherwise does this item not have growing stats?
-                if (statModifiers != default || mItem.StatRanges?.Length == 0 || (mItem.StatRanges != default && mItem.StatRanges[i].LowRange == 0 && mItem.StatRanges[i].HighRange == 0))
-                {
-                    var flatStat = mItem.StatsGiven[i];
-                    if (statModifiers != default)
-                    {
-                        flatStat += statModifiers[i];
-                    }
-
-                    if (flatStat != 0 && mItem.PercentageStatsGiven[i] != 0)
-                    {
-                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.RegularAndPercentage.ToString(flatStat, mItem.PercentageStatsGiven[i]));
-                    }
-                    else if (flatStat != 0)
-                    {
-                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], flatStat.ToString());
-                    }
-                    else if (mItem.PercentageStatsGiven[i] != 0)
-                    {
-                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], Strings.ItemDescription.Percentage.ToString(mItem.PercentageStatsGiven[i]));
-                    }
-                }
-                // We do not have item properties and have growing stats! So don't display a finished stat but a range instead.
-                else
-                {
-                    if (mItem.TryGetRangeFor((Stat)i, out var range))
-                    {
-                        var statGiven = mItem.StatsGiven[i];
-                        var percentageStatGiven = mItem.PercentageStatsGiven[i];
-                        var statLow = statGiven + range.LowRange;
-                        var statHigh = statGiven + range.HighRange;
-
-                        var statMessage = Strings.ItemDescription.StatGrowthRange.ToString(statLow, statHigh);
-
-                        if (percentageStatGiven != 0)
-                        {
-                            statMessage = Strings.ItemDescription.RegularAndPercentage.ToString(statMessage, percentageStatGiven);
-                        }
-                        rows.AddKeyValueRow(Strings.ItemDescription.StatCounts[i], statMessage);
-                    }
-            }
-        }
-
-            // Bonus Effect
-            foreach (var effect in mItem.Effects)
-            {
-                if (effect.Type != ItemEffect.None && effect.Percentage != 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.BonusEffects[(int)effect.Type], Strings.ItemDescription.Percentage.ToString(effect.Percentage));
-                }
-            }
-
-            // Resize the container.
-            rows.SizeToChildren(true, true);
-        }
-
-        protected void SetupConsumableInfo()
-        {
-            // Add a divider.
-            AddDivider();
-
-            // Add a row component.
-            var rows = AddRowContainer();
-
-            // Consumable data.
-            if (mItem.Consumable != null)
-            {
-                if (mItem.Consumable.Value > 0 && mItem.Consumable.Percentage > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.RegularAndPercentage.ToString(mItem.Consumable.Value, mItem.Consumable.Percentage));
-                }
-                else if (mItem.Consumable.Value > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], mItem.Consumable.Value.ToString());
-                }
-                else if (mItem.Consumable.Percentage > 0)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)mItem.Consumable.Type], Strings.ItemDescription.Percentage.ToString(mItem.Consumable.Percentage));
-                }
+                rows.AddKeyValueRow(item.Item1, item.Item2);
             }
 
             // Resize and position the container.
             rows.SizeToChildren(true, true);
         }
+    }
 
-        protected void SetupSpellInfo()
-        {
-            // Add a divider.
-            AddDivider();
-
-            // Add a row component.
-            var rows = AddRowContainer();
-
-            // Spell data.
-            if (mItem.Spell != null)
-            {
-                if (mItem.QuickCast)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.CastSpell.ToString(mItem.Spell.Name), string.Empty);
-                }
-                else
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.TeachSpell.ToString(mItem.Spell.Name), string.Empty);
-                }
-
-                if (mItem.SingleUse)
-                {
-                    rows.AddKeyValueRow(Strings.ItemDescription.SingleUse, string.Empty);
-                }
-            }
-
-            // Resize and position the container.
-            rows.SizeToChildren(true, true);
-        }
-
-        protected void SetupBagInfo()
-        {
-            // Add a divider.
-            AddDivider();
-
-            // Add a row component.
-            var rows = AddRowContainer();
-
-            // Bag data.
-            rows.AddKeyValueRow(Strings.ItemDescription.BagSlots, mItem.SlotCount.ToString());
-
-            // Resize and position the container.
-            rows.SizeToChildren(true, true);
-        }
-
-        protected void SetupExtraInfo()
-        {
-            // Our list of data to add, should we need to.
-            var data = new List<Tuple<string, string>>();
-
-            // Display our amount, but only if we are stackable and have more than one.
-            if (mItem.IsStackable && mAmount > 1)
-            {
-                data.Add(new Tuple<string, string>(Strings.ItemDescription.Amount, mAmount.ToString("N0").Replace(",", Strings.Numbers.Comma)));
-            }
-
-            // Display item drop chance if configured.
-            if (mItem.DropChanceOnDeath > 0)
-            {
-                data.Add(new Tuple<string, string>(Strings.ItemDescription.DropOnDeath, Strings.ItemDescription.Percentage.ToString(mItem.DropChanceOnDeath)));
-            }
-
-            // Display shop value if we have one.
-            if (!string.IsNullOrWhiteSpace(mValueLabel))
-            {
-                data.Add(new Tuple<string, string>(mValueLabel, string.Empty));
-            }
-
-            // Do we have any data to display? If so, generate the element and add the data to it.
-            if (data.Count > 0)
-            {
-                // Add a divider.
-                AddDivider();
-
-                // Add a row component.
-                var rows = AddRowContainer();
-
-                foreach (var item in data)
-                {
-                    rows.AddKeyValueRow(item.Item1, item.Item2);
-                }
-
-                // Resize and position the container.
-                rows.SizeToChildren(true, true);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Dispose()
-        {
-            base.Dispose();
-            mSpellDescWindow?.Dispose();
-        }
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        base.Dispose();
+        mSpellDescWindow?.Dispose();
     }
 }

--- a/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -5,182 +5,336 @@ using Intersect.Client.Localization;
 using Intersect.Utilities;
 using Intersect.Client.Framework.Gwen.Control;
 
-namespace Intersect.Client.Interface.Game.DescriptionWindows
+namespace Intersect.Client.Interface.Game.DescriptionWindows;
+
+public partial class SpellDescriptionWindow : DescriptionWindowBase
 {
-    public partial class SpellDescriptionWindow : DescriptionWindowBase
+    protected SpellBase mSpell;
+
+    public SpellDescriptionWindow(Guid spellId, int x, int y, bool centerOnPosition = false) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
     {
-        protected SpellBase mSpell;
+        mSpell = SpellBase.Get(spellId);
 
-        public SpellDescriptionWindow(Guid spellId, int x, int y, bool centerOnPosition = false) : base(Interface.GameUi.GameCanvas, "DescriptionWindow", centerOnPosition)
+        GenerateComponents();
+        SetupDescriptionWindow();
+        SetPosition(x, y);
+    }
+
+    public SpellDescriptionWindow(Guid spellId, ImagePanel _statusIcon) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+    {
+        mSpell = SpellBase.Get(spellId);
+
+        GenerateComponents();
+        SetupDescriptionWindow();
+        SetPosition(_statusIcon, this);
+    }
+
+    protected void SetupDescriptionWindow()
+    {
+        if (mSpell == null)
         {
-            mSpell = SpellBase.Get(spellId);
-
-            GenerateComponents();
-            SetupDescriptionWindow();
-            SetPosition(x, y);
+            return;
         }
 
-        public SpellDescriptionWindow(Guid spellId, ImagePanel _statusIcon) : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
-        {
-            mSpell = SpellBase.Get(spellId);
+        // Set up our header information.
+        SetupHeader();
 
-            GenerateComponents();
-            SetupDescriptionWindow();
-            SetPosition(_statusIcon, this);
+        // Set up our basic spell info.
+        SetupSpellInfo();
+
+        // if we have a description, set that up.
+        if (!string.IsNullOrWhiteSpace(mSpell.Description))
+        {
+            SetupDescription();
         }
 
-        protected void SetupDescriptionWindow()
+        // Set up information depending on the item type.
+        switch (mSpell.SpellType)
         {
-            if (mSpell == null)
-            {
-                return;
-            }
-
-            // Set up our header information.
-            SetupHeader();
-
-            // Set up our basic spell info.
-            SetupSpellInfo();
-
-            // if we have a description, set that up.
-            if (!string.IsNullOrWhiteSpace(mSpell.Description))
-            {
-                SetupDescription();
-            }
-
-            // Set up information depending on the item type.
-            switch (mSpell.SpellType)
-            {
-                case SpellType.CombatSpell:
-                case SpellType.WarpTo:
-                    SetupCombatInfo();
-                    break;
-                case SpellType.Dash:
-                    SetupDashInfo();
-                    break;
-            }
-
-            // Set up bind info, if applicable.
-            SetupExtraInfo();
-
-
-            // Resize the container, correct the display and position our window.
-            FinalizeWindow();
+            case SpellType.CombatSpell:
+            case SpellType.WarpTo:
+                SetupCombatInfo();
+                break;
+            case SpellType.Dash:
+                SetupDashInfo();
+                break;
         }
 
-        protected void SetupHeader()
-        {
-            // Create our header, but do not load our layout yet since we're adding components manually.
-            var header = AddHeader();
+        // Set up bind info, if applicable.
+        SetupExtraInfo();
 
-            // Set up the icon, if we can load it.
-            var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Spell, mSpell.Icon);
-            if (tex != null)
+
+        // Resize the container, correct the display and position our window.
+        FinalizeWindow();
+    }
+
+    protected void SetupHeader()
+    {
+        // Create our header, but do not load our layout yet since we're adding components manually.
+        var header = AddHeader();
+
+        // Set up the icon, if we can load it.
+        var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Spell, mSpell.Icon);
+        if (tex != null)
+        {
+            header.SetIcon(tex, Color.White);
+        }
+
+        // Set up the header as the item name.
+        header.SetTitle(mSpell.Name, Color.White);
+
+        // Set up the spell type description.
+        Strings.SpellDescription.SpellTypes.TryGetValue((int)mSpell.SpellType, out var spellType);
+        header.SetSubtitle(spellType, Color.White);
+
+        // Set up the spelldescription based on what kind of spell it is.
+        if (mSpell.SpellType == (int)SpellType.CombatSpell)
+        {
+            if (mSpell.Combat.TargetType == SpellTargetType.Projectile)
             {
-                header.SetIcon(tex, Color.White);
+                var proj = ProjectileBase.Get(mSpell.Combat.ProjectileId);
+                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)mSpell.Combat.TargetType].ToString(proj?.Range ?? 0, mSpell.Combat.HitRadius), Color.White);
+            }
+            else
+            {
+                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)mSpell.Combat.TargetType].ToString(mSpell.Combat.CastRange, mSpell.Combat.HitRadius), Color.White);
+            }
+        }
+
+        header.SizeToChildren(true, false);
+    }
+
+    protected void SetupSpellInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a new row control to add our details into.
+        var rows = AddRowContainer();
+
+        // Friendly / Non Friendly for combat spells.
+        if (mSpell.SpellType == SpellType.CombatSpell || mSpell.SpellType == SpellType.WarpTo)
+        {
+            if (mSpell.Combat.Friendly)
+            {
+                rows.AddKeyValueRow(Strings.SpellDescription.Friendly, string.Empty);
+            }
+            else
+            {
+                rows.AddKeyValueRow(Strings.SpellDescription.Unfriendly, string.Empty);
+            }
+        }
+
+        // Add cast time
+        var castTime = Strings.SpellDescription.Instant;
+        if (mSpell.CastDuration > 0)
+        {
+            castTime = TimeSpan.FromMilliseconds(mSpell.CastDuration).WithSuffix();
+        }
+        rows.AddKeyValueRow(Strings.SpellDescription.CastTime, castTime);
+
+        // Add Vital Costs
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            if (mSpell.VitalCost[i] != 0)
+            {
+                rows.AddKeyValueRow(Strings.SpellDescription.VitalCosts[i], mSpell.VitalCost[i].ToString());
+            }
+        }
+
+        // Add Cooldown time
+        if (mSpell.CooldownDuration > 0)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.Cooldown, TimeSpan.FromMilliseconds(mSpell.CooldownDuration).WithSuffix());
+        }
+
+        // Add Cooldown Group
+        if (!string.IsNullOrWhiteSpace(mSpell.CooldownGroup))
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.CooldownGroup, mSpell.CooldownGroup);
+        }
+
+        // Ignores global cooldown if enabled?
+        if (Options.Instance.CombatOpts.EnableGlobalCooldowns && mSpell.IgnoreGlobalCooldown)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreGlobalCooldown, string.Empty);
+        }
+
+        // Ignore cooldown reduction stat?
+        if (mSpell.IgnoreCooldownReduction)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreCooldownReduction, string.Empty);
+        }
+
+        // Resize the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupDescription()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add the actual description.
+        var description = AddDescription();
+        description.AddText(Strings.ItemDescription.Description.ToString(mSpell.Description), Color.White);
+    }
+
+    protected void SetupCombatInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Vital Damage, if 0 don't display!
+        // This bit is a bit iffy.. since in
+        var isHeal = false;
+        var isDamage = false;
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            if (mSpell.Combat.VitalDiff[i] < 0)
+            {
+                rows.AddKeyValueRow(Strings.SpellDescription.VitalRecovery[i], Math.Abs(mSpell.Combat.VitalDiff[i]).ToString());
+                isHeal = true;
+            }
+            else if (mSpell.Combat.VitalDiff[i] > 0)
+            {
+                rows.AddKeyValueRow(Strings.SpellDescription.VitalDamage[i], mSpell.Combat.VitalDiff[i].ToString());
+                isDamage = true;
+            }
+        }
+
+        // Damage Type:
+        Strings.SpellDescription.DamageTypes.TryGetValue(mSpell.Combat.DamageType, out var damageType);
+        rows.AddKeyValueRow(Strings.SpellDescription.DamageType, damageType);
+
+        if (mSpell.Combat.Scaling > 0)
+        {
+            Strings.SpellDescription.Stats.TryGetValue(mSpell.Combat.ScalingStat, out var stat);
+            rows.AddKeyValueRow(Strings.SpellDescription.ScalingStat, stat);
+            rows.AddKeyValueRow(Strings.SpellDescription.ScalingPercentage, Strings.SpellDescription.Percentage.ToString(mSpell.Combat.Scaling));
+        }
+
+        // Crit Chance
+        if (mSpell.Combat.CritChance > 0)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.CritChance, Strings.SpellDescription.Percentage.ToString(mSpell.Combat.CritChance));
+            rows.AddKeyValueRow(Strings.SpellDescription.CritMultiplier, Strings.SpellDescription.Multiplier.ToString(mSpell.Combat.CritMultiplier));
+        }
+
+        var showDuration = false;
+        // Handle Stat Buffs
+        var blankAdded = false;
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            Tuple<string, string> data = null;
+            if (mSpell.Combat.StatDiff[i] != 0 && mSpell.Combat.PercentageStatDiff[i] != 0)
+            {
+                data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], Strings.SpellDescription.RegularAndPercentage.ToString(mSpell.Combat.StatDiff[i], mSpell.Combat.PercentageStatDiff[i]));
+            }
+            else if (mSpell.Combat.StatDiff[i] != 0)
+            {
+                data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], mSpell.Combat.StatDiff[i].ToString());
+            }
+            else if (mSpell.Combat.PercentageStatDiff[i] != 0)
+            {
+                data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], Strings.ItemDescription.Percentage.ToString(mSpell.Combat.PercentageStatDiff[i]));
             }
 
-            // Set up the header as the item name.
-            header.SetTitle(mSpell.Name, Color.White);
-
-            // Set up the spell type description.
-            Strings.SpellDescription.SpellTypes.TryGetValue((int)mSpell.SpellType, out var spellType);
-            header.SetSubtitle(spellType, Color.White);
-
-            // Set up the spelldescription based on what kind of spell it is.
-            if (mSpell.SpellType == (int)SpellType.CombatSpell)
+            // Make sure we only add a blank row the first time we add a stat row.
+            if (data != null)
             {
-                if (mSpell.Combat.TargetType == SpellTargetType.Projectile)
+                if (!blankAdded)
                 {
-                    var proj = ProjectileBase.Get(mSpell.Combat.ProjectileId);
-                    header.SetDescription(Strings.SpellDescription.TargetTypes[(int)mSpell.Combat.TargetType].ToString(proj?.Range ?? 0, mSpell.Combat.HitRadius), Color.White);
+                    rows.AddKeyValueRow(string.Empty, string.Empty);
+                    rows.AddKeyValueRow(Strings.SpellDescription.StatBuff, string.Empty);
+                    blankAdded = true;
                 }
-                else
-                {
-                    header.SetDescription(Strings.SpellDescription.TargetTypes[(int)mSpell.Combat.TargetType].ToString(mSpell.Combat.CastRange, mSpell.Combat.HitRadius), Color.White);
-                }
-            }
 
-            header.SizeToChildren(true, false);
+                rows.AddKeyValueRow(data.Item1, data.Item2);
+                showDuration = true;
+            }
         }
 
-        protected void SetupSpellInfo()
+        // Handle HoT and DoT displays.
+        if (mSpell.Combat.HoTDoT)
         {
-            // Add a divider.
-            AddDivider();
-
-            // Add a new row control to add our details into.
-            var rows = AddRowContainer();
-
-            // Friendly / Non Friendly for combat spells.
-            if (mSpell.SpellType == SpellType.CombatSpell || mSpell.SpellType == SpellType.WarpTo)
+            showDuration = true;
+            rows.AddKeyValueRow(string.Empty, string.Empty);
+            if (isHeal)
             {
-                if (mSpell.Combat.Friendly)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.Friendly, string.Empty);
-                }
-                else
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.Unfriendly, string.Empty);
-                }
+                rows.AddKeyValueRow(Strings.SpellDescription.HoT, string.Empty);
             }
-
-            // Add cast time
-            var castTime = Strings.SpellDescription.Instant;
-            if (mSpell.CastDuration > 0)
+            else if (isDamage)
             {
-                castTime = TimeSpan.FromMilliseconds(mSpell.CastDuration).WithSuffix();
+                rows.AddKeyValueRow(Strings.SpellDescription.DoT, string.Empty);
             }
-            rows.AddKeyValueRow(Strings.SpellDescription.CastTime, castTime);
-
-            // Add Vital Costs
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                if (mSpell.VitalCost[i] != 0)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.VitalCosts[i], mSpell.VitalCost[i].ToString());
-                }
-            }
-
-            // Add Cooldown time
-            if (mSpell.CooldownDuration > 0)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.Cooldown, TimeSpan.FromMilliseconds(mSpell.CooldownDuration).WithSuffix());
-            }
-
-            // Add Cooldown Group
-            if (!string.IsNullOrWhiteSpace(mSpell.CooldownGroup))
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.CooldownGroup, mSpell.CooldownGroup);
-            }
-
-            // Ignores global cooldown if enabled?
-            if (Options.Instance.CombatOpts.EnableGlobalCooldowns && mSpell.IgnoreGlobalCooldown)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreGlobalCooldown, string.Empty);
-            }
-
-            // Ignore cooldown reduction stat?
-            if (mSpell.IgnoreCooldownReduction)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreCooldownReduction, string.Empty);
-            }
-
-            // Resize the container.
-            rows.SizeToChildren(true, true);
+            rows.AddKeyValueRow(Strings.SpellDescription.Tick, TimeSpan.FromMilliseconds(mSpell.Combat.HotDotInterval).WithSuffix());
         }
 
-        protected void SetupDescription()
+        // Handle effect display.
+        if (mSpell.Combat.Effect != SpellEffect.None)
         {
-            // Add a divider.
-            AddDivider();
-
-            // Add the actual description.
-            var description = AddDescription();
-            description.AddText(Strings.ItemDescription.Description.ToString(mSpell.Description), Color.White);
+            showDuration = true;
+            rows.AddKeyValueRow(string.Empty, string.Empty);
+            rows.AddKeyValueRow(Strings.SpellDescription.Effect, Strings.SpellDescription.Effects[(int)mSpell.Combat.Effect]);
         }
 
-        protected void SetupCombatInfo()
+        // Show Stat Buff / Effect / HoT / DoT duration.
+        if (showDuration)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.Duration, TimeSpan.FromMilliseconds(mSpell.Combat.Duration).WithSuffix("0.#"));
+        }
+
+        // Resize and position the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupDashInfo()
+    {
+        // Add a divider.
+        AddDivider();
+
+        // Add a row component.
+        var rows = AddRowContainer();
+
+        // Dash Distance Information.
+        rows.AddKeyValueRow(Strings.SpellDescription.Distance, Strings.SpellDescription.Tiles.ToString(mSpell.Combat.CastRange));
+
+        // Ignore map blocks?
+        if (mSpell.Dash.IgnoreMapBlocks)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreMapBlock, String.Empty);
+        }
+
+        // Ignore resource blocks?
+        if (mSpell.Dash.IgnoreActiveResources)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreResourceBlock, String.Empty);
+        }
+
+        // Ignore inactive resource blocks?
+        if (mSpell.Dash.IgnoreInactiveResources)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreConsumedResourceBlock, String.Empty);
+        }
+
+        // Ignore Z-Dimension?
+        if (Options.Map.ZDimensionVisible && mSpell.Dash.IgnoreZDimensionAttributes)
+        {
+            rows.AddKeyValueRow(Strings.SpellDescription.IgnoreZDimension, String.Empty);
+        }
+
+        // Resize and position the container.
+        rows.SizeToChildren(true, true);
+    }
+
+    protected void SetupExtraInfo()
+    {
+        // Display only if this spell is bound.
+        if (mSpell.Bound)
         {
             // Add a divider.
             AddDivider();
@@ -188,166 +342,11 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows
             // Add a row component.
             var rows = AddRowContainer();
 
-            // Vital Damage, if 0 don't display!
-            // This bit is a bit iffy.. since in
-            var isHeal = false;
-            var isDamage = false;
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                if (mSpell.Combat.VitalDiff[i] < 0)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.VitalRecovery[i], Math.Abs(mSpell.Combat.VitalDiff[i]).ToString());
-                    isHeal = true;
-                }
-                else if (mSpell.Combat.VitalDiff[i] > 0)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.VitalDamage[i], mSpell.Combat.VitalDiff[i].ToString());
-                    isDamage = true;
-                }
-            }
-
-            // Damage Type:
-            Strings.SpellDescription.DamageTypes.TryGetValue(mSpell.Combat.DamageType, out var damageType);
-            rows.AddKeyValueRow(Strings.SpellDescription.DamageType, damageType);
-
-            if (mSpell.Combat.Scaling > 0)
-            {
-                Strings.SpellDescription.Stats.TryGetValue(mSpell.Combat.ScalingStat, out var stat);
-                rows.AddKeyValueRow(Strings.SpellDescription.ScalingStat, stat);
-                rows.AddKeyValueRow(Strings.SpellDescription.ScalingPercentage, Strings.SpellDescription.Percentage.ToString(mSpell.Combat.Scaling));
-            }
-
-            // Crit Chance
-            if (mSpell.Combat.CritChance > 0)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.CritChance, Strings.SpellDescription.Percentage.ToString(mSpell.Combat.CritChance));
-                rows.AddKeyValueRow(Strings.SpellDescription.CritMultiplier, Strings.SpellDescription.Multiplier.ToString(mSpell.Combat.CritMultiplier));
-            }
-
-            var showDuration = false;
-            // Handle Stat Buffs
-            var blankAdded = false;
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                Tuple<string, string> data = null;
-                if (mSpell.Combat.StatDiff[i] != 0 && mSpell.Combat.PercentageStatDiff[i] != 0)
-                {
-                    data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], Strings.SpellDescription.RegularAndPercentage.ToString(mSpell.Combat.StatDiff[i], mSpell.Combat.PercentageStatDiff[i]));
-                }
-                else if (mSpell.Combat.StatDiff[i] != 0)
-                {
-                    data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], mSpell.Combat.StatDiff[i].ToString());
-                }
-                else if (mSpell.Combat.PercentageStatDiff[i] != 0)
-                {
-                    data = new Tuple<string, string>(Strings.SpellDescription.StatCounts[i], Strings.ItemDescription.Percentage.ToString(mSpell.Combat.PercentageStatDiff[i]));
-                }
-
-                // Make sure we only add a blank row the first time we add a stat row.
-                if (data != null)
-                {
-                    if (!blankAdded)
-                    {
-                        rows.AddKeyValueRow(string.Empty, string.Empty);
-                        rows.AddKeyValueRow(Strings.SpellDescription.StatBuff, string.Empty);
-                        blankAdded = true;
-                    }
-
-                    rows.AddKeyValueRow(data.Item1, data.Item2);
-                    showDuration = true;
-                }
-            }
-
-            // Handle HoT and DoT displays.
-            if (mSpell.Combat.HoTDoT)
-            {
-                showDuration = true;
-                rows.AddKeyValueRow(string.Empty, string.Empty);
-                if (isHeal)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.HoT, string.Empty);
-                }
-                else if (isDamage)
-                {
-                    rows.AddKeyValueRow(Strings.SpellDescription.DoT, string.Empty);
-                }
-                rows.AddKeyValueRow(Strings.SpellDescription.Tick, TimeSpan.FromMilliseconds(mSpell.Combat.HotDotInterval).WithSuffix());
-            }
-
-            // Handle effect display.
-            if (mSpell.Combat.Effect != SpellEffect.None)
-            {
-                showDuration = true;
-                rows.AddKeyValueRow(string.Empty, string.Empty);
-                rows.AddKeyValueRow(Strings.SpellDescription.Effect, Strings.SpellDescription.Effects[(int)mSpell.Combat.Effect]);
-            }
-
-            // Show Stat Buff / Effect / HoT / DoT duration.
-            if (showDuration)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.Duration, TimeSpan.FromMilliseconds(mSpell.Combat.Duration).WithSuffix("0.#"));
-            }
+            // Display shop value.
+            rows.AddKeyValueRow(Strings.SpellDescription.Bound, string.Empty);
 
             // Resize and position the container.
             rows.SizeToChildren(true, true);
-        }
-
-        protected void SetupDashInfo()
-        {
-            // Add a divider.
-            AddDivider();
-
-            // Add a row component.
-            var rows = AddRowContainer();
-
-            // Dash Distance Information.
-            rows.AddKeyValueRow(Strings.SpellDescription.Distance, Strings.SpellDescription.Tiles.ToString(mSpell.Combat.CastRange));
-
-            // Ignore map blocks?
-            if (mSpell.Dash.IgnoreMapBlocks)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreMapBlock, String.Empty);
-            }
-
-            // Ignore resource blocks?
-            if (mSpell.Dash.IgnoreActiveResources)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreResourceBlock, String.Empty);
-            }
-
-            // Ignore inactive resource blocks?
-            if (mSpell.Dash.IgnoreInactiveResources)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreConsumedResourceBlock, String.Empty);
-            }
-
-            // Ignore Z-Dimension?
-            if (Options.Map.ZDimensionVisible && mSpell.Dash.IgnoreZDimensionAttributes)
-            {
-                rows.AddKeyValueRow(Strings.SpellDescription.IgnoreZDimension, String.Empty);
-            }
-
-            // Resize and position the container.
-            rows.SizeToChildren(true, true);
-        }
-
-        protected void SetupExtraInfo()
-        {
-            // Display only if this spell is bound.
-            if (mSpell.Bound)
-            {
-                // Add a divider.
-                AddDivider();
-
-                // Add a row component.
-                var rows = AddRowContainer();
-
-                // Display shop value.
-                rows.AddKeyValueRow(Strings.SpellDescription.Bound, string.Empty);
-
-                // Resize and position the container.
-                rows.SizeToChildren(true, true);
-            }
         }
     }
 }

--- a/Intersect.Client/Interface/Game/Draggable.cs
+++ b/Intersect.Client/Interface/Game/Draggable.cs
@@ -6,65 +6,63 @@ using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+partial class Draggable
 {
 
-    partial class Draggable
+    public static Draggable Active = null;
+
+    ImagePanel mPnl;
+
+    public Draggable(int x, int y, GameTexture tex, Color color)
     {
+        mPnl = new ImagePanel(Interface.GameUi.GameCanvas, "Draggable");
+        mPnl.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        mPnl.SetPosition(
+            InputHandler.MousePosition.X - mPnl.Width / 2, InputHandler.MousePosition.Y - mPnl.Height / 2
+        );
 
-        public static Draggable Active = null;
+        mPnl.Texture = tex;
+        mPnl.RenderColor = color;
+        Active = this;
+    }
 
-        ImagePanel mPnl;
+    public int X
+    {
+        get => mPnl.X;
+        set => mPnl.X = value;
+    }
 
-        public Draggable(int x, int y, GameTexture tex, Color color)
+    public int Y
+    {
+        get => mPnl.Y;
+        set => mPnl.Y = value;
+    }
+
+    public bool Update()
+    {
+        mPnl.SetPosition(
+            InputHandler.MousePosition.X - mPnl.Width / 2, InputHandler.MousePosition.Y - mPnl.Height / 2
+        );
+
+        if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            mPnl = new ImagePanel(Interface.GameUi.GameCanvas, "Draggable");
-            mPnl.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-            mPnl.SetPosition(
-                InputHandler.MousePosition.X - mPnl.Width / 2, InputHandler.MousePosition.Y - mPnl.Height / 2
-            );
-
-            mPnl.Texture = tex;
-            mPnl.RenderColor = color;
-            Active = this;
+            return true;
         }
 
-        public int X
+        return false;
+    }
+
+    public void Dispose()
+    {
+        if (Active == this)
         {
-            get => mPnl.X;
-            set => mPnl.X = value;
+            Active = null;
         }
 
-        public int Y
-        {
-            get => mPnl.Y;
-            set => mPnl.Y = value;
-        }
-
-        public bool Update()
-        {
-            mPnl.SetPosition(
-                InputHandler.MousePosition.X - mPnl.Width / 2, InputHandler.MousePosition.Y - mPnl.Height / 2
-            );
-
-            if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public void Dispose()
-        {
-            if (Active == this)
-            {
-                Active = null;
-            }
-
-            Interface.GameUi.GameCanvas.RemoveChild(mPnl, false);
-        }
-
+        Interface.GameUi.GameCanvas.RemoveChild(mPnl, false);
     }
 
 }

--- a/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/EntityBox.cs
@@ -14,1047 +14,1045 @@ using Intersect.GameObjects;
 using Intersect.Logging;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.EntityPanel
+namespace Intersect.Client.Interface.Game.EntityPanel;
+
+
+public partial class EntityBox
 {
+    public readonly Label EntityLevel;
 
-    public partial class EntityBox
+    public readonly Label EntityMap;
+
+    public readonly Label EntityName;
+
+    public readonly Label EntityNameAndLevel;
+
+    //Controls
+    public readonly ImagePanel EntityWindow;
+
+    public float CurExpSize = -1;
+
+    public float CurHpSize = -1;
+
+    public float CurMpSize = -1;
+
+    public float CurShieldSize = -1;
+
+    public ImagePanel EntityFace;
+
+    public ImagePanel EntityFaceContainer;
+
+    public ImagePanel EntityInfoPanel;
+
+    private ImagePanel EntityStatusWindow;
+
+    public ScrollControl EntityStatusPanel;
+
+    public EntityType EntityType;
+
+    public RichLabel EventDesc;
+
+    public ImagePanel ExpBackground;
+
+    public ImagePanel ExpBar;
+
+    public Label ExpLbl;
+
+    public Label ExpTitle;
+
+    //public Button FriendLabel;
+
+    public ImagePanel HpBackground;
+
+    public ImagePanel HpBar;
+
+    public Label HpLbl;
+
+    public Label HpTitle;
+
+    private Dictionary<Guid, SpellStatus> mActiveStatuses = new Dictionary<Guid, SpellStatus>();
+
+    private string mCurrentSprite = "";
+
+    private long mLastUpdateTime;
+
+    public ImagePanel MpBackground;
+
+    public ImagePanel MpBar;
+
+    public Label MpLbl;
+
+    public Label MpTitle;
+
+    public Entity MyEntity;
+
+    public ImagePanel[] PaperdollPanels;
+
+    public string[] PaperdollTextures;
+
+    private bool _isPlayerBox;
+
+    public ImagePanel ShieldBar;
+
+    public bool ShouldUpdateStatuses;
+
+    public bool IsHidden;
+
+    // Context menu
+    private Button _contextMenuButton;
+    
+    private Framework.Gwen.Control.Menu _contextMenu;
+
+    private MenuItem _tradeMenuItem;
+
+    private MenuItem _partyMenuItem;
+
+    private MenuItem _friendMenuItem;
+
+    private MenuItem _guildMenuItem;
+
+    //Init
+    public EntityBox(Canvas gameCanvas, EntityType entityType, Entity myEntity, bool isPlayerBox = false)
     {
-        public readonly Label EntityLevel;
+        MyEntity = myEntity;
+        EntityType = entityType;
+        _isPlayerBox = isPlayerBox;
+        EntityWindow =
+            _isPlayerBox ? new ImagePanel(gameCanvas, "PlayerBox") : new ImagePanel(gameCanvas, "TargetBox");
 
-        public readonly Label EntityMap;
+        EntityWindow.ShouldCacheToTexture = true;
 
-        public readonly Label EntityName;
+        EntityInfoPanel = new ImagePanel(EntityWindow, "EntityInfoPanel");
 
-        public readonly Label EntityNameAndLevel;
+        EntityName = new Label(EntityInfoPanel, "EntityNameLabel") { Text = myEntity?.Name };
+        EntityLevel = new Label(EntityInfoPanel, "EntityLevelLabel");
+        EntityNameAndLevel = new Label(EntityInfoPanel, "NameAndLevelLabel")
+        { IsHidden = true };
 
-        //Controls
-        public readonly ImagePanel EntityWindow;
+        EntityMap = new Label(EntityInfoPanel, "EntityMapLabel");
 
-        public float CurExpSize = -1;
-
-        public float CurHpSize = -1;
-
-        public float CurMpSize = -1;
-
-        public float CurShieldSize = -1;
-
-        public ImagePanel EntityFace;
-
-        public ImagePanel EntityFaceContainer;
-
-        public ImagePanel EntityInfoPanel;
-
-        private ImagePanel EntityStatusWindow;
-
-        public ScrollControl EntityStatusPanel;
-
-        public EntityType EntityType;
-
-        public RichLabel EventDesc;
-
-        public ImagePanel ExpBackground;
-
-        public ImagePanel ExpBar;
-
-        public Label ExpLbl;
-
-        public Label ExpTitle;
-
-        //public Button FriendLabel;
-
-        public ImagePanel HpBackground;
-
-        public ImagePanel HpBar;
-
-        public Label HpLbl;
-
-        public Label HpTitle;
-
-        private Dictionary<Guid, SpellStatus> mActiveStatuses = new Dictionary<Guid, SpellStatus>();
-
-        private string mCurrentSprite = "";
-
-        private long mLastUpdateTime;
-
-        public ImagePanel MpBackground;
-
-        public ImagePanel MpBar;
-
-        public Label MpLbl;
-
-        public Label MpTitle;
-
-        public Entity MyEntity;
-
-        public ImagePanel[] PaperdollPanels;
-
-        public string[] PaperdollTextures;
-
-        private bool _isPlayerBox;
-
-        public ImagePanel ShieldBar;
-
-        public bool ShouldUpdateStatuses;
-
-        public bool IsHidden;
-
-        // Context menu
-        private Button _contextMenuButton;
-        
-        private Framework.Gwen.Control.Menu _contextMenu;
-
-        private MenuItem _tradeMenuItem;
-
-        private MenuItem _partyMenuItem;
-
-        private MenuItem _friendMenuItem;
-
-        private MenuItem _guildMenuItem;
-
-        //Init
-        public EntityBox(Canvas gameCanvas, EntityType entityType, Entity myEntity, bool isPlayerBox = false)
+        PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count];
+        PaperdollTextures = new string[Options.EquipmentSlots.Count];
+        var i = 0;
+        for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
         {
-            MyEntity = myEntity;
-            EntityType = entityType;
-            _isPlayerBox = isPlayerBox;
-            EntityWindow =
-                _isPlayerBox ? new ImagePanel(gameCanvas, "PlayerBox") : new ImagePanel(gameCanvas, "TargetBox");
-
-            EntityWindow.ShouldCacheToTexture = true;
-
-            EntityInfoPanel = new ImagePanel(EntityWindow, "EntityInfoPanel");
-
-            EntityName = new Label(EntityInfoPanel, "EntityNameLabel") { Text = myEntity?.Name };
-            EntityLevel = new Label(EntityInfoPanel, "EntityLevelLabel");
-            EntityNameAndLevel = new Label(EntityInfoPanel, "NameAndLevelLabel")
-            { IsHidden = true };
-
-            EntityMap = new Label(EntityInfoPanel, "EntityMapLabel");
-
-            PaperdollPanels = new ImagePanel[Options.EquipmentSlots.Count];
-            PaperdollTextures = new string[Options.EquipmentSlots.Count];
-            var i = 0;
-            for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+            if (Options.PaperdollOrder[1][z] == "Player")
             {
-                if (Options.PaperdollOrder[1][z] == "Player")
-                {
-                    EntityFaceContainer = new ImagePanel(EntityInfoPanel, "EntityGraphicContainer");
+                EntityFaceContainer = new ImagePanel(EntityInfoPanel, "EntityGraphicContainer");
 
-                    EntityFace = new ImagePanel(EntityFaceContainer);
-                    EntityFace.SetSize(64, 64);
-                    EntityFace.AddAlignment(Alignments.Center);
-                }
-                else
-                {
-                    PaperdollPanels[i] = new ImagePanel(EntityFaceContainer);
-                    PaperdollTextures[i] = "";
-                    PaperdollPanels[i].Hide();
-                    i++;
-                }
+                EntityFace = new ImagePanel(EntityFaceContainer);
+                EntityFace.SetSize(64, 64);
+                EntityFace.AddAlignment(Alignments.Center);
             }
-
-            if (!_isPlayerBox)
+            else
             {
-                EventDesc = new RichLabel(EntityInfoPanel, "EventDescLabel");
-            }
-
-            HpBackground = new ImagePanel(EntityInfoPanel, "HPBarBackground");
-            HpBar = new ImagePanel(EntityInfoPanel, "HPBar");
-            ShieldBar = new ImagePanel(EntityInfoPanel, "ShieldBar");
-            HpTitle = new Label(EntityInfoPanel, "HPTitle");
-            HpTitle.SetText(Strings.EntityBox.Vital0);
-            HpLbl = new Label(EntityInfoPanel, "HPLabel");
-
-            MpBackground = new ImagePanel(EntityInfoPanel, "MPBackground");
-            MpBar = new ImagePanel(EntityInfoPanel, "MPBar");
-            MpTitle = new Label(EntityInfoPanel, "MPTitle");
-            MpTitle.SetText(Strings.EntityBox.Vital1);
-            MpLbl = new Label(EntityInfoPanel, "MPLabel");
-
-            ExpBackground = new ImagePanel(EntityInfoPanel, "EXPBackground");
-            ExpBar = new ImagePanel(EntityInfoPanel, "EXPBar");
-            ExpTitle = new Label(EntityInfoPanel, "EXPTitle");
-            ExpTitle.SetText(Strings.EntityBox.Exp);
-            ExpLbl = new Label(EntityInfoPanel, "EXPLabel");
-
-            // Target context menu with basic options.
-            if (!_isPlayerBox)
-            {
-                _contextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "TargetContextMenu")
-                {
-                    IsHidden = true,
-                    IconMarginDisabled = true
-                };
-
-                _contextMenu.Children.Clear();
-
-                _tradeMenuItem = _contextMenu.AddItem(Strings.EntityBox.Trade);
-                _tradeMenuItem.Clicked += tradeRequest_Clicked;
-
-                _partyMenuItem = _contextMenu.AddItem(Strings.EntityBox.Party);
-                _partyMenuItem.Clicked += invite_Clicked;
-
-                _friendMenuItem = _contextMenu.AddItem(Strings.EntityBox.Friend);
-                _friendMenuItem.Clicked += friendRequest_Clicked;
-
-                _guildMenuItem = _contextMenu.AddItem(Strings.Guilds.Guild);
-                _guildMenuItem.Clicked += guildRequest_Clicked;
-
-                _contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                _contextMenuButton = new Button(EntityInfoPanel, "ContextMenuButton");
-                _contextMenuButton.Clicked += (sender, e) =>
-                {
-                    _contextMenu.SizeToChildren();
-                    _contextMenu.Open(Pos.None);
-                    _contextMenu.SetPosition(_contextMenuButton.LocalPosToCanvas(new Point(0, 0)).X,
-                    _contextMenuButton.LocalPosToCanvas(new Point(0, 0)).Y + _contextMenuButton.Height);
-                };
-
-                EntityStatusWindow = new ImagePanel(EntityWindow, "EntityStatusWindow");
-                EntityStatusPanel = new ScrollControl(EntityStatusWindow, "StatusArea");
-            }
-
-            EntityWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            SetEntity(myEntity);
-
-            i = 0;
-            for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
-            {
-                if (Options.PaperdollOrder[1][z] == "Player")
-                {
-                    EntityFace.RenderColor = EntityFaceContainer.RenderColor;
-                }
-                else
-                {
-                    PaperdollPanels[i].RenderColor = EntityFaceContainer.RenderColor;
-                    i++;
-                }
-            }
-
-            EntityWindow.Hide();
-
-            mLastUpdateTime = Timing.Global.MillisecondsUtc;
-        }
-
-        public void SetEntity(Entity entity)
-        {
-            MyEntity = entity;
-            if (MyEntity != null)
-            {
-                SetupEntityElements();
-                ShouldUpdateStatuses = !_isPlayerBox;
-
-                if (EntityType == EntityType.Event)
-                {
-                    EventDesc.ClearText();
-                    EventDesc.AddText(((Event)MyEntity).Desc, Color.White);
-                    EventDesc.SizeToChildren(false, true);
-                }
+                PaperdollPanels[i] = new ImagePanel(EntityFaceContainer);
+                PaperdollTextures[i] = "";
+                PaperdollPanels[i].Hide();
+                i++;
             }
         }
 
-        public void SetEntity(Entity entity, EntityType type)
+        if (!_isPlayerBox)
         {
-            MyEntity = entity;
-            EntityType = type;
-            if (MyEntity != null)
+            EventDesc = new RichLabel(EntityInfoPanel, "EventDescLabel");
+        }
+
+        HpBackground = new ImagePanel(EntityInfoPanel, "HPBarBackground");
+        HpBar = new ImagePanel(EntityInfoPanel, "HPBar");
+        ShieldBar = new ImagePanel(EntityInfoPanel, "ShieldBar");
+        HpTitle = new Label(EntityInfoPanel, "HPTitle");
+        HpTitle.SetText(Strings.EntityBox.Vital0);
+        HpLbl = new Label(EntityInfoPanel, "HPLabel");
+
+        MpBackground = new ImagePanel(EntityInfoPanel, "MPBackground");
+        MpBar = new ImagePanel(EntityInfoPanel, "MPBar");
+        MpTitle = new Label(EntityInfoPanel, "MPTitle");
+        MpTitle.SetText(Strings.EntityBox.Vital1);
+        MpLbl = new Label(EntityInfoPanel, "MPLabel");
+
+        ExpBackground = new ImagePanel(EntityInfoPanel, "EXPBackground");
+        ExpBar = new ImagePanel(EntityInfoPanel, "EXPBar");
+        ExpTitle = new Label(EntityInfoPanel, "EXPTitle");
+        ExpTitle.SetText(Strings.EntityBox.Exp);
+        ExpLbl = new Label(EntityInfoPanel, "EXPLabel");
+
+        // Target context menu with basic options.
+        if (!_isPlayerBox)
+        {
+            _contextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "TargetContextMenu")
             {
-                SetupEntityElements();
-                ShouldUpdateStatuses = !_isPlayerBox;
-                
-                if (EntityType == EntityType.Event)
+                IsHidden = true,
+                IconMarginDisabled = true
+            };
+
+            _contextMenu.Children.Clear();
+
+            _tradeMenuItem = _contextMenu.AddItem(Strings.EntityBox.Trade);
+            _tradeMenuItem.Clicked += tradeRequest_Clicked;
+
+            _partyMenuItem = _contextMenu.AddItem(Strings.EntityBox.Party);
+            _partyMenuItem.Clicked += invite_Clicked;
+
+            _friendMenuItem = _contextMenu.AddItem(Strings.EntityBox.Friend);
+            _friendMenuItem.Clicked += friendRequest_Clicked;
+
+            _guildMenuItem = _contextMenu.AddItem(Strings.Guilds.Guild);
+            _guildMenuItem.Clicked += guildRequest_Clicked;
+
+            _contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            _contextMenuButton = new Button(EntityInfoPanel, "ContextMenuButton");
+            _contextMenuButton.Clicked += (sender, e) =>
+            {
+                _contextMenu.SizeToChildren();
+                _contextMenu.Open(Pos.None);
+                _contextMenu.SetPosition(_contextMenuButton.LocalPosToCanvas(new Point(0, 0)).X,
+                _contextMenuButton.LocalPosToCanvas(new Point(0, 0)).Y + _contextMenuButton.Height);
+            };
+
+            EntityStatusWindow = new ImagePanel(EntityWindow, "EntityStatusWindow");
+            EntityStatusPanel = new ScrollControl(EntityStatusWindow, "StatusArea");
+        }
+
+        EntityWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        SetEntity(myEntity);
+
+        i = 0;
+        for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+        {
+            if (Options.PaperdollOrder[1][z] == "Player")
+            {
+                EntityFace.RenderColor = EntityFaceContainer.RenderColor;
+            }
+            else
+            {
+                PaperdollPanels[i].RenderColor = EntityFaceContainer.RenderColor;
+                i++;
+            }
+        }
+
+        EntityWindow.Hide();
+
+        mLastUpdateTime = Timing.Global.MillisecondsUtc;
+    }
+
+    public void SetEntity(Entity entity)
+    {
+        MyEntity = entity;
+        if (MyEntity != null)
+        {
+            SetupEntityElements();
+            ShouldUpdateStatuses = !_isPlayerBox;
+
+            if (EntityType == EntityType.Event)
+            {
+                EventDesc.ClearText();
+                EventDesc.AddText(((Event)MyEntity).Desc, Color.White);
+                EventDesc.SizeToChildren(false, true);
+            }
+        }
+    }
+
+    public void SetEntity(Entity entity, EntityType type)
+    {
+        MyEntity = entity;
+        EntityType = type;
+        if (MyEntity != null)
+        {
+            SetupEntityElements();
+            ShouldUpdateStatuses = !_isPlayerBox;
+            
+            if (EntityType == EntityType.Event)
+            {
+                EventDesc.ClearText();
+                EventDesc.AddText(((Event)MyEntity).Desc, Color.White);
+                EventDesc.SizeToChildren(false, true);
+            }
+        }
+    }
+
+    public void ShowAllElements()
+    {
+        ExpBackground.Show();
+        ExpBar.Show();
+        ExpLbl.Show();
+        ExpTitle.Show();
+        EntityMap.Show();
+
+        if (!_isPlayerBox)
+        {
+            TryShowGuildButton();
+            _contextMenuButton.Show();
+            EventDesc.Show();
+        }
+
+        MpBackground.Show();
+        MpBar.Show();
+        MpTitle.Show();
+        MpLbl.Show();
+        HpBackground.Show();
+        HpBar.Show();
+        HpLbl.Show();
+        HpTitle.Show();
+    }
+
+    public void SetupEntityElements()
+    {
+        ShowAllElements();
+
+        //Update Bars
+        CurHpSize = -1;
+        CurShieldSize = -1;
+        CurMpSize = -1;
+        CurExpSize = -1;
+        ShieldBar.Hide();
+        UpdateHpBar(0, true);
+        UpdateMpBar(0, true);
+        if (MyEntity is Player)
+        {
+            UpdateXpBar(0, true);
+        }
+
+        switch (EntityType)
+        {
+            case EntityType.Player:
+                if (Globals.Me != null && Globals.Me == MyEntity)
                 {
-                    EventDesc.ClearText();
-                    EventDesc.AddText(((Event)MyEntity).Desc, Color.White);
-                    EventDesc.SizeToChildren(false, true);
-                }
-            }
-        }
-
-        public void ShowAllElements()
-        {
-            ExpBackground.Show();
-            ExpBar.Show();
-            ExpLbl.Show();
-            ExpTitle.Show();
-            EntityMap.Show();
-
-            if (!_isPlayerBox)
-            {
-                TryShowGuildButton();
-                _contextMenuButton.Show();
-                EventDesc.Show();
-            }
-
-            MpBackground.Show();
-            MpBar.Show();
-            MpTitle.Show();
-            MpLbl.Show();
-            HpBackground.Show();
-            HpBar.Show();
-            HpLbl.Show();
-            HpTitle.Show();
-        }
-
-        public void SetupEntityElements()
-        {
-            ShowAllElements();
-
-            //Update Bars
-            CurHpSize = -1;
-            CurShieldSize = -1;
-            CurMpSize = -1;
-            CurExpSize = -1;
-            ShieldBar.Hide();
-            UpdateHpBar(0, true);
-            UpdateMpBar(0, true);
-            if (MyEntity is Player)
-            {
-                UpdateXpBar(0, true);
-            }
-
-            switch (EntityType)
-            {
-                case EntityType.Player:
-                    if (Globals.Me != null && Globals.Me == MyEntity)
+                    if (!_isPlayerBox)
                     {
-                        if (!_isPlayerBox)
-                        {
-                            _contextMenuButton.Hide();
-                            ExpBackground.Hide();
-                            ExpBar.Hide();
-                            ExpLbl.Hide();
-                            ExpTitle.Hide();
-                            EntityMap.Hide();
-                        }
-                    }
-                    else
-                    {
+                        _contextMenuButton.Hide();
                         ExpBackground.Hide();
                         ExpBar.Hide();
                         ExpLbl.Hide();
                         ExpTitle.Hide();
                         EntityMap.Hide();
                     }
-
-                    EventDesc?.Hide();
-                    EntityLevel.Show();
-
-                    break;
-                case EntityType.GlobalEntity:
-                    EventDesc.Hide();
+                }
+                else
+                {
                     ExpBackground.Hide();
                     ExpBar.Hide();
                     ExpLbl.Hide();
                     ExpTitle.Hide();
-                    _contextMenuButton.Hide();
                     EntityMap.Hide();
-                    EntityLevel.Show();
+                }
 
-                    break;
-                case EntityType.Event:
-                    EventDesc.Show();
-                    EntityLevel.Hide();
-                    ExpBackground.Hide();
-                    ExpBar.Hide();
-                    ExpLbl.Hide();
-                    ExpTitle.Hide();
-                    MpBackground.Hide();
-                    MpBar.Hide();
-                    MpTitle.Hide();
-                    MpLbl.Hide();
-                    HpBackground.Hide();
-                    HpBar.Hide();
-                    HpLbl.Hide();
-                    HpTitle.Hide();
-                    _contextMenuButton.Hide();
-                    EntityMap.Hide();
+                EventDesc?.Hide();
+                EntityLevel.Show();
 
-                    break;
+                break;
+            case EntityType.GlobalEntity:
+                EventDesc.Hide();
+                ExpBackground.Hide();
+                ExpBar.Hide();
+                ExpLbl.Hide();
+                ExpTitle.Hide();
+                _contextMenuButton.Hide();
+                EntityMap.Hide();
+                EntityLevel.Show();
+
+                break;
+            case EntityType.Event:
+                EventDesc.Show();
+                EntityLevel.Hide();
+                ExpBackground.Hide();
+                ExpBar.Hide();
+                ExpLbl.Hide();
+                ExpTitle.Hide();
+                MpBackground.Hide();
+                MpBar.Hide();
+                MpTitle.Hide();
+                MpLbl.Hide();
+                HpBackground.Hide();
+                HpBar.Hide();
+                HpLbl.Hide();
+                HpTitle.Hide();
+                _contextMenuButton.Hide();
+                EntityMap.Hide();
+
+                break;
+        }
+
+        EntityName.SetText(MyEntity.Name);
+    }
+
+    //Update
+    public void Update()
+    {
+        if (MyEntity == null || MyEntity.IsDisposed())
+        {
+            if (!EntityWindow.IsHidden)
+            {
+                EntityWindow.Hide();
             }
 
+            return;
+        }
+        else
+        {
+            if (EntityWindow.IsHidden)
+            {
+                Show();
+            }
+        }
+
+        if (_isPlayerBox)
+        {
+            if (EntityWindow.IsHidden)
+            {
+                Show();
+            }
+
+            if (MyEntity.IsDisposed())
+            {
+                Dispose();
+            }
+        }
+
+        //Time since this window was last updated (for bar animations)
+        var elapsedTime = (Timing.Global.MillisecondsUtc - mLastUpdateTime) / 1000.0f;
+
+        //Update the event/entity face.
+        UpdateImage();
+
+        IsHidden = true;
+        if (EntityType != EntityType.Event)
+        {
             EntityName.SetText(MyEntity.Name);
+            UpdateLevel();
+            UpdateMap();
+            UpdateHpBar(elapsedTime);
+            UpdateMpBar(elapsedTime);
+            IsHidden = false;
         }
-
-        //Update
-        public void Update()
+        else
         {
-            if (MyEntity == null || MyEntity.IsDisposed())
-            {
-                if (!EntityWindow.IsHidden)
-                {
-                    EntityWindow.Hide();
-                }
-
-                return;
-            }
-            else
-            {
-                if (EntityWindow.IsHidden)
-                {
-                    Show();
-                }
-            }
-
-            if (_isPlayerBox)
-            {
-                if (EntityWindow.IsHidden)
-                {
-                    Show();
-                }
-
-                if (MyEntity.IsDisposed())
-                {
-                    Dispose();
-                }
-            }
-
-            //Time since this window was last updated (for bar animations)
-            var elapsedTime = (Timing.Global.MillisecondsUtc - mLastUpdateTime) / 1000.0f;
-
-            //Update the event/entity face.
-            UpdateImage();
-
-            IsHidden = true;
-            if (EntityType != EntityType.Event)
-            {
-                EntityName.SetText(MyEntity.Name);
-                UpdateLevel();
-                UpdateMap();
-                UpdateHpBar(elapsedTime);
-                UpdateMpBar(elapsedTime);
-                IsHidden = false;
-            }
-            else
-            {
-                if (!EntityNameAndLevel.IsHidden)
-                {
-                    EntityNameAndLevel.Text = MyEntity.Name;
-                }
-            }
-
-            //If player draw exp bar
-            if (_isPlayerBox && MyEntity == Globals.Me)
-            {
-                UpdateXpBar(elapsedTime);
-            }
-
-            if (MyEntity.Type == EntityType.Player && MyEntity != Globals.Me)
-            {
-                if (MyEntity.Vital[(int)Vital.Health] <= 0)
-                {
-                    _contextMenuButton.Hide();
-                }
-                else if (_contextMenuButton.IsHidden && !_isPlayerBox)
-                {
-                    TryShowGuildButton();
-                    _contextMenuButton.Show();
-                }
-            }
-
-            ShouldUpdateStatuses = !_isPlayerBox;
-            if (ShouldUpdateStatuses)
-            {
-                SpellStatus.UpdateSpellStatus(MyEntity, EntityStatusPanel, mActiveStatuses);
-                EntityStatusWindow.IsHidden = mActiveStatuses.Count < 1;
-
-                foreach (var itm in mActiveStatuses)
-                {
-                    itm.Value.Update();
-                }
-
-                ShouldUpdateStatuses = false;
-            }
-
-            mLastUpdateTime = Timing.Global.MillisecondsUtc;
-        }
-
-        private void UpdateLevel()
-        {
-            var levelString = Strings.EntityBox.Level.ToString(MyEntity.Level);
-            if (!EntityLevel.IsHidden)
-            {
-                EntityLevel.Text = levelString;
-            }
-
             if (!EntityNameAndLevel.IsHidden)
             {
-                EntityNameAndLevel.Text = Strings.EntityBox.NameAndLevel.ToString(MyEntity.Name, levelString);
+                EntityNameAndLevel.Text = MyEntity.Name;
             }
         }
 
-        private void UpdateMap()
+        //If player draw exp bar
+        if (_isPlayerBox && MyEntity == Globals.Me)
         {
-            if (Globals.Me.MapInstance != null)
+            UpdateXpBar(elapsedTime);
+        }
+
+        if (MyEntity.Type == EntityType.Player && MyEntity != Globals.Me)
+        {
+            if (MyEntity.Vital[(int)Vital.Health] <= 0)
             {
-                EntityMap.SetText(Strings.EntityBox.Map.ToString(Globals.Me.MapInstance.Name));
+                _contextMenuButton.Hide();
             }
-            else
+            else if (_contextMenuButton.IsHidden && !_isPlayerBox)
             {
-                EntityMap.SetText(Strings.EntityBox.Map.ToString(""));
+                TryShowGuildButton();
+                _contextMenuButton.Show();
             }
         }
 
-        private static float SetTargetBarSize(float barRatio, int barSize)
+        ShouldUpdateStatuses = !_isPlayerBox;
+        if (ShouldUpdateStatuses)
         {
-            var barFillRatio = Math.Min(1, Math.Max(0, barRatio));
+            SpellStatus.UpdateSpellStatus(MyEntity, EntityStatusPanel, mActiveStatuses);
+            EntityStatusWindow.IsHidden = mActiveStatuses.Count < 1;
 
-            return (float)Math.Ceiling((barFillRatio * barSize));
+            foreach (var itm in mActiveStatuses)
+            {
+                itm.Value.Update();
+            }
+
+            ShouldUpdateStatuses = false;
         }
 
-        private static float SetCurrentBarSize(float elapsedTime, bool instant, float targetSize, float currentSize)
+        mLastUpdateTime = Timing.Global.MillisecondsUtc;
+    }
+
+    private void UpdateLevel()
+    {
+        var levelString = Strings.EntityBox.Level.ToString(MyEntity.Level);
+        if (!EntityLevel.IsHidden)
         {
-            if (instant)
-            {
-                return (int)targetSize;
-            }
-
-            if ((int)targetSize > currentSize)
-            {
-                currentSize += 100f * elapsedTime;
-                if (currentSize > (int)targetSize)
-                {
-                    currentSize = targetSize;
-                }
-            }
-            else
-            {
-                currentSize -= 100f * elapsedTime;
-                if (currentSize < targetSize)
-                {
-                    currentSize = targetSize;
-                }
-            }
-
-            return currentSize;
+            EntityLevel.Text = levelString;
         }
 
-        private static void UpdateGauge(
-            Base backgroundBar,
-            ImagePanel foregroundBar,
-            float currentBarSize,
-            DisplayDirection direction,
-            bool isShield = false
-        )
+        if (!EntityNameAndLevel.IsHidden)
         {
-            //If this method is called to update the shield, we need to invert the directions
-            if (isShield)
+            EntityNameAndLevel.Text = Strings.EntityBox.NameAndLevel.ToString(MyEntity.Name, levelString);
+        }
+    }
+
+    private void UpdateMap()
+    {
+        if (Globals.Me.MapInstance != null)
+        {
+            EntityMap.SetText(Strings.EntityBox.Map.ToString(Globals.Me.MapInstance.Name));
+        }
+        else
+        {
+            EntityMap.SetText(Strings.EntityBox.Map.ToString(""));
+        }
+    }
+
+    private static float SetTargetBarSize(float barRatio, int barSize)
+    {
+        var barFillRatio = Math.Min(1, Math.Max(0, barRatio));
+
+        return (float)Math.Ceiling((barFillRatio * barSize));
+    }
+
+    private static float SetCurrentBarSize(float elapsedTime, bool instant, float targetSize, float currentSize)
+    {
+        if (instant)
+        {
+            return (int)targetSize;
+        }
+
+        if ((int)targetSize > currentSize)
+        {
+            currentSize += 100f * elapsedTime;
+            if (currentSize > (int)targetSize)
             {
-                switch (direction)
-                {
-                    case DisplayDirection.StartToEnd:
-                        direction = DisplayDirection.EndToStart;
-                        foregroundBar.X = backgroundBar.X;
-                        break;
-
-                    case DisplayDirection.EndToStart:
-                        direction = DisplayDirection.StartToEnd;
-                        foregroundBar.X = backgroundBar.X;
-                        break;
-
-                    case DisplayDirection.TopToBottom:
-                        direction = DisplayDirection.BottomToTop;
-                        foregroundBar.X = backgroundBar.X;
-                        break;
-
-                    case DisplayDirection.BottomToTop:
-                        direction = DisplayDirection.TopToBottom;
-                        foregroundBar.X = backgroundBar.X;
-                        break;
-                }
+                currentSize = targetSize;
             }
+        }
+        else
+        {
+            currentSize -= 100f * elapsedTime;
+            if (currentSize < targetSize)
+            {
+                currentSize = targetSize;
+            }
+        }
 
-            var backgroundWidthFactor = backgroundBar.Width - (int)currentBarSize;
-            var backgroundHeightFactor = backgroundBar.Height - (int)currentBarSize;
+        return currentSize;
+    }
 
+    private static void UpdateGauge(
+        Base backgroundBar,
+        ImagePanel foregroundBar,
+        float currentBarSize,
+        DisplayDirection direction,
+        bool isShield = false
+    )
+    {
+        //If this method is called to update the shield, we need to invert the directions
+        if (isShield)
+        {
             switch (direction)
             {
                 case DisplayDirection.StartToEnd:
-                    foregroundBar.SetBounds(
-                        foregroundBar.X,
-                        foregroundBar.Y,
-                        (int)currentBarSize,
-                        foregroundBar.Height
-                    );
-                    foregroundBar.SetTextureRect(
-                        0, 0, (int)currentBarSize, foregroundBar.Height
-                    );
+                    direction = DisplayDirection.EndToStart;
+                    foregroundBar.X = backgroundBar.X;
                     break;
 
                 case DisplayDirection.EndToStart:
-                    foregroundBar.SetBounds(
-                        backgroundBar.X + backgroundWidthFactor,
-                        foregroundBar.Y,
-                        (int)currentBarSize,
-                        foregroundBar.Height
-                    );
-                    foregroundBar.SetTextureRect(
-                        backgroundWidthFactor, 0, (int)currentBarSize, foregroundBar.Height
-                    );
+                    direction = DisplayDirection.StartToEnd;
+                    foregroundBar.X = backgroundBar.X;
                     break;
 
                 case DisplayDirection.TopToBottom:
-                    foregroundBar.SetBounds(
-                        foregroundBar.X,
-                        foregroundBar.Y,
-                        foregroundBar.Width,
-                        (int)currentBarSize
-                    );
-                    foregroundBar.SetTextureRect(
-                        0, 0, foregroundBar.Width, (int)currentBarSize
-                    );
+                    direction = DisplayDirection.BottomToTop;
+                    foregroundBar.X = backgroundBar.X;
                     break;
 
                 case DisplayDirection.BottomToTop:
-                    foregroundBar.SetBounds(
-                        foregroundBar.X,
-                        backgroundBar.Y + backgroundHeightFactor,
-                        foregroundBar.Width,
-                        (int)currentBarSize
-                    );
-                    foregroundBar.SetTextureRect(
-                        0, backgroundHeightFactor, foregroundBar.Width, (int)currentBarSize
-                    );
+                    direction = DisplayDirection.TopToBottom;
+                    foregroundBar.X = backgroundBar.X;
                     break;
             }
-
-            foregroundBar.IsHidden = false;
         }
 
-        private void UpdateHpBar(float elapsedTime, bool instant = false)
+        var backgroundWidthFactor = backgroundBar.Width - (int)currentBarSize;
+        var backgroundHeightFactor = backgroundBar.Height - (int)currentBarSize;
+
+        switch (direction)
         {
-            float targetHpSize;
-            float targetShieldSize;
-            var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Health];
-            var barPercentageSetting = Globals.Database.ShowHealthAsPercentage;
-            var entityVital = MyEntity.Vital[(int)Vital.Health];
-            var entityMaxVital = MyEntity.MaxVital[(int)Vital.Health];
+            case DisplayDirection.StartToEnd:
+                foregroundBar.SetBounds(
+                    foregroundBar.X,
+                    foregroundBar.Y,
+                    (int)currentBarSize,
+                    foregroundBar.Height
+                );
+                foregroundBar.SetTextureRect(
+                    0, 0, (int)currentBarSize, foregroundBar.Height
+                );
+                break;
 
-            if (entityVital > 0)
+            case DisplayDirection.EndToStart:
+                foregroundBar.SetBounds(
+                    backgroundBar.X + backgroundWidthFactor,
+                    foregroundBar.Y,
+                    (int)currentBarSize,
+                    foregroundBar.Height
+                );
+                foregroundBar.SetTextureRect(
+                    backgroundWidthFactor, 0, (int)currentBarSize, foregroundBar.Height
+                );
+                break;
+
+            case DisplayDirection.TopToBottom:
+                foregroundBar.SetBounds(
+                    foregroundBar.X,
+                    foregroundBar.Y,
+                    foregroundBar.Width,
+                    (int)currentBarSize
+                );
+                foregroundBar.SetTextureRect(
+                    0, 0, foregroundBar.Width, (int)currentBarSize
+                );
+                break;
+
+            case DisplayDirection.BottomToTop:
+                foregroundBar.SetBounds(
+                    foregroundBar.X,
+                    backgroundBar.Y + backgroundHeightFactor,
+                    foregroundBar.Width,
+                    (int)currentBarSize
+                );
+                foregroundBar.SetTextureRect(
+                    0, backgroundHeightFactor, foregroundBar.Width, (int)currentBarSize
+                );
+                break;
+        }
+
+        foregroundBar.IsHidden = false;
+    }
+
+    private void UpdateHpBar(float elapsedTime, bool instant = false)
+    {
+        float targetHpSize;
+        float targetShieldSize;
+        var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Health];
+        var barPercentageSetting = Globals.Database.ShowHealthAsPercentage;
+        var entityVital = MyEntity.Vital[(int)Vital.Health];
+        var entityMaxVital = MyEntity.MaxVital[(int)Vital.Health];
+
+        if (entityVital > 0)
+        {
+            
+            var shieldSize = MyEntity.GetShieldSize();
+            var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
+                ? HpBackground.Width
+                : HpBackground.Height;
+
+            //We have to get the maxVital value before being changed by the shield
+            //Shield changes vitalMax only on client, showing incorrect values
+            if (shieldSize + entityVital > entityMaxVital)
             {
-                
-                var shieldSize = MyEntity.GetShieldSize();
-                var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
-                    ? HpBackground.Width
-                    : HpBackground.Height;
+                entityMaxVital = shieldSize + entityVital;
+            }
 
-                //We have to get the maxVital value before being changed by the shield
-                //Shield changes vitalMax only on client, showing incorrect values
-                if (shieldSize + entityVital > entityMaxVital)
-                {
-                    entityMaxVital = shieldSize + entityVital;
-                }
+            var entityVitalRatio = (float)entityVital / entityMaxVital;
+            var entityShieldRatio = (float)shieldSize / entityMaxVital;
+            var hpPercentage = entityVitalRatio * 100;
+            var hpPercentageText = $"{hpPercentage:0.##}%";
+            var hpValueText = Strings.EntityBox.Vital0Value.ToString(entityVital, entityMaxVital);
+            HpLbl.Text = barPercentageSetting ? hpPercentageText : hpValueText;
+            HpBackground.SetToolTipText(barPercentageSetting ? hpValueText : hpPercentageText);
+            targetHpSize = SetTargetBarSize(entityVitalRatio, vitalSize);
+            targetShieldSize = SetTargetBarSize(entityShieldRatio, vitalSize);
+        }
+        else
+        {
+            HpLbl.Text = barPercentageSetting ? "0%" : Strings.EntityBox.Vital0Value.ToString(0, entityMaxVital);
+            HpBackground.SetToolTipText(barPercentageSetting ? Strings.EntityBox.Vital0Value.ToString(0, entityMaxVital) : "0%");
+            targetHpSize = 0;
+            targetShieldSize = 0;
+        }
 
-                var entityVitalRatio = (float)entityVital / entityMaxVital;
-                var entityShieldRatio = (float)shieldSize / entityMaxVital;
-                var hpPercentage = entityVitalRatio * 100;
-                var hpPercentageText = $"{hpPercentage:0.##}%";
-                var hpValueText = Strings.EntityBox.Vital0Value.ToString(entityVital, entityMaxVital);
-                HpLbl.Text = barPercentageSetting ? hpPercentageText : hpValueText;
-                HpBackground.SetToolTipText(barPercentageSetting ? hpValueText : hpPercentageText);
-                targetHpSize = SetTargetBarSize(entityVitalRatio, vitalSize);
-                targetShieldSize = SetTargetBarSize(entityShieldRatio, vitalSize);
+        if ((int)targetHpSize != (int)CurHpSize)
+        {
+            CurHpSize = SetCurrentBarSize(elapsedTime, instant, targetHpSize, CurHpSize);
+
+            if (CurHpSize == 0)
+            {
+                HpBar.IsHidden = true;
             }
             else
             {
-                HpLbl.Text = barPercentageSetting ? "0%" : Strings.EntityBox.Vital0Value.ToString(0, entityMaxVital);
-                HpBackground.SetToolTipText(barPercentageSetting ? Strings.EntityBox.Vital0Value.ToString(0, entityMaxVital) : "0%");
-                targetHpSize = 0;
-                targetShieldSize = 0;
-            }
-
-            if ((int)targetHpSize != (int)CurHpSize)
-            {
-                CurHpSize = SetCurrentBarSize(elapsedTime, instant, targetHpSize, CurHpSize);
-
-                if (CurHpSize == 0)
-                {
-                    HpBar.IsHidden = true;
-                }
-                else
-                {
-                    UpdateGauge(HpBackground, HpBar, CurHpSize, barDirectionSetting);
-                }
-            }
-
-            if ((int)targetShieldSize != (int)CurShieldSize)
-            {
-                CurShieldSize = SetCurrentBarSize(elapsedTime, instant, targetShieldSize, CurShieldSize);
-
-                if (CurShieldSize == 0)
-                {
-                    ShieldBar.IsHidden = true;
-                }
-                else
-                {
-                    UpdateGauge(HpBackground, ShieldBar, CurShieldSize, barDirectionSetting, true);
-                }
+                UpdateGauge(HpBackground, HpBar, CurHpSize, barDirectionSetting);
             }
         }
 
-        private void UpdateMpBar(float elapsedTime, bool instant = false)
+        if ((int)targetShieldSize != (int)CurShieldSize)
         {
-            float targetMpSize;
-            var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Mana];
-            var barPercentageSetting = Globals.Database.ShowManaAsPercentage;
-            var entityVital = MyEntity.Vital[(int)Vital.Mana];
-            var entityMaxVital = MyEntity.MaxVital[(int)Vital.Mana];
+            CurShieldSize = SetCurrentBarSize(elapsedTime, instant, targetShieldSize, CurShieldSize);
 
-            if (entityVital > 0)
+            if (CurShieldSize == 0)
             {
-                
-                var entityVitalRatio = (float)entityVital / entityMaxVital;
-                var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
-                    ? MpBackground.Width
-                    : MpBackground.Height;
-                float mpPercentage = entityVitalRatio * 100;
-                var mpPercentageText = $"{mpPercentage:0.##}%";
-                var mpValueText = Strings.EntityBox.Vital1Value.ToString(entityVital, entityMaxVital);
-                MpLbl.Text = barPercentageSetting ? mpPercentageText : mpValueText;
-                MpBackground.SetToolTipText(barPercentageSetting ? mpValueText : mpPercentageText);
-                targetMpSize = SetTargetBarSize(entityVitalRatio, vitalSize);
+                ShieldBar.IsHidden = true;
             }
             else
             {
-                MpLbl.Text = barPercentageSetting ? "0%" : Strings.EntityBox.Vital1Value.ToString(0, entityMaxVital);
-                MpBackground.SetToolTipText(barPercentageSetting ? Strings.EntityBox.Vital1Value.ToString(0, entityMaxVital) : "0%");
-                targetMpSize = 0;
+                UpdateGauge(HpBackground, ShieldBar, CurShieldSize, barDirectionSetting, true);
             }
+        }
+    }
 
-            if ((int)targetMpSize != (int)CurMpSize)
+    private void UpdateMpBar(float elapsedTime, bool instant = false)
+    {
+        float targetMpSize;
+        var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[(int)Vital.Mana];
+        var barPercentageSetting = Globals.Database.ShowManaAsPercentage;
+        var entityVital = MyEntity.Vital[(int)Vital.Mana];
+        var entityMaxVital = MyEntity.MaxVital[(int)Vital.Mana];
+
+        if (entityVital > 0)
+        {
+            
+            var entityVitalRatio = (float)entityVital / entityMaxVital;
+            var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
+                ? MpBackground.Width
+                : MpBackground.Height;
+            float mpPercentage = entityVitalRatio * 100;
+            var mpPercentageText = $"{mpPercentage:0.##}%";
+            var mpValueText = Strings.EntityBox.Vital1Value.ToString(entityVital, entityMaxVital);
+            MpLbl.Text = barPercentageSetting ? mpPercentageText : mpValueText;
+            MpBackground.SetToolTipText(barPercentageSetting ? mpValueText : mpPercentageText);
+            targetMpSize = SetTargetBarSize(entityVitalRatio, vitalSize);
+        }
+        else
+        {
+            MpLbl.Text = barPercentageSetting ? "0%" : Strings.EntityBox.Vital1Value.ToString(0, entityMaxVital);
+            MpBackground.SetToolTipText(barPercentageSetting ? Strings.EntityBox.Vital1Value.ToString(0, entityMaxVital) : "0%");
+            targetMpSize = 0;
+        }
+
+        if ((int)targetMpSize != (int)CurMpSize)
+        {
+            CurMpSize = SetCurrentBarSize(elapsedTime, instant, targetMpSize, CurMpSize);
+
+            if (CurMpSize == 0)
             {
-                CurMpSize = SetCurrentBarSize(elapsedTime, instant, targetMpSize, CurMpSize);
+                MpBar.IsHidden = true;
+            }
+            else
+            {
+                UpdateGauge(MpBackground, MpBar, CurMpSize, barDirectionSetting);
+            }
+        }
+    }
 
-                if (CurMpSize == 0)
+    private void UpdateXpBar(float elapsedTime, bool instant = false)
+    {
+        float targetExpSize;
+        var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[Enum.GetValues<Vital>().Length];
+        var barPercentageSetting = Globals.Database.ShowExperienceAsPercentage;
+        var entityExperienceToNextLevel = ((Player)MyEntity).GetNextLevelExperience();
+
+        if (entityExperienceToNextLevel > 0)
+        {
+            var entityExperience = ((Player)MyEntity).Experience;
+            var entityExperienceRatio = (float)entityExperience / entityExperienceToNextLevel;
+            var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
+                ? ExpBackground.Width
+                : ExpBackground.Height;
+            var expPercentage = entityExperienceRatio * 100;
+            var expPercentageText = $"{expPercentage:0.##}%";
+            var expValueText = Strings.EntityBox.ExpValue.ToString(entityExperience, entityExperienceToNextLevel);
+            ExpLbl.Text = barPercentageSetting ? expPercentageText : expValueText;
+            ExpBackground.SetToolTipText(barPercentageSetting ? expValueText : expPercentageText);
+            targetExpSize = SetTargetBarSize(entityExperienceRatio, vitalSize);
+        }
+        else
+        {
+            targetExpSize = 1f;
+            ExpLbl.Text = Strings.EntityBox.MaxLevel;
+            ExpBackground.SetToolTipText(Strings.EntityBox.MaxLevel);
+        }
+
+        if (Math.Abs((int)targetExpSize - CurExpSize) < 0.01)
+        {
+            return;
+        }
+
+        CurExpSize = SetCurrentBarSize(elapsedTime, instant, targetExpSize, CurExpSize);
+
+        if (CurExpSize == 0)
+        {
+            ExpBar.IsHidden = true;
+        }
+        else
+        {
+            UpdateGauge(ExpBackground, ExpBar, CurExpSize, barDirectionSetting);
+        }
+    }
+
+    private void UpdateImage()
+    {
+        var faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, MyEntity.Face);
+        var entityTex = MyEntity.Texture;
+        if (faceTex != null && faceTex != EntityFace.Texture)
+        {
+            EntityFace.Texture = faceTex;
+            EntityFace.RenderColor = MyEntity.Color ?? new Color(255, 255, 255, 255);
+            EntityFace.SetTextureRect(0, 0, faceTex.GetWidth(), faceTex.GetHeight());
+            EntityFace.SizeToContents();
+            Align.Center(EntityFace);
+            mCurrentSprite = MyEntity.Face;
+            EntityFace.IsHidden = false;
+            var i = 0;
+            for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+            {
+                if (Options.PaperdollOrder[1][z] != "Player")
                 {
-                    MpBar.IsHidden = true;
-                }
-                else
-                {
-                    UpdateGauge(MpBackground, MpBar, CurMpSize, barDirectionSetting);
+                    if (PaperdollPanels == null)
+                    {
+                        Log.Warn($@"{nameof(PaperdollPanels)} is null.");
+                    }
+                    else if (PaperdollPanels[i] == null)
+                    {
+                        Log.Warn($@"{nameof(PaperdollPanels)}[{i}] is null.");
+                    }
+
+                    PaperdollPanels?[i]?.Hide();
+                    i++;
                 }
             }
         }
-
-        private void UpdateXpBar(float elapsedTime, bool instant = false)
+        else if (entityTex != null && faceTex == null || faceTex != null && faceTex != EntityFace.Texture)
         {
-            float targetExpSize;
-            var barDirectionSetting = ClientConfiguration.Instance.EntityBarDirections[Enum.GetValues<Vital>().Length];
-            var barPercentageSetting = Globals.Database.ShowExperienceAsPercentage;
-            var entityExperienceToNextLevel = ((Player)MyEntity).GetNextLevelExperience();
-
-            if (entityExperienceToNextLevel > 0)
+            if (entityTex != EntityFace.Texture)
             {
-                var entityExperience = ((Player)MyEntity).Experience;
-                var entityExperienceRatio = (float)entityExperience / entityExperienceToNextLevel;
-                var vitalSize = (int)barDirectionSetting < (int)DisplayDirection.TopToBottom
-                    ? ExpBackground.Width
-                    : ExpBackground.Height;
-                var expPercentage = entityExperienceRatio * 100;
-                var expPercentageText = $"{expPercentage:0.##}%";
-                var expValueText = Strings.EntityBox.ExpValue.ToString(entityExperience, entityExperienceToNextLevel);
-                ExpLbl.Text = barPercentageSetting ? expPercentageText : expValueText;
-                ExpBackground.SetToolTipText(barPercentageSetting ? expValueText : expPercentageText);
-                targetExpSize = SetTargetBarSize(entityExperienceRatio, vitalSize);
-            }
-            else
-            {
-                targetExpSize = 1f;
-                ExpLbl.Text = Strings.EntityBox.MaxLevel;
-                ExpBackground.SetToolTipText(Strings.EntityBox.MaxLevel);
-            }
-
-            if (Math.Abs((int)targetExpSize - CurExpSize) < 0.01)
-            {
-                return;
-            }
-
-            CurExpSize = SetCurrentBarSize(elapsedTime, instant, targetExpSize, CurExpSize);
-
-            if (CurExpSize == 0)
-            {
-                ExpBar.IsHidden = true;
-            }
-            else
-            {
-                UpdateGauge(ExpBackground, ExpBar, CurExpSize, barDirectionSetting);
-            }
-        }
-
-        private void UpdateImage()
-        {
-            var faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, MyEntity.Face);
-            var entityTex = MyEntity.Texture;
-            if (faceTex != null && faceTex != EntityFace.Texture)
-            {
-                EntityFace.Texture = faceTex;
+                EntityFace.Texture = entityTex;
                 EntityFace.RenderColor = MyEntity.Color ?? new Color(255, 255, 255, 255);
-                EntityFace.SetTextureRect(0, 0, faceTex.GetWidth(), faceTex.GetHeight());
+                EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
                 EntityFace.SizeToContents();
                 Align.Center(EntityFace);
-                mCurrentSprite = MyEntity.Face;
+                mCurrentSprite = MyEntity.Sprite;
                 EntityFace.IsHidden = false;
-                var i = 0;
-                for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
-                {
-                    if (Options.PaperdollOrder[1][z] != "Player")
-                    {
-                        if (PaperdollPanels == null)
-                        {
-                            Log.Warn($@"{nameof(PaperdollPanels)} is null.");
-                        }
-                        else if (PaperdollPanels[i] == null)
-                        {
-                            Log.Warn($@"{nameof(PaperdollPanels)}[{i}] is null.");
-                        }
+            }
 
-                        PaperdollPanels?[i]?.Hide();
-                        i++;
+            var equipment = MyEntity.Equipment;
+            if (MyEntity == Globals.Me)
+            {
+                for (var i = 0; i < MyEntity.MyEquipment.Length; i++)
+                {
+                    var eqp = MyEntity.MyEquipment[i];
+                    if (eqp > -1 && eqp < Options.MaxInvItems)
+                    {
+                        equipment[i] = MyEntity.Inventory[eqp].ItemId;
+                    }
+                    else
+                    {
+                        equipment[i] = Guid.Empty;
                     }
                 }
             }
-            else if (entityTex != null && faceTex == null || faceTex != null && faceTex != EntityFace.Texture)
-            {
-                if (entityTex != EntityFace.Texture)
-                {
-                    EntityFace.Texture = entityTex;
-                    EntityFace.RenderColor = MyEntity.Color ?? new Color(255, 255, 255, 255);
-                    EntityFace.SetTextureRect(0, 0, entityTex.GetWidth() / Options.Instance.Sprites.NormalFrames, entityTex.GetHeight() / Options.Instance.Sprites.Directions);
-                    EntityFace.SizeToContents();
-                    Align.Center(EntityFace);
-                    mCurrentSprite = MyEntity.Sprite;
-                    EntityFace.IsHidden = false;
-                }
 
-                var equipment = MyEntity.Equipment;
-                if (MyEntity == Globals.Me)
+            var n = 0;
+            for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+            {
+                var paperdollPanel = PaperdollPanels[n];
+                var paperdoll = string.Empty;
+                if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1 &&
+                    equipment.Length == Options.EquipmentSlots.Count)
                 {
-                    for (var i = 0; i < MyEntity.MyEquipment.Length; i++)
+                    if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] != Guid.Empty)
                     {
-                        var eqp = MyEntity.MyEquipment[i];
-                        if (eqp > -1 && eqp < Options.MaxInvItems)
+                        var itemId = equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])];
+                        if (ItemBase.TryGet(itemId, out var itemDescriptor))
                         {
-                            equipment[i] = MyEntity.Inventory[eqp].ItemId;
-                        }
-                        else
-                        {
-                            equipment[i] = Guid.Empty;
+                            paperdoll = MyEntity.Gender == 0
+                                ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                            paperdollPanel.RenderColor = itemDescriptor.Color;
                         }
                     }
                 }
 
-                var n = 0;
-                for (var z = 0; z < Options.PaperdollOrder[1].Count; z++)
+                //Check for Player layer
+                if (Options.PaperdollOrder[1][z] == "Player")
                 {
-                    var paperdollPanel = PaperdollPanels[n];
-                    var paperdoll = string.Empty;
-                    if (Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z]) > -1 &&
-                        equipment.Length == Options.EquipmentSlots.Count)
-                    {
-                        if (equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])] != Guid.Empty)
-                        {
-                            var itemId = equipment[Options.EquipmentSlots.IndexOf(Options.PaperdollOrder[1][z])];
-                            if (ItemBase.TryGet(itemId, out var itemDescriptor))
-                            {
-                                paperdoll = MyEntity.Gender == 0
-                                    ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
-                                paperdollPanel.RenderColor = itemDescriptor.Color;
-                            }
-                        }
-                    }
-
-                    //Check for Player layer
-                    if (Options.PaperdollOrder[1][z] == "Player")
-                    {
-                        continue;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[n]))
-                    {
-                        paperdollPanel.Texture = null;
-                        paperdollPanel.Hide();
-                        PaperdollTextures[n] = string.Empty;
-                    }
-                    else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != PaperdollTextures[n])
-                    {
-                        var paperdollTex = Globals.ContentManager.GetTexture(
-                            Framework.Content.TextureType.Paperdoll, paperdoll
-                        );
-
-                        paperdollPanel.Texture = paperdollTex;
-                        if (paperdollTex != null)
-                        {
-                            paperdollPanel
-                                .SetTextureRect(
-                                    0, 0, paperdollPanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    paperdollPanel.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            paperdollPanel
-                                .SetSize(
-                                    paperdollPanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                    paperdollPanel.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                );
-
-                            paperdollPanel
-                                .SetPosition(
-                                    (EntityFaceContainer.Width - paperdollPanel.Width) / 2,
-                                    (EntityFaceContainer.Height - paperdollPanel.Height) / 2
-                                );
-                        }
-
-                        paperdollPanel.Show();
-                        PaperdollTextures[n] = paperdoll;
-                    }
-
-                    //Check for Player layer
-                    if (Options.PaperdollOrder[1][z] != "Player")
-                    {
-                        n++;
-                    }
+                    continue;
                 }
-            }
-            else if (MyEntity.Sprite != mCurrentSprite && MyEntity.Face != mCurrentSprite)
-            {
-                EntityFace.IsHidden = true;
-                for (var i = 0; i < Options.EquipmentSlots.Count; i++)
+
+                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[n]))
                 {
-                    PaperdollPanels[i]?.Hide();
+                    paperdollPanel.Texture = null;
+                    paperdollPanel.Hide();
+                    PaperdollTextures[n] = string.Empty;
                 }
-            }
-
-            if (EntityFace.RenderColor != MyEntity.Color)
-            {
-                EntityFace.RenderColor = MyEntity.Color;
-            }
-        }
-
-        public void Dispose()
-        {
-            EntityWindow.Hide();
-            Interface.GameUi.GameCanvas.RemoveChild(EntityWindow, false);
-            EntityWindow.Dispose();
-        }
-
-        //Input Handlers
-        void invite_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
-            {
-                if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
+                else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != PaperdollTextures[n])
                 {
-                    PacketSender.SendPartyInvite(Globals.Me.TargetIndex);
+                    var paperdollTex = Globals.ContentManager.GetTexture(
+                        Framework.Content.TextureType.Paperdoll, paperdoll
+                    );
+
+                    paperdollPanel.Texture = paperdollTex;
+                    if (paperdollTex != null)
+                    {
+                        paperdollPanel
+                            .SetTextureRect(
+                                0, 0, paperdollPanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                paperdollPanel.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                            );
+
+                        paperdollPanel
+                            .SetSize(
+                                paperdollPanel.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                paperdollPanel.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                            );
+
+                        paperdollPanel
+                            .SetPosition(
+                                (EntityFaceContainer.Width - paperdollPanel.Width) / 2,
+                                (EntityFaceContainer.Height - paperdollPanel.Height) / 2
+                            );
+                    }
+
+                    paperdollPanel.Show();
+                    PaperdollTextures[n] = paperdoll;
                 }
-                else
+
+                //Check for Player layer
+                if (Options.PaperdollOrder[1][z] != "Player")
                 {
-                    PacketSender.SendChatMsg(Strings.Parties.InFight.ToString(), 4);
+                    n++;
                 }
             }
         }
-
-        //Input Handlers
-        void tradeRequest_Clicked(Base sender, ClickedEventArgs arguments)
+        else if (MyEntity.Sprite != mCurrentSprite && MyEntity.Face != mCurrentSprite)
         {
-            if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
+            EntityFace.IsHidden = true;
+            for (var i = 0; i < Options.EquipmentSlots.Count; i++)
             {
-                if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
-                {
-                    PacketSender.SendTradeRequest(Globals.Me.TargetIndex);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(Strings.Trading.InFight.ToString(), 4);
-                }
+                PaperdollPanels[i]?.Hide();
             }
         }
 
-        //Input Handlers
-        void friendRequest_Clicked(Base sender, ClickedEventArgs arguments)
+        if (EntityFace.RenderColor != MyEntity.Color)
         {
-            if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
+            EntityFace.RenderColor = MyEntity.Color;
+        }
+    }
+
+    public void Dispose()
+    {
+        EntityWindow.Hide();
+        Interface.GameUi.GameCanvas.RemoveChild(EntityWindow, false);
+        EntityWindow.Dispose();
+    }
+
+    //Input Handlers
+    void invite_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
+        {
+            if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
             {
-                if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
-                {
-                    PacketSender.SendAddFriend(MyEntity.Name);
-                }
-                else
-                {
-                    PacketSender.SendChatMsg(Strings.Friends.InFight.ToString(), 4);
-                }
+                PacketSender.SendPartyInvite(Globals.Me.TargetIndex);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(Strings.Parties.InFight.ToString(), 4);
             }
         }
+    }
 
-
-        void guildRequest_Clicked(Base sender, ClickedEventArgs arguments)
+    //Input Handlers
+    void tradeRequest_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
         {
-            if (MyEntity is Player plyr && MyEntity != Globals.Me)
+            if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
             {
-                if (string.IsNullOrWhiteSpace(plyr.Guild))
-                {
-                    if (Globals.Me?.GuildRank?.Permissions?.Invite ?? false)
-                    {
-                        if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
-                        {
-                            PacketSender.SendInviteGuild(MyEntity.Name);
-                        }
-                        else
-                        {
-                            PacketSender.SendChatMsg(Strings.Friends.InFight.ToString(), 4);
-                        }
-                    }
-                }
-                else
-                {
-                    Chat.ChatboxMsg.AddMessage(new Chat.ChatboxMsg(Strings.Guilds.InviteAlreadyInGuild, Color.Red, ChatMessageType.Guild));
-                }
+                PacketSender.SendTradeRequest(Globals.Me.TargetIndex);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(Strings.Trading.InFight.ToString(), 4);
             }
         }
+    }
 
-        void TryShowGuildButton()
+    //Input Handlers
+    void friendRequest_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me.TargetIndex != Guid.Empty && Globals.Me.TargetIndex != Globals.Me.Id)
         {
-            var shouldShow = false;
-            if (MyEntity is Player plyr && MyEntity != Globals.Me && string.IsNullOrWhiteSpace(plyr.Guild))
+            if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
+            {
+                PacketSender.SendAddFriend(MyEntity.Name);
+            }
+            else
+            {
+                PacketSender.SendChatMsg(Strings.Friends.InFight.ToString(), 4);
+            }
+        }
+    }
+
+
+    void guildRequest_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (MyEntity is Player plyr && MyEntity != Globals.Me)
+        {
+            if (string.IsNullOrWhiteSpace(plyr.Guild))
             {
                 if (Globals.Me?.GuildRank?.Permissions?.Invite ?? false)
                 {
-                    shouldShow = true;
-                }
-            }
-
-            if (shouldShow)
-            {
-                if (!_contextMenu.Children.Contains(_guildMenuItem))
-                {
-                    _contextMenu.Children.Add(_guildMenuItem);
+                    if (Globals.Me.CombatTimer < Timing.Global.Milliseconds)
+                    {
+                        PacketSender.SendInviteGuild(MyEntity.Name);
+                    }
+                    else
+                    {
+                        PacketSender.SendChatMsg(Strings.Friends.InFight.ToString(), 4);
+                    }
                 }
             }
             else
             {
-                if (_contextMenu.Children.Contains(_guildMenuItem))
-                {
-                    _contextMenu.Children.Remove(_guildMenuItem);
-                }
+                Chat.ChatboxMsg.AddMessage(new Chat.ChatboxMsg(Strings.Guilds.InviteAlreadyInGuild, Color.Red, ChatMessageType.Guild));
             }
         }
+    }
 
-
-        public void Hide()
+    void TryShowGuildButton()
+    {
+        var shouldShow = false;
+        if (MyEntity is Player plyr && MyEntity != Globals.Me && string.IsNullOrWhiteSpace(plyr.Guild))
         {
-            EntityWindow.Hide();
-        }
-
-        public void Show()
-        {
-            if (!Options.Instance.CombatOpts.EnableTargetWindow && !_isPlayerBox)
+            if (Globals.Me?.GuildRank?.Permissions?.Invite ?? false)
             {
-                return;
+                shouldShow = true;
             }
-
-            EntityWindow.Show();
         }
 
+        if (shouldShow)
+        {
+            if (!_contextMenu.Children.Contains(_guildMenuItem))
+            {
+                _contextMenu.Children.Add(_guildMenuItem);
+            }
+        }
+        else
+        {
+            if (_contextMenu.Children.Contains(_guildMenuItem))
+            {
+                _contextMenu.Children.Remove(_guildMenuItem);
+            }
+        }
+    }
+
+
+    public void Hide()
+    {
+        EntityWindow.Hide();
+    }
+
+    public void Show()
+    {
+        if (!Options.Instance.CombatOpts.EnableTargetWindow && !_isPlayerBox)
+        {
+            return;
+        }
+
+        EntityWindow.Show();
     }
 
 }

--- a/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/PlayerStatusWindow.cs
@@ -4,65 +4,64 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 
-namespace Intersect.Client.Interface.Game.EntityPanel
+namespace Intersect.Client.Interface.Game.EntityPanel;
+
+
+public partial class PlayerStatusWindow : ImagePanel
 {
+    private readonly Dictionary<Guid, SpellStatus> _activeStatuses = new Dictionary<Guid, SpellStatus>();
 
-    public partial class PlayerStatusWindow : ImagePanel
+    public Player MyEntity;
+
+    public bool ShouldUpdateStatuses;
+
+    public readonly ImagePanel _playerStatusWindow;
+
+    public readonly ScrollControl _playerStatusControl;
+
+    public PlayerStatusWindow(Canvas gameCanvas) : base(gameCanvas, "PlayerStatusWindow")
     {
-        private readonly Dictionary<Guid, SpellStatus> _activeStatuses = new Dictionary<Guid, SpellStatus>();
+        MyEntity = Globals.Me;
+        _playerStatusControl = new ScrollControl(this, "PlayerStatusControl");
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        public Player MyEntity;
-
-        public bool ShouldUpdateStatuses;
-
-        public readonly ImagePanel _playerStatusWindow;
-
-        public readonly ScrollControl _playerStatusControl;
-
-        public PlayerStatusWindow(Canvas gameCanvas) : base(gameCanvas, "PlayerStatusWindow")
+    public void Update()
+    {
+        if (MyEntity == null || MyEntity.IsDisposed())
         {
-            MyEntity = Globals.Me;
-            _playerStatusControl = new ScrollControl(this, "PlayerStatusControl");
-            LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-        }
-
-        public void Update()
-        {
-            if (MyEntity == null || MyEntity.IsDisposed())
-            {
-                if (!IsHidden)
-                {
-                    Hide();
-                }
-
-                return;
-            }
-
-            if (MyEntity.IsDisposed())
-            {
-                Dispose();
-                return;
-            }
-
-            if (ShouldUpdateStatuses)
-            {
-                SpellStatus.UpdateSpellStatus(MyEntity, _playerStatusControl, _activeStatuses);
-
-                foreach (var itm in _activeStatuses)
-                {
-                    itm.Value.Update();
-                }
-
-                ShouldUpdateStatuses = false;
-            }
-
-            IsHidden = _activeStatuses.Count < 1;
-
             if (!IsHidden)
             {
-                ShouldUpdateStatuses = true;
-                Show();
+                Hide();
             }
+
+            return;
+        }
+
+        if (MyEntity.IsDisposed())
+        {
+            Dispose();
+            return;
+        }
+
+        if (ShouldUpdateStatuses)
+        {
+            SpellStatus.UpdateSpellStatus(MyEntity, _playerStatusControl, _activeStatuses);
+
+            foreach (var itm in _activeStatuses)
+            {
+                itm.Value.Update();
+            }
+
+            ShouldUpdateStatuses = false;
+        }
+
+        IsHidden = _activeStatuses.Count < 1;
+
+        if (!IsHidden)
+        {
+            ShouldUpdateStatuses = true;
+            Show();
         }
     }
 }

--- a/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
+++ b/Intersect.Client/Interface/Game/EntityPanel/SpellStatus.cs
@@ -7,178 +7,167 @@ using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.EntityPanel
+namespace Intersect.Client.Interface.Game.EntityPanel;
+
+
+public partial class SpellStatus
 {
+    private Guid _currentSpellId;
 
-    public partial class SpellStatus
+    private SpellDescriptionWindow? _descriptionWindow;
+
+    private Label _durationLabel;
+
+    private Status _status;
+
+    private string _textureLoaded = string.Empty;
+
+    private ImagePanel _statusIcon;
+
+    private ImagePanel _spellStatusContainer;
+
+    public SpellStatus(Status status)
     {
-        private Guid _currentSpellId;
+        _status = status;
+    }
 
-        private SpellDescriptionWindow? _descriptionWindow;
+    public void Setup()
+    {
+        _statusIcon = new ImagePanel(_spellStatusContainer, "StatusIcon");
+        _statusIcon.HoverEnter += pnl_HoverEnter;
+        _statusIcon.HoverLeave += pnl_HoverLeave;
+        _durationLabel = new Label(_spellStatusContainer, "DurationLabel");
+    }
 
-        private Label _durationLabel;
-
-        private Status _status;
-
-        private string _textureLoaded = string.Empty;
-
-        private ImagePanel _statusIcon;
-
-        private ImagePanel _spellStatusContainer;
-
-        public SpellStatus(Status status)
+    public void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        if (_descriptionWindow != null)
         {
-            _status = status;
+            _descriptionWindow.Dispose();
+            _descriptionWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (_descriptionWindow != null)
+        {
+            _descriptionWindow.Dispose();
+            _descriptionWindow = null;
         }
 
-        public void Setup()
+        var X = _statusIcon.LocalPosToCanvas(new Point(0, 0)).X;
+        var Y = _statusIcon.LocalPosToCanvas(new Point(0, 0)).Y;
+
+        _descriptionWindow = new SpellDescriptionWindow(_status.SpellId, _statusIcon);
+    }
+
+    public void UpdateStatus(Status status)
+    {
+        _status = status;
+    }
+
+    public static void UpdateSpellStatus(
+    Entity myEntity,
+    ScrollControl spellStatusControl,
+    Dictionary<Guid, SpellStatus> activeStatuses
+    )
+    {
+        if (myEntity == null)
         {
-            _statusIcon = new ImagePanel(_spellStatusContainer, "StatusIcon");
-            _statusIcon.HoverEnter += pnl_HoverEnter;
-            _statusIcon.HoverLeave += pnl_HoverLeave;
-            _durationLabel = new Label(_spellStatusContainer, "DurationLabel");
+            return;
         }
 
-        public void pnl_HoverLeave(Base sender, EventArgs arguments)
+        //Remove 'Dead' Statuses
+        var statuses = activeStatuses.Keys.ToArray();
+        foreach (var status in statuses)
         {
-            if (_descriptionWindow != null)
+            if (!myEntity.StatusActive(status))
             {
-                _descriptionWindow.Dispose();
-                _descriptionWindow = null;
+                var s = activeStatuses[status];
+                s._statusIcon.Texture = null;
+                s._spellStatusContainer.Hide();
+                s._spellStatusContainer.Texture = null;
+                spellStatusControl.RemoveChild(s._spellStatusContainer, true);
+                s.pnl_HoverLeave(null, null);
+                activeStatuses.Remove(status);
+            }
+            else
+            {
+                activeStatuses[status].UpdateStatus(myEntity.GetStatus(status) as Status);
             }
         }
 
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
+        //Add all of the spell status effects
+        for (var i = 0; i < myEntity.Status.Count; i++)
         {
-            if (_descriptionWindow != null)
+            var id = myEntity.Status[i].SpellId;
+            SpellStatus itm;
+            if (!activeStatuses.ContainsKey(id) && myEntity.Status[i] is Status status)
             {
-                _descriptionWindow.Dispose();
-                _descriptionWindow = null;
-            }
-
-            var X = _statusIcon.LocalPosToCanvas(new Point(0, 0)).X;
-            var Y = _statusIcon.LocalPosToCanvas(new Point(0, 0)).Y;
-
-            _descriptionWindow = new SpellDescriptionWindow(_status.SpellId, _statusIcon);
-        }
-
-        public void UpdateStatus(Status status)
-        {
-            _status = status;
-        }
-
-        public static void UpdateSpellStatus(
-        Entity myEntity,
-        ScrollControl spellStatusControl,
-        Dictionary<Guid, SpellStatus> activeStatuses
-        )
-        {
-            if (myEntity == null)
-            {
-                return;
-            }
-
-            //Remove 'Dead' Statuses
-            var statuses = activeStatuses.Keys.ToArray();
-            foreach (var status in statuses)
-            {
-                if (!myEntity.StatusActive(status))
+                itm = new SpellStatus(status)
                 {
-                    var s = activeStatuses[status];
-                    s._statusIcon.Texture = null;
-                    s._spellStatusContainer.Hide();
-                    s._spellStatusContainer.Texture = null;
-                    spellStatusControl.RemoveChild(s._spellStatusContainer, true);
-                    s.pnl_HoverLeave(null, null);
-                    activeStatuses.Remove(status);
-                }
-                else
-                {
-                    activeStatuses[status].UpdateStatus(myEntity.GetStatus(status) as Status);
-                }
-            }
+                    _spellStatusContainer = new ImagePanel(spellStatusControl, "SpellStatusIcon")
+                };
 
-            //Add all of the spell status effects
-            for (var i = 0; i < myEntity.Status.Count; i++)
+                itm.Setup();
+                itm._spellStatusContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+                itm._spellStatusContainer.Name = string.Empty;
+                activeStatuses.Add(id, itm);
+            }
+            else
             {
-                var id = myEntity.Status[i].SpellId;
-                SpellStatus itm;
-                if (!activeStatuses.ContainsKey(id) && myEntity.Status[i] is Status status)
-                {
-                    itm = new SpellStatus(status)
-                    {
-                        _spellStatusContainer = new ImagePanel(spellStatusControl, "SpellStatusIcon")
-                    };
-
-                    itm.Setup();
-                    itm._spellStatusContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-                    itm._spellStatusContainer.Name = string.Empty;
-                    activeStatuses.Add(id, itm);
-                }
-                else
-                {
-                    itm = activeStatuses[id];
-                }
-
-                var xPadding = itm._spellStatusContainer.Margin.Left + itm._spellStatusContainer.Margin.Right;
-                var yPadding = itm._spellStatusContainer.Margin.Top + itm._spellStatusContainer.Margin.Bottom;
-
-                // Calculate how many icons fit in a row
-                int iconsPerRow = spellStatusControl.Width / Math.Max(1, itm._spellStatusContainer.Width + xPadding);
-
-                // Calculate which row the icon should be in
-                int row = i / Math.Max(1, iconsPerRow);
-
-                // Calculate which column the icon should be in
-                int column = i % Math.Max(1, iconsPerRow);
-
-                // Calculate the x and y position
-                int xPos = column * (itm._spellStatusContainer.Width + xPadding) + xPadding;
-                int yPos = row * (itm._spellStatusContainer.Height + yPadding) + yPadding;
-
-                itm._spellStatusContainer.SetPosition(xPos, yPos);
+                itm = activeStatuses[id];
             }
+
+            var xPadding = itm._spellStatusContainer.Margin.Left + itm._spellStatusContainer.Margin.Right;
+            var yPadding = itm._spellStatusContainer.Margin.Top + itm._spellStatusContainer.Margin.Bottom;
+
+            // Calculate how many icons fit in a row
+            int iconsPerRow = spellStatusControl.Width / Math.Max(1, itm._spellStatusContainer.Width + xPadding);
+
+            // Calculate which row the icon should be in
+            int row = i / Math.Max(1, iconsPerRow);
+
+            // Calculate which column the icon should be in
+            int column = i % Math.Max(1, iconsPerRow);
+
+            // Calculate the x and y position
+            int xPos = column * (itm._spellStatusContainer.Width + xPadding) + xPadding;
+            int yPos = row * (itm._spellStatusContainer.Height + yPadding) + yPadding;
+
+            itm._spellStatusContainer.SetPosition(xPos, yPos);
+        }
+    }
+
+    public void Update()
+    {
+        if (_status == null)
+        {
+            return;
         }
 
-        public void Update()
+        var remaining = _status.RemainingMs;
+        var spell = SpellBase.Get(_status.SpellId);
+
+        _durationLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix();
+
+        if ((_textureLoaded != "" && spell == null ||
+             spell != null && _textureLoaded != spell.Icon ||
+             _currentSpellId != _status.SpellId) &&
+            remaining > 0)
         {
-            if (_status == null)
+            _spellStatusContainer.Show();
+            if (spell != null)
             {
-                return;
-            }
+                var spellTex = Globals.ContentManager.GetTexture(
+                    Framework.Content.TextureType.Spell, spell.Icon
+                );
 
-            var remaining = _status.RemainingMs;
-            var spell = SpellBase.Get(_status.SpellId);
-
-            _durationLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix();
-
-            if ((_textureLoaded != "" && spell == null ||
-                 spell != null && _textureLoaded != spell.Icon ||
-                 _currentSpellId != _status.SpellId) &&
-                remaining > 0)
-            {
-                _spellStatusContainer.Show();
-                if (spell != null)
+                if (spellTex != null)
                 {
-                    var spellTex = Globals.ContentManager.GetTexture(
-                        Framework.Content.TextureType.Spell, spell.Icon
-                    );
-
-                    if (spellTex != null)
-                    {
-                        _statusIcon.Texture = spellTex;
-                        _statusIcon.IsHidden = false;
-                    }
-                    else
-                    {
-                        if (_statusIcon.Texture != null)
-                        {
-                            _statusIcon.Texture = null;
-                        }
-                    }
-
-                    _textureLoaded = spell.Icon;
-                    _currentSpellId = _status.SpellId;
+                    _statusIcon.Texture = spellTex;
+                    _statusIcon.IsHidden = false;
                 }
                 else
                 {
@@ -186,20 +175,30 @@ namespace Intersect.Client.Interface.Game.EntityPanel
                     {
                         _statusIcon.Texture = null;
                     }
-
-                    _textureLoaded = "";
                 }
+
+                _textureLoaded = spell.Icon;
+                _currentSpellId = _status.SpellId;
             }
-            else if (remaining <= 0)
+            else
             {
                 if (_statusIcon.Texture != null)
                 {
                     _statusIcon.Texture = null;
                 }
 
-                _spellStatusContainer.Hide();
                 _textureLoaded = "";
             }
+        }
+        else if (remaining <= 0)
+        {
+            if (_statusIcon.Texture != null)
+            {
+                _statusIcon.Texture = null;
+            }
+
+            _spellStatusContainer.Hide();
+            _textureLoaded = "";
         }
     }
 }

--- a/Intersect.Client/Interface/Game/EventWindow.cs
+++ b/Intersect.Client/Interface/Game/EventWindow.cs
@@ -10,386 +10,385 @@ using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class EventWindow : Base
 {
 
-    public partial class EventWindow : Base
+    private ScrollControl mEventDialogArea;
+
+    private ScrollControl mEventDialogAreaNoFace;
+
+    private RichLabel mEventDialogLabel;
+
+    private RichLabel mEventDialogLabelNoFace;
+
+    private Label mEventDialogLabelNoFaceTemplate;
+
+    private Label mEventDialogLabelTemplate;
+
+    //Window Controls
+    private ImagePanel mEventDialogWindow;
+
+    private ImagePanel mEventFace;
+
+    private Button mEventResponse1;
+
+    private Button mEventResponse2;
+
+    private Button mEventResponse3;
+
+    private Button mEventResponse4;
+
+    private bool _typewriting = false;
+
+    private readonly Typewriter _writer;
+
+    private readonly long _typewriterResponseDelay = ClientConfiguration.Instance.TypewriterResponseDelay;
+
+    //Init
+    public EventWindow(Canvas gameCanvas)
     {
+        //Event Dialog Window
+        mEventDialogWindow = new ImagePanel(gameCanvas, "EventDialogueWindow");
+        mEventDialogWindow.Hide();
+        Interface.InputBlockingElements.Add(mEventDialogWindow);
 
-        private ScrollControl mEventDialogArea;
+        mEventFace = new ImagePanel(mEventDialogWindow, "EventFacePanel");
 
-        private ScrollControl mEventDialogAreaNoFace;
+        mEventDialogArea = new ScrollControl(mEventDialogWindow, "EventDialogArea");
+        mEventDialogLabelTemplate = new Label(mEventDialogArea, "EventDialogLabel");
+        mEventDialogLabel = new RichLabel(mEventDialogArea);
 
-        private RichLabel mEventDialogLabel;
+        mEventDialogAreaNoFace = new ScrollControl(mEventDialogWindow, "EventDialogAreaNoFace");
+        mEventDialogLabelNoFaceTemplate = new Label(mEventDialogAreaNoFace, "EventDialogLabel");
+        mEventDialogLabelNoFace = new RichLabel(mEventDialogAreaNoFace);
 
-        private RichLabel mEventDialogLabelNoFace;
+        mEventResponse1 = new Button(mEventDialogWindow, "EventResponse1");
+        mEventResponse1.Clicked += EventResponse1_Clicked;
 
-        private Label mEventDialogLabelNoFaceTemplate;
+        mEventResponse2 = new Button(mEventDialogWindow, "EventResponse2");
+        mEventResponse2.Clicked += EventResponse2_Clicked;
 
-        private Label mEventDialogLabelTemplate;
+        mEventResponse3 = new Button(mEventDialogWindow, "EventResponse3");
+        mEventResponse3.Clicked += EventResponse3_Clicked;
 
-        //Window Controls
-        private ImagePanel mEventDialogWindow;
+        mEventResponse4 = new Button(mEventDialogWindow, "EventResponse4");
+        mEventResponse4.Clicked += EventResponse4_Clicked;
 
-        private ImagePanel mEventFace;
+        _writer = new Typewriter();
 
-        private Button mEventResponse1;
+        mEventDialogWindow.Clicked += Dialog_Clicked;
+    }
 
-        private Button mEventResponse2;
+    private void Dialog_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        SkipTypewriting();
+    }
 
-        private Button mEventResponse3;
-
-        private Button mEventResponse4;
-
-        private bool _typewriting = false;
-
-        private readonly Typewriter _writer;
-
-        private readonly long _typewriterResponseDelay = ClientConfiguration.Instance.TypewriterResponseDelay;
-
-        //Init
-        public EventWindow(Canvas gameCanvas)
+    //Update
+    public void Update()
+    {
+        if (mEventDialogWindow.IsHidden)
         {
-            //Event Dialog Window
-            mEventDialogWindow = new ImagePanel(gameCanvas, "EventDialogueWindow");
-            mEventDialogWindow.Hide();
-            Interface.InputBlockingElements.Add(mEventDialogWindow);
-
-            mEventFace = new ImagePanel(mEventDialogWindow, "EventFacePanel");
-
-            mEventDialogArea = new ScrollControl(mEventDialogWindow, "EventDialogArea");
-            mEventDialogLabelTemplate = new Label(mEventDialogArea, "EventDialogLabel");
-            mEventDialogLabel = new RichLabel(mEventDialogArea);
-
-            mEventDialogAreaNoFace = new ScrollControl(mEventDialogWindow, "EventDialogAreaNoFace");
-            mEventDialogLabelNoFaceTemplate = new Label(mEventDialogAreaNoFace, "EventDialogLabel");
-            mEventDialogLabelNoFace = new RichLabel(mEventDialogAreaNoFace);
-
-            mEventResponse1 = new Button(mEventDialogWindow, "EventResponse1");
-            mEventResponse1.Clicked += EventResponse1_Clicked;
-
-            mEventResponse2 = new Button(mEventDialogWindow, "EventResponse2");
-            mEventResponse2.Clicked += EventResponse2_Clicked;
-
-            mEventResponse3 = new Button(mEventDialogWindow, "EventResponse3");
-            mEventResponse3.Clicked += EventResponse3_Clicked;
-
-            mEventResponse4 = new Button(mEventDialogWindow, "EventResponse4");
-            mEventResponse4.Clicked += EventResponse4_Clicked;
-
-            _writer = new Typewriter();
-
-            mEventDialogWindow.Clicked += Dialog_Clicked;
+            Interface.InputBlockingElements.Remove(this);
+        }
+        else
+        {
+            if (!Interface.InputBlockingElements.Contains(this))
+            {
+                Interface.InputBlockingElements.Add(this);
+            }
         }
 
-        private void Dialog_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            SkipTypewriting();
-        }
-
-        //Update
-        public void Update()
+        if (Globals.EventDialogs.Count > 0)
         {
             if (mEventDialogWindow.IsHidden)
             {
-                Interface.InputBlockingElements.Remove(this);
-            }
-            else
-            {
-                if (!Interface.InputBlockingElements.Contains(this))
+                base.Show();
+                mEventDialogWindow.Show();
+                mEventDialogWindow.MakeModal();
+                mEventDialogArea.ScrollToTop();
+                mEventDialogWindow.BringToFront();
+                var faceTex = Globals.ContentManager.GetTexture(
+                    Framework.Content.TextureType.Face, Globals.EventDialogs[0].Face
+                );
+
+                var responseCount = 0;
+                var maxResponse = 1;
+                if (Globals.EventDialogs[0].Opt1.Length > 0)
                 {
-                    Interface.InputBlockingElements.Add(this);
+                    responseCount++;
                 }
-            }
 
-            if (Globals.EventDialogs.Count > 0)
-            {
-                if (mEventDialogWindow.IsHidden)
+                if (Globals.EventDialogs[0].Opt2.Length > 0)
                 {
-                    base.Show();
-                    mEventDialogWindow.Show();
-                    mEventDialogWindow.MakeModal();
-                    mEventDialogArea.ScrollToTop();
-                    mEventDialogWindow.BringToFront();
-                    var faceTex = Globals.ContentManager.GetTexture(
-                        Framework.Content.TextureType.Face, Globals.EventDialogs[0].Face
-                    );
+                    responseCount++;
+                    maxResponse = 2;
+                }
 
-                    var responseCount = 0;
-                    var maxResponse = 1;
-                    if (Globals.EventDialogs[0].Opt1.Length > 0)
-                    {
-                        responseCount++;
-                    }
+                if (Globals.EventDialogs[0].Opt3.Length > 0)
+                {
+                    responseCount++;
+                    maxResponse = 3;
+                }
 
-                    if (Globals.EventDialogs[0].Opt2.Length > 0)
-                    {
-                        responseCount++;
-                        maxResponse = 2;
-                    }
+                if (Globals.EventDialogs[0].Opt4.Length > 0)
+                {
+                    responseCount++;
+                    maxResponse = 4;
+                }
 
-                    if (Globals.EventDialogs[0].Opt3.Length > 0)
-                    {
-                        responseCount++;
-                        maxResponse = 3;
-                    }
+                _typewriting = ClientConfiguration.Instance.TypewriterEnabled && Globals.Database.TypewriterBehavior == Enums.TypewriterBehavior.Word;
 
-                    if (Globals.EventDialogs[0].Opt4.Length > 0)
-                    {
-                        responseCount++;
-                        maxResponse = 4;
-                    }
+                mEventResponse1.Name = "";
+                mEventResponse2.Name = "";
+                mEventResponse3.Name = "";
+                mEventResponse4.Name = "";
+                switch (maxResponse)
+                {
+                    case 1:
+                        mEventDialogWindow.Name = "EventDialogWindow_1Response";
+                        mEventResponse1.Name = "Response1Button";
 
-                    _typewriting = ClientConfiguration.Instance.TypewriterEnabled && Globals.Database.TypewriterBehavior == Enums.TypewriterBehavior.Word;
+                        break;
+                    case 2:
+                        mEventDialogWindow.Name = "EventDialogWindow_2Responses";
+                        mEventResponse1.Name = "Response1Button";
+                        mEventResponse2.Name = "Response2Button";
 
-                    mEventResponse1.Name = "";
-                    mEventResponse2.Name = "";
-                    mEventResponse3.Name = "";
-                    mEventResponse4.Name = "";
-                    switch (maxResponse)
-                    {
-                        case 1:
-                            mEventDialogWindow.Name = "EventDialogWindow_1Response";
-                            mEventResponse1.Name = "Response1Button";
+                        break;
+                    case 3:
+                        mEventDialogWindow.Name = "EventDialogWindow_3Responses";
+                        mEventResponse1.Name = "Response1Button";
+                        mEventResponse2.Name = "Response2Button";
+                        mEventResponse3.Name = "Response3Button";
 
-                            break;
-                        case 2:
-                            mEventDialogWindow.Name = "EventDialogWindow_2Responses";
-                            mEventResponse1.Name = "Response1Button";
-                            mEventResponse2.Name = "Response2Button";
+                        break;
+                    case 4:
+                        mEventDialogWindow.Name = "EventDialogWindow_4Responses";
+                        mEventResponse1.Name = "Response1Button";
+                        mEventResponse2.Name = "Response2Button";
+                        mEventResponse3.Name = "Response3Button";
+                        mEventResponse4.Name = "Response4Button";
 
-                            break;
-                        case 3:
-                            mEventDialogWindow.Name = "EventDialogWindow_3Responses";
-                            mEventResponse1.Name = "Response1Button";
-                            mEventResponse2.Name = "Response2Button";
-                            mEventResponse3.Name = "Response3Button";
+                        break;
+                }
 
-                            break;
-                        case 4:
-                            mEventDialogWindow.Name = "EventDialogWindow_4Responses";
-                            mEventResponse1.Name = "Response1Button";
-                            mEventResponse2.Name = "Response2Button";
-                            mEventResponse3.Name = "Response3Button";
-                            mEventResponse4.Name = "Response4Button";
+                mEventDialogWindow.LoadJsonUi(
+                    GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString()
+                );
 
-                            break;
-                    }
+                if (faceTex != null)
+                {
+                    mEventFace.Show();
+                    mEventFace.Texture = faceTex;
+                    mEventDialogArea.Show();
+                    mEventDialogAreaNoFace.Hide();
+                }
+                else
+                {
+                    mEventFace.Hide();
+                    mEventDialogArea.Hide();
+                    mEventDialogAreaNoFace.Show();
+                }
 
-                    mEventDialogWindow.LoadJsonUi(
-                        GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString()
-                    );
-
-                    if (faceTex != null)
-                    {
-                        mEventFace.Show();
-                        mEventFace.Texture = faceTex;
-                        mEventDialogArea.Show();
-                        mEventDialogAreaNoFace.Hide();
-                    }
-                    else
-                    {
-                        mEventFace.Hide();
-                        mEventDialogArea.Hide();
-                        mEventDialogAreaNoFace.Show();
-                    }
-
-                    if (responseCount == 0)
+                if (responseCount == 0)
+                {
+                    mEventResponse1.Show();
+                    mEventResponse1.SetText(Strings.EventWindow.Continue);
+                    mEventResponse2.Hide();
+                    mEventResponse3.Hide();
+                    mEventResponse4.Hide();
+                }
+                else
+                {
+                    if (Globals.EventDialogs[0].Opt1 != "")
                     {
                         mEventResponse1.Show();
-                        mEventResponse1.SetText(Strings.EventWindow.Continue);
+                        mEventResponse1.SetText(Globals.EventDialogs[0].Opt1);
+                    }
+                    else
+                    {
+                        mEventResponse1.Hide();
+                    }
+
+                    if (Globals.EventDialogs[0].Opt2 != "")
+                    {
+                        mEventResponse2.Show();
+                        mEventResponse2.SetText(Globals.EventDialogs[0].Opt2);
+                    }
+                    else
+                    {
                         mEventResponse2.Hide();
+                    }
+
+                    if (Globals.EventDialogs[0].Opt3 != "")
+                    {
+                        mEventResponse3.Show();
+                        mEventResponse3.SetText(Globals.EventDialogs[0].Opt3);
+                    }
+                    else
+                    {
                         mEventResponse3.Hide();
+                    }
+
+                    if (Globals.EventDialogs[0].Opt4 != "")
+                    {
+                        mEventResponse4.Show();
+                        mEventResponse4.SetText(Globals.EventDialogs[0].Opt4);
+                    }
+                    else
+                    {
                         mEventResponse4.Hide();
                     }
-                    else
-                    {
-                        if (Globals.EventDialogs[0].Opt1 != "")
-                        {
-                            mEventResponse1.Show();
-                            mEventResponse1.SetText(Globals.EventDialogs[0].Opt1);
-                        }
-                        else
-                        {
-                            mEventResponse1.Hide();
-                        }
-
-                        if (Globals.EventDialogs[0].Opt2 != "")
-                        {
-                            mEventResponse2.Show();
-                            mEventResponse2.SetText(Globals.EventDialogs[0].Opt2);
-                        }
-                        else
-                        {
-                            mEventResponse2.Hide();
-                        }
-
-                        if (Globals.EventDialogs[0].Opt3 != "")
-                        {
-                            mEventResponse3.Show();
-                            mEventResponse3.SetText(Globals.EventDialogs[0].Opt3);
-                        }
-                        else
-                        {
-                            mEventResponse3.Hide();
-                        }
-
-                        if (Globals.EventDialogs[0].Opt4 != "")
-                        {
-                            mEventResponse4.Show();
-                            mEventResponse4.SetText(Globals.EventDialogs[0].Opt4);
-                        }
-                        else
-                        {
-                            mEventResponse4.Hide();
-                        }
-                    }
-
-                    mEventDialogWindow.SetSize(
-                        mEventDialogWindow.Texture.GetWidth(), mEventDialogWindow.Texture.GetHeight()
-                    );
-
-                    var prompt = Globals.EventDialogs[0].Prompt;
-                    if (faceTex != null)
-                    {
-                        ShowDialog(mEventDialogLabel, 
-                            mEventDialogLabelTemplate, 
-                            mEventDialogArea, 
-                            prompt);
-                    }
-                    else
-                    {
-                        ShowDialog(mEventDialogLabelNoFace,
-                            mEventDialogLabelNoFaceTemplate,
-                            mEventDialogAreaNoFace,
-                            prompt);
-                    }
                 }
-                else if (_typewriting)
+
+                mEventDialogWindow.SetSize(
+                    mEventDialogWindow.Texture.GetWidth(), mEventDialogWindow.Texture.GetHeight()
+                );
+
+                var prompt = Globals.EventDialogs[0].Prompt;
+                if (faceTex != null)
                 {
-                    var voiceIdx = Randomization.Next(0, ClientConfiguration.Instance.TypewriterSounds.Count);
+                    ShowDialog(mEventDialogLabel, 
+                        mEventDialogLabelTemplate, 
+                        mEventDialogArea, 
+                        prompt);
+                }
+                else
+                {
+                    ShowDialog(mEventDialogLabelNoFace,
+                        mEventDialogLabelNoFaceTemplate,
+                        mEventDialogAreaNoFace,
+                        prompt);
+                }
+            }
+            else if (_typewriting)
+            {
+                var voiceIdx = Randomization.Next(0, ClientConfiguration.Instance.TypewriterSounds.Count);
 
-                    var dialog = Globals.EventDialogs[0];
+                var dialog = Globals.EventDialogs[0];
 
-                    // Always show option 1 ("continue" if options empty)
-                    mEventResponse1.IsHidden = !_writer.IsDone; 
-                    mEventResponse2.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt2);
-                    mEventResponse3.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt3);
-                    mEventResponse4.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt4);
+                // Always show option 1 ("continue" if options empty)
+                mEventResponse1.IsHidden = !_writer.IsDone; 
+                mEventResponse2.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt2);
+                mEventResponse3.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt3);
+                mEventResponse4.IsHidden = !_writer.IsDone || string.IsNullOrEmpty(dialog.Opt4);
 
-                    _writer.Write(ClientConfiguration.Instance.TypewriterSounds.ElementAtOrDefault(voiceIdx));
-                    if (_writer.IsDone)
-                    {
-                        var disableResponse = Timing.Global.MillisecondsUtc - _writer.DoneAtMilliseconds < _typewriterResponseDelay;
-                        mEventResponse1.IsDisabled = disableResponse;
-                        mEventResponse2.IsDisabled = disableResponse;
-                        mEventResponse3.IsDisabled = disableResponse;
-                        mEventResponse4.IsDisabled = disableResponse;
-                    }
-                    else if (Controls.KeyDown(Control.AttackInteract))
-                    {
-                        SkipTypewriting();
-                    }
+                _writer.Write(ClientConfiguration.Instance.TypewriterSounds.ElementAtOrDefault(voiceIdx));
+                if (_writer.IsDone)
+                {
+                    var disableResponse = Timing.Global.MillisecondsUtc - _writer.DoneAtMilliseconds < _typewriterResponseDelay;
+                    mEventResponse1.IsDisabled = disableResponse;
+                    mEventResponse2.IsDisabled = disableResponse;
+                    mEventResponse3.IsDisabled = disableResponse;
+                    mEventResponse4.IsDisabled = disableResponse;
+                }
+                else if (Controls.KeyDown(Control.AttackInteract))
+                {
+                    SkipTypewriting();
                 }
             }
         }
+    }
 
-        private void ShowDialog(RichLabel dialogLabel, Label dialogLabelTemplate, ScrollControl dialogArea, string prompt)
+    private void ShowDialog(RichLabel dialogLabel, Label dialogLabelTemplate, ScrollControl dialogArea, string prompt)
+    {
+        if (dialogLabel == default || dialogLabelTemplate == default || dialogArea == default)
         {
-            if (dialogLabel == default || dialogLabelTemplate == default || dialogArea == default)
-            {
-                return;
-            }
-
-            dialogLabel.ClearText();
-            dialogLabel.Width = dialogArea.Width - dialogArea.GetVerticalScrollBar().Width;
-
-            dialogLabel.AddText(prompt, dialogLabelTemplate);
-
-            dialogLabel.SizeToChildren(false, true);
-
-            // Do this _after_ sizing so we have lines broken up
-            if (_typewriting)
-            {
-                _writer.Initialize(dialogLabel.FormattedLabels);
-                mEventResponse1.Hide();
-                mEventResponse2.Hide();
-                mEventResponse3.Hide();
-                mEventResponse4.Hide();
-            }
-
-            dialogArea.ScrollToTop();
+            return;
         }
 
-        //Input Handlers
-        void EventResponse4_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var ed = Globals.EventDialogs[0];
-            if (ed.ResponseSent != 0)
-            {
-                return;
-            }
+        dialogLabel.ClearText();
+        dialogLabel.Width = dialogArea.Width - dialogArea.GetVerticalScrollBar().Width;
 
-            PacketSender.SendEventResponse(4, ed);
-            mEventDialogWindow.RemoveModal();
-            mEventDialogWindow.IsHidden = true;
-            ed.ResponseSent = 1;
-            base.Hide();
+        dialogLabel.AddText(prompt, dialogLabelTemplate);
+
+        dialogLabel.SizeToChildren(false, true);
+
+        // Do this _after_ sizing so we have lines broken up
+        if (_typewriting)
+        {
+            _writer.Initialize(dialogLabel.FormattedLabels);
+            mEventResponse1.Hide();
+            mEventResponse2.Hide();
+            mEventResponse3.Hide();
+            mEventResponse4.Hide();
         }
 
-        void EventResponse3_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var ed = Globals.EventDialogs[0];
-            if (ed.ResponseSent != 0)
-            {
-                return;
-            }
+        dialogArea.ScrollToTop();
+    }
 
-            PacketSender.SendEventResponse(3, ed);
-            mEventDialogWindow.RemoveModal();
-            mEventDialogWindow.IsHidden = true;
-            ed.ResponseSent = 1;
-            base.Hide();
+    //Input Handlers
+    void EventResponse4_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var ed = Globals.EventDialogs[0];
+        if (ed.ResponseSent != 0)
+        {
+            return;
         }
 
-        void EventResponse2_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var ed = Globals.EventDialogs[0];
-            if (ed.ResponseSent != 0)
-            {
-                return;
-            }
+        PacketSender.SendEventResponse(4, ed);
+        mEventDialogWindow.RemoveModal();
+        mEventDialogWindow.IsHidden = true;
+        ed.ResponseSent = 1;
+        base.Hide();
+    }
 
-            PacketSender.SendEventResponse(2, ed);
-            mEventDialogWindow.RemoveModal();
-            mEventDialogWindow.IsHidden = true;
-            ed.ResponseSent = 1;
-            base.Hide();
+    void EventResponse3_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var ed = Globals.EventDialogs[0];
+        if (ed.ResponseSent != 0)
+        {
+            return;
         }
 
-        public void EventResponse1_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var ed = Globals.EventDialogs[0];
-            if (ed.ResponseSent != 0)
-            {
-                return;
-            }
+        PacketSender.SendEventResponse(3, ed);
+        mEventDialogWindow.RemoveModal();
+        mEventDialogWindow.IsHidden = true;
+        ed.ResponseSent = 1;
+        base.Hide();
+    }
 
-            PacketSender.SendEventResponse(1, ed);
-            mEventDialogWindow.RemoveModal();
-            mEventDialogWindow.IsHidden = true;
-            ed.ResponseSent = 1;
-            base.Hide();
+    void EventResponse2_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var ed = Globals.EventDialogs[0];
+        if (ed.ResponseSent != 0)
+        {
+            return;
         }
 
-        private void SkipTypewriting()
-        {
-            if (_writer?.IsDone ?? true)
-            {
-                return;
-            }
+        PacketSender.SendEventResponse(2, ed);
+        mEventDialogWindow.RemoveModal();
+        mEventDialogWindow.IsHidden = true;
+        ed.ResponseSent = 1;
+        base.Hide();
+    }
 
-            _writer.End();
+    public void EventResponse1_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var ed = Globals.EventDialogs[0];
+        if (ed.ResponseSent != 0)
+        {
+            return;
         }
+
+        PacketSender.SendEventResponse(1, ed);
+        mEventDialogWindow.RemoveModal();
+        mEventDialogWindow.IsHidden = true;
+        ed.ResponseSent = 1;
+        base.Hide();
+    }
+
+    private void SkipTypewriting()
+    {
+        if (_writer?.IsDone ?? true)
+        {
+            return;
+        }
+
+        _writer.End();
     }
 }

--- a/Intersect.Client/Interface/Game/Friends/FriendsRow.cs
+++ b/Intersect.Client/Interface/Game/Friends/FriendsRow.cs
@@ -6,112 +6,111 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+public partial class FriendsRow
 {
-    public partial class FriendsRow
+    private Base mParent;
+
+    private ImagePanel mRowContainer;
+
+    private ImagePanel mOnlineSymbol;
+
+    private ImagePanel mOfflineSymbol;
+
+    private Label mName;
+
+    private Label mStatus;
+
+    private Button mTell;
+
+    private Button mRemove;
+
+    private string mMyName;
+
+    private string mMyStatus;
+
+    private bool mMyOnline;
+
+    public FriendsRow(Base parent, string name, string status, bool online)
     {
-        private Base mParent;
+        // Set up our basic values.
+        mParent = parent;
+        mMyName = name;
+        mMyStatus = status;
+        mMyOnline = online;
 
-        private ImagePanel mRowContainer;
+        // Generate our layout controls and load the layout from our json files.
+        GenerateControls();
+        mRowContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        private ImagePanel mOnlineSymbol;
+        // Update our display.
+        UpdateControls();
+    }
 
-        private ImagePanel mOfflineSymbol;
+    private void GenerateControls()
+    {
+        // Generate our controls.
+        mRowContainer = new ImagePanel(mParent, "FriendRow");
+        mOnlineSymbol = new ImagePanel(mRowContainer, "OnlineSymbol");
+        mOfflineSymbol = new ImagePanel(mRowContainer, "OfflineSymbol");
+        mName = new Label(mRowContainer, "Name");
+        mStatus = new Label(mRowContainer, "Status");
+        mTell = new Button(mRowContainer, "Tell");
+        mRemove = new Button(mRowContainer, "Remove");
 
-        private Label mName;
+        // Set up events.
+        mTell.Clicked += MTell_Clicked;
+        mRemove.Clicked += MRemove_Clicked;
+    }
 
-        private Label mStatus;
-
-        private Button mTell;
-
-        private Button mRemove;
-
-        private string mMyName;
-
-        private string mMyStatus;
-
-        private bool mMyOnline;
-
-        public FriendsRow(Base parent, string name, string status, bool online)
+    private void UpdateControls()
+    {
+        // If this friend is online or offline, show the correct dot and if they're offline hide the tell button.
+        if (mMyOnline)
         {
-            // Set up our basic values.
-            mParent = parent;
-            mMyName = name;
-            mMyStatus = status;
-            mMyOnline = online;
-
-            // Generate our layout controls and load the layout from our json files.
-            GenerateControls();
-            mRowContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            // Update our display.
-            UpdateControls();
+            mOnlineSymbol.Show();
+            mOfflineSymbol.Hide();
+            mTell.Show();
+        }
+        else
+        {
+            mOnlineSymbol.Hide();
+            mOfflineSymbol.Show();
+            mTell.Hide();
         }
 
-        private void GenerateControls()
-        {
-            // Generate our controls.
-            mRowContainer = new ImagePanel(mParent, "FriendRow");
-            mOnlineSymbol = new ImagePanel(mRowContainer, "OnlineSymbol");
-            mOfflineSymbol = new ImagePanel(mRowContainer, "OfflineSymbol");
-            mName = new Label(mRowContainer, "Name");
-            mStatus = new Label(mRowContainer, "Status");
-            mTell = new Button(mRowContainer, "Tell");
-            mRemove = new Button(mRowContainer, "Remove");
-
-            // Set up events.
-            mTell.Clicked += MTell_Clicked;
-            mRemove.Clicked += MRemove_Clicked;
-        }
-
-        private void UpdateControls()
-        {
-            // If this friend is online or offline, show the correct dot and if they're offline hide the tell button.
-            if (mMyOnline)
-            {
-                mOnlineSymbol.Show();
-                mOfflineSymbol.Hide();
-                mTell.Show();
-            }
-            else
-            {
-                mOnlineSymbol.Hide();
-                mOfflineSymbol.Show();
-                mTell.Hide();
-            }
-
-            // Update our fields.
-            mName.SetText(mMyName);
-            mStatus.SetText(mMyOnline ? mMyStatus : Strings.Friends.Offline.ToString());
-
-        }
-
-        private void MRemove_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var iBox = new InputBox(
-                Strings.Friends.RemoveFriend, Strings.Friends.RemoveFriendPrompt.ToString(mMyName), true,
-                InputBox.InputType.YesNo, RemoveFriend, null, 0
-            );
-        }
-
-        private void RemoveFriend(Object sender, EventArgs e)
-        {
-            PacketSender.SendRemoveFriend(mMyName);
-        }
-
-        private void MTell_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Interface.GameUi.SetChatboxText($"/pm {mMyName} ");
-        }
-
-        public Rectangle Bounds => mRowContainer.Bounds;
-
-        public void SetPosition(float x, float y) => mRowContainer.SetPosition(x, y);
-
-        public void Dispose()
-        {
-            mParent.RemoveChild(mRowContainer, true);
-        }
+        // Update our fields.
+        mName.SetText(mMyName);
+        mStatus.SetText(mMyOnline ? mMyStatus : Strings.Friends.Offline.ToString());
 
     }
+
+    private void MRemove_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var iBox = new InputBox(
+            Strings.Friends.RemoveFriend, Strings.Friends.RemoveFriendPrompt.ToString(mMyName), true,
+            InputBox.InputType.YesNo, RemoveFriend, null, 0
+        );
+    }
+
+    private void RemoveFriend(Object sender, EventArgs e)
+    {
+        PacketSender.SendRemoveFriend(mMyName);
+    }
+
+    private void MTell_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Interface.GameUi.SetChatboxText($"/pm {mMyName} ");
+    }
+
+    public Rectangle Bounds => mRowContainer.Bounds;
+
+    public void SetPosition(float x, float y) => mRowContainer.SetPosition(x, y);
+
+    public void Dispose()
+    {
+        mParent.RemoveChild(mRowContainer, true);
+    }
+
 }

--- a/Intersect.Client/Interface/Game/GameInterface.cs
+++ b/Intersect.Client/Interface/Game/GameInterface.cs
@@ -13,575 +13,573 @@ using Intersect.Client.Networking;
 using Intersect.Enums;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class GameInterface : MutableInterface
 {
 
-    public partial class GameInterface : MutableInterface
+    public bool FocusChat;
+
+    public bool UnfocusChat;
+
+    public bool ChatFocussed => mChatBox.HasFocus;
+
+    //Public Components - For clicking/dragging
+    public HotBarWindow Hotbar;
+
+    private AdminWindow? mAdminWindow;
+
+    private BagWindow mBagWindow;
+
+    private BankWindow mBankWindow;
+
+    private Chatbox mChatBox;
+
+    private CraftingWindow mCraftingWindow;
+
+    private EventWindow mEventWindow;
+
+    private PictureWindow mPictureWindow;
+
+    private QuestOfferWindow mQuestOfferWindow;
+
+    private ShopWindow mShopWindow;
+
+    private MapItemWindow mMapItemWindow;
+
+    private bool mShouldCloseBag;
+
+    private bool mShouldCloseBank;
+
+    private bool mShouldCloseCraftingTable;
+
+    private bool mShouldCloseShop;
+
+    private bool mShouldCloseTrading;
+
+    private bool mShouldOpenAdminWindow;
+
+    private bool mShouldOpenBag;
+
+    private bool mShouldOpenBank;
+
+    private bool mShouldOpenCraftingTable;
+
+    private bool mShouldOpenShop;
+
+    private bool mShouldOpenTrading;
+
+    private bool mShouldUpdateQuestLog = true;
+
+    private bool mShouldUpdateFriendsList;
+
+    private bool mShouldUpdateGuildList;
+
+    private bool mShouldHideGuildWindow;
+
+    private string mTradingTarget;
+
+    private bool mCraftJournal {  get; set; }
+
+    private TradingWindow? mTradingWindow;
+
+    public EntityBox PlayerBox;
+
+    public PlayerStatusWindow PlayerStatusWindow;
+
+    public GameInterface(Canvas canvas) : base(canvas)
     {
+        GameCanvas = canvas;
+        EscapeMenu = new EscapeMenu(GameCanvas) {IsHidden = true};
+        AnnouncementWindow = new AnnouncementWindow(GameCanvas) { IsHidden = true };
 
-        public bool FocusChat;
+        InitGameGui();
+    }
 
-        public bool UnfocusChat;
+    public Canvas GameCanvas { get; }
 
-        public bool ChatFocussed => mChatBox.HasFocus;
+    public EscapeMenu EscapeMenu { get; }
 
-        //Public Components - For clicking/dragging
-        public HotBarWindow Hotbar;
+    public AnnouncementWindow AnnouncementWindow { get; }
 
-        private AdminWindow? mAdminWindow;
+    public Menu GameMenu { get; private set; }
 
-        private BagWindow mBagWindow;
-
-        private BankWindow mBankWindow;
-
-        private Chatbox mChatBox;
-
-        private CraftingWindow mCraftingWindow;
-
-        private EventWindow mEventWindow;
-
-        private PictureWindow mPictureWindow;
-
-        private QuestOfferWindow mQuestOfferWindow;
-
-        private ShopWindow mShopWindow;
-
-        private MapItemWindow mMapItemWindow;
-
-        private bool mShouldCloseBag;
-
-        private bool mShouldCloseBank;
-
-        private bool mShouldCloseCraftingTable;
-
-        private bool mShouldCloseShop;
-
-        private bool mShouldCloseTrading;
-
-        private bool mShouldOpenAdminWindow;
-
-        private bool mShouldOpenBag;
-
-        private bool mShouldOpenBank;
-
-        private bool mShouldOpenCraftingTable;
-
-        private bool mShouldOpenShop;
-
-        private bool mShouldOpenTrading;
-
-        private bool mShouldUpdateQuestLog = true;
-
-        private bool mShouldUpdateFriendsList;
-
-        private bool mShouldUpdateGuildList;
-
-        private bool mShouldHideGuildWindow;
-
-        private string mTradingTarget;
-
-        private bool mCraftJournal {  get; set; }
-
-        private TradingWindow? mTradingWindow;
-
-        public EntityBox PlayerBox;
-
-        public PlayerStatusWindow PlayerStatusWindow;
-
-        public GameInterface(Canvas canvas) : base(canvas)
+    public void InitGameGui()
+    {
+        mChatBox = new Chatbox(GameCanvas, this);
+        GameMenu = new Menu(GameCanvas);
+        Hotbar = new HotBarWindow(GameCanvas);
+        PlayerBox = new EntityBox(GameCanvas, EntityType.Player, Globals.Me, true);
+        PlayerBox.SetEntity(Globals.Me);
+        PlayerStatusWindow = new PlayerStatusWindow(GameCanvas);
+        if (mPictureWindow == null)
         {
-            GameCanvas = canvas;
-            EscapeMenu = new EscapeMenu(GameCanvas) {IsHidden = true};
-            AnnouncementWindow = new AnnouncementWindow(GameCanvas) { IsHidden = true };
-
-            InitGameGui();
+            mPictureWindow = new PictureWindow(GameCanvas);
         }
 
-        public Canvas GameCanvas { get; }
+        mEventWindow = new EventWindow(GameCanvas);
+        mQuestOfferWindow = new QuestOfferWindow(GameCanvas);
+        mMapItemWindow = new MapItemWindow(GameCanvas);
+        mBankWindow = new BankWindow(GameCanvas);
+    }
 
-        public EscapeMenu EscapeMenu { get; }
+    //Chatbox
+    public void SetChatboxText(string msg)
+    {
+        mChatBox.SetChatboxText(msg);
+    }
 
-        public AnnouncementWindow AnnouncementWindow { get; }
+    //Friends Window
+    public void NotifyUpdateFriendsList()
+    {
+        mShouldUpdateFriendsList = true;
+    }
 
-        public Menu GameMenu { get; private set; }
+    //Guild Window
+    public void NotifyUpdateGuildList()
+    {
+        mShouldUpdateGuildList = true;
+    }
 
-        public void InitGameGui()
+    public void HideGuildWindow()
+    {
+        mShouldHideGuildWindow = true;
+    }
+
+    //Admin Window
+    public void NotifyOpenAdminWindow()
+    {
+        mShouldOpenAdminWindow = true;
+    }
+
+    public void OpenAdminWindow()
+    {
+        if (mAdminWindow == null)
         {
-            mChatBox = new Chatbox(GameCanvas, this);
-            GameMenu = new Menu(GameCanvas);
-            Hotbar = new HotBarWindow(GameCanvas);
-            PlayerBox = new EntityBox(GameCanvas, EntityType.Player, Globals.Me, true);
-            PlayerBox.SetEntity(Globals.Me);
-            PlayerStatusWindow = new PlayerStatusWindow(GameCanvas);
-            if (mPictureWindow == null)
+            mAdminWindow ??= new AdminWindow(GameCanvas);
+        }
+        else if (mAdminWindow.IsVisible())
+        {
+            mAdminWindow.Hide();
+        }
+        else
+        {
+            mAdminWindow.Show();
+        }
+
+        mShouldOpenAdminWindow = false;
+    }
+
+    //Shop
+    public void NotifyOpenShop()
+    {
+        mShouldOpenShop = true;
+    }
+
+    public void NotifyCloseShop()
+    {
+        mShouldCloseShop = true;
+    }
+
+    public void OpenShop()
+    {
+        mShopWindow?.Close();
+
+        mShopWindow = new ShopWindow(GameCanvas);
+        mShouldOpenShop = false;
+    }
+
+    //Bank
+    public void NotifyOpenBank()
+    {
+        mShouldOpenBank = true;
+    }
+
+    public void NotifyCloseBank()
+    {
+        mShouldCloseBank = true;
+    }
+
+    public void OpenBank()
+    {
+        mBankWindow.Open();
+        mShouldOpenBank = false;
+        Globals.InBank = true;
+    }
+
+    //Bag
+    public void NotifyOpenBag()
+    {
+        mShouldOpenBag = true;
+    }
+
+    public void NotifyCloseBag()
+    {
+        mShouldCloseBag = true;
+    }
+
+    public void OpenBag()
+    {
+        mBagWindow?.Close();
+
+        mBagWindow = new BagWindow(GameCanvas);
+        mShouldOpenBag = false;
+        Globals.InBag = true;
+    }
+
+    public BagWindow GetBagWindow()
+    {
+        return mBagWindow;
+    }
+
+    public BankWindow GetBankWindow()
+    {
+        return mBankWindow;
+    }
+
+    //Crafting
+    public void NotifyOpenCraftingTable(bool journalMode)
+    {
+        mShouldOpenCraftingTable = true;
+        mCraftJournal = journalMode;
+    }
+
+    public void NotifyCloseCraftingTable()
+    {
+        mShouldCloseCraftingTable = true;
+        mCraftJournal = false;
+    }
+
+    public void OpenCraftingTable()
+    {
+        if (mCraftingWindow != null)
+        {
+            mCraftingWindow.Close();
+        }
+
+        mCraftingWindow = new CraftingWindow(GameCanvas, mCraftJournal);
+        mShouldOpenCraftingTable = false;
+        Globals.InCraft = true;
+    }
+
+    //Quest Log
+    public void NotifyQuestsUpdated()
+    {
+        mShouldUpdateQuestLog = true;
+    }
+
+    //Trading
+    public void NotifyOpenTrading(string traderName)
+    {
+        mShouldOpenTrading = true;
+        mTradingTarget = traderName;
+    }
+
+    public void NotifyCloseTrading()
+    {
+        mShouldCloseTrading = true;
+    }
+
+    public void OpenTrading()
+    {
+        mTradingWindow?.Close();
+        mTradingWindow = new TradingWindow(GameCanvas, mTradingTarget);
+        mShouldOpenTrading = false;
+        Globals.InTrade = true;
+    }
+
+    public bool AdminWindowOpen()
+    {
+        return mAdminWindow?.IsVisible() ?? false;
+    }
+
+    public void AdminWindowSelectName(string name)
+    {
+        mAdminWindow?.SetName(name);
+    }
+
+    public void Update()
+    {
+        if (Globals.Me != null && PlayerBox?.MyEntity != Globals.Me)
+        {
+            PlayerBox?.SetEntity(Globals.Me);
+        }
+
+        mChatBox?.Update();
+        GameMenu?.Update(mShouldUpdateQuestLog);
+        mShouldUpdateQuestLog = false;
+        Hotbar?.Update();
+        EscapeMenu.Update();
+        PlayerBox?.Update();
+        PlayerStatusWindow?.Update();
+        mMapItemWindow.Update();
+        AnnouncementWindow?.Update();
+        mPictureWindow?.Update();
+
+        if (Globals.QuestOffers.Count > 0)
+        {
+            var quest = QuestBase.Get(Globals.QuestOffers[0]);
+            mQuestOfferWindow.Update(quest);
+        }
+        else
+        {
+            mQuestOfferWindow.Hide();
+        }
+
+        if (Globals.Picture != null)
+        {
+            if (mPictureWindow.Picture != Globals.Picture.Picture ||
+                mPictureWindow.Size != Globals.Picture.Size ||
+                mPictureWindow.Clickable != Globals.Picture.Clickable)
             {
-                mPictureWindow = new PictureWindow(GameCanvas);
+                mPictureWindow.Setup(Globals.Picture.Picture, Globals.Picture.Size, Globals.Picture.Clickable);
             }
-
-            mEventWindow = new EventWindow(GameCanvas);
-            mQuestOfferWindow = new QuestOfferWindow(GameCanvas);
-            mMapItemWindow = new MapItemWindow(GameCanvas);
-            mBankWindow = new BankWindow(GameCanvas);
         }
-
-        //Chatbox
-        public void SetChatboxText(string msg)
+        else
         {
-            mChatBox.SetChatboxText(msg);
-        }
-
-        //Friends Window
-        public void NotifyUpdateFriendsList()
-        {
-            mShouldUpdateFriendsList = true;
-        }
-
-        //Guild Window
-        public void NotifyUpdateGuildList()
-        {
-            mShouldUpdateGuildList = true;
-        }
-
-        public void HideGuildWindow()
-        {
-            mShouldHideGuildWindow = true;
-        }
-
-        //Admin Window
-        public void NotifyOpenAdminWindow()
-        {
-            mShouldOpenAdminWindow = true;
-        }
-
-        public void OpenAdminWindow()
-        {
-            if (mAdminWindow == null)
+            if (mPictureWindow != null)
             {
-                mAdminWindow ??= new AdminWindow(GameCanvas);
-            }
-            else if (mAdminWindow.IsVisible())
-            {
-                mAdminWindow.Hide();
-            }
-            else
-            {
-                mAdminWindow.Show();
-            }
-
-            mShouldOpenAdminWindow = false;
-        }
-
-        //Shop
-        public void NotifyOpenShop()
-        {
-            mShouldOpenShop = true;
-        }
-
-        public void NotifyCloseShop()
-        {
-            mShouldCloseShop = true;
-        }
-
-        public void OpenShop()
-        {
-            mShopWindow?.Close();
-
-            mShopWindow = new ShopWindow(GameCanvas);
-            mShouldOpenShop = false;
-        }
-
-        //Bank
-        public void NotifyOpenBank()
-        {
-            mShouldOpenBank = true;
-        }
-
-        public void NotifyCloseBank()
-        {
-            mShouldCloseBank = true;
-        }
-
-        public void OpenBank()
-        {
-            mBankWindow.Open();
-            mShouldOpenBank = false;
-            Globals.InBank = true;
-        }
-
-        //Bag
-        public void NotifyOpenBag()
-        {
-            mShouldOpenBag = true;
-        }
-
-        public void NotifyCloseBag()
-        {
-            mShouldCloseBag = true;
-        }
-
-        public void OpenBag()
-        {
-            mBagWindow?.Close();
-
-            mBagWindow = new BagWindow(GameCanvas);
-            mShouldOpenBag = false;
-            Globals.InBag = true;
-        }
-
-        public BagWindow GetBagWindow()
-        {
-            return mBagWindow;
-        }
-
-        public BankWindow GetBankWindow()
-        {
-            return mBankWindow;
-        }
-
-        //Crafting
-        public void NotifyOpenCraftingTable(bool journalMode)
-        {
-            mShouldOpenCraftingTable = true;
-            mCraftJournal = journalMode;
-        }
-
-        public void NotifyCloseCraftingTable()
-        {
-            mShouldCloseCraftingTable = true;
-            mCraftJournal = false;
-        }
-
-        public void OpenCraftingTable()
-        {
-            if (mCraftingWindow != null)
-            {
-                mCraftingWindow.Close();
-            }
-
-            mCraftingWindow = new CraftingWindow(GameCanvas, mCraftJournal);
-            mShouldOpenCraftingTable = false;
-            Globals.InCraft = true;
-        }
-
-        //Quest Log
-        public void NotifyQuestsUpdated()
-        {
-            mShouldUpdateQuestLog = true;
-        }
-
-        //Trading
-        public void NotifyOpenTrading(string traderName)
-        {
-            mShouldOpenTrading = true;
-            mTradingTarget = traderName;
-        }
-
-        public void NotifyCloseTrading()
-        {
-            mShouldCloseTrading = true;
-        }
-
-        public void OpenTrading()
-        {
-            mTradingWindow?.Close();
-            mTradingWindow = new TradingWindow(GameCanvas, mTradingTarget);
-            mShouldOpenTrading = false;
-            Globals.InTrade = true;
-        }
-
-        public bool AdminWindowOpen()
-        {
-            return mAdminWindow?.IsVisible() ?? false;
-        }
-
-        public void AdminWindowSelectName(string name)
-        {
-            mAdminWindow?.SetName(name);
-        }
-
-        public void Update()
-        {
-            if (Globals.Me != null && PlayerBox?.MyEntity != Globals.Me)
-            {
-                PlayerBox?.SetEntity(Globals.Me);
-            }
-
-            mChatBox?.Update();
-            GameMenu?.Update(mShouldUpdateQuestLog);
-            mShouldUpdateQuestLog = false;
-            Hotbar?.Update();
-            EscapeMenu.Update();
-            PlayerBox?.Update();
-            PlayerStatusWindow?.Update();
-            mMapItemWindow.Update();
-            AnnouncementWindow?.Update();
-            mPictureWindow?.Update();
-
-            if (Globals.QuestOffers.Count > 0)
-            {
-                var quest = QuestBase.Get(Globals.QuestOffers[0]);
-                mQuestOfferWindow.Update(quest);
-            }
-            else
-            {
-                mQuestOfferWindow.Hide();
-            }
-
-            if (Globals.Picture != null)
-            {
-                if (mPictureWindow.Picture != Globals.Picture.Picture ||
-                    mPictureWindow.Size != Globals.Picture.Size ||
-                    mPictureWindow.Clickable != Globals.Picture.Clickable)
-                {
-                    mPictureWindow.Setup(Globals.Picture.Picture, Globals.Picture.Size, Globals.Picture.Clickable);
-                }
-            }
-            else
-            {
-                if (mPictureWindow != null)
-                {
-                    mPictureWindow.Close();
-                }
-            }
-
-            mEventWindow?.Update();
-
-            //Admin window update
-            if (mShouldOpenAdminWindow)
-            {
-                OpenAdminWindow();
-            }
-
-            //Shop Update
-            if (mShouldOpenShop)
-            {
-                OpenShop();
-                GameMenu.OpenInventory();
-            }
-
-            if (mShopWindow != null && (!mShopWindow.IsVisible() || mShouldCloseShop))
-            {
-                CloseShop();
-            }
-
-            mShouldCloseShop = false;
-
-            //Bank Update
-            if (mShouldOpenBank)
-            {
-                OpenBank();
-                GameMenu.OpenInventory();
-            }
-            else if (mShouldCloseBank)
-            {
-                CloseBank();
-            }
-            else
-            {
-                mBankWindow.Update();
-            }
-
-
-
-            //Bag Update
-            if (mShouldOpenBag)
-            {
-                OpenBag();
-            }
-
-            if (mBagWindow != null)
-            {
-                if (!mBagWindow.IsVisible() || mShouldCloseBag)
-                {
-                    CloseBagWindow();
-                }
-                else
-                {
-                    mBagWindow.Update();
-                }
-            }
-
-            mShouldCloseBag = false;
-
-            //Crafting station update
-            if (mShouldOpenCraftingTable)
-            {
-                OpenCraftingTable();
-                GameMenu.OpenInventory();
-            }
-
-            if (mCraftingWindow != null)
-            {
-                if (!mCraftingWindow.IsVisible() || mShouldCloseCraftingTable)
-                {
-                    CloseCraftingTable();
-                }
-                else
-                {
-                    mCraftingWindow.Update();
-                }
-            }
-
-            mShouldCloseCraftingTable = false;
-
-            //Trading update
-            if (mShouldOpenTrading)
-            {
-                OpenTrading();
-                GameMenu.OpenInventory();
-            }
-
-            if (mTradingWindow != null)
-            {
-                if (mShouldCloseTrading)
-                {
-                    CloseTrading();
-                    mShouldCloseTrading = false;
-                }
-                else
-                {
-                    if (!mTradingWindow.IsVisible())
-                    {
-                        CloseTrading();
-                    }
-                    else
-                    {
-                        mTradingWindow.Update();
-                    }
-                }
-            }
-
-            if (mShouldUpdateFriendsList)
-            {
-                GameMenu.UpdateFriendsList();
-                mShouldUpdateFriendsList = false;
-            }
-
-            if (mShouldUpdateGuildList)
-            {
-                GameMenu.UpdateGuildList();
-                mShouldUpdateGuildList = false;
-            }
-
-            if (mShouldHideGuildWindow)
-            {
-                GameMenu.HideGuildWindow();
-                mShouldHideGuildWindow = false;
-            }
-
-            mShouldCloseTrading = false;
-
-            if (FocusChat)
-            {
-                mChatBox.Focus();
-                FocusChat = false;
-            }
-
-            if (UnfocusChat)
-            {
-                mChatBox.UnFocus();
-                UnfocusChat = false;
+                mPictureWindow.Close();
             }
         }
 
-        public void Draw()
+        mEventWindow?.Update();
+
+        //Admin window update
+        if (mShouldOpenAdminWindow)
         {
-            GameCanvas.RenderCanvas();
+            OpenAdminWindow();
         }
 
-        private void CloseShop()
+        //Shop Update
+        if (mShouldOpenShop)
         {
-            Globals.GameShop = null;
-            mShopWindow?.Close();
-            mShopWindow = null;
-            PacketSender.SendCloseShop();
+            OpenShop();
+            GameMenu.OpenInventory();
         }
 
-        private void CloseBank()
+        if (mShopWindow != null && (!mShopWindow.IsVisible() || mShouldCloseShop))
         {
-            mBankWindow.Close();
-            Globals.InBank = false;
-            PacketSender.SendCloseBank();
-            mShouldCloseBank = false;
+            CloseShop();
         }
 
-        private void CloseBagWindow()
+        mShouldCloseShop = false;
+
+        //Bank Update
+        if (mShouldOpenBank)
         {
-            mBagWindow?.Close();
-            mBagWindow = null;
-            Globals.InBag = false;
-            PacketSender.SendCloseBag();
+            OpenBank();
+            GameMenu.OpenInventory();
+        }
+        else if (mShouldCloseBank)
+        {
+            CloseBank();
+        }
+        else
+        {
+            mBankWindow.Update();
         }
 
-        private void CloseCraftingTable()
+
+
+        //Bag Update
+        if (mShouldOpenBag)
         {
-            mCraftingWindow?.Close();
-            mCraftingWindow = null;
-            Globals.InCraft = false;
-            PacketSender.SendCloseCrafting();
+            OpenBag();
         }
 
-        private void CloseTrading()
+        if (mBagWindow != null)
         {
-            mTradingWindow?.Close();
-            mTradingWindow = null;
-            Globals.InTrade = false;
-            PacketSender.SendDeclineTrade();
-        }
-
-        public bool CloseAllWindows()
-        {
-            var closedWindows = false;
-            if (mBagWindow != null && mBagWindow.IsVisible())
+            if (!mBagWindow.IsVisible() || mShouldCloseBag)
             {
                 CloseBagWindow();
-                closedWindows = true;
             }
-
-            if (mTradingWindow != null && mTradingWindow.IsVisible())
+            else
             {
-                CloseTrading();
-                closedWindows = true;
+                mBagWindow.Update();
             }
+        }
 
-            if (mBankWindow != null && mBankWindow.IsVisible())
-            {
-                CloseBank();
-                closedWindows = true;
-            }
+        mShouldCloseBag = false;
 
-            if (mCraftingWindow != null && mCraftingWindow.IsVisible() && !mCraftingWindow.IsCrafting)
+        //Crafting station update
+        if (mShouldOpenCraftingTable)
+        {
+            OpenCraftingTable();
+            GameMenu.OpenInventory();
+        }
+
+        if (mCraftingWindow != null)
+        {
+            if (!mCraftingWindow.IsVisible() || mShouldCloseCraftingTable)
             {
                 CloseCraftingTable();
-                closedWindows = true;
             }
-
-            if (mShopWindow != null && mShopWindow.IsVisible())
+            else
             {
-                CloseShop();
-                closedWindows = true;
+                mCraftingWindow.Update();
             }
-
-            if (GameMenu != null && GameMenu.HasWindowsOpen())
-            {
-                GameMenu.CloseAllWindows();
-                closedWindows = true;
-            }
-
-            return closedWindows;
         }
 
-        //Dispose
-        public void Dispose()
+        mShouldCloseCraftingTable = false;
+
+        //Trading update
+        if (mShouldOpenTrading)
+        {
+            OpenTrading();
+            GameMenu.OpenInventory();
+        }
+
+        if (mTradingWindow != null)
+        {
+            if (mShouldCloseTrading)
+            {
+                CloseTrading();
+                mShouldCloseTrading = false;
+            }
+            else
+            {
+                if (!mTradingWindow.IsVisible())
+                {
+                    CloseTrading();
+                }
+                else
+                {
+                    mTradingWindow.Update();
+                }
+            }
+        }
+
+        if (mShouldUpdateFriendsList)
+        {
+            GameMenu.UpdateFriendsList();
+            mShouldUpdateFriendsList = false;
+        }
+
+        if (mShouldUpdateGuildList)
+        {
+            GameMenu.UpdateGuildList();
+            mShouldUpdateGuildList = false;
+        }
+
+        if (mShouldHideGuildWindow)
+        {
+            GameMenu.HideGuildWindow();
+            mShouldHideGuildWindow = false;
+        }
+
+        mShouldCloseTrading = false;
+
+        if (FocusChat)
+        {
+            mChatBox.Focus();
+            FocusChat = false;
+        }
+
+        if (UnfocusChat)
+        {
+            mChatBox.UnFocus();
+            UnfocusChat = false;
+        }
+    }
+
+    public void Draw()
+    {
+        GameCanvas.RenderCanvas();
+    }
+
+    private void CloseShop()
+    {
+        Globals.GameShop = null;
+        mShopWindow?.Close();
+        mShopWindow = null;
+        PacketSender.SendCloseShop();
+    }
+
+    private void CloseBank()
+    {
+        mBankWindow.Close();
+        Globals.InBank = false;
+        PacketSender.SendCloseBank();
+        mShouldCloseBank = false;
+    }
+
+    private void CloseBagWindow()
+    {
+        mBagWindow?.Close();
+        mBagWindow = null;
+        Globals.InBag = false;
+        PacketSender.SendCloseBag();
+    }
+
+    private void CloseCraftingTable()
+    {
+        mCraftingWindow?.Close();
+        mCraftingWindow = null;
+        Globals.InCraft = false;
+        PacketSender.SendCloseCrafting();
+    }
+
+    private void CloseTrading()
+    {
+        mTradingWindow?.Close();
+        mTradingWindow = null;
+        Globals.InTrade = false;
+        PacketSender.SendDeclineTrade();
+    }
+
+    public bool CloseAllWindows()
+    {
+        var closedWindows = false;
+        if (mBagWindow != null && mBagWindow.IsVisible())
         {
             CloseBagWindow();
-            CloseBank();
-            CloseCraftingTable();
-            CloseShop();
-            CloseTrading();
-            GameCanvas.Dispose();
+            closedWindows = true;
         }
 
+        if (mTradingWindow != null && mTradingWindow.IsVisible())
+        {
+            CloseTrading();
+            closedWindows = true;
+        }
+
+        if (mBankWindow != null && mBankWindow.IsVisible())
+        {
+            CloseBank();
+            closedWindows = true;
+        }
+
+        if (mCraftingWindow != null && mCraftingWindow.IsVisible() && !mCraftingWindow.IsCrafting)
+        {
+            CloseCraftingTable();
+            closedWindows = true;
+        }
+
+        if (mShopWindow != null && mShopWindow.IsVisible())
+        {
+            CloseShop();
+            closedWindows = true;
+        }
+
+        if (GameMenu != null && GameMenu.HasWindowsOpen())
+        {
+            GameMenu.CloseAllWindows();
+            closedWindows = true;
+        }
+
+        return closedWindows;
+    }
+
+    //Dispose
+    public void Dispose()
+    {
+        CloseBagWindow();
+        CloseBank();
+        CloseCraftingTable();
+        CloseShop();
+        CloseTrading();
+        GameCanvas.Dispose();
     }
 
 }

--- a/Intersect.Client/Interface/Game/GuildWindow.cs
+++ b/Intersect.Client/Interface/Game/GuildWindow.cs
@@ -7,415 +7,413 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+partial class GuildWindow
 {
 
-    partial class GuildWindow
+    private Button mAddButton;
+
+    private Button mAddPopupButton;
+
+    private Button mLeave;
+
+    private ListBox mGuildMembers;
+
+    //Controls
+    private WindowControl mGuildWindow;
+
+    private TextBox mSearchTextbox;
+
+    private ImagePanel mTextboxContainer;
+
+    private bool mAddButtonUsed;
+
+    private bool mAddPopupButtonUsed;
+
+    //Context Menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mPmOption;
+
+    private MenuItem[] mPromoteOptions;
+
+    private MenuItem[] mDemoteOptions;
+
+    private MenuItem mKickOption;
+
+    private MenuItem mTransferOption;
+
+    private GuildMember mSelectedMember;
+
+    //Init
+    public GuildWindow(Canvas gameCanvas)
     {
+        mGuildWindow = new WindowControl(gameCanvas, Globals.Me.Guild, false, "GuildWindow");
+        mGuildWindow.DisableResizing();
 
-        private Button mAddButton;
+        mTextboxContainer = new ImagePanel(mGuildWindow, "SearchContainer");
+        mSearchTextbox = new TextBox(mTextboxContainer, "SearchTextbox");
+        Interface.FocusElements.Add(mSearchTextbox);
 
-        private Button mAddPopupButton;
+        mGuildMembers = new ListBox(mGuildWindow, "GuildMembers");
 
-        private Button mLeave;
+        mAddButton = new Button(mGuildWindow, "InviteButton");
+        mAddButton.SetText("+");
+        mAddButton.Clicked += addButton_Clicked;
 
-        private ListBox mGuildMembers;
+        mLeave = new Button(mGuildWindow, "LeaveButton");
+        mLeave.SetText(Strings.Guilds.Leave);
+        mLeave.Clicked += leave_Clicked;
 
-        //Controls
-        private WindowControl mGuildWindow;
+        mAddPopupButton = new Button(mGuildWindow, "InvitePopupButton");
+        mAddPopupButton.IsHidden = true;
+        mAddPopupButton.SetText(Strings.Guilds.Invite);
+        mAddPopupButton.Clicked += addPopupButton_Clicked;
 
-        private TextBox mSearchTextbox;
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "GuildContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
 
-        private ImagePanel mTextboxContainer;
+        //Add Context Menu Options
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
 
-        private bool mAddButtonUsed;
+        mPmOption = mContextMenu.AddItem(Strings.Guilds.PM.ToString());
+        mPmOption.Clicked += pmOption_Clicked;
 
-        private bool mAddPopupButtonUsed;
-
-        //Context Menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mPmOption;
-
-        private MenuItem[] mPromoteOptions;
-
-        private MenuItem[] mDemoteOptions;
-
-        private MenuItem mKickOption;
-
-        private MenuItem mTransferOption;
-
-        private GuildMember mSelectedMember;
-
-        //Init
-        public GuildWindow(Canvas gameCanvas)
+        mPromoteOptions = new MenuItem[Options.Instance.Guild.Ranks.Length - 2];
+        for (int i = 1; i < Options.Instance.Guild.Ranks.Length - 1; i++)
         {
-            mGuildWindow = new WindowControl(gameCanvas, Globals.Me.Guild, false, "GuildWindow");
-            mGuildWindow.DisableResizing();
-
-            mTextboxContainer = new ImagePanel(mGuildWindow, "SearchContainer");
-            mSearchTextbox = new TextBox(mTextboxContainer, "SearchTextbox");
-            Interface.FocusElements.Add(mSearchTextbox);
-
-            mGuildMembers = new ListBox(mGuildWindow, "GuildMembers");
-
-            mAddButton = new Button(mGuildWindow, "InviteButton");
-            mAddButton.SetText("+");
-            mAddButton.Clicked += addButton_Clicked;
-
-            mLeave = new Button(mGuildWindow, "LeaveButton");
-            mLeave.SetText(Strings.Guilds.Leave);
-            mLeave.Clicked += leave_Clicked;
-
-            mAddPopupButton = new Button(mGuildWindow, "InvitePopupButton");
-            mAddPopupButton.IsHidden = true;
-            mAddPopupButton.SetText(Strings.Guilds.Invite);
-            mAddPopupButton.Clicked += addPopupButton_Clicked;
-
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "GuildContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-
-            //Add Context Menu Options
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-
-            mPmOption = mContextMenu.AddItem(Strings.Guilds.PM.ToString());
-            mPmOption.Clicked += pmOption_Clicked;
-
-            mPromoteOptions = new MenuItem[Options.Instance.Guild.Ranks.Length - 2];
-            for (int i = 1; i < Options.Instance.Guild.Ranks.Length - 1; i++)
-            {
-                mPromoteOptions[i - 1] = mContextMenu.AddItem(Strings.Guilds.Promote.ToString(Options.Instance.Guild.Ranks[i].Title));
-                mPromoteOptions[i - 1].UserData = i;
-                mPromoteOptions[i - 1].Clicked += promoteOption_Clicked;
-            }
-
-            mDemoteOptions = new MenuItem[Options.Instance.Guild.Ranks.Length - 2];
-            for (int i = 2; i < Options.Instance.Guild.Ranks.Length; i++)
-            {
-                mDemoteOptions[i - 2] = mContextMenu.AddItem(Strings.Guilds.Demote.ToString(Options.Instance.Guild.Ranks[i].Title));
-                mDemoteOptions[i - 2].UserData = i;
-                mDemoteOptions[i - 2].Clicked += demoteOption_Clicked;
-            }
-
-            mKickOption = mContextMenu.AddItem(Strings.Guilds.Kick.ToString());
-            mKickOption.Clicked += kickOption_Clicked;
-
-            mTransferOption = mContextMenu.AddItem(Strings.Guilds.Transfer.ToString());
-            mTransferOption.Clicked += transferOption_Clicked;
-
-            UpdateList();
-
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-            mGuildWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            mAddButtonUsed = !mAddButton.IsHidden;
-            mAddPopupButtonUsed = !mAddPopupButton.IsHidden;
+            mPromoteOptions[i - 1] = mContextMenu.AddItem(Strings.Guilds.Promote.ToString(Options.Instance.Guild.Ranks[i].Title));
+            mPromoteOptions[i - 1].UserData = i;
+            mPromoteOptions[i - 1].Clicked += promoteOption_Clicked;
         }
 
-        //Methods
-        public void Update()
+        mDemoteOptions = new MenuItem[Options.Instance.Guild.Ranks.Length - 2];
+        for (int i = 2; i < Options.Instance.Guild.Ranks.Length; i++)
         {
-            if (mGuildWindow.IsHidden)
-            {
-                return;
-            }
-
-            // Force our window title to co-operate, might be empty after creating/joining a guild.
-            if (mGuildWindow.Title != Globals.Me.Guild)
-            {
-                mGuildWindow.Title = Globals.Me.Guild;
-            }
+            mDemoteOptions[i - 2] = mContextMenu.AddItem(Strings.Guilds.Demote.ToString(Options.Instance.Guild.Ranks[i].Title));
+            mDemoteOptions[i - 2].UserData = i;
+            mDemoteOptions[i - 2].Clicked += demoteOption_Clicked;
         }
 
-        public void Show()
-        {
-            mGuildWindow.IsHidden = false;
-        }
+        mKickOption = mContextMenu.AddItem(Strings.Guilds.Kick.ToString());
+        mKickOption.Clicked += kickOption_Clicked;
 
-        public bool IsVisible()
-        {
-            return !mGuildWindow.IsHidden;
-        }
+        mTransferOption = mContextMenu.AddItem(Strings.Guilds.Transfer.ToString());
+        mTransferOption.Clicked += transferOption_Clicked;
 
-        public void Hide()
-        {
-            mContextMenu?.Close();
-            mGuildWindow.IsHidden = true;
-        }
+        UpdateList();
 
-        #region "Adding/Leaving"
-        void addButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (mSearchTextbox.Text.Trim().Length >= 3) //Don't bother sending a packet less than the char limit
-            {
-                PacketSender.SendInviteGuild(mSearchTextbox.Text);
-            }
-        }
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        mGuildWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        void addPopupButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var iBox = new InputBox(
-                Strings.Guilds.InviteMemberTitle, Strings.Guilds.InviteMemberPrompt.ToString(Globals.Me.Guild), true, InputBox.InputType.TextInput,
-                AddMember, null, 0
-            );
-        }
-
-        private void leave_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var iBox = new InputBox(
-                Strings.Guilds.LeaveTitle, Strings.Guilds.LeavePrompt, true, InputBox.InputType.YesNo,
-                LeaveGuild, null, 0
-            );
-        }
-
-        private void LeaveGuild(object sender, EventArgs e)
-        {
-            PacketSender.SendLeaveGuild();
-        }
-
-        private void AddMember(Object sender, EventArgs e)
-        {
-            var ibox = (InputBox)sender;
-            if (ibox.TextValue.Trim().Length >= 3) //Don't bother sending a packet less than the char limit
-            {
-                PacketSender.SendInviteGuild(ibox.TextValue);
-            }
-        }
-
-        #endregion
-
-        #region "Member List"
-        public void UpdateList()
-        {
-            //Clear previous instances if already existing
-            if (mGuildMembers != null)
-            {
-                mGuildMembers.Clear();
-            }
-
-            foreach (var f in Globals.Me.GuildMembers)
-            {
-                var str = f.Online ? Strings.Guilds.OnlineListEntry : Strings.Guilds.OfflineListEntry;
-                var row = mGuildMembers.AddRow(str.ToString(Options.Instance.Guild.Ranks[f.Rank].Title, f.Name, f.Map));
-                row.Name = "GuildMemberRow";
-                row.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-                row.SetToolTipText(Strings.Guilds.Tooltip.ToString(f.Level, f.Class));
-                row.UserData = f;
-                row.Clicked += member_Clicked;
-                row.RightClicked += member_RightClicked;
-
-                //Row Render color (red = offline, green = online)
-                if (f.Online == true)
-                {
-                    row.SetTextColor(Color.Green);
-                }
-                else
-                {
-                    row.SetTextColor(Color.Red);
-                }
-
-                row.RenderColor = new Color(50, 255, 255, 255);
-            }
-
-            //Determine if we can invite
-            mAddButton.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddButtonUsed;
-            mTextboxContainer.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddButtonUsed;
-            mAddPopupButton.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddPopupButtonUsed;
-            mLeave.IsHidden = Globals.Me != null && Globals.Me.Rank == 0;
-        }
-
-        void member_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var row = (ListBoxRow)sender;
-            var member = (GuildMember)row.UserData;
-
-            //Only pm online players
-            if (member?.Online == true && member?.Id != Globals.Me?.Id)
-            {
-                Interface.GameUi.SetChatboxText("/pm " + member.Name + " ");
-            }
-        }
-
-        private void member_RightClicked(Base sender, ClickedEventArgs arguments)
-        {
-            var row = (ListBoxRow)sender;
-            var member = (GuildMember)row.UserData;
-
-            //Only pm online players
-            if (member != null && member.Id != Globals.Me?.Id)
-            {
-                mSelectedMember = member;
-
-                var rank = Globals.Me?.GuildRank ?? null;
-
-                if (rank != null)
-                {
-                    //Remove and re-add children
-                    foreach (var child in mContextMenu.Children.ToArray())
-                    {
-                        mContextMenu.RemoveChild(child, false);
-                    }
-
-                    var rankIndex = Globals.Me.Rank;
-                    var isOwner = rankIndex == 0;
-
-                    if (mSelectedMember?.Online ?? false)
-                    {
-                        mContextMenu.AddChild(mPmOption);
-                    }
-
-                    //Promote Options
-                    foreach (var opt in mPromoteOptions)
-                    {
-                        if ((isOwner || rank.Permissions.Promote) && (int)opt.UserData > rankIndex && (int)opt.UserData < member.Rank && member.Rank > rankIndex)
-                        {
-                            mContextMenu.AddChild(opt);
-                        }
-                    }
-
-                    //Demote Options
-                    foreach (var opt in mDemoteOptions)
-                    {
-                        if ((isOwner || rank.Permissions.Demote) && (int)opt.UserData > rankIndex && (int)opt.UserData > member.Rank && member.Rank > rankIndex)
-                        {
-                            mContextMenu.AddChild(opt);
-                        }
-                    }
-
-                    if ((rank.Permissions.Kick || isOwner) && member.Rank > rankIndex)
-                    {
-                        mContextMenu.AddChild(mKickOption);
-                    }
-
-                    if (isOwner)
-                    {
-                        mContextMenu.AddChild(mTransferOption);
-                    }
-
-                    mContextMenu.SizeToChildren();
-                    mContextMenu.Open(Framework.Gwen.Pos.None);
-                }
-            }
-        }
-
-        #endregion
-
-        #region "Kicking"
-        private void kickOption_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rank = Globals.Me?.GuildRank ?? null;
-            var rankIndex = Globals.Me?.Rank;
-            var isOwner = rankIndex == 0;
-            if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
-            {
-                var iBox = new InputBox(
-                    Strings.Guilds.KickTitle, Strings.Guilds.KickPrompt.ToString(mSelectedMember?.Name), true, InputBox.InputType.YesNo,
-                    KickMember, null, mSelectedMember
-                );
-            }
-        }
-
-        private void KickMember(object sender, EventArgs e)
-        {
-            var input = (InputBox)sender;
-            var member = (GuildMember)input.UserData;
-            PacketSender.SendKickGuildMember(member.Id);
-        }
-
-        #endregion
-
-        #region "Transferring"
-        private void transferOption_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rank = Globals.Me?.GuildRank ?? null;
-            var rankIndex = Globals.Me?.Rank;
-            var isOwner = rankIndex == 0;
-            if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
-            {
-                var iBox = new InputBox(
-                    Strings.Guilds.TransferTitle, Strings.Guilds.TransferPrompt.ToString(mSelectedMember?.Name, rank.Title, Globals.Me?.Guild), true, InputBox.InputType.TextInput,
-                    TransferGuild, null, mSelectedMember
-                );
-            }
-        }
-
-        private void TransferGuild(object sender, EventArgs e)
-        {
-            var input = (InputBox)sender;
-            var member = (GuildMember)input.UserData;
-            var text = input.TextValue;
-            if (text == Globals.Me?.Guild)
-            {
-                PacketSender.SendTransferGuild(member.Id);
-            }
-        }
-
-        #endregion
-
-
-
-        private void pmOption_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            //Only pm online players
-            if (mSelectedMember?.Online == true && mSelectedMember?.Id != Globals.Me?.Id)
-            {
-                Interface.GameUi.SetChatboxText("/pm " + mSelectedMember.Name + " ");
-            }
-        }
-
-        #region "Promoting"
-        private void promoteOption_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rank = Globals.Me?.GuildRank ?? null;
-            var rankIndex = Globals.Me?.Rank;
-            var isOwner = rankIndex == 0;
-            var newRank = (int)sender.UserData;
-            if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
-            {
-                var iBox = new InputBox(
-                    Strings.Guilds.PromoteTitle, Strings.Guilds.PromotePrompt.ToString(mSelectedMember?.Name, Options.Instance.Guild.Ranks[newRank].Title), true, InputBox.InputType.YesNo,
-                    PromoteMember, null, new KeyValuePair<GuildMember, int>(mSelectedMember, newRank)
-                );
-            }
-        }
-
-        private void PromoteMember(object sender, EventArgs e)
-        {
-            var input = (InputBox)sender;
-            var memberRankPair = (KeyValuePair<GuildMember, int>)input.UserData;
-            PacketSender.SendPromoteGuildMember(memberRankPair.Key?.Id ?? Guid.Empty, memberRankPair.Value);
-        }
-
-        #endregion
-
-
-        #region "Demoting"
-        private void demoteOption_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var rank = Globals.Me?.GuildRank ?? null;
-            var rankIndex = Globals.Me?.Rank;
-            var isOwner = rankIndex == 0;
-            var newRank = (int)sender.UserData;
-            if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
-            {
-                var iBox = new InputBox(
-                    Strings.Guilds.DemoteTitle, Strings.Guilds.DemotePrompt.ToString(mSelectedMember?.Name, Options.Instance.Guild.Ranks[newRank].Title), true, InputBox.InputType.YesNo,
-                    DemoteMember, null, new KeyValuePair<GuildMember, int>(mSelectedMember, newRank)
-                );
-            }
-        }
-
-        private void DemoteMember(object sender, EventArgs e)
-        {
-            var input = (InputBox)sender;
-            var memberRankPair = (KeyValuePair<GuildMember, int>)input.UserData;
-            PacketSender.SendDemoteGuildMember(memberRankPair.Key?.Id ?? Guid.Empty, memberRankPair.Value);
-        }
-
-        #endregion
-
+        mAddButtonUsed = !mAddButton.IsHidden;
+        mAddPopupButtonUsed = !mAddPopupButton.IsHidden;
     }
+
+    //Methods
+    public void Update()
+    {
+        if (mGuildWindow.IsHidden)
+        {
+            return;
+        }
+
+        // Force our window title to co-operate, might be empty after creating/joining a guild.
+        if (mGuildWindow.Title != Globals.Me.Guild)
+        {
+            mGuildWindow.Title = Globals.Me.Guild;
+        }
+    }
+
+    public void Show()
+    {
+        mGuildWindow.IsHidden = false;
+    }
+
+    public bool IsVisible()
+    {
+        return !mGuildWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mContextMenu?.Close();
+        mGuildWindow.IsHidden = true;
+    }
+
+    #region "Adding/Leaving"
+    void addButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (mSearchTextbox.Text.Trim().Length >= 3) //Don't bother sending a packet less than the char limit
+        {
+            PacketSender.SendInviteGuild(mSearchTextbox.Text);
+        }
+    }
+
+    void addPopupButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var iBox = new InputBox(
+            Strings.Guilds.InviteMemberTitle, Strings.Guilds.InviteMemberPrompt.ToString(Globals.Me.Guild), true, InputBox.InputType.TextInput,
+            AddMember, null, 0
+        );
+    }
+
+    private void leave_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var iBox = new InputBox(
+            Strings.Guilds.LeaveTitle, Strings.Guilds.LeavePrompt, true, InputBox.InputType.YesNo,
+            LeaveGuild, null, 0
+        );
+    }
+
+    private void LeaveGuild(object sender, EventArgs e)
+    {
+        PacketSender.SendLeaveGuild();
+    }
+
+    private void AddMember(Object sender, EventArgs e)
+    {
+        var ibox = (InputBox)sender;
+        if (ibox.TextValue.Trim().Length >= 3) //Don't bother sending a packet less than the char limit
+        {
+            PacketSender.SendInviteGuild(ibox.TextValue);
+        }
+    }
+
+    #endregion
+
+    #region "Member List"
+    public void UpdateList()
+    {
+        //Clear previous instances if already existing
+        if (mGuildMembers != null)
+        {
+            mGuildMembers.Clear();
+        }
+
+        foreach (var f in Globals.Me.GuildMembers)
+        {
+            var str = f.Online ? Strings.Guilds.OnlineListEntry : Strings.Guilds.OfflineListEntry;
+            var row = mGuildMembers.AddRow(str.ToString(Options.Instance.Guild.Ranks[f.Rank].Title, f.Name, f.Map));
+            row.Name = "GuildMemberRow";
+            row.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            row.SetToolTipText(Strings.Guilds.Tooltip.ToString(f.Level, f.Class));
+            row.UserData = f;
+            row.Clicked += member_Clicked;
+            row.RightClicked += member_RightClicked;
+
+            //Row Render color (red = offline, green = online)
+            if (f.Online == true)
+            {
+                row.SetTextColor(Color.Green);
+            }
+            else
+            {
+                row.SetTextColor(Color.Red);
+            }
+
+            row.RenderColor = new Color(50, 255, 255, 255);
+        }
+
+        //Determine if we can invite
+        mAddButton.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddButtonUsed;
+        mTextboxContainer.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddButtonUsed;
+        mAddPopupButton.IsHidden = Globals.Me == null || Globals.Me.GuildRank == null || !Globals.Me.GuildRank.Permissions.Invite || !mAddPopupButtonUsed;
+        mLeave.IsHidden = Globals.Me != null && Globals.Me.Rank == 0;
+    }
+
+    void member_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var row = (ListBoxRow)sender;
+        var member = (GuildMember)row.UserData;
+
+        //Only pm online players
+        if (member?.Online == true && member?.Id != Globals.Me?.Id)
+        {
+            Interface.GameUi.SetChatboxText("/pm " + member.Name + " ");
+        }
+    }
+
+    private void member_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        var row = (ListBoxRow)sender;
+        var member = (GuildMember)row.UserData;
+
+        //Only pm online players
+        if (member != null && member.Id != Globals.Me?.Id)
+        {
+            mSelectedMember = member;
+
+            var rank = Globals.Me?.GuildRank ?? null;
+
+            if (rank != null)
+            {
+                //Remove and re-add children
+                foreach (var child in mContextMenu.Children.ToArray())
+                {
+                    mContextMenu.RemoveChild(child, false);
+                }
+
+                var rankIndex = Globals.Me.Rank;
+                var isOwner = rankIndex == 0;
+
+                if (mSelectedMember?.Online ?? false)
+                {
+                    mContextMenu.AddChild(mPmOption);
+                }
+
+                //Promote Options
+                foreach (var opt in mPromoteOptions)
+                {
+                    if ((isOwner || rank.Permissions.Promote) && (int)opt.UserData > rankIndex && (int)opt.UserData < member.Rank && member.Rank > rankIndex)
+                    {
+                        mContextMenu.AddChild(opt);
+                    }
+                }
+
+                //Demote Options
+                foreach (var opt in mDemoteOptions)
+                {
+                    if ((isOwner || rank.Permissions.Demote) && (int)opt.UserData > rankIndex && (int)opt.UserData > member.Rank && member.Rank > rankIndex)
+                    {
+                        mContextMenu.AddChild(opt);
+                    }
+                }
+
+                if ((rank.Permissions.Kick || isOwner) && member.Rank > rankIndex)
+                {
+                    mContextMenu.AddChild(mKickOption);
+                }
+
+                if (isOwner)
+                {
+                    mContextMenu.AddChild(mTransferOption);
+                }
+
+                mContextMenu.SizeToChildren();
+                mContextMenu.Open(Framework.Gwen.Pos.None);
+            }
+        }
+    }
+
+    #endregion
+
+    #region "Kicking"
+    private void kickOption_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rank = Globals.Me?.GuildRank ?? null;
+        var rankIndex = Globals.Me?.Rank;
+        var isOwner = rankIndex == 0;
+        if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
+        {
+            var iBox = new InputBox(
+                Strings.Guilds.KickTitle, Strings.Guilds.KickPrompt.ToString(mSelectedMember?.Name), true, InputBox.InputType.YesNo,
+                KickMember, null, mSelectedMember
+            );
+        }
+    }
+
+    private void KickMember(object sender, EventArgs e)
+    {
+        var input = (InputBox)sender;
+        var member = (GuildMember)input.UserData;
+        PacketSender.SendKickGuildMember(member.Id);
+    }
+
+    #endregion
+
+    #region "Transferring"
+    private void transferOption_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rank = Globals.Me?.GuildRank ?? null;
+        var rankIndex = Globals.Me?.Rank;
+        var isOwner = rankIndex == 0;
+        if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
+        {
+            var iBox = new InputBox(
+                Strings.Guilds.TransferTitle, Strings.Guilds.TransferPrompt.ToString(mSelectedMember?.Name, rank.Title, Globals.Me?.Guild), true, InputBox.InputType.TextInput,
+                TransferGuild, null, mSelectedMember
+            );
+        }
+    }
+
+    private void TransferGuild(object sender, EventArgs e)
+    {
+        var input = (InputBox)sender;
+        var member = (GuildMember)input.UserData;
+        var text = input.TextValue;
+        if (text == Globals.Me?.Guild)
+        {
+            PacketSender.SendTransferGuild(member.Id);
+        }
+    }
+
+    #endregion
+
+
+
+    private void pmOption_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        //Only pm online players
+        if (mSelectedMember?.Online == true && mSelectedMember?.Id != Globals.Me?.Id)
+        {
+            Interface.GameUi.SetChatboxText("/pm " + mSelectedMember.Name + " ");
+        }
+    }
+
+    #region "Promoting"
+    private void promoteOption_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rank = Globals.Me?.GuildRank ?? null;
+        var rankIndex = Globals.Me?.Rank;
+        var isOwner = rankIndex == 0;
+        var newRank = (int)sender.UserData;
+        if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
+        {
+            var iBox = new InputBox(
+                Strings.Guilds.PromoteTitle, Strings.Guilds.PromotePrompt.ToString(mSelectedMember?.Name, Options.Instance.Guild.Ranks[newRank].Title), true, InputBox.InputType.YesNo,
+                PromoteMember, null, new KeyValuePair<GuildMember, int>(mSelectedMember, newRank)
+            );
+        }
+    }
+
+    private void PromoteMember(object sender, EventArgs e)
+    {
+        var input = (InputBox)sender;
+        var memberRankPair = (KeyValuePair<GuildMember, int>)input.UserData;
+        PacketSender.SendPromoteGuildMember(memberRankPair.Key?.Id ?? Guid.Empty, memberRankPair.Value);
+    }
+
+    #endregion
+
+
+    #region "Demoting"
+    private void demoteOption_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var rank = Globals.Me?.GuildRank ?? null;
+        var rankIndex = Globals.Me?.Rank;
+        var isOwner = rankIndex == 0;
+        var newRank = (int)sender.UserData;
+        if (mSelectedMember != null && (rank.Permissions.Kick || isOwner) && mSelectedMember.Rank > rankIndex)
+        {
+            var iBox = new InputBox(
+                Strings.Guilds.DemoteTitle, Strings.Guilds.DemotePrompt.ToString(mSelectedMember?.Name, Options.Instance.Guild.Ranks[newRank].Title), true, InputBox.InputType.YesNo,
+                DemoteMember, null, new KeyValuePair<GuildMember, int>(mSelectedMember, newRank)
+            );
+        }
+    }
+
+    private void DemoteMember(object sender, EventArgs e)
+    {
+        var input = (InputBox)sender;
+        var memberRankPair = (KeyValuePair<GuildMember, int>)input.UserData;
+        PacketSender.SendDemoteGuildMember(memberRankPair.Key?.Id ?? Guid.Empty, memberRankPair.Value);
+    }
+
+    #endregion
 
 }

--- a/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotBar.cs
@@ -4,73 +4,71 @@ using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 
-namespace Intersect.Client.Interface.Game.Hotbar
+namespace Intersect.Client.Interface.Game.Hotbar;
+
+
+public partial class HotBarWindow
 {
 
-    public partial class HotBarWindow
+    //Controls
+    public ImagePanel HotbarWindow;
+
+    //Item List
+    public List<HotbarItem> Items = new List<HotbarItem>();
+
+    //Init
+    public HotBarWindow(Canvas gameCanvas)
     {
+        HotbarWindow = new ImagePanel(gameCanvas, "HotbarWindow");
+        HotbarWindow.ShouldCacheToTexture = true;
+        InitHotbarItems();
+        HotbarWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        //Controls
-        public ImagePanel HotbarWindow;
-
-        //Item List
-        public List<HotbarItem> Items = new List<HotbarItem>();
-
-        //Init
-        public HotBarWindow(Canvas gameCanvas)
+        for (var i = 0; i < Items.Count; i++)
         {
-            HotbarWindow = new ImagePanel(gameCanvas, "HotbarWindow");
-            HotbarWindow.ShouldCacheToTexture = true;
-            InitHotbarItems();
-            HotbarWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            for (var i = 0; i < Items.Count; i++)
+            if (Items[i].EquipPanel.Texture == null)
             {
-                if (Items[i].EquipPanel.Texture == null)
-                {
-                    Items[i].EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
-                }
+                Items[i].EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
             }
         }
+    }
 
-        private void InitHotbarItems()
+    private void InitHotbarItems()
+    {
+        var x = 12;
+        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
         {
-            var x = 12;
-            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-            {
-                Items.Add(new HotbarItem((byte) i, HotbarWindow));
-                Items[i].Pnl = new ImagePanel(HotbarWindow, "HotbarContainer" + i);
-                Items[i].Setup();
-                Items[i].KeyLabel = new Label(Items[i].Pnl, "HotbarLabel" + i);
-            }
+            Items.Add(new HotbarItem((byte) i, HotbarWindow));
+            Items[i].Pnl = new ImagePanel(HotbarWindow, "HotbarContainer" + i);
+            Items[i].Setup();
+            Items[i].KeyLabel = new Label(Items[i].Pnl, "HotbarLabel" + i);
+        }
+    }
+
+    public void Update()
+    {
+        if (Globals.Me == null)
+        {
+            return;
         }
 
-        public void Update()
+        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
         {
-            if (Globals.Me == null)
-            {
-                return;
-            }
-
-            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-            {
-                Items[i].Update();
-            }
+            Items[i].Update();
         }
+    }
 
-        public FloatRect RenderBounds()
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            var rect = new FloatRect()
-            {
-                X = HotbarWindow.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = HotbarWindow.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = HotbarWindow.Width,
-                Height = HotbarWindow.Height
-            };
+            X = HotbarWindow.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = HotbarWindow.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = HotbarWindow.Width,
+            Height = HotbarWindow.Height
+        };
 
-            return rect;
-        }
-
+        return rect;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client/Interface/Game/Hotbar/HotbarItem.cs
@@ -13,539 +13,537 @@ using Intersect.Client.Spells;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Hotbar
+namespace Intersect.Client.Interface.Game.Hotbar;
+
+
+public partial class HotbarItem
 {
 
-    public partial class HotbarItem
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public Label EquipLabel;
+
+    public ImagePanel EquipPanel;
+
+    public bool IsDragging;
+
+    public Label KeyLabel;
+
+    //Dragging
+    private bool mCanDrag;
+
+    private long mClickTime;
+
+    //pnl is the background iamge
+    private ImagePanel mContentPanel;
+
+    private Label mCooldownLabel;
+
+    //Item Info
+    private Guid mCurrentId = Guid.Empty;
+
+    private ItemBase mCurrentItem = null;
+
+    private SpellBase mCurrentSpell = null;
+
+    private Draggable mDragIcon;
+
+    //Textures
+    private Base mHotbarWindow;
+
+    private ControlValue mHotKey;
+
+    private Item mInventoryItem = null;
+
+    private int mInventoryItemIndex = -1;
+
+    private bool mIsEquipped;
+
+    private bool mIsFaded;
+
+    private ItemDescriptionWindow mItemDescWindow;
+
+    //Mouse Event Variables
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    private Spell mSpellBookItem = null;
+
+    private SpellDescriptionWindow mSpellDescWindow;
+
+    private bool mTexLoaded;
+
+    private byte mYindex;
+
+    public ImagePanel Pnl;
+
+    public HotbarItem(byte index, Base hotbarWindow)
     {
+        mYindex = index;
+        mHotbarWindow = hotbarWindow;
+    }
 
-        private static int sItemXPadding = 4;
+    public void Setup()
+    {
+        //Content Panel is layered on top of the container.
+        //Shows the Item or Spell Icon
+        mContentPanel = new ImagePanel(Pnl, "HotbarIcon" + mYindex);
+        mContentPanel.HoverEnter += pnl_HoverEnter;
+        mContentPanel.HoverLeave += pnl_HoverLeave;
+        mContentPanel.RightClicked += pnl_RightClicked;
+        mContentPanel.Clicked += pnl_Clicked;
 
-        private static int sItemYPadding = 4;
+        EquipPanel = new ImagePanel(mContentPanel, "HotbarEquipedIcon" + mYindex);
+        EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
+        EquipLabel = new Label(Pnl, "HotbarEquippedLabel" + mYindex);
+        EquipLabel.IsHidden = true;
+        EquipLabel.Text = Strings.Inventory.EquippedSymbol;
+        EquipLabel.TextColor = new Color(0, 255, 255, 255);
+        mCooldownLabel = new Label(Pnl, "HotbarCooldownLabel" + mYindex);
+        mCooldownLabel.IsHidden = true;
+        mCooldownLabel.TextColor = new Color(0, 255, 255, 255);
+    }
 
-        public Label EquipLabel;
-
-        public ImagePanel EquipPanel;
-
-        public bool IsDragging;
-
-        public Label KeyLabel;
-
-        //Dragging
-        private bool mCanDrag;
-
-        private long mClickTime;
-
-        //pnl is the background iamge
-        private ImagePanel mContentPanel;
-
-        private Label mCooldownLabel;
-
-        //Item Info
-        private Guid mCurrentId = Guid.Empty;
-
-        private ItemBase mCurrentItem = null;
-
-        private SpellBase mCurrentSpell = null;
-
-        private Draggable mDragIcon;
-
-        //Textures
-        private Base mHotbarWindow;
-
-        private ControlValue mHotKey;
-
-        private Item mInventoryItem = null;
-
-        private int mInventoryItemIndex = -1;
-
-        private bool mIsEquipped;
-
-        private bool mIsFaded;
-
-        private ItemDescriptionWindow mItemDescWindow;
-
-        //Mouse Event Variables
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        private Spell mSpellBookItem = null;
-
-        private SpellDescriptionWindow mSpellDescWindow;
-
-        private bool mTexLoaded;
-
-        private byte mYindex;
-
-        public ImagePanel Pnl;
-
-        public HotbarItem(byte index, Base hotbarWindow)
+    public void Activate()
+    {
+        if (mCurrentId != Guid.Empty)
         {
-            mYindex = index;
-            mHotbarWindow = hotbarWindow;
-        }
-
-        public void Setup()
-        {
-            //Content Panel is layered on top of the container.
-            //Shows the Item or Spell Icon
-            mContentPanel = new ImagePanel(Pnl, "HotbarIcon" + mYindex);
-            mContentPanel.HoverEnter += pnl_HoverEnter;
-            mContentPanel.HoverLeave += pnl_HoverLeave;
-            mContentPanel.RightClicked += pnl_RightClicked;
-            mContentPanel.Clicked += pnl_Clicked;
-
-            EquipPanel = new ImagePanel(mContentPanel, "HotbarEquipedIcon" + mYindex);
-            EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
-            EquipLabel = new Label(Pnl, "HotbarEquippedLabel" + mYindex);
-            EquipLabel.IsHidden = true;
-            EquipLabel.Text = Strings.Inventory.EquippedSymbol;
-            EquipLabel.TextColor = new Color(0, 255, 255, 255);
-            mCooldownLabel = new Label(Pnl, "HotbarCooldownLabel" + mYindex);
-            mCooldownLabel.IsHidden = true;
-            mCooldownLabel.TextColor = new Color(0, 255, 255, 255);
-        }
-
-        public void Activate()
-        {
-            if (mCurrentId != Guid.Empty)
+            if (mCurrentItem != null)
             {
-                if (mCurrentItem != null)
+                if (mInventoryItemIndex > -1)
                 {
-                    if (mInventoryItemIndex > -1)
-                    {
-                        Globals.Me.TryUseItem(mInventoryItemIndex);
-                    }
-                }
-                else if (mCurrentSpell != null)
-                {
-                    Globals.Me.TryUseSpell(mCurrentSpell.Id);
+                    Globals.Me.TryUseItem(mInventoryItemIndex);
                 }
             }
+            else if (mCurrentSpell != null)
+            {
+                Globals.Me.TryUseSpell(mCurrentSpell.Id);
+            }
+        }
+    }
+
+    void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.Me.AddToHotbar(mYindex, -1, -1);
+    }
+
+    void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mClickTime = Timing.Global.MillisecondsUtc + 500;
+    }
+
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (mItemDescWindow != null)
+        {
+            mItemDescWindow.Dispose();
+            mItemDescWindow = null;
         }
 
-        void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+        if (mSpellDescWindow != null)
         {
-            Globals.Me.AddToHotbar(mYindex, -1, -1);
+            mSpellDescWindow.Dispose();
+            mSpellDescWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+        mMouseOver = true;
+        mCanDrag = true;
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            mClickTime = Timing.Global.MillisecondsUtc + 500;
+            mCanDrag = false;
+
+            return;
         }
 
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
+        if (mCurrentItem != null)
         {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
             if (mItemDescWindow != null)
             {
                 mItemDescWindow.Dispose();
                 mItemDescWindow = null;
             }
 
+            mItemDescWindow = new ItemDescriptionWindow(
+                mCurrentItem, 1, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2,
+                mInventoryItem?.ItemProperties, mCurrentItem.Name, "", true
+            );
+        }
+        else if (mCurrentSpell != null)
+        {
             if (mSpellDescWindow != null)
             {
                 mSpellDescWindow.Dispose();
                 mSpellDescWindow = null;
             }
+
+            mSpellDescWindow = new SpellDescriptionWindow(
+                mCurrentSpell.Id, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2, true
+            );
+        }
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
+
+        return rect;
+    }
+
+    public void Update()
+    {
+        if (Globals.Me == null)
+        {
+            return;
         }
 
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
+        //See if Label Should be changed
+        var keybind = Controls.ActiveControls.ControlMapping[Control.Hotkey1 + mYindex].Bindings[0];
+        if (mHotKey == null || mHotKey.Modifier != keybind.Modifier || mHotKey.Key != keybind.Key)
         {
-            if (InputHandler.MouseFocus != null)
+            if (keybind.Modifier != Keys.None)
             {
-                return;
+                KeyLabel.SetText(string.Format("{00} + {01}",
+                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Modifier).ToLower()],
+                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Key).ToLower()]
+                ));
+            }
+            else
+            {
+                KeyLabel.SetText(
+                    Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Key).ToLower()]
+                );
+            }
+            
+
+            mHotKey = keybind;
+        }
+
+        var slot = Globals.Me.Hotbar[mYindex];
+        var updateDisplay =
+            mCurrentId != slot.ItemOrSpellId ||
+            mTexLoaded ==
+            false; //Update display if the hotbar item changes or we dont have a texture for the current item
+
+        if (mCurrentId != slot.ItemOrSpellId)
+        {
+            mCurrentItem = null;
+            mCurrentSpell = null;
+            var itm = ItemBase.Get(slot.ItemOrSpellId);
+            var spl = SpellBase.Get(slot.ItemOrSpellId);
+            if (itm != null)
+            {
+                mCurrentItem = itm;
             }
 
-            mMouseOver = true;
-            mCanDrag = true;
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+            if (spl != null)
             {
-                mCanDrag = false;
-
-                return;
+                mCurrentSpell = spl;
             }
 
+            mCurrentId = slot.ItemOrSpellId;
+        }
+
+        mSpellBookItem = null;
+        mInventoryItem = null;
+        mInventoryItemIndex = -1;
+
+        if (mCurrentItem != null)
+        {
+            var itmIndex = Globals.Me.FindHotbarItem(slot);
+            if (itmIndex > -1)
+            {
+                mInventoryItemIndex = itmIndex;
+                mInventoryItem = Globals.Me.Inventory[itmIndex] as Item;
+            }
+        }
+        else if (mCurrentSpell != null)
+        {
+            var splIndex = Globals.Me.FindHotbarSpell(slot);
+            if (splIndex > -1)
+            {
+                mSpellBookItem = Globals.Me.Spells[splIndex] as Spell;
+            }
+        }
+
+        if (mCurrentItem != null) //When it's an item
+        {
+            //We don't have it, and the icon isn't faded
+            if (mInventoryItem == null && !mIsFaded)
+            {
+                updateDisplay = true;
+            }
+
+            //We have it, and the equip icon doesn't match equipped status
+            if (mInventoryItem != null && Globals.Me.IsEquipped(mInventoryItemIndex) != mIsEquipped)
+            {
+                updateDisplay = true;
+            }
+
+            //We have it, and it's on cd
+            if (mInventoryItem != null && Globals.Me.IsItemOnCooldown(mInventoryItemIndex))
+            {
+                updateDisplay = true;
+            }
+
+            //We have it, and it's on cd, and the fade is incorrect
+            if (mInventoryItem != null && Globals.Me.IsItemOnCooldown(mInventoryItemIndex) != mIsFaded)
+            {
+                updateDisplay = true;
+            }
+        }
+
+        if (mCurrentSpell != null) //When it's a spell
+        {
+            //We don't know it, and the icon isn't faded!
+            if (mSpellBookItem == null && !mIsFaded)
+            {
+                updateDisplay = true;
+            }
+
+            //Spell on cd
+            if (mSpellBookItem != null &&
+                Globals.Me.GetSpellCooldown(mSpellBookItem.Id) > Timing.Global.Milliseconds)
+            {
+                updateDisplay = true;
+            }
+
+            //Spell on cd and the fade is incorrect
+            if (mSpellBookItem != null &&
+                Globals.Me.GetSpellCooldown(mSpellBookItem.Id) > Timing.Global.Milliseconds != mIsFaded)
+            {
+                updateDisplay = true;
+            }
+        }
+
+        if (updateDisplay) //Item on cd and fade is incorrect
+        {
             if (mCurrentItem != null)
             {
-                if (mItemDescWindow != null)
-                {
-                    mItemDescWindow.Dispose();
-                    mItemDescWindow = null;
-                }
-
-                mItemDescWindow = new ItemDescriptionWindow(
-                    mCurrentItem, 1, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2,
-                    mInventoryItem?.ItemProperties, mCurrentItem.Name, "", true
+                mCooldownLabel.IsHidden = true;
+                mContentPanel.Show();
+                mContentPanel.Texture = Globals.ContentManager.GetTexture(
+                    Framework.Content.TextureType.Item, mCurrentItem.Icon
                 );
-            }
-            else if (mCurrentSpell != null)
-            {
-                if (mSpellDescWindow != null)
+
+                if (mInventoryItemIndex > -1)
                 {
-                    mSpellDescWindow.Dispose();
-                    mSpellDescWindow = null;
-                }
+                    EquipPanel.IsHidden = !Globals.Me.IsEquipped(mInventoryItemIndex);
+                    EquipLabel.IsHidden = !Globals.Me.IsEquipped(mInventoryItemIndex);
+                    mIsFaded = Globals.Me.IsItemOnCooldown(mInventoryItemIndex);
+                    if (mIsFaded)
+                    {
+                        mCooldownLabel.IsHidden = false;
+                        mCooldownLabel.Text = TimeSpan
+                            .FromMilliseconds(Globals.Me.GetItemRemainingCooldown(mInventoryItemIndex))
+                            .WithSuffix();
+                    }
 
-                mSpellDescWindow = new SpellDescriptionWindow(
-                    mCurrentSpell.Id, mHotbarWindow.X + (mHotbarWindow.Width / 2), mHotbarWindow.Y + mHotbarWindow.Height + 2, true
-                );
-            }
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
-
-            return rect;
-        }
-
-        public void Update()
-        {
-            if (Globals.Me == null)
-            {
-                return;
-            }
-
-            //See if Label Should be changed
-            var keybind = Controls.ActiveControls.ControlMapping[Control.Hotkey1 + mYindex].Bindings[0];
-            if (mHotKey == null || mHotKey.Modifier != keybind.Modifier || mHotKey.Key != keybind.Key)
-            {
-                if (keybind.Modifier != Keys.None)
-                {
-                    KeyLabel.SetText(string.Format("{00} + {01}",
-                        Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Modifier).ToLower()],
-                        Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Key).ToLower()]
-                    ));
+                    mIsEquipped = Globals.Me.IsEquipped(mInventoryItemIndex);
                 }
                 else
                 {
-                    KeyLabel.SetText(
-                        Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), keybind.Key).ToLower()]
-                    );
+                    EquipPanel.IsHidden = true;
+                    EquipLabel.IsHidden = true;
+                    mIsEquipped = false;
+                    mIsFaded = true;
+                }
+
+                mTexLoaded = true;
+            }
+            else if (mCurrentSpell != null)
+            {
+                mContentPanel.Show();
+                mContentPanel.Texture = Globals.ContentManager.GetTexture(
+                    Framework.Content.TextureType.Spell, mCurrentSpell.Icon
+                );
+
+                EquipPanel.IsHidden = true;
+                EquipLabel.IsHidden = true;
+                mCooldownLabel.IsHidden = true;
+                if (mSpellBookItem != null)
+                {
+                    var spellSlot = Globals.Me.FindHotbarSpell(slot);
+                    mIsFaded = Globals.Me.IsSpellOnCooldown(spellSlot);
+                    if (mIsFaded)
+                    {
+                        mCooldownLabel.IsHidden = false;
+                        var remaining = Globals.Me.GetSpellRemainingCooldown(spellSlot);
+                        mCooldownLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix("0.0");
+                    }
+                }
+                else
+                {
+                    mIsFaded = true;
+                }
+
+                mTexLoaded = true;
+                mIsEquipped = false;
+            }
+            else
+            {
+                mContentPanel.Hide();
+                mTexLoaded = true;
+                mIsEquipped = false;
+                EquipPanel.IsHidden = true;
+                EquipLabel.IsHidden = true;
+                mCooldownLabel.IsHidden = true;
+            }
+
+            if (mIsFaded)
+            {
+                if (mCurrentSpell != null)
+                {
+                    mContentPanel.RenderColor = new Color(100, 255, 255, 255);
                 }
                 
-
-                mHotKey = keybind;
-            }
-
-            var slot = Globals.Me.Hotbar[mYindex];
-            var updateDisplay =
-                mCurrentId != slot.ItemOrSpellId ||
-                mTexLoaded ==
-                false; //Update display if the hotbar item changes or we dont have a texture for the current item
-
-            if (mCurrentId != slot.ItemOrSpellId)
-            {
-                mCurrentItem = null;
-                mCurrentSpell = null;
-                var itm = ItemBase.Get(slot.ItemOrSpellId);
-                var spl = SpellBase.Get(slot.ItemOrSpellId);
-                if (itm != null)
-                {
-                    mCurrentItem = itm;
-                }
-
-                if (spl != null)
-                {
-                    mCurrentSpell = spl;
-                }
-
-                mCurrentId = slot.ItemOrSpellId;
-            }
-
-            mSpellBookItem = null;
-            mInventoryItem = null;
-            mInventoryItemIndex = -1;
-
-            if (mCurrentItem != null)
-            {
-                var itmIndex = Globals.Me.FindHotbarItem(slot);
-                if (itmIndex > -1)
-                {
-                    mInventoryItemIndex = itmIndex;
-                    mInventoryItem = Globals.Me.Inventory[itmIndex] as Item;
-                }
-            }
-            else if (mCurrentSpell != null)
-            {
-                var splIndex = Globals.Me.FindHotbarSpell(slot);
-                if (splIndex > -1)
-                {
-                    mSpellBookItem = Globals.Me.Spells[splIndex] as Spell;
-                }
-            }
-
-            if (mCurrentItem != null) //When it's an item
-            {
-                //We don't have it, and the icon isn't faded
-                if (mInventoryItem == null && !mIsFaded)
-                {
-                    updateDisplay = true;
-                }
-
-                //We have it, and the equip icon doesn't match equipped status
-                if (mInventoryItem != null && Globals.Me.IsEquipped(mInventoryItemIndex) != mIsEquipped)
-                {
-                    updateDisplay = true;
-                }
-
-                //We have it, and it's on cd
-                if (mInventoryItem != null && Globals.Me.IsItemOnCooldown(mInventoryItemIndex))
-                {
-                    updateDisplay = true;
-                }
-
-                //We have it, and it's on cd, and the fade is incorrect
-                if (mInventoryItem != null && Globals.Me.IsItemOnCooldown(mInventoryItemIndex) != mIsFaded)
-                {
-                    updateDisplay = true;
-                }
-            }
-
-            if (mCurrentSpell != null) //When it's a spell
-            {
-                //We don't know it, and the icon isn't faded!
-                if (mSpellBookItem == null && !mIsFaded)
-                {
-                    updateDisplay = true;
-                }
-
-                //Spell on cd
-                if (mSpellBookItem != null &&
-                    Globals.Me.GetSpellCooldown(mSpellBookItem.Id) > Timing.Global.Milliseconds)
-                {
-                    updateDisplay = true;
-                }
-
-                //Spell on cd and the fade is incorrect
-                if (mSpellBookItem != null &&
-                    Globals.Me.GetSpellCooldown(mSpellBookItem.Id) > Timing.Global.Milliseconds != mIsFaded)
-                {
-                    updateDisplay = true;
-                }
-            }
-
-            if (updateDisplay) //Item on cd and fade is incorrect
-            {
                 if (mCurrentItem != null)
                 {
-                    mCooldownLabel.IsHidden = true;
-                    mContentPanel.Show();
-                    mContentPanel.Texture = Globals.ContentManager.GetTexture(
-                        Framework.Content.TextureType.Item, mCurrentItem.Icon
-                    );
-
-                    if (mInventoryItemIndex > -1)
-                    {
-                        EquipPanel.IsHidden = !Globals.Me.IsEquipped(mInventoryItemIndex);
-                        EquipLabel.IsHidden = !Globals.Me.IsEquipped(mInventoryItemIndex);
-                        mIsFaded = Globals.Me.IsItemOnCooldown(mInventoryItemIndex);
-                        if (mIsFaded)
-                        {
-                            mCooldownLabel.IsHidden = false;
-                            mCooldownLabel.Text = TimeSpan
-                                .FromMilliseconds(Globals.Me.GetItemRemainingCooldown(mInventoryItemIndex))
-                                .WithSuffix();
-                        }
-
-                        mIsEquipped = Globals.Me.IsEquipped(mInventoryItemIndex);
-                    }
-                    else
-                    {
-                        EquipPanel.IsHidden = true;
-                        EquipLabel.IsHidden = true;
-                        mIsEquipped = false;
-                        mIsFaded = true;
-                    }
-
-                    mTexLoaded = true;
-                }
-                else if (mCurrentSpell != null)
-                {
-                    mContentPanel.Show();
-                    mContentPanel.Texture = Globals.ContentManager.GetTexture(
-                        Framework.Content.TextureType.Spell, mCurrentSpell.Icon
-                    );
-
-                    EquipPanel.IsHidden = true;
-                    EquipLabel.IsHidden = true;
-                    mCooldownLabel.IsHidden = true;
-                    if (mSpellBookItem != null)
-                    {
-                        var spellSlot = Globals.Me.FindHotbarSpell(slot);
-                        mIsFaded = Globals.Me.IsSpellOnCooldown(spellSlot);
-                        if (mIsFaded)
-                        {
-                            mCooldownLabel.IsHidden = false;
-                            var remaining = Globals.Me.GetSpellRemainingCooldown(spellSlot);
-                            mCooldownLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix("0.0");
-                        }
-                    }
-                    else
-                    {
-                        mIsFaded = true;
-                    }
-
-                    mTexLoaded = true;
-                    mIsEquipped = false;
-                }
-                else
-                {
-                    mContentPanel.Hide();
-                    mTexLoaded = true;
-                    mIsEquipped = false;
-                    EquipPanel.IsHidden = true;
-                    EquipLabel.IsHidden = true;
-                    mCooldownLabel.IsHidden = true;
-                }
-
-                if (mIsFaded)
-                {
-                    if (mCurrentSpell != null)
-                    {
-                        mContentPanel.RenderColor = new Color(100, 255, 255, 255);
-                    }
-                    
-                    if (mCurrentItem != null)
-                    {
-                        mContentPanel.RenderColor = new Color(100, mCurrentItem.Color.R, mCurrentItem.Color.G, mCurrentItem.Color.B);
-                    } 
-                }
-                else
-                {
-                    if (mCurrentSpell != null)
-                    {
-                        mContentPanel.RenderColor = Color.White;
-                    }
-                    
-                    if (mCurrentItem != null)
-                    {
-                        mContentPanel.RenderColor = mCurrentItem.Color;
-                    }
-                }
+                    mContentPanel.RenderColor = new Color(100, mCurrentItem.Color.R, mCurrentItem.Color.G, mCurrentItem.Color.B);
+                } 
             }
-
-            if (mCurrentItem != null || mCurrentSpell != null)
+            else
             {
-                if (!IsDragging)
+                if (mCurrentSpell != null)
                 {
-                    mContentPanel.IsHidden = false;
-                    if (mMouseOver)
-                    {
-                        if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-                        {
-                            mCanDrag = true;
-                            mMouseX = -1;
-                            mMouseY = -1;
-                            if (Timing.Global.MillisecondsUtc < mClickTime)
-                            {
-                                Activate();
-                                mClickTime = 0;
-                            }
-                        }
-                        else
-                        {
-                            if (mCanDrag && Draggable.Active == null)
-                            {
-                                if (mMouseX == -1 || mMouseY == -1)
-                                {
-                                    mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
-                                    mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
-                                }
-                                else
-                                {
-                                    var xdiff = mMouseX -
-                                                (InputHandler.MousePosition.X -
-                                                 Pnl.LocalPosToCanvas(new Point(0, 0)).X);
-
-                                    var ydiff = mMouseY -
-                                                (InputHandler.MousePosition.Y -
-                                                 Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
-
-                                    if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
-                                    {
-                                        IsDragging = true;
-                                        mDragIcon = new Draggable(
-                                            Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
-                                            Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, mContentPanel.Texture, mContentPanel.RenderColor
-                                        );
-
-                                        //SOMETHING SHOULD BE RENDERED HERE, RIGHT?
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    mContentPanel.RenderColor = Color.White;
                 }
-                else
+                
+                if (mCurrentItem != null)
                 {
-                    if (mDragIcon.Update())
-                    {
-                        //Drug the item and now we stopped
-                        IsDragging = false;
-                        var dragRect = new FloatRect(
-                            mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
-                            sItemYPadding / 2 + 32
-                        );
-
-                        float bestIntersect = 0;
-                        var bestIntersectIndex = -1;
-
-                        if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
-                        {
-                            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-                            {
-                                if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
-                                {
-                                    if (FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
-                                            .Width *
-                                        FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
-                                            .Height >
-                                        bestIntersect)
-                                    {
-                                        bestIntersect =
-                                            FloatRect.Intersect(
-                                                    Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
-                                                )
-                                                .Width *
-                                            FloatRect.Intersect(
-                                                    Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
-                                                )
-                                                .Height;
-
-                                        bestIntersectIndex = i;
-                                    }
-                                }
-                            }
-
-                            if (bestIntersectIndex > -1 && bestIntersectIndex != mYindex)
-                            {
-                                Globals.Me.HotbarSwap(mYindex, (byte) bestIntersectIndex);
-                            }
-                        }
-
-                        mDragIcon.Dispose();
-                    }
-                    else
-                    {
-                        mContentPanel.IsHidden = true;
-                    }
+                    mContentPanel.RenderColor = mCurrentItem.Color;
                 }
             }
         }
 
+        if (mCurrentItem != null || mCurrentSpell != null)
+        {
+            if (!IsDragging)
+            {
+                mContentPanel.IsHidden = false;
+                if (mMouseOver)
+                {
+                    if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                    {
+                        mCanDrag = true;
+                        mMouseX = -1;
+                        mMouseY = -1;
+                        if (Timing.Global.MillisecondsUtc < mClickTime)
+                        {
+                            Activate();
+                            mClickTime = 0;
+                        }
+                    }
+                    else
+                    {
+                        if (mCanDrag && Draggable.Active == null)
+                        {
+                            if (mMouseX == -1 || mMouseY == -1)
+                            {
+                                mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
+                                mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
+                            }
+                            else
+                            {
+                                var xdiff = mMouseX -
+                                            (InputHandler.MousePosition.X -
+                                             Pnl.LocalPosToCanvas(new Point(0, 0)).X);
+
+                                var ydiff = mMouseY -
+                                            (InputHandler.MousePosition.Y -
+                                             Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
+
+                                if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
+                                {
+                                    IsDragging = true;
+                                    mDragIcon = new Draggable(
+                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
+                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, mContentPanel.Texture, mContentPanel.RenderColor
+                                    );
+
+                                    //SOMETHING SHOULD BE RENDERED HERE, RIGHT?
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (mDragIcon.Update())
+                {
+                    //Drug the item and now we stopped
+                    IsDragging = false;
+                    var dragRect = new FloatRect(
+                        mDragIcon.X - sItemXPadding / 2, mDragIcon.Y - sItemYPadding / 2, sItemXPadding / 2 + 32,
+                        sItemYPadding / 2 + 32
+                    );
+
+                    float bestIntersect = 0;
+                    var bestIntersectIndex = -1;
+
+                    if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
+                    {
+                        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+                        {
+                            if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
+                            {
+                                if (FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
+                                        .Width *
+                                    FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
+                                        .Height >
+                                    bestIntersect)
+                                {
+                                    bestIntersect =
+                                        FloatRect.Intersect(
+                                                Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
+                                            )
+                                            .Width *
+                                        FloatRect.Intersect(
+                                                Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
+                                            )
+                                            .Height;
+
+                                    bestIntersectIndex = i;
+                                }
+                            }
+                        }
+
+                        if (bestIntersectIndex > -1 && bestIntersectIndex != mYindex)
+                        {
+                            Globals.Me.HotbarSwap(mYindex, (byte) bestIntersectIndex);
+                        }
+                    }
+
+                    mDragIcon.Dispose();
+                }
+                else
+                {
+                    mContentPanel.IsHidden = true;
+                }
+            }
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Game/InputBox.cs
+++ b/Intersect.Client/Interface/Game/InputBox.cs
@@ -5,366 +5,364 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Localization;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class InputBox : Base
 {
+    public static void Open(
+        string title,
+        string prompt,
+        bool modal,
+        InputType inputType,
+        EventHandler onSuccess,
+        EventHandler onCancel,
+        object userData,
+        int quantity = 0,
+        int maxQuantity = int.MaxValue,
+        Base parent = null,
+        GameContentManager.UI stage = GameContentManager.UI.InGame
+    ) => new InputBox(
+        title: title,
+        prompt: prompt,
+        modal: modal,
+        inputType: inputType,
+        onSuccess: onSuccess,
+        onCancel: onCancel,
+        userData: userData,
+        quantity: quantity,
+        maxQuantity: maxQuantity,
+        parent: parent,
+        stage: stage
+    );
 
-    public partial class InputBox : Base
+    public enum InputType
     {
-        public static void Open(
-            string title,
-            string prompt,
-            bool modal,
-            InputType inputType,
-            EventHandler onSuccess,
-            EventHandler onCancel,
-            object userData,
-            int quantity = 0,
-            int maxQuantity = int.MaxValue,
-            Base parent = null,
-            GameContentManager.UI stage = GameContentManager.UI.InGame
-        ) => new InputBox(
-            title: title,
-            prompt: prompt,
-            modal: modal,
-            inputType: inputType,
-            onSuccess: onSuccess,
-            onCancel: onCancel,
-            userData: userData,
-            quantity: quantity,
-            maxQuantity: maxQuantity,
-            parent: parent,
-            stage: stage
-        );
 
-        public enum InputType
+        OkayOnly,
+
+        YesNo,
+
+        NumericInput,
+
+        TextInput,
+
+        NumericSliderInput,
+
+    }
+
+    private GameContentManager.UI _uiStage;
+
+    private bool mInitialized = false;
+
+    private InputType mInputType;
+
+    private WindowControl mMyWindow;
+
+    private Button mNoButton;
+
+    private TextBoxNumeric mNumericTextbox;
+
+    private ImagePanel mNumericTextboxBg;
+
+    private ImagePanel mNumericSliderboxBg;
+
+    private HorizontalSlider mNumericSlider;
+
+    private TextBoxNumeric mNumericSliderTextbox;
+
+    private Button mOkayButton;
+
+    private string mPrompt = "";
+
+    private Label mPromptLabel;
+
+    private TextBox mTextbox;
+
+    private ImagePanel mTextboxBg;
+
+    private Button mYesButton;
+
+    public string TextValue { get; set; }
+
+    public object UserData { get; set; }
+
+    public double Value { get; set; }
+
+    public new string Name { get; set; } = "InputBox";
+
+    public InputBox(
+        string title,
+        string prompt,
+        bool modal,
+        InputType inputType,
+        EventHandler onSuccess,
+        EventHandler onCancel,
+        object userData,
+        int quantity = 0,
+        int maxQuantity = Int32.MaxValue,
+        Base parent = null,
+        GameContentManager.UI stage = GameContentManager.UI.InGame
+    ) : base(parent)
+    {
+        if (parent == null)
         {
-
-            OkayOnly,
-
-            YesNo,
-
-            NumericInput,
-
-            TextInput,
-
-            NumericSliderInput,
-
+            parent = Interface.GameUi.GameCanvas;
         }
 
-        private GameContentManager.UI _uiStage;
+        OkayEventHandler = onSuccess;
+        CancelEventHandler = onCancel;
+        UserData = userData;
+        mInputType = inputType;
+        _uiStage = stage;
+        mPrompt = prompt;
 
-        private bool mInitialized = false;
+        mMyWindow = new WindowControl(parent, title, modal, "InputBox");
+        mMyWindow.BeforeDraw += _myWindow_BeforeDraw;
+        mMyWindow.DisableResizing();
 
-        private InputType mInputType;
+        mNumericTextboxBg = new ImagePanel(mMyWindow, "Textbox");
+        mNumericTextbox = new TextBoxNumeric(mNumericTextboxBg, "TextboxText");
+        mNumericTextbox.SubmitPressed += TextBox_SubmitPressed;
+        mNumericTextbox.Value = quantity;
 
-        private WindowControl mMyWindow;
+        mTextboxBg = new ImagePanel(mMyWindow, "Textbox");
+        mTextbox = new TextBox(mTextboxBg, "TextboxText");
+        mTextbox.SubmitPressed += TextBox_SubmitPressed;
 
-        private Button mNoButton;
+        mNumericSliderboxBg = new ImagePanel(mMyWindow, "Sliderbox");
+        mNumericSlider = new HorizontalSlider(mNumericSliderboxBg, "Slider");
+        mNumericSlider.SetRange(1, maxQuantity);
+        mNumericSlider.NotchCount = maxQuantity;
+        mNumericSlider.SnapToNotches = true;
+        mNumericSlider.Value = quantity;
+        mNumericSlider.ValueChanged += MNumericSlider_ValueChanged;
+        mNumericSliderTextbox = new TextBoxNumeric(mNumericSliderboxBg, "SliderboxText");
+        mNumericSliderTextbox.Value = quantity;
+        mNumericSliderTextbox.TextChanged += MNumericSliderTextbox_TextChanged;
+        mNumericSliderTextbox.SubmitPressed += MNumericSliderTextbox_SubmitPressed;
 
-        private TextBoxNumeric mNumericTextbox;
-
-        private ImagePanel mNumericTextboxBg;
-
-        private ImagePanel mNumericSliderboxBg;
-
-        private HorizontalSlider mNumericSlider;
-
-        private TextBoxNumeric mNumericSliderTextbox;
-
-        private Button mOkayButton;
-
-        private string mPrompt = "";
-
-        private Label mPromptLabel;
-
-        private TextBox mTextbox;
-
-        private ImagePanel mTextboxBg;
-
-        private Button mYesButton;
-
-        public string TextValue { get; set; }
-
-        public object UserData { get; set; }
-
-        public double Value { get; set; }
-
-        public new string Name { get; set; } = "InputBox";
-
-        public InputBox(
-            string title,
-            string prompt,
-            bool modal,
-            InputType inputType,
-            EventHandler onSuccess,
-            EventHandler onCancel,
-            object userData,
-            int quantity = 0,
-            int maxQuantity = Int32.MaxValue,
-            Base parent = null,
-            GameContentManager.UI stage = GameContentManager.UI.InGame
-        ) : base(parent)
+        if (inputType == InputType.NumericInput)
         {
-            if (parent == null)
-            {
-                parent = Interface.GameUi.GameCanvas;
-            }
-
-            OkayEventHandler = onSuccess;
-            CancelEventHandler = onCancel;
-            UserData = userData;
-            mInputType = inputType;
-            _uiStage = stage;
-            mPrompt = prompt;
-
-            mMyWindow = new WindowControl(parent, title, modal, "InputBox");
-            mMyWindow.BeforeDraw += _myWindow_BeforeDraw;
-            mMyWindow.DisableResizing();
-
-            mNumericTextboxBg = new ImagePanel(mMyWindow, "Textbox");
-            mNumericTextbox = new TextBoxNumeric(mNumericTextboxBg, "TextboxText");
-            mNumericTextbox.SubmitPressed += TextBox_SubmitPressed;
-            mNumericTextbox.Value = quantity;
-
-            mTextboxBg = new ImagePanel(mMyWindow, "Textbox");
-            mTextbox = new TextBox(mTextboxBg, "TextboxText");
-            mTextbox.SubmitPressed += TextBox_SubmitPressed;
-
-            mNumericSliderboxBg = new ImagePanel(mMyWindow, "Sliderbox");
-            mNumericSlider = new HorizontalSlider(mNumericSliderboxBg, "Slider");
-            mNumericSlider.SetRange(1, maxQuantity);
-            mNumericSlider.NotchCount = maxQuantity;
-            mNumericSlider.SnapToNotches = true;
-            mNumericSlider.Value = quantity;
-            mNumericSlider.ValueChanged += MNumericSlider_ValueChanged;
-            mNumericSliderTextbox = new TextBoxNumeric(mNumericSliderboxBg, "SliderboxText");
-            mNumericSliderTextbox.Value = quantity;
-            mNumericSliderTextbox.TextChanged += MNumericSliderTextbox_TextChanged;
-            mNumericSliderTextbox.SubmitPressed += MNumericSliderTextbox_SubmitPressed;
-
-            if (inputType == InputType.NumericInput)
-            {
-                mNumericTextbox.Focus();
-            }
-
-            if (inputType == InputType.TextInput)
-            {
-                mTextbox.Focus();
-            }
-
-            if (inputType != InputType.NumericInput)
-            {
-                mNumericTextboxBg.IsHidden = true;
-            }
-
-            if (inputType == InputType.NumericSliderInput)
-            {
-                mNumericSliderTextbox.Focus();
-            }
-
-            if (inputType != InputType.NumericSliderInput)
-            {
-                mNumericSliderboxBg.Hide();
-            }
-
-
-            if (inputType != InputType.TextInput)
-            {
-                mTextboxBg.IsHidden = true;
-            }
-
-            mYesButton = new Button(mMyWindow, "YesButton");
-            mYesButton.SetText(Strings.InputBox.Okay);
-            mYesButton.Clicked += okayBtn_Clicked;
-
-            mNoButton = new Button(mMyWindow, "NoButton");
-            mNoButton.SetText(Strings.InputBox.Cancel);
-            mNoButton.Clicked += cancelBtn_Clicked;
-
-            mOkayButton = new Button(mMyWindow, "OkayButton");
-            mOkayButton.SetText(Strings.InputBox.Okay);
-            mOkayButton.Clicked += okayBtn_Clicked;
-
-            mPromptLabel = new Label(mMyWindow, "PromptLabel");
-            Interface.InputBlockingElements.Add(this);
-
-            Value = quantity;
+            mNumericTextbox.Focus();
         }
 
-        private void MNumericSliderTextbox_TextChanged(Base sender, EventArgs arguments)
+        if (inputType == InputType.TextInput)
         {
-            if (sender is HorizontalSlider box && box == mNumericSlider)
+            mTextbox.Focus();
+        }
+
+        if (inputType != InputType.NumericInput)
+        {
+            mNumericTextboxBg.IsHidden = true;
+        }
+
+        if (inputType == InputType.NumericSliderInput)
+        {
+            mNumericSliderTextbox.Focus();
+        }
+
+        if (inputType != InputType.NumericSliderInput)
+        {
+            mNumericSliderboxBg.Hide();
+        }
+
+
+        if (inputType != InputType.TextInput)
+        {
+            mTextboxBg.IsHidden = true;
+        }
+
+        mYesButton = new Button(mMyWindow, "YesButton");
+        mYesButton.SetText(Strings.InputBox.Okay);
+        mYesButton.Clicked += okayBtn_Clicked;
+
+        mNoButton = new Button(mMyWindow, "NoButton");
+        mNoButton.SetText(Strings.InputBox.Cancel);
+        mNoButton.Clicked += cancelBtn_Clicked;
+
+        mOkayButton = new Button(mMyWindow, "OkayButton");
+        mOkayButton.SetText(Strings.InputBox.Okay);
+        mOkayButton.Clicked += okayBtn_Clicked;
+
+        mPromptLabel = new Label(mMyWindow, "PromptLabel");
+        Interface.InputBlockingElements.Add(this);
+
+        Value = quantity;
+    }
+
+    private void MNumericSliderTextbox_TextChanged(Base sender, EventArgs arguments)
+    {
+        if (sender is HorizontalSlider box && box == mNumericSlider)
+        {
+            return;
+        }
+
+        mNumericSlider.Value = mNumericSliderTextbox.Value;
+    }
+
+    private void MNumericSliderTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        SubmitInput();
+    }
+
+    private void MNumericSlider_ValueChanged(Base sender, EventArgs arguments)
+    {
+        if (sender is TextBoxNumeric box && box == mNumericSliderTextbox)
+        {
+            return;
+        }
+
+        var value = (int)Math.Round(mNumericSlider.Value);
+        mNumericSliderTextbox.Value = value;
+    }
+
+    private void TextBox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        SubmitInput();
+    }
+
+    private void _myWindow_BeforeDraw(Base sender, EventArgs arguments)
+    {
+        if (!mInitialized)
+        {
+            mMyWindow.LoadJsonUi(_uiStage, Graphics.Renderer.GetResolutionString(), true);
+            var text = Interface.WrapText(mPrompt, mPromptLabel.Width, mPromptLabel.Font);
+            var y = mPromptLabel.Y;
+            foreach (var s in text)
             {
-                return;
-            }
-
-            mNumericSlider.Value = mNumericSliderTextbox.Value;
-        }
-
-        private void MNumericSliderTextbox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            SubmitInput();
-        }
-
-        private void MNumericSlider_ValueChanged(Base sender, EventArgs arguments)
-        {
-            if (sender is TextBoxNumeric box && box == mNumericSliderTextbox)
-            {
-                return;
-            }
-
-            var value = (int)Math.Round(mNumericSlider.Value);
-            mNumericSliderTextbox.Value = value;
-        }
-
-        private void TextBox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            SubmitInput();
-        }
-
-        private void _myWindow_BeforeDraw(Base sender, EventArgs arguments)
-        {
-            if (!mInitialized)
-            {
-                mMyWindow.LoadJsonUi(_uiStage, Graphics.Renderer.GetResolutionString(), true);
-                var text = Interface.WrapText(mPrompt, mPromptLabel.Width, mPromptLabel.Font);
-                var y = mPromptLabel.Y;
-                foreach (var s in text)
+                var label = new Label(mMyWindow)
                 {
-                    var label = new Label(mMyWindow)
-                    {
-                        Text = s,
-                        TextColorOverride = mPromptLabel.TextColor,
-                        Font = mPromptLabel.Font
-                    };
+                    Text = s,
+                    TextColorOverride = mPromptLabel.TextColor,
+                    Font = mPromptLabel.Font
+                };
 
-                    label.SetPosition(mPromptLabel.X, y);
-                    y += label.Height;
-                    Align.CenterHorizontally(label);
-                }
-
-                switch (mInputType)
-                {
-                    case InputType.YesNo:
-                        mYesButton.Text = Strings.InputBox.Yes;
-                        mNoButton.Text = Strings.InputBox.No;
-                        mOkayButton.Hide();
-                        mYesButton.Show();
-                        mNoButton.Show();
-                        mNumericTextboxBg.Hide();
-                        mNumericSliderboxBg.Hide();
-                        mTextboxBg.Hide();
-
-                        break;
-                    case InputType.OkayOnly:
-                        mOkayButton.Show();
-                        mYesButton.Hide();
-                        mNoButton.Hide();
-                        mNumericTextboxBg.Hide();
-                        mNumericSliderboxBg.Hide();
-                        mTextboxBg.Hide();
-
-                        break;
-                    case InputType.NumericInput:
-                        mOkayButton.Hide();
-                        mYesButton.Show();
-                        mNoButton.Show();
-                        mNumericTextboxBg.Show();
-                        mNumericSliderboxBg.Hide();
-                        mTextboxBg.Hide();
-
-                        break;
-                    case InputType.NumericSliderInput:
-                        mOkayButton.Hide();
-                        mYesButton.Show();
-                        mNoButton.Show();
-                        mNumericTextboxBg.Hide();
-                        mNumericSliderboxBg.Show();
-                        mTextboxBg.Hide();
-
-                        break;
-                    case InputType.TextInput:
-                        mOkayButton.Hide();
-                        mYesButton.Show();
-                        mNoButton.Show();
-                        mNumericTextboxBg.Hide();
-                        mNumericSliderboxBg.Hide();
-                        mTextboxBg.Show();
-
-                        break;
-                }
-
-                mMyWindow.Show();
-                mMyWindow.Focus();
-                mInitialized = true;
+                label.SetPosition(mPromptLabel.X, y);
+                y += label.Height;
+                Align.CenterHorizontally(label);
             }
+
+            switch (mInputType)
+            {
+                case InputType.YesNo:
+                    mYesButton.Text = Strings.InputBox.Yes;
+                    mNoButton.Text = Strings.InputBox.No;
+                    mOkayButton.Hide();
+                    mYesButton.Show();
+                    mNoButton.Show();
+                    mNumericTextboxBg.Hide();
+                    mNumericSliderboxBg.Hide();
+                    mTextboxBg.Hide();
+
+                    break;
+                case InputType.OkayOnly:
+                    mOkayButton.Show();
+                    mYesButton.Hide();
+                    mNoButton.Hide();
+                    mNumericTextboxBg.Hide();
+                    mNumericSliderboxBg.Hide();
+                    mTextboxBg.Hide();
+
+                    break;
+                case InputType.NumericInput:
+                    mOkayButton.Hide();
+                    mYesButton.Show();
+                    mNoButton.Show();
+                    mNumericTextboxBg.Show();
+                    mNumericSliderboxBg.Hide();
+                    mTextboxBg.Hide();
+
+                    break;
+                case InputType.NumericSliderInput:
+                    mOkayButton.Hide();
+                    mYesButton.Show();
+                    mNoButton.Show();
+                    mNumericTextboxBg.Hide();
+                    mNumericSliderboxBg.Show();
+                    mTextboxBg.Hide();
+
+                    break;
+                case InputType.TextInput:
+                    mOkayButton.Hide();
+                    mYesButton.Show();
+                    mNoButton.Show();
+                    mNumericTextboxBg.Hide();
+                    mNumericSliderboxBg.Hide();
+                    mTextboxBg.Show();
+
+                    break;
+            }
+
+            mMyWindow.Show();
+            mMyWindow.Focus();
+            mInitialized = true;
         }
+    }
 
-        private event EventHandler OkayEventHandler;
+    private event EventHandler OkayEventHandler;
 
-        private event EventHandler CancelEventHandler;
+    private event EventHandler CancelEventHandler;
 
-        void cancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    void cancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (mInputType == InputType.NumericInput)
         {
-            if (mInputType == InputType.NumericInput)
-            {
-                Value = mNumericTextbox.Value;
-            }
-
-            if (mInputType == InputType.TextInput)
-            {
-                TextValue = mTextbox.Text;
-            }
-
-            if (mInputType == InputType.NumericSliderInput)
-            {
-                Value = mNumericSlider.Value;
-            }
-
-            if (CancelEventHandler != null)
-            {
-                CancelEventHandler(this, EventArgs.Empty);
-            }
-
-            Dispose();
+            Value = mNumericTextbox.Value;
         }
 
-        public void okayBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        if (mInputType == InputType.TextInput)
         {
-            SubmitInput();
+            TextValue = mTextbox.Text;
         }
 
-        private void SubmitInput()
+        if (mInputType == InputType.NumericSliderInput)
         {
-            if (mInputType == InputType.NumericInput)
-            {
-                Value = mNumericTextbox.Value;
-            }
-
-            if (mInputType == InputType.TextInput)
-            {
-                TextValue = mTextbox.Text;
-            }
-
-            if (mInputType == InputType.NumericSliderInput)
-            {
-                Value = mNumericSlider.Value;
-            }
-
-            OkayEventHandler?.Invoke(this, EventArgs.Empty);
-
-            Dispose();
+            Value = mNumericSlider.Value;
         }
 
-        public void Dispose()
+        if (CancelEventHandler != null)
         {
-            mMyWindow.Close();
-            mMyWindow.Parent.RemoveChild(mMyWindow, false);
-            mMyWindow.Dispose();
-
-            base.Hide();
+            CancelEventHandler(this, EventArgs.Empty);
         }
 
+        Dispose();
+    }
+
+    public void okayBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        SubmitInput();
+    }
+
+    private void SubmitInput()
+    {
+        if (mInputType == InputType.NumericInput)
+        {
+            Value = mNumericTextbox.Value;
+        }
+
+        if (mInputType == InputType.TextInput)
+        {
+            TextValue = mTextbox.Text;
+        }
+
+        if (mInputType == InputType.NumericSliderInput)
+        {
+            Value = mNumericSlider.Value;
+        }
+
+        OkayEventHandler?.Invoke(this, EventArgs.Empty);
+
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        mMyWindow.Close();
+        mMyWindow.Parent.RemoveChild(mMyWindow, false);
+        mMyWindow.Dispose();
+
+        base.Hide();
     }
 
 }

--- a/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryWindow.cs
@@ -6,309 +6,307 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Inventory
+namespace Intersect.Client.Interface.Game.Inventory;
+
+
+public partial class InventoryWindow
 {
 
-    public partial class InventoryWindow
+    //Item List
+    public List<InventoryItem> Items = new List<InventoryItem>();
+
+    //Initialized Items?
+    private bool mInitializedItems = false;
+
+    //Controls
+    private WindowControl mInventoryWindow;
+
+    private ScrollControl mItemContainer;
+
+    private List<Label> mValues = new List<Label>();
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mUseItemContextItem;
+
+    private MenuItem mActionItemContextItem;
+
+    private MenuItem mDropItemContextItem;
+
+    //Init
+    public InventoryWindow(Canvas gameCanvas)
     {
+        mInventoryWindow = new WindowControl(gameCanvas, Strings.Inventory.Title, false, "InventoryWindow");
+        mInventoryWindow.DisableResizing();
 
-        //Item List
-        public List<InventoryItem> Items = new List<InventoryItem>();
+        mItemContainer = new ScrollControl(mInventoryWindow, "ItemsContainer");
+        mItemContainer.EnableScroll(false, true);
+        mInventoryWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        //Initialized Items?
-        private bool mInitializedItems = false;
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "InventoryContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mUseItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Use);
+        mUseItemContextItem.Clicked += MUseItemContextItem_Clicked;
+        mDropItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Drop);
+        mDropItemContextItem.Clicked += MDropItemContextItem_Clicked;
+        mActionItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Bank);
+        mActionItemContextItem.Clicked += MActionItemContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        //Controls
-        private WindowControl mInventoryWindow;
+    }
 
-        private ScrollControl mItemContainer;
+    public void OpenContextMenu(int slot)
+    {
+        // Clear out the old options.
+        mContextMenu.RemoveChild(mUseItemContextItem, false);
+        mContextMenu.RemoveChild(mActionItemContextItem, false);
+        mContextMenu.RemoveChild(mDropItemContextItem, false);
+        mContextMenu.Children.Clear();
 
-        private List<Label> mValues = new List<Label>();
+        var item = ItemBase.Get(Globals.Me.Inventory[slot].ItemId);
 
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mUseItemContextItem;
-
-        private MenuItem mActionItemContextItem;
-
-        private MenuItem mDropItemContextItem;
-
-        //Init
-        public InventoryWindow(Canvas gameCanvas)
+        // No point showing a menu for blank space.
+        if (item == null)
         {
-            mInventoryWindow = new WindowControl(gameCanvas, Strings.Inventory.Title, false, "InventoryWindow");
-            mInventoryWindow.DisableResizing();
-
-            mItemContainer = new ScrollControl(mInventoryWindow, "ItemsContainer");
-            mItemContainer.EnableScroll(false, true);
-            mInventoryWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "InventoryContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mUseItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Use);
-            mUseItemContextItem.Clicked += MUseItemContextItem_Clicked;
-            mDropItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Drop);
-            mDropItemContextItem.Clicked += MDropItemContextItem_Clicked;
-            mActionItemContextItem = mContextMenu.AddItem(Strings.ItemContextMenu.Bank);
-            mActionItemContextItem.Clicked += MActionItemContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
+            return;
         }
 
-        public void OpenContextMenu(int slot)
+        // Add our use Item prompt, assuming we have a valid usecase.
+        switch (item.ItemType)
         {
-            // Clear out the old options.
-            mContextMenu.RemoveChild(mUseItemContextItem, false);
-            mContextMenu.RemoveChild(mActionItemContextItem, false);
-            mContextMenu.RemoveChild(mDropItemContextItem, false);
-            mContextMenu.Children.Clear();
+            case Enums.ItemType.Spell:
+                mContextMenu.AddChild(mUseItemContextItem);
+                mUseItemContextItem.SetText(item.QuickCast
+                    ? Strings.ItemContextMenu.Cast.ToString(item.Name)
+                    : Strings.ItemContextMenu.Learn.ToString(item.Name));
+                break;
 
-            var item = ItemBase.Get(Globals.Me.Inventory[slot].ItemId);
+            case Enums.ItemType.Event:
+            case Enums.ItemType.Consumable:
+                mContextMenu.AddChild(mUseItemContextItem);
+                mUseItemContextItem.SetText(Strings.ItemContextMenu.Use.ToString(item.Name));
+                break;
 
-            // No point showing a menu for blank space.
-            if (item == null)
-            {
-                return;
-            }
+            case Enums.ItemType.Bag:
+                mContextMenu.AddChild(mUseItemContextItem);
+                mUseItemContextItem.SetText(Strings.ItemContextMenu.Open.ToString(item.Name));
+                break;
 
-            // Add our use Item prompt, assuming we have a valid usecase.
-            switch (item.ItemType)
-            {
-                case Enums.ItemType.Spell:
-                    mContextMenu.AddChild(mUseItemContextItem);
-                    mUseItemContextItem.SetText(item.QuickCast
-                        ? Strings.ItemContextMenu.Cast.ToString(item.Name)
-                        : Strings.ItemContextMenu.Learn.ToString(item.Name));
-                    break;
-
-                case Enums.ItemType.Event:
-                case Enums.ItemType.Consumable:
-                    mContextMenu.AddChild(mUseItemContextItem);
-                    mUseItemContextItem.SetText(Strings.ItemContextMenu.Use.ToString(item.Name));
-                    break;
-
-                case Enums.ItemType.Bag:
-                    mContextMenu.AddChild(mUseItemContextItem);
-                    mUseItemContextItem.SetText(Strings.ItemContextMenu.Open.ToString(item.Name));
-                    break;
-
-                case Enums.ItemType.Equipment:
-                    mContextMenu.AddChild(mUseItemContextItem);
-                    // Show the correct equip/unequip prompts.
-                    if (Globals.Me.MyEquipment.Contains(slot))
-                    {
-                        mUseItemContextItem.SetText(Strings.ItemContextMenu.Unequip.ToString(item.Name));
-                    }
-                    else
-                    {
-                        mUseItemContextItem.SetText(Strings.ItemContextMenu.Equip.ToString(item.Name));
-                    }
-                    
-                    break;
-            }
-
-            // Set up the correct contextual additional action.
-            if (Globals.InBag && item.CanBag)
-            {
-                mContextMenu.AddChild(mActionItemContextItem);
-                mActionItemContextItem.SetText(Strings.ItemContextMenu.Bag.ToString(item.Name));
-            }
-            else if (Globals.InBank && (item.CanBank || item.CanGuildBank))
-            {
-                mContextMenu.AddChild(mActionItemContextItem);
-                mActionItemContextItem.SetText(Strings.ItemContextMenu.Bank.ToString(item.Name));
-            }
-            else if (Globals.InTrade && item.CanTrade)
-            {
-                mContextMenu.AddChild(mActionItemContextItem);
-                mActionItemContextItem.SetText(Strings.ItemContextMenu.Trade.ToString(item.Name));
-            }
-            else if (Globals.GameShop != null && item.CanSell)
-            {
-                mContextMenu.AddChild(mActionItemContextItem);
-                mActionItemContextItem.SetText(Strings.ItemContextMenu.Sell.ToString(item.Name));
-            }
-
-            // Can we drop this item? if so show the user!
-            if (item.CanDrop)
-            {
-                mContextMenu.AddChild(mDropItemContextItem);
-                mDropItemContextItem.SetText(Strings.ItemContextMenu.Drop.ToString(item.Name));
-            }
-
-            // Set our Inventory slot as userdata for future reference.
-            mContextMenu.UserData = slot;
-
-            // Display our menu.. If we have anything to display.
-            if (mContextMenu.Children.Count > 0)
-            {
-                mContextMenu.SizeToChildren();
-                mContextMenu.Open(Framework.Gwen.Pos.None);
-            }
-        }
-
-        private void MUseItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
-        {
-            var slot = (int)sender.Parent.UserData;
-            Globals.Me.TryUseItem(slot);
-        }
-
-        private void MActionItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
-        {
-            var slot = (int)sender.Parent.UserData;
-            if (Globals.GameShop != null)
-            {
-                Globals.Me.TrySellItem(slot);
-            }
-            else if (Globals.InBank)
-            {
-                Globals.Me.TryDepositItem(slot);
-            }
-            else if (Globals.InBag)
-            {
-                Globals.Me.TryStoreBagItem(slot, -1);
-            }
-            else if (Globals.InTrade)
-            {
-                Globals.Me.TryTradeItem(slot);
-            }
-        }
-
-        private void MDropItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
-        {
-            var slot = (int) sender.Parent.UserData;
-            Globals.Me.TryDropItem(slot);
-        }
-
-        //Location
-        //Location
-        public int X => mInventoryWindow.X;
-
-        public int Y => mInventoryWindow.Y;
-
-        //Methods
-        public void Update()
-        {
-            if (!mInitializedItems)
-            {
-                mInitializedItems = true;
-                InitItemContainer();
-            }
-
-            if (mInventoryWindow.IsHidden)
-            {
-                return;
-            }
-
-            mInventoryWindow.IsClosable = Globals.CanCloseInventory;
-
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                var item = ItemBase.Get(Globals.Me.Inventory[i].ItemId);
-                if (item != null)
+            case Enums.ItemType.Equipment:
+                mContextMenu.AddChild(mUseItemContextItem);
+                // Show the correct equip/unequip prompts.
+                if (Globals.Me.MyEquipment.Contains(slot))
                 {
-                    Items[i].Pnl.IsHidden = false;
-                    if (item.IsStackable)
-                    {
-                        mValues[i].IsHidden = Globals.Me.Inventory[i].Quantity <= 1;
-                        mValues[i].Text = Strings.FormatQuantityAbbreviated(Globals.Me.Inventory[i].Quantity);
-                    }
-                    else
-                    {
-                        mValues[i].IsHidden = true;
-                    }
-
-                    if (Items[i].IsDragging)
-                    {
-                        Items[i].Pnl.IsHidden = true;
-                        mValues[i].IsHidden = true;
-                    }
-
-                    Items[i].Update();
+                    mUseItemContextItem.SetText(Strings.ItemContextMenu.Unequip.ToString(item.Name));
                 }
                 else
+                {
+                    mUseItemContextItem.SetText(Strings.ItemContextMenu.Equip.ToString(item.Name));
+                }
+                
+                break;
+        }
+
+        // Set up the correct contextual additional action.
+        if (Globals.InBag && item.CanBag)
+        {
+            mContextMenu.AddChild(mActionItemContextItem);
+            mActionItemContextItem.SetText(Strings.ItemContextMenu.Bag.ToString(item.Name));
+        }
+        else if (Globals.InBank && (item.CanBank || item.CanGuildBank))
+        {
+            mContextMenu.AddChild(mActionItemContextItem);
+            mActionItemContextItem.SetText(Strings.ItemContextMenu.Bank.ToString(item.Name));
+        }
+        else if (Globals.InTrade && item.CanTrade)
+        {
+            mContextMenu.AddChild(mActionItemContextItem);
+            mActionItemContextItem.SetText(Strings.ItemContextMenu.Trade.ToString(item.Name));
+        }
+        else if (Globals.GameShop != null && item.CanSell)
+        {
+            mContextMenu.AddChild(mActionItemContextItem);
+            mActionItemContextItem.SetText(Strings.ItemContextMenu.Sell.ToString(item.Name));
+        }
+
+        // Can we drop this item? if so show the user!
+        if (item.CanDrop)
+        {
+            mContextMenu.AddChild(mDropItemContextItem);
+            mDropItemContextItem.SetText(Strings.ItemContextMenu.Drop.ToString(item.Name));
+        }
+
+        // Set our Inventory slot as userdata for future reference.
+        mContextMenu.UserData = slot;
+
+        // Display our menu.. If we have anything to display.
+        if (mContextMenu.Children.Count > 0)
+        {
+            mContextMenu.SizeToChildren();
+            mContextMenu.Open(Framework.Gwen.Pos.None);
+        }
+    }
+
+    private void MUseItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int)sender.Parent.UserData;
+        Globals.Me.TryUseItem(slot);
+    }
+
+    private void MActionItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int)sender.Parent.UserData;
+        if (Globals.GameShop != null)
+        {
+            Globals.Me.TrySellItem(slot);
+        }
+        else if (Globals.InBank)
+        {
+            Globals.Me.TryDepositItem(slot);
+        }
+        else if (Globals.InBag)
+        {
+            Globals.Me.TryStoreBagItem(slot, -1);
+        }
+        else if (Globals.InTrade)
+        {
+            Globals.Me.TryTradeItem(slot);
+        }
+    }
+
+    private void MDropItemContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int) sender.Parent.UserData;
+        Globals.Me.TryDropItem(slot);
+    }
+
+    //Location
+    //Location
+    public int X => mInventoryWindow.X;
+
+    public int Y => mInventoryWindow.Y;
+
+    //Methods
+    public void Update()
+    {
+        if (!mInitializedItems)
+        {
+            mInitializedItems = true;
+            InitItemContainer();
+        }
+
+        if (mInventoryWindow.IsHidden)
+        {
+            return;
+        }
+
+        mInventoryWindow.IsClosable = Globals.CanCloseInventory;
+
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            var item = ItemBase.Get(Globals.Me.Inventory[i].ItemId);
+            if (item != null)
+            {
+                Items[i].Pnl.IsHidden = false;
+                if (item.IsStackable)
+                {
+                    mValues[i].IsHidden = Globals.Me.Inventory[i].Quantity <= 1;
+                    mValues[i].Text = Strings.FormatQuantityAbbreviated(Globals.Me.Inventory[i].Quantity);
+                }
+                else
+                {
+                    mValues[i].IsHidden = true;
+                }
+
+                if (Items[i].IsDragging)
                 {
                     Items[i].Pnl.IsHidden = true;
                     mValues[i].IsHidden = true;
                 }
+
+                Items[i].Update();
+            }
+            else
+            {
+                Items[i].Pnl.IsHidden = true;
+                mValues[i].IsHidden = true;
             }
         }
+    }
 
-        private void InitItemContainer()
+    private void InitItemContainer()
+    {
+        for (var i = 0; i < Options.MaxInvItems; i++)
         {
-            for (var i = 0; i < Options.MaxInvItems; i++)
+            Items.Add(new InventoryItem(this, i));
+            Items[i].Container = new ImagePanel(mItemContainer, "InventoryItem");
+            Items[i].Setup();
+
+            mValues.Add(new Label(Items[i].Container, "InventoryItemValue"));
+            mValues[i].Text = "";
+
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            if (Items[i].EquipPanel.Texture == null)
             {
-                Items.Add(new InventoryItem(this, i));
-                Items[i].Container = new ImagePanel(mItemContainer, "InventoryItem");
-                Items[i].Setup();
-
-                mValues.Add(new Label(Items[i].Container, "InventoryItemValue"));
-                mValues[i].Text = "";
-
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                if (Items[i].EquipPanel.Texture == null)
-                {
-                    Items[i].EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
-                }
-
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
-            }
-        }
-
-        public void Show()
-        {
-            mInventoryWindow.IsHidden = false;
-        }
-
-        public bool IsVisible()
-        {
-            return !mInventoryWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            if (!Globals.CanCloseInventory)
-            {
-                return;
+                Items[i].EquipPanel.Texture = Graphics.Renderer.GetWhiteTexture();
             }
 
-            mContextMenu?.Close();
-            mInventoryWindow.IsHidden = true;
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
         }
+    }
 
-        public FloatRect RenderBounds()
+    public void Show()
+    {
+        mInventoryWindow.IsHidden = false;
+    }
+
+    public bool IsVisible()
+    {
+        return !mInventoryWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        if (!Globals.CanCloseInventory)
         {
-            var rect = new FloatRect()
-            {
-                X = mInventoryWindow.LocalPosToCanvas(new Point(0, 0)).X -
-                    (Items[0].Container.Padding.Left + Items[0].Container.Padding.Right) / 2,
-                Y = mInventoryWindow.LocalPosToCanvas(new Point(0, 0)).Y -
-                    (Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom) / 2,
-                Width = mInventoryWindow.Width + Items[0].Container.Padding.Left + Items[0].Container.Padding.Right,
-                Height = mInventoryWindow.Height + Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom
-            };
-
-            return rect;
+            return;
         }
 
+        mContextMenu?.Close();
+        mInventoryWindow.IsHidden = true;
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = mInventoryWindow.LocalPosToCanvas(new Point(0, 0)).X -
+                (Items[0].Container.Padding.Left + Items[0].Container.Padding.Right) / 2,
+            Y = mInventoryWindow.LocalPosToCanvas(new Point(0, 0)).Y -
+                (Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom) / 2,
+            Width = mInventoryWindow.Width + Items[0].Container.Padding.Left + Items[0].Container.Padding.Right,
+            Height = mInventoryWindow.Height + Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom
+        };
+
+        return rect;
     }
 
 }

--- a/Intersect.Client/Interface/Game/MapItem/MapItemWindow.cs
+++ b/Intersect.Client/Interface/Game/MapItem/MapItemWindow.cs
@@ -8,294 +8,293 @@ using Intersect.Client.Localization;
 using Intersect.Client.Maps;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Inventory
+namespace Intersect.Client.Interface.Game.Inventory;
+
+
+public partial class MapItemWindow
 {
+    //Item List
+    public List<MapItemIcon> Items = new List<MapItemIcon>();
+    private List<Label> mValues = new List<Label>();
 
-    public partial class MapItemWindow
+    //Controls
+    private ImagePanel mMapItemWindow;
+
+    private Label mMenuHeader;
+
+    private ScrollControl mItemContainer;
+
+    private Button mBtnLootAll;
+
+    private bool mFoundItems;
+
+    private int mScanTimer = 250;   // How often do we scan for items in Milliseconds?
+
+    private long mLastItemScan;
+
+    //Init
+    public MapItemWindow(Canvas gameCanvas)
     {
-        //Item List
-        public List<MapItemIcon> Items = new List<MapItemIcon>();
-        private List<Label> mValues = new List<Label>();
+        mMapItemWindow = new ImagePanel(gameCanvas, "MapItemWindow");
+        mMenuHeader = new Label(mMapItemWindow, "Title");
+        mMenuHeader.SetText(Strings.MapItemWindow.Title);
 
-        //Controls
-        private ImagePanel mMapItemWindow;
+        mItemContainer = new ScrollControl(mMapItemWindow, "ItemsContainer");
+        mItemContainer.EnableScroll(false, true);
 
-        private Label mMenuHeader;
+        mBtnLootAll = new Button(mMapItemWindow, "LootAllButton");
+        mBtnLootAll.Text = Strings.MapItemWindow.LootButton;
+        mBtnLootAll.Clicked += MBtnLootAll_Clicked;
 
-        private ScrollControl mItemContainer;
+        mMapItemWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        private Button mBtnLootAll;
+        CreateItemContainer();
+    }
 
-        private bool mFoundItems;
+    //Location
+    public int X => mMapItemWindow.X;
 
-        private int mScanTimer = 250;   // How often do we scan for items in Milliseconds?
+    public int Y => mMapItemWindow.Y;
 
-        private long mLastItemScan;
-
-        //Init
-        public MapItemWindow(Canvas gameCanvas)
+    //Methods
+    public void Update()
+    {
+        // Is this disabled from the server config? If so, skip doing anything.
+        if (!Options.Loot.EnableLootWindow)
         {
-            mMapItemWindow = new ImagePanel(gameCanvas, "MapItemWindow");
-            mMenuHeader = new Label(mMapItemWindow, "Title");
-            mMenuHeader.SetText(Strings.MapItemWindow.Title);
-
-            mItemContainer = new ScrollControl(mMapItemWindow, "ItemsContainer");
-            mItemContainer.EnableScroll(false, true);
-
-            mBtnLootAll = new Button(mMapItemWindow, "LootAllButton");
-            mBtnLootAll.Text = Strings.MapItemWindow.LootButton;
-            mBtnLootAll.Clicked += MBtnLootAll_Clicked;
-
-            mMapItemWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            CreateItemContainer();
+            mMapItemWindow.Hide();
+            return;
         }
 
-        //Location
-        public int X => mMapItemWindow.X;
-
-        public int Y => mMapItemWindow.Y;
-
-        //Methods
-        public void Update()
+        // Are we allowed to scan for items?
+        if (mLastItemScan < Timing.Global.Milliseconds)
         {
-            // Is this disabled from the server config? If so, skip doing anything.
-            if (!Options.Loot.EnableLootWindow)
-            {
-                mMapItemWindow.Hide();
-                return;
-            }
+            // Reset if we've found items
+            mFoundItems = false;
 
-            // Are we allowed to scan for items?
-            if (mLastItemScan < Timing.Global.Milliseconds)
+            // Find all valid locations near our location and iterate through them to find items we can display.
+            var itemSlot = 0;
+            foreach (var map in FindSurroundingTiles(Globals.Me.X, Globals.Me.Y, Options.Loot.MaximumLootWindowDistance))
             {
-                // Reset if we've found items
-                mFoundItems = false;
+                var mapItems = map.Key.MapItems;
+                var tiles = map.Value;
 
-                // Find all valid locations near our location and iterate through them to find items we can display.
-                var itemSlot = 0;
-                foreach (var map in FindSurroundingTiles(Globals.Me.X, Globals.Me.Y, Options.Loot.MaximumLootWindowDistance))
+                // iterate through all locations on this map to see if we've got items there.
+                foreach (var tileIndex in tiles)
                 {
-                    var mapItems = map.Key.MapItems;
-                    var tiles = map.Value;
-
-                    // iterate through all locations on this map to see if we've got items there.
-                    foreach (var tileIndex in tiles)
+                    // When no items have ever been on this location, just skip straight away.
+                    if (!mapItems.ContainsKey(tileIndex))
                     {
-                        // When no items have ever been on this location, just skip straight away.
-                        if (!mapItems.ContainsKey(tileIndex))
+                        continue;
+                    }
+
+                    // Go through each item up to our display limit and add them to our window.
+                    foreach (var mapItem in mapItems[tileIndex])
+                    {
+                        // Skip rendering this item if we're already past the cap we are allowed to display.
+                        if (itemSlot > Options.Loot.MaximumLootWindowItems - 1)
                         {
                             continue;
                         }
 
-                        // Go through each item up to our display limit and add them to our window.
-                        foreach (var mapItem in mapItems[tileIndex])
+                        var finalItem = mapItem.Base;
+                        if (finalItem != null)
                         {
-                            // Skip rendering this item if we're already past the cap we are allowed to display.
-                            if (itemSlot > Options.Loot.MaximumLootWindowItems - 1)
+                            Items[itemSlot].TileIndex = tileIndex;
+                            Items[itemSlot].MapId = map.Key.Id;
+                            Items[itemSlot].MyItem = mapItem as MapItemInstance;
+                            Items[itemSlot].Pnl.IsHidden = false;
+                            if (finalItem.IsStackable)
                             {
-                                continue;
-                            }
-
-                            var finalItem = mapItem.Base;
-                            if (finalItem != null)
-                            {
-                                Items[itemSlot].TileIndex = tileIndex;
-                                Items[itemSlot].MapId = map.Key.Id;
-                                Items[itemSlot].MyItem = mapItem as MapItemInstance;
-                                Items[itemSlot].Pnl.IsHidden = false;
-                                if (finalItem.IsStackable)
-                                {
-                                    mValues[itemSlot].IsHidden = mapItem.Quantity <= 1;
-                                    mValues[itemSlot].Text = Strings.FormatQuantityAbbreviated(mapItem.Quantity);
-                                }
-                                else
-                                {
-                                    mValues[itemSlot].IsHidden = true;
-                                }
-
-                                mFoundItems = true;
-                                itemSlot++;
+                                mValues[itemSlot].IsHidden = mapItem.Quantity <= 1;
+                                mValues[itemSlot].Text = Strings.FormatQuantityAbbreviated(mapItem.Quantity);
                             }
                             else
                             {
-                                Items[itemSlot].TileIndex = -1;
-                                Items[itemSlot].MyItem = null;
-                                Items[itemSlot].Pnl.IsHidden = true;
                                 mValues[itemSlot].IsHidden = true;
                             }
+
+                            mFoundItems = true;
+                            itemSlot++;
+                        }
+                        else
+                        {
+                            Items[itemSlot].TileIndex = -1;
+                            Items[itemSlot].MyItem = null;
+                            Items[itemSlot].Pnl.IsHidden = true;
+                            mValues[itemSlot].IsHidden = true;
                         }
                     }
                 }
+            }
 
-                // Update our UI and hide our unused icons.
-                for (var slot = 0; slot < Options.Loot.MaximumLootWindowItems; slot++)
+            // Update our UI and hide our unused icons.
+            for (var slot = 0; slot < Options.Loot.MaximumLootWindowItems; slot++)
+            {
+                if (slot > itemSlot - 1)
                 {
-                    if (slot > itemSlot - 1)
-                    {
-                        Items[slot].MyItem = null;
-                        Items[slot].Pnl.IsHidden = true;
-                        mValues[slot].IsHidden = true;
-                    }
-
-                    Items[slot].Update();
+                    Items[slot].MyItem = null;
+                    Items[slot].Pnl.IsHidden = true;
+                    mValues[slot].IsHidden = true;
                 }
 
-                // Set up our timer
-                mLastItemScan = Timing.Global.Milliseconds + mScanTimer;
+                Items[slot].Update();
             }
 
-            // Do we display our window?
-            if (!mFoundItems)
-            {
-                mMapItemWindow.Hide();
-            }
-            else
-            {
-                mMapItemWindow.Show();
-            }
-
+            // Set up our timer
+            mLastItemScan = Timing.Global.Milliseconds + mScanTimer;
         }
 
-        private void CreateItemContainer()
+        // Do we display our window?
+        if (!mFoundItems)
         {
-            for (var i = 0; i < Options.Loot.MaximumLootWindowItems; i++)
-            {
-                Items.Add(new MapItemIcon(this));
-                Items[i].Container = new ImagePanel(mItemContainer, "MapItemIcon");
-                Items[i].Setup();
-
-                mValues.Add(new Label(Items[i].Container, "MapItemValue"));
-                mValues[i].Text = "";
-
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
-            }
+            mMapItemWindow.Hide();
         }
-
-        private void MBtnLootAll_Clicked(Base sender, ClickedEventArgs arguments)
+        else
         {
-            if (Globals.Me.MapInstance == null)
-            {
-                return;
-            }
-
-            // Try and pick up everything on our location.
-            var currentMap = Globals.Me.MapInstance as MapInstance;
-            Globals.Me.TryPickupItem(currentMap.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X);
-            
-        }
-
-        private Dictionary<MapInstance, List<int>> FindSurroundingTiles(int myX, int myY, int distance)
-        {
-            // Loop through all locations surrounding us to get valid tiles.
-            var locations = new Dictionary<MapInstance, List<int>>();
-            for (var x = 0 - distance; x <= distance; x++)
-            {
-                for (var y = 0 - distance; y <= distance; y++)
-                {
-                    // Use these to keep track of our translation.
-                    var currentMap = Globals.Me.MapInstance as MapInstance;
-                    var currentX = myX + x;
-                    var currentY = myY + y;
-
-                    // Are we on a valid map at all?
-                    if (currentMap == null)
-                    {
-                        break;
-                    }
-
-                    // Are we going to the map on our left?
-                    if (currentX < 0)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Left != Guid.Empty)
-                        {
-                            currentMap = MapInstance.Get(currentMap.Left);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentX = (Options.MapWidth + 1) + x;
-                        }
-                    }
-
-                    // Are we going to the map on our right?
-                    if (currentX >= Options.MapWidth)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Right != Guid.Empty)
-                        {
-                            currentMap = MapInstance.Get(currentMap.Right);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentX = -1 + x;
-                        }
-                    }
-
-                    // Are we going to the map up from us?
-                    if (currentY < 0)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Up != Guid.Empty)
-                        {
-                            currentMap = MapInstance.Get(currentMap.Up);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentY = (Options.MapHeight + 1) + y;
-                        }
-                    }
-
-                    // Are we going to the map down from us?
-                    if (currentY >= Options.MapHeight)
-                    {
-                        var oldMap = currentMap;
-                        if (currentMap.Down != Guid.Empty)
-                        {
-                            currentMap = MapInstance.Get(currentMap.Down);
-                            if (currentMap == null)
-                            {
-                                currentMap = oldMap;
-                                continue;
-                            }
-
-                            currentY = -1 + y;
-                        }
-                    }
-
-                    if (!locations.ContainsKey(currentMap))
-                    {
-                        locations.Add(currentMap, new List<int>());
-                    }
-                    locations[currentMap].Add(currentY * Options.MapWidth + currentX);
-                }
-            }
-
-            return locations;
+            mMapItemWindow.Show();
         }
 
     }
+
+    private void CreateItemContainer()
+    {
+        for (var i = 0; i < Options.Loot.MaximumLootWindowItems; i++)
+        {
+            Items.Add(new MapItemIcon(this));
+            Items[i].Container = new ImagePanel(mItemContainer, "MapItemIcon");
+            Items[i].Setup();
+
+            mValues.Add(new Label(Items[i].Container, "MapItemValue"));
+            mValues[i].Text = "";
+
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
+        }
+    }
+
+    private void MBtnLootAll_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me.MapInstance == null)
+        {
+            return;
+        }
+
+        // Try and pick up everything on our location.
+        var currentMap = Globals.Me.MapInstance as MapInstance;
+        Globals.Me.TryPickupItem(currentMap.Id, Globals.Me.Y * Options.MapWidth + Globals.Me.X);
+        
+    }
+
+    private Dictionary<MapInstance, List<int>> FindSurroundingTiles(int myX, int myY, int distance)
+    {
+        // Loop through all locations surrounding us to get valid tiles.
+        var locations = new Dictionary<MapInstance, List<int>>();
+        for (var x = 0 - distance; x <= distance; x++)
+        {
+            for (var y = 0 - distance; y <= distance; y++)
+            {
+                // Use these to keep track of our translation.
+                var currentMap = Globals.Me.MapInstance as MapInstance;
+                var currentX = myX + x;
+                var currentY = myY + y;
+
+                // Are we on a valid map at all?
+                if (currentMap == null)
+                {
+                    break;
+                }
+
+                // Are we going to the map on our left?
+                if (currentX < 0)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Left != Guid.Empty)
+                    {
+                        currentMap = MapInstance.Get(currentMap.Left);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentX = (Options.MapWidth + 1) + x;
+                    }
+                }
+
+                // Are we going to the map on our right?
+                if (currentX >= Options.MapWidth)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Right != Guid.Empty)
+                    {
+                        currentMap = MapInstance.Get(currentMap.Right);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentX = -1 + x;
+                    }
+                }
+
+                // Are we going to the map up from us?
+                if (currentY < 0)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Up != Guid.Empty)
+                    {
+                        currentMap = MapInstance.Get(currentMap.Up);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentY = (Options.MapHeight + 1) + y;
+                    }
+                }
+
+                // Are we going to the map down from us?
+                if (currentY >= Options.MapHeight)
+                {
+                    var oldMap = currentMap;
+                    if (currentMap.Down != Guid.Empty)
+                    {
+                        currentMap = MapInstance.Get(currentMap.Down);
+                        if (currentMap == null)
+                        {
+                            currentMap = oldMap;
+                            continue;
+                        }
+
+                        currentY = -1 + y;
+                    }
+                }
+
+                if (!locations.ContainsKey(currentMap))
+                {
+                    locations.Add(currentMap, new List<int>());
+                }
+                locations[currentMap].Add(currentY * Options.MapWidth + currentX);
+            }
+        }
+
+        return locations;
+    }
+
 }

--- a/Intersect.Client/Interface/Game/Menu.cs
+++ b/Intersect.Client/Interface/Game/Menu.cs
@@ -11,396 +11,394 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Enums;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class Menu
 {
 
-    public partial class Menu
+    private readonly ImagePanel mCharacterBackground;
+
+    private readonly Button mCharacterButton;
+
+    private readonly CharacterWindow mCharacterWindow;
+
+    private readonly ImagePanel mFriendsBackground;
+
+    private readonly Button mFriendsButton;
+
+    private readonly FriendsWindow mFriendsWindow;
+
+    private readonly ImagePanel mInventoryBackground;
+
+    private readonly Button mInventoryButton;
+
+    private readonly InventoryWindow mInventoryWindow;
+
+    private readonly ImagePanel mMenuBackground;
+
+    private readonly Button mMenuButton;
+
+    //Menu Container
+    private readonly ImagePanel mMenuContainer;
+
+    private readonly ImagePanel mPartyBackground;
+
+    private readonly Button mPartyButton;
+
+    private readonly PartyWindow mPartyWindow;
+
+    private readonly ImagePanel mQuestsBackground;
+
+    private readonly Button mQuestsButton;
+
+    private readonly QuestsWindow mQuestsWindow;
+
+    private readonly ImagePanel mSpellsBackground;
+
+    private readonly Button mSpellsButton;
+
+    private readonly SpellsWindow mSpellsWindow;
+
+    private readonly MapItemWindow mMapItemWindow;
+
+    private readonly ImagePanel mGuildBackground;
+
+    private readonly Button mGuildButton;
+
+    private readonly GuildWindow mGuildWindow;
+
+    private int mBackgroundHeight = 42;
+
+    private int mBackgroundWidth = 42;
+
+    private int mButtonHeight = 34;
+
+    private int mButtonMargin = 8;
+
+    private int mButtonWidth = 34;
+
+    //Canvas instance
+    private Canvas mGameCanvas;
+
+    //Init
+    public Menu(Canvas gameCanvas)
     {
+        mGameCanvas = gameCanvas;
 
-        private readonly ImagePanel mCharacterBackground;
+        mMenuContainer = new ImagePanel(gameCanvas, "MenuContainer");
+        mMenuContainer.ShouldCacheToTexture = true;
 
-        private readonly Button mCharacterButton;
+        mInventoryBackground = new ImagePanel(mMenuContainer, "InventoryContainer");
+        mInventoryButton = new Button(mInventoryBackground, "InventoryButton");
+        mInventoryButton.SetToolTipText(Strings.GameMenu.Items);
+        mInventoryButton.Clicked += InventoryButton_Clicked;
 
-        private readonly CharacterWindow mCharacterWindow;
+        mSpellsBackground = new ImagePanel(mMenuContainer, "SpellsContainer");
+        mSpellsButton = new Button(mSpellsBackground, "SpellsButton");
+        mSpellsButton.SetToolTipText(Strings.GameMenu.Spells);
+        mSpellsButton.Clicked += SpellsButton_Clicked;
 
-        private readonly ImagePanel mFriendsBackground;
+        mCharacterBackground = new ImagePanel(mMenuContainer, "CharacterContainer");
+        mCharacterButton = new Button(mCharacterBackground, "CharacterButton");
+        mCharacterButton.SetToolTipText(Strings.GameMenu.Character);
+        mCharacterButton.Clicked += CharacterButton_Clicked;
 
-        private readonly Button mFriendsButton;
+        mQuestsBackground = new ImagePanel(mMenuContainer, "QuestsContainer");
+        mQuestsButton = new Button(mQuestsBackground, "QuestsButton");
+        mQuestsButton.SetToolTipText(Strings.GameMenu.Quest);
+        mQuestsButton.Clicked += QuestBtn_Clicked;
 
-        private readonly FriendsWindow mFriendsWindow;
+        mFriendsBackground = new ImagePanel(mMenuContainer, "FriendsContainer");
+        mFriendsButton = new Button(mFriendsBackground, "FriendsButton");
+        mFriendsButton.SetToolTipText(Strings.GameMenu.Friends);
+        mFriendsButton.Clicked += FriendsBtn_Clicked;
 
-        private readonly ImagePanel mInventoryBackground;
+        mPartyBackground = new ImagePanel(mMenuContainer, "PartyContainer");
+        mPartyButton = new Button(mPartyBackground, "PartyButton");
+        mPartyButton.SetToolTipText(Strings.GameMenu.Party);
+        mPartyButton.Clicked += PartyBtn_Clicked;
 
-        private readonly Button mInventoryButton;
+        mGuildBackground = new ImagePanel(mMenuContainer, "GuildContainer");
+        mGuildButton = new Button(mGuildBackground, "GuildButton");
+        mGuildButton.SetToolTipText(Strings.Guilds.Guild);
+        mGuildButton.Clicked += GuildBtn_Clicked;
 
-        private readonly InventoryWindow mInventoryWindow;
+        mMenuBackground = new ImagePanel(mMenuContainer, "MenuContainer");
+        mMenuButton = new Button(mMenuBackground, "MenuButton");
+        mMenuButton.SetToolTipText(Strings.GameMenu.Menu);
+        mMenuButton.Clicked += MenuButtonClicked;
 
-        private readonly ImagePanel mMenuBackground;
+        mMenuContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        private readonly Button mMenuButton;
+        //Assign Window References
+        mPartyWindow = new PartyWindow(gameCanvas);
+        mFriendsWindow = new FriendsWindow(gameCanvas);
+        mInventoryWindow = new InventoryWindow(gameCanvas);
+        mSpellsWindow = new SpellsWindow(gameCanvas);
+        mCharacterWindow = new CharacterWindow(gameCanvas);
+        mQuestsWindow = new QuestsWindow(gameCanvas);
+        mMapItemWindow = new MapItemWindow(gameCanvas);
+        mGuildWindow = new GuildWindow(gameCanvas);
+    }
 
-        //Menu Container
-        private readonly ImagePanel mMenuContainer;
+    //Methods
+    public void Update(bool updateQuestLog)
+    {
+        mInventoryWindow.Update();
+        mSpellsWindow.Update();
+        mCharacterWindow.Update();
+        mPartyWindow.Update();
+        mFriendsWindow.Update();
+        mQuestsWindow.Update(updateQuestLog);
+        mMapItemWindow.Update();
+        mGuildWindow.Update();
+    }
 
-        private readonly ImagePanel mPartyBackground;
+    public void UpdateFriendsList()
+    {
+        mFriendsWindow.UpdateList();
+    }
 
-        private readonly Button mPartyButton;
+    public void UpdateGuildList()
+    {
+        mGuildWindow.UpdateList();
+    }
 
-        private readonly PartyWindow mPartyWindow;
-
-        private readonly ImagePanel mQuestsBackground;
-
-        private readonly Button mQuestsButton;
-
-        private readonly QuestsWindow mQuestsWindow;
-
-        private readonly ImagePanel mSpellsBackground;
-
-        private readonly Button mSpellsButton;
-
-        private readonly SpellsWindow mSpellsWindow;
-
-        private readonly MapItemWindow mMapItemWindow;
-
-        private readonly ImagePanel mGuildBackground;
-
-        private readonly Button mGuildButton;
-
-        private readonly GuildWindow mGuildWindow;
-
-        private int mBackgroundHeight = 42;
-
-        private int mBackgroundWidth = 42;
-
-        private int mButtonHeight = 34;
-
-        private int mButtonMargin = 8;
-
-        private int mButtonWidth = 34;
-
-        //Canvas instance
-        private Canvas mGameCanvas;
-
-        //Init
-        public Menu(Canvas gameCanvas)
+    public void HideWindows()
+    {
+        if (!Globals.Database.HideOthersOnWindowOpen)
         {
-            mGameCanvas = gameCanvas;
-
-            mMenuContainer = new ImagePanel(gameCanvas, "MenuContainer");
-            mMenuContainer.ShouldCacheToTexture = true;
-
-            mInventoryBackground = new ImagePanel(mMenuContainer, "InventoryContainer");
-            mInventoryButton = new Button(mInventoryBackground, "InventoryButton");
-            mInventoryButton.SetToolTipText(Strings.GameMenu.Items);
-            mInventoryButton.Clicked += InventoryButton_Clicked;
-
-            mSpellsBackground = new ImagePanel(mMenuContainer, "SpellsContainer");
-            mSpellsButton = new Button(mSpellsBackground, "SpellsButton");
-            mSpellsButton.SetToolTipText(Strings.GameMenu.Spells);
-            mSpellsButton.Clicked += SpellsButton_Clicked;
-
-            mCharacterBackground = new ImagePanel(mMenuContainer, "CharacterContainer");
-            mCharacterButton = new Button(mCharacterBackground, "CharacterButton");
-            mCharacterButton.SetToolTipText(Strings.GameMenu.Character);
-            mCharacterButton.Clicked += CharacterButton_Clicked;
-
-            mQuestsBackground = new ImagePanel(mMenuContainer, "QuestsContainer");
-            mQuestsButton = new Button(mQuestsBackground, "QuestsButton");
-            mQuestsButton.SetToolTipText(Strings.GameMenu.Quest);
-            mQuestsButton.Clicked += QuestBtn_Clicked;
-
-            mFriendsBackground = new ImagePanel(mMenuContainer, "FriendsContainer");
-            mFriendsButton = new Button(mFriendsBackground, "FriendsButton");
-            mFriendsButton.SetToolTipText(Strings.GameMenu.Friends);
-            mFriendsButton.Clicked += FriendsBtn_Clicked;
-
-            mPartyBackground = new ImagePanel(mMenuContainer, "PartyContainer");
-            mPartyButton = new Button(mPartyBackground, "PartyButton");
-            mPartyButton.SetToolTipText(Strings.GameMenu.Party);
-            mPartyButton.Clicked += PartyBtn_Clicked;
-
-            mGuildBackground = new ImagePanel(mMenuContainer, "GuildContainer");
-            mGuildButton = new Button(mGuildBackground, "GuildButton");
-            mGuildButton.SetToolTipText(Strings.Guilds.Guild);
-            mGuildButton.Clicked += GuildBtn_Clicked;
-
-            mMenuBackground = new ImagePanel(mMenuContainer, "MenuContainer");
-            mMenuButton = new Button(mMenuBackground, "MenuButton");
-            mMenuButton.SetToolTipText(Strings.GameMenu.Menu);
-            mMenuButton.Clicked += MenuButtonClicked;
-
-            mMenuContainer.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            //Assign Window References
-            mPartyWindow = new PartyWindow(gameCanvas);
-            mFriendsWindow = new FriendsWindow(gameCanvas);
-            mInventoryWindow = new InventoryWindow(gameCanvas);
-            mSpellsWindow = new SpellsWindow(gameCanvas);
-            mCharacterWindow = new CharacterWindow(gameCanvas);
-            mQuestsWindow = new QuestsWindow(gameCanvas);
-            mMapItemWindow = new MapItemWindow(gameCanvas);
-            mGuildWindow = new GuildWindow(gameCanvas);
+            return;
         }
 
-        //Methods
-        public void Update(bool updateQuestLog)
-        {
-            mInventoryWindow.Update();
-            mSpellsWindow.Update();
-            mCharacterWindow.Update();
-            mPartyWindow.Update();
-            mFriendsWindow.Update();
-            mQuestsWindow.Update(updateQuestLog);
-            mMapItemWindow.Update();
-            mGuildWindow.Update();
-        }
+        mCharacterWindow.Hide();
+        mFriendsWindow.Hide();
+        mInventoryWindow.Hide();
+        mPartyWindow.Hide();
+        mQuestsWindow.Hide();
+        mSpellsWindow.Hide();
+        mGuildWindow.Hide();
+    }
 
-        public void UpdateFriendsList()
-        {
-            mFriendsWindow.UpdateList();
-        }
-
-        public void UpdateGuildList()
-        {
-            mGuildWindow.UpdateList();
-        }
-
-        public void HideWindows()
-        {
-            if (!Globals.Database.HideOthersOnWindowOpen)
-            {
-                return;
-            }
-
-            mCharacterWindow.Hide();
-            mFriendsWindow.Hide();
-            mInventoryWindow.Hide();
-            mPartyWindow.Hide();
-            mQuestsWindow.Hide();
-            mSpellsWindow.Hide();
-            mGuildWindow.Hide();
-        }
-
-        public void ToggleCharacterWindow()
-        {
-            if (mCharacterWindow.IsVisible())
-            {
-                mCharacterWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                mCharacterWindow.Show();
-            }
-        }
-
-        public bool ToggleFriendsWindow()
-        {
-            if (mFriendsWindow.IsVisible)
-            {
-                mFriendsWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                PacketSender.SendRequestFriends();
-                mFriendsWindow.UpdateList();
-                mFriendsWindow.Show();
-            }
-
-            return mFriendsWindow.IsVisible;
-        }
-
-        public bool ToggleGuildWindow()
-        {
-            if (mGuildWindow.IsVisible())
-            {
-                mGuildWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                PacketSender.SendRequestGuild();
-                mGuildWindow.UpdateList();
-                mGuildWindow.Show();
-            }
-
-            return mGuildWindow.IsVisible();
-        }
-
-        public void HideGuildWindow()
-        {
-            mGuildWindow.Hide();
-        }
-
-        public void ToggleInventoryWindow()
-        {
-            if (mInventoryWindow.IsVisible())
-            {
-                mInventoryWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                mInventoryWindow.Show();
-            }
-        }
-
-        public void OpenInventory()
-        {
-            mInventoryWindow.Show();
-        }
-
-        public InventoryWindow GetInventoryWindow()
-        {
-            return mInventoryWindow;
-        }
-
-        public void TogglePartyWindow()
-        {
-            if (mPartyWindow.IsVisible())
-            {
-                mPartyWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                mPartyWindow.Show();
-            }
-        }
-
-        public void ToggleQuestsWindow()
-        {
-            if (mQuestsWindow.IsVisible())
-            {
-                mQuestsWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                mQuestsWindow.Show();
-            }
-        }
-
-        public void ToggleSpellsWindow()
-        {
-            if (mSpellsWindow.IsVisible())
-            {
-                mSpellsWindow.Hide();
-            }
-            else
-            {
-                HideWindows();
-                mSpellsWindow.Show();
-            }
-        }
-
-        public void CloseAllWindows()
+    public void ToggleCharacterWindow()
+    {
+        if (mCharacterWindow.IsVisible())
         {
             mCharacterWindow.Hide();
-
-            mFriendsWindow.Hide();
-
-            mInventoryWindow.Hide();
-
-            mQuestsWindow.Hide();
-
-            mSpellsWindow.Hide();
-
-            mPartyWindow.Hide();
-
-            mGuildWindow.Hide();
         }
-
-        public bool HasWindowsOpen()
+        else
         {
-            var windowsOpen = false;
-
-            if (mCharacterWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            if (mFriendsWindow.IsVisible)
-            {
-                windowsOpen = true;
-            }
-
-            if (mInventoryWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            if (mQuestsWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            if (mSpellsWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            if (mPartyWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            if (mGuildWindow.IsVisible())
-            {
-                windowsOpen = true;
-            }
-
-            return windowsOpen;
-        }
-
-        //Input Handlers
-        private static void MenuButtonClicked(Base sender, ClickedEventArgs arguments)
-        {
-            Interface.GameUi?.EscapeMenu?.ToggleHidden();
-        }
-
-        private void PartyBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            TogglePartyWindow();
-        }
-
-        private void FriendsBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            ToggleFriendsWindow();
-        }
-
-        private void GuildBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (!string.IsNullOrEmpty(Globals.Me.Guild))
-            {
-                ToggleGuildWindow();
-            }
-            else
-            {
-                ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotInGuild, CustomColors.Alerts.Error, ChatMessageType.Guild));
-            }
-        }
-
-        private void QuestBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            ToggleQuestsWindow();
-        }
-
-        private void InventoryButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            ToggleInventoryWindow();
-        }
-
-        private void SpellsButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            ToggleSpellsWindow();
-        }
-
-        private void CharacterButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            ToggleCharacterWindow();
+            HideWindows();
+            mCharacterWindow.Show();
         }
     }
 
+    public bool ToggleFriendsWindow()
+    {
+        if (mFriendsWindow.IsVisible)
+        {
+            mFriendsWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            PacketSender.SendRequestFriends();
+            mFriendsWindow.UpdateList();
+            mFriendsWindow.Show();
+        }
+
+        return mFriendsWindow.IsVisible;
+    }
+
+    public bool ToggleGuildWindow()
+    {
+        if (mGuildWindow.IsVisible())
+        {
+            mGuildWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            PacketSender.SendRequestGuild();
+            mGuildWindow.UpdateList();
+            mGuildWindow.Show();
+        }
+
+        return mGuildWindow.IsVisible();
+    }
+
+    public void HideGuildWindow()
+    {
+        mGuildWindow.Hide();
+    }
+
+    public void ToggleInventoryWindow()
+    {
+        if (mInventoryWindow.IsVisible())
+        {
+            mInventoryWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            mInventoryWindow.Show();
+        }
+    }
+
+    public void OpenInventory()
+    {
+        mInventoryWindow.Show();
+    }
+
+    public InventoryWindow GetInventoryWindow()
+    {
+        return mInventoryWindow;
+    }
+
+    public void TogglePartyWindow()
+    {
+        if (mPartyWindow.IsVisible())
+        {
+            mPartyWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            mPartyWindow.Show();
+        }
+    }
+
+    public void ToggleQuestsWindow()
+    {
+        if (mQuestsWindow.IsVisible())
+        {
+            mQuestsWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            mQuestsWindow.Show();
+        }
+    }
+
+    public void ToggleSpellsWindow()
+    {
+        if (mSpellsWindow.IsVisible())
+        {
+            mSpellsWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            mSpellsWindow.Show();
+        }
+    }
+
+    public void CloseAllWindows()
+    {
+        mCharacterWindow.Hide();
+
+        mFriendsWindow.Hide();
+
+        mInventoryWindow.Hide();
+
+        mQuestsWindow.Hide();
+
+        mSpellsWindow.Hide();
+
+        mPartyWindow.Hide();
+
+        mGuildWindow.Hide();
+    }
+
+    public bool HasWindowsOpen()
+    {
+        var windowsOpen = false;
+
+        if (mCharacterWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        if (mFriendsWindow.IsVisible)
+        {
+            windowsOpen = true;
+        }
+
+        if (mInventoryWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        if (mQuestsWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        if (mSpellsWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        if (mPartyWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        if (mGuildWindow.IsVisible())
+        {
+            windowsOpen = true;
+        }
+
+        return windowsOpen;
+    }
+
+    //Input Handlers
+    private static void MenuButtonClicked(Base sender, ClickedEventArgs arguments)
+    {
+        Interface.GameUi?.EscapeMenu?.ToggleHidden();
+    }
+
+    private void PartyBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        TogglePartyWindow();
+    }
+
+    private void FriendsBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ToggleFriendsWindow();
+    }
+
+    private void GuildBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (!string.IsNullOrEmpty(Globals.Me.Guild))
+        {
+            ToggleGuildWindow();
+        }
+        else
+        {
+            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Guilds.NotInGuild, CustomColors.Alerts.Error, ChatMessageType.Guild));
+        }
+    }
+
+    private void QuestBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ToggleQuestsWindow();
+    }
+
+    private void InventoryButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ToggleInventoryWindow();
+    }
+
+    private void SpellsButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ToggleSpellsWindow();
+    }
+
+    private void CharacterButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        ToggleCharacterWindow();
+    }
 }

--- a/Intersect.Client/Interface/Game/PartyWindow.cs
+++ b/Intersect.Client/Interface/Game/PartyWindow.cs
@@ -7,339 +7,337 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Enums;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class PartyWindow
 {
 
-    public partial class PartyWindow
+    private List<ImagePanel> mHpBar = new List<ImagePanel>();
+
+    private List<ImagePanel> mHpBarContainer = new List<ImagePanel>();
+
+    private List<Label> mHpLabel = new List<Label>();
+
+    private List<Label> mHpValue = new List<Label>();
+
+    private List<Button> mKickButtons = new List<Button>();
+
+    private List<Label> mLblnames = new List<Label>();
+
+    private ImagePanel mLeader;
+
+    private Label mLeaderText;
+
+    private Button mLeaveButton;
+
+    private List<ImagePanel> mMpBar = new List<ImagePanel>();
+
+    private List<ImagePanel> mMpBarContainer = new List<ImagePanel>();
+
+    private List<Label> mMpLabel = new List<Label>();
+
+    private List<Label> mMpValue = new List<Label>();
+
+    //Controls
+    private WindowControl mPartyWindow;
+
+    //Init
+    public PartyWindow(Canvas gameCanvas)
     {
+        mPartyWindow = new WindowControl(gameCanvas, Strings.Parties.Title, false, "PartyWindow");
+        mPartyWindow.DisableResizing();
 
-        private List<ImagePanel> mHpBar = new List<ImagePanel>();
+        //Add the icon representing party leader (ALWAYS member 1 in the party list)
+        mLeader = new ImagePanel(mPartyWindow, "LeaderIcon");
+        mLeader.SetToolTipText(Strings.Parties.LeaderTip);
+        mLeader.Hide();
 
-        private List<ImagePanel> mHpBarContainer = new List<ImagePanel>();
+        mLeaderText = new Label(mPartyWindow, "LeaderText");
+        mLeaderText.SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
+        mLeaderText.Text = Strings.Parties.Leader;
+        mLeaderText.Hide();
 
-        private List<Label> mHpLabel = new List<Label>();
-
-        private List<Label> mHpValue = new List<Label>();
-
-        private List<Button> mKickButtons = new List<Button>();
-
-        private List<Label> mLblnames = new List<Label>();
-
-        private ImagePanel mLeader;
-
-        private Label mLeaderText;
-
-        private Button mLeaveButton;
-
-        private List<ImagePanel> mMpBar = new List<ImagePanel>();
-
-        private List<ImagePanel> mMpBarContainer = new List<ImagePanel>();
-
-        private List<Label> mMpLabel = new List<Label>();
-
-        private List<Label> mMpValue = new List<Label>();
-
-        //Controls
-        private WindowControl mPartyWindow;
-
-        //Init
-        public PartyWindow(Canvas gameCanvas)
+        if (Globals.Me.Party.Count > 0)
         {
-            mPartyWindow = new WindowControl(gameCanvas, Strings.Parties.Title, false, "PartyWindow");
-            mPartyWindow.DisableResizing();
+            mLeader.Show();
+            mLeaderText.Show();
+        }
 
-            //Add the icon representing party leader (ALWAYS member 1 in the party list)
-            mLeader = new ImagePanel(mPartyWindow, "LeaderIcon");
-            mLeader.SetToolTipText(Strings.Parties.LeaderTip);
-            mLeader.Hide();
+        mLblnames.Clear();
+        mKickButtons.Clear();
+        mHpBarContainer.Clear();
+        mHpBar.Clear();
 
-            mLeaderText = new Label(mPartyWindow, "LeaderText");
-            mLeaderText.SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
-            mLeaderText.Text = Strings.Parties.Leader;
-            mLeaderText.Hide();
-
-            if (Globals.Me.Party.Count > 0)
+        for (var i = 0; i < Options.Party.MaximumMembers; i++)
+        {
+            //Labels
+            mLblnames.Add(new Label(mPartyWindow, "MemberName" + i));
+            if (i < Globals.Me.Party.Count)
             {
-                mLeader.Show();
-                mLeaderText.Show();
+                mLblnames[i].Text = Strings.Parties.Name.ToString(
+                    Globals.Me.Party[i].Name, Globals.Me.Party[i].Level
+                );
+            }
+            else
+            {
+                mLblnames[i].Text = "";
             }
 
-            mLblnames.Clear();
-            mKickButtons.Clear();
-            mHpBarContainer.Clear();
-            mHpBar.Clear();
-
-            for (var i = 0; i < Options.Party.MaximumMembers; i++)
+            //Health bars
+            mHpBarContainer.Add(new ImagePanel(mPartyWindow, "HealthBarContainer" + i));
+            mHpBarContainer[i].Hide();
+            mHpLabel.Add(new Label(mPartyWindow, "HealthLabel" + i));
+            mHpLabel[i].Hide();
+            mHpLabel[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
+            mHpLabel[i].Text = Strings.Parties.Vital0;
+            mHpValue.Add(new Label(mPartyWindow, "HealthValue" + i));
+            mHpValue[i].Hide();
+            mHpValue[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
+            if (i < Globals.Me.Party.Count)
             {
-                //Labels
-                mLblnames.Add(new Label(mPartyWindow, "MemberName" + i));
+                mHpBarContainer[i].Show();
+            }
+
+            mHpBar.Add(new ImagePanel(mHpBarContainer[i], "HealthBar" + i));
+
+            //Mana bars
+            mMpBarContainer.Add(new ImagePanel(mPartyWindow, "ManaBarContainer" + i));
+            mMpBarContainer[i].Hide();
+            mMpBarContainer[i].RenderColor = new Color(0, 0, 0, 0);
+            mMpLabel.Add(new Label(mPartyWindow, "ManaLabel" + i));
+            mMpLabel[i].Hide();
+            mMpLabel[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
+            mMpLabel[i].Text = Strings.Parties.Vital1;
+            mMpValue.Add(new Label(mPartyWindow, "ManaValue" + i));
+            mMpValue[i].Hide();
+            mMpValue[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
+            mMpBar.Add(new ImagePanel(mMpBarContainer[i], "ManaBar" + i));
+            mMpBar[i].RenderColor = new Color(0, 0, 0, 0);
+
+            if (i == 0)
+            {
+                mKickButtons.Add(null);
+            }
+            else
+            {
+                mKickButtons.Add(new Button(mPartyWindow, "KickButton" + i));
+                mKickButtons[i].Clicked += kick_Clicked;
+                mKickButtons[i].Text = Strings.Parties.KickLabel;
                 if (i < Globals.Me.Party.Count)
                 {
-                    mLblnames[i].Text = Strings.Parties.Name.ToString(
+                    mKickButtons[i]
+                        .SetToolTipText(
+                            Strings.Parties.Kick.ToString(Globals.Entities[Globals.Me.Party[i].Id].Name)
+                        );
+                }
+                else
+                {
+                    mKickButtons[i].SetToolTipText("");
+                }
+
+                mKickButtons[i].Hide();
+
+                //Only show the kick buttons if its you or you are the party leader
+                if (i < Globals.Me.Party.Count)
+                {
+                    if (Globals.Me.Party[0].Id == Globals.Me.Id)
+                    {
+                        mKickButtons[i].Show();
+                    }
+                }
+            }
+        }
+
+        mLeaveButton = new Button(mPartyWindow, "LeavePartyButton");
+        mLeaveButton.Text = Strings.Parties.Leave;
+        mLeaveButton.SetToolTipText(Strings.Parties.LeaveTip);
+        mLeaveButton.Clicked += leave_Clicked;
+
+        mPartyWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+
+    //Methods
+    public void Update()
+    {
+        if (mPartyWindow.IsHidden)
+        {
+            return;
+        }
+
+        mLeader.Hide();
+        mLeaderText.Hide();
+        mLeaveButton.Hide();
+        for (var i = 0; i < Options.Instance.PartyOpts.MaximumMembers; i++)
+        {
+            mHpBarContainer[i].Hide();
+            mHpLabel[i].Hide();
+            mHpValue[i].Hide();
+            mLblnames[i].Text = "";
+            mMpBarContainer[i].Hide();
+            mMpLabel[i].Hide();
+            mMpValue[i].Hide();
+            if (i > 0)
+            {
+                mKickButtons[i].Hide();
+            }
+        }
+
+        if (Globals.Me.IsInParty())
+        {
+            mLeader.Show();
+            mLeaderText.Show();
+            mLeaveButton.Show();
+
+            for (var i = 0; i < Options.Instance.PartyOpts.MaximumMembers; i++)
+            {
+                if (i < Globals.Me.Party.Count)
+                {
+                    mHpLabel[i].Show();
+                    mHpValue[i].Show();
+                    mHpBarContainer[i].Show();
+
+                    mMpLabel[i].Show();
+                    mMpValue[i].Show();
+                    mMpBarContainer[i].Show();
+
+                    var nameLabel = mLblnames[i];
+
+                    nameLabel.Text = Strings.Parties.Name.ToString(
                         Globals.Me.Party[i].Name, Globals.Me.Party[i].Level
                     );
-                }
-                else
-                {
-                    mLblnames[i].Text = "";
-                }
 
-                //Health bars
-                mHpBarContainer.Add(new ImagePanel(mPartyWindow, "HealthBarContainer" + i));
-                mHpBarContainer[i].Hide();
-                mHpLabel.Add(new Label(mPartyWindow, "HealthLabel" + i));
-                mHpLabel[i].Hide();
-                mHpLabel[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
-                mHpLabel[i].Text = Strings.Parties.Vital0;
-                mHpValue.Add(new Label(mPartyWindow, "HealthValue" + i));
-                mHpValue[i].Hide();
-                mHpValue[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
-                if (i < Globals.Me.Party.Count)
-                {
-                    mHpBarContainer[i].Show();
-                }
+                    nameLabel.UserData = Globals.Me.Party[i].Id;
+                    nameLabel.Clicked += PartyWindow_Clicked;
 
-                mHpBar.Add(new ImagePanel(mHpBarContainer[i], "HealthBar" + i));
-
-                //Mana bars
-                mMpBarContainer.Add(new ImagePanel(mPartyWindow, "ManaBarContainer" + i));
-                mMpBarContainer[i].Hide();
-                mMpBarContainer[i].RenderColor = new Color(0, 0, 0, 0);
-                mMpLabel.Add(new Label(mPartyWindow, "ManaLabel" + i));
-                mMpLabel[i].Hide();
-                mMpLabel[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
-                mMpLabel[i].Text = Strings.Parties.Vital1;
-                mMpValue.Add(new Label(mPartyWindow, "ManaValue" + i));
-                mMpValue[i].Hide();
-                mMpValue[i].SetTextColor(new Color(0, 0, 0, 0), Label.ControlState.Normal);
-                mMpBar.Add(new ImagePanel(mMpBarContainer[i], "ManaBar" + i));
-                mMpBar[i].RenderColor = new Color(0, 0, 0, 0);
-
-                if (i == 0)
-                {
-                    mKickButtons.Add(null);
-                }
-                else
-                {
-                    mKickButtons.Add(new Button(mPartyWindow, "KickButton" + i));
-                    mKickButtons[i].Clicked += kick_Clicked;
-                    mKickButtons[i].Text = Strings.Parties.KickLabel;
-                    if (i < Globals.Me.Party.Count)
+                    if (mHpBar[i].Texture != null)
                     {
-                        mKickButtons[i]
-                            .SetToolTipText(
-                                Strings.Parties.Kick.ToString(Globals.Entities[Globals.Me.Party[i].Id].Name)
+                        var partyHpWidthRatio = 1f;
+                        if (Globals.Me.Party[i].MaxVital[(int)Vital.Health] > 0)
+                        {
+                            var vitalHp = Globals.Me.Party[i].Vital[(int)Vital.Health];
+                            var vitalMaxHp = Globals.Me.Party[i].MaxVital[(int)Vital.Health];
+                            var ratioHp = (float)vitalHp / (float)vitalMaxHp;
+                            partyHpWidthRatio = Math.Min(1, Math.Max(0, ratioHp));
+                        }
+
+                        mHpBar[i]
+                            .SetTextureRect(
+                                0, 0, Convert.ToInt32(mHpBar[i].Texture.GetWidth() * partyHpWidthRatio),
+                                mHpBar[i].Texture.GetHeight()
+                            );
+
+                        mHpBar[i]
+                            .SetSize(
+                                Convert.ToInt32(partyHpWidthRatio * mHpBarContainer[i].Width), mHpBarContainer[i].Height
                             );
                     }
-                    else
+
+                    mHpValue[i].Text = Strings.Parties.Vital0Value.ToString(
+                        Globals.Me.Party[i].Vital[(int) Vital.Health],
+                        Globals.Me.Party[i].MaxVital[(int) Vital.Health]
+                    );
+
+                    if (mMpBar[i].Texture != null)
+                    {
+                        var partyMpWidthRatio = 1f;
+                        if (Globals.Me.Party[i].MaxVital[(int)Vital.Mana] > 0)
+                        {
+                            var vitalMp = Globals.Me.Party[i].Vital[(int)Vital.Mana];
+                            var vitalMaxMp = Globals.Me.Party[i].MaxVital[(int)Vital.Mana];
+                            var ratioMp = (float)vitalMp / (float)vitalMaxMp;
+                            partyMpWidthRatio = Math.Min(1, Math.Max(0, ratioMp));
+                        }
+
+                        mMpBar[i]
+                            .SetTextureRect(
+                                0, 0, Convert.ToInt32(mMpBar[i].Texture.GetWidth() * partyMpWidthRatio),
+                                mMpBar[i].Texture.GetHeight()
+                            );
+
+                        mMpBar[i]
+                            .SetSize(
+                                Convert.ToInt32(partyMpWidthRatio * mMpBarContainer[i].Width), mMpBarContainer[i].Height
+                            );
+                    }
+
+                    mMpValue[i].Text = Strings.Parties.Vital1Value.ToString(
+                        Globals.Me.Party[i].Vital[(int) Vital.Mana],
+                        Globals.Me.Party[i].MaxVital[(int) Vital.Mana]
+                    );
+
+                    if (i > 0)
+                    {
+                        mKickButtons[i].Hide();
+                    }
+
+                    //Only show the kick buttons if its you or you are the party leader
+                    if (Globals.Me.Party[0].Id == Globals.Me.Id && i > 0)
+                    {
+                        mKickButtons[i].Show();
+                        mKickButtons[i].SetToolTipText(Strings.Parties.Kick.ToString(Globals.Me.Party[i].Name));
+                    }
+                }
+                else
+                {
+                    if (i > 0)
                     {
                         mKickButtons[i].SetToolTipText("");
                     }
 
-                    mKickButtons[i].Hide();
-
-                    //Only show the kick buttons if its you or you are the party leader
-                    if (i < Globals.Me.Party.Count)
-                    {
-                        if (Globals.Me.Party[0].Id == Globals.Me.Id)
-                        {
-                            mKickButtons[i].Show();
-                        }
-                    }
+                    mLblnames[i].Text = "";
+                    mHpBar[i].SetSize(0, mHpBarContainer[i].Height);
+                    mHpBarContainer[i].Hide();
                 }
             }
-
-            mLeaveButton = new Button(mPartyWindow, "LeavePartyButton");
-            mLeaveButton.Text = Strings.Parties.Leave;
-            mLeaveButton.SetToolTipText(Strings.Parties.LeaveTip);
-            mLeaveButton.Clicked += leave_Clicked;
-
-            mPartyWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         }
+    }
 
-        //Methods
-        public void Update()
+    private void PartyWindow_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var memberId = (Guid)((Label)sender).UserData;
+
+        if (Globals.Entities.TryGetValue(memberId, out var teammate))
         {
-            if (mPartyWindow.IsHidden)
+            Globals.Me.TryTarget(teammate);
+        }
+    }
+
+    public void Show()
+    {
+        mPartyWindow.IsHidden = false;
+    }
+
+    public bool IsVisible()
+    {
+        return !mPartyWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mPartyWindow.IsHidden = true;
+    }
+
+    //Input Handlers
+    void kick_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        for (var i = 1; i < Globals.Me.Party.Count; i++)
+        {
+            if (mKickButtons[i] == sender)
             {
+                PacketSender.SendPartyKick(Globals.Me.Party[i].Id);
+
                 return;
             }
-
-            mLeader.Hide();
-            mLeaderText.Hide();
-            mLeaveButton.Hide();
-            for (var i = 0; i < Options.Instance.PartyOpts.MaximumMembers; i++)
-            {
-                mHpBarContainer[i].Hide();
-                mHpLabel[i].Hide();
-                mHpValue[i].Hide();
-                mLblnames[i].Text = "";
-                mMpBarContainer[i].Hide();
-                mMpLabel[i].Hide();
-                mMpValue[i].Hide();
-                if (i > 0)
-                {
-                    mKickButtons[i].Hide();
-                }
-            }
-
-            if (Globals.Me.IsInParty())
-            {
-                mLeader.Show();
-                mLeaderText.Show();
-                mLeaveButton.Show();
-
-                for (var i = 0; i < Options.Instance.PartyOpts.MaximumMembers; i++)
-                {
-                    if (i < Globals.Me.Party.Count)
-                    {
-                        mHpLabel[i].Show();
-                        mHpValue[i].Show();
-                        mHpBarContainer[i].Show();
-
-                        mMpLabel[i].Show();
-                        mMpValue[i].Show();
-                        mMpBarContainer[i].Show();
-
-                        var nameLabel = mLblnames[i];
-
-                        nameLabel.Text = Strings.Parties.Name.ToString(
-                            Globals.Me.Party[i].Name, Globals.Me.Party[i].Level
-                        );
-
-                        nameLabel.UserData = Globals.Me.Party[i].Id;
-                        nameLabel.Clicked += PartyWindow_Clicked;
-
-                        if (mHpBar[i].Texture != null)
-                        {
-                            var partyHpWidthRatio = 1f;
-                            if (Globals.Me.Party[i].MaxVital[(int)Vital.Health] > 0)
-                            {
-                                var vitalHp = Globals.Me.Party[i].Vital[(int)Vital.Health];
-                                var vitalMaxHp = Globals.Me.Party[i].MaxVital[(int)Vital.Health];
-                                var ratioHp = (float)vitalHp / (float)vitalMaxHp;
-                                partyHpWidthRatio = Math.Min(1, Math.Max(0, ratioHp));
-                            }
-
-                            mHpBar[i]
-                                .SetTextureRect(
-                                    0, 0, Convert.ToInt32(mHpBar[i].Texture.GetWidth() * partyHpWidthRatio),
-                                    mHpBar[i].Texture.GetHeight()
-                                );
-
-                            mHpBar[i]
-                                .SetSize(
-                                    Convert.ToInt32(partyHpWidthRatio * mHpBarContainer[i].Width), mHpBarContainer[i].Height
-                                );
-                        }
-
-                        mHpValue[i].Text = Strings.Parties.Vital0Value.ToString(
-                            Globals.Me.Party[i].Vital[(int) Vital.Health],
-                            Globals.Me.Party[i].MaxVital[(int) Vital.Health]
-                        );
-
-                        if (mMpBar[i].Texture != null)
-                        {
-                            var partyMpWidthRatio = 1f;
-                            if (Globals.Me.Party[i].MaxVital[(int)Vital.Mana] > 0)
-                            {
-                                var vitalMp = Globals.Me.Party[i].Vital[(int)Vital.Mana];
-                                var vitalMaxMp = Globals.Me.Party[i].MaxVital[(int)Vital.Mana];
-                                var ratioMp = (float)vitalMp / (float)vitalMaxMp;
-                                partyMpWidthRatio = Math.Min(1, Math.Max(0, ratioMp));
-                            }
-
-                            mMpBar[i]
-                                .SetTextureRect(
-                                    0, 0, Convert.ToInt32(mMpBar[i].Texture.GetWidth() * partyMpWidthRatio),
-                                    mMpBar[i].Texture.GetHeight()
-                                );
-
-                            mMpBar[i]
-                                .SetSize(
-                                    Convert.ToInt32(partyMpWidthRatio * mMpBarContainer[i].Width), mMpBarContainer[i].Height
-                                );
-                        }
-
-                        mMpValue[i].Text = Strings.Parties.Vital1Value.ToString(
-                            Globals.Me.Party[i].Vital[(int) Vital.Mana],
-                            Globals.Me.Party[i].MaxVital[(int) Vital.Mana]
-                        );
-
-                        if (i > 0)
-                        {
-                            mKickButtons[i].Hide();
-                        }
-
-                        //Only show the kick buttons if its you or you are the party leader
-                        if (Globals.Me.Party[0].Id == Globals.Me.Id && i > 0)
-                        {
-                            mKickButtons[i].Show();
-                            mKickButtons[i].SetToolTipText(Strings.Parties.Kick.ToString(Globals.Me.Party[i].Name));
-                        }
-                    }
-                    else
-                    {
-                        if (i > 0)
-                        {
-                            mKickButtons[i].SetToolTipText("");
-                        }
-
-                        mLblnames[i].Text = "";
-                        mHpBar[i].SetSize(0, mHpBarContainer[i].Height);
-                        mHpBarContainer[i].Hide();
-                    }
-                }
-            }
         }
+    }
 
-        private void PartyWindow_Clicked(Base sender, ClickedEventArgs arguments)
+    void leave_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.Me.Party.Count > 0)
         {
-            var memberId = (Guid)((Label)sender).UserData;
-
-            if (Globals.Entities.TryGetValue(memberId, out var teammate))
-            {
-                Globals.Me.TryTarget(teammate);
-            }
+            PacketSender.SendPartyLeave();
         }
-
-        public void Show()
-        {
-            mPartyWindow.IsHidden = false;
-        }
-
-        public bool IsVisible()
-        {
-            return !mPartyWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mPartyWindow.IsHidden = true;
-        }
-
-        //Input Handlers
-        void kick_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            for (var i = 1; i < Globals.Me.Party.Count; i++)
-            {
-                if (mKickButtons[i] == sender)
-                {
-                    PacketSender.SendPartyKick(Globals.Me.Party[i].Id);
-
-                    return;
-                }
-            }
-        }
-
-        void leave_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.Me.Party.Count > 0)
-            {
-                PacketSender.SendPartyLeave();
-            }
-        }
-
     }
 
 }

--- a/Intersect.Client/Interface/Game/PictureWindow.cs
+++ b/Intersect.Client/Interface/Game/PictureWindow.cs
@@ -6,135 +6,133 @@ using Intersect.Client.Networking;
 
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+partial class PictureWindow
 {
 
-    partial class PictureWindow
+    //Controls
+    private Canvas mGameCanvas;
+
+    private ImagePanel mPicture;
+
+    public PictureWindow(Canvas gameCanvas)
     {
+        mGameCanvas = gameCanvas;
+        mPicture = new ImagePanel(gameCanvas);
+        mPicture.Clicked += MPicture_Clicked;
+    }
 
-        //Controls
-        private Canvas mGameCanvas;
+    public string Picture { get; private set; }
 
-        private ImagePanel mPicture;
+    public int Size { get; private set; }
 
-        public PictureWindow(Canvas gameCanvas)
+    public bool Clickable { get; private set; }
+
+    public void Setup(string picture, int size, bool clickable)
+    {
+        Picture = picture;
+        Size = size;
+        Clickable = clickable;
+
+        mPicture.Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, picture);
+        if (mPicture.Texture != null)
         {
-            mGameCanvas = gameCanvas;
-            mPicture = new ImagePanel(gameCanvas);
-            mPicture.Clicked += MPicture_Clicked;
-        }
+            mPicture.SetSize(mPicture.Texture.GetWidth(), mPicture.Texture.GetHeight());
+            Align.Center(mPicture);
 
-        public string Picture { get; private set; }
-
-        public int Size { get; private set; }
-
-        public bool Clickable { get; private set; }
-
-        public void Setup(string picture, int size, bool clickable)
-        {
-            Picture = picture;
-            Size = size;
-            Clickable = clickable;
-
-            mPicture.Texture = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, picture);
-            if (mPicture.Texture != null)
+            if (size != (int) PictureSize.Original) // Don't scale if you want to keep the original size.
             {
-                mPicture.SetSize(mPicture.Texture.GetWidth(), mPicture.Texture.GetHeight());
-                Align.Center(mPicture);
-
-                if (size != (int) PictureSize.Original) // Don't scale if you want to keep the original size.
+                if (size == (int) PictureSize.StretchToFit)
                 {
-                    if (size == (int) PictureSize.StretchToFit)
+                    mPicture.SetSize(mGameCanvas.Width, mGameCanvas.Height);
+                    Align.Center(mPicture);
+                }
+                else
+                {
+                    var n = 1;
+
+                    //If you want half fullscreen size set n to 2.
+                    if (size == (int) PictureSize.HalfScreen)
                     {
-                        mPicture.SetSize(mGameCanvas.Width, mGameCanvas.Height);
+                        n = 2;
+                    }
+
+                    var ar = (float) mPicture.Width / (float) mPicture.Height;
+                    var heightLimit = true;
+                    if (mGameCanvas.Width < mGameCanvas.Height * ar)
+                    {
+                        heightLimit = false;
+                    }
+
+                    if (heightLimit)
+                    {
+                        var height = mGameCanvas.Height;
+                        var width = mGameCanvas.Height * ar;
+                        mPicture.SetSize((int) (width / n), (int) (height / n));
                         Align.Center(mPicture);
                     }
                     else
                     {
-                        var n = 1;
-
-                        //If you want half fullscreen size set n to 2.
-                        if (size == (int) PictureSize.HalfScreen)
-                        {
-                            n = 2;
-                        }
-
-                        var ar = (float) mPicture.Width / (float) mPicture.Height;
-                        var heightLimit = true;
-                        if (mGameCanvas.Width < mGameCanvas.Height * ar)
-                        {
-                            heightLimit = false;
-                        }
-
-                        if (heightLimit)
-                        {
-                            var height = mGameCanvas.Height;
-                            var width = mGameCanvas.Height * ar;
-                            mPicture.SetSize((int) (width / n), (int) (height / n));
-                            Align.Center(mPicture);
-                        }
-                        else
-                        {
-                            var width = mGameCanvas.Width;
-                            var height = width / ar;
-                            mPicture.SetSize((int) (width / n), (int) (height / n));
-                            Align.Center(mPicture);
-                        }
+                        var width = mGameCanvas.Width;
+                        var height = width / ar;
+                        mPicture.SetSize((int) (width / n), (int) (height / n));
+                        Align.Center(mPicture);
                     }
                 }
-
-                mPicture.BringToFront();
-                mPicture.Show();
             }
-            else
+
+            mPicture.BringToFront();
+            mPicture.Show();
+        }
+        else
+        {
+            Close();
+        }
+    }
+
+    private void MPicture_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Clickable)
+        {
+            Close();
+        }
+    }
+
+    public void Close()
+    {
+        if (Picture != null)
+        {
+            PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
+            Globals.Picture = null;
+            Picture = null;
+            mPicture.Hide();
+        }
+    }
+
+    public void Update()
+    {
+        if (Picture != null)
+        {
+            if (Globals.Picture != null && Globals.Picture.HideTime > 0 && Timing.Global.Milliseconds > Globals.Picture.ReceiveTime + Globals.Picture.HideTime)
             {
+                //Should auto close this picture
                 Close();
             }
         }
+    }
 
-        private void MPicture_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Clickable)
-            {
-                Close();
-            }
-        }
+    private enum PictureSize
+    {
 
-        public void Close()
-        {
-            if (Picture != null)
-            {
-                PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
-                Globals.Picture = null;
-                Picture = null;
-                mPicture.Hide();
-            }
-        }
+        Original = 0,
 
-        public void Update()
-        {
-            if (Picture != null)
-            {
-                if (Globals.Picture != null && Globals.Picture.HideTime > 0 && Timing.Global.Milliseconds > Globals.Picture.ReceiveTime + Globals.Picture.HideTime)
-                {
-                    //Should auto close this picture
-                    Close();
-                }
-            }
-        }
+        FullScreen,
 
-        private enum PictureSize
-        {
+        HalfScreen,
 
-            Original = 0,
-
-            FullScreen,
-
-            HalfScreen,
-
-            StretchToFit,
-
-        }
+        StretchToFit,
 
     }
 

--- a/Intersect.Client/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client/Interface/Game/QuestOfferWindow.cs
@@ -7,118 +7,116 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class QuestOfferWindow
 {
 
-    public partial class QuestOfferWindow
+    private Button mAcceptButton;
+
+    private Button mDeclineButton;
+
+    private string mQuestOfferText = "";
+
+    //Controls
+    private WindowControl mQuestOfferWindow;
+
+    private ScrollControl mQuestPromptArea;
+
+    private RichLabel mQuestPromptLabel;
+
+    private Label mQuestPromptTemplate;
+
+    private Label mQuestTitle;
+
+    public QuestOfferWindow(Canvas gameCanvas)
     {
+        mQuestOfferWindow = new WindowControl(gameCanvas, Strings.QuestOffer.Title, false, "QuestOfferWindow");
+        mQuestOfferWindow.DisableResizing();
+        mQuestOfferWindow.IsClosable = false;
 
-        private Button mAcceptButton;
+        //Menu Header
+        mQuestTitle = new Label(mQuestOfferWindow, "QuestTitle");
 
-        private Button mDeclineButton;
+        mQuestPromptArea = new ScrollControl(mQuestOfferWindow, "QuestOfferArea");
 
-        private string mQuestOfferText = "";
+        mQuestPromptTemplate = new Label(mQuestPromptArea, "QuestOfferTemplate");
 
-        //Controls
-        private WindowControl mQuestOfferWindow;
+        mQuestPromptLabel = new RichLabel(mQuestPromptArea);
 
-        private ScrollControl mQuestPromptArea;
+        //Accept Button
+        mAcceptButton = new Button(mQuestOfferWindow, "AcceptButton");
+        mAcceptButton.SetText(Strings.QuestOffer.Accept);
+        mAcceptButton.Clicked += _acceptButton_Clicked;
 
-        private RichLabel mQuestPromptLabel;
+        //Decline Button
+        mDeclineButton = new Button(mQuestOfferWindow, "DeclineButton");
+        mDeclineButton.SetText(Strings.QuestOffer.Decline);
+        mDeclineButton.Clicked += _declineButton_Clicked;
 
-        private Label mQuestPromptTemplate;
+        mQuestOfferWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        Interface.InputBlockingElements.Add(mQuestOfferWindow);
+    }
 
-        private Label mQuestTitle;
-
-        public QuestOfferWindow(Canvas gameCanvas)
+    private void _declineButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.QuestOffers.Count > 0)
         {
-            mQuestOfferWindow = new WindowControl(gameCanvas, Strings.QuestOffer.Title, false, "QuestOfferWindow");
-            mQuestOfferWindow.DisableResizing();
-            mQuestOfferWindow.IsClosable = false;
-
-            //Menu Header
-            mQuestTitle = new Label(mQuestOfferWindow, "QuestTitle");
-
-            mQuestPromptArea = new ScrollControl(mQuestOfferWindow, "QuestOfferArea");
-
-            mQuestPromptTemplate = new Label(mQuestPromptArea, "QuestOfferTemplate");
-
-            mQuestPromptLabel = new RichLabel(mQuestPromptArea);
-
-            //Accept Button
-            mAcceptButton = new Button(mQuestOfferWindow, "AcceptButton");
-            mAcceptButton.SetText(Strings.QuestOffer.Accept);
-            mAcceptButton.Clicked += _acceptButton_Clicked;
-
-            //Decline Button
-            mDeclineButton = new Button(mQuestOfferWindow, "DeclineButton");
-            mDeclineButton.SetText(Strings.QuestOffer.Decline);
-            mDeclineButton.Clicked += _declineButton_Clicked;
-
-            mQuestOfferWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-            Interface.InputBlockingElements.Add(mQuestOfferWindow);
+            PacketSender.SendDeclineQuest(Globals.QuestOffers[0]);
+            Globals.QuestOffers.RemoveAt(0);
         }
+    }
 
-        private void _declineButton_Clicked(Base sender, ClickedEventArgs arguments)
+    private void _acceptButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.QuestOffers.Count > 0)
         {
-            if (Globals.QuestOffers.Count > 0)
+            PacketSender.SendAcceptQuest(Globals.QuestOffers[0]);
+            Globals.QuestOffers.RemoveAt(0);
+        }
+    }
+
+    public void Update(QuestBase quest)
+    {
+        if (quest == null)
+        {
+            Hide();
+        }
+        else
+        {
+            Show();
+            mQuestTitle.Text = quest.Name;
+            if (mQuestOfferText != quest.StartDescription)
             {
-                PacketSender.SendDeclineQuest(Globals.QuestOffers[0]);
-                Globals.QuestOffers.RemoveAt(0);
+                mQuestPromptLabel.ClearText();
+                mQuestPromptLabel.Width = mQuestPromptArea.Width - mQuestPromptArea.GetVerticalScrollBar().Width;
+                mQuestPromptLabel.AddText(quest.StartDescription, mQuestPromptTemplate);
+
+                mQuestPromptLabel.SizeToChildren(false, true);
+                mQuestOfferText = quest.StartDescription;
             }
         }
+    }
 
-        private void _acceptButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.QuestOffers.Count > 0)
-            {
-                PacketSender.SendAcceptQuest(Globals.QuestOffers[0]);
-                Globals.QuestOffers.RemoveAt(0);
-            }
-        }
+    public void Show()
+    {
+        mQuestOfferWindow.IsHidden = false;
+    }
 
-        public void Update(QuestBase quest)
-        {
-            if (quest == null)
-            {
-                Hide();
-            }
-            else
-            {
-                Show();
-                mQuestTitle.Text = quest.Name;
-                if (mQuestOfferText != quest.StartDescription)
-                {
-                    mQuestPromptLabel.ClearText();
-                    mQuestPromptLabel.Width = mQuestPromptArea.Width - mQuestPromptArea.GetVerticalScrollBar().Width;
-                    mQuestPromptLabel.AddText(quest.StartDescription, mQuestPromptTemplate);
+    public void Close()
+    {
+        mQuestOfferWindow.Close();
+    }
 
-                    mQuestPromptLabel.SizeToChildren(false, true);
-                    mQuestOfferText = quest.StartDescription;
-                }
-            }
-        }
+    public bool IsVisible()
+    {
+        return !mQuestOfferWindow.IsHidden;
+    }
 
-        public void Show()
-        {
-            mQuestOfferWindow.IsHidden = false;
-        }
-
-        public void Close()
-        {
-            mQuestOfferWindow.Close();
-        }
-
-        public bool IsVisible()
-        {
-            return !mQuestOfferWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mQuestOfferWindow.IsHidden = true;
-        }
-
+    public void Hide()
+    {
+        mQuestOfferWindow.IsHidden = true;
     }
 
 }

--- a/Intersect.Client/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client/Interface/Game/QuestsWindow.cs
@@ -9,422 +9,420 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game
+namespace Intersect.Client.Interface.Game;
+
+
+public partial class QuestsWindow
 {
 
-    public partial class QuestsWindow
+    private Button mBackButton;
+
+    private ScrollControl mQuestDescArea;
+
+    private RichLabel mQuestDescLabel;
+
+    private Label mQuestDescTemplateLabel;
+
+    private ListBox mQuestList;
+
+    private Label mQuestStatus;
+
+    //Controls
+    private WindowControl mQuestsWindow;
+
+    private Label mQuestTitle;
+
+    private Button mQuitButton;
+
+    private QuestBase mSelectedQuest;
+
+    //Init
+    public QuestsWindow(Canvas gameCanvas)
     {
+        mQuestsWindow = new WindowControl(gameCanvas, Strings.QuestLog.Title, false, "QuestsWindow");
+        mQuestsWindow.DisableResizing();
 
-        private Button mBackButton;
+        mQuestList = new ListBox(mQuestsWindow, "QuestList");
+        mQuestList.EnableScroll(false, true);
 
-        private ScrollControl mQuestDescArea;
+        mQuestTitle = new Label(mQuestsWindow, "QuestTitle");
+        mQuestTitle.SetText("");
 
-        private RichLabel mQuestDescLabel;
+        mQuestStatus = new Label(mQuestsWindow, "QuestStatus");
+        mQuestStatus.SetText("");
 
-        private Label mQuestDescTemplateLabel;
+        mQuestDescArea = new ScrollControl(mQuestsWindow, "QuestDescription");
 
-        private ListBox mQuestList;
+        mQuestDescTemplateLabel = new Label(mQuestsWindow, "QuestDescriptionTemplate");
 
-        private Label mQuestStatus;
+        mQuestDescLabel = new RichLabel(mQuestDescArea);
 
-        //Controls
-        private WindowControl mQuestsWindow;
+        mBackButton = new Button(mQuestsWindow, "BackButton");
+        mBackButton.Text = Strings.QuestLog.Back;
+        mBackButton.Clicked += _backButton_Clicked;
 
-        private Label mQuestTitle;
+        mQuitButton = new Button(mQuestsWindow, "AbandonQuestButton");
+        mQuitButton.SetText(Strings.QuestLog.Abandon);
+        mQuitButton.Clicked += _quitButton_Clicked;
 
-        private Button mQuitButton;
+        mQuestsWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        private QuestBase mSelectedQuest;
-
-        //Init
-        public QuestsWindow(Canvas gameCanvas)
+    private void _quitButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (mSelectedQuest != null)
         {
-            mQuestsWindow = new WindowControl(gameCanvas, Strings.QuestLog.Title, false, "QuestsWindow");
-            mQuestsWindow.DisableResizing();
-
-            mQuestList = new ListBox(mQuestsWindow, "QuestList");
-            mQuestList.EnableScroll(false, true);
-
-            mQuestTitle = new Label(mQuestsWindow, "QuestTitle");
-            mQuestTitle.SetText("");
-
-            mQuestStatus = new Label(mQuestsWindow, "QuestStatus");
-            mQuestStatus.SetText("");
-
-            mQuestDescArea = new ScrollControl(mQuestsWindow, "QuestDescription");
-
-            mQuestDescTemplateLabel = new Label(mQuestsWindow, "QuestDescriptionTemplate");
-
-            mQuestDescLabel = new RichLabel(mQuestDescArea);
-
-            mBackButton = new Button(mQuestsWindow, "BackButton");
-            mBackButton.Text = Strings.QuestLog.Back;
-            mBackButton.Clicked += _backButton_Clicked;
-
-            mQuitButton = new Button(mQuestsWindow, "AbandonQuestButton");
-            mQuitButton.SetText(Strings.QuestLog.Abandon);
-            mQuitButton.Clicked += _quitButton_Clicked;
-
-            mQuestsWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            new InputBox(
+                Strings.QuestLog.AbandonTitle.ToString(mSelectedQuest.Name),
+                Strings.QuestLog.AbandonPrompt.ToString(mSelectedQuest.Name), true, InputBox.InputType.YesNo,
+                AbandonQuest, null, mSelectedQuest.Id
+            );
         }
+    }
 
-        private void _quitButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (mSelectedQuest != null)
-            {
-                new InputBox(
-                    Strings.QuestLog.AbandonTitle.ToString(mSelectedQuest.Name),
-                    Strings.QuestLog.AbandonPrompt.ToString(mSelectedQuest.Name), true, InputBox.InputType.YesNo,
-                    AbandonQuest, null, mSelectedQuest.Id
-                );
-            }
-        }
+    void AbandonQuest(object sender, EventArgs e)
+    {
+        PacketSender.SendAbandonQuest((Guid) ((InputBox) sender).UserData);
+    }
 
-        void AbandonQuest(object sender, EventArgs e)
-        {
-            PacketSender.SendAbandonQuest((Guid) ((InputBox) sender).UserData);
-        }
+    private void _backButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mSelectedQuest = null;
+        UpdateSelectedQuest();
+    }
 
-        private void _backButton_Clicked(Base sender, ClickedEventArgs arguments)
+    //Methods
+    public void Update(bool shouldUpdateList)
+    {
+        if (shouldUpdateList)
         {
-            mSelectedQuest = null;
+            UpdateQuestList();
             UpdateSelectedQuest();
         }
 
-        //Methods
-        public void Update(bool shouldUpdateList)
+        if (mQuestsWindow.IsHidden)
         {
-            if (shouldUpdateList)
-            {
-                UpdateQuestList();
-                UpdateSelectedQuest();
-            }
+            return;
+        }
 
-            if (mQuestsWindow.IsHidden)
+        if (mSelectedQuest != null)
+        {
+            if (Globals.Me.QuestProgress.ContainsKey(mSelectedQuest.Id))
             {
-                return;
-            }
-
-            if (mSelectedQuest != null)
-            {
-                if (Globals.Me.QuestProgress.ContainsKey(mSelectedQuest.Id))
+                if (Globals.Me.QuestProgress[mSelectedQuest.Id].Completed &&
+                    Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId == Guid.Empty)
                 {
-                    if (Globals.Me.QuestProgress[mSelectedQuest.Id].Completed &&
-                        Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId == Guid.Empty)
+                    //Completed
+                    if (!mSelectedQuest.LogAfterComplete)
                     {
-                        //Completed
-                        if (!mSelectedQuest.LogAfterComplete)
+                        mSelectedQuest = null;
+                        UpdateSelectedQuest();
+                    }
+
+                    return;
+                }
+                else
+                {
+                    if (Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId == Guid.Empty)
+                    {
+                        //Not Started
+                        if (!mSelectedQuest.LogBeforeOffer)
                         {
                             mSelectedQuest = null;
                             UpdateSelectedQuest();
                         }
-
-                        return;
                     }
-                    else
-                    {
-                        if (Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId == Guid.Empty)
-                        {
-                            //Not Started
-                            if (!mSelectedQuest.LogBeforeOffer)
-                            {
-                                mSelectedQuest = null;
-                                UpdateSelectedQuest();
-                            }
-                        }
 
-                        return;
-                    }
-                }
-
-                if (!mSelectedQuest.LogBeforeOffer)
-                {
-                    mSelectedQuest = null;
-                    UpdateSelectedQuest();
-                }
-            }
-        }
-
-        private void UpdateQuestList()
-        {
-            mQuestList.RemoveAllRows();
-            if (Globals.Me != null)
-            {
-                var quests = QuestBase.Lookup.Values;
-
-                var dict = new Dictionary<string, List<Tuple<QuestBase, int, Color>>>();
-
-                foreach (QuestBase quest in quests)
-                {
-                    if (quest != null)
-                    {
-                        AddQuestToDict(dict, quest);
-                    }
-                }
-
-
-                foreach (var category in Options.Instance.Quest.Categories)
-                {
-                    if (dict.ContainsKey(category))
-                    {
-                        AddCategoryToList(category, Color.White);
-                        var sortedList = dict[category].OrderBy(l => l.Item2).ThenBy(l => l.Item1.OrderValue).ToList();
-                        foreach (var qst in sortedList)
-                        {
-                            AddQuestToList(qst.Item1.Name, qst.Item3, qst.Item1.Id, true);
-                        }
-                    }
-                }
-
-                if (dict.ContainsKey(""))
-                {
-                    var sortedList = dict[""].OrderBy(l => l.Item2).ThenBy(l => l.Item1.OrderValue).ToList();
-                    foreach (var qst in sortedList)
-                    {
-                        AddQuestToList(qst.Item1.Name, qst.Item3, qst.Item1.Id, false);
-                    }
-                }
-
-            }
-        }
-
-        private void AddQuestToDict(Dictionary<string, List<Tuple<QuestBase, int, Color>>> dict, QuestBase quest)
-        {
-            var category = "";
-            var add = false;
-            var color = Color.White;
-            var orderVal = -1;
-            if (Globals.Me.QuestProgress.ContainsKey(quest.Id))
-            {
-                if (Globals.Me.QuestProgress[quest.Id].TaskId != Guid.Empty)
-                {
-                    add = true;
-                    category = !TextUtils.IsNone(quest.InProgressCategory) ? quest.InProgressCategory : "";
-                    color = CustomColors.QuestWindow.InProgress;
-                    orderVal = 1;
-                }
-                else
-                {
-                    if (Globals.Me.QuestProgress[quest.Id].Completed)
-                    {
-                        if (quest.LogAfterComplete)
-                        {
-                            add = true;
-                            category = !TextUtils.IsNone(quest.CompletedCategory) ? quest.CompletedCategory : "";
-                            color = CustomColors.QuestWindow.Completed;
-                            orderVal = 3;
-                        }
-                    }
-                    else
-                    {
-                        if (quest.LogBeforeOffer && !Globals.Me.HiddenQuests.Contains(quest.Id))
-                        {
-                            add = true;
-                            category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
-                            color = CustomColors.QuestWindow.NotStarted;
-                            orderVal = 2;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (quest.LogBeforeOffer && !Globals.Me.HiddenQuests.Contains(quest.Id))
-                {
-                    add = true;
-                    category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
-                    color = CustomColors.QuestWindow.NotStarted;
-                    orderVal = 2;
+                    return;
                 }
             }
 
-            if (add)
+            if (!mSelectedQuest.LogBeforeOffer)
             {
-                if (!dict.ContainsKey(category))
-                {
-                    dict.Add(category, new List<Tuple<QuestBase, int, Color>>());
-                }
-
-                dict[category].Add(new Tuple<QuestBase, int, Color>(quest, orderVal, color));
-            }
-        }
-
-        private void AddQuestToList(string name, Color clr, Guid questId, bool indented = true)
-        {
-            var item = mQuestList.AddRow((indented ? "\t\t\t" : "") + name);
-            item.UserData = questId;
-            item.Clicked += QuestListItem_Clicked;
-            item.Selected += Item_Selected;
-            item.SetTextColor(clr);
-            item.RenderColor = new Color(50, 255, 255, 255);
-        }
-
-        private void AddCategoryToList(string name, Color clr)
-        {
-            var item = mQuestList.AddRow(name);
-            item.MouseInputEnabled = false;
-            item.SetTextColor(clr);
-            item.RenderColor = new Color(0, 255, 255, 255);
-        }
-
-        private void Item_Selected(Base sender, ItemSelectedEventArgs arguments)
-        {
-            mQuestList.UnselectAll();
-        }
-
-        private void QuestListItem_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            var questNum = (Guid) ((ListBoxRow) sender).UserData;
-            var quest = QuestBase.Get(questNum);
-            if (quest != null)
-            {
-                mSelectedQuest = quest;
+                mSelectedQuest = null;
                 UpdateSelectedQuest();
             }
-
-            mQuestList.UnselectAll();
         }
+    }
 
-        private void UpdateSelectedQuest()
+    private void UpdateQuestList()
+    {
+        mQuestList.RemoveAllRows();
+        if (Globals.Me != null)
         {
-            if (mSelectedQuest == null)
+            var quests = QuestBase.Lookup.Values;
+
+            var dict = new Dictionary<string, List<Tuple<QuestBase, int, Color>>>();
+
+            foreach (QuestBase quest in quests)
             {
-                mQuestList.Show();
-                mQuestTitle.Hide();
-                mQuestDescArea.Hide();
-                mQuestStatus.Hide();
-                mBackButton.Hide();
-                mQuitButton.Hide();
+                if (quest != null)
+                {
+                    AddQuestToDict(dict, quest);
+                }
+            }
+
+
+            foreach (var category in Options.Instance.Quest.Categories)
+            {
+                if (dict.ContainsKey(category))
+                {
+                    AddCategoryToList(category, Color.White);
+                    var sortedList = dict[category].OrderBy(l => l.Item2).ThenBy(l => l.Item1.OrderValue).ToList();
+                    foreach (var qst in sortedList)
+                    {
+                        AddQuestToList(qst.Item1.Name, qst.Item3, qst.Item1.Id, true);
+                    }
+                }
+            }
+
+            if (dict.ContainsKey(""))
+            {
+                var sortedList = dict[""].OrderBy(l => l.Item2).ThenBy(l => l.Item1.OrderValue).ToList();
+                foreach (var qst in sortedList)
+                {
+                    AddQuestToList(qst.Item1.Name, qst.Item3, qst.Item1.Id, false);
+                }
+            }
+
+        }
+    }
+
+    private void AddQuestToDict(Dictionary<string, List<Tuple<QuestBase, int, Color>>> dict, QuestBase quest)
+    {
+        var category = "";
+        var add = false;
+        var color = Color.White;
+        var orderVal = -1;
+        if (Globals.Me.QuestProgress.ContainsKey(quest.Id))
+        {
+            if (Globals.Me.QuestProgress[quest.Id].TaskId != Guid.Empty)
+            {
+                add = true;
+                category = !TextUtils.IsNone(quest.InProgressCategory) ? quest.InProgressCategory : "";
+                color = CustomColors.QuestWindow.InProgress;
+                orderVal = 1;
             }
             else
             {
-                mQuestDescLabel.ClearText();
-                mQuitButton.IsDisabled = true;
-                ListBoxRow rw;
-                string[] myText = null;
-                var taskString = new List<string>();
-                if (Globals.Me.QuestProgress.ContainsKey(mSelectedQuest.Id))
+                if (Globals.Me.QuestProgress[quest.Id].Completed)
                 {
-                    if (Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId != Guid.Empty)
+                    if (quest.LogAfterComplete)
                     {
-                        //In Progress
-                        mQuestStatus.SetText(Strings.QuestLog.InProgress);
-                        mQuestStatus.SetTextColor(CustomColors.QuestWindow.InProgress, Label.ControlState.Normal);
-                        mQuestDescTemplateLabel.SetTextColor(CustomColors.QuestWindow.QuestDesc, Label.ControlState.Normal);
-                        
-                        if (mSelectedQuest.InProgressDescription.Length > 0)
-                        {    
-                            mQuestDescLabel.AddText(mSelectedQuest.InProgressDescription, mQuestDescTemplateLabel);
-
-                            mQuestDescLabel.AddLineBreak();
-                            mQuestDescLabel.AddLineBreak();
-                        }
-
-                        mQuestDescLabel.AddText(Strings.QuestLog.CurrentTask, mQuestDescTemplateLabel);
-
-                        mQuestDescLabel.AddLineBreak();
-                        for (var i = 0; i < mSelectedQuest.Tasks.Count; i++)
-                        {
-                            if (mSelectedQuest.Tasks[i].Id == Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId)
-                            {
-                                if (mSelectedQuest.Tasks[i].Description.Length > 0)
-                                {
-                                    mQuestDescLabel.AddText(mSelectedQuest.Tasks[i].Description, mQuestDescTemplateLabel);
-
-                                    mQuestDescLabel.AddLineBreak();
-                                    mQuestDescLabel.AddLineBreak();
-                                }
-
-                                if (mSelectedQuest.Tasks[i].Objective == QuestObjective.GatherItems) //Gather Items
-                                {
-                                    mQuestDescLabel.AddText(
-                                        Strings.QuestLog.TaskItem.ToString(
-                                            Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
-                                            mSelectedQuest.Tasks[i].Quantity,
-                                            ItemBase.GetName(mSelectedQuest.Tasks[i].TargetId)
-                                        ), mQuestDescTemplateLabel
-                                    );
-                                }
-                                else if (mSelectedQuest.Tasks[i].Objective == QuestObjective.KillNpcs) //Kill Npcs
-                                {
-                                    mQuestDescLabel.AddText(
-                                        Strings.QuestLog.TaskNpc.ToString(
-                                            Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
-                                            mSelectedQuest.Tasks[i].Quantity,
-                                            NpcBase.GetName(mSelectedQuest.Tasks[i].TargetId)
-                                        ), mQuestDescTemplateLabel
-                                    );
-                                }
-                            }
-                        }
-
-                        mQuitButton.IsDisabled = !mSelectedQuest.Quitable;
-                    }
-                    else
-                    {
-                        if (Globals.Me.QuestProgress[mSelectedQuest.Id].Completed)
-                        {
-                            //Completed
-                            if (mSelectedQuest.LogAfterComplete)
-                            {
-                                mQuestStatus.SetText(Strings.QuestLog.Completed);
-                                mQuestStatus.SetTextColor(CustomColors.QuestWindow.Completed, Label.ControlState.Normal);
-                                mQuestDescLabel.AddText(mSelectedQuest.EndDescription, mQuestDescTemplateLabel);
-                            }
-                        }
-                        else
-                        {
-                            //Not Started
-                            if (mSelectedQuest.LogBeforeOffer)
-                            {
-                                mQuestStatus.SetText(Strings.QuestLog.NotStarted);
-                                mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
-                                mQuestDescLabel.AddText(mSelectedQuest.BeforeDescription, mQuestDescTemplateLabel);
-
-                                mQuitButton?.Hide();
-                            }
-                        }
+                        add = true;
+                        category = !TextUtils.IsNone(quest.CompletedCategory) ? quest.CompletedCategory : "";
+                        color = CustomColors.QuestWindow.Completed;
+                        orderVal = 3;
                     }
                 }
                 else
                 {
-                    //Not Started
-                    if (mSelectedQuest.LogBeforeOffer)
+                    if (quest.LogBeforeOffer && !Globals.Me.HiddenQuests.Contains(quest.Id))
                     {
-                        mQuestStatus.SetText(Strings.QuestLog.NotStarted);
-                        mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
-                        mQuestDescLabel.AddText(mSelectedQuest.BeforeDescription, mQuestDescTemplateLabel);
+                        add = true;
+                        category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
+                        color = CustomColors.QuestWindow.NotStarted;
+                        orderVal = 2;
                     }
                 }
-
-                mQuestList.Hide();
-                mQuestTitle.IsHidden = false;
-                mQuestTitle.Text = mSelectedQuest.Name;
-                mQuestDescArea.IsHidden = false;
-                mQuestDescLabel.Width = mQuestDescArea.Width - mQuestDescArea.GetVerticalScrollBar().Width;
-                mQuestDescLabel.SizeToChildren(false, true);
-                mQuestStatus.Show();
-                mBackButton.Show();
-                mQuitButton.Show();
+            }
+        }
+        else
+        {
+            if (quest.LogBeforeOffer && !Globals.Me.HiddenQuests.Contains(quest.Id))
+            {
+                add = true;
+                category = !TextUtils.IsNone(quest.UnstartedCategory) ? quest.UnstartedCategory : "";
+                color = CustomColors.QuestWindow.NotStarted;
+                orderVal = 2;
             }
         }
 
-        public void Show()
+        if (add)
         {
-            mQuestsWindow.IsHidden = false;
+            if (!dict.ContainsKey(category))
+            {
+                dict.Add(category, new List<Tuple<QuestBase, int, Color>>());
+            }
+
+            dict[category].Add(new Tuple<QuestBase, int, Color>(quest, orderVal, color));
+        }
+    }
+
+    private void AddQuestToList(string name, Color clr, Guid questId, bool indented = true)
+    {
+        var item = mQuestList.AddRow((indented ? "\t\t\t" : "") + name);
+        item.UserData = questId;
+        item.Clicked += QuestListItem_Clicked;
+        item.Selected += Item_Selected;
+        item.SetTextColor(clr);
+        item.RenderColor = new Color(50, 255, 255, 255);
+    }
+
+    private void AddCategoryToList(string name, Color clr)
+    {
+        var item = mQuestList.AddRow(name);
+        item.MouseInputEnabled = false;
+        item.SetTextColor(clr);
+        item.RenderColor = new Color(0, 255, 255, 255);
+    }
+
+    private void Item_Selected(Base sender, ItemSelectedEventArgs arguments)
+    {
+        mQuestList.UnselectAll();
+    }
+
+    private void QuestListItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var questNum = (Guid) ((ListBoxRow) sender).UserData;
+        var quest = QuestBase.Get(questNum);
+        if (quest != null)
+        {
+            mSelectedQuest = quest;
+            UpdateSelectedQuest();
         }
 
-        public bool IsVisible()
-        {
-            return !mQuestsWindow.IsHidden;
-        }
+        mQuestList.UnselectAll();
+    }
 
-        public void Hide()
+    private void UpdateSelectedQuest()
+    {
+        if (mSelectedQuest == null)
         {
-            mQuestsWindow.IsHidden = true;
-            mSelectedQuest = null;
+            mQuestList.Show();
+            mQuestTitle.Hide();
+            mQuestDescArea.Hide();
+            mQuestStatus.Hide();
+            mBackButton.Hide();
+            mQuitButton.Hide();
         }
+        else
+        {
+            mQuestDescLabel.ClearText();
+            mQuitButton.IsDisabled = true;
+            ListBoxRow rw;
+            string[] myText = null;
+            var taskString = new List<string>();
+            if (Globals.Me.QuestProgress.ContainsKey(mSelectedQuest.Id))
+            {
+                if (Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId != Guid.Empty)
+                {
+                    //In Progress
+                    mQuestStatus.SetText(Strings.QuestLog.InProgress);
+                    mQuestStatus.SetTextColor(CustomColors.QuestWindow.InProgress, Label.ControlState.Normal);
+                    mQuestDescTemplateLabel.SetTextColor(CustomColors.QuestWindow.QuestDesc, Label.ControlState.Normal);
+                    
+                    if (mSelectedQuest.InProgressDescription.Length > 0)
+                    {    
+                        mQuestDescLabel.AddText(mSelectedQuest.InProgressDescription, mQuestDescTemplateLabel);
 
+                        mQuestDescLabel.AddLineBreak();
+                        mQuestDescLabel.AddLineBreak();
+                    }
+
+                    mQuestDescLabel.AddText(Strings.QuestLog.CurrentTask, mQuestDescTemplateLabel);
+
+                    mQuestDescLabel.AddLineBreak();
+                    for (var i = 0; i < mSelectedQuest.Tasks.Count; i++)
+                    {
+                        if (mSelectedQuest.Tasks[i].Id == Globals.Me.QuestProgress[mSelectedQuest.Id].TaskId)
+                        {
+                            if (mSelectedQuest.Tasks[i].Description.Length > 0)
+                            {
+                                mQuestDescLabel.AddText(mSelectedQuest.Tasks[i].Description, mQuestDescTemplateLabel);
+
+                                mQuestDescLabel.AddLineBreak();
+                                mQuestDescLabel.AddLineBreak();
+                            }
+
+                            if (mSelectedQuest.Tasks[i].Objective == QuestObjective.GatherItems) //Gather Items
+                            {
+                                mQuestDescLabel.AddText(
+                                    Strings.QuestLog.TaskItem.ToString(
+                                        Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
+                                        mSelectedQuest.Tasks[i].Quantity,
+                                        ItemBase.GetName(mSelectedQuest.Tasks[i].TargetId)
+                                    ), mQuestDescTemplateLabel
+                                );
+                            }
+                            else if (mSelectedQuest.Tasks[i].Objective == QuestObjective.KillNpcs) //Kill Npcs
+                            {
+                                mQuestDescLabel.AddText(
+                                    Strings.QuestLog.TaskNpc.ToString(
+                                        Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
+                                        mSelectedQuest.Tasks[i].Quantity,
+                                        NpcBase.GetName(mSelectedQuest.Tasks[i].TargetId)
+                                    ), mQuestDescTemplateLabel
+                                );
+                            }
+                        }
+                    }
+
+                    mQuitButton.IsDisabled = !mSelectedQuest.Quitable;
+                }
+                else
+                {
+                    if (Globals.Me.QuestProgress[mSelectedQuest.Id].Completed)
+                    {
+                        //Completed
+                        if (mSelectedQuest.LogAfterComplete)
+                        {
+                            mQuestStatus.SetText(Strings.QuestLog.Completed);
+                            mQuestStatus.SetTextColor(CustomColors.QuestWindow.Completed, Label.ControlState.Normal);
+                            mQuestDescLabel.AddText(mSelectedQuest.EndDescription, mQuestDescTemplateLabel);
+                        }
+                    }
+                    else
+                    {
+                        //Not Started
+                        if (mSelectedQuest.LogBeforeOffer)
+                        {
+                            mQuestStatus.SetText(Strings.QuestLog.NotStarted);
+                            mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
+                            mQuestDescLabel.AddText(mSelectedQuest.BeforeDescription, mQuestDescTemplateLabel);
+
+                            mQuitButton?.Hide();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                //Not Started
+                if (mSelectedQuest.LogBeforeOffer)
+                {
+                    mQuestStatus.SetText(Strings.QuestLog.NotStarted);
+                    mQuestStatus.SetTextColor(CustomColors.QuestWindow.NotStarted, Label.ControlState.Normal);
+                    mQuestDescLabel.AddText(mSelectedQuest.BeforeDescription, mQuestDescTemplateLabel);
+                }
+            }
+
+            mQuestList.Hide();
+            mQuestTitle.IsHidden = false;
+            mQuestTitle.Text = mSelectedQuest.Name;
+            mQuestDescArea.IsHidden = false;
+            mQuestDescLabel.Width = mQuestDescArea.Width - mQuestDescArea.GetVerticalScrollBar().Width;
+            mQuestDescLabel.SizeToChildren(false, true);
+            mQuestStatus.Show();
+            mBackButton.Show();
+            mQuitButton.Show();
+        }
+    }
+
+    public void Show()
+    {
+        mQuestsWindow.IsHidden = false;
+    }
+
+    public bool IsVisible()
+    {
+        return !mQuestsWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mQuestsWindow.IsHidden = true;
+        mSelectedQuest = null;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
+++ b/Intersect.Client/Interface/Game/Shop/ShopWindow.cs
@@ -5,127 +5,125 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Shop
+namespace Intersect.Client.Interface.Game.Shop;
+
+
+public partial class ShopWindow
 {
 
-    public partial class ShopWindow
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public List<ShopItem> Items = new List<ShopItem>();
+
+    private ScrollControl mItemContainer;
+
+    //Controls
+    private WindowControl mShopWindow;
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mBuyContextItem;
+
+    //Init
+    public ShopWindow(Canvas gameCanvas)
     {
+        mShopWindow = new WindowControl(gameCanvas, Globals.GameShop.Name, false, "ShopWindow");
+        mShopWindow.DisableResizing();
+        Interface.InputBlockingElements.Add(mShopWindow);
 
-        private static int sItemXPadding = 4;
+        mItemContainer = new ScrollControl(mShopWindow, "ItemContainer");
+        mItemContainer.EnableScroll(false, true);
 
-        private static int sItemYPadding = 4;
+        mShopWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        public List<ShopItem> Items = new List<ShopItem>();
+        InitItemContainer();
 
-        private ScrollControl mItemContainer;
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "ShopContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mBuyContextItem = mContextMenu.AddItem(Strings.ShopContextMenu.Buy);
+        mBuyContextItem.Clicked += MBuyContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        //Controls
-        private WindowControl mShopWindow;
+    public void OpenContextMenu(int slot)
+    {
+        var item = ItemBase.Get(Globals.GameShop.SellingItems[slot].ItemId);
 
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mBuyContextItem;
-
-        //Init
-        public ShopWindow(Canvas gameCanvas)
+        // No point showing a menu for blank space.
+        if (item == null)
         {
-            mShopWindow = new WindowControl(gameCanvas, Globals.GameShop.Name, false, "ShopWindow");
-            mShopWindow.DisableResizing();
-            Interface.InputBlockingElements.Add(mShopWindow);
-
-            mItemContainer = new ScrollControl(mShopWindow, "ItemContainer");
-            mItemContainer.EnableScroll(false, true);
-
-            mShopWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            InitItemContainer();
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "ShopContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mBuyContextItem = mContextMenu.AddItem(Strings.ShopContextMenu.Buy);
-            mBuyContextItem.Clicked += MBuyContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            return;
         }
 
-        public void OpenContextMenu(int slot)
+        mBuyContextItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
+
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = slot;
+
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+    }
+
+    private void MBuyContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int) sender.Parent.UserData;
+        Globals.Me.TryBuyItem(slot);
+    }
+
+    //Location
+    public int X => mShopWindow.X;
+
+    public int Y => mShopWindow.Y;
+
+    public void Close()
+    {
+        mContextMenu?.Close();
+        mShopWindow.Close();
+    }
+
+    public bool IsVisible()
+    {
+        return !mShopWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mShopWindow.IsHidden = true;
+    }
+
+    private void InitItemContainer()
+    {
+        for (var i = 0; i < Globals.GameShop.SellingItems.Count; i++)
         {
-            var item = ItemBase.Get(Globals.GameShop.SellingItems[slot].ItemId);
+            Items.Add(new ShopItem(this, i));
+            Items[i].Container = new ImagePanel(mItemContainer, "ShopItem");
+            Items[i].Setup();
 
-            // No point showing a menu for blank space.
-            if (item == null)
-            {
-                return;
-            }
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-            mBuyContextItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
+            Items[i].LoadItem();
 
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = slot;
-
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
         }
-
-        private void MBuyContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
-        {
-            var slot = (int) sender.Parent.UserData;
-            Globals.Me.TryBuyItem(slot);
-        }
-
-        //Location
-        public int X => mShopWindow.X;
-
-        public int Y => mShopWindow.Y;
-
-        public void Close()
-        {
-            mContextMenu?.Close();
-            mShopWindow.Close();
-        }
-
-        public bool IsVisible()
-        {
-            return !mShopWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mShopWindow.IsHidden = true;
-        }
-
-        private void InitItemContainer()
-        {
-            for (var i = 0; i < Globals.GameShop.SellingItems.Count; i++)
-            {
-                Items.Add(new ShopItem(this, i));
-                Items[i].Container = new ImagePanel(mItemContainer, "ShopItem");
-                Items[i].Setup();
-
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                Items[i].LoadItem();
-
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
-            }
-        }
-
     }
 
 }

--- a/Intersect.Client/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellItem.cs
@@ -9,181 +9,162 @@ using Intersect.Configuration;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Spells
+namespace Intersect.Client.Interface.Game.Spells;
+
+
+public partial class SpellItem
 {
 
-    public partial class SpellItem
+    public ImagePanel Container;
+
+    public bool IsDragging;
+
+    private bool mCanDrag;
+
+    private long mClickTime;
+
+    private Label mCooldownLabel;
+
+    private Guid mCurrentSpellId;
+
+    private SpellDescriptionWindow mDescWindow;
+
+    private Draggable mDragIcon;
+
+    private bool mIconCd;
+
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    //Drag/Drop References
+    private SpellsWindow mSpellWindow;
+
+    private string mTexLoaded = "";
+
+    private int mYindex;
+
+    public ImagePanel Pnl;
+
+    public SpellItem(SpellsWindow spellWindow, int index)
     {
+        mSpellWindow = spellWindow;
+        mYindex = index;
+    }
 
-        public ImagePanel Container;
+    public void Setup()
+    {
+        Pnl = new ImagePanel(Container, "SpellIcon");
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+        Pnl.RightClicked += pnl_RightClicked;
+        Pnl.Clicked += pnl_Clicked;
+        Pnl.DoubleClicked += Pnl_DoubleClicked;
+        mCooldownLabel = new Label(Pnl, "SpellCooldownLabel");
+        mCooldownLabel.IsHidden = true;
+        mCooldownLabel.TextColor = new Color(0, 255, 255, 255);
+    }
 
-        public bool IsDragging;
+    private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.Me.TryUseSpell(mYindex);
+    }
 
-        private bool mCanDrag;
+    void pnl_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mClickTime = Timing.Global.MillisecondsUtc + 500;
+    }
 
-        private long mClickTime;
-
-        private Label mCooldownLabel;
-
-        private Guid mCurrentSpellId;
-
-        private SpellDescriptionWindow mDescWindow;
-
-        private Draggable mDragIcon;
-
-        private bool mIconCd;
-
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        //Drag/Drop References
-        private SpellsWindow mSpellWindow;
-
-        private string mTexLoaded = "";
-
-        private int mYindex;
-
-        public ImagePanel Pnl;
-
-        public SpellItem(SpellsWindow spellWindow, int index)
+    void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (ClientConfiguration.Instance.EnableContextMenus)
         {
-            mSpellWindow = spellWindow;
-            mYindex = index;
+            mSpellWindow.OpenContextMenu(mYindex);
+        }
+        else
+        {
+            Globals.Me.TryForgetSpell(mYindex);
+        }   
+    }
+
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        public void Setup()
+        mMouseOver = true;
+        mCanDrag = true;
+        if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
         {
-            Pnl = new ImagePanel(Container, "SpellIcon");
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-            Pnl.RightClicked += pnl_RightClicked;
-            Pnl.Clicked += pnl_Clicked;
-            Pnl.DoubleClicked += Pnl_DoubleClicked;
-            mCooldownLabel = new Label(Pnl, "SpellCooldownLabel");
+            mCanDrag = false;
+
+            return;
+        }
+
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+
+        mDescWindow = new SpellDescriptionWindow(Globals.Me.Spells[mYindex].Id, mSpellWindow.X, mSpellWindow.Y);
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
+        {
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
+
+        return rect;
+    }
+
+    public void Update()
+    {
+        var spell = SpellBase.Get(Globals.Me.Spells[mYindex].Id);
+        if (!IsDragging &&
+            (mTexLoaded != "" && spell == null ||
+             spell != null && mTexLoaded != spell.Icon ||
+             mCurrentSpellId != Globals.Me.Spells[mYindex].Id ||
+             mIconCd !=
+             Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) > Timing.Global.Milliseconds ||
+             Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) > Timing.Global.Milliseconds))
+        {
             mCooldownLabel.IsHidden = true;
-            mCooldownLabel.TextColor = new Color(0, 255, 255, 255);
-        }
-
-        private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
-        {
-            Globals.Me.TryUseSpell(mYindex);
-        }
-
-        void pnl_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mClickTime = Timing.Global.MillisecondsUtc + 500;
-        }
-
-        void pnl_RightClicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (ClientConfiguration.Instance.EnableContextMenus)
+            if (spell != null)
             {
-                mSpellWindow.OpenContextMenu(mYindex);
-            }
-            else
-            {
-                Globals.Me.TryForgetSpell(mYindex);
-            }   
-        }
-
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
-        {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-        }
-
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
-        {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
-
-            mMouseOver = true;
-            mCanDrag = true;
-            if (Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-            {
-                mCanDrag = false;
-
-                return;
-            }
-
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-
-            mDescWindow = new SpellDescriptionWindow(Globals.Me.Spells[mYindex].Id, mSpellWindow.X, mSpellWindow.Y);
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
-
-            return rect;
-        }
-
-        public void Update()
-        {
-            var spell = SpellBase.Get(Globals.Me.Spells[mYindex].Id);
-            if (!IsDragging &&
-                (mTexLoaded != "" && spell == null ||
-                 spell != null && mTexLoaded != spell.Icon ||
-                 mCurrentSpellId != Globals.Me.Spells[mYindex].Id ||
-                 mIconCd !=
-                 Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) > Timing.Global.Milliseconds ||
-                 Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) > Timing.Global.Milliseconds))
-            {
-                mCooldownLabel.IsHidden = true;
-                if (spell != null)
+                var spellTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Spell, spell.Icon);
+                if (spellTex != null)
                 {
-                    var spellTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Spell, spell.Icon);
-                    if (spellTex != null)
+                    Pnl.Texture = spellTex;
+                    if (Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) >
+                        Timing.Global.Milliseconds)
                     {
-                        Pnl.Texture = spellTex;
-                        if (Globals.Me.GetSpellCooldown(Globals.Me.Spells[mYindex].Id) >
-                            Timing.Global.Milliseconds)
-                        {
-                            Pnl.RenderColor = new Color(100, 255, 255, 255);
-                        }
-                        else
-                        {
-                            Pnl.RenderColor = new Color(255, 255, 255, 255);
-                        }
+                        Pnl.RenderColor = new Color(100, 255, 255, 255);
                     }
                     else
                     {
-                        if (Pnl.Texture != null)
-                        {
-                            Pnl.Texture = null;
-                        }
-                    }
-
-                    mTexLoaded = spell.Icon;
-                    mCurrentSpellId = Globals.Me.Spells[mYindex].Id;
-                    mIconCd = Globals.Me.IsSpellOnCooldown(mYindex);
-
-                    if (mIconCd)
-                    {
-                        mCooldownLabel.IsHidden = false;
-                        var remaining = Globals.Me.GetSpellRemainingCooldown(mYindex);
-                        mCooldownLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix();
+                        Pnl.RenderColor = new Color(255, 255, 255, 255);
                     }
                 }
                 else
@@ -192,139 +173,156 @@ namespace Intersect.Client.Interface.Game.Spells
                     {
                         Pnl.Texture = null;
                     }
-
-                    mTexLoaded = "";
                 }
-            }
 
-            if (!IsDragging)
-            {
-                if (mMouseOver)
+                mTexLoaded = spell.Icon;
+                mCurrentSpellId = Globals.Me.Spells[mYindex].Id;
+                mIconCd = Globals.Me.IsSpellOnCooldown(mYindex);
+
+                if (mIconCd)
                 {
-                    if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
-                    {
-                        mCanDrag = true;
-                        mMouseX = -1;
-                        mMouseY = -1;
-                        if (Timing.Global.MillisecondsUtc < mClickTime)
-                        {
-                            mClickTime = 0;
-                        }
-                    }
-                    else
-                    {
-                        if (mCanDrag && Draggable.Active == null)
-                        {
-                            if (mMouseX == -1 || mMouseY == -1)
-                            {
-                                mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
-                                mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
-                            }
-                            else
-                            {
-                                var xdiff = mMouseX -
-                                            (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
-
-                                var ydiff = mMouseY -
-                                            (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
-
-                                if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
-                                {
-                                    IsDragging = true;
-                                    mDragIcon = new Draggable(
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
-                                        Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
-                                    );
-
-                                    mTexLoaded = "";
-                                }
-                            }
-                        }
-                    }
+                    mCooldownLabel.IsHidden = false;
+                    var remaining = Globals.Me.GetSpellRemainingCooldown(mYindex);
+                    mCooldownLabel.Text = TimeSpan.FromMilliseconds(remaining).WithSuffix();
                 }
             }
             else
             {
-                if (mDragIcon.Update())
+                if (Pnl.Texture != null)
                 {
-                    //Drug the item and now we stopped
-                    IsDragging = false;
-                    var dragRect = new FloatRect(
-                        mDragIcon.X - (Container.Padding.Left + Container.Padding.Right) / 2,
-                        mDragIcon.Y - (Container.Padding.Top + Container.Padding.Bottom) / 2,
-                        (Container.Padding.Left + Container.Padding.Right) / 2 + Pnl.Width,
-                        (Container.Padding.Top + Container.Padding.Bottom) / 2 + Pnl.Height
-                    );
-
-                    float bestIntersect = 0;
-                    var bestIntersectIndex = -1;
-
-                    //So we picked up an item and then dropped it. Lets see where we dropped it to.
-                    //Check spell first.
-                    if (mSpellWindow.RenderBounds().IntersectsWith(dragRect))
-                    {
-                        for (var i = 0; i < Options.MaxInvItems; i++)
-                        {
-                            if (i < mSpellWindow.Items.Count &&
-                                mSpellWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
-                            {
-                                if (FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Width *
-                                    FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Height >
-                                    bestIntersect)
-                                {
-                                    bestIntersect =
-                                        FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Width *
-                                        FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Height;
-
-                                    bestIntersectIndex = i;
-                                }
-                            }
-                        }
-
-                        if (bestIntersectIndex > -1)
-                        {
-                            if (mYindex != bestIntersectIndex && !Globals.Me.IsCasting)
-                            {
-                                Globals.Me.SwapSpells(bestIntersectIndex, mYindex);
-                            }
-                        }
-                    }
-                    else if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
-                    {
-                        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-                        {
-                            if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
-                            {
-                                if (FloatRect.Intersect(
-                                            Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
-                                        )
-                                        .Width *
-                                    FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
-                                        .Height >
-                                    bestIntersect)
-                                {
-                                    bestIntersect =
-                                        FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
-                                            .Width *
-                                        FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
-                                            .Height;
-
-                                    bestIntersectIndex = i;
-                                }
-                            }
-                        }
-
-                        if (bestIntersectIndex > -1)
-                        {
-                            Globals.Me.AddToHotbar((byte) bestIntersectIndex, 1, mYindex);
-                        }
-                    }
-
-                    mDragIcon.Dispose();
+                    Pnl.Texture = null;
                 }
+
+                mTexLoaded = "";
             }
         }
 
+        if (!IsDragging)
+        {
+            if (mMouseOver)
+            {
+                if (!Globals.InputManager.MouseButtonDown(MouseButtons.Left))
+                {
+                    mCanDrag = true;
+                    mMouseX = -1;
+                    mMouseY = -1;
+                    if (Timing.Global.MillisecondsUtc < mClickTime)
+                    {
+                        mClickTime = 0;
+                    }
+                }
+                else
+                {
+                    if (mCanDrag && Draggable.Active == null)
+                    {
+                        if (mMouseX == -1 || mMouseY == -1)
+                        {
+                            mMouseX = InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X;
+                            mMouseY = InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y;
+                        }
+                        else
+                        {
+                            var xdiff = mMouseX -
+                                        (InputHandler.MousePosition.X - Pnl.LocalPosToCanvas(new Point(0, 0)).X);
+
+                            var ydiff = mMouseY -
+                                        (InputHandler.MousePosition.Y - Pnl.LocalPosToCanvas(new Point(0, 0)).Y);
+
+                            if (Math.Sqrt(Math.Pow(xdiff, 2) + Math.Pow(ydiff, 2)) > 5)
+                            {
+                                IsDragging = true;
+                                mDragIcon = new Draggable(
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseX,
+                                    Pnl.LocalPosToCanvas(new Point(0, 0)).X + mMouseY, Pnl.Texture, Pnl.RenderColor
+                                );
+
+                                mTexLoaded = "";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (mDragIcon.Update())
+            {
+                //Drug the item and now we stopped
+                IsDragging = false;
+                var dragRect = new FloatRect(
+                    mDragIcon.X - (Container.Padding.Left + Container.Padding.Right) / 2,
+                    mDragIcon.Y - (Container.Padding.Top + Container.Padding.Bottom) / 2,
+                    (Container.Padding.Left + Container.Padding.Right) / 2 + Pnl.Width,
+                    (Container.Padding.Top + Container.Padding.Bottom) / 2 + Pnl.Height
+                );
+
+                float bestIntersect = 0;
+                var bestIntersectIndex = -1;
+
+                //So we picked up an item and then dropped it. Lets see where we dropped it to.
+                //Check spell first.
+                if (mSpellWindow.RenderBounds().IntersectsWith(dragRect))
+                {
+                    for (var i = 0; i < Options.MaxInvItems; i++)
+                    {
+                        if (i < mSpellWindow.Items.Count &&
+                            mSpellWindow.Items[i].RenderBounds().IntersectsWith(dragRect))
+                        {
+                            if (FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Width *
+                                FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Height >
+                                bestIntersect)
+                            {
+                                bestIntersect =
+                                    FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Width *
+                                    FloatRect.Intersect(mSpellWindow.Items[i].RenderBounds(), dragRect).Height;
+
+                                bestIntersectIndex = i;
+                            }
+                        }
+                    }
+
+                    if (bestIntersectIndex > -1)
+                    {
+                        if (mYindex != bestIntersectIndex && !Globals.Me.IsCasting)
+                        {
+                            Globals.Me.SwapSpells(bestIntersectIndex, mYindex);
+                        }
+                    }
+                }
+                else if (Interface.GameUi.Hotbar.RenderBounds().IntersectsWith(dragRect))
+                {
+                    for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+                    {
+                        if (Interface.GameUi.Hotbar.Items[i].RenderBounds().IntersectsWith(dragRect))
+                        {
+                            if (FloatRect.Intersect(
+                                        Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect
+                                    )
+                                    .Width *
+                                FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
+                                    .Height >
+                                bestIntersect)
+                            {
+                                bestIntersect =
+                                    FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
+                                        .Width *
+                                    FloatRect.Intersect(Interface.GameUi.Hotbar.Items[i].RenderBounds(), dragRect)
+                                        .Height;
+
+                                bestIntersectIndex = i;
+                            }
+                        }
+                    }
+
+                    if (bestIntersectIndex > -1)
+                    {
+                        Globals.Me.AddToHotbar((byte) bestIntersectIndex, 1, mYindex);
+                    }
+                }
+
+                mDragIcon.Dispose();
+            }
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client/Interface/Game/Spells/SpellsWindow.cs
@@ -6,188 +6,186 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Spells
+namespace Intersect.Client.Interface.Game.Spells;
+
+
+public partial class SpellsWindow
 {
 
-    public partial class SpellsWindow
+    //Spell List
+    public List<SpellItem> Items = new List<SpellItem>();
+
+    //Initialized
+    private bool mInitializedSpells;
+
+    //Item/Spell Rendering
+    private ScrollControl mItemContainer;
+
+    //Controls
+    private WindowControl mSpellWindow;
+
+    //Location
+    public int X;
+
+    public int Y;
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mUseSpellContextItem;
+
+    private MenuItem mForgetSpellContextItem;
+
+    //Init
+    public SpellsWindow(Canvas gameCanvas)
     {
+        mSpellWindow = new WindowControl(gameCanvas, Strings.Spells.Title, false, "SpellsWindow");
+        mSpellWindow.DisableResizing();
 
-        //Spell List
-        public List<SpellItem> Items = new List<SpellItem>();
+        mItemContainer = new ScrollControl(mSpellWindow, "SpellsContainer");
+        mItemContainer.EnableScroll(false, true);
+        mSpellWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-        //Initialized
-        private bool mInitializedSpells;
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "SpellContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mUseSpellContextItem = mContextMenu.AddItem(Strings.SpellContextMenu.Cast);
+        mUseSpellContextItem.Clicked += MUseSpellContextItem_Clicked;
+        mForgetSpellContextItem = mContextMenu.AddItem(Strings.SpellContextMenu.Forget);
+        mForgetSpellContextItem.Clicked += MForgetSpellContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-        //Item/Spell Rendering
-        private ScrollControl mItemContainer;
+    public void OpenContextMenu(int slot)
+    {
+        // Clear out the old options.
+        mContextMenu.RemoveChild(mUseSpellContextItem, false);
+        mContextMenu.RemoveChild(mForgetSpellContextItem, false);
+        mContextMenu.Children.Clear();
 
-        //Controls
-        private WindowControl mSpellWindow;
+        var spell = SpellBase.Get(Globals.Me.Spells[slot].Id);
 
-        //Location
-        public int X;
-
-        public int Y;
-
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mUseSpellContextItem;
-
-        private MenuItem mForgetSpellContextItem;
-
-        //Init
-        public SpellsWindow(Canvas gameCanvas)
+        // No point showing a menu for blank space.
+        if (spell == null)
         {
-            mSpellWindow = new WindowControl(gameCanvas, Strings.Spells.Title, false, "SpellsWindow");
-            mSpellWindow.DisableResizing();
-
-            mItemContainer = new ScrollControl(mSpellWindow, "SpellsContainer");
-            mItemContainer.EnableScroll(false, true);
-            mSpellWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "SpellContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mUseSpellContextItem = mContextMenu.AddItem(Strings.SpellContextMenu.Cast);
-            mUseSpellContextItem.Clicked += MUseSpellContextItem_Clicked;
-            mForgetSpellContextItem = mContextMenu.AddItem(Strings.SpellContextMenu.Forget);
-            mForgetSpellContextItem.Clicked += MForgetSpellContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            return;
         }
 
-        public void OpenContextMenu(int slot)
+        // Add our use spell option.
+        mContextMenu.AddChild(mUseSpellContextItem);
+        mUseSpellContextItem.SetText(Strings.SpellContextMenu.Cast.ToString(spell.Name));
+
+        // If this spell is not bound, allow users to forget it!
+        if (!spell.Bound)
         {
-            // Clear out the old options.
-            mContextMenu.RemoveChild(mUseSpellContextItem, false);
-            mContextMenu.RemoveChild(mForgetSpellContextItem, false);
-            mContextMenu.Children.Clear();
-
-            var spell = SpellBase.Get(Globals.Me.Spells[slot].Id);
-
-            // No point showing a menu for blank space.
-            if (spell == null)
-            {
-                return;
-            }
-
-            // Add our use spell option.
-            mContextMenu.AddChild(mUseSpellContextItem);
-            mUseSpellContextItem.SetText(Strings.SpellContextMenu.Cast.ToString(spell.Name));
-
-            // If this spell is not bound, allow users to forget it!
-            if (!spell.Bound)
-            {
-                mContextMenu.AddChild(mForgetSpellContextItem);
-                mForgetSpellContextItem.SetText(Strings.SpellContextMenu.Forget.ToString(spell.Name));
-            }
-
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = slot;
-
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
+            mContextMenu.AddChild(mForgetSpellContextItem);
+            mForgetSpellContextItem.SetText(Strings.SpellContextMenu.Forget.ToString(spell.Name));
         }
 
-        private void MForgetSpellContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = slot;
+
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+    }
+
+    private void MForgetSpellContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int)sender.Parent.UserData;
+        Globals.Me.TryForgetSpell(slot);
+    }
+
+    private void MUseSpellContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+    {
+        var slot = (int)sender.Parent.UserData;
+        Globals.Me.TryUseSpell(slot);
+    }
+
+    //Methods
+    public void Update()
+    {
+        if (!mInitializedSpells)
         {
-            var slot = (int)sender.Parent.UserData;
-            Globals.Me.TryForgetSpell(slot);
+            InitItemContainer();
+            mInitializedSpells = true;
         }
 
-        private void MUseSpellContextItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.ClickedEventArgs arguments)
+        if (mSpellWindow.IsHidden == true)
         {
-            var slot = (int)sender.Parent.UserData;
-            Globals.Me.TryUseSpell(slot);
+            return;
         }
 
-        //Methods
-        public void Update()
+        X = mSpellWindow.X;
+        Y = mSpellWindow.Y;
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
         {
-            if (!mInitializedSpells)
+            var spell = SpellBase.Get(Globals.Me.Spells[i].Id);
+            Items[i].Pnl.IsHidden = spell == null || Items[i].IsDragging;
+            if (spell != null)
             {
-                InitItemContainer();
-                mInitializedSpells = true;
-            }
-
-            if (mSpellWindow.IsHidden == true)
-            {
-                return;
-            }
-
-            X = mSpellWindow.X;
-            Y = mSpellWindow.Y;
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
-            {
-                var spell = SpellBase.Get(Globals.Me.Spells[i].Id);
-                Items[i].Pnl.IsHidden = spell == null || Items[i].IsDragging;
-                if (spell != null)
-                {
-                    Items[i].Update();
-                }
+                Items[i].Update();
             }
         }
+    }
 
-        private void InitItemContainer()
+    private void InitItemContainer()
+    {
+        for (var i = 0; i < Options.MaxPlayerSkills; i++)
         {
-            for (var i = 0; i < Options.MaxPlayerSkills; i++)
-            {
-                Items.Add(new SpellItem(this, i));
-                Items[i].Container = new ImagePanel(mItemContainer, "Spell");
-                Items[i].Setup();
+            Items.Add(new SpellItem(this, i));
+            Items[i].Container = new ImagePanel(mItemContainer, "Spell");
+            Items[i].Setup();
 
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
-            }
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (mItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
         }
+    }
 
-        public void Show()
+    public void Show()
+    {
+        mSpellWindow.IsHidden = false;
+    }
+
+    public bool IsVisible()
+    {
+        return !mSpellWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mContextMenu?.Close();
+        mSpellWindow.IsHidden = true;
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            mSpellWindow.IsHidden = false;
-        }
+            X = mSpellWindow.LocalPosToCanvas(new Point(0, 0)).X -
+                (Items[0].Container.Padding.Left + Items[0].Container.Padding.Right) / 2,
+            Y = mSpellWindow.LocalPosToCanvas(new Point(0, 0)).Y -
+                (Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom) / 2,
+            Width = mSpellWindow.Width + Items[0].Container.Padding.Left + Items[0].Container.Padding.Right,
+            Height = mSpellWindow.Height + Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom
+        };
 
-        public bool IsVisible()
-        {
-            return !mSpellWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mContextMenu?.Close();
-            mSpellWindow.IsHidden = true;
-        }
-
-        public FloatRect RenderBounds()
-        {
-            var rect = new FloatRect()
-            {
-                X = mSpellWindow.LocalPosToCanvas(new Point(0, 0)).X -
-                    (Items[0].Container.Padding.Left + Items[0].Container.Padding.Right) / 2,
-                Y = mSpellWindow.LocalPosToCanvas(new Point(0, 0)).Y -
-                    (Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom) / 2,
-                Width = mSpellWindow.Width + Items[0].Container.Padding.Left + Items[0].Container.Padding.Right,
-                Height = mSpellWindow.Height + Items[0].Container.Padding.Top + Items[0].Container.Padding.Bottom
-            };
-
-            return rect;
-        }
-
+        return rect;
     }
 
 }

--- a/Intersect.Client/Interface/Game/Trades/TradeItem.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradeItem.cs
@@ -7,160 +7,152 @@ using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Configuration;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Trades
+namespace Intersect.Client.Interface.Game.Trades;
+
+
+public partial class TradeItem
 {
 
-    public partial class TradeItem
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public ImagePanel Container;
+
+    private Guid mCurrentItemId;
+
+    private ItemDescriptionWindow mDescWindow;
+
+    private Draggable mDragIcon;
+
+    //Mouse Event Variables
+    private bool mMouseOver;
+
+    private int mMouseX = -1;
+
+    private int mMouseY = -1;
+
+    private int mMySide;
+
+    //Slot info
+    private int mMySlot;
+
+    //Drag/Drop References
+    private TradingWindow mTradeWindow;
+
+    public ImagePanel Pnl;
+
+    public TradeItem(TradingWindow tradeWindow, int index, int side)
     {
+        mTradeWindow = tradeWindow;
+        mMySlot = index;
+        mMySide = side;
+    }
 
-        private static int sItemXPadding = 4;
+    public void Setup()
+    {
+        Pnl = new ImagePanel(Container, "TradeIcon");
+        Pnl.HoverEnter += pnl_HoverEnter;
+        Pnl.HoverLeave += pnl_HoverLeave;
+        Pnl.RightClicked += Pnl_RightClicked;
+        Pnl.DoubleClicked += Pnl_DoubleClicked;
+    }
 
-        private static int sItemYPadding = 4;
-
-        public ImagePanel Container;
-
-        private Guid mCurrentItemId;
-
-        private ItemDescriptionWindow mDescWindow;
-
-        private Draggable mDragIcon;
-
-        //Mouse Event Variables
-        private bool mMouseOver;
-
-        private int mMouseX = -1;
-
-        private int mMouseY = -1;
-
-        private int mMySide;
-
-        //Slot info
-        private int mMySlot;
-
-        //Drag/Drop References
-        private TradingWindow mTradeWindow;
-
-        public ImagePanel Pnl;
-
-        public TradeItem(TradingWindow tradeWindow, int index, int side)
+    private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Are we operating our own side? if not ignore it.
+        if (mMySide != 0)
         {
-            mTradeWindow = tradeWindow;
-            mMySlot = index;
-            mMySide = side;
+            return;
         }
 
-        public void Setup()
+        if (ClientConfiguration.Instance.EnableContextMenus)
         {
-            Pnl = new ImagePanel(Container, "TradeIcon");
-            Pnl.HoverEnter += pnl_HoverEnter;
-            Pnl.HoverLeave += pnl_HoverLeave;
-            Pnl.RightClicked += Pnl_RightClicked;
-            Pnl.DoubleClicked += Pnl_DoubleClicked;
+            mTradeWindow.OpenContextMenu(mMySide, mMySlot);
+        }
+        else
+        {
+            Pnl_DoubleClicked(sender, arguments);
+        }
+    }
+
+    private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Are we operating our own side? if not ignore it.
+        if (mMySide != 0)
+        {
+            return;
         }
 
-        private void Pnl_RightClicked(Base sender, ClickedEventArgs arguments)
+        if (Globals.InTrade)
         {
-            // Are we operating our own side? if not ignore it.
-            if (mMySide != 0)
-            {
-                return;
-            }
+            Globals.Me.TryRevokeItem(mMySlot);
+        }
+    }
 
-            if (ClientConfiguration.Instance.EnableContextMenus)
-            {
-                mTradeWindow.OpenContextMenu(mMySide, mMySlot);
-            }
-            else
-            {
-                Pnl_DoubleClicked(sender, arguments);
-            }
+    void pnl_HoverLeave(Base sender, EventArgs arguments)
+    {
+        mMouseOver = false;
+        mMouseX = -1;
+        mMouseY = -1;
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
+        }
+    }
+
+    void pnl_HoverEnter(Base sender, EventArgs arguments)
+    {
+        if (InputHandler.MouseFocus != null)
+        {
+            return;
         }
 
-        private void Pnl_DoubleClicked(Base sender, ClickedEventArgs arguments)
-        {
-            // Are we operating our own side? if not ignore it.
-            if (mMySide != 0)
-            {
-                return;
-            }
+        mMouseOver = true;
 
-            if (Globals.InTrade)
-            {
-                Globals.Me.TryRevokeItem(mMySlot);
-            }
+        if (mDescWindow != null)
+        {
+            mDescWindow.Dispose();
+            mDescWindow = null;
         }
 
-        void pnl_HoverLeave(Base sender, EventArgs arguments)
+        if (ItemBase.Get(Globals.Trade[mMySide, mMySlot].ItemId) != null)
         {
-            mMouseOver = false;
-            mMouseX = -1;
-            mMouseY = -1;
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
+            mDescWindow = new ItemDescriptionWindow(
+                Globals.Trade[mMySide, mMySlot].Base, Globals.Trade[mMySide, mMySlot].Quantity, mTradeWindow.X,
+                mTradeWindow.Y, Globals.Trade[mMySide, mMySlot].ItemProperties
+            );
         }
+    }
 
-        void pnl_HoverEnter(Base sender, EventArgs arguments)
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            if (InputHandler.MouseFocus != null)
-            {
-                return;
-            }
+            X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
+            Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
+            Width = Pnl.Width,
+            Height = Pnl.Height
+        };
 
-            mMouseOver = true;
+        return rect;
+    }
 
-            if (mDescWindow != null)
-            {
-                mDescWindow.Dispose();
-                mDescWindow = null;
-            }
-
-            if (ItemBase.Get(Globals.Trade[mMySide, mMySlot].ItemId) != null)
-            {
-                mDescWindow = new ItemDescriptionWindow(
-                    Globals.Trade[mMySide, mMySlot].Base, Globals.Trade[mMySide, mMySlot].Quantity, mTradeWindow.X,
-                    mTradeWindow.Y, Globals.Trade[mMySide, mMySlot].ItemProperties
-                );
-            }
-        }
-
-        public FloatRect RenderBounds()
+    public void Update()
+    {
+        var n = mMySide;
+        if (Globals.Trade[n, mMySlot].ItemId != mCurrentItemId)
         {
-            var rect = new FloatRect()
+            mCurrentItemId = Globals.Trade[n, mMySlot].ItemId;
+            var item = ItemBase.Get(Globals.Trade[n, mMySlot].ItemId);
+            if (item != null)
             {
-                X = Pnl.LocalPosToCanvas(new Point(0, 0)).X,
-                Y = Pnl.LocalPosToCanvas(new Point(0, 0)).Y,
-                Width = Pnl.Width,
-                Height = Pnl.Height
-            };
-
-            return rect;
-        }
-
-        public void Update()
-        {
-            var n = mMySide;
-            if (Globals.Trade[n, mMySlot].ItemId != mCurrentItemId)
-            {
-                mCurrentItemId = Globals.Trade[n, mMySlot].ItemId;
-                var item = ItemBase.Get(Globals.Trade[n, mMySlot].ItemId);
-                if (item != null)
+                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+                if (itemTex != null)
                 {
-                    var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
-                    if (itemTex != null)
-                    {
-                        Pnl.Texture = itemTex;
-                        Pnl.RenderColor = item.Color;
-                    }
-                    else
-                    {
-                        if (Pnl.Texture != null)
-                        {
-                            Pnl.Texture = null;
-                        }
-                    }
+                    Pnl.Texture = itemTex;
+                    Pnl.RenderColor = item.Color;
                 }
                 else
                 {
@@ -170,8 +162,14 @@ namespace Intersect.Client.Interface.Game.Trades
                     }
                 }
             }
+            else
+            {
+                if (Pnl.Texture != null)
+                {
+                    Pnl.Texture = null;
+                }
+            }
         }
-
     }
 
 }

--- a/Intersect.Client/Interface/Game/Trades/TradeSegment.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradeSegment.cs
@@ -3,85 +3,83 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Localization;
 
-namespace Intersect.Client.Interface.Game.Trades
+namespace Intersect.Client.Interface.Game.Trades;
+
+
+public partial class TradeSegment
 {
 
-    public partial class TradeSegment
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    public Label GoldValue;
+
+    public ScrollControl ItemContainer;
+
+    public List<TradeItem> Items = new List<TradeItem>();
+
+    private ImagePanel mItemTemplate;
+
+    private TradingWindow mParent;
+
+    public int MyIndex;
+
+    public List<Label> Values = new List<Label>();
+
+    public TradeSegment(TradingWindow parent, WindowControl tradeWindow, int index)
     {
+        MyIndex = index;
+        mParent = parent;
 
-        private static int sItemXPadding = 4;
-
-        private static int sItemYPadding = 4;
-
-        public Label GoldValue;
-
-        public ScrollControl ItemContainer;
-
-        public List<TradeItem> Items = new List<TradeItem>();
-
-        private ImagePanel mItemTemplate;
-
-        private TradingWindow mParent;
-
-        public int MyIndex;
-
-        public List<Label> Values = new List<Label>();
-
-        public TradeSegment(TradingWindow parent, WindowControl tradeWindow, int index)
+        var prefix = "Your";
+        if (MyIndex == 1)
         {
-            MyIndex = index;
-            mParent = parent;
-
-            var prefix = "Your";
-            if (MyIndex == 1)
-            {
-                prefix = "Their";
-            }
-
-            ItemContainer = new ScrollControl(tradeWindow, prefix + "ItemContainer");
-            ItemContainer.EnableScroll(false, true);
-
-            GoldValue = new Label(tradeWindow, prefix + "GoldValue")
-            {
-                Text = Strings.Trading.Value.ToString(0)
-            };
+            prefix = "Their";
         }
 
-        public void InitItemContainer(int index)
+        ItemContainer = new ScrollControl(tradeWindow, prefix + "ItemContainer");
+        ItemContainer.EnableScroll(false, true);
+
+        GoldValue = new Label(tradeWindow, prefix + "GoldValue")
         {
-            var prefix = "Your";
-            if (MyIndex == 1)
-            {
-                prefix = "Their";
-            }
+            Text = Strings.Trading.Value.ToString(0)
+        };
+    }
 
-            for (var i = 0; i < Options.MaxInvItems; i++)
-            {
-                Items.Add(new TradeItem(mParent, i, index));
-                Items[i].Container = new ImagePanel(ItemContainer, prefix + "TradeItem");
-                Items[i].Setup();
-
-                Values.Add(new Label(Items[i].Container, "TradeValue"));
-                Values[i].Text = "";
-
-                Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-                var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
-                var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
-                Items[i]
-                    .Container.SetPosition(
-                        i %
-                        (ItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Width + xPadding) +
-                        xPadding,
-                        i /
-                        (ItemContainer.Width / (Items[i].Container.Width + xPadding)) *
-                        (Items[i].Container.Height + yPadding) +
-                        yPadding
-                    );
-            }
+    public void InitItemContainer(int index)
+    {
+        var prefix = "Your";
+        if (MyIndex == 1)
+        {
+            prefix = "Their";
         }
 
+        for (var i = 0; i < Options.MaxInvItems; i++)
+        {
+            Items.Add(new TradeItem(mParent, i, index));
+            Items[i].Container = new ImagePanel(ItemContainer, prefix + "TradeItem");
+            Items[i].Setup();
+
+            Values.Add(new Label(Items[i].Container, "TradeValue"));
+            Values[i].Text = "";
+
+            Items[i].Container.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+            var xPadding = Items[i].Container.Margin.Left + Items[i].Container.Margin.Right;
+            var yPadding = Items[i].Container.Margin.Top + Items[i].Container.Margin.Bottom;
+            Items[i]
+                .Container.SetPosition(
+                    i %
+                    (ItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Width + xPadding) +
+                    xPadding,
+                    i /
+                    (ItemContainer.Width / (Items[i].Container.Width + xPadding)) *
+                    (Items[i].Container.Height + yPadding) +
+                    yPadding
+                );
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client/Interface/Game/Trades/TradingWindow.cs
@@ -8,198 +8,196 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.GameObjects;
 
-namespace Intersect.Client.Interface.Game.Trades
+namespace Intersect.Client.Interface.Game.Trades;
+
+
+public partial class TradingWindow
 {
 
-    public partial class TradingWindow
+    private static int sItemXPadding = 4;
+
+    private static int sItemYPadding = 4;
+
+    private Label mTheirOffer;
+
+    //Trade button
+    private Button mTrade;
+
+    private WindowControl mTradeWindow;
+
+    //Name tags
+    private Label mYourOffer;
+
+    public List<TradeSegment> TradeSegment = new List<TradeSegment>();
+
+    // Context menu
+    private Framework.Gwen.Control.Menu mContextMenu;
+
+    private MenuItem mWithdrawContextItem;
+
+    //Init
+    public TradingWindow(Canvas gameCanvas, string traderName)
     {
+        mTradeWindow = new WindowControl(
+            gameCanvas, Strings.Trading.Title.ToString(traderName), false, "TradeWindow"
+        );
 
-        private static int sItemXPadding = 4;
+        mTradeWindow.DisableResizing();
+        Interface.InputBlockingElements.Add(mTradeWindow);
 
-        private static int sItemYPadding = 4;
-
-        private Label mTheirOffer;
-
-        //Trade button
-        private Button mTrade;
-
-        private WindowControl mTradeWindow;
-
-        //Name tags
-        private Label mYourOffer;
-
-        public List<TradeSegment> TradeSegment = new List<TradeSegment>();
-
-        // Context menu
-        private Framework.Gwen.Control.Menu mContextMenu;
-
-        private MenuItem mWithdrawContextItem;
-
-        //Init
-        public TradingWindow(Canvas gameCanvas, string traderName)
+        mYourOffer = new Label(mTradeWindow, "YourOfferLabel")
         {
-            mTradeWindow = new WindowControl(
-                gameCanvas, Strings.Trading.Title.ToString(traderName), false, "TradeWindow"
-            );
+            Text = Strings.Trading.YourOffer
+        };
 
-            mTradeWindow.DisableResizing();
-            Interface.InputBlockingElements.Add(mTradeWindow);
+        mTheirOffer = new Label(mTradeWindow, "TheirOfferLabel")
+        {
+            Text = Strings.Trading.TheirOffer
+        };
 
-            mYourOffer = new Label(mTradeWindow, "YourOfferLabel")
-            {
-                Text = Strings.Trading.YourOffer
-            };
+        mTrade = new Button(mTradeWindow, "TradeButton");
+        mTrade.SetText(Strings.Trading.Accept);
+        mTrade.Clicked += trade_Clicked;
 
-            mTheirOffer = new Label(mTradeWindow, "TheirOfferLabel")
-            {
-                Text = Strings.Trading.TheirOffer
-            };
-
-            mTrade = new Button(mTradeWindow, "TradeButton");
-            mTrade.SetText(Strings.Trading.Accept);
-            mTrade.Clicked += trade_Clicked;
-
-            for (var i = 0; i < 2; i++)
-            {
-                TradeSegment.Add(new TradeSegment(this, mTradeWindow, i));
-            }
-
-            mTradeWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-
-            for (var i = 0; i < 2; i++)
-            {
-                TradeSegment[i].InitItemContainer(i);
-            }
-
-            // Generate our context menu with basic options.
-            mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "TradeContextMenu");
-            mContextMenu.IsHidden = true;
-            mContextMenu.IconMarginDisabled = true;
-            //TODO: Is this a memory leak?
-            mContextMenu.Children.Clear();
-            mWithdrawContextItem = mContextMenu.AddItem(Strings.TradeContextMenu.Withdraw);
-            mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
-            mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        for (var i = 0; i < 2; i++)
+        {
+            TradeSegment.Add(new TradeSegment(this, mTradeWindow, i));
         }
 
-        private void MWithdrawContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+        mTradeWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        for (var i = 0; i < 2; i++)
         {
-            var slot = (int) sender.Parent.UserData;
-            Globals.Me.TryRevokeItem(slot);
+            TradeSegment[i].InitItemContainer(i);
         }
 
-        public void OpenContextMenu(int side, int slot)
-        {
-            var item = ItemBase.Get(Globals.Trade[side, slot].ItemId);
+        // Generate our context menu with basic options.
+        mContextMenu = new Framework.Gwen.Control.Menu(gameCanvas, "TradeContextMenu");
+        mContextMenu.IsHidden = true;
+        mContextMenu.IconMarginDisabled = true;
+        //TODO: Is this a memory leak?
+        mContextMenu.Children.Clear();
+        mWithdrawContextItem = mContextMenu.AddItem(Strings.TradeContextMenu.Withdraw);
+        mWithdrawContextItem.Clicked += MWithdrawContextItem_Clicked;
+        mContextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
 
-            // No point showing a menu for blank space.
-            if (item == null)
+    private void MWithdrawContextItem_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var slot = (int) sender.Parent.UserData;
+        Globals.Me.TryRevokeItem(slot);
+    }
+
+    public void OpenContextMenu(int side, int slot)
+    {
+        var item = ItemBase.Get(Globals.Trade[side, slot].ItemId);
+
+        // No point showing a menu for blank space.
+        if (item == null)
+        {
+            return;
+        }
+
+        mWithdrawContextItem.SetText(Strings.TradeContextMenu.Withdraw.ToString(item.Name));
+
+        // Set our spell slot as userdata for future reference.
+        mContextMenu.UserData = slot ;
+
+        mContextMenu.IsHidden = false;
+        mContextMenu.SetSize(mContextMenu.Width, mContextMenu.Height);
+        mContextMenu.SizeToChildren();
+        mContextMenu.Open(Framework.Gwen.Pos.None);
+        mContextMenu.MoveTo(mContextMenu.X, mContextMenu.Y);
+    }
+
+    //Location
+    public int X => mTradeWindow.X;
+
+    public int Y => mTradeWindow.Y;
+
+    public void Close()
+    {
+        mContextMenu?.Close();
+        mTradeWindow.Close();
+    }
+
+    public bool IsVisible()
+    {
+        return !mTradeWindow.IsHidden;
+    }
+
+    public void Hide()
+    {
+        mTradeWindow.IsHidden = true;
+    }
+
+    public void Update()
+    {
+        var g = 0;
+
+        if (mTradeWindow.IsHidden == true)
+        {
+            return;
+        }
+
+        for (var n = 0; n < 2; n++)
+        {
+            for (var i = 0; i < Options.MaxInvItems; i++)
             {
-                return;
-            }
-
-            mWithdrawContextItem.SetText(Strings.TradeContextMenu.Withdraw.ToString(item.Name));
-
-            // Set our spell slot as userdata for future reference.
-            mContextMenu.UserData = slot ;
-
-            mContextMenu.IsHidden = false;
-            mContextMenu.SetSize(mContextMenu.Width, mContextMenu.Height);
-            mContextMenu.SizeToChildren();
-            mContextMenu.Open(Framework.Gwen.Pos.None);
-            mContextMenu.MoveTo(mContextMenu.X, mContextMenu.Y);
-        }
-
-        //Location
-        public int X => mTradeWindow.X;
-
-        public int Y => mTradeWindow.Y;
-
-        public void Close()
-        {
-            mContextMenu?.Close();
-            mTradeWindow.Close();
-        }
-
-        public bool IsVisible()
-        {
-            return !mTradeWindow.IsHidden;
-        }
-
-        public void Hide()
-        {
-            mTradeWindow.IsHidden = true;
-        }
-
-        public void Update()
-        {
-            var g = 0;
-
-            if (mTradeWindow.IsHidden == true)
-            {
-                return;
-            }
-
-            for (var n = 0; n < 2; n++)
-            {
-                for (var i = 0; i < Options.MaxInvItems; i++)
+                if (Globals.Trade[n, i] != null && Globals.Trade[n, i].ItemId != Guid.Empty)
                 {
-                    if (Globals.Trade[n, i] != null && Globals.Trade[n, i].ItemId != Guid.Empty)
+                    var item = ItemBase.Get(Globals.Trade[n, i].ItemId);
+                    if (item == null)
                     {
-                        var item = ItemBase.Get(Globals.Trade[n, i].ItemId);
-                        if (item == null)
-                        {
-                            continue;
-                        }
+                        continue;
+                    }
 
-                        g += item.Price * Globals.Trade[n, i].Quantity;
-                        TradeSegment[n].Items[i].Pnl.IsHidden = false;
-                        if (item.IsStackable)
-                        {
-                            TradeSegment[n].Values[i].IsHidden = Globals.Trade[n, i].Quantity <= 1;
-                            TradeSegment[n].Values[i].Text =
-                                Strings.FormatQuantityAbbreviated(Globals.Trade[n, i].Quantity);
-                        }
-                        else
-                        {
-                            TradeSegment[n].Values[i].IsHidden = true;
-                        }
-
-                        TradeSegment[n].Items[i].Update();
+                    g += item.Price * Globals.Trade[n, i].Quantity;
+                    TradeSegment[n].Items[i].Pnl.IsHidden = false;
+                    if (item.IsStackable)
+                    {
+                        TradeSegment[n].Values[i].IsHidden = Globals.Trade[n, i].Quantity <= 1;
+                        TradeSegment[n].Values[i].Text =
+                            Strings.FormatQuantityAbbreviated(Globals.Trade[n, i].Quantity);
                     }
                     else
                     {
-                        TradeSegment[n].Items[i].Pnl.IsHidden = true;
                         TradeSegment[n].Values[i].IsHidden = true;
                     }
+
+                    TradeSegment[n].Items[i].Update();
                 }
-
-                TradeSegment[n].GoldValue.Text = Strings.Trading.Value.ToString(g);
-                g = 0;
+                else
+                {
+                    TradeSegment[n].Items[i].Pnl.IsHidden = true;
+                    TradeSegment[n].Values[i].IsHidden = true;
+                }
             }
-        }
 
-        public FloatRect RenderBounds()
+            TradeSegment[n].GoldValue.Text = Strings.Trading.Value.ToString(g);
+            g = 0;
+        }
+    }
+
+    public FloatRect RenderBounds()
+    {
+        var rect = new FloatRect()
         {
-            var rect = new FloatRect()
-            {
-                X = mTradeWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
-                Y = mTradeWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
-                Width = mTradeWindow.Width + sItemXPadding,
-                Height = mTradeWindow.Height + sItemYPadding
-            };
+            X = mTradeWindow.LocalPosToCanvas(new Point(0, 0)).X - sItemXPadding / 2,
+            Y = mTradeWindow.LocalPosToCanvas(new Point(0, 0)).Y - sItemYPadding / 2,
+            Width = mTradeWindow.Width + sItemXPadding,
+            Height = mTradeWindow.Height + sItemYPadding
+        };
 
-            return rect;
-        }
+        return rect;
+    }
 
-        //Trade the item
-        void trade_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mTrade.Text = Strings.Trading.Pending;
-            mTrade.IsDisabled = true;
-            PacketSender.SendAcceptTrade();
-        }
-
+    //Trade the item
+    void trade_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mTrade.Text = Strings.Trading.Pending;
+        mTrade.IsDisabled = true;
+        PacketSender.SendAcceptTrade();
     }
 
 }

--- a/Intersect.Client/Interface/Game/Typewriting/Typewriter.cs
+++ b/Intersect.Client/Interface/Game/Typewriting/Typewriter.cs
@@ -3,141 +3,140 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Configuration;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Game.Typewriting
+namespace Intersect.Client.Interface.Game.Typewriting;
+
+internal sealed class Typewriter
 {
-    internal sealed class Typewriter
+    private static List<char> _fullStopChars => ClientConfiguration.Instance.TypewriterFullStopCharacters;
+    private static long _fullStopSpeed => ClientConfiguration.Instance.TypewriterFullStopDelay;
+    private static List<char> _partialStopChars => ClientConfiguration.Instance.TypewriterPauseCharacters;
+    private static long _partialStopSpeed => ClientConfiguration.Instance.TypewriterPauseDelay;
+    private static long _typingSpeed => ClientConfiguration.Instance.TypewriterPartDelay;
+
+    private List<Label> _labels;
+    private string[] _lines;
+    private int _lineCount;
+    private int _lineIndex;
+    private int _charIndex;
+    private char? _lastChar;
+    private long _nextUpdateTime;
+
+    public bool IsDone { get; private set; }
+    public long DoneAtMilliseconds { get; private set; }
+
+    public void Initialize(List<Label> labels)
     {
-        private static List<char> _fullStopChars => ClientConfiguration.Instance.TypewriterFullStopCharacters;
-        private static long _fullStopSpeed => ClientConfiguration.Instance.TypewriterFullStopDelay;
-        private static List<char> _partialStopChars => ClientConfiguration.Instance.TypewriterPauseCharacters;
-        private static long _partialStopSpeed => ClientConfiguration.Instance.TypewriterPauseDelay;
-        private static long _typingSpeed => ClientConfiguration.Instance.TypewriterPartDelay;
+        _nextUpdateTime = Timing.Global.MillisecondsUtc;
+        _labels = labels;
+        _lines = _labels.Select(l => l.Text).ToArray();
+        _labels.ForEach(l =>
+            l.SetText(string.Empty)); // Clear the text from the labels. The writer is the captain now
+        _lineIndex = 0;
+        _charIndex = 0;
+        _lastChar = null;
+        _lineCount = _lines.Length;
+        IsDone = false;
+    }
 
-        private List<Label> _labels;
-        private string[] _lines;
-        private int _lineCount;
-        private int _lineIndex;
-        private int _charIndex;
-        private char? _lastChar;
-        private long _nextUpdateTime;
-
-        public bool IsDone { get; private set; }
-        public long DoneAtMilliseconds { get; private set; }
-
-        public void Initialize(List<Label> labels)
+    private void NewLine()
+    {
+        _lineIndex++;
+        if (_lineIndex >= _lineCount)
         {
-            _nextUpdateTime = Timing.Global.MillisecondsUtc;
-            _labels = labels;
-            _lines = _labels.Select(l => l.Text).ToArray();
-            _labels.ForEach(l =>
-                l.SetText(string.Empty)); // Clear the text from the labels. The writer is the captain now
-            _lineIndex = 0;
-            _charIndex = 0;
-            _lastChar = null;
-            _lineCount = _lines.Length;
-            IsDone = false;
+            End();
+            return;
         }
 
-        private void NewLine()
-        {
-            _lineIndex++;
-            if (_lineIndex >= _lineCount)
-            {
-                End();
-                return;
-            }
+        _charIndex = 0;
+        _lastChar = null;
+    }
 
-            _charIndex = 0;
-            _lastChar = null;
+    public void Write(string voice)
+    {
+        if (IsDone)
+        {
+            return;
         }
 
-        public void Write(string voice)
+        if (_lineIndex >= _lineCount || _labels[_lineIndex] == null)
         {
-            if (IsDone)
-            {
-                return;
-            }
-
-            if (_lineIndex >= _lineCount || _labels[_lineIndex] == null)
-            {
-                End();
-                return;
-            }
-
-            if (Timing.Global.MillisecondsUtc < _nextUpdateTime)
-            {
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(voice) && _charIndex % ClientConfiguration.Instance.TypewriterSoundFrequency == 0)
-            {
-                Audio.StopAllGameSoundsOf(ClientConfiguration.Instance.TypewriterSounds.ToArray());
-                Audio.AddGameSound(voice ?? string.Empty, false);
-            }
-
-            var currentLine = _lines[_lineIndex];
-            _charIndex++;
-
-            if (_charIndex >= currentLine.Length)
-            {
-                _labels[_lineIndex].SetText(currentLine);
-                NewLine();
-                return;
-            }
-
-            _lastChar = currentLine[_charIndex - 1];
-            var written = currentLine.Substring(0, _charIndex);
-            _labels[_lineIndex].SetText(written);
-
-            _nextUpdateTime = Timing.Global.MillisecondsUtc + GetTypingDelayFor(currentLine[_charIndex], _lastChar);
+            End();
+            return;
         }
 
-        private static long GetTypingDelayFor(char currentChar, char? lastChar)
+        if (Timing.Global.MillisecondsUtc < _nextUpdateTime)
         {
-            if (lastChar == null)
-            {
-                return _typingSpeed;
-            }
+            return;
+        }
 
-            var lastCharVal = lastChar.Value;
+        if (!string.IsNullOrEmpty(voice) && _charIndex % ClientConfiguration.Instance.TypewriterSoundFrequency == 0)
+        {
+            Audio.StopAllGameSoundsOf(ClientConfiguration.Instance.TypewriterSounds.ToArray());
+            Audio.AddGameSound(voice ?? string.Empty, false);
+        }
 
-            if (currentChar == lastCharVal)
-            {
-                return _typingSpeed;
-            }
+        var currentLine = _lines[_lineIndex];
+        _charIndex++;
 
-            if (_fullStopChars.Contains(lastCharVal))
-            {
-                return _fullStopSpeed;
-            }
+        if (_charIndex >= currentLine.Length)
+        {
+            _labels[_lineIndex].SetText(currentLine);
+            NewLine();
+            return;
+        }
 
-            if (_partialStopChars.Contains(lastCharVal))
-            {
-                return _partialStopSpeed;
-            }
+        _lastChar = currentLine[_charIndex - 1];
+        var written = currentLine.Substring(0, _charIndex);
+        _labels[_lineIndex].SetText(written);
 
+        _nextUpdateTime = Timing.Global.MillisecondsUtc + GetTypingDelayFor(currentLine[_charIndex], _lastChar);
+    }
+
+    private static long GetTypingDelayFor(char currentChar, char? lastChar)
+    {
+        if (lastChar == null)
+        {
             return _typingSpeed;
         }
 
-        public void End()
+        var lastCharVal = lastChar.Value;
+
+        if (currentChar == lastCharVal)
         {
-            if (IsDone || (_lines?.Length ?? 0) == 0)
-            {
-                return;
-            }
-
-            for (var i = 0; i < _lineCount; i++)
-            {
-                if (i >= _labels.Count)
-                {
-                    continue;
-                }
-
-                _labels[i].SetText(_lines[i]);
-            }
-
-            IsDone = true;
-            DoneAtMilliseconds = Timing.Global.MillisecondsUtc;
+            return _typingSpeed;
         }
+
+        if (_fullStopChars.Contains(lastCharVal))
+        {
+            return _fullStopSpeed;
+        }
+
+        if (_partialStopChars.Contains(lastCharVal))
+        {
+            return _partialStopSpeed;
+        }
+
+        return _typingSpeed;
+    }
+
+    public void End()
+    {
+        if (IsDone || (_lines?.Length ?? 0) == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _lineCount; i++)
+        {
+            if (i >= _labels.Count)
+            {
+                continue;
+            }
+
+            _labels[i].SetText(_lines[i]);
+        }
+
+        IsDone = true;
+        DoneAtMilliseconds = Timing.Global.MillisecondsUtc;
     }
 }

--- a/Intersect.Client/Interface/Interface.cs
+++ b/Intersect.Client/Interface/Interface.cs
@@ -12,351 +12,350 @@ using Intersect.Configuration;
 
 using Base = Intersect.Client.Framework.Gwen.Renderer.Base;
 
-namespace Intersect.Client.Interface
+namespace Intersect.Client.Interface;
+
+
+public static partial class Interface
 {
 
-    public static partial class Interface
+    private static readonly Queue<KeyValuePair<string, string>> _errorMessages = new();
+
+    public static bool TryDequeueErrorMessage(out KeyValuePair<string, string> message) => _errorMessages.TryDequeue(out message);
+
+    public static void ShowError(string message, string? header = default)
     {
+        _errorMessages.Enqueue(new KeyValuePair<string, string>(header ?? string.Empty, message));
+    }
 
-        private static readonly Queue<KeyValuePair<string, string>> _errorMessages = new();
+    public static ErrorHandler ErrorMsgHandler;
 
-        public static bool TryDequeueErrorMessage(out KeyValuePair<string, string> message) => _errorMessages.TryDequeue(out message);
+    //GWEN GUI
+    public static bool GwenInitialized;
 
-        public static void ShowError(string message, string? header = default)
+    public static InputBase GwenInput;
+
+    public static Base GwenRenderer;
+
+    public static bool HideUi;
+
+    private static Canvas sGameCanvas;
+
+    private static Canvas sMenuCanvas;
+
+    public static bool SetupHandlers { get; set; }
+
+    public static GameInterface GameUi { get; private set; }
+
+    public static MenuGuiBase MenuUi { get; private set; }
+
+    public static MutableInterface CurrentInterface => GameUi as MutableInterface ?? MenuUi?.MainMenu;
+
+    public static TexturedBase Skin { get; set; }
+
+    //Input Handling
+    public static List<Framework.Gwen.Control.Base> FocusElements { get; set; }
+
+    public static List<Framework.Gwen.Control.Base> InputBlockingElements { get; set; }
+
+    #region "Gwen Setup and Input"
+
+    //Gwen Low Level Functions
+    public static void InitGwen()
+    {
+        // Preserve the debug window
+        MutableInterface.DetachDebugWindow();
+
+        //TODO: Make it easier to modify skin.
+        if (Skin == null)
         {
-            _errorMessages.Enqueue(new KeyValuePair<string, string>(header ?? string.Empty, message));
+            Skin = TexturedBase.FindSkin(GwenRenderer, Globals.ContentManager, ClientConfiguration.Instance.UiSkin);
+            Skin.DefaultFont = Graphics.UIFont;
         }
 
-        public static ErrorHandler ErrorMsgHandler;
+        MenuUi?.Dispose();
 
-        //GWEN GUI
-        public static bool GwenInitialized;
+        GameUi?.Dispose();
 
-        public static InputBase GwenInput;
-
-        public static Base GwenRenderer;
-
-        public static bool HideUi;
-
-        private static Canvas sGameCanvas;
-
-        private static Canvas sMenuCanvas;
-
-        public static bool SetupHandlers { get; set; }
-
-        public static GameInterface GameUi { get; private set; }
-
-        public static MenuGuiBase MenuUi { get; private set; }
-
-        public static MutableInterface CurrentInterface => GameUi as MutableInterface ?? MenuUi?.MainMenu;
-
-        public static TexturedBase Skin { get; set; }
-
-        //Input Handling
-        public static List<Framework.Gwen.Control.Base> FocusElements { get; set; }
-
-        public static List<Framework.Gwen.Control.Base> InputBlockingElements { get; set; }
-
-        #region "Gwen Setup and Input"
-
-        //Gwen Low Level Functions
-        public static void InitGwen()
+        // Create a Canvas (it's root, on which all other GWEN controls are created)
+        sMenuCanvas = new Canvas(Skin, "MainMenu")
         {
-            // Preserve the debug window
-            MutableInterface.DetachDebugWindow();
+            Scale = 1f //(GameGraphics.Renderer.GetScreenWidth()/1920f);
+        };
 
-            //TODO: Make it easier to modify skin.
-            if (Skin == null)
-            {
-                Skin = TexturedBase.FindSkin(GwenRenderer, Globals.ContentManager, ClientConfiguration.Instance.UiSkin);
-                Skin.DefaultFont = Graphics.UIFont;
-            }
+        sMenuCanvas.SetSize(
+            (int) (Graphics.Renderer.GetScreenWidth() / sMenuCanvas.Scale),
+            (int) (Graphics.Renderer.GetScreenHeight() / sMenuCanvas.Scale)
+        );
 
-            MenuUi?.Dispose();
+        sMenuCanvas.ShouldDrawBackground = false;
+        sMenuCanvas.BackgroundColor = Color.FromArgb(255, 150, 170, 170);
+        sMenuCanvas.KeyboardInputEnabled = true;
 
-            GameUi?.Dispose();
+        // Create the game Canvas (it's root, on which all other GWEN controls are created)
+        sGameCanvas = new Canvas(Skin, "InGame");
 
-            // Create a Canvas (it's root, on which all other GWEN controls are created)
-            sMenuCanvas = new Canvas(Skin, "MainMenu")
-            {
-                Scale = 1f //(GameGraphics.Renderer.GetScreenWidth()/1920f);
-            };
+        //_gameCanvas.Scale = (GameGraphics.Renderer.GetScreenWidth() / 1920f);
+        sGameCanvas.SetSize(
+            (int) (Graphics.Renderer.GetScreenWidth() / sGameCanvas.Scale),
+            (int) (Graphics.Renderer.GetScreenHeight() / sGameCanvas.Scale)
+        );
 
-            sMenuCanvas.SetSize(
-                (int) (Graphics.Renderer.GetScreenWidth() / sMenuCanvas.Scale),
-                (int) (Graphics.Renderer.GetScreenHeight() / sMenuCanvas.Scale)
-            );
+        sGameCanvas.ShouldDrawBackground = false;
+        sGameCanvas.BackgroundColor = Color.FromArgb(255, 150, 170, 170);
+        sGameCanvas.KeyboardInputEnabled = true;
 
-            sMenuCanvas.ShouldDrawBackground = false;
-            sMenuCanvas.BackgroundColor = Color.FromArgb(255, 150, 170, 170);
-            sMenuCanvas.KeyboardInputEnabled = true;
-
-            // Create the game Canvas (it's root, on which all other GWEN controls are created)
-            sGameCanvas = new Canvas(Skin, "InGame");
-
-            //_gameCanvas.Scale = (GameGraphics.Renderer.GetScreenWidth() / 1920f);
-            sGameCanvas.SetSize(
-                (int) (Graphics.Renderer.GetScreenWidth() / sGameCanvas.Scale),
-                (int) (Graphics.Renderer.GetScreenHeight() / sGameCanvas.Scale)
-            );
-
-            sGameCanvas.ShouldDrawBackground = false;
-            sGameCanvas.BackgroundColor = Color.FromArgb(255, 150, 170, 170);
-            sGameCanvas.KeyboardInputEnabled = true;
-
-            // Create GWEN input processor
-            if (Globals.GameState == GameStates.Intro || Globals.GameState == GameStates.Menu)
-            {
-                GwenInput.Initialize(sMenuCanvas);
-            }
-            else
-            {
-                GwenInput.Initialize(sGameCanvas);
-            }
-
-            FocusElements = new List<Framework.Gwen.Control.Base>();
-            InputBlockingElements = new List<Framework.Gwen.Control.Base>();
-            ErrorMsgHandler = new ErrorHandler(sMenuCanvas, sGameCanvas);
-
-            if (Globals.GameState == GameStates.Intro || Globals.GameState == GameStates.Menu)
-            {
-                MenuUi = new MenuGuiBase(sMenuCanvas);
-                GameUi = null;
-            }
-            else
-            {
-                GameUi = new GameInterface(sGameCanvas);
-                MenuUi = null;
-            }
-
-            Globals.OnLifecycleChangeState();
-
-            GwenInitialized = true;
+        // Create GWEN input processor
+        if (Globals.GameState == GameStates.Intro || Globals.GameState == GameStates.Menu)
+        {
+            GwenInput.Initialize(sMenuCanvas);
+        }
+        else
+        {
+            GwenInput.Initialize(sGameCanvas);
         }
 
-        public static void DestroyGwen(bool exiting = false)
+        FocusElements = new List<Framework.Gwen.Control.Base>();
+        InputBlockingElements = new List<Framework.Gwen.Control.Base>();
+        ErrorMsgHandler = new ErrorHandler(sMenuCanvas, sGameCanvas);
+
+        if (Globals.GameState == GameStates.Intro || Globals.GameState == GameStates.Menu)
         {
-            // Preserve the debug window
-            MutableInterface.DetachDebugWindow();
-
-            //The canvases dispose of all of their children.
-            sMenuCanvas?.Dispose();
-            sGameCanvas?.Dispose();
-            GameUi?.Dispose();
-
-            // Destroy our target UI as well! Above code does NOT appear to clear this properly.
-            if (Globals.Me != null)
-            {
-                Globals.Me.ClearTarget();
-                Globals.Me.TargetBox?.Dispose();
-                Globals.Me.TargetBox = null;
-            }
-
-            GwenInitialized = false;
-
-            if (exiting)
-            {
-                MutableInterface.DisposeDebugWindow();
-            }
+            MenuUi = new MenuGuiBase(sMenuCanvas);
+            GameUi = null;
+        }
+        else
+        {
+            GameUi = new GameInterface(sGameCanvas);
+            MenuUi = null;
         }
 
-        public static bool HasInputFocus()
-        {
-            if (FocusElements == null || InputBlockingElements == null)
-            {
-                return false;
-            }
+        Globals.OnLifecycleChangeState();
 
-            return FocusElements.Any(t => t.MouseInputEnabled && (t?.HasFocus ?? false)) || InputBlockingElements.Any(t => t?.IsHidden == false);
+        GwenInitialized = true;
+    }
+
+    public static void DestroyGwen(bool exiting = false)
+    {
+        // Preserve the debug window
+        MutableInterface.DetachDebugWindow();
+
+        //The canvases dispose of all of their children.
+        sMenuCanvas?.Dispose();
+        sGameCanvas?.Dispose();
+        GameUi?.Dispose();
+
+        // Destroy our target UI as well! Above code does NOT appear to clear this properly.
+        if (Globals.Me != null)
+        {
+            Globals.Me.ClearTarget();
+            Globals.Me.TargetBox?.Dispose();
+            Globals.Me.TargetBox = null;
         }
 
-        #endregion
+        GwenInitialized = false;
 
-        #region "GUI Functions"
-
-        //Actual Drawing Function
-        public static void DrawGui()
+        if (exiting)
         {
-            if (!GwenInitialized)
-            {
-                InitGwen();
-            }
+            MutableInterface.DisposeDebugWindow();
+        }
+    }
 
-            if (Globals.GameState == GameStates.Menu)
-            {
-                MenuUi.Update();
-            }
-            else if (Globals.GameState == GameStates.InGame)
-            {
-                GameUi.Update();
-            }
+    public static bool HasInputFocus()
+    {
+        if (FocusElements == null || InputBlockingElements == null)
+        {
+            return false;
+        }
 
-            //Do not allow hiding of UI under several conditions
-            var forceShowUi = Globals.InCraft || Globals.InBank || Globals.InShop || Globals.InTrade || Globals.InBag || Globals.EventDialogs?.Count > 0 || HasInputFocus() || (!Interface.GameUi?.EscapeMenu?.IsHidden ?? true);
+        return FocusElements.Any(t => t.MouseInputEnabled && (t?.HasFocus ?? false)) || InputBlockingElements.Any(t => t?.IsHidden == false);
+    }
 
-            ErrorMsgHandler.Update();
-            sGameCanvas.RestrictToParent = false;
-            if (Globals.GameState == GameStates.Menu)
+    #endregion
+
+    #region "GUI Functions"
+
+    //Actual Drawing Function
+    public static void DrawGui()
+    {
+        if (!GwenInitialized)
+        {
+            InitGwen();
+        }
+
+        if (Globals.GameState == GameStates.Menu)
+        {
+            MenuUi.Update();
+        }
+        else if (Globals.GameState == GameStates.InGame)
+        {
+            GameUi.Update();
+        }
+
+        //Do not allow hiding of UI under several conditions
+        var forceShowUi = Globals.InCraft || Globals.InBank || Globals.InShop || Globals.InTrade || Globals.InBag || Globals.EventDialogs?.Count > 0 || HasInputFocus() || (!Interface.GameUi?.EscapeMenu?.IsHidden ?? true);
+
+        ErrorMsgHandler.Update();
+        sGameCanvas.RestrictToParent = false;
+        if (Globals.GameState == GameStates.Menu)
+        {
+            MenuUi.Draw();
+        }
+        else if (Globals.GameState == GameStates.InGame)
+        {
+            if (HideUi && !forceShowUi)
             {
-                MenuUi.Draw();
-            }
-            else if (Globals.GameState == GameStates.InGame)
-            {
-                if (HideUi && !forceShowUi)
+                if (sGameCanvas.IsVisible)
                 {
-                    if (sGameCanvas.IsVisible)
+                    sGameCanvas.Hide();
+                }
+            }
+            else
+            {
+                if (!sGameCanvas.IsVisible)
+                {
+                    sGameCanvas.Show();
+                }
+                GameUi.Draw();
+            }
+        }
+    }
+
+    public static void ToggleInput(bool val)
+    {
+        GwenInput.HandleInput = val;
+    }
+
+    public static bool MouseHitGui()
+    {
+        for (var i = 0; i < sGameCanvas.Children.Count; i++)
+        {
+            if (MouseHitBase(sGameCanvas.Children[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool MouseHitBase(Framework.Gwen.Control.Base obj)
+    {
+        if (obj.IsHidden == true)
+        {
+            return false;
+        }
+        else if (!obj.MouseInputEnabled)
+        {
+            // Check if we're hitting a child element.
+            for (var i = 0; i < obj.Children.Count; i++)
+            {
+                if (MouseHitBase(obj.Children[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        else
+        {
+            var rect = new FloatRect(
+                obj.LocalPosToCanvas(new Point(0, 0)).X, obj.LocalPosToCanvas(new Point(0, 0)).Y, obj.Width,
+                obj.Height
+            );
+
+            if (rect.Contains(InputHandler.MousePosition.X, InputHandler.MousePosition.Y))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static string[] WrapText(string input, int width, GameFont font)
+    {
+        var myOutput = new List<string>();
+        if (input == null)
+        {
+            myOutput.Add("");
+        }
+        else
+        {
+            var lastSpace = 0;
+            var curPos = 0;
+            var curLen = 1;
+            var lastOk = 0;
+            var lastCut = 0;
+            input = input.Replace("\r\n", "\n");
+            float measured;
+            string line;
+            while (curPos + curLen < input.Length)
+            {
+                line = input.Substring(curPos, curLen);
+                measured = Graphics.Renderer.MeasureText(line, font, 1).X;
+                if (measured < width)
+                {
+                    lastOk = lastSpace;
+                    switch (input[curPos + curLen])
                     {
-                        sGameCanvas.Hide();
+                        case ' ':
+                        case '-':
+                            lastSpace = curLen;
+
+                            break;
+
+                        case '\n':
+                            myOutput.Add(input.Substring(curPos, curLen).Trim());
+                            lastSpace = 0;
+                            curPos = curPos + curLen + 1;
+                            curLen = 1;
+
+                            break;
                     }
                 }
                 else
                 {
-                    if (!sGameCanvas.IsVisible)
+                    if (lastOk == 0)
                     {
-                        sGameCanvas.Show();
-                    }
-                    GameUi.Draw();
-                }
-            }
-        }
-
-        public static void ToggleInput(bool val)
-        {
-            GwenInput.HandleInput = val;
-        }
-
-        public static bool MouseHitGui()
-        {
-            for (var i = 0; i < sGameCanvas.Children.Count; i++)
-            {
-                if (MouseHitBase(sGameCanvas.Children[i]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public static bool MouseHitBase(Framework.Gwen.Control.Base obj)
-        {
-            if (obj.IsHidden == true)
-            {
-                return false;
-            }
-            else if (!obj.MouseInputEnabled)
-            {
-                // Check if we're hitting a child element.
-                for (var i = 0; i < obj.Children.Count; i++)
-                {
-                    if (MouseHitBase(obj.Children[i]))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-            else
-            {
-                var rect = new FloatRect(
-                    obj.LocalPosToCanvas(new Point(0, 0)).X, obj.LocalPosToCanvas(new Point(0, 0)).Y, obj.Width,
-                    obj.Height
-                );
-
-                if (rect.Contains(InputHandler.MousePosition.X, InputHandler.MousePosition.Y))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public static string[] WrapText(string input, int width, GameFont font)
-        {
-            var myOutput = new List<string>();
-            if (input == null)
-            {
-                myOutput.Add("");
-            }
-            else
-            {
-                var lastSpace = 0;
-                var curPos = 0;
-                var curLen = 1;
-                var lastOk = 0;
-                var lastCut = 0;
-                input = input.Replace("\r\n", "\n");
-                float measured;
-                string line;
-                while (curPos + curLen < input.Length)
-                {
-                    line = input.Substring(curPos, curLen);
-                    measured = Graphics.Renderer.MeasureText(line, font, 1).X;
-                    if (measured < width)
-                    {
-                        lastOk = lastSpace;
-                        switch (input[curPos + curLen])
-                        {
-                            case ' ':
-                            case '-':
-                                lastSpace = curLen;
-
-                                break;
-
-                            case '\n':
-                                myOutput.Add(input.Substring(curPos, curLen).Trim());
-                                lastSpace = 0;
-                                curPos = curPos + curLen + 1;
-                                curLen = 1;
-
-                                break;
-                        }
-                    }
-                    else
-                    {
-                        if (lastOk == 0)
-                        {
-                            lastOk = curLen - 1;
-                        }
-
-                        line = input.Substring(curPos, lastOk).Trim();
-                        myOutput.Add(line);
-                        curPos = curPos + lastOk;
-                        lastOk = 0;
-                        lastSpace = 0;
-                        curLen = 1;
+                        lastOk = curLen - 1;
                     }
 
-                    curLen++;
+                    line = input.Substring(curPos, lastOk).Trim();
+                    myOutput.Add(line);
+                    curPos = curPos + lastOk;
+                    lastOk = 0;
+                    lastSpace = 0;
+                    curLen = 1;
                 }
 
-                myOutput.Add(input.Substring(curPos, input.Length - curPos).Trim());
+                curLen++;
             }
 
-            return myOutput.ToArray();
+            myOutput.Add(input.Substring(curPos, input.Length - curPos).Trim());
         }
 
-        #endregion
-
-        public static Framework.Gwen.Control.Base FindControlAtCursor()
-        {
-            var currentElement = CurrentInterface?.Root;
-            var cursor = new Point(InputHandler.MousePosition.X, InputHandler.MousePosition.Y);
-
-            while (default != currentElement)
-            {
-                var elementAt = currentElement.GetControlAt(cursor);
-                if (elementAt == currentElement || elementAt == default)
-                {
-                    break;
+        return myOutput.ToArray();
     }
 
-                currentElement = elementAt;
-            }
+    #endregion
 
-            return currentElement;
+    public static Framework.Gwen.Control.Base FindControlAtCursor()
+    {
+        var currentElement = CurrentInterface?.Root;
+        var cursor = new Point(InputHandler.MousePosition.X, InputHandler.MousePosition.Y);
+
+        while (default != currentElement)
+        {
+            var elementAt = currentElement.GetControlAt(cursor);
+            if (elementAt == currentElement || elementAt == default)
+            {
+                break;
+}
+
+            currentElement = elementAt;
         }
+
+        return currentElement;
     }
 }

--- a/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreateCharacterWindow.cs
@@ -9,555 +9,553 @@ using Intersect.Client.Networking;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class CreateCharacterWindow
 {
 
-    public partial class CreateCharacterWindow
+    private Button mBackButton;
+
+    private ImagePanel mCharacterContainer;
+
+    private ImagePanel mCharacterNameBackground;
+
+    private ImagePanel mCharacterPortrait;
+
+    //Image
+    private string mCharacterPortraitImg = "";
+
+    private Label mCharCreationHeader;
+
+    //Controls
+    private ImagePanel mCharCreationPanel;
+
+    private Label mCharnameLabel;
+
+    private TextBox mCharnameTextbox;
+
+    private ImagePanel mClassBackground;
+
+    private ComboBox mClassCombobox;
+
+    private Label mClassLabel;
+
+    private Button mCreateButton;
+
+    private int mDisplaySpriteIndex = -1;
+
+    private LabeledCheckBox mFemaleChk;
+
+    private List<KeyValuePair<int, ClassSprite>> mFemaleSprites = new List<KeyValuePair<int, ClassSprite>>();
+
+    private ImagePanel mGenderBackground;
+
+    private Label mGenderLabel;
+
+    private Label mHint2Label;
+
+    private Label mHintLabel;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    private LabeledCheckBox mMaleChk;
+
+    //Class Info
+    private List<KeyValuePair<int, ClassSprite>> mMaleSprites = new List<KeyValuePair<int, ClassSprite>>();
+
+    private Button mNextSpriteButton;
+
+    private Button mPrevSpriteButton;
+
+    private SelectCharacterWindow mSelectCharacterWindow;
+
+    //Init
+    public CreateCharacterWindow(
+        Canvas parent,
+        MainMenu mainMenu,
+        SelectCharacterWindow selectCharacterWindow
+    )
     {
+        //Assign References
+        mMainMenu = mainMenu;
+        mSelectCharacterWindow = selectCharacterWindow;
 
-        private Button mBackButton;
+        //Main Menu Window
+        mCharCreationPanel = new ImagePanel(parent, "CharacterCreationWindow");
+        mCharCreationPanel.IsHidden = true;
 
-        private ImagePanel mCharacterContainer;
+        //Menu Header
+        mCharCreationHeader = new Label(mCharCreationPanel, "CharacterCreationHeader");
+        mCharCreationHeader.SetText(Strings.CharacterCreation.Title);
 
-        private ImagePanel mCharacterNameBackground;
+        //Character Name Background
+        mCharacterNameBackground = new ImagePanel(mCharCreationPanel, "CharacterNamePanel");
 
-        private ImagePanel mCharacterPortrait;
+        //Character name Label
+        mCharnameLabel = new Label(mCharacterNameBackground, "CharacterNameLabel");
+        mCharnameLabel.SetText(Strings.CharacterCreation.Name);
 
-        //Image
-        private string mCharacterPortraitImg = "";
+        //Character name Textbox
+        mCharnameTextbox = new TextBox(mCharacterNameBackground, "CharacterNameField");
+        mCharnameTextbox.SubmitPressed += CharnameTextbox_SubmitPressed;
 
-        private Label mCharCreationHeader;
+        //Class Background
+        mClassBackground = new ImagePanel(mCharCreationPanel, "ClassPanel");
 
-        //Controls
-        private ImagePanel mCharCreationPanel;
+        //Class Label
+        mClassLabel = new Label(mClassBackground, "ClassLabel");
+        mClassLabel.SetText(Strings.CharacterCreation.Class);
 
-        private Label mCharnameLabel;
+        //Class Combobox
+        mClassCombobox = new ComboBox(mClassBackground, "ClassCombobox");
+        mClassCombobox.ItemSelected += classCombobox_ItemSelected;
 
-        private TextBox mCharnameTextbox;
+        //Hint Label
+        mHintLabel = new Label(mCharCreationPanel, "HintLabel");
+        mHintLabel.SetText(Strings.CharacterCreation.Hint);
+        mHintLabel.IsHidden = true;
 
-        private ImagePanel mClassBackground;
+        //Hint2 Label
+        mHint2Label = new Label(mCharCreationPanel, "Hint2Label");
+        mHint2Label.SetText(Strings.CharacterCreation.Hint2);
+        mHint2Label.IsHidden = true;
 
-        private ComboBox mClassCombobox;
+        //Character Container
+        mCharacterContainer = new ImagePanel(mCharCreationPanel, "CharacterContainer");
 
-        private Label mClassLabel;
+        //Character sprite
+        mCharacterPortrait = new ImagePanel(mCharacterContainer, "CharacterPortait");
+        mCharacterPortrait.SetSize(48, 48);
 
-        private Button mCreateButton;
+        //Next Sprite Button
+        mNextSpriteButton = new Button(mCharacterContainer, "NextSpriteButton");
+        mNextSpriteButton.Clicked += _nextSpriteButton_Clicked;
 
-        private int mDisplaySpriteIndex = -1;
+        //Prev Sprite Button
+        mPrevSpriteButton = new Button(mCharacterContainer, "PreviousSpriteButton");
+        mPrevSpriteButton.Clicked += _prevSpriteButton_Clicked;
 
-        private LabeledCheckBox mFemaleChk;
+        //Class Background
+        mGenderBackground = new ImagePanel(mCharCreationPanel, "GenderPanel");
 
-        private List<KeyValuePair<int, ClassSprite>> mFemaleSprites = new List<KeyValuePair<int, ClassSprite>>();
+        //Gender Label
+        mGenderLabel = new Label(mGenderBackground, "GenderLabel");
+        mGenderLabel.SetText(Strings.CharacterCreation.Gender);
 
-        private ImagePanel mGenderBackground;
-
-        private Label mGenderLabel;
-
-        private Label mHint2Label;
-
-        private Label mHintLabel;
-
-        //Parent
-        private MainMenu mMainMenu;
-
-        private LabeledCheckBox mMaleChk;
-
-        //Class Info
-        private List<KeyValuePair<int, ClassSprite>> mMaleSprites = new List<KeyValuePair<int, ClassSprite>>();
-
-        private Button mNextSpriteButton;
-
-        private Button mPrevSpriteButton;
-
-        private SelectCharacterWindow mSelectCharacterWindow;
-
-        //Init
-        public CreateCharacterWindow(
-            Canvas parent,
-            MainMenu mainMenu,
-            SelectCharacterWindow selectCharacterWindow
-        )
+        //Male Checkbox
+        mMaleChk = new LabeledCheckBox(mGenderBackground, "MaleCheckbox")
         {
-            //Assign References
-            mMainMenu = mainMenu;
-            mSelectCharacterWindow = selectCharacterWindow;
+            Text = Strings.CharacterCreation.Male
+        };
 
-            //Main Menu Window
-            mCharCreationPanel = new ImagePanel(parent, "CharacterCreationWindow");
-            mCharCreationPanel.IsHidden = true;
+        mMaleChk.IsChecked = true;
+        mMaleChk.Checked += maleChk_Checked;
+        mMaleChk.UnChecked += femaleChk_Checked; // If you notice this, feel free to hate us ;)
 
-            //Menu Header
-            mCharCreationHeader = new Label(mCharCreationPanel, "CharacterCreationHeader");
-            mCharCreationHeader.SetText(Strings.CharacterCreation.Title);
-
-            //Character Name Background
-            mCharacterNameBackground = new ImagePanel(mCharCreationPanel, "CharacterNamePanel");
-
-            //Character name Label
-            mCharnameLabel = new Label(mCharacterNameBackground, "CharacterNameLabel");
-            mCharnameLabel.SetText(Strings.CharacterCreation.Name);
-
-            //Character name Textbox
-            mCharnameTextbox = new TextBox(mCharacterNameBackground, "CharacterNameField");
-            mCharnameTextbox.SubmitPressed += CharnameTextbox_SubmitPressed;
-
-            //Class Background
-            mClassBackground = new ImagePanel(mCharCreationPanel, "ClassPanel");
-
-            //Class Label
-            mClassLabel = new Label(mClassBackground, "ClassLabel");
-            mClassLabel.SetText(Strings.CharacterCreation.Class);
-
-            //Class Combobox
-            mClassCombobox = new ComboBox(mClassBackground, "ClassCombobox");
-            mClassCombobox.ItemSelected += classCombobox_ItemSelected;
-
-            //Hint Label
-            mHintLabel = new Label(mCharCreationPanel, "HintLabel");
-            mHintLabel.SetText(Strings.CharacterCreation.Hint);
-            mHintLabel.IsHidden = true;
-
-            //Hint2 Label
-            mHint2Label = new Label(mCharCreationPanel, "Hint2Label");
-            mHint2Label.SetText(Strings.CharacterCreation.Hint2);
-            mHint2Label.IsHidden = true;
-
-            //Character Container
-            mCharacterContainer = new ImagePanel(mCharCreationPanel, "CharacterContainer");
-
-            //Character sprite
-            mCharacterPortrait = new ImagePanel(mCharacterContainer, "CharacterPortait");
-            mCharacterPortrait.SetSize(48, 48);
-
-            //Next Sprite Button
-            mNextSpriteButton = new Button(mCharacterContainer, "NextSpriteButton");
-            mNextSpriteButton.Clicked += _nextSpriteButton_Clicked;
-
-            //Prev Sprite Button
-            mPrevSpriteButton = new Button(mCharacterContainer, "PreviousSpriteButton");
-            mPrevSpriteButton.Clicked += _prevSpriteButton_Clicked;
-
-            //Class Background
-            mGenderBackground = new ImagePanel(mCharCreationPanel, "GenderPanel");
-
-            //Gender Label
-            mGenderLabel = new Label(mGenderBackground, "GenderLabel");
-            mGenderLabel.SetText(Strings.CharacterCreation.Gender);
-
-            //Male Checkbox
-            mMaleChk = new LabeledCheckBox(mGenderBackground, "MaleCheckbox")
-            {
-                Text = Strings.CharacterCreation.Male
-            };
-
-            mMaleChk.IsChecked = true;
-            mMaleChk.Checked += maleChk_Checked;
-            mMaleChk.UnChecked += femaleChk_Checked; // If you notice this, feel free to hate us ;)
-
-            //Female Checkbox
-            mFemaleChk = new LabeledCheckBox(mGenderBackground, "FemaleCheckbox")
-            {
-                Text = Strings.CharacterCreation.Female
-            };
-
-            mFemaleChk.Checked += femaleChk_Checked;
-            mFemaleChk.UnChecked += maleChk_Checked;
-
-            //Register - Send Registration Button
-            mCreateButton = new Button(mCharCreationPanel, "CreateButton");
-            mCreateButton.SetText(Strings.CharacterCreation.Create);
-            mCreateButton.Clicked += CreateButton_Clicked;
-
-            mBackButton = new Button(mCharCreationPanel, "BackButton");
-            mBackButton.IsHidden = true;
-            mBackButton.SetText(Strings.CharacterCreation.Back);
-            mBackButton.Clicked += BackButton_Clicked;
-
-            mCharCreationPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
-        }
-
-        public bool IsHidden => mCharCreationPanel.IsHidden;
-
-        public void Init()
+        //Female Checkbox
+        mFemaleChk = new LabeledCheckBox(mGenderBackground, "FemaleCheckbox")
         {
-            mClassCombobox.DeleteAll();
-            var classCount = 0;
-            foreach (ClassBase cls in ClassBase.Lookup.Values)
-            {
-                if (!cls.Locked)
-                {
-                    mClassCombobox.AddItem(cls.Name);
-                    classCount++;
-                }
-            }
+            Text = Strings.CharacterCreation.Female
+        };
 
-            LoadClass();
-            UpdateDisplay();
-        }
+        mFemaleChk.Checked += femaleChk_Checked;
+        mFemaleChk.UnChecked += maleChk_Checked;
 
-        public void Update()
+        //Register - Send Registration Button
+        mCreateButton = new Button(mCharCreationPanel, "CreateButton");
+        mCreateButton.SetText(Strings.CharacterCreation.Create);
+        mCreateButton.Clicked += CreateButton_Clicked;
+
+        mBackButton = new Button(mCharCreationPanel, "BackButton");
+        mBackButton.IsHidden = true;
+        mBackButton.SetText(Strings.CharacterCreation.Back);
+        mBackButton.Clicked += BackButton_Clicked;
+
+        mCharCreationPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    }
+
+    public bool IsHidden => mCharCreationPanel.IsHidden;
+
+    public void Init()
+    {
+        mClassCombobox.DeleteAll();
+        var classCount = 0;
+        foreach (ClassBase cls in ClassBase.Lookup.Values)
         {
-            if (!Networking.Network.IsConnected)
+            if (!cls.Locked)
             {
-                Hide();
-                mMainMenu.Show();
-                return;
-            }
-
-            // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
-            if (!Globals.WaitingOnServer && mCreateButton.IsDisabled)
-            {
-                mCreateButton.Enable();
+                mClassCombobox.AddItem(cls.Name);
+                classCount++;
             }
         }
 
-        //Methods
-        private void UpdateDisplay()
+        LoadClass();
+        UpdateDisplay();
+    }
+
+    public void Update()
+    {
+        if (!Networking.Network.IsConnected)
         {
-            var isFace = true;
-            if (GetClass() != null && mDisplaySpriteIndex != -1)
-            {
-                mCharacterPortrait.IsHidden = false;
-                if (GetClass().Sprites.Count > 0)
-                {
-                    if (mMaleChk.IsChecked)
-                    {
-                        mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
-                            Framework.Content.TextureType.Face, mMaleSprites[mDisplaySpriteIndex].Value.Face
-                        );
-
-                        if (mCharacterPortrait.Texture == null)
-                        {
-                            mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
-                                Framework.Content.TextureType.Entity, mMaleSprites[mDisplaySpriteIndex].Value.Sprite
-                            );
-
-                            isFace = false;
-                        }
-                    }
-                    else
-                    {
-                        mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
-                            Framework.Content.TextureType.Face, mFemaleSprites[mDisplaySpriteIndex].Value.Face
-                        );
-
-                        if (mCharacterPortrait.Texture == null)
-                        {
-                            mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
-                                Framework.Content.TextureType.Entity, mFemaleSprites[mDisplaySpriteIndex].Value.Sprite
-                            );
-
-                            isFace = false;
-                        }
-                    }
-
-                    if (mCharacterPortrait.Texture != null)
-                    {
-                        if (isFace)
-                        {
-                            mCharacterPortrait.SetTextureRect(
-                                0, 0, mCharacterPortrait.Texture.GetWidth(), mCharacterPortrait.Texture.GetHeight()
-                            );
-
-                            var scale = Math.Min(
-                                mCharacterContainer.InnerWidth / (double) mCharacterPortrait.Texture.GetWidth(),
-                                mCharacterContainer.InnerHeight / (double) mCharacterPortrait.Texture.GetHeight()
-                            );
-
-                            mCharacterPortrait.SetSize(
-                                (int) (mCharacterPortrait.Texture.GetWidth() * scale),
-                                (int) (mCharacterPortrait.Texture.GetHeight() * scale)
-                            );
-
-                            mCharacterPortrait.SetPosition(
-                                mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
-                                mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
-                            );
-                        }
-                        else
-                        {
-                            mCharacterPortrait.SetTextureRect(
-                                0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                            );
-
-                            mCharacterPortrait.SetSize(
-                                mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                            );
-
-                            mCharacterPortrait.SetPosition(
-                                mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
-                                mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
-                            );
-                        }
-                    }
-                }
-            }
-            else
-            {
-                mCharacterPortrait.IsHidden = true;
-            }
+            Hide();
+            mMainMenu.Show();
+            return;
         }
 
-        public void Show()
+        // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
+        if (!Globals.WaitingOnServer && mCreateButton.IsDisabled)
         {
-            mCharCreationPanel.Show();
+            mCreateButton.Enable();
         }
+    }
 
-        public void Hide()
+    //Methods
+    private void UpdateDisplay()
+    {
+        var isFace = true;
+        if (GetClass() != null && mDisplaySpriteIndex != -1)
         {
-            mCharCreationPanel.Hide();
-        }
-
-        private ClassBase GetClass()
-        {
-            if (mClassCombobox.SelectedItem == null)
-            {
-                return null;
-            }
-
-            foreach (var cls in ClassBase.Lookup)
-            {
-                if (mClassCombobox.SelectedItem.Text == cls.Value.Name && !((ClassBase) cls.Value).Locked)
-                {
-                    return (ClassBase) cls.Value;
-                }
-            }
-
-            return null;
-        }
-
-        private void LoadClass()
-        {
-            var cls = GetClass();
-            mMaleSprites.Clear();
-            mFemaleSprites.Clear();
-            mDisplaySpriteIndex = -1;
-            if (cls != null)
-            {
-                for (var i = 0; i < cls.Sprites.Count; i++)
-                {
-                    if (cls.Sprites[i].Gender == 0)
-                    {
-                        mMaleSprites.Add(new KeyValuePair<int, ClassSprite>(i, cls.Sprites[i]));
-                    }
-                    else
-                    {
-                        mFemaleSprites.Add(new KeyValuePair<int, ClassSprite>(i, cls.Sprites[i]));
-                    }
-                }
-            }
-
-            ResetSprite();
-        }
-
-        private void ResetSprite()
-        {
-            mNextSpriteButton.IsHidden = true;
-            mPrevSpriteButton.IsHidden = true;
-            if (mMaleChk.IsChecked)
-            {
-                if (mMaleSprites.Count > 0)
-                {
-                    mDisplaySpriteIndex = 0;
-                    if (mMaleSprites.Count > 1)
-                    {
-                        mNextSpriteButton.IsHidden = false;
-                        mPrevSpriteButton.IsHidden = false;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-            else
-            {
-                if (mFemaleSprites.Count > 0)
-                {
-                    mDisplaySpriteIndex = 0;
-                    if (mFemaleSprites.Count > 1)
-                    {
-                        mNextSpriteButton.IsHidden = false;
-                        mPrevSpriteButton.IsHidden = false;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-        }
-
-        private void _prevSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mDisplaySpriteIndex--;
-            if (mMaleChk.IsChecked)
-            {
-                if (mMaleSprites.Count > 0)
-                {
-                    if (mDisplaySpriteIndex == -1)
-                    {
-                        mDisplaySpriteIndex = mMaleSprites.Count - 1;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-            else
-            {
-                if (mFemaleSprites.Count > 0)
-                {
-                    if (mDisplaySpriteIndex == -1)
-                    {
-                        mDisplaySpriteIndex = mFemaleSprites.Count - 1;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-
-            UpdateDisplay();
-        }
-
-        private void _nextSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mDisplaySpriteIndex++;
-            if (mMaleChk.IsChecked)
-            {
-                if (mMaleSprites.Count > 0)
-                {
-                    if (mDisplaySpriteIndex >= mMaleSprites.Count)
-                    {
-                        mDisplaySpriteIndex = 0;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-            else
-            {
-                if (mFemaleSprites.Count > 0)
-                {
-                    if (mDisplaySpriteIndex >= mFemaleSprites.Count)
-                    {
-                        mDisplaySpriteIndex = 0;
-                    }
-                }
-                else
-                {
-                    mDisplaySpriteIndex = -1;
-                }
-            }
-
-            UpdateDisplay();
-        }
-
-        void TryCreateCharacter(int gender)
-        {
-            if (Globals.WaitingOnServer || mDisplaySpriteIndex == -1)
-            {
-                return;
-            }
-
-            if (FieldChecking.IsValidUsername(mCharnameTextbox.Text, Strings.Regex.Username))
+            mCharacterPortrait.IsHidden = false;
+            if (GetClass().Sprites.Count > 0)
             {
                 if (mMaleChk.IsChecked)
                 {
-                    PacketSender.SendCreateCharacter(
-                        mCharnameTextbox.Text, GetClass().Id, mMaleSprites[mDisplaySpriteIndex].Key
+                    mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
+                        Framework.Content.TextureType.Face, mMaleSprites[mDisplaySpriteIndex].Value.Face
                     );
+
+                    if (mCharacterPortrait.Texture == null)
+                    {
+                        mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
+                            Framework.Content.TextureType.Entity, mMaleSprites[mDisplaySpriteIndex].Value.Sprite
+                        );
+
+                        isFace = false;
+                    }
                 }
                 else
                 {
-                    PacketSender.SendCreateCharacter(
-                        mCharnameTextbox.Text, GetClass().Id, mFemaleSprites[mDisplaySpriteIndex].Key
+                    mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
+                        Framework.Content.TextureType.Face, mFemaleSprites[mDisplaySpriteIndex].Value.Face
                     );
+
+                    if (mCharacterPortrait.Texture == null)
+                    {
+                        mCharacterPortrait.Texture = Globals.ContentManager.GetTexture(
+                            Framework.Content.TextureType.Entity, mFemaleSprites[mDisplaySpriteIndex].Value.Sprite
+                        );
+
+                        isFace = false;
+                    }
                 }
 
-                Globals.WaitingOnServer = true;
-                mCreateButton.Disable();
-                ChatboxMsg.ClearMessages();
+                if (mCharacterPortrait.Texture != null)
+                {
+                    if (isFace)
+                    {
+                        mCharacterPortrait.SetTextureRect(
+                            0, 0, mCharacterPortrait.Texture.GetWidth(), mCharacterPortrait.Texture.GetHeight()
+                        );
+
+                        var scale = Math.Min(
+                            mCharacterContainer.InnerWidth / (double) mCharacterPortrait.Texture.GetWidth(),
+                            mCharacterContainer.InnerHeight / (double) mCharacterPortrait.Texture.GetHeight()
+                        );
+
+                        mCharacterPortrait.SetSize(
+                            (int) (mCharacterPortrait.Texture.GetWidth() * scale),
+                            (int) (mCharacterPortrait.Texture.GetHeight() * scale)
+                        );
+
+                        mCharacterPortrait.SetPosition(
+                            mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
+                            mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
+                        );
+                    }
+                    else
+                    {
+                        mCharacterPortrait.SetTextureRect(
+                            0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                            mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                        );
+
+                        mCharacterPortrait.SetSize(
+                            mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                        );
+
+                        mCharacterPortrait.SetPosition(
+                            mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
+                            mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
+                        );
+                    }
+                }
+            }
+        }
+        else
+        {
+            mCharacterPortrait.IsHidden = true;
+        }
+    }
+
+    public void Show()
+    {
+        mCharCreationPanel.Show();
+    }
+
+    public void Hide()
+    {
+        mCharCreationPanel.Hide();
+    }
+
+    private ClassBase GetClass()
+    {
+        if (mClassCombobox.SelectedItem == null)
+        {
+            return null;
+        }
+
+        foreach (var cls in ClassBase.Lookup)
+        {
+            if (mClassCombobox.SelectedItem.Text == cls.Value.Name && !((ClassBase) cls.Value).Locked)
+            {
+                return (ClassBase) cls.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private void LoadClass()
+    {
+        var cls = GetClass();
+        mMaleSprites.Clear();
+        mFemaleSprites.Clear();
+        mDisplaySpriteIndex = -1;
+        if (cls != null)
+        {
+            for (var i = 0; i < cls.Sprites.Count; i++)
+            {
+                if (cls.Sprites[i].Gender == 0)
+                {
+                    mMaleSprites.Add(new KeyValuePair<int, ClassSprite>(i, cls.Sprites[i]));
+                }
+                else
+                {
+                    mFemaleSprites.Add(new KeyValuePair<int, ClassSprite>(i, cls.Sprites[i]));
+                }
+            }
+        }
+
+        ResetSprite();
+    }
+
+    private void ResetSprite()
+    {
+        mNextSpriteButton.IsHidden = true;
+        mPrevSpriteButton.IsHidden = true;
+        if (mMaleChk.IsChecked)
+        {
+            if (mMaleSprites.Count > 0)
+            {
+                mDisplaySpriteIndex = 0;
+                if (mMaleSprites.Count > 1)
+                {
+                    mNextSpriteButton.IsHidden = false;
+                    mPrevSpriteButton.IsHidden = false;
+                }
             }
             else
             {
-                Interface.ShowError(Strings.CharacterCreation.InvalidName);
+                mDisplaySpriteIndex = -1;
             }
         }
-
-        //Input Handlers
-        void CharnameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+        else
         {
-            if (mMaleChk.IsChecked == true)
+            if (mFemaleSprites.Count > 0)
             {
-                TryCreateCharacter(0);
+                mDisplaySpriteIndex = 0;
+                if (mFemaleSprites.Count > 1)
+                {
+                    mNextSpriteButton.IsHidden = false;
+                    mPrevSpriteButton.IsHidden = false;
+                }
             }
             else
             {
-                TryCreateCharacter(1);
+                mDisplaySpriteIndex = -1;
             }
         }
+    }
 
-        void classCombobox_ItemSelected(Base control, ItemSelectedEventArgs args)
+    private void _prevSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mDisplaySpriteIndex--;
+        if (mMaleChk.IsChecked)
         {
-            LoadClass();
-            UpdateDisplay();
-        }
-
-        void maleChk_Checked(Base sender, EventArgs arguments)
-        {
-            mMaleChk.IsChecked = true;
-            mFemaleChk.IsChecked = false;
-            ResetSprite();
-            UpdateDisplay();
-        }
-
-        void femaleChk_Checked(Base sender, EventArgs arguments)
-        {
-            mFemaleChk.IsChecked = true;
-            mMaleChk.IsChecked = false;
-            ResetSprite();
-            UpdateDisplay();
-        }
-
-        void CreateButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.WaitingOnServer)
+            if (mMaleSprites.Count > 0)
             {
-                return;
-            }
-
-            if (mMaleChk.IsChecked == true)
-            {
-                TryCreateCharacter(0);
+                if (mDisplaySpriteIndex == -1)
+                {
+                    mDisplaySpriteIndex = mMaleSprites.Count - 1;
+                }
             }
             else
             {
-                TryCreateCharacter(1);
+                mDisplaySpriteIndex = -1;
             }
         }
-
-        private void BackButton_Clicked(Base sender, ClickedEventArgs arguments)
+        else
         {
-            Hide();
-            if (Options.Player.MaxCharacters <= 1)
+            if (mFemaleSprites.Count > 0)
             {
-                //Logout
-                mMainMenu.Show();
+                if (mDisplaySpriteIndex == -1)
+                {
+                    mDisplaySpriteIndex = mFemaleSprites.Count - 1;
+                }
             }
             else
             {
-                //Character Selection Screen
-                mSelectCharacterWindow.Show();
+                mDisplaySpriteIndex = -1;
             }
         }
 
+        UpdateDisplay();
+    }
+
+    private void _nextSpriteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mDisplaySpriteIndex++;
+        if (mMaleChk.IsChecked)
+        {
+            if (mMaleSprites.Count > 0)
+            {
+                if (mDisplaySpriteIndex >= mMaleSprites.Count)
+                {
+                    mDisplaySpriteIndex = 0;
+                }
+            }
+            else
+            {
+                mDisplaySpriteIndex = -1;
+            }
+        }
+        else
+        {
+            if (mFemaleSprites.Count > 0)
+            {
+                if (mDisplaySpriteIndex >= mFemaleSprites.Count)
+                {
+                    mDisplaySpriteIndex = 0;
+                }
+            }
+            else
+            {
+                mDisplaySpriteIndex = -1;
+            }
+        }
+
+        UpdateDisplay();
+    }
+
+    void TryCreateCharacter(int gender)
+    {
+        if (Globals.WaitingOnServer || mDisplaySpriteIndex == -1)
+        {
+            return;
+        }
+
+        if (FieldChecking.IsValidUsername(mCharnameTextbox.Text, Strings.Regex.Username))
+        {
+            if (mMaleChk.IsChecked)
+            {
+                PacketSender.SendCreateCharacter(
+                    mCharnameTextbox.Text, GetClass().Id, mMaleSprites[mDisplaySpriteIndex].Key
+                );
+            }
+            else
+            {
+                PacketSender.SendCreateCharacter(
+                    mCharnameTextbox.Text, GetClass().Id, mFemaleSprites[mDisplaySpriteIndex].Key
+                );
+            }
+
+            Globals.WaitingOnServer = true;
+            mCreateButton.Disable();
+            ChatboxMsg.ClearMessages();
+        }
+        else
+        {
+            Interface.ShowError(Strings.CharacterCreation.InvalidName);
+        }
+    }
+
+    //Input Handlers
+    void CharnameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        if (mMaleChk.IsChecked == true)
+        {
+            TryCreateCharacter(0);
+        }
+        else
+        {
+            TryCreateCharacter(1);
+        }
+    }
+
+    void classCombobox_ItemSelected(Base control, ItemSelectedEventArgs args)
+    {
+        LoadClass();
+        UpdateDisplay();
+    }
+
+    void maleChk_Checked(Base sender, EventArgs arguments)
+    {
+        mMaleChk.IsChecked = true;
+        mFemaleChk.IsChecked = false;
+        ResetSprite();
+        UpdateDisplay();
+    }
+
+    void femaleChk_Checked(Base sender, EventArgs arguments)
+    {
+        mFemaleChk.IsChecked = true;
+        mMaleChk.IsChecked = false;
+        ResetSprite();
+        UpdateDisplay();
+    }
+
+    void CreateButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
+        }
+
+        if (mMaleChk.IsChecked == true)
+        {
+            TryCreateCharacter(0);
+        }
+        else
+        {
+            TryCreateCharacter(1);
+        }
+    }
+
+    private void BackButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        if (Options.Player.MaxCharacters <= 1)
+        {
+            //Logout
+            mMainMenu.Show();
+        }
+        else
+        {
+            //Character Selection Screen
+            mSelectCharacterWindow.Show();
+        }
     }
 
 }

--- a/Intersect.Client/Interface/Menu/CreditsParser.cs
+++ b/Intersect.Client/Interface/Menu/CreditsParser.cs
@@ -1,39 +1,37 @@
 ﻿using Intersect.Client.Framework.Gwen;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+partial class Credits
 {
 
-    partial class Credits
+    public List<CreditsLine> Lines = new List<CreditsLine>();
+
+    public partial struct CreditsLine
     {
 
-        public List<CreditsLine> Lines = new List<CreditsLine>();
+        public string Text;
 
-        public partial struct CreditsLine
+        public string Font;
+
+        public int Size;
+
+        public string Alignment;
+
+        public Color Clr;
+
+        public Alignments GetAlignment()
         {
-
-            public string Text;
-
-            public string Font;
-
-            public int Size;
-
-            public string Alignment;
-
-            public Color Clr;
-
-            public Alignments GetAlignment()
+            switch (Alignment)
             {
-                switch (Alignment)
-                {
-                    case "center":
-                        return Alignments.CenterH;
-                    case "right":
-                        return Alignments.Right;
-                    default:
-                        return Alignments.Left;
-                }
+                case "center":
+                    return Alignments.CenterH;
+                case "right":
+                    return Alignments.Right;
+                default:
+                    return Alignments.Left;
             }
-
         }
 
     }

--- a/Intersect.Client/Interface/Menu/CreditsWindow.cs
+++ b/Intersect.Client/Interface/Menu/CreditsWindow.cs
@@ -6,112 +6,110 @@ using Intersect.Client.Localization;
 using Intersect.Configuration;
 using Newtonsoft.Json;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class CreditsWindow : IMainMenuWindow
 {
 
-    public partial class CreditsWindow : IMainMenuWindow
+    private Button mBackBtn;
+
+    //Content
+    private ScrollControl mCreditsContent;
+
+    //Parent
+    private Label mCreditsHeader;
+
+    //Controls
+    private ImagePanel mCreditsWindow;
+
+    private MainMenu mMainMenu;
+
+    private RichLabel mRichLabel;
+
+    //Init
+    public CreditsWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        private Button mBackBtn;
+        //Main Menu Window
+        mCreditsWindow = new ImagePanel(parent, "CreditsWindow");
 
-        //Content
-        private ScrollControl mCreditsContent;
+        //Menu Header
+        mCreditsHeader = new Label(mCreditsWindow, "CreditsHeader");
+        mCreditsHeader.SetText(Strings.Credits.Title);
 
-        //Parent
-        private Label mCreditsHeader;
+        mCreditsContent = new ScrollControl(mCreditsWindow, "CreditsScrollview");
+        mCreditsContent.EnableScroll(false, true);
 
-        //Controls
-        private ImagePanel mCreditsWindow;
+        mRichLabel = new RichLabel(mCreditsContent, "CreditsLabel");
 
-        private MainMenu mMainMenu;
+        //Back Button
+        mBackBtn = new Button(mCreditsWindow, "BackButton");
+        mBackBtn.SetText(Strings.Credits.Back);
+        mBackBtn.Clicked += BackBtn_Clicked;
 
-        private RichLabel mRichLabel;
+        mCreditsWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    }
 
-        //Init
-        public CreditsWindow(Canvas parent, MainMenu mainMenu)
+    private void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        mMainMenu.Show();
+    }
+
+    //Methods
+    public void Update()
+    {
+    }
+
+    public void Hide()
+    {
+        mCreditsWindow.IsHidden = true;
+    }
+
+    public void Show()
+    {
+        mCreditsWindow.IsHidden = false;
+        mRichLabel.ClearText();
+        var credits = new Credits();
+        var creditsFile = Path.Combine(ClientConfiguration.ResourcesDirectory, "credits.json");
+        if (File.Exists(creditsFile))
         {
-            //Assign References
-            mMainMenu = mainMenu;
-
-            //Main Menu Window
-            mCreditsWindow = new ImagePanel(parent, "CreditsWindow");
-
-            //Menu Header
-            mCreditsHeader = new Label(mCreditsWindow, "CreditsHeader");
-            mCreditsHeader.SetText(Strings.Credits.Title);
-
-            mCreditsContent = new ScrollControl(mCreditsWindow, "CreditsScrollview");
-            mCreditsContent.EnableScroll(false, true);
-
-            mRichLabel = new RichLabel(mCreditsContent, "CreditsLabel");
-
-            //Back Button
-            mBackBtn = new Button(mCreditsWindow, "BackButton");
-            mBackBtn.SetText(Strings.Credits.Back);
-            mBackBtn.Clicked += BackBtn_Clicked;
-
-            mCreditsWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+            credits = JsonConvert.DeserializeObject<Credits>(File.ReadAllText(creditsFile));
+        }
+        else
+        {
+            var line = new Credits.CreditsLine();
+            line.Text = "Insert your credits here!";
+            line.Alignment = "center";
+            line.Size = 12;
+            line.Clr = Intersect.Color.White;
+            line.Font = "sourcesansproblack";
+            credits.Lines.Add(line);
         }
 
-        private void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Hide();
-            mMainMenu.Show();
-        }
+        File.WriteAllText(creditsFile, JsonConvert.SerializeObject(credits, Formatting.Indented));
 
-        //Methods
-        public void Update()
+        foreach (var line in credits.Lines)
         {
-        }
-
-        public void Hide()
-        {
-            mCreditsWindow.IsHidden = true;
-        }
-
-        public void Show()
-        {
-            mCreditsWindow.IsHidden = false;
-            mRichLabel.ClearText();
-            var credits = new Credits();
-            var creditsFile = Path.Combine(ClientConfiguration.ResourcesDirectory, "credits.json");
-            if (File.Exists(creditsFile))
+            if (line.Text.Trim().Length == 0)
             {
-                credits = JsonConvert.DeserializeObject<Credits>(File.ReadAllText(creditsFile));
+                mRichLabel.AddLineBreak();
             }
             else
             {
-                var line = new Credits.CreditsLine();
-                line.Text = "Insert your credits here!";
-                line.Alignment = "center";
-                line.Size = 12;
-                line.Clr = Intersect.Color.White;
-                line.Font = "sourcesansproblack";
-                credits.Lines.Add(line);
+                mRichLabel.AddText(
+                    line.Text, new Color(line.Clr.A, line.Clr.R, line.Clr.G, line.Clr.B), line.GetAlignment(),
+                    GameContentManager.Current.GetFont(line.Font, line.Size)
+                );
+
+                mRichLabel.AddLineBreak();
             }
-
-            File.WriteAllText(creditsFile, JsonConvert.SerializeObject(credits, Formatting.Indented));
-
-            foreach (var line in credits.Lines)
-            {
-                if (line.Text.Trim().Length == 0)
-                {
-                    mRichLabel.AddLineBreak();
-                }
-                else
-                {
-                    mRichLabel.AddText(
-                        line.Text, new Color(line.Clr.A, line.Clr.R, line.Clr.G, line.Clr.B), line.GetAlignment(),
-                        GameContentManager.Current.GetFont(line.Font, line.Size)
-                    );
-
-                    mRichLabel.AddLineBreak();
-                }
-            }
-
-            mRichLabel.SizeToChildren(false, true);
         }
 
+        mRichLabel.SizeToChildren(false, true);
     }
 
 }

--- a/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
+++ b/Intersect.Client/Interface/Menu/ForgotPasswordWindow.cs
@@ -8,158 +8,156 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class ForgotPasswordWindow
 {
 
-    public partial class ForgotPasswordWindow
+    private Button mBackBtn;
+
+    private RichLabel mHintLabel;
+
+    private Label mHintLabelTemplate;
+
+    //Controls
+    private ImagePanel mInputBackground;
+
+    private Label mInputLabel;
+
+    private TextBox mInputTextbox;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    //Controls
+    private ImagePanel mResetWindow;
+
+    private Button mSubmitBtn;
+
+    private Label mWindowHeader;
+
+    //Init
+    public ForgotPasswordWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        private Button mBackBtn;
+        //Main Menu Window
+        mResetWindow = new ImagePanel(parent, "ForgotPasswordWindow");
+        mResetWindow.IsHidden = true;
 
-        private RichLabel mHintLabel;
+        //Menu Header
+        mWindowHeader = new Label(mResetWindow, "Header");
+        mWindowHeader.SetText(Strings.ForgotPass.Title);
 
-        private Label mHintLabelTemplate;
+        mInputBackground = new ImagePanel(mResetWindow, "InputPanel");
 
-        //Controls
-        private ImagePanel mInputBackground;
+        //Login Username Label
+        mInputLabel = new Label(mInputBackground, "InputLabel");
+        mInputLabel.SetText(Strings.ForgotPass.Label);
 
-        private Label mInputLabel;
+        //Login Username Textbox
+        mInputTextbox = new TextBox(mInputBackground, "InputField");
+        mInputTextbox.SubmitPressed += Textbox_SubmitPressed;
+        mInputTextbox.Clicked += Textbox_Clicked;
 
-        private TextBox mInputTextbox;
+        mHintLabelTemplate = new Label(mResetWindow, "HintLabel");
+        mHintLabelTemplate.IsHidden = true;
 
-        //Parent
-        private MainMenu mMainMenu;
+        //Login - Send Login Button
+        mSubmitBtn = new Button(mResetWindow, "SubmitButton");
+        mSubmitBtn.SetText(Strings.ForgotPass.Submit);
+        mSubmitBtn.Clicked += SubmitBtn_Clicked;
 
-        //Controls
-        private ImagePanel mResetWindow;
+        //Login - Back Button
+        mBackBtn = new Button(mResetWindow, "BackButton");
+        mBackBtn.SetText(Strings.ForgotPass.Back);
+        mBackBtn.Clicked += BackBtn_Clicked;
 
-        private Button mSubmitBtn;
+        mResetWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
 
-        private Label mWindowHeader;
+        mHintLabel = new RichLabel(mResetWindow);
+        mHintLabel.SetBounds(mHintLabelTemplate.Bounds);
+        mHintLabelTemplate.IsHidden = false;
+        mHintLabel.AddText(Strings.ForgotPass.Hint, mHintLabelTemplate);
+    }
 
-        //Init
-        public ForgotPasswordWindow(Canvas parent, MainMenu mainMenu)
-        {
-            //Assign References
-            mMainMenu = mainMenu;
+    public bool IsHidden => mResetWindow.IsHidden;
 
-            //Main Menu Window
-            mResetWindow = new ImagePanel(parent, "ForgotPasswordWindow");
-            mResetWindow.IsHidden = true;
+    private void Textbox_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.InputManager.OpenKeyboard(KeyboardType.Normal, mInputTextbox.Text, false, false, false);
+    }
 
-            //Menu Header
-            mWindowHeader = new Label(mResetWindow, "Header");
-            mWindowHeader.SetText(Strings.ForgotPass.Title);
-
-            mInputBackground = new ImagePanel(mResetWindow, "InputPanel");
-
-            //Login Username Label
-            mInputLabel = new Label(mInputBackground, "InputLabel");
-            mInputLabel.SetText(Strings.ForgotPass.Label);
-
-            //Login Username Textbox
-            mInputTextbox = new TextBox(mInputBackground, "InputField");
-            mInputTextbox.SubmitPressed += Textbox_SubmitPressed;
-            mInputTextbox.Clicked += Textbox_Clicked;
-
-            mHintLabelTemplate = new Label(mResetWindow, "HintLabel");
-            mHintLabelTemplate.IsHidden = true;
-
-            //Login - Send Login Button
-            mSubmitBtn = new Button(mResetWindow, "SubmitButton");
-            mSubmitBtn.SetText(Strings.ForgotPass.Submit);
-            mSubmitBtn.Clicked += SubmitBtn_Clicked;
-
-            //Login - Back Button
-            mBackBtn = new Button(mResetWindow, "BackButton");
-            mBackBtn.SetText(Strings.ForgotPass.Back);
-            mBackBtn.Clicked += BackBtn_Clicked;
-
-            mResetWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
-
-            mHintLabel = new RichLabel(mResetWindow);
-            mHintLabel.SetBounds(mHintLabelTemplate.Bounds);
-            mHintLabelTemplate.IsHidden = false;
-            mHintLabel.AddText(Strings.ForgotPass.Hint, mHintLabelTemplate);
-        }
-
-        public bool IsHidden => mResetWindow.IsHidden;
-
-        private void Textbox_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Globals.InputManager.OpenKeyboard(KeyboardType.Normal, mInputTextbox.Text, false, false, false);
-        }
-
-        //Methods
-        public void Update()
-        {
-            if (!Networking.Network.IsConnected)
-            {
-                Hide();
-                mMainMenu.Show();
-            }
-
-            // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
-            if (!Globals.WaitingOnServer && mSubmitBtn.IsDisabled)
-            {
-                mSubmitBtn.Enable();
-            }
-        }
-
-        public void Hide()
-        {
-            mResetWindow.IsHidden = true;
-        }
-
-        public void Show()
-        {
-            mResetWindow.IsHidden = false;
-            mInputTextbox.Text = "";
-        }
-
-        void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    //Methods
+    public void Update()
+    {
+        if (!Networking.Network.IsConnected)
         {
             Hide();
-            Interface.MenuUi.MainMenu.NotifyOpenLogin();
+            mMainMenu.Show();
         }
 
-        void Textbox_SubmitPressed(Base sender, EventArgs arguments)
+        // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
+        if (!Globals.WaitingOnServer && mSubmitBtn.IsDisabled)
         {
-            TrySendCode();
+            mSubmitBtn.Enable();
         }
+    }
 
-        void SubmitBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    public void Hide()
+    {
+        mResetWindow.IsHidden = true;
+    }
+
+    public void Show()
+    {
+        mResetWindow.IsHidden = false;
+        mInputTextbox.Text = "";
+    }
+
+    void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        Interface.MenuUi.MainMenu.NotifyOpenLogin();
+    }
+
+    void Textbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TrySendCode();
+    }
+
+    void SubmitBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.WaitingOnServer)
         {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            TrySendCode();
-
-            mSubmitBtn.Disable();
+            return;
         }
 
-        public void TrySendCode()
+        TrySendCode();
+
+        mSubmitBtn.Disable();
+    }
+
+    public void TrySendCode()
+    {
+        if (!Networking.Network.IsConnected)
         {
-            if (!Networking.Network.IsConnected)
-            {
-                Interface.ShowError(Strings.Errors.NotConnected);
+            Interface.ShowError(Strings.Errors.NotConnected);
 
-                return;
-            }
-
-            if (!FieldChecking.IsValidUsername(mInputTextbox?.Text, Strings.Regex.Username) &&
-                !FieldChecking.IsWellformedEmailAddress(mInputTextbox?.Text, Strings.Regex.Email))
-            {
-                Interface.ShowError(Strings.Errors.UsernameInvalid);
-                return;
-            }
-
-            Interface.MenuUi.MainMenu.OpenResetPassword(mInputTextbox?.Text);
-            PacketSender.SendRequestPasswordReset(mInputTextbox?.Text);
+            return;
         }
 
+        if (!FieldChecking.IsValidUsername(mInputTextbox?.Text, Strings.Regex.Username) &&
+            !FieldChecking.IsWellformedEmailAddress(mInputTextbox?.Text, Strings.Regex.Email))
+        {
+            Interface.ShowError(Strings.Errors.UsernameInvalid);
+            return;
+        }
+
+        Interface.MenuUi.MainMenu.OpenResetPassword(mInputTextbox?.Text);
+        PacketSender.SendRequestPasswordReset(mInputTextbox?.Text);
     }
 
 }

--- a/Intersect.Client/Interface/Menu/LoginWindow.cs
+++ b/Intersect.Client/Interface/Menu/LoginWindow.cs
@@ -12,302 +12,300 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class LoginWindow : IMainMenuWindow
 {
 
-    public partial class LoginWindow : IMainMenuWindow
+    private Button mBackBtn;
+
+    private Button mForgotPassswordButton;
+
+    private Button mLoginBtn;
+
+    private Label mLoginHeader;
+
+    //Controls
+    private ImagePanel mLoginWindow;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    private ImagePanel mPasswordBackground;
+
+    private Label mPasswordLabel;
+
+    private TextBoxPassword mPasswordTextbox;
+
+    private string mSavedPass = "";
+
+    private LabeledCheckBox mSavePassChk;
+
+    //Controls
+    private ImagePanel mUsernameBackground;
+
+    private Label mUsernameLabel;
+
+    private TextBox mUsernameTextbox;
+
+    private bool mUseSavedPass;
+
+    //Init
+    public LoginWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        private Button mBackBtn;
+        //Main Menu Window
+        mLoginWindow = new ImagePanel(parent, "LoginWindow");
 
-        private Button mForgotPassswordButton;
+        //Menu Header
+        mLoginHeader = new Label(mLoginWindow, "LoginHeader");
+        mLoginHeader.SetText(Strings.LoginWindow.Title);
 
-        private Button mLoginBtn;
+        mUsernameBackground = new ImagePanel(mLoginWindow, "UsernamePanel");
 
-        private Label mLoginHeader;
+        //Login Username Label
+        mUsernameLabel = new Label(mUsernameBackground, "UsernameLabel");
+        mUsernameLabel.SetText(Strings.LoginWindow.Username);
 
-        //Controls
-        private ImagePanel mLoginWindow;
+        //Login Username Textbox
+        mUsernameTextbox = new TextBox(mUsernameBackground, "UsernameField");
+        mUsernameTextbox.SubmitPressed += UsernameTextbox_SubmitPressed;
+        mUsernameTextbox.Clicked += _usernameTextbox_Clicked;
 
-        //Parent
-        private MainMenu mMainMenu;
+        mPasswordBackground = new ImagePanel(mLoginWindow, "PasswordPanel");
 
-        private ImagePanel mPasswordBackground;
+        //Login Password Label
+        mPasswordLabel = new Label(mPasswordBackground, "PasswordLabel");
+        mPasswordLabel.SetText(Strings.LoginWindow.Password);
 
-        private Label mPasswordLabel;
+        //Login Password Textbox
+        mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "PasswordField");
+        mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
+        mPasswordTextbox.TextChanged += _passwordTextbox_TextChanged;
+        mPasswordTextbox.Clicked += MPasswordTextboxOnClicked;
 
-        private TextBoxPassword mPasswordTextbox;
-
-        private string mSavedPass = "";
-
-        private LabeledCheckBox mSavePassChk;
-
-        //Controls
-        private ImagePanel mUsernameBackground;
-
-        private Label mUsernameLabel;
-
-        private TextBox mUsernameTextbox;
-
-        private bool mUseSavedPass;
-
-        //Init
-        public LoginWindow(Canvas parent, MainMenu mainMenu)
+        //Login Save Pass Checkbox
+        mSavePassChk = new LabeledCheckBox(mLoginWindow, "SavePassCheckbox")
         {
-            //Assign References
-            mMainMenu = mainMenu;
+            // IsTabable = true,
+            Text = Strings.LoginWindow.SavePassword,
+        };
 
-            //Main Menu Window
-            mLoginWindow = new ImagePanel(parent, "LoginWindow");
-
-            //Menu Header
-            mLoginHeader = new Label(mLoginWindow, "LoginHeader");
-            mLoginHeader.SetText(Strings.LoginWindow.Title);
-
-            mUsernameBackground = new ImagePanel(mLoginWindow, "UsernamePanel");
-
-            //Login Username Label
-            mUsernameLabel = new Label(mUsernameBackground, "UsernameLabel");
-            mUsernameLabel.SetText(Strings.LoginWindow.Username);
-
-            //Login Username Textbox
-            mUsernameTextbox = new TextBox(mUsernameBackground, "UsernameField");
-            mUsernameTextbox.SubmitPressed += UsernameTextbox_SubmitPressed;
-            mUsernameTextbox.Clicked += _usernameTextbox_Clicked;
-
-            mPasswordBackground = new ImagePanel(mLoginWindow, "PasswordPanel");
-
-            //Login Password Label
-            mPasswordLabel = new Label(mPasswordBackground, "PasswordLabel");
-            mPasswordLabel.SetText(Strings.LoginWindow.Password);
-
-            //Login Password Textbox
-            mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "PasswordField");
-            mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
-            mPasswordTextbox.TextChanged += _passwordTextbox_TextChanged;
-            mPasswordTextbox.Clicked += MPasswordTextboxOnClicked;
-
-            //Login Save Pass Checkbox
-            mSavePassChk = new LabeledCheckBox(mLoginWindow, "SavePassCheckbox")
-            {
-                // IsTabable = true,
-                Text = Strings.LoginWindow.SavePassword,
-            };
-
-            //Forgot Password Button
-            mForgotPassswordButton = new Button(mLoginWindow, "ForgotPasswordButton")
-            {
-                IsHidden = true,
-                // IsTabable = true,
-                Text = Strings.LoginWindow.ForgotPassword,
-            };
-            mForgotPassswordButton.Clicked += mForgotPassswordButton_Clicked;
-
-            //Login - Send Login Button
-            mLoginBtn = new Button(mLoginWindow, "LoginButton")
-            {
-                // IsTabable = true,
-                Text = Strings.LoginWindow.Login,
-            };
-            mLoginBtn.Clicked += LoginBtn_Clicked;
-
-            //Login - Back Button
-            mBackBtn = new Button(mLoginWindow, "BackButton")
-            {
-                // IsTabable = true,
-                Text = Strings.LoginWindow.Back,
-            };
-            mBackBtn.Clicked += BackBtn_Clicked;
-
-            LoadCredentials();
-
-            mLoginWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
-
-        }
-
-        private void MPasswordTextboxOnClicked(Base sender, ClickedEventArgs arguments)
+        //Forgot Password Button
+        mForgotPassswordButton = new Button(mLoginWindow, "ForgotPasswordButton")
         {
-            Globals.InputManager.OpenKeyboard(
-                KeyboardType.Password,
-                text => mPasswordTextbox.Text = text ?? string.Empty,
-                "Password",
-                mPasswordTextbox.Text
-            );
-        }
+            IsHidden = true,
+            // IsTabable = true,
+            Text = Strings.LoginWindow.ForgotPassword,
+        };
+        mForgotPassswordButton.Clicked += mForgotPassswordButton_Clicked;
 
-        public bool IsHidden => mLoginWindow.IsHidden;
-
-        private void mForgotPassswordButton_Clicked(Base sender, ClickedEventArgs arguments)
+        //Login - Send Login Button
+        mLoginBtn = new Button(mLoginWindow, "LoginButton")
         {
-            Interface.MenuUi.MainMenu.NotifyOpenForgotPassword();
-        }
+            // IsTabable = true,
+            Text = Strings.LoginWindow.Login,
+        };
+        mLoginBtn.Clicked += LoginBtn_Clicked;
 
-        private void _usernameTextbox_Clicked(Base sender, ClickedEventArgs arguments)
+        //Login - Back Button
+        mBackBtn = new Button(mLoginWindow, "BackButton")
         {
-            Globals.InputManager.OpenKeyboard(
-                KeyboardType.Normal,
-                text => mUsernameTextbox.Text = text ?? string.Empty,
-                "Username",
-                mUsernameTextbox.Text,
-                inputBounds: mUsernameTextbox.BoundsGlobal
-            );
-        }
+            // IsTabable = true,
+            Text = Strings.LoginWindow.Back,
+        };
+        mBackBtn.Clicked += BackBtn_Clicked;
 
-        //Methods
-        public void Update()
-        {
-            if (!Networking.Network.IsConnected)
-            {
-                Hide();
-                mMainMenu.Show();
-                return;
-            }
+        LoadCredentials();
 
-            // Re-Enable our buttons button if we're not waiting for the server anymore with it disabled.
-            if (!Globals.WaitingOnServer && mLoginBtn.IsDisabled)
-            {
-                mLoginBtn.Enable();
-            }
-        }
+        mLoginWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
 
-        public void Hide()
-        {
-            mLoginWindow.IsHidden = true;
-        }
+    }
 
-        public void Show()
-        {
-            mLoginWindow.IsHidden = false;
-            if (!mForgotPassswordButton.IsHidden)
-            {
-                mForgotPassswordButton.IsHidden = !Options.Instance.SmtpValid;
-            }
+    private void MPasswordTextboxOnClicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.InputManager.OpenKeyboard(
+            KeyboardType.Password,
+            text => mPasswordTextbox.Text = text ?? string.Empty,
+            "Password",
+            mPasswordTextbox.Text
+        );
+    }
 
-            // Set focus to the appropriate elements.
-            if (!string.IsNullOrWhiteSpace(mUsernameTextbox.Text))
-            {
-                mPasswordTextbox.Focus();
-            }
-            else
-            {
-                mUsernameTextbox.Focus();
-            }
-        }
+    public bool IsHidden => mLoginWindow.IsHidden;
 
-        //Input Handlers
-        void _passwordTextbox_TextChanged(Base sender, EventArgs arguments)
-        {
-            mUseSavedPass = false;
-        }
+    private void mForgotPassswordButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Interface.MenuUi.MainMenu.NotifyOpenForgotPassword();
+    }
 
-        void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    private void _usernameTextbox_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.InputManager.OpenKeyboard(
+            KeyboardType.Normal,
+            text => mUsernameTextbox.Text = text ?? string.Empty,
+            "Username",
+            mUsernameTextbox.Text,
+            inputBounds: mUsernameTextbox.BoundsGlobal
+        );
+    }
+
+    //Methods
+    public void Update()
+    {
+        if (!Networking.Network.IsConnected)
         {
             Hide();
             mMainMenu.Show();
-
-            Networking.Network.DebounceClose("returning_to_main_menu");
+            return;
         }
 
-        void UsernameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+        // Re-Enable our buttons button if we're not waiting for the server anymore with it disabled.
+        if (!Globals.WaitingOnServer && mLoginBtn.IsDisabled)
         {
-            TryLogin();
+            mLoginBtn.Enable();
+        }
+    }
+
+    public void Hide()
+    {
+        mLoginWindow.IsHidden = true;
+    }
+
+    public void Show()
+    {
+        mLoginWindow.IsHidden = false;
+        if (!mForgotPassswordButton.IsHidden)
+        {
+            mForgotPassswordButton.IsHidden = !Options.Instance.SmtpValid;
         }
 
-        void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
+        // Set focus to the appropriate elements.
+        if (!string.IsNullOrWhiteSpace(mUsernameTextbox.Text))
         {
-            TryLogin();
+            mPasswordTextbox.Focus();
+        }
+        else
+        {
+            mUsernameTextbox.Focus();
+        }
+    }
+
+    //Input Handlers
+    void _passwordTextbox_TextChanged(Base sender, EventArgs arguments)
+    {
+        mUseSavedPass = false;
+    }
+
+    void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        mMainMenu.Show();
+
+        Networking.Network.DebounceClose("returning_to_main_menu");
+    }
+
+    void UsernameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryLogin();
+    }
+
+    void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryLogin();
+    }
+
+    void LoginBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        TryLogin();
+    }
+
+    public void TryLogin()
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
         }
 
-        void LoginBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        if (!Networking.Network.IsConnected)
         {
-            TryLogin();
+            Interface.ShowError(Strings.Errors.NotConnected);
+            return;
         }
 
-        public void TryLogin()
+        if (!FieldChecking.IsValidUsername(mUsernameTextbox?.Text, Strings.Regex.Username))
         {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
+            Interface.ShowError(Strings.Errors.UsernameInvalid);
+            return;
+        }
 
-            if (!Networking.Network.IsConnected)
-            {
-                Interface.ShowError(Strings.Errors.NotConnected);
-                return;
-            }
-
-            if (!FieldChecking.IsValidUsername(mUsernameTextbox?.Text, Strings.Regex.Username))
-            {
-                Interface.ShowError(Strings.Errors.UsernameInvalid);
-                return;
-            }
-
-            if (!FieldChecking.IsValidPassword(mPasswordTextbox?.Text, Strings.Regex.Password))
-            {
-                if (!mUseSavedPass)
-                {
-                    Interface.ShowError(Strings.Errors.PasswordInvalid);
-                    return;
-                }
-            }
-
-            var password = mSavedPass;
+        if (!FieldChecking.IsValidPassword(mPasswordTextbox?.Text, Strings.Regex.Password))
+        {
             if (!mUseSavedPass)
             {
-                password = ComputePasswordHash(mPasswordTextbox?.Text?.Trim());
-            }
-
-            Globals.WaitingOnServer = true;
-            mLoginBtn.Disable();
-            PacketSender.SendLogin(mUsernameTextbox?.Text, password);
-            SaveCredentials();
-            ChatboxMsg.ClearMessages();
-        }
-
-        private void LoadCredentials()
-        {
-            var name = Globals.Database.LoadPreference("Username");
-            if (string.IsNullOrEmpty(name))
-            {
+                Interface.ShowError(Strings.Errors.PasswordInvalid);
                 return;
             }
-
-            mUsernameTextbox.Text = name;
-            var pass = Globals.Database.LoadPreference("Password");
-            if (string.IsNullOrEmpty(pass))
-            {
-                return;
-            }
-
-            mPasswordTextbox.Text = "****************";
-            mSavedPass = pass;
-            mUseSavedPass = true;
-            mSavePassChk.IsChecked = true;
         }
 
-        private static string ComputePasswordHash(string password)
+        var password = mSavedPass;
+        if (!mUseSavedPass)
         {
-            using (var sha = new SHA256Managed())
-            {
-                return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(password ?? ""))).Replace("-", "");
-            }
+            password = ComputePasswordHash(mPasswordTextbox?.Text?.Trim());
         }
 
-        private void SaveCredentials()
+        Globals.WaitingOnServer = true;
+        mLoginBtn.Disable();
+        PacketSender.SendLogin(mUsernameTextbox?.Text, password);
+        SaveCredentials();
+        ChatboxMsg.ClearMessages();
+    }
+
+    private void LoadCredentials()
+    {
+        var name = Globals.Database.LoadPreference("Username");
+        if (string.IsNullOrEmpty(name))
         {
-            var username = "";
-            var password = "";
-
-            if (mSavePassChk.IsChecked)
-            {
-                username = mUsernameTextbox?.Text?.Trim();
-                password = mUseSavedPass ? mSavedPass : ComputePasswordHash(mPasswordTextbox?.Text?.Trim());
-            }
-
-            Globals.Database.SavePreference("Username", username);
-            Globals.Database.SavePreference("Password", password);
+            return;
         }
 
+        mUsernameTextbox.Text = name;
+        var pass = Globals.Database.LoadPreference("Password");
+        if (string.IsNullOrEmpty(pass))
+        {
+            return;
+        }
+
+        mPasswordTextbox.Text = "****************";
+        mSavedPass = pass;
+        mUseSavedPass = true;
+        mSavePassChk.IsChecked = true;
+    }
+
+    private static string ComputePasswordHash(string password)
+    {
+        using (var sha = new SHA256Managed())
+        {
+            return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(password ?? ""))).Replace("-", "");
+        }
+    }
+
+    private void SaveCredentials()
+    {
+        var username = "";
+        var password = "";
+
+        if (mSavePassChk.IsChecked)
+        {
+            username = mUsernameTextbox?.Text?.Trim();
+            password = mUseSavedPass ? mSavedPass : ComputePasswordHash(mPasswordTextbox?.Text?.Trim());
+        }
+
+        Globals.Database.SavePreference("Username", username);
+        Globals.Database.SavePreference("Password", password);
     }
 
 }

--- a/Intersect.Client/Interface/Menu/MainMenu.cs
+++ b/Intersect.Client/Interface/Menu/MainMenu.cs
@@ -6,256 +6,255 @@ using Intersect.Client.Interface.Shared;
 using Intersect.Network;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class MainMenu : MutableInterface
 {
-
-    public partial class MainMenu : MutableInterface
+    public static void HandleReceivedConfiguration()
     {
-        public static void HandleReceivedConfiguration()
+        ReceivedConfiguration?.Invoke(default, EventArgs.Empty);
+    }
+
+    internal static event EventHandler? ReceivedConfiguration;
+
+    public delegate void NetworkStatusHandler();
+
+    public static NetworkStatus ActiveNetworkStatus;
+
+    public static NetworkStatusHandler NetworkStatusChanged;
+
+    private readonly CreateCharacterWindow mCreateCharacterWindow;
+
+    private readonly CreditsWindow mCreditsWindow;
+
+    private readonly ForgotPasswordWindow mForgotPasswordWindow;
+
+    private readonly LoginWindow mLoginWindow;
+
+    //Controls
+    private readonly Canvas mMenuCanvas;
+
+    private readonly Label mMenuHeader;
+
+    private readonly SettingsWindow mSettingsWindow;
+
+    private readonly RegisterWindow mRegisterWindow;
+
+    private readonly ResetPasswordWindow mResetPasswordWindow;
+
+    private readonly SelectCharacterWindow mSelectCharacterWindow;
+
+    //Character creation feild check
+    private bool mHasMadeCharacterCreation;
+
+    private bool mShouldOpenCharacterCreation;
+
+    private bool mShouldOpenCharacterSelection;
+
+    private readonly MainMenuWindow _mainMenuWindow;
+
+    //Init
+    public MainMenu(Canvas menuCanvas) : base(menuCanvas)
+    {
+        mMenuCanvas = menuCanvas;
+
+        _mainMenuWindow = new MainMenuWindow(mMenuCanvas, this);
+
+        var logo = new ImagePanel(menuCanvas, "Logo");
+        logo.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+
+        NetworkStatusChanged += HandleNetworkStatusChanged;
+
+        //Settings Controls
+        mSettingsWindow = new SettingsWindow(menuCanvas, this, null);
+
+        //Login Controls
+        mLoginWindow = new LoginWindow(menuCanvas, this);
+
+        //Register Controls
+        mRegisterWindow = new RegisterWindow(menuCanvas, this);
+
+        //Forgot Password Controls
+        mForgotPasswordWindow = new ForgotPasswordWindow(menuCanvas, this);
+
+        //Reset Password Controls
+        mResetPasswordWindow = new ResetPasswordWindow(menuCanvas, this);
+
+        //Character Selection Controls
+        mSelectCharacterWindow = new SelectCharacterWindow(mMenuCanvas, this);
+
+        //Character Creation Controls
+        mCreateCharacterWindow = new CreateCharacterWindow(mMenuCanvas, this, mSelectCharacterWindow);
+
+        //Credits Controls
+        mCreditsWindow = new CreditsWindow(mMenuCanvas, this);
+    }
+
+    ~MainMenu()
+    {
+        // ReSharper disable once DelegateSubtraction
+        NetworkStatusChanged -= HandleNetworkStatusChanged;
+    }
+
+    //Methods
+    public void Update()
+    {
+        if (_mainMenuWindow.IsVisible)
         {
-            ReceivedConfiguration?.Invoke(default, EventArgs.Empty);
+            _mainMenuWindow.Update();
         }
 
-        internal static event EventHandler? ReceivedConfiguration;
-
-        public delegate void NetworkStatusHandler();
-
-        public static NetworkStatus ActiveNetworkStatus;
-
-        public static NetworkStatusHandler NetworkStatusChanged;
-
-        private readonly CreateCharacterWindow mCreateCharacterWindow;
-
-        private readonly CreditsWindow mCreditsWindow;
-
-        private readonly ForgotPasswordWindow mForgotPasswordWindow;
-
-        private readonly LoginWindow mLoginWindow;
-
-        //Controls
-        private readonly Canvas mMenuCanvas;
-
-        private readonly Label mMenuHeader;
-
-        private readonly SettingsWindow mSettingsWindow;
-
-        private readonly RegisterWindow mRegisterWindow;
-
-        private readonly ResetPasswordWindow mResetPasswordWindow;
-
-        private readonly SelectCharacterWindow mSelectCharacterWindow;
-
-        //Character creation feild check
-        private bool mHasMadeCharacterCreation;
-
-        private bool mShouldOpenCharacterCreation;
-
-        private bool mShouldOpenCharacterSelection;
-
-        private readonly MainMenuWindow _mainMenuWindow;
-
-        //Init
-        public MainMenu(Canvas menuCanvas) : base(menuCanvas)
+        if (mShouldOpenCharacterSelection)
         {
-            mMenuCanvas = menuCanvas;
-
-            _mainMenuWindow = new MainMenuWindow(mMenuCanvas, this);
-
-            var logo = new ImagePanel(menuCanvas, "Logo");
-            logo.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
-
-            NetworkStatusChanged += HandleNetworkStatusChanged;
-
-            //Settings Controls
-            mSettingsWindow = new SettingsWindow(menuCanvas, this, null);
-
-            //Login Controls
-            mLoginWindow = new LoginWindow(menuCanvas, this);
-
-            //Register Controls
-            mRegisterWindow = new RegisterWindow(menuCanvas, this);
-
-            //Forgot Password Controls
-            mForgotPasswordWindow = new ForgotPasswordWindow(menuCanvas, this);
-
-            //Reset Password Controls
-            mResetPasswordWindow = new ResetPasswordWindow(menuCanvas, this);
-
-            //Character Selection Controls
-            mSelectCharacterWindow = new SelectCharacterWindow(mMenuCanvas, this);
-
-            //Character Creation Controls
-            mCreateCharacterWindow = new CreateCharacterWindow(mMenuCanvas, this, mSelectCharacterWindow);
-
-            //Credits Controls
-            mCreditsWindow = new CreditsWindow(mMenuCanvas, this);
+            CreateCharacterSelection();
         }
 
-        ~MainMenu()
+        if (mShouldOpenCharacterCreation)
         {
-            // ReSharper disable once DelegateSubtraction
-            NetworkStatusChanged -= HandleNetworkStatusChanged;
+            CreateCharacterCreation();
         }
 
-        //Methods
-        public void Update()
+        if (!mLoginWindow.IsHidden)
         {
-            if (_mainMenuWindow.IsVisible)
-            {
-                _mainMenuWindow.Update();
-            }
-
-            if (mShouldOpenCharacterSelection)
-            {
-                CreateCharacterSelection();
-            }
-
-            if (mShouldOpenCharacterCreation)
-            {
-                CreateCharacterCreation();
-            }
-
-            if (!mLoginWindow.IsHidden)
-            {
-                mLoginWindow.Update();
-            }
-
-            if (!mCreateCharacterWindow.IsHidden)
-            {
-                mCreateCharacterWindow.Update();
-            }
-
-            if (!mRegisterWindow.IsHidden)
-            {
-                mRegisterWindow.Update();
-            }
-
-            if (!mSelectCharacterWindow.IsHidden)
-            {
-                mSelectCharacterWindow.Update();
-            }
-
-            mSettingsWindow.Update();
+            mLoginWindow.Update();
         }
 
-        public void Reset()
+        if (!mCreateCharacterWindow.IsHidden)
         {
-            mLoginWindow.Hide();
-            mRegisterWindow.Hide();
-            mSettingsWindow.Hide();
-            mCreditsWindow.Hide();
-            mForgotPasswordWindow.Hide();
-            mResetPasswordWindow.Hide();
-            if (mCreateCharacterWindow != null)
-            {
-                mCreateCharacterWindow.Hide();
-            }
-
-            if (mSelectCharacterWindow != null)
-            {
-                mSelectCharacterWindow.Hide();
-            }
-
-            _mainMenuWindow.Show();
-            _mainMenuWindow.Reset();
+            mCreateCharacterWindow.Update();
         }
 
-        public void Show() => _mainMenuWindow.Show();
-
-        public void Hide() => _mainMenuWindow.Hide();
-
-        public void NotifyOpenCharacterSelection(List<Character> characters)
+        if (!mRegisterWindow.IsHidden)
         {
-            mShouldOpenCharacterSelection = true;
-            mSelectCharacterWindow.Characters = characters;
+            mRegisterWindow.Update();
         }
 
-        public void NotifyOpenForgotPassword()
+        if (!mSelectCharacterWindow.IsHidden)
         {
-            Reset();
-            Hide();
-            mForgotPasswordWindow.Show();
+            mSelectCharacterWindow.Update();
         }
 
-        public void NotifyOpenLogin()
+        mSettingsWindow.Update();
+    }
+
+    public void Reset()
+    {
+        mLoginWindow.Hide();
+        mRegisterWindow.Hide();
+        mSettingsWindow.Hide();
+        mCreditsWindow.Hide();
+        mForgotPasswordWindow.Hide();
+        mResetPasswordWindow.Hide();
+        if (mCreateCharacterWindow != null)
         {
-            Reset();
-            Hide();
+            mCreateCharacterWindow.Hide();
+        }
+
+        if (mSelectCharacterWindow != null)
+        {
+            mSelectCharacterWindow.Hide();
+        }
+
+        _mainMenuWindow.Show();
+        _mainMenuWindow.Reset();
+    }
+
+    public void Show() => _mainMenuWindow.Show();
+
+    public void Hide() => _mainMenuWindow.Hide();
+
+    public void NotifyOpenCharacterSelection(List<Character> characters)
+    {
+        mShouldOpenCharacterSelection = true;
+        mSelectCharacterWindow.Characters = characters;
+    }
+
+    public void NotifyOpenForgotPassword()
+    {
+        Reset();
+        Hide();
+        mForgotPasswordWindow.Show();
+    }
+
+    public void NotifyOpenLogin()
+    {
+        Reset();
+        Hide();
+        mLoginWindow.Show();
+    }
+
+    public void OpenResetPassword(string nameEmail)
+    {
+        Reset();
+        Hide();
+        mResetPasswordWindow.Target = nameEmail;
+        mResetPasswordWindow.Show();
+    }
+
+    public void CreateCharacterSelection()
+    {
+        Hide();
+        mLoginWindow.Hide();
+        mRegisterWindow.Hide();
+        mSettingsWindow.Hide();
+        mCreateCharacterWindow.Hide();
+        mSelectCharacterWindow.Show();
+        mShouldOpenCharacterSelection = false;
+    }
+
+    public void NotifyOpenCharacterCreation()
+    {
+        mShouldOpenCharacterCreation = true;
+    }
+
+    public void CreateCharacterCreation()
+    {
+        Hide();
+        mLoginWindow.Hide();
+        mRegisterWindow.Hide();
+        mSettingsWindow.Hide();
+        mSelectCharacterWindow.Hide();
+        mCreateCharacterWindow.Show();
+        mCreateCharacterWindow.Init();
+        mHasMadeCharacterCreation = true;
+        mShouldOpenCharacterCreation = false;
+    }
+
+    internal void SwitchToWindow<TMainMenuWindow>() where TMainMenuWindow : IMainMenuWindow
+    {
+        _mainMenuWindow.Hide();
+        if (typeof(TMainMenuWindow) == typeof(LoginWindow))
+        {
             mLoginWindow.Show();
         }
-
-        public void OpenResetPassword(string nameEmail)
+        else if (typeof(TMainMenuWindow) == typeof(RegisterWindow))
         {
-            Reset();
-            Hide();
-            mResetPasswordWindow.Target = nameEmail;
-            mResetPasswordWindow.Show();
+            mRegisterWindow.Show();
         }
-
-        public void CreateCharacterSelection()
+        else if (typeof(TMainMenuWindow) == typeof(CreditsWindow))
         {
-            Hide();
-            mLoginWindow.Hide();
-            mRegisterWindow.Hide();
-            mSettingsWindow.Hide();
-            mCreateCharacterWindow.Hide();
-            mSelectCharacterWindow.Show();
-            mShouldOpenCharacterSelection = false;
+            mCreditsWindow.Show();
         }
-
-        public void NotifyOpenCharacterCreation()
-        {
-            mShouldOpenCharacterCreation = true;
-        }
-
-        public void CreateCharacterCreation()
-        {
-            Hide();
-            mLoginWindow.Hide();
-            mRegisterWindow.Hide();
-            mSettingsWindow.Hide();
-            mSelectCharacterWindow.Hide();
-            mCreateCharacterWindow.Show();
-            mCreateCharacterWindow.Init();
-            mHasMadeCharacterCreation = true;
-            mShouldOpenCharacterCreation = false;
-        }
-
-        internal void SwitchToWindow<TMainMenuWindow>() where TMainMenuWindow : IMainMenuWindow
-        {
-            _mainMenuWindow.Hide();
-            if (typeof(TMainMenuWindow) == typeof(LoginWindow))
-            {
-                mLoginWindow.Show();
-            }
-            else if (typeof(TMainMenuWindow) == typeof(RegisterWindow))
-            {
-                mRegisterWindow.Show();
-            }
-            else if (typeof(TMainMenuWindow) == typeof(CreditsWindow))
-            {
-                mCreditsWindow.Show();
-            }
-        }
-
-        internal void SettingsButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Hide();
-            mSettingsWindow.Show(true);
-        }
-
-        private void HandleNetworkStatusChanged()
-        {
-            _mainMenuWindow.UpdateDisabled();
-        }
-
-        public static void SetNetworkStatus(NetworkStatus networkStatus, bool resetStatusCheck = false)
-        {
-            ActiveNetworkStatus = networkStatus;
-            NetworkStatusChanged?.Invoke();
-            LastNetworkStatusChangeTime = resetStatusCheck ? -1 : Timing.Global.MillisecondsUtc;
-        }
-
-        public static long LastNetworkStatusChangeTime { get; private set; }
     }
+
+    internal void SettingsButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        mSettingsWindow.Show(true);
+    }
+
+    private void HandleNetworkStatusChanged()
+    {
+        _mainMenuWindow.UpdateDisabled();
+    }
+
+    public static void SetNetworkStatus(NetworkStatus networkStatus, bool resetStatusCheck = false)
+    {
+        ActiveNetworkStatus = networkStatus;
+        NetworkStatusChanged?.Invoke();
+        LastNetworkStatusChangeTime = resetStatusCheck ? -1 : Timing.Global.MillisecondsUtc;
+    }
+
+    public static long LastNetworkStatusChangeTime { get; private set; }
 }

--- a/Intersect.Client/Interface/Menu/MenuGuiBase.cs
+++ b/Intersect.Client/Interface/Menu/MenuGuiBase.cs
@@ -4,98 +4,96 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class MenuGuiBase : IMutableInterface
 {
 
-    public partial class MenuGuiBase : IMutableInterface
+    private static MainMenu.NetworkStatusHandler sNetworkStatusChanged;
+
+    private readonly Canvas mMenuCanvas;
+
+    private readonly ImagePanel mServerStatusArea;
+
+    private readonly Label mServerStatusLabel;
+
+    public MainMenu MainMenu { get; }
+
+    private bool mShouldReset;
+
+    public MenuGuiBase(Canvas myCanvas)
     {
-
-        private static MainMenu.NetworkStatusHandler sNetworkStatusChanged;
-
-        private readonly Canvas mMenuCanvas;
-
-        private readonly ImagePanel mServerStatusArea;
-
-        private readonly Label mServerStatusLabel;
-
-        public MainMenu MainMenu { get; }
-
-        private bool mShouldReset;
-
-        public MenuGuiBase(Canvas myCanvas)
+        mMenuCanvas = myCanvas;
+        MainMenu = new MainMenu(mMenuCanvas);
+        mServerStatusArea = new ImagePanel(mMenuCanvas, "ServerStatusArea");
+        mServerStatusLabel = new Label(mServerStatusArea, "ServerStatusLabel")
         {
-            mMenuCanvas = myCanvas;
-            MainMenu = new MainMenu(mMenuCanvas);
-            mServerStatusArea = new ImagePanel(mMenuCanvas, "ServerStatusArea");
-            mServerStatusLabel = new Label(mServerStatusArea, "ServerStatusLabel")
-            {
-                IsHidden = ClientContext.IsSinglePlayer,
-                Text = Strings.Server.StatusLabel.ToString(MainMenu.ActiveNetworkStatus.ToLocalizedString()),
-            };
+            IsHidden = ClientContext.IsSinglePlayer,
+            Text = Strings.Server.StatusLabel.ToString(MainMenu.ActiveNetworkStatus.ToLocalizedString()),
+        };
 
-            mServerStatusArea.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
-            MainMenu.NetworkStatusChanged += HandleNetworkStatusChanged;
-        }
-
-        ~MenuGuiBase()
-        {
-            // ReSharper disable once DelegateSubtraction
-            MainMenu.NetworkStatusChanged -= HandleNetworkStatusChanged;
-        }
-
-        private void HandleNetworkStatusChanged()
-        {
-            mServerStatusLabel.Text =
-                Strings.Server.StatusLabel.ToString(MainMenu.ActiveNetworkStatus.ToLocalizedString());
-        }
-
-        public void Update()
-        {
-            if (mShouldReset)
-            {
-                MainMenu.Reset();
-                mShouldReset = false;
-            }
-
-            mServerStatusArea.IsHidden = ClientContext.IsSinglePlayer;
-            MainMenu.Update();
-        }
-
-        public void Draw()
-        {
-            mMenuCanvas.RenderCanvas();
-        }
-
-        public void Reset()
-        {
-            mShouldReset = true;
-        }
-
-        //Dispose
-        public void Dispose()
-        {
-            mMenuCanvas?.Dispose();
-        }
-
-        /// <inheritdoc />
-        public List<Base> Children => MainMenu.Children;
-
-        /// <inheritdoc />
-        public TElement Create<TElement>(params object[] parameters) where TElement : Base =>
-            MainMenu.Create<TElement>(parameters);
-
-        /// <inheritdoc />
-        public TElement Find<TElement>(string name = null, bool recurse = false) where TElement : Base =>
-            MainMenu.Find<TElement>(name, recurse);
-
-        /// <inheritdoc />
-        public IEnumerable<TElement> FindAll<TElement>(bool recurse = false) where TElement : Base =>
-            MainMenu.FindAll<TElement>(recurse);
-
-        /// <inheritdoc />
-        public void Remove<TElement>(TElement element, bool dispose = false) where TElement : Base =>
-            MainMenu.Remove(element, dispose);
-
+        mServerStatusArea.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+        MainMenu.NetworkStatusChanged += HandleNetworkStatusChanged;
     }
+
+    ~MenuGuiBase()
+    {
+        // ReSharper disable once DelegateSubtraction
+        MainMenu.NetworkStatusChanged -= HandleNetworkStatusChanged;
+    }
+
+    private void HandleNetworkStatusChanged()
+    {
+        mServerStatusLabel.Text =
+            Strings.Server.StatusLabel.ToString(MainMenu.ActiveNetworkStatus.ToLocalizedString());
+    }
+
+    public void Update()
+    {
+        if (mShouldReset)
+        {
+            MainMenu.Reset();
+            mShouldReset = false;
+        }
+
+        mServerStatusArea.IsHidden = ClientContext.IsSinglePlayer;
+        MainMenu.Update();
+    }
+
+    public void Draw()
+    {
+        mMenuCanvas.RenderCanvas();
+    }
+
+    public void Reset()
+    {
+        mShouldReset = true;
+    }
+
+    //Dispose
+    public void Dispose()
+    {
+        mMenuCanvas?.Dispose();
+    }
+
+    /// <inheritdoc />
+    public List<Base> Children => MainMenu.Children;
+
+    /// <inheritdoc />
+    public TElement Create<TElement>(params object[] parameters) where TElement : Base =>
+        MainMenu.Create<TElement>(parameters);
+
+    /// <inheritdoc />
+    public TElement Find<TElement>(string name = null, bool recurse = false) where TElement : Base =>
+        MainMenu.Find<TElement>(name, recurse);
+
+    /// <inheritdoc />
+    public IEnumerable<TElement> FindAll<TElement>(bool recurse = false) where TElement : Base =>
+        MainMenu.FindAll<TElement>(recurse);
+
+    /// <inheritdoc />
+    public void Remove<TElement>(TElement element, bool dispose = false) where TElement : Base =>
+        MainMenu.Remove(element, dispose);
 
 }

--- a/Intersect.Client/Interface/Menu/RegisterWindow.cs
+++ b/Intersect.Client/Interface/Menu/RegisterWindow.cs
@@ -11,269 +11,267 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class RegisterWindow : IMainMenuWindow
 {
 
-    public partial class RegisterWindow : IMainMenuWindow
+    private Button mBackBtn;
+
+    private ImagePanel mEmailBackground;
+
+    private Label mEmailLabel;
+
+    private TextBox mEmailTextbox;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    private ImagePanel mPasswordBackground;
+
+    private ImagePanel mPasswordBackground2;
+
+    private Label mPasswordLabel;
+
+    private Label mPasswordLabel2;
+
+    private TextBoxPassword mPasswordTextbox;
+
+    private TextBoxPassword mPasswordTextbox2;
+
+    private Button mRegisterBtn;
+
+    private Label mRegistrationHeader;
+
+    //Controls
+    private ImagePanel mRegistrationPanel;
+
+    private ImagePanel mUsernameBackground;
+
+    private Label mUsernameLabel;
+
+    private TextBox mUsernameTextbox;
+
+    //Init
+    public RegisterWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        private Button mBackBtn;
+        //Main Menu Window
+        mRegistrationPanel = new ImagePanel(parent, "RegistrationWindow");
 
-        private ImagePanel mEmailBackground;
+        //Menu Header
+        mRegistrationHeader = new Label(mRegistrationPanel, "RegistrationLabel");
+        mRegistrationHeader.SetText(Strings.Registration.Title);
 
-        private Label mEmailLabel;
+        //Register Username Background
+        mUsernameBackground = new ImagePanel(mRegistrationPanel, "UsernamePanel");
 
-        private TextBox mEmailTextbox;
+        //Register Username Label
+        mUsernameLabel = new Label(mUsernameBackground, "UsernameLabel");
+        mUsernameLabel.SetText(Strings.Registration.Username);
 
-        //Parent
-        private MainMenu mMainMenu;
-
-        private ImagePanel mPasswordBackground;
-
-        private ImagePanel mPasswordBackground2;
-
-        private Label mPasswordLabel;
-
-        private Label mPasswordLabel2;
-
-        private TextBoxPassword mPasswordTextbox;
-
-        private TextBoxPassword mPasswordTextbox2;
-
-        private Button mRegisterBtn;
-
-        private Label mRegistrationHeader;
-
-        //Controls
-        private ImagePanel mRegistrationPanel;
-
-        private ImagePanel mUsernameBackground;
-
-        private Label mUsernameLabel;
-
-        private TextBox mUsernameTextbox;
-
-        //Init
-        public RegisterWindow(Canvas parent, MainMenu mainMenu)
+        //Register Username Textbox
+        mUsernameTextbox = new TextBox(mUsernameBackground, "UsernameField")
         {
-            //Assign References
-            mMainMenu = mainMenu;
+            IsTabable = true,
+        };
+        mUsernameTextbox.SubmitPressed += UsernameTextbox_SubmitPressed;
 
-            //Main Menu Window
-            mRegistrationPanel = new ImagePanel(parent, "RegistrationWindow");
+        //Register Email Background
+        mEmailBackground = new ImagePanel(mRegistrationPanel, "EmailPanel");
 
-            //Menu Header
-            mRegistrationHeader = new Label(mRegistrationPanel, "RegistrationLabel");
-            mRegistrationHeader.SetText(Strings.Registration.Title);
+        //Register Email Label
+        mEmailLabel = new Label(mEmailBackground, "EmailLabel");
+        mEmailLabel.SetText(Strings.Registration.Email);
 
-            //Register Username Background
-            mUsernameBackground = new ImagePanel(mRegistrationPanel, "UsernamePanel");
+        //Register Email Textbox
+        mEmailTextbox = new TextBox(mEmailBackground, "EmailField")
+        {
+            IsTabable = true,
+        };
+        mEmailTextbox.SubmitPressed += EmailTextbox_SubmitPressed;
 
-            //Register Username Label
-            mUsernameLabel = new Label(mUsernameBackground, "UsernameLabel");
-            mUsernameLabel.SetText(Strings.Registration.Username);
+        //Register Password Background
+        mPasswordBackground = new ImagePanel(mRegistrationPanel, "Password1Panel");
 
-            //Register Username Textbox
-            mUsernameTextbox = new TextBox(mUsernameBackground, "UsernameField")
-            {
-                IsTabable = true,
-            };
-            mUsernameTextbox.SubmitPressed += UsernameTextbox_SubmitPressed;
+        //Register Password Label
+        mPasswordLabel = new Label(mPasswordBackground, "Password1Label");
+        mPasswordLabel.SetText(Strings.Registration.Password);
 
-            //Register Email Background
-            mEmailBackground = new ImagePanel(mRegistrationPanel, "EmailPanel");
+        //Register Password Textbox
+        mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "Password1Field")
+        {
+            IsTabable = true,
+        };
+        mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
 
-            //Register Email Label
-            mEmailLabel = new Label(mEmailBackground, "EmailLabel");
-            mEmailLabel.SetText(Strings.Registration.Email);
+        //Register Password Background
+        mPasswordBackground2 = new ImagePanel(mRegistrationPanel, "Password2Panel");
 
-            //Register Email Textbox
-            mEmailTextbox = new TextBox(mEmailBackground, "EmailField")
-            {
-                IsTabable = true,
-            };
-            mEmailTextbox.SubmitPressed += EmailTextbox_SubmitPressed;
+        //Register Password Label2
+        mPasswordLabel2 = new Label(mPasswordBackground2, "Password2Label");
+        mPasswordLabel2.SetText(Strings.Registration.ConfirmPassword);
 
-            //Register Password Background
-            mPasswordBackground = new ImagePanel(mRegistrationPanel, "Password1Panel");
+        //Register Password Textbox2
+        mPasswordTextbox2 = new TextBoxPassword(mPasswordBackground2, "Password2Field")
+        {
+            IsTabable = true,
+        };
+        mPasswordTextbox2.SubmitPressed += PasswordTextbox2_SubmitPressed;
 
-            //Register Password Label
-            mPasswordLabel = new Label(mPasswordBackground, "Password1Label");
-            mPasswordLabel.SetText(Strings.Registration.Password);
+        //Register - Send Registration Button
+        mRegisterBtn = new Button(mRegistrationPanel, "RegisterButton")
+        {
+            // IsTabable = true,
+            Text = Strings.Registration.Register,
+        };
+        mRegisterBtn.Clicked += RegisterBtn_Clicked;
 
-            //Register Password Textbox
-            mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "Password1Field")
-            {
-                IsTabable = true,
-            };
-            mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
+        //Register - Back Button
+        mBackBtn = new Button(mRegistrationPanel, "BackButton")
+        {
+            // IsTabable = true,
+            Text = Strings.Registration.Back,
+        };
+        mBackBtn.Clicked += BackBtn_Clicked;
 
-            //Register Password Background
-            mPasswordBackground2 = new ImagePanel(mRegistrationPanel, "Password2Panel");
+        mRegistrationPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    }
 
-            //Register Password Label2
-            mPasswordLabel2 = new Label(mPasswordBackground2, "Password2Label");
-            mPasswordLabel2.SetText(Strings.Registration.ConfirmPassword);
+    public bool IsHidden => mRegistrationPanel.IsHidden;
 
-            //Register Password Textbox2
-            mPasswordTextbox2 = new TextBoxPassword(mPasswordBackground2, "Password2Field")
-            {
-                IsTabable = true,
-            };
-            mPasswordTextbox2.SubmitPressed += PasswordTextbox2_SubmitPressed;
-
-            //Register - Send Registration Button
-            mRegisterBtn = new Button(mRegistrationPanel, "RegisterButton")
-            {
-                // IsTabable = true,
-                Text = Strings.Registration.Register,
-            };
-            mRegisterBtn.Clicked += RegisterBtn_Clicked;
-
-            //Register - Back Button
-            mBackBtn = new Button(mRegistrationPanel, "BackButton")
-            {
-                // IsTabable = true,
-                Text = Strings.Registration.Back,
-            };
-            mBackBtn.Clicked += BackBtn_Clicked;
-
-            mRegistrationPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    //Methods
+    public void Update()
+    {
+        if (!Networking.Network.IsConnected)
+        {
+            Hide();
+            mMainMenu.Show();
         }
 
-        public bool IsHidden => mRegistrationPanel.IsHidden;
-
-        //Methods
-        public void Update()
+        // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
+        if (!Globals.WaitingOnServer && mRegisterBtn.IsDisabled)
         {
-            if (!Networking.Network.IsConnected)
-            {
-                Hide();
-                mMainMenu.Show();
-            }
+            mRegisterBtn.Enable();
+        }
+    }
 
-            // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
-            if (!Globals.WaitingOnServer && mRegisterBtn.IsDisabled)
-            {
-                mRegisterBtn.Enable();
-            }
+    public void Show()
+    {
+        mRegistrationPanel.Show();
+        mUsernameTextbox.Focus();
+    }
+
+    public void Hide()
+    {
+        mRegistrationPanel.Hide();
+    }
+
+    private static string ComputePasswordHash(string password)
+    {
+        using (var sha = new SHA256Managed())
+        {
+            return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(password ?? ""))).Replace("-", "");
+        }
+    }
+
+    void TryRegister()
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
         }
 
-        public void Show()
+        if (Networking.Network.IsConnected)
         {
-            mRegistrationPanel.Show();
-            mUsernameTextbox.Focus();
-        }
-
-        public void Hide()
-        {
-            mRegistrationPanel.Hide();
-        }
-
-        private static string ComputePasswordHash(string password)
-        {
-            using (var sha = new SHA256Managed())
+            if (FieldChecking.IsValidUsername(mUsernameTextbox.Text, Strings.Regex.Username))
             {
-                return BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(password ?? ""))).Replace("-", "");
-            }
-        }
-
-        void TryRegister()
-        {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            if (Networking.Network.IsConnected)
-            {
-                if (FieldChecking.IsValidUsername(mUsernameTextbox.Text, Strings.Regex.Username))
+                if (mPasswordTextbox.Text == mPasswordTextbox2.Text)
                 {
-                    if (mPasswordTextbox.Text == mPasswordTextbox2.Text)
+                    if (FieldChecking.IsValidPassword(mPasswordTextbox.Text, Strings.Regex.Password))
                     {
-                        if (FieldChecking.IsValidPassword(mPasswordTextbox.Text, Strings.Regex.Password))
+                        if (FieldChecking.IsWellformedEmailAddress(mEmailTextbox.Text, Strings.Regex.Email))
                         {
-                            if (FieldChecking.IsWellformedEmailAddress(mEmailTextbox.Text, Strings.Regex.Email))
+                            Hide();
+
+                            //Hash Password
+                            using (var sha = new SHA256Managed())
                             {
-                                Hide();
+                                var hashedPass = BitConverter.ToString(
+                                        sha.ComputeHash(Encoding.UTF8.GetBytes(mPasswordTextbox.Text.Trim()))
+                                    )
+                                    .Replace("-", "");
 
-                                //Hash Password
-                                using (var sha = new SHA256Managed())
-                                {
-                                    var hashedPass = BitConverter.ToString(
-                                            sha.ComputeHash(Encoding.UTF8.GetBytes(mPasswordTextbox.Text.Trim()))
-                                        )
-                                        .Replace("-", "");
-
-                                    PacketSender.SendCreateAccount(
-                                        mUsernameTextbox.Text, hashedPass, mEmailTextbox.Text
-                                    );
-                                }
-
-                                Globals.WaitingOnServer = true;
-                                mRegisterBtn.Disable();
-                                ChatboxMsg.ClearMessages();
+                                PacketSender.SendCreateAccount(
+                                    mUsernameTextbox.Text, hashedPass, mEmailTextbox.Text
+                                );
                             }
-                            else
-                            {
-                                Interface.ShowError(Strings.Registration.EmailInvalid);
-                            }
+
+                            Globals.WaitingOnServer = true;
+                            mRegisterBtn.Disable();
+                            ChatboxMsg.ClearMessages();
                         }
                         else
                         {
-                            Interface.ShowError(Strings.Errors.PasswordInvalid);
+                            Interface.ShowError(Strings.Registration.EmailInvalid);
                         }
                     }
                     else
                     {
-                        Interface.ShowError(Strings.Registration.PasswordMismatch);
+                        Interface.ShowError(Strings.Errors.PasswordInvalid);
                     }
                 }
                 else
                 {
-                    Interface.ShowError(Strings.Errors.UsernameInvalid);
+                    Interface.ShowError(Strings.Registration.PasswordMismatch);
                 }
             }
             else
             {
-                Interface.ShowError(Strings.Errors.NotConnected);
+                Interface.ShowError(Strings.Errors.UsernameInvalid);
             }
         }
-
-        //Input Handlers
-        void UsernameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+        else
         {
-            TryRegister();
+            Interface.ShowError(Strings.Errors.NotConnected);
         }
+    }
 
-        void EmailTextbox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TryRegister();
-        }
+    //Input Handlers
+    void UsernameTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryRegister();
+    }
 
-        void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TryRegister();
-        }
+    void EmailTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryRegister();
+    }
 
-        void PasswordTextbox2_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TryRegister();
-        }
+    void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryRegister();
+    }
 
-        void RegisterBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            TryRegister();
-        }
+    void PasswordTextbox2_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TryRegister();
+    }
 
-        void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Hide();
-            mMainMenu.Show();
+    void RegisterBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        TryRegister();
+    }
 
-            Networking.Network.DebounceClose("returning_to_main_menu");
-        }
+    void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        mMainMenu.Show();
 
+        Networking.Network.DebounceClose("returning_to_main_menu");
     }
 
 }

--- a/Intersect.Client/Interface/Menu/ResetPasswordWindow.cs
+++ b/Intersect.Client/Interface/Menu/ResetPasswordWindow.cs
@@ -12,221 +12,219 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class ResetPasswordWindow
 {
 
-    public partial class ResetPasswordWindow
+    private Button mBackBtn;
+
+    //Reset Code
+    private ImagePanel mCodeInputBackground;
+
+    private Label mCodeInputLabel;
+
+    private TextBox mCodeInputTextbox;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    //Password Fields
+    private ImagePanel mPasswordBackground;
+
+    private ImagePanel mPasswordBackground2;
+
+    private Label mPasswordLabel;
+
+    private Label mPasswordLabel2;
+
+    private TextBoxPassword mPasswordTextbox;
+
+    private TextBoxPassword mPasswordTextbox2;
+
+    //Controls
+    private ImagePanel mResetWindow;
+
+    private Button mSubmitBtn;
+
+    private Label mWindowHeader;
+
+    //Init
+    public ResetPasswordWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        private Button mBackBtn;
+        //Main Menu Window
+        mResetWindow = new ImagePanel(parent, "ResetPasswordWindow");
+        mResetWindow.IsHidden = true;
 
-        //Reset Code
-        private ImagePanel mCodeInputBackground;
+        //Menu Header
+        mWindowHeader = new Label(mResetWindow, "Header");
+        mWindowHeader.SetText(Strings.ResetPass.Title);
 
-        private Label mCodeInputLabel;
+        //Code Fields/Labels
+        mCodeInputBackground = new ImagePanel(mResetWindow, "CodePanel");
 
-        private TextBox mCodeInputTextbox;
+        mCodeInputLabel = new Label(mCodeInputBackground, "CodeLabel");
+        mCodeInputLabel.SetText(Strings.ResetPass.Code);
 
-        //Parent
-        private MainMenu mMainMenu;
-
-        //Password Fields
-        private ImagePanel mPasswordBackground;
-
-        private ImagePanel mPasswordBackground2;
-
-        private Label mPasswordLabel;
-
-        private Label mPasswordLabel2;
-
-        private TextBoxPassword mPasswordTextbox;
-
-        private TextBoxPassword mPasswordTextbox2;
-
-        //Controls
-        private ImagePanel mResetWindow;
-
-        private Button mSubmitBtn;
-
-        private Label mWindowHeader;
-
-        //Init
-        public ResetPasswordWindow(Canvas parent, MainMenu mainMenu)
+        mCodeInputTextbox = new TextBox(mCodeInputBackground, "CodeField")
         {
-            //Assign References
-            mMainMenu = mainMenu;
+            IsTabable = true,
+        };
+        mCodeInputTextbox.SubmitPressed += Textbox_SubmitPressed;
+        mCodeInputTextbox.Clicked += Textbox_Clicked;
 
-            //Main Menu Window
-            mResetWindow = new ImagePanel(parent, "ResetPasswordWindow");
-            mResetWindow.IsHidden = true;
+        //Password Fields/Labels
+        //Register Password Background
+        mPasswordBackground = new ImagePanel(mResetWindow, "Password1Panel");
 
-            //Menu Header
-            mWindowHeader = new Label(mResetWindow, "Header");
-            mWindowHeader.SetText(Strings.ResetPass.Title);
+        mPasswordLabel = new Label(mPasswordBackground, "Password1Label");
+        mPasswordLabel.SetText(Strings.ResetPass.NewPassword);
 
-            //Code Fields/Labels
-            mCodeInputBackground = new ImagePanel(mResetWindow, "CodePanel");
+        mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "Password1Field")
+        {
+            IsTabable = true,
+        };
+        mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
 
-            mCodeInputLabel = new Label(mCodeInputBackground, "CodeLabel");
-            mCodeInputLabel.SetText(Strings.ResetPass.Code);
+        //Confirm Password Fields/Labels
+        mPasswordBackground2 = new ImagePanel(mResetWindow, "Password2Panel");
 
-            mCodeInputTextbox = new TextBox(mCodeInputBackground, "CodeField")
-            {
-                IsTabable = true,
-            };
-            mCodeInputTextbox.SubmitPressed += Textbox_SubmitPressed;
-            mCodeInputTextbox.Clicked += Textbox_Clicked;
+        mPasswordLabel2 = new Label(mPasswordBackground2, "Password2Label");
+        mPasswordLabel2.SetText(Strings.ResetPass.ConfirmPassword);
 
-            //Password Fields/Labels
-            //Register Password Background
-            mPasswordBackground = new ImagePanel(mResetWindow, "Password1Panel");
+        mPasswordTextbox2 = new TextBoxPassword(mPasswordBackground2, "Password2Field")
+        {
+            IsTabable = true,
+        };
+        mPasswordTextbox2.SubmitPressed += PasswordTextbox2_SubmitPressed;
 
-            mPasswordLabel = new Label(mPasswordBackground, "Password1Label");
-            mPasswordLabel.SetText(Strings.ResetPass.NewPassword);
+        //Login - Send Login Button
+        mSubmitBtn = new Button(mResetWindow, "SubmitButton")
+        {
+            IsTabable = true,
+        };
+        mSubmitBtn.SetText(Strings.ResetPass.Submit);
+        mSubmitBtn.Clicked += SubmitBtn_Clicked;
 
-            mPasswordTextbox = new TextBoxPassword(mPasswordBackground, "Password1Field")
-            {
-                IsTabable = true,
-            };
-            mPasswordTextbox.SubmitPressed += PasswordTextbox_SubmitPressed;
+        //Login - Back Button
+        mBackBtn = new Button(mResetWindow, "BackButton")
+        {
+            IsTabable = true,
+        };
+        mBackBtn.SetText(Strings.ResetPass.Back);
+        mBackBtn.Clicked += BackBtn_Clicked;
 
-            //Confirm Password Fields/Labels
-            mPasswordBackground2 = new ImagePanel(mResetWindow, "Password2Panel");
+        mResetWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    }
 
-            mPasswordLabel2 = new Label(mPasswordBackground2, "Password2Label");
-            mPasswordLabel2.SetText(Strings.ResetPass.ConfirmPassword);
+    public bool IsHidden => mResetWindow.IsHidden;
 
-            mPasswordTextbox2 = new TextBoxPassword(mPasswordBackground2, "Password2Field")
-            {
-                IsTabable = true,
-            };
-            mPasswordTextbox2.SubmitPressed += PasswordTextbox2_SubmitPressed;
+    //The username or email of the acc we are resetting the pass for
+    public string Target { set; get; } = "";
 
-            //Login - Send Login Button
-            mSubmitBtn = new Button(mResetWindow, "SubmitButton")
-            {
-                IsTabable = true,
-            };
-            mSubmitBtn.SetText(Strings.ResetPass.Submit);
-            mSubmitBtn.Clicked += SubmitBtn_Clicked;
+    private void Textbox_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Globals.InputManager.OpenKeyboard(
+            KeyboardType.Normal, mCodeInputTextbox.Text, false, false, false
+        );
+    }
 
-            //Login - Back Button
-            mBackBtn = new Button(mResetWindow, "BackButton")
-            {
-                IsTabable = true,
-            };
-            mBackBtn.SetText(Strings.ResetPass.Back);
-            mBackBtn.Clicked += BackBtn_Clicked;
+    //Methods
+    public void Update()
+    {
+        // ReSharper disable once InvertIf
+        if (!Networking.Network.IsConnected)
+        {
+            Hide();
+            mMainMenu.Show();
+        }
+    }
 
-            mResetWindow.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    public void Hide()
+    {
+        mResetWindow.IsHidden = true;
+    }
+
+    public void Show()
+    {
+        mResetWindow.IsHidden = false;
+        mCodeInputTextbox.Text = "";
+        mPasswordTextbox.Text = "";
+        mPasswordTextbox2.Text = "";
+    }
+
+    void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Hide();
+        Interface.MenuUi.MainMenu.NotifyOpenLogin();
+    }
+
+    void Textbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TrySendCode();
+    }
+
+    void SubmitBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        TrySendCode();
+    }
+
+    void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TrySendCode();
+    }
+
+    void PasswordTextbox2_SubmitPressed(Base sender, EventArgs arguments)
+    {
+        TrySendCode();
+    }
+
+    public void TrySendCode()
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
         }
 
-        public bool IsHidden => mResetWindow.IsHidden;
-
-        //The username or email of the acc we are resetting the pass for
-        public string Target { set; get; } = "";
-
-        private void Textbox_Clicked(Base sender, ClickedEventArgs arguments)
+        if (!Networking.Network.IsConnected)
         {
-            Globals.InputManager.OpenKeyboard(
-                KeyboardType.Normal, mCodeInputTextbox.Text, false, false, false
+            Interface.ShowError(Strings.Errors.NotConnected);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(mCodeInputTextbox?.Text))
+        {
+            Interface.ShowError(Strings.ResetPass.InputCode);
+            return;
+        }
+
+        if (mPasswordTextbox.Text != mPasswordTextbox2.Text)
+        {
+            Interface.ShowError(Strings.Registration.PasswordMismatch);
+            return;
+        }
+
+        if (!FieldChecking.IsValidPassword(mPasswordTextbox.Text, Strings.Regex.Password))
+        {
+            Interface.ShowError(Strings.Errors.PasswordInvalid);
+            return;
+        }
+
+        using (var sha = new SHA256Managed())
+        {
+            PacketSender.SendResetPassword(
+                Target, mCodeInputTextbox?.Text,
+                BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(mPasswordTextbox.Text.Trim())))
+                    .Replace("-", "")
             );
         }
 
-        //Methods
-        public void Update()
-        {
-            // ReSharper disable once InvertIf
-            if (!Networking.Network.IsConnected)
-            {
-                Hide();
-                mMainMenu.Show();
-            }
-        }
-
-        public void Hide()
-        {
-            mResetWindow.IsHidden = true;
-        }
-
-        public void Show()
-        {
-            mResetWindow.IsHidden = false;
-            mCodeInputTextbox.Text = "";
-            mPasswordTextbox.Text = "";
-            mPasswordTextbox2.Text = "";
-        }
-
-        void BackBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Hide();
-            Interface.MenuUi.MainMenu.NotifyOpenLogin();
-        }
-
-        void Textbox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TrySendCode();
-        }
-
-        void SubmitBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            TrySendCode();
-        }
-
-        void PasswordTextbox_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TrySendCode();
-        }
-
-        void PasswordTextbox2_SubmitPressed(Base sender, EventArgs arguments)
-        {
-            TrySendCode();
-        }
-
-        public void TrySendCode()
-        {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            if (!Networking.Network.IsConnected)
-            {
-                Interface.ShowError(Strings.Errors.NotConnected);
-                return;
-            }
-
-            if (string.IsNullOrEmpty(mCodeInputTextbox?.Text))
-            {
-                Interface.ShowError(Strings.ResetPass.InputCode);
-                return;
-            }
-
-            if (mPasswordTextbox.Text != mPasswordTextbox2.Text)
-            {
-                Interface.ShowError(Strings.Registration.PasswordMismatch);
-                return;
-            }
-
-            if (!FieldChecking.IsValidPassword(mPasswordTextbox.Text, Strings.Regex.Password))
-            {
-                Interface.ShowError(Strings.Errors.PasswordInvalid);
-                return;
-            }
-
-            using (var sha = new SHA256Managed())
-            {
-                PacketSender.SendResetPassword(
-                    Target, mCodeInputTextbox?.Text,
-                    BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(mPasswordTextbox.Text.Trim())))
-                        .Replace("-", "")
-                );
-            }
-
-            Globals.WaitingOnServer = true;
-            ChatboxMsg.ClearMessages();
-        }
-
+        Globals.WaitingOnServer = true;
+        ChatboxMsg.ClearMessages();
     }
 
 }

--- a/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
+++ b/Intersect.Client/Interface/Menu/SelectCharacterWindow.cs
@@ -9,481 +9,479 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Client.Interface.Menu
+namespace Intersect.Client.Interface.Menu;
+
+
+public partial class SelectCharacterWindow
 {
 
-    public partial class SelectCharacterWindow
+    public List<Character> Characters = new List<Character>();
+
+    private ImagePanel mCharacterContainer;
+
+    private ImagePanel mCharacterPortrait;
+
+    //Image
+    private string mCharacterPortraitImg = "";
+
+    private Label mCharacterSelectionHeader;
+
+    private ImagePanel mCharacterSelectionPanel;
+
+    private Label mCharnameLabel;
+
+    private Button mDeleteButton;
+
+    private Label mInfoLabel;
+
+    private Button mLogoutButton;
+
+    //Parent
+    private MainMenu mMainMenu;
+
+    private Button mNewButton;
+
+    //Controls
+    private Button mNextCharButton;
+
+    private ImagePanel[] mPaperdollPortraits;
+
+    private Button mPlayButton;
+
+    private Button mPrevCharButton;
+
+    //Selected Char
+    private int mSelectedChar = 0;
+
+    //Init
+    public SelectCharacterWindow(Canvas parent, MainMenu mainMenu)
     {
+        //Assign References
+        mMainMenu = mainMenu;
 
-        public List<Character> Characters = new List<Character>();
+        //Main Menu Window
+        mCharacterSelectionPanel = new ImagePanel(parent, "CharacterSelectionWindow");
 
-        private ImagePanel mCharacterContainer;
+        //Menu Header
+        mCharacterSelectionHeader = new Label(mCharacterSelectionPanel, "CharacterSelectionHeader");
+        mCharacterSelectionHeader.SetText(Strings.CharacterSelection.Title);
 
-        private ImagePanel mCharacterPortrait;
+        //Character Name
+        mCharnameLabel = new Label(mCharacterSelectionPanel, "CharacterNameLabel");
+        mCharnameLabel.SetText(Strings.CharacterSelection.Empty);
 
-        //Image
-        private string mCharacterPortraitImg = "";
+        //Character Info
+        mInfoLabel = new Label(mCharacterSelectionPanel, "CharacterInfoLabel");
+        mInfoLabel.SetText(Strings.CharacterSelection.New);
 
-        private Label mCharacterSelectionHeader;
+        //Character Container
+        mCharacterContainer = new ImagePanel(mCharacterSelectionPanel, "CharacterContainer");
 
-        private ImagePanel mCharacterSelectionPanel;
+        //Next char Button
+        mNextCharButton = new Button(mCharacterContainer, "NextCharacterButton");
+        mNextCharButton.Clicked += _nextCharButton_Clicked;
 
-        private Label mCharnameLabel;
+        //Prev Char Button
+        mPrevCharButton = new Button(mCharacterContainer, "PreviousCharacterButton");
+        mPrevCharButton.Clicked += _prevCharButton_Clicked;
 
-        private Button mDeleteButton;
+        //Play Button
+        mPlayButton = new Button(mCharacterSelectionPanel, "PlayButton");
+        mPlayButton.SetText(Strings.CharacterSelection.Play);
+        mPlayButton.Clicked += _playButton_Clicked;
+        mPlayButton.Hide();
 
-        private Label mInfoLabel;
+        //Delete Button
+        mDeleteButton = new Button(mCharacterSelectionPanel, "DeleteButton");
+        mDeleteButton.SetText(Strings.CharacterSelection.Delete);
+        mDeleteButton.Clicked += _deleteButton_Clicked;
+        mDeleteButton.Hide();
 
-        private Button mLogoutButton;
+        //Create new char Button
+        mNewButton = new Button(mCharacterSelectionPanel, "NewButton");
+        mNewButton.SetText(Strings.CharacterSelection.New);
+        mNewButton.Clicked += _newButton_Clicked;
 
-        //Parent
-        private MainMenu mMainMenu;
+        //Logout Button
+        mLogoutButton = new Button(mCharacterSelectionPanel, "LogoutButton");
+        mLogoutButton.SetText(Strings.CharacterSelection.Logout);
+        mLogoutButton.IsHidden = true;
+        mLogoutButton.Clicked += mLogoutButton_Clicked;
 
-        private Button mNewButton;
+        mCharacterSelectionPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+    }
 
-        //Controls
-        private Button mNextCharButton;
+    public bool IsHidden => mCharacterSelectionPanel.IsHidden;
 
-        private ImagePanel[] mPaperdollPortraits;
-
-        private Button mPlayButton;
-
-        private Button mPrevCharButton;
-
-        //Selected Char
-        private int mSelectedChar = 0;
-
-        //Init
-        public SelectCharacterWindow(Canvas parent, MainMenu mainMenu)
+    //Methods
+    public void Update()
+    {
+        if (!Networking.Network.IsConnected)
         {
-            //Assign References
-            mMainMenu = mainMenu;
-
-            //Main Menu Window
-            mCharacterSelectionPanel = new ImagePanel(parent, "CharacterSelectionWindow");
-
-            //Menu Header
-            mCharacterSelectionHeader = new Label(mCharacterSelectionPanel, "CharacterSelectionHeader");
-            mCharacterSelectionHeader.SetText(Strings.CharacterSelection.Title);
-
-            //Character Name
-            mCharnameLabel = new Label(mCharacterSelectionPanel, "CharacterNameLabel");
-            mCharnameLabel.SetText(Strings.CharacterSelection.Empty);
-
-            //Character Info
-            mInfoLabel = new Label(mCharacterSelectionPanel, "CharacterInfoLabel");
-            mInfoLabel.SetText(Strings.CharacterSelection.New);
-
-            //Character Container
-            mCharacterContainer = new ImagePanel(mCharacterSelectionPanel, "CharacterContainer");
-
-            //Next char Button
-            mNextCharButton = new Button(mCharacterContainer, "NextCharacterButton");
-            mNextCharButton.Clicked += _nextCharButton_Clicked;
-
-            //Prev Char Button
-            mPrevCharButton = new Button(mCharacterContainer, "PreviousCharacterButton");
-            mPrevCharButton.Clicked += _prevCharButton_Clicked;
-
-            //Play Button
-            mPlayButton = new Button(mCharacterSelectionPanel, "PlayButton");
-            mPlayButton.SetText(Strings.CharacterSelection.Play);
-            mPlayButton.Clicked += _playButton_Clicked;
-            mPlayButton.Hide();
-
-            //Delete Button
-            mDeleteButton = new Button(mCharacterSelectionPanel, "DeleteButton");
-            mDeleteButton.SetText(Strings.CharacterSelection.Delete);
-            mDeleteButton.Clicked += _deleteButton_Clicked;
-            mDeleteButton.Hide();
-
-            //Create new char Button
-            mNewButton = new Button(mCharacterSelectionPanel, "NewButton");
-            mNewButton.SetText(Strings.CharacterSelection.New);
-            mNewButton.Clicked += _newButton_Clicked;
-
-            //Logout Button
-            mLogoutButton = new Button(mCharacterSelectionPanel, "LogoutButton");
-            mLogoutButton.SetText(Strings.CharacterSelection.Logout);
-            mLogoutButton.IsHidden = true;
-            mLogoutButton.Clicked += mLogoutButton_Clicked;
-
-            mCharacterSelectionPanel.LoadJsonUi(GameContentManager.UI.Menu, Graphics.Renderer.GetResolutionString());
+            Hide();
+            mMainMenu.Show();
         }
 
-        public bool IsHidden => mCharacterSelectionPanel.IsHidden;
-
-        //Methods
-        public void Update()
+        // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
+        if (!Globals.WaitingOnServer)
         {
-            if (!Networking.Network.IsConnected)
+            if (mPlayButton.IsDisabled)
             {
-                Hide();
-                mMainMenu.Show();
+                mPlayButton.Enable();
             }
 
-            // Re-Enable our buttons if we're not waiting for the server anymore with it disabled.
-            if (!Globals.WaitingOnServer)
+            if (mNewButton.IsDisabled)
             {
-                if (mPlayButton.IsDisabled)
-                {
-                    mPlayButton.Enable();
-                }
+                mNewButton.Enable();
+            }
 
-                if (mNewButton.IsDisabled)
-                {
-                    mNewButton.Enable();
-                }
+            if (mDeleteButton.IsDisabled)
+            {
+                mDeleteButton.Enable();
+            }
 
-                if (mDeleteButton.IsDisabled)
-                {
-                    mDeleteButton.Enable();
-                }
-
-                if (mLogoutButton.IsDisabled)
-                {
-                    mLogoutButton.Enable();
-                }
+            if (mLogoutButton.IsDisabled)
+            {
+                mLogoutButton.Enable();
             }
         }
+    }
 
-        private void UpdateDisplay()
+    private void UpdateDisplay()
+    {
+        var isFace = true;
+
+        //Show and hide Options based on the character count
+        if (Characters.Count > 1)
         {
-            var isFace = true;
+            mNextCharButton.Show();
+            mPrevCharButton.Show();
+        }
 
-            //Show and hide Options based on the character count
-            if (Characters.Count > 1)
-            {
-                mNextCharButton.Show();
-                mPrevCharButton.Show();
-            }
+        if (Characters.Count <= 1)
+        {
+            mNextCharButton.Hide();
+            mPrevCharButton.Hide();
+        }
 
-            if (Characters.Count <= 1)
-            {
-                mNextCharButton.Hide();
-                mPrevCharButton.Hide();
-            }
-
-            if (mPaperdollPortraits == null)
-            {
-                mPaperdollPortraits = new ImagePanel[Options.EquipmentSlots.Count + 1];
-                mCharacterPortrait = new ImagePanel(mCharacterContainer);
-                for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
-                {
-                    mPaperdollPortraits[i] = new ImagePanel(mCharacterContainer);
-                }
-
-                mNextCharButton.BringToFront();
-                mPrevCharButton.BringToFront();
-            }
-
-            for (var i = 0; i < mPaperdollPortraits.Length; i++)
-            {
-                mPaperdollPortraits[i]?.Hide();
-            }
-
-            if (Characters[mSelectedChar] == null)
-            {
-                mPlayButton.Hide();
-                mDeleteButton.Hide();
-                mNewButton.Show();
-
-                mCharnameLabel.SetText(Strings.CharacterSelection.Empty);
-                mInfoLabel.SetText("");
-
-                mCharacterPortrait.Texture = null;
-                return;
-            }
-
-
-            mCharnameLabel.SetText(Strings.CharacterSelection.Name.ToString(Characters[mSelectedChar].Name));
-            mInfoLabel.SetText(
-                Strings.CharacterSelection.Info.ToString(
-                    Characters[mSelectedChar].Level, Characters[mSelectedChar].Class
-                )
-            );
-
-            mPlayButton.Show();
-            mDeleteButton.Show();
-            mNewButton.Hide();
-
+        if (mPaperdollPortraits == null)
+        {
+            mPaperdollPortraits = new ImagePanel[Options.EquipmentSlots.Count + 1];
+            mCharacterPortrait = new ImagePanel(mCharacterContainer);
             for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
             {
-                if (string.Equals("Player", Characters[mSelectedChar].Equipment[i]?.Name, StringComparison.Ordinal))
-                {
-                    mCharacterPortrait = mPaperdollPortraits[i];
-                }
+                mPaperdollPortraits[i] = new ImagePanel(mCharacterContainer);
             }
 
-            if (mCharacterPortrait == null)
+            mNextCharButton.BringToFront();
+            mPrevCharButton.BringToFront();
+        }
+
+        for (var i = 0; i < mPaperdollPortraits.Length; i++)
+        {
+            mPaperdollPortraits[i]?.Hide();
+        }
+
+        if (Characters[mSelectedChar] == null)
+        {
+            mPlayButton.Hide();
+            mDeleteButton.Hide();
+            mNewButton.Show();
+
+            mCharnameLabel.SetText(Strings.CharacterSelection.Empty);
+            mInfoLabel.SetText("");
+
+            mCharacterPortrait.Texture = null;
+            return;
+        }
+
+
+        mCharnameLabel.SetText(Strings.CharacterSelection.Name.ToString(Characters[mSelectedChar].Name));
+        mInfoLabel.SetText(
+            Strings.CharacterSelection.Info.ToString(
+                Characters[mSelectedChar].Level, Characters[mSelectedChar].Class
+            )
+        );
+
+        mPlayButton.Show();
+        mDeleteButton.Show();
+        mNewButton.Hide();
+
+        for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
+        {
+            if (string.Equals("Player", Characters[mSelectedChar].Equipment[i]?.Name, StringComparison.Ordinal))
             {
-                mCharacterPortrait = mPaperdollPortraits[0];
+                mCharacterPortrait = mPaperdollPortraits[i];
             }
+        }
 
-            var portraitTexture = Globals.ContentManager.GetTexture(
-                Framework.Content.TextureType.Face, Characters[mSelectedChar].Face
+        if (mCharacterPortrait == null)
+        {
+            mCharacterPortrait = mPaperdollPortraits[0];
+        }
+
+        var portraitTexture = Globals.ContentManager.GetTexture(
+            Framework.Content.TextureType.Face, Characters[mSelectedChar].Face
+        );
+
+        if (portraitTexture == null)
+        {
+            portraitTexture = Globals.ContentManager.GetTexture(
+                Framework.Content.TextureType.Entity, Characters[mSelectedChar].Sprite
             );
 
-            if (portraitTexture == null)
+            isFace = false;
+        }
+
+        mCharacterPortrait.Texture = portraitTexture;
+
+        if (portraitTexture != null)
+        {
+            if (isFace)
             {
-                portraitTexture = Globals.ContentManager.GetTexture(
-                    Framework.Content.TextureType.Entity, Characters[mSelectedChar].Sprite
+                mCharacterPortrait.SetTextureRect(
+                    0, 0, mCharacterPortrait.Texture.GetWidth(), mCharacterPortrait.Texture.GetHeight()
                 );
 
-                isFace = false;
+                var scale = Math.Min(
+                    mCharacterContainer.InnerWidth / (double)mCharacterPortrait.Texture.GetWidth(),
+                    mCharacterContainer.InnerHeight / (double)mCharacterPortrait.Texture.GetHeight()
+                );
+
+                mCharacterPortrait.SetSize(
+                    (int)(mCharacterPortrait.Texture.GetWidth() * scale),
+                    (int)(mCharacterPortrait.Texture.GetHeight() * scale)
+                );
+
+                mCharacterPortrait.SetPosition(
+                    mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
+                    mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
+                );
+
+                mCharacterPortrait.Show();
             }
-
-            mCharacterPortrait.Texture = portraitTexture;
-
-            if (portraitTexture != null)
+            else
             {
-                if (isFace)
+                mCharacterPortrait.SetTextureRect(
+                    0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                );
+
+                mCharacterPortrait.SetSize(
+                    mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                );
+
+                mCharacterPortrait.SetPosition(
+                    mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
+                    mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
+                );
+
+                for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
                 {
-                    mCharacterPortrait.SetTextureRect(
-                        0, 0, mCharacterPortrait.Texture.GetWidth(), mCharacterPortrait.Texture.GetHeight()
-                    );
+                    var equipment = Characters[mSelectedChar].Equipment[i];
+                    var paperdollPortrait = mPaperdollPortraits[i];
 
-                    var scale = Math.Min(
-                        mCharacterContainer.InnerWidth / (double)mCharacterPortrait.Texture.GetWidth(),
-                        mCharacterContainer.InnerHeight / (double)mCharacterPortrait.Texture.GetHeight()
-                    );
-
-                    mCharacterPortrait.SetSize(
-                        (int)(mCharacterPortrait.Texture.GetWidth() * scale),
-                        (int)(mCharacterPortrait.Texture.GetHeight() * scale)
-                    );
-
-                    mCharacterPortrait.SetPosition(
-                        mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
-                        mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
-                    );
-
-                    mCharacterPortrait.Show();
-                }
-                else
-                {
-                    mCharacterPortrait.SetTextureRect(
-                        0, 0, mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                    );
-
-                    mCharacterPortrait.SetSize(
-                        mCharacterPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames, mCharacterPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                    );
-
-                    mCharacterPortrait.SetPosition(
-                        mCharacterContainer.Width / 2 - mCharacterPortrait.Width / 2,
-                        mCharacterContainer.Height / 2 - mCharacterPortrait.Height / 2
-                    );
-
-                    for (var i = 0; i <= Options.EquipmentSlots.Count; i++)
+                    if (paperdollPortrait != mCharacterPortrait)
                     {
-                        var equipment = Characters[mSelectedChar].Equipment[i];
-                        var paperdollPortrait = mPaperdollPortraits[i];
-
-                        if (paperdollPortrait != mCharacterPortrait)
+                        if (equipment == null)
                         {
-                            if (equipment == null)
-                            {
-                                paperdollPortrait.Texture = null;
-                                continue;
-                            }
-
-                            paperdollPortrait.Texture = Globals.ContentManager.GetTexture(
-                                Framework.Content.TextureType.Paperdoll, equipment.Name
-                            );
-
-                            if (paperdollPortrait.Texture != null)
-                            {
-                                paperdollPortrait
-                                    .SetTextureRect(
-                                        0, 0, paperdollPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                        paperdollPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                    );
-
-                                paperdollPortrait
-                                    .SetSize(
-                                        paperdollPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
-                                        paperdollPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
-                                    );
-
-                                paperdollPortrait
-                                    .SetPosition(
-                                        (mCharacterContainer.Width - paperdollPortrait.Width) / 2,
-                                        (mCharacterContainer.Height - paperdollPortrait.Height) / 2
-                                    );
-
-                                paperdollPortrait.RenderColor = equipment.RenderColor;
-
-                                paperdollPortrait.Show();
-                            }
+                            paperdollPortrait.Texture = null;
+                            continue;
                         }
-                        else if (paperdollPortrait.Texture != null)
+
+                        paperdollPortrait.Texture = Globals.ContentManager.GetTexture(
+                            Framework.Content.TextureType.Paperdoll, equipment.Name
+                        );
+
+                        if (paperdollPortrait.Texture != null)
                         {
+                            paperdollPortrait
+                                .SetTextureRect(
+                                    0, 0, paperdollPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    paperdollPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                                );
+
+                            paperdollPortrait
+                                .SetSize(
+                                    paperdollPortrait.Texture.GetWidth() / Options.Instance.Sprites.NormalFrames,
+                                    paperdollPortrait.Texture.GetHeight() / Options.Instance.Sprites.Directions
+                                );
+
+                            paperdollPortrait
+                                .SetPosition(
+                                    (mCharacterContainer.Width - paperdollPortrait.Width) / 2,
+                                    (mCharacterContainer.Height - paperdollPortrait.Height) / 2
+                                );
+
+                            paperdollPortrait.RenderColor = equipment.RenderColor;
+
                             paperdollPortrait.Show();
                         }
+                    }
+                    else if (paperdollPortrait.Texture != null)
+                    {
+                        paperdollPortrait.Show();
                     }
                 }
             }
         }
-
-        public void Show()
-        {
-            mSelectedChar = 0;
-            UpdateDisplay();
-            mCharacterSelectionPanel.Show();
-        }
-
-        public void Hide()
-        {
-            mCharacterSelectionPanel.Hide();
-        }
-
-        private void mLogoutButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            Main.Logout(false, skipFade: true);
-            mMainMenu.Reset();
-        }
-
-        private void _prevCharButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mSelectedChar--;
-            if (mSelectedChar < 0)
-            {
-                mSelectedChar = Characters.Count - 1;
-            }
-
-            UpdateDisplay();
-        }
-
-        private void _nextCharButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mSelectedChar++;
-            if (mSelectedChar >= Characters.Count)
-            {
-                mSelectedChar = 0;
-            }
-
-            UpdateDisplay();
-        }
-
-        private void _playButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            ChatboxMsg.ClearMessages();
-            PacketSender.SendSelectCharacter(Characters[mSelectedChar].Id);
-
-            Globals.WaitingOnServer = true;
-            mPlayButton.Disable();
-            mNewButton.Disable();
-            mDeleteButton.Disable();
-            mLogoutButton.Disable();
-        }
-
-        private void _deleteButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            var iBox = new InputBox(
-                Strings.CharacterSelection.DeleteTitle.ToString(Characters[mSelectedChar].Name),
-                Strings.CharacterSelection.DeletePrompt.ToString(Characters[mSelectedChar].Name), true,
-                InputBox.InputType.YesNo, DeleteCharacter, null, Characters[mSelectedChar].Id, 0, 0,
-                mCharacterSelectionPanel.Parent, GameContentManager.UI.Menu
-            );
-        }
-
-        private void DeleteCharacter(Object sender, EventArgs e)
-        {
-            PacketSender.SendDeleteCharacter((Guid) ((InputBox) sender).UserData);
-
-            Globals.WaitingOnServer = true;
-            mPlayButton.Disable();
-            mNewButton.Disable();
-            mDeleteButton.Disable();
-            mLogoutButton.Disable();
-
-            mSelectedChar = 0;
-            UpdateDisplay();
-        }
-
-        private void _newButton_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            if (Globals.WaitingOnServer)
-            {
-                return;
-            }
-
-            PacketSender.SendNewCharacter();
-
-            Globals.WaitingOnServer = true;
-            mPlayButton.Disable();
-            mNewButton.Disable();
-            mDeleteButton.Disable();
-            mLogoutButton.Disable();
-        }
-
     }
 
-    public partial class Character
+    public void Show()
     {
+        mSelectedChar = 0;
+        UpdateDisplay();
+        mCharacterSelectionPanel.Show();
+    }
 
-        public string Class = "";
+    public void Hide()
+    {
+        mCharacterSelectionPanel.Hide();
+    }
 
-        public EquipmentFragment[] Equipment = new EquipmentFragment[Options.EquipmentSlots.Count + 1];
+    private void mLogoutButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        Main.Logout(false, skipFade: true);
+        mMainMenu.Reset();
+    }
 
-        public bool Exists = false;
-
-        public string Face = "";
-
-        public Guid Id;
-
-        public int Level = 1;
-
-        public string Name = "";
-
-        public string Sprite = "";
-
-        public Character(Guid id)
+    private void _prevCharButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mSelectedChar--;
+        if (mSelectedChar < 0)
         {
-            Id = id;
+            mSelectedChar = Characters.Count - 1;
         }
 
-        public Character(
-            Guid id,
-            string name,
-            string sprite,
-            string face,
-            int level,
-            string charClass,
-            EquipmentFragment[] equipment
-        )
+        UpdateDisplay();
+    }
+
+    private void _nextCharButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mSelectedChar++;
+        if (mSelectedChar >= Characters.Count)
         {
-            Equipment = equipment;
-            Id = id;
-            Name = name;
-            Sprite = sprite;
-            Face = face;
-            Level = level;
-            Class = charClass;
-            Exists = true;
+            mSelectedChar = 0;
         }
 
-        public Character()
-        {
-            for (var i = 0; i < Options.EquipmentSlots.Count + 1; i++)
-            {
-                Equipment[i] = default;
-            }
+        UpdateDisplay();
+    }
 
-            Equipment[0] = new EquipmentFragment { Name = "Player" };
+    private void _playButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
         }
 
+        ChatboxMsg.ClearMessages();
+        PacketSender.SendSelectCharacter(Characters[mSelectedChar].Id);
+
+        Globals.WaitingOnServer = true;
+        mPlayButton.Disable();
+        mNewButton.Disable();
+        mDeleteButton.Disable();
+        mLogoutButton.Disable();
+    }
+
+    private void _deleteButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
+        }
+
+        var iBox = new InputBox(
+            Strings.CharacterSelection.DeleteTitle.ToString(Characters[mSelectedChar].Name),
+            Strings.CharacterSelection.DeletePrompt.ToString(Characters[mSelectedChar].Name), true,
+            InputBox.InputType.YesNo, DeleteCharacter, null, Characters[mSelectedChar].Id, 0, 0,
+            mCharacterSelectionPanel.Parent, GameContentManager.UI.Menu
+        );
+    }
+
+    private void DeleteCharacter(Object sender, EventArgs e)
+    {
+        PacketSender.SendDeleteCharacter((Guid) ((InputBox) sender).UserData);
+
+        Globals.WaitingOnServer = true;
+        mPlayButton.Disable();
+        mNewButton.Disable();
+        mDeleteButton.Disable();
+        mLogoutButton.Disable();
+
+        mSelectedChar = 0;
+        UpdateDisplay();
+    }
+
+    private void _newButton_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        if (Globals.WaitingOnServer)
+        {
+            return;
+        }
+
+        PacketSender.SendNewCharacter();
+
+        Globals.WaitingOnServer = true;
+        mPlayButton.Disable();
+        mNewButton.Disable();
+        mDeleteButton.Disable();
+        mLogoutButton.Disable();
+    }
+
+}
+
+public partial class Character
+{
+
+    public string Class = "";
+
+    public EquipmentFragment[] Equipment = new EquipmentFragment[Options.EquipmentSlots.Count + 1];
+
+    public bool Exists = false;
+
+    public string Face = "";
+
+    public Guid Id;
+
+    public int Level = 1;
+
+    public string Name = "";
+
+    public string Sprite = "";
+
+    public Character(Guid id)
+    {
+        Id = id;
+    }
+
+    public Character(
+        Guid id,
+        string name,
+        string sprite,
+        string face,
+        int level,
+        string charClass,
+        EquipmentFragment[] equipment
+    )
+    {
+        Equipment = equipment;
+        Id = id;
+        Name = name;
+        Sprite = sprite;
+        Face = face;
+        Level = level;
+        Class = charClass;
+        Exists = true;
+    }
+
+    public Character()
+    {
+        for (var i = 0; i < Options.EquipmentSlots.Count + 1; i++)
+        {
+            Equipment[i] = default;
+        }
+
+        Equipment[0] = new EquipmentFragment { Name = "Player" };
     }
 
 }

--- a/Intersect.Client/Interface/MutableInterface.cs
+++ b/Intersect.Client/Interface/MutableInterface.cs
@@ -2,101 +2,100 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Debugging;
 using Intersect.Reflection;
 
-namespace Intersect.Client.Interface
+namespace Intersect.Client.Interface;
+
+
+public abstract partial class MutableInterface : IMutableInterface
 {
 
-    public abstract partial class MutableInterface : IMutableInterface
+    private static DebugWindow _debugWindow;
+
+    public static void DetachDebugWindow()
     {
-
-        private static DebugWindow _debugWindow;
-
-        public static void DetachDebugWindow()
+        if (_debugWindow != null)
         {
-            if (_debugWindow != null)
-            {
-                _debugWindow.Parent = default;
-            }
+            _debugWindow.Parent = default;
+        }
+    }
+
+    internal static void DisposeDebugWindow() => _debugWindow?.Dispose();
+
+    private static void EnsureDebugWindowInitialized(Base parent)
+    {
+        if (_debugWindow == default)
+        {
+            _debugWindow = new DebugWindow(parent);
         }
 
-        internal static void DisposeDebugWindow() => _debugWindow?.Dispose();
+        _debugWindow.Parent = parent;
+    }
 
-        private static void EnsureDebugWindowInitialized(Base parent)
+    protected internal MutableInterface(Base root)
+    {
+        Root = root;
+
+        EnsureDebugWindowInitialized(root);
+    }
+
+    internal Base Root { get; }
+
+    /// <inheritdoc />
+    public List<Base> Children => Root.Children ?? new List<Base>();
+
+    /// <inheritdoc />
+    public TElement Create<TElement>(params object[] parameters) where TElement : Base
+    {
+        var fullParameterList = new List<object?> {Root};
+        fullParameterList.AddRange(parameters);
+
+        var fullParameters = fullParameterList.ToArray();
+        var constructor = typeof(TElement).FindConstructors(fullParameters).FirstOrDefault();
+
+        if (constructor != null)
         {
-            if (_debugWindow == default)
+            var constructorParameters = constructor.GetParameters();
+            if (fullParameters.Length != constructorParameters.Length)
             {
-                _debugWindow = new DebugWindow(parent);
-            }
-
-            _debugWindow.Parent = parent;
-        }
-
-        protected internal MutableInterface(Base root)
-        {
-            Root = root;
-
-            EnsureDebugWindowInitialized(root);
-        }
-
-        internal Base Root { get; }
-
-        /// <inheritdoc />
-        public List<Base> Children => Root.Children ?? new List<Base>();
-
-        /// <inheritdoc />
-        public TElement Create<TElement>(params object[] parameters) where TElement : Base
-        {
-            var fullParameterList = new List<object?> {Root};
-            fullParameterList.AddRange(parameters);
-
-            var fullParameters = fullParameterList.ToArray();
-            var constructor = typeof(TElement).FindConstructors(fullParameters).FirstOrDefault();
-
-            if (constructor != null)
-            {
-                var constructorParameters = constructor.GetParameters();
-                if (fullParameters.Length != constructorParameters.Length)
-                {
-                    fullParameters = fullParameters.Concat(
-                            Enumerable.Range(0, constructorParameters.Length - fullParameters.Length)
-                                .Select(_ => default(object))
-                        )
-                        .ToArray();
-                }
-
-                if (constructor.Invoke(fullParameters) is not TElement constructedElement)
-                {
-                    throw new NullReferenceException("Failed to invoke constructor that matches parameters.");
-                }
-
-                return constructedElement;
+                fullParameters = fullParameters.Concat(
+                        Enumerable.Range(0, constructorParameters.Length - fullParameters.Length)
+                            .Select(_ => default(object))
+                    )
+                    .ToArray();
             }
 
-            throw new NullReferenceException("Failed to find constructor that matches parameters.");
-        }
-
-        /// <inheritdoc />
-        public TElement Find<TElement>(string name = null, bool recurse = false) where TElement : Base
-        {
-            if (!string.IsNullOrWhiteSpace(name))
+            if (constructor.Invoke(fullParameters) is not TElement constructedElement)
             {
-                return Root.FindChildByName(name, recurse) as TElement;
+                throw new NullReferenceException("Failed to invoke constructor that matches parameters.");
             }
 
-            return Root.Find(child => child is TElement) as TElement;
+            return constructedElement;
         }
 
-        /// <inheritdoc />
-        public IEnumerable<TElement> FindAll<TElement>(bool recurse = false) where TElement : Base =>
-            Root.FindAll(child => child is TElement, recurse).Select(child => child as TElement);
+        throw new NullReferenceException("Failed to find constructor that matches parameters.");
+    }
 
-        /// <inheritdoc />
-        public void Remove<TElement>(TElement element, bool dispose = false) where TElement : Base =>
-            Root.RemoveChild(element, dispose);
-
-        public static bool ToggleDebug()
+    /// <inheritdoc />
+    public TElement Find<TElement>(string name = null, bool recurse = false) where TElement : Base
+    {
+        if (!string.IsNullOrWhiteSpace(name))
         {
-            _debugWindow.ToggleHidden();
-            return _debugWindow.IsVisible;
+            return Root.FindChildByName(name, recurse) as TElement;
         }
+
+        return Root.Find(child => child is TElement) as TElement;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TElement> FindAll<TElement>(bool recurse = false) where TElement : Base =>
+        Root.FindAll(child => child is TElement, recurse).Select(child => child as TElement);
+
+    /// <inheritdoc />
+    public void Remove<TElement>(TElement element, bool dispose = false) where TElement : Base =>
+        Root.RemoveChild(element, dispose);
+
+    public static bool ToggleDebug()
+    {
+        _debugWindow.ToggleHidden();
+        return _debugWindow.IsVisible;
     }
 }

--- a/Intersect.Client/Interface/Shared/Errors/ErrorHandler.cs
+++ b/Intersect.Client/Interface/Shared/Errors/ErrorHandler.cs
@@ -1,47 +1,45 @@
 ﻿using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Localization;
 
-namespace Intersect.Client.Interface.Shared.Errors
+namespace Intersect.Client.Interface.Shared.Errors;
+
+
+public partial class ErrorHandler
 {
 
-    public partial class ErrorHandler
+    //Controls
+    private readonly List<ErrorWindow> _windows = new();
+
+    //Canvasses
+    private readonly Canvas _gameCanvas;
+    private readonly Canvas _menuCanvas;
+
+    //Init
+    public ErrorHandler(Canvas menuCanvas, Canvas gameCanvas)
     {
+        _gameCanvas = gameCanvas;
+        _menuCanvas = menuCanvas;
+    }
 
-        //Controls
-        private readonly List<ErrorWindow> _windows = new();
-
-        //Canvasses
-        private readonly Canvas _gameCanvas;
-        private readonly Canvas _menuCanvas;
-
-        //Init
-        public ErrorHandler(Canvas menuCanvas, Canvas gameCanvas)
+    public void Update()
+    {
+        while (Interface.TryDequeueErrorMessage(out var message))
         {
-            _gameCanvas = gameCanvas;
-            _menuCanvas = menuCanvas;
+            _windows.Add(
+                new ErrorWindow(
+                    _gameCanvas,
+                    _menuCanvas,
+                    message.Value,
+                    string.IsNullOrWhiteSpace(message.Key) ? Strings.Errors.Title.ToString() : message.Key
+                )
+            );
         }
 
-        public void Update()
+        var windowsToRemove = _windows.Where(window => !window.Update()).ToArray();
+        foreach (var window in windowsToRemove)
         {
-            while (Interface.TryDequeueErrorMessage(out var message))
-            {
-                _windows.Add(
-                    new ErrorWindow(
-                        _gameCanvas,
-                        _menuCanvas,
-                        message.Value,
-                        string.IsNullOrWhiteSpace(message.Key) ? Strings.Errors.Title.ToString() : message.Key
-                    )
-                );
-            }
-
-            var windowsToRemove = _windows.Where(window => !window.Update()).ToArray();
-            foreach (var window in windowsToRemove)
-            {
-                _windows.Remove(window);
-            }
+            _windows.Remove(window);
         }
-
     }
 
 }

--- a/Intersect.Client/Interface/Shared/Errors/ErrorWindow.cs
+++ b/Intersect.Client/Interface/Shared/Errors/ErrorWindow.cs
@@ -3,50 +3,48 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Game;
 
-namespace Intersect.Client.Interface.Shared.Errors
+namespace Intersect.Client.Interface.Shared.Errors;
+
+
+partial class ErrorWindow
 {
 
-    partial class ErrorWindow
+    List<InputBox> mErrorWindows = new List<InputBox>();
+
+    public ErrorWindow(Canvas gameCanvas, Canvas menuCanvas, string error, string header)
     {
+        CreateErrorWindow(gameCanvas, error, header, GameContentManager.UI.InGame);
+        CreateErrorWindow(menuCanvas, error, header, GameContentManager.UI.Menu);
+    }
 
-        List<InputBox> mErrorWindows = new List<InputBox>();
+    private void CreateErrorWindow(Canvas canvas, string error, string header, GameContentManager.UI stage)
+    {
+        var window = new InputBox(
+            header, error, false, InputBox.InputType.OkayOnly, OkayClicked, null, -1, 0, 0, canvas, stage
+        );
 
-        public ErrorWindow(Canvas gameCanvas, Canvas menuCanvas, string error, string header)
+        mErrorWindows.Add(window);
+    }
+
+    private void OkayClicked(Object sender, EventArgs args)
+    {
+        foreach (var window in mErrorWindows)
         {
-            CreateErrorWindow(gameCanvas, error, header, GameContentManager.UI.InGame);
-            CreateErrorWindow(menuCanvas, error, header, GameContentManager.UI.Menu);
+            window.Dispose();
         }
+    }
 
-        private void CreateErrorWindow(Canvas canvas, string error, string header, GameContentManager.UI stage)
-        {
-            var window = new InputBox(
-                header, error, false, InputBox.InputType.OkayOnly, OkayClicked, null, -1, 0, 0, canvas, stage
-            );
+    public bool Update()
+    {
+        return true;
+    }
 
-            mErrorWindows.Add(window);
-        }
-
-        private void OkayClicked(Object sender, EventArgs args)
-        {
-            foreach (var window in mErrorWindows)
-            {
-                window.Dispose();
-            }
-        }
-
-        public bool Update()
-        {
-            return true;
-        }
-
-        protected virtual void ErrorBox_Resized(Base sender, EventArgs arguments)
-        {
-            sender.SetPosition(
-                Graphics.Renderer.GetScreenWidth() / 2 - sender.Width / 2,
-                Graphics.Renderer.GetScreenHeight() / 2 - sender.Height / 2
-            );
-        }
-
+    protected virtual void ErrorBox_Resized(Base sender, EventArgs arguments)
+    {
+        sender.SetPosition(
+            Graphics.Renderer.GetScreenWidth() / 2 - sender.Width / 2,
+            Graphics.Renderer.GetScreenHeight() / 2 - sender.Height / 2
+        );
     }
 
 }

--- a/Intersect.Client/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client/Interface/Shared/SettingsWindow.cs
@@ -13,604 +13,489 @@ using Intersect.Utilities;
 using static Intersect.Client.Framework.File_Management.GameContentManager;
 using MathHelper = Intersect.Client.Utilities.MathHelper;
 
-namespace Intersect.Client.Interface.Shared
+namespace Intersect.Client.Interface.Shared;
+
+public partial class SettingsWindow
 {
-    public partial class SettingsWindow
+    // Parent Window.
+    private readonly MainMenu mMainMenu;
+
+    private readonly EscapeMenu mEscapeMenu;
+
+    // Settings Window.
+    private readonly Label mSettingsHeader;
+
+    private readonly ImagePanel mSettingsPanel;
+
+    private readonly Button mSettingsApplyBtn;
+
+    private readonly Button mSettingsCancelBtn;
+
+    // Settings Containers.
+    private readonly ScrollControl mGameSettingsContainer;
+
+    private readonly ScrollControl mVideoSettingsContainer;
+
+    private readonly ScrollControl mAudioSettingsContainer;
+
+    private readonly ScrollControl mKeybindingSettingsContainer;
+
+    // Tabs.
+    private readonly Button mGameSettingsTab;
+
+    private readonly Button mVideoSettingsTab;
+
+    private readonly Button mAudioSettingsTab;
+
+    private readonly Button mKeybindingSettingsTab;
+
+    // Game Settings - Interface.
+    private readonly ScrollControl mInterfaceSettings;
+
+    private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
+
+    private readonly LabeledCheckBox mAutoToggleChatLogCheckbox;
+
+    private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
+
+    private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
+
+    private readonly LabeledCheckBox mShowManaAsPercentageCheckbox;
+
+    // Game Settings - Information.
+    private readonly ScrollControl mInformationSettings;
+
+    private readonly LabeledCheckBox mFriendOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mGuildMemberOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mMyOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mNpcOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mPartyMemberOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
+
+    private readonly LabeledCheckBox mFriendOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mGuildMemberOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mMyOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mNpcOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mPartyMemberOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mPlayerOverheadHpBarCheckbox;
+
+    private readonly LabeledCheckBox mTypewriterCheckbox;
+
+    // Game Settings - Targeting.
+    private readonly ScrollControl mTargetingSettings;
+
+    private readonly LabeledCheckBox mStickyTarget;
+
+    private readonly LabeledCheckBox mAutoTurnToTarget;
+
+    // Video Settings.
+    private readonly ComboBox mResolutionList;
+
+    private MenuItem mCustomResolutionMenuItem;
+
+    private readonly ComboBox mFpsList;
+
+    private readonly LabeledHorizontalSlider _worldScale;
+
+    private readonly LabeledHorizontalSlider _uiScale;
+
+    private readonly LabeledCheckBox mFullscreenCheckbox;
+
+    private readonly LabeledCheckBox mLightingEnabledCheckbox;
+
+    // Audio Settings.
+    private readonly HorizontalSlider mMusicSlider;
+
+    private int mPreviousMusicVolume;
+
+    private readonly Label mMusicLabel;
+
+    private readonly HorizontalSlider mSoundSlider;
+
+    private int mPreviousSoundVolume;
+
+    private readonly Label mSoundLabel;
+
+    // Keybinding Settings.
+    private Control mKeybindingEditControl;
+
+    private Controls mKeybindingEditControls;
+
+    private Button? mKeybindingEditBtn;
+
+    private readonly Button mKeybindingRestoreBtn;
+
+    private long mKeybindingListeningTimer;
+
+    private int mKeyEdit = -1;
+
+    private readonly Dictionary<Control, Button[]> mKeybindingBtns = new Dictionary<Control, Button[]>();
+
+    // Open Settings.
+    private bool mReturnToMenu;
+
+    // Initialize.
+    public SettingsWindow(Base parent, MainMenu mainMenu, EscapeMenu escapeMenu)
     {
-        // Parent Window.
-        private readonly MainMenu mMainMenu;
+        // Assign References.
+        mMainMenu = mainMenu;
+        mEscapeMenu = escapeMenu;
 
-        private readonly EscapeMenu mEscapeMenu;
+        // Main Menu Window.
+        mSettingsPanel = new ImagePanel(parent, "SettingsWindow") { IsHidden = true };
+        Interface.InputBlockingElements.Add(mSettingsPanel);
 
-        // Settings Window.
-        private readonly Label mSettingsHeader;
+        // Menu Header.
+        mSettingsHeader = new Label(mSettingsPanel, "SettingsHeader");
+        mSettingsHeader.SetText(Strings.Settings.Title);
 
-        private readonly ImagePanel mSettingsPanel;
+        // Apply Button.
+        mSettingsApplyBtn = new Button(mSettingsPanel, "SettingsApplyBtn");
+        mSettingsApplyBtn.SetText(Strings.Settings.Apply);
+        mSettingsApplyBtn.Clicked += SettingsApplyBtn_Clicked;
 
-        private readonly Button mSettingsApplyBtn;
+        // Cancel Button.
+        mSettingsCancelBtn = new Button(mSettingsPanel, "SettingsCancelBtn");
+        mSettingsCancelBtn.SetText(Strings.Settings.Cancel);
+        mSettingsCancelBtn.Clicked += SettingsCancelBtn_Clicked;
 
-        private readonly Button mSettingsCancelBtn;
+        #region InitGameSettings
 
-        // Settings Containers.
-        private readonly ScrollControl mGameSettingsContainer;
+        // Init GameSettings Tab.
+        mGameSettingsTab = new Button(mSettingsPanel, "GameSettingsTab");
+        mGameSettingsTab.Text = Strings.Settings.GameSettingsTab;
+        mGameSettingsTab.Clicked += GameSettingsTab_Clicked;
 
-        private readonly ScrollControl mVideoSettingsContainer;
+        // Game Settings are stored in the GameSettings Scroll Control.
+        mGameSettingsContainer = new ScrollControl(mSettingsPanel, "GameSettingsContainer");
+        mGameSettingsContainer.EnableScroll(false, false);
 
-        private readonly ScrollControl mAudioSettingsContainer;
-
-        private readonly ScrollControl mKeybindingSettingsContainer;
-
-        // Tabs.
-        private readonly Button mGameSettingsTab;
-
-        private readonly Button mVideoSettingsTab;
-
-        private readonly Button mAudioSettingsTab;
-
-        private readonly Button mKeybindingSettingsTab;
+        // Game Settings subcategories are stored in the GameSettings List.
+        var gameSettingsList = new ListBox(mGameSettingsContainer, "GameSettingsList");
+        gameSettingsList.AddRow(Strings.Settings.InterfaceSettings);
+        gameSettingsList.AddRow(Strings.Settings.InformationSettings);
+        gameSettingsList.AddRow(Strings.Settings.TargetingSettings);
+        gameSettingsList.EnableScroll(false, true);
+        gameSettingsList.SelectedRowIndex = 0;
+        gameSettingsList[0].Clicked += InterfaceSettings_Clicked;
+        gameSettingsList[1].Clicked += InformationSettings_Clicked;
+        gameSettingsList[2].Clicked += TargetingSettings_Clicked;
 
         // Game Settings - Interface.
-        private readonly ScrollControl mInterfaceSettings;
+        mInterfaceSettings = new ScrollControl(mGameSettingsContainer, "InterfaceSettings");
+        mInterfaceSettings.EnableScroll(false, true);
 
-        private readonly LabeledCheckBox mAutoCloseWindowsCheckbox;
+        // Game Settings - Interface: Auto-close Windows.
+        mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
+        mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
 
-        private readonly LabeledCheckBox mAutoToggleChatLogCheckbox;
+        // Game Settings - Interface: Auto-toggle chat log visibility.
+        mAutoToggleChatLogCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoToggleChatLogCheckbox");
+        mAutoToggleChatLogCheckbox.Text = Strings.Settings.AutoToggleChatLog;
 
-        private readonly LabeledCheckBox mShowExperienceAsPercentageCheckbox;
-
-        private readonly LabeledCheckBox mShowHealthAsPercentageCheckbox;
-
-        private readonly LabeledCheckBox mShowManaAsPercentageCheckbox;
+        // Game Settings - Interface: Show EXP/HP/MP as Percentage.
+        mShowExperienceAsPercentageCheckbox =
+            new LabeledCheckBox(mInterfaceSettings, "ShowExperienceAsPercentageCheckbox");
+        mShowExperienceAsPercentageCheckbox.Text = Strings.Settings.ShowExperienceAsPercentage;
+        mShowHealthAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowHealthAsPercentageCheckbox");
+        mShowHealthAsPercentageCheckbox.Text = Strings.Settings.ShowHealthAsPercentage;
+        mShowManaAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowManaAsPercentageCheckbox");
+        mShowManaAsPercentageCheckbox.Text = Strings.Settings.ShowManaAsPercentage;
 
         // Game Settings - Information.
-        private readonly ScrollControl mInformationSettings;
+        mInformationSettings = new ScrollControl(mGameSettingsContainer, "InformationSettings");
+        mInformationSettings.EnableScroll(false, true);
 
-        private readonly LabeledCheckBox mFriendOverheadInfoCheckbox;
+        // Game Settings - Information: Friends.
+        mFriendOverheadInfoCheckbox =
+            new LabeledCheckBox(mInformationSettings, "FriendOverheadInfoCheckbox");
+        mFriendOverheadInfoCheckbox.Text = Strings.Settings.ShowFriendOverheadInformation;
 
-        private readonly LabeledCheckBox mGuildMemberOverheadInfoCheckbox;
+        // Game Settings - Information: Guild Members.
+        mGuildMemberOverheadInfoCheckbox =
+            new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadInfoCheckbox");
+        mGuildMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowGuildOverheadInformation;
 
-        private readonly LabeledCheckBox mMyOverheadInfoCheckbox;
+        // Game Settings - Information: Myself.
+        mMyOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "MyOverheadInfoCheckbox");
+        mMyOverheadInfoCheckbox.Text = Strings.Settings.ShowMyOverheadInformation;
 
-        private readonly LabeledCheckBox mNpcOverheadInfoCheckbox;
+        // Game Settings - Information: NPCs.
+        mNpcOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "NpcOverheadInfoCheckbox");
+        mNpcOverheadInfoCheckbox.Text = Strings.Settings.ShowNpcOverheadInformation;
 
-        private readonly LabeledCheckBox mPartyMemberOverheadInfoCheckbox;
+        // Game Settings - Information: Party Members.
+        mPartyMemberOverheadInfoCheckbox =
+            new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadInfoCheckbox");
+        mPartyMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowPartyOverheadInformation;
 
-        private readonly LabeledCheckBox mPlayerOverheadInfoCheckbox;
+        // Game Settings - Information: Players.
+        mPlayerOverheadInfoCheckbox =
+            new LabeledCheckBox(mInformationSettings, "PlayerOverheadInfoCheckbox");
+        mPlayerOverheadInfoCheckbox.Text = Strings.Settings.ShowPlayerOverheadInformation;
 
-        private readonly LabeledCheckBox mFriendOverheadHpBarCheckbox;
+        // Game Settings - Information: friends overhead hp bar.
+        mFriendOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "FriendOverheadHpBarCheckbox");
+        mFriendOverheadHpBarCheckbox.Text = Strings.Settings.ShowFriendOverheadHpBar;
 
-        private readonly LabeledCheckBox mGuildMemberOverheadHpBarCheckbox;
+        // Game Settings - Information: guild members overhead hp bar.
+        mGuildMemberOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadHpBarCheckbox");
+        mGuildMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowGuildOverheadHpBar;
 
-        private readonly LabeledCheckBox mMyOverheadHpBarCheckbox;
+        // Game Settings - Information: my overhead hp bar.
+        mMyOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "MyOverheadHpBarCheckbox");
+        mMyOverheadHpBarCheckbox.Text = Strings.Settings.ShowMyOverheadHpBar;
 
-        private readonly LabeledCheckBox mNpcOverheadHpBarCheckbox;
+        // Game Settings - Information: NPC overhead hp bar.
+        mNpcOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "NpcOverheadHpBarCheckbox");
+        mNpcOverheadHpBarCheckbox.Text = Strings.Settings.ShowNpcOverheadHpBar;
 
-        private readonly LabeledCheckBox mPartyMemberOverheadHpBarCheckbox;
+        // Game Settings - Information: party members overhead hp bar.
+        mPartyMemberOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadHpBarCheckbox");
+        mPartyMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowPartyOverheadHpBar;
 
-        private readonly LabeledCheckBox mPlayerOverheadHpBarCheckbox;
-
-        private readonly LabeledCheckBox mTypewriterCheckbox;
+        // Game Settings - Information: players overhead hp bar.
+        mPlayerOverheadHpBarCheckbox =
+            new LabeledCheckBox(mInformationSettings, "PlayerOverheadHpBarCheckbox");
+        mPlayerOverheadHpBarCheckbox.Text = Strings.Settings.ShowPlayerOverheadHpBar;
 
         // Game Settings - Targeting.
-        private readonly ScrollControl mTargetingSettings;
+        mTargetingSettings = new ScrollControl(mGameSettingsContainer, "TargetingSettings");
+        mTargetingSettings.EnableScroll(false, false);
 
-        private readonly LabeledCheckBox mStickyTarget;
+        // Game Settings - Targeting: Sticky Target.
+        mStickyTarget = new LabeledCheckBox(mTargetingSettings, "StickyTargetCheckbox");
+        mStickyTarget.Text = Strings.Settings.StickyTarget;
 
-        private readonly LabeledCheckBox mAutoTurnToTarget;
+        // Game Settings - Targeting: Auto-turn to Target.
+        mAutoTurnToTarget = new LabeledCheckBox(mTargetingSettings, "AutoTurnToTargetCheckbox");
+        mAutoTurnToTarget.Text = Strings.Settings.AutoTurnToTarget;
 
-        // Video Settings.
-        private readonly ComboBox mResolutionList;
+        // Game Settings - Typewriter Text
+        mTypewriterCheckbox = new LabeledCheckBox(mInterfaceSettings, "TypewriterCheckbox");
+        mTypewriterCheckbox.Text = Strings.Settings.TypewriterText;
 
-        private MenuItem mCustomResolutionMenuItem;
+        #endregion
 
-        private readonly ComboBox mFpsList;
+        #region InitVideoSettings
 
-        private readonly LabeledHorizontalSlider _worldScale;
+        // Init VideoSettings Tab.
+        mVideoSettingsTab = new Button(mSettingsPanel, "VideoSettingsTab");
+        mVideoSettingsTab.Text = Strings.Settings.VideoSettingsTab;
+        mVideoSettingsTab.Clicked += VideoSettingsTab_Clicked;
 
-        private readonly LabeledHorizontalSlider _uiScale;
+        // Video Settings Get Stored in the VideoSettings Scroll Control.
+        mVideoSettingsContainer = new ScrollControl(mSettingsPanel, "VideoSettingsContainer");
+        mVideoSettingsContainer.EnableScroll(false, false);
 
-        private readonly LabeledCheckBox mFullscreenCheckbox;
+        // Video Settings - Resolution Background.
+        var resolutionBackground = new ImagePanel(mVideoSettingsContainer, "ResolutionPanel");
 
-        private readonly LabeledCheckBox mLightingEnabledCheckbox;
+        // Video Settings - Resolution Label.
+        var resolutionLabel = new Label(resolutionBackground, "ResolutionLabel");
+        resolutionLabel.SetText(Strings.Settings.Resolution);
 
-        // Audio Settings.
-        private readonly HorizontalSlider mMusicSlider;
-
-        private int mPreviousMusicVolume;
-
-        private readonly Label mMusicLabel;
-
-        private readonly HorizontalSlider mSoundSlider;
-
-        private int mPreviousSoundVolume;
-
-        private readonly Label mSoundLabel;
-
-        // Keybinding Settings.
-        private Control mKeybindingEditControl;
-
-        private Controls mKeybindingEditControls;
-
-        private Button? mKeybindingEditBtn;
-
-        private readonly Button mKeybindingRestoreBtn;
-
-        private long mKeybindingListeningTimer;
-
-        private int mKeyEdit = -1;
-
-        private readonly Dictionary<Control, Button[]> mKeybindingBtns = new Dictionary<Control, Button[]>();
-
-        // Open Settings.
-        private bool mReturnToMenu;
-
-        // Initialize.
-        public SettingsWindow(Base parent, MainMenu mainMenu, EscapeMenu escapeMenu)
-        {
-            // Assign References.
-            mMainMenu = mainMenu;
-            mEscapeMenu = escapeMenu;
-
-            // Main Menu Window.
-            mSettingsPanel = new ImagePanel(parent, "SettingsWindow") { IsHidden = true };
-            Interface.InputBlockingElements.Add(mSettingsPanel);
-
-            // Menu Header.
-            mSettingsHeader = new Label(mSettingsPanel, "SettingsHeader");
-            mSettingsHeader.SetText(Strings.Settings.Title);
-
-            // Apply Button.
-            mSettingsApplyBtn = new Button(mSettingsPanel, "SettingsApplyBtn");
-            mSettingsApplyBtn.SetText(Strings.Settings.Apply);
-            mSettingsApplyBtn.Clicked += SettingsApplyBtn_Clicked;
-
-            // Cancel Button.
-            mSettingsCancelBtn = new Button(mSettingsPanel, "SettingsCancelBtn");
-            mSettingsCancelBtn.SetText(Strings.Settings.Cancel);
-            mSettingsCancelBtn.Clicked += SettingsCancelBtn_Clicked;
-
-            #region InitGameSettings
-
-            // Init GameSettings Tab.
-            mGameSettingsTab = new Button(mSettingsPanel, "GameSettingsTab");
-            mGameSettingsTab.Text = Strings.Settings.GameSettingsTab;
-            mGameSettingsTab.Clicked += GameSettingsTab_Clicked;
-
-            // Game Settings are stored in the GameSettings Scroll Control.
-            mGameSettingsContainer = new ScrollControl(mSettingsPanel, "GameSettingsContainer");
-            mGameSettingsContainer.EnableScroll(false, false);
-
-            // Game Settings subcategories are stored in the GameSettings List.
-            var gameSettingsList = new ListBox(mGameSettingsContainer, "GameSettingsList");
-            gameSettingsList.AddRow(Strings.Settings.InterfaceSettings);
-            gameSettingsList.AddRow(Strings.Settings.InformationSettings);
-            gameSettingsList.AddRow(Strings.Settings.TargetingSettings);
-            gameSettingsList.EnableScroll(false, true);
-            gameSettingsList.SelectedRowIndex = 0;
-            gameSettingsList[0].Clicked += InterfaceSettings_Clicked;
-            gameSettingsList[1].Clicked += InformationSettings_Clicked;
-            gameSettingsList[2].Clicked += TargetingSettings_Clicked;
-
-            // Game Settings - Interface.
-            mInterfaceSettings = new ScrollControl(mGameSettingsContainer, "InterfaceSettings");
-            mInterfaceSettings.EnableScroll(false, true);
-
-            // Game Settings - Interface: Auto-close Windows.
-            mAutoCloseWindowsCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoCloseWindowsCheckbox");
-            mAutoCloseWindowsCheckbox.Text = Strings.Settings.AutoCloseWindows;
-
-            // Game Settings - Interface: Auto-toggle chat log visibility.
-            mAutoToggleChatLogCheckbox = new LabeledCheckBox(mInterfaceSettings, "AutoToggleChatLogCheckbox");
-            mAutoToggleChatLogCheckbox.Text = Strings.Settings.AutoToggleChatLog;
-
-            // Game Settings - Interface: Show EXP/HP/MP as Percentage.
-            mShowExperienceAsPercentageCheckbox =
-                new LabeledCheckBox(mInterfaceSettings, "ShowExperienceAsPercentageCheckbox");
-            mShowExperienceAsPercentageCheckbox.Text = Strings.Settings.ShowExperienceAsPercentage;
-            mShowHealthAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowHealthAsPercentageCheckbox");
-            mShowHealthAsPercentageCheckbox.Text = Strings.Settings.ShowHealthAsPercentage;
-            mShowManaAsPercentageCheckbox = new LabeledCheckBox(mInterfaceSettings, "ShowManaAsPercentageCheckbox");
-            mShowManaAsPercentageCheckbox.Text = Strings.Settings.ShowManaAsPercentage;
-
-            // Game Settings - Information.
-            mInformationSettings = new ScrollControl(mGameSettingsContainer, "InformationSettings");
-            mInformationSettings.EnableScroll(false, true);
-
-            // Game Settings - Information: Friends.
-            mFriendOverheadInfoCheckbox =
-                new LabeledCheckBox(mInformationSettings, "FriendOverheadInfoCheckbox");
-            mFriendOverheadInfoCheckbox.Text = Strings.Settings.ShowFriendOverheadInformation;
-
-            // Game Settings - Information: Guild Members.
-            mGuildMemberOverheadInfoCheckbox =
-                new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadInfoCheckbox");
-            mGuildMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowGuildOverheadInformation;
-
-            // Game Settings - Information: Myself.
-            mMyOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "MyOverheadInfoCheckbox");
-            mMyOverheadInfoCheckbox.Text = Strings.Settings.ShowMyOverheadInformation;
-
-            // Game Settings - Information: NPCs.
-            mNpcOverheadInfoCheckbox = new LabeledCheckBox(mInformationSettings, "NpcOverheadInfoCheckbox");
-            mNpcOverheadInfoCheckbox.Text = Strings.Settings.ShowNpcOverheadInformation;
-
-            // Game Settings - Information: Party Members.
-            mPartyMemberOverheadInfoCheckbox =
-                new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadInfoCheckbox");
-            mPartyMemberOverheadInfoCheckbox.Text = Strings.Settings.ShowPartyOverheadInformation;
-
-            // Game Settings - Information: Players.
-            mPlayerOverheadInfoCheckbox =
-                new LabeledCheckBox(mInformationSettings, "PlayerOverheadInfoCheckbox");
-            mPlayerOverheadInfoCheckbox.Text = Strings.Settings.ShowPlayerOverheadInformation;
-
-            // Game Settings - Information: friends overhead hp bar.
-            mFriendOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "FriendOverheadHpBarCheckbox");
-            mFriendOverheadHpBarCheckbox.Text = Strings.Settings.ShowFriendOverheadHpBar;
-
-            // Game Settings - Information: guild members overhead hp bar.
-            mGuildMemberOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "GuildMemberOverheadHpBarCheckbox");
-            mGuildMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowGuildOverheadHpBar;
-
-            // Game Settings - Information: my overhead hp bar.
-            mMyOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "MyOverheadHpBarCheckbox");
-            mMyOverheadHpBarCheckbox.Text = Strings.Settings.ShowMyOverheadHpBar;
-
-            // Game Settings - Information: NPC overhead hp bar.
-            mNpcOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "NpcOverheadHpBarCheckbox");
-            mNpcOverheadHpBarCheckbox.Text = Strings.Settings.ShowNpcOverheadHpBar;
-
-            // Game Settings - Information: party members overhead hp bar.
-            mPartyMemberOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "PartyMemberOverheadHpBarCheckbox");
-            mPartyMemberOverheadHpBarCheckbox.Text = Strings.Settings.ShowPartyOverheadHpBar;
-
-            // Game Settings - Information: players overhead hp bar.
-            mPlayerOverheadHpBarCheckbox =
-                new LabeledCheckBox(mInformationSettings, "PlayerOverheadHpBarCheckbox");
-            mPlayerOverheadHpBarCheckbox.Text = Strings.Settings.ShowPlayerOverheadHpBar;
-
-            // Game Settings - Targeting.
-            mTargetingSettings = new ScrollControl(mGameSettingsContainer, "TargetingSettings");
-            mTargetingSettings.EnableScroll(false, false);
-
-            // Game Settings - Targeting: Sticky Target.
-            mStickyTarget = new LabeledCheckBox(mTargetingSettings, "StickyTargetCheckbox");
-            mStickyTarget.Text = Strings.Settings.StickyTarget;
-
-            // Game Settings - Targeting: Auto-turn to Target.
-            mAutoTurnToTarget = new LabeledCheckBox(mTargetingSettings, "AutoTurnToTargetCheckbox");
-            mAutoTurnToTarget.Text = Strings.Settings.AutoTurnToTarget;
-
-            // Game Settings - Typewriter Text
-            mTypewriterCheckbox = new LabeledCheckBox(mInterfaceSettings, "TypewriterCheckbox");
-            mTypewriterCheckbox.Text = Strings.Settings.TypewriterText;
-
-            #endregion
-
-            #region InitVideoSettings
-
-            // Init VideoSettings Tab.
-            mVideoSettingsTab = new Button(mSettingsPanel, "VideoSettingsTab");
-            mVideoSettingsTab.Text = Strings.Settings.VideoSettingsTab;
-            mVideoSettingsTab.Clicked += VideoSettingsTab_Clicked;
-
-            // Video Settings Get Stored in the VideoSettings Scroll Control.
-            mVideoSettingsContainer = new ScrollControl(mSettingsPanel, "VideoSettingsContainer");
-            mVideoSettingsContainer.EnableScroll(false, false);
-
-            // Video Settings - Resolution Background.
-            var resolutionBackground = new ImagePanel(mVideoSettingsContainer, "ResolutionPanel");
-
-            // Video Settings - Resolution Label.
-            var resolutionLabel = new Label(resolutionBackground, "ResolutionLabel");
-            resolutionLabel.SetText(Strings.Settings.Resolution);
-
-            // Video Settings - Resolution List.
-            mResolutionList = new ComboBox(resolutionBackground, "ResolutionCombobox");
-            var myModes = Graphics.Renderer.GetValidVideoModes();
-            myModes?.ForEach(
-                t =>
-                {
-                    var item = mResolutionList.AddItem(t);
-                    item.Alignment = Pos.Left;
-                }
-            );
-
-            Globals.Database.WorldZoom = MathHelper.Clamp(Globals.Database.WorldZoom, 1, 4);
-
-            var worldScaleNotches = new double[] { 1, 2, 4 }.Select(n => n * Graphics.BaseWorldScale).ToArray();
-            _worldScale = new LabeledHorizontalSlider(mVideoSettingsContainer, "WorldScale")
+        // Video Settings - Resolution List.
+        mResolutionList = new ComboBox(resolutionBackground, "ResolutionCombobox");
+        var myModes = Graphics.Renderer.GetValidVideoModes();
+        myModes?.ForEach(
+            t =>
             {
-                Label = Strings.Settings.WorldScale,
-                Min = worldScaleNotches.Min(),
-                Max = worldScaleNotches.Max(),
-                Notches = worldScaleNotches,
-                SnapToNotches = false,
-                Value = Globals.Database.WorldZoom,
+                var item = mResolutionList.AddItem(t);
+                item.Alignment = Pos.Left;
+            }
+        );
+
+        Globals.Database.WorldZoom = MathHelper.Clamp(Globals.Database.WorldZoom, 1, 4);
+
+        var worldScaleNotches = new double[] { 1, 2, 4 }.Select(n => n * Graphics.BaseWorldScale).ToArray();
+        _worldScale = new LabeledHorizontalSlider(mVideoSettingsContainer, "WorldScale")
+        {
+            Label = Strings.Settings.WorldScale,
+            Min = worldScaleNotches.Min(),
+            Max = worldScaleNotches.Max(),
+            Notches = worldScaleNotches,
+            SnapToNotches = false,
+            Value = Globals.Database.WorldZoom,
+        };
+
+        // _uiScale = new LabeledHorizontalSlider(mVideoSettingsContainer, "UIScale")
+        // {
+        //     Label = Strings.Settings.UIScale,
+        //     Min = 0.5f,
+        //     Max = 4f,
+        //     Notches = new double[] { 0.5, 1, 2, 4 },
+        //     SnapToNotches = true,
+        //     Value = 1f,
+        // };
+
+        // Video Settings - FPS Background.
+        var fpsBackground = new ImagePanel(mVideoSettingsContainer, "FPSPanel");
+
+        // Video Settings - FPS Label.
+        var fpsLabel = new Label(fpsBackground, "FPSLabel");
+        fpsLabel.SetText(Strings.Settings.TargetFps);
+        
+        // Video Settings - FPS List.
+        mFpsList = new ComboBox(fpsBackground, "FPSCombobox");
+        mFpsList.AddItem(Strings.Settings.Vsync);
+        mFpsList.AddItem(Strings.Settings.Fps30);
+        mFpsList.AddItem(Strings.Settings.Fps60);
+        mFpsList.AddItem(Strings.Settings.Fps90);
+        mFpsList.AddItem(Strings.Settings.Fps120);
+        mFpsList.AddItem(Strings.Settings.UnlimitedFps);
+
+        // Video Settings - Fullscreen Checkbox.
+        mFullscreenCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "FullscreenCheckbox")
+        {
+            Text = Strings.Settings.Fullscreen
+        };
+
+        // Video Settings - Enable Lighting Checkbox
+        mLightingEnabledCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "EnableLightingCheckbox")
+        {
+            Text = Strings.Settings.EnableLighting
+        };
+
+        #endregion
+
+        #region InitAudioSettings
+
+        // Init AudioSettingsTab.
+        mAudioSettingsTab = new Button(mSettingsPanel, "AudioSettingsTab");
+        mAudioSettingsTab.Text = Strings.Settings.AudioSettingsTab;
+        mAudioSettingsTab.Clicked += AudioSettingsTab_Clicked;
+
+        // Audio Settings Get Stored in the AudioSettings Scroll Control.
+        mAudioSettingsContainer = new ScrollControl(mSettingsPanel, "AudioSettingsContainer");
+        mAudioSettingsContainer.EnableScroll(false, false);
+
+        // Audio Settings - Sound Label
+        mSoundLabel = new Label(mAudioSettingsContainer, "SoundLabel");
+        mSoundLabel.SetText(Strings.Settings.SoundVolume.ToString(100));
+
+        // Audio Settings - Sound Slider
+        mSoundSlider = new HorizontalSlider(mAudioSettingsContainer, "SoundSlider");
+        mSoundSlider.Min = 0;
+        mSoundSlider.Max = 100;
+        mSoundSlider.ValueChanged += SoundSlider_ValueChanged;
+
+        // Audio Settings - Music Label
+        mMusicLabel = new Label(mAudioSettingsContainer, "MusicLabel");
+        mMusicLabel.SetText(Strings.Settings.MusicVolume.ToString(100));
+
+        // Audio Settings - Music Slider
+        mMusicSlider = new HorizontalSlider(mAudioSettingsContainer, "MusicSlider");
+        mMusicSlider.Min = 0;
+        mMusicSlider.Max = 100;
+        mMusicSlider.ValueChanged += MusicSlider_ValueChanged;
+
+        #endregion
+
+        #region InitKeybindingSettings
+
+        // Init KeybindingsSettings Tab.
+        mKeybindingSettingsTab = new Button(mSettingsPanel, "KeybindingSettingsTab");
+        mKeybindingSettingsTab.Text = Strings.Settings.KeyBindingSettingsTab;
+        mKeybindingSettingsTab.Clicked += KeybindingSettingsTab_Clicked;
+
+        // KeybindingSettings Get Stored in the KeybindingSettings Scroll Control
+        mKeybindingSettingsContainer = new ScrollControl(mSettingsPanel, "KeybindingSettingsContainer");
+        mKeybindingSettingsContainer.EnableScroll(false, true);
+
+        // Keybinding Settings - Restore Default Keys Button.
+        mKeybindingRestoreBtn = new Button(mSettingsPanel, "KeybindingsRestoreBtn");
+        mKeybindingRestoreBtn.Text = Strings.Settings.Restore;
+        mKeybindingRestoreBtn.Clicked += KeybindingsRestoreBtn_Clicked;
+
+        // Keybinding Settings - Controls 
+        var row = 0;
+        var defaultFont = Current.GetFont("sourcesansproblack", 10);
+        foreach (Control control in Enum.GetValues(typeof(Control)))
+        {
+            var offset = row++ * 32;
+            var name = Enum.GetName(typeof(Control), control)?.ToLower();
+
+            var prefix = $"Control{Enum.GetName(typeof(Control), control)}";
+            var label = new Label(mKeybindingSettingsContainer, $"{prefix}Label")
+            {
+                Text = Strings.Controls.KeyDictionary[name],
+                AutoSizeToContents = true,
+                Font = defaultFont,
             };
+            label.SetBounds(14, 11 + offset, 21, 16);
+            label.SetTextColor(new Color(255, 255, 255, 255), Label.ControlState.Normal);
 
-            // _uiScale = new LabeledHorizontalSlider(mVideoSettingsContainer, "UIScale")
-            // {
-            //     Label = Strings.Settings.UIScale,
-            //     Min = 0.5f,
-            //     Max = 4f,
-            //     Notches = new double[] { 0.5, 1, 2, 4 },
-            //     SnapToNotches = true,
-            //     Value = 1f,
-            // };
-
-            // Video Settings - FPS Background.
-            var fpsBackground = new ImagePanel(mVideoSettingsContainer, "FPSPanel");
-
-            // Video Settings - FPS Label.
-            var fpsLabel = new Label(fpsBackground, "FPSLabel");
-            fpsLabel.SetText(Strings.Settings.TargetFps);
-            
-            // Video Settings - FPS List.
-            mFpsList = new ComboBox(fpsBackground, "FPSCombobox");
-            mFpsList.AddItem(Strings.Settings.Vsync);
-            mFpsList.AddItem(Strings.Settings.Fps30);
-            mFpsList.AddItem(Strings.Settings.Fps60);
-            mFpsList.AddItem(Strings.Settings.Fps90);
-            mFpsList.AddItem(Strings.Settings.Fps120);
-            mFpsList.AddItem(Strings.Settings.UnlimitedFps);
-
-            // Video Settings - Fullscreen Checkbox.
-            mFullscreenCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "FullscreenCheckbox")
+            var key1 = new Button(mKeybindingSettingsContainer, $"{prefix}Button1")
             {
-                Text = Strings.Settings.Fullscreen
+                AutoSizeToContents = false,
+                Font = defaultFont,
+                Text = string.Empty,
+                UserData = new KeyValuePair<Control, int>(control, 0),
             };
+            key1.SetTextColor(Color.White, Label.ControlState.Normal);
+            key1.SetImage("control_button.png", Button.ControlState.Normal);
+            key1.SetImage("control_button_hovered.png", Button.ControlState.Hovered);
+            key1.SetImage("control_button_clicked.png", Button.ControlState.Clicked);
+            key1.SetHoverSound("octave-tap-resonant.wav");
+            key1.SetMouseDownSound("octave-tap-warm.wav");
+            key1.SetBounds(181, 6 + offset, 120, 28);
+            key1.Clicked += Key_Clicked;
 
-            // Video Settings - Enable Lighting Checkbox
-            mLightingEnabledCheckbox = new LabeledCheckBox(mVideoSettingsContainer, "EnableLightingCheckbox")
+            var key2 = new Button(mKeybindingSettingsContainer, $"{prefix}Button2")
             {
-                Text = Strings.Settings.EnableLighting
+                AutoSizeToContents = false,
+                Font = defaultFont,
+                Text = string.Empty,
+                UserData = new KeyValuePair<Control, int>(control, 1),
             };
+            key2.SetTextColor(Color.White, Label.ControlState.Normal);
+            key2.SetImage("control_button.png", Button.ControlState.Normal);
+            key2.SetImage("control_button_hovered.png", Button.ControlState.Hovered);
+            key2.SetImage("control_button_clicked.png", Button.ControlState.Clicked);
+            key2.SetHoverSound("octave-tap-resonant.wav");
+            key2.SetMouseDownSound("octave-tap-warm.wav");
+            key2.SetBounds(309, 6 + offset, 120, 28);
+            key2.Clicked += Key_Clicked;
 
-            #endregion
-
-            #region InitAudioSettings
-
-            // Init AudioSettingsTab.
-            mAudioSettingsTab = new Button(mSettingsPanel, "AudioSettingsTab");
-            mAudioSettingsTab.Text = Strings.Settings.AudioSettingsTab;
-            mAudioSettingsTab.Clicked += AudioSettingsTab_Clicked;
-
-            // Audio Settings Get Stored in the AudioSettings Scroll Control.
-            mAudioSettingsContainer = new ScrollControl(mSettingsPanel, "AudioSettingsContainer");
-            mAudioSettingsContainer.EnableScroll(false, false);
-
-            // Audio Settings - Sound Label
-            mSoundLabel = new Label(mAudioSettingsContainer, "SoundLabel");
-            mSoundLabel.SetText(Strings.Settings.SoundVolume.ToString(100));
-
-            // Audio Settings - Sound Slider
-            mSoundSlider = new HorizontalSlider(mAudioSettingsContainer, "SoundSlider");
-            mSoundSlider.Min = 0;
-            mSoundSlider.Max = 100;
-            mSoundSlider.ValueChanged += SoundSlider_ValueChanged;
-
-            // Audio Settings - Music Label
-            mMusicLabel = new Label(mAudioSettingsContainer, "MusicLabel");
-            mMusicLabel.SetText(Strings.Settings.MusicVolume.ToString(100));
-
-            // Audio Settings - Music Slider
-            mMusicSlider = new HorizontalSlider(mAudioSettingsContainer, "MusicSlider");
-            mMusicSlider.Min = 0;
-            mMusicSlider.Max = 100;
-            mMusicSlider.ValueChanged += MusicSlider_ValueChanged;
-
-            #endregion
-
-            #region InitKeybindingSettings
-
-            // Init KeybindingsSettings Tab.
-            mKeybindingSettingsTab = new Button(mSettingsPanel, "KeybindingSettingsTab");
-            mKeybindingSettingsTab.Text = Strings.Settings.KeyBindingSettingsTab;
-            mKeybindingSettingsTab.Clicked += KeybindingSettingsTab_Clicked;
-
-            // KeybindingSettings Get Stored in the KeybindingSettings Scroll Control
-            mKeybindingSettingsContainer = new ScrollControl(mSettingsPanel, "KeybindingSettingsContainer");
-            mKeybindingSettingsContainer.EnableScroll(false, true);
-
-            // Keybinding Settings - Restore Default Keys Button.
-            mKeybindingRestoreBtn = new Button(mSettingsPanel, "KeybindingsRestoreBtn");
-            mKeybindingRestoreBtn.Text = Strings.Settings.Restore;
-            mKeybindingRestoreBtn.Clicked += KeybindingsRestoreBtn_Clicked;
-
-            // Keybinding Settings - Controls 
-            var row = 0;
-            var defaultFont = Current.GetFont("sourcesansproblack", 10);
-            foreach (Control control in Enum.GetValues(typeof(Control)))
-            {
-                var offset = row++ * 32;
-                var name = Enum.GetName(typeof(Control), control)?.ToLower();
-
-                var prefix = $"Control{Enum.GetName(typeof(Control), control)}";
-                var label = new Label(mKeybindingSettingsContainer, $"{prefix}Label")
-                {
-                    Text = Strings.Controls.KeyDictionary[name],
-                    AutoSizeToContents = true,
-                    Font = defaultFont,
-                };
-                label.SetBounds(14, 11 + offset, 21, 16);
-                label.SetTextColor(new Color(255, 255, 255, 255), Label.ControlState.Normal);
-
-                var key1 = new Button(mKeybindingSettingsContainer, $"{prefix}Button1")
-                {
-                    AutoSizeToContents = false,
-                    Font = defaultFont,
-                    Text = string.Empty,
-                    UserData = new KeyValuePair<Control, int>(control, 0),
-                };
-                key1.SetTextColor(Color.White, Label.ControlState.Normal);
-                key1.SetImage("control_button.png", Button.ControlState.Normal);
-                key1.SetImage("control_button_hovered.png", Button.ControlState.Hovered);
-                key1.SetImage("control_button_clicked.png", Button.ControlState.Clicked);
-                key1.SetHoverSound("octave-tap-resonant.wav");
-                key1.SetMouseDownSound("octave-tap-warm.wav");
-                key1.SetBounds(181, 6 + offset, 120, 28);
-                key1.Clicked += Key_Clicked;
-
-                var key2 = new Button(mKeybindingSettingsContainer, $"{prefix}Button2")
-                {
-                    AutoSizeToContents = false,
-                    Font = defaultFont,
-                    Text = string.Empty,
-                    UserData = new KeyValuePair<Control, int>(control, 1),
-                };
-                key2.SetTextColor(Color.White, Label.ControlState.Normal);
-                key2.SetImage("control_button.png", Button.ControlState.Normal);
-                key2.SetImage("control_button_hovered.png", Button.ControlState.Hovered);
-                key2.SetImage("control_button_clicked.png", Button.ControlState.Clicked);
-                key2.SetHoverSound("octave-tap-resonant.wav");
-                key2.SetMouseDownSound("octave-tap-warm.wav");
-                key2.SetBounds(309, 6 + offset, 120, 28);
-                key2.Clicked += Key_Clicked;
-
-                mKeybindingBtns.Add(control, new[] { key1, key2 });
-            }
-
-            Input.KeyDown += OnKeyDown;
-            Input.MouseDown += OnKeyDown;
-            Input.KeyUp += OnKeyUp;
-            Input.MouseUp += OnKeyUp;
-
-            #endregion
-
-            mSettingsPanel.LoadJsonUi(UI.Shared, Graphics.Renderer.GetResolutionString());
+            mKeybindingBtns.Add(control, new[] { key1, key2 });
         }
 
-        private void GameSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
+        Input.KeyDown += OnKeyDown;
+        Input.MouseDown += OnKeyDown;
+        Input.KeyUp += OnKeyUp;
+        Input.MouseUp += OnKeyUp;
+
+        #endregion
+
+        mSettingsPanel.LoadJsonUi(UI.Shared, Graphics.Renderer.GetResolutionString());
+    }
+
+    private void GameSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Determine if GameSettingsContainer is currently being shown or not.
+        if (!mGameSettingsContainer.IsVisible)
         {
-            // Determine if GameSettingsContainer is currently being shown or not.
-            if (!mGameSettingsContainer.IsVisible)
-            {
-                // Disable the GameSettingsTab to fake it being selected visually.
-                mGameSettingsTab.Disable();
-                mVideoSettingsTab.Enable();
-                mAudioSettingsTab.Enable();
-                mKeybindingSettingsTab.Enable();
-
-                // Containers.
-                mGameSettingsContainer.Show();
-                mVideoSettingsContainer.Hide();
-                mAudioSettingsContainer.Hide();
-                mKeybindingSettingsContainer.Hide();
-
-                // Restore Default KeybindingSettings Button.
-                mKeybindingRestoreBtn.Hide();
-            }
-        }
-
-        void InterfaceSettings_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mInterfaceSettings.Show();
-            mInformationSettings.Hide();
-            mTargetingSettings.Hide();
-        }
-
-        void InformationSettings_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mInterfaceSettings.Hide();
-            mInformationSettings.Show();
-            mTargetingSettings.Hide();
-        }
-
-        void TargetingSettings_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mInterfaceSettings.Hide();
-            mInformationSettings.Hide();
-            mTargetingSettings.Show();
-            mAutoTurnToTarget.IsDisabled = !(Options.Instance?.PlayerOpts?.EnableAutoTurnToTarget ?? false);
-        }
-
-        private void VideoSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            // Determine if VideoSettingsContainer is currently being shown or not.
-            if (!mVideoSettingsContainer.IsVisible)
-            {
-                // Disable the VideoSettingsTab to fake it being selected visually.
-                mGameSettingsTab.Enable();
-                mVideoSettingsTab.Disable();
-                mAudioSettingsTab.Enable();
-                mKeybindingSettingsTab.Enable();
-
-                // Containers.
-                mGameSettingsContainer.Hide();
-                mVideoSettingsContainer.Show();
-                mAudioSettingsContainer.Hide();
-                mKeybindingSettingsContainer.Hide();
-
-                // Restore Default KeybindingSettings Button.
-                mKeybindingRestoreBtn.Hide();
-            }
-        }
-
-        private void AudioSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            // Determine if AudioSettingsContainer is currently being shown or not.
-            if (!mAudioSettingsContainer.IsVisible)
-            {
-                // Disable the AudioSettingsTab to fake it being selected visually.
-                mGameSettingsTab.Enable();
-                mVideoSettingsTab.Enable();
-                mAudioSettingsTab.Disable();
-                mKeybindingSettingsTab.Enable();
-
-                // Containers.
-                mGameSettingsContainer.Hide();
-                mVideoSettingsContainer.Hide();
-                mAudioSettingsContainer.Show();
-                mKeybindingSettingsContainer.Hide();
-
-                // Restore Default KeybindingSettings Button.
-                mKeybindingRestoreBtn.Hide();
-            }
-        }
-
-        private void KeybindingSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            // Determine if controls are currently being shown or not.
-            if (!mKeybindingSettingsContainer.IsVisible)
-            {
-                // Disable the KeybindingSettingsTab to fake it being selected visually.
-                mGameSettingsTab.Enable();
-                mVideoSettingsTab.Enable();
-                mAudioSettingsTab.Enable();
-                mKeybindingSettingsTab.Disable();
-
-                // Containers.
-                mGameSettingsContainer.Hide();
-                mVideoSettingsContainer.Hide();
-                mAudioSettingsContainer.Hide();
-                mKeybindingSettingsContainer.Show();
-
-                // Restore Default KeybindingSettings Button.
-                mKeybindingRestoreBtn.Show();
-
-                // KeybindingBtns.
-                foreach (Control control in Enum.GetValues(typeof(Control)))
-                {
-                    var controlMapping = mKeybindingEditControls.ControlMapping[control];
-                    for (var bindingIndex = 0; bindingIndex < controlMapping.Bindings.Count; bindingIndex++)
-                    {
-                        var binding = controlMapping.Bindings[bindingIndex];
-                        mKeybindingBtns[control][bindingIndex].Text = Strings.Keys.FormatKeyName(binding.Modifier, binding.Key);
-                    }
-                }
-            }
-        }
-
-        private void LoadSettingsWindow()
-        {
-            // Settings Window Title.
-            mSettingsHeader.SetText(Strings.Settings.Title);
+            // Disable the GameSettingsTab to fake it being selected visually.
+            mGameSettingsTab.Disable();
+            mVideoSettingsTab.Enable();
+            mAudioSettingsTab.Enable();
+            mKeybindingSettingsTab.Enable();
 
             // Containers.
             mGameSettingsContainer.Show();
@@ -618,283 +503,98 @@ namespace Intersect.Client.Interface.Shared
             mAudioSettingsContainer.Hide();
             mKeybindingSettingsContainer.Hide();
 
-            // Tabs.
-            mGameSettingsTab.Show();
-            mVideoSettingsTab.Show();
-            mAudioSettingsTab.Show();
-            mKeybindingSettingsTab.Show();
+            // Restore Default KeybindingSettings Button.
+            mKeybindingRestoreBtn.Hide();
+        }
+    }
 
-            // Disable the GameSettingsTab to fake it being selected visually by default.
-            mGameSettingsTab.Disable();
-            mVideoSettingsTab.Enable();
+    void InterfaceSettings_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mInterfaceSettings.Show();
+        mInformationSettings.Hide();
+        mTargetingSettings.Hide();
+    }
+
+    void InformationSettings_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mInterfaceSettings.Hide();
+        mInformationSettings.Show();
+        mTargetingSettings.Hide();
+    }
+
+    void TargetingSettings_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mInterfaceSettings.Hide();
+        mInformationSettings.Hide();
+        mTargetingSettings.Show();
+        mAutoTurnToTarget.IsDisabled = !(Options.Instance?.PlayerOpts?.EnableAutoTurnToTarget ?? false);
+    }
+
+    private void VideoSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Determine if VideoSettingsContainer is currently being shown or not.
+        if (!mVideoSettingsContainer.IsVisible)
+        {
+            // Disable the VideoSettingsTab to fake it being selected visually.
+            mGameSettingsTab.Enable();
+            mVideoSettingsTab.Disable();
             mAudioSettingsTab.Enable();
             mKeybindingSettingsTab.Enable();
 
-            // Buttons.
-            mSettingsApplyBtn.Show();
-            mSettingsCancelBtn.Show();
+            // Containers.
+            mGameSettingsContainer.Hide();
+            mVideoSettingsContainer.Show();
+            mAudioSettingsContainer.Hide();
+            mKeybindingSettingsContainer.Hide();
+
+            // Restore Default KeybindingSettings Button.
             mKeybindingRestoreBtn.Hide();
-
-            var worldScaleNotches = new double[] { 1, 2, 4 }.Select(n => n * Graphics.BaseWorldScale).ToArray();
-
-            Globals.Database.WorldZoom = (float)MathHelper.Clamp(
-                Globals.Database.WorldZoom,
-                worldScaleNotches.Min(),
-                worldScaleNotches.Max()
-            );
-            _worldScale.Min = worldScaleNotches.Min();
-            _worldScale.Max = worldScaleNotches.Max();
-            _worldScale.Value = Globals.Database.WorldZoom;
         }
+    }
 
-        private readonly HashSet<Keys> _keysDown = new HashSet<Keys>();
-
-        private void OnKeyDown(Keys modifier, Keys key)
+    private void AudioSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Determine if AudioSettingsContainer is currently being shown or not.
+        if (!mAudioSettingsContainer.IsVisible)
         {
-            if (mKeybindingEditBtn != default)
-            {
-                _ = _keysDown.Add(key);
-            }
+            // Disable the AudioSettingsTab to fake it being selected visually.
+            mGameSettingsTab.Enable();
+            mVideoSettingsTab.Enable();
+            mAudioSettingsTab.Disable();
+            mKeybindingSettingsTab.Enable();
+
+            // Containers.
+            mGameSettingsContainer.Hide();
+            mVideoSettingsContainer.Hide();
+            mAudioSettingsContainer.Show();
+            mKeybindingSettingsContainer.Hide();
+
+            // Restore Default KeybindingSettings Button.
+            mKeybindingRestoreBtn.Hide();
         }
+    }
 
-        private void OnKeyUp(Keys modifier, Keys key)
+    private void KeybindingSettingsTab_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Determine if controls are currently being shown or not.
+        if (!mKeybindingSettingsContainer.IsVisible)
         {
-            if (mKeybindingEditBtn == null)
-            {
-                return;
-            }
+            // Disable the KeybindingSettingsTab to fake it being selected visually.
+            mGameSettingsTab.Enable();
+            mVideoSettingsTab.Enable();
+            mAudioSettingsTab.Enable();
+            mKeybindingSettingsTab.Disable();
 
-            if (key != Keys.None && !_keysDown.Remove(key))
-            {
-                return;
-            }
+            // Containers.
+            mGameSettingsContainer.Hide();
+            mVideoSettingsContainer.Hide();
+            mAudioSettingsContainer.Hide();
+            mKeybindingSettingsContainer.Show();
 
-            mKeybindingEditControls.UpdateControl(mKeybindingEditControl, mKeyEdit, modifier, key);
-            mKeybindingEditBtn.Text = Strings.Keys.FormatKeyName(modifier, key);
+            // Restore Default KeybindingSettings Button.
+            mKeybindingRestoreBtn.Show();
 
-            if (key != Keys.None)
-            {
-                foreach (var control in mKeybindingEditControls.ControlMapping)
-                {
-                    if (control.Key == mKeybindingEditControl)
-                    {
-                        continue;
-                    }
-
-                    var bindings = control.Value.Bindings;
-                    for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
-                    {
-                        var binding = bindings[bindingIndex];
-
-                        if (binding.Modifier == modifier && binding.Key == key)
-                        {
-                            // Remove this mapping.
-                            mKeybindingEditControls.UpdateControl(control.Key, bindingIndex, Keys.None, Keys.None);
-
-                            // Update UI.
-                            mKeybindingBtns[control.Key][bindingIndex].Text = Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), Keys.None).ToLower()];
-                        }
-                    }
-                }
-
-                mKeybindingEditBtn.PlayHoverSound();
-            }
-
-            mKeybindingEditBtn = null;
-            _keysDown.Clear();
-            Interface.GwenInput.HandleInput = true;
-        }
-
-        // Methods.
-        public void Update()
-        {
-            if (IsVisible &&
-                mKeybindingEditBtn != null &&
-                mKeybindingListeningTimer < Timing.Global.MillisecondsUtc)
-            {
-                OnKeyUp(Keys.None, Keys.None);
-            }
-        }
-
-        public void Show(bool returnToMenu = false)
-        {
-            // Take over all input when we're in-game.
-            if (Globals.GameState == GameStates.InGame)
-            {
-                mSettingsPanel.MakeModal(true);
-            }
-
-            // Game Settings.
-            mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
-            mAutoToggleChatLogCheckbox.IsChecked = Globals.Database.AutoToggleChatLog;
-            mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
-            mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
-            mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
-            mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
-            mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
-            mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
-            mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
-            mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
-            mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
-            mFriendOverheadHpBarCheckbox.IsChecked = Globals.Database.FriendOverheadHpBar;
-            mGuildMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.GuildMemberOverheadHpBar;
-            mMyOverheadHpBarCheckbox.IsChecked = Globals.Database.MyOverheadHpBar;
-            mNpcOverheadHpBarCheckbox.IsChecked = Globals.Database.NpcOverheadHpBar;
-            mPartyMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.PartyMemberOverheadHpBar;
-            mPlayerOverheadHpBarCheckbox.IsChecked = Globals.Database.PlayerOverheadHpBar;
-            mStickyTarget.IsChecked = Globals.Database.StickyTarget;
-            mAutoTurnToTarget.IsChecked = Globals.Database.AutoTurnToTarget;
-            mTypewriterCheckbox.IsChecked = Globals.Database.TypewriterBehavior == Enums.TypewriterBehavior.Word;
-
-            // Video Settings.
-            mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
-            mLightingEnabledCheckbox.IsChecked = Globals.Database.EnableLighting;
-
-            // _uiScale.Value = Globals.Database.UIScale;
-            _worldScale.Value = Globals.Database.WorldZoom;
-
-            if (Graphics.Renderer.GetValidVideoModes().Count > 0)
-            {
-                string resolutionLabel;
-                if (Graphics.Renderer.HasOverrideResolution)
-                {
-                    resolutionLabel = Strings.Settings.ResolutionCustom;
-
-                    if (mCustomResolutionMenuItem == null)
-                    {
-                        mCustomResolutionMenuItem = mResolutionList.AddItem(Strings.Settings.ResolutionCustom);
-                    }
-
-                    mCustomResolutionMenuItem.Show();
-                }
-                else
-                {
-                    var validVideoModes = Graphics.Renderer.GetValidVideoModes();
-                    var targetResolution = Globals.Database.TargetResolution;
-                    resolutionLabel = targetResolution < 0 || validVideoModes.Count <= targetResolution ? Strings.Settings.ResolutionCustom : validVideoModes[Globals.Database.TargetResolution];
-                }
-
-                mResolutionList.SelectByText(resolutionLabel);
-            }
-
-            switch (Globals.Database.TargetFps)
-            {
-                case -1: // Unlimited.
-                    mFpsList.SelectByText(Strings.Settings.UnlimitedFps);
-
-                    break;
-                case 0: // Vertical Sync.
-                    mFpsList.SelectByText(Strings.Settings.Vsync);
-
-                    break;
-                case 1: // 30 Frames per second.
-                    mFpsList.SelectByText(Strings.Settings.Fps30);
-
-                    break;
-                case 2: // 60 Frames per second.
-                    mFpsList.SelectByText(Strings.Settings.Fps60);
-
-                    break;
-                case 3: // 90 Frames per second.
-                    mFpsList.SelectByText(Strings.Settings.Fps90);
-
-                    break;
-                case 4: // 120 Frames per second.
-                    mFpsList.SelectByText(Strings.Settings.Fps120);
-
-                    break;
-                default:
-                    mFpsList.SelectByText(Strings.Settings.Vsync);
-
-                    break;
-            }
-
-            // Audio Settings.
-            mPreviousMusicVolume = Globals.Database.MusicVolume;
-            mPreviousSoundVolume = Globals.Database.SoundVolume;
-            mMusicSlider.Value = Globals.Database.MusicVolume;
-            mSoundSlider.Value = Globals.Database.SoundVolume;
-            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
-            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
-
-            // Control Settings.
-            mKeybindingEditControls = new Controls(Controls.ActiveControls);
-
-            // Settings Window is not hidden anymore.
-            mSettingsPanel.Show();
-
-            // Load every GUI element to their default state when showing up the settings window (pressed tabs, containers, etc.)
-            LoadSettingsWindow();
-
-            // Set up whether we're supposed to return to the previous menu.
-            mReturnToMenu = returnToMenu;
-        }
-
-        public bool IsVisible => !mSettingsPanel.IsHidden;
-
-        public void Hide()
-        {
-            // Hide the current window.
-            mSettingsPanel.Hide();
-            mSettingsPanel.RemoveModal();
-
-            // Return to our previous menus (or not) depending on gamestate and the method we'd been opened.
-            if (mReturnToMenu)
-            {
-                switch (Globals.GameState)
-                {
-                    case GameStates.Menu:
-                        mMainMenu?.Show();
-                        break;
-
-                    case GameStates.InGame:
-                        mEscapeMenu?.Show();
-                        break;
-
-                    default:
-                        throw new NotImplementedException();
-                }
-
-                mReturnToMenu = false;
-            }
-        }
-
-        // Input Handlers
-        private void MusicSlider_ValueChanged(Base sender, EventArgs arguments)
-        {
-            mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
-            Globals.Database.MusicVolume = (int)mMusicSlider.Value;
-            Audio.UpdateGlobalVolume();
-        }
-
-        private void SoundSlider_ValueChanged(Base sender, EventArgs arguments)
-        {
-            mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
-            Globals.Database.SoundVolume = (int)mSoundSlider.Value;
-            Audio.UpdateGlobalVolume();
-        }
-
-        private void Key_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            EditKeyPressed((Button)sender);
-        }
-
-        private void EditKeyPressed(Button sender)
-        {
-            if (mKeybindingEditBtn == null)
-            {
-                sender.Text = Strings.Controls.Listening;
-                mKeyEdit = ((KeyValuePair<Control, int>)sender.UserData).Value;
-                mKeybindingEditControl = ((KeyValuePair<Control, int>)sender.UserData).Key;
-                mKeybindingEditBtn = sender;
-                Interface.GwenInput.HandleInput = false;
-                mKeybindingListeningTimer = Timing.Global.MillisecondsUtc + 3000;
-            }
-        }
-
-        private void KeybindingsRestoreBtn_Clicked(Base sender, ClickedEventArgs arguments)
-        {
-            mKeybindingEditControls.ResetDefaults();
+            // KeybindingBtns.
             foreach (Control control in Enum.GetValues(typeof(Control)))
             {
                 var controlMapping = mKeybindingEditControls.ControlMapping[control];
@@ -905,119 +605,418 @@ namespace Intersect.Client.Interface.Shared
                 }
             }
         }
+    }
 
-        private void SettingsApplyBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    private void LoadSettingsWindow()
+    {
+        // Settings Window Title.
+        mSettingsHeader.SetText(Strings.Settings.Title);
+
+        // Containers.
+        mGameSettingsContainer.Show();
+        mVideoSettingsContainer.Hide();
+        mAudioSettingsContainer.Hide();
+        mKeybindingSettingsContainer.Hide();
+
+        // Tabs.
+        mGameSettingsTab.Show();
+        mVideoSettingsTab.Show();
+        mAudioSettingsTab.Show();
+        mKeybindingSettingsTab.Show();
+
+        // Disable the GameSettingsTab to fake it being selected visually by default.
+        mGameSettingsTab.Disable();
+        mVideoSettingsTab.Enable();
+        mAudioSettingsTab.Enable();
+        mKeybindingSettingsTab.Enable();
+
+        // Buttons.
+        mSettingsApplyBtn.Show();
+        mSettingsCancelBtn.Show();
+        mKeybindingRestoreBtn.Hide();
+
+        var worldScaleNotches = new double[] { 1, 2, 4 }.Select(n => n * Graphics.BaseWorldScale).ToArray();
+
+        Globals.Database.WorldZoom = (float)MathHelper.Clamp(
+            Globals.Database.WorldZoom,
+            worldScaleNotches.Min(),
+            worldScaleNotches.Max()
+        );
+        _worldScale.Min = worldScaleNotches.Min();
+        _worldScale.Max = worldScaleNotches.Max();
+        _worldScale.Value = Globals.Database.WorldZoom;
+    }
+
+    private readonly HashSet<Keys> _keysDown = new HashSet<Keys>();
+
+    private void OnKeyDown(Keys modifier, Keys key)
+    {
+        if (mKeybindingEditBtn != default)
         {
-            var shouldReset = false;
+            _ = _keysDown.Add(key);
+        }
+    }
 
-            // Game Settings.
-            Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
-            Globals.Database.AutoToggleChatLog = mAutoToggleChatLogCheckbox.IsChecked;
-            Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
-            Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
-            Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;
-            Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
-            Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
-            Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
-            Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
-            Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
-            Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
-            Globals.Database.FriendOverheadHpBar = mFriendOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.GuildMemberOverheadHpBar = mGuildMemberOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.MyOverheadHpBar= mMyOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.NpcOverheadHpBar= mNpcOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.PartyMemberOverheadHpBar = mPartyMemberOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.PlayerOverheadHpBar = mPlayerOverheadHpBarCheckbox.IsChecked;
-            Globals.Database.StickyTarget = mStickyTarget.IsChecked;
-            Globals.Database.AutoTurnToTarget = mAutoTurnToTarget.IsChecked;
-            Globals.Database.TypewriterBehavior = mTypewriterCheckbox.IsChecked ? Enums.TypewriterBehavior.Word : Enums.TypewriterBehavior.Off;
-
-            // Video Settings.
-
-            // Globals.Database.UIScale = (float)_uiScale.Value;
-            Globals.Database.WorldZoom = (float)_worldScale.Value;
-
-            var resolution = mResolutionList.SelectedItem;
-            var validVideoModes = Graphics.Renderer.GetValidVideoModes();
-            var targetResolution = validVideoModes?.FindIndex(videoMode =>
-                string.Equals(videoMode, resolution.Text)) ?? -1;
-            var newFps = 0;
-
-            Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;
-
-            if (targetResolution > -1)
-            {
-                shouldReset = Globals.Database.TargetResolution != targetResolution ||
-                              Graphics.Renderer.HasOverrideResolution;
-                Globals.Database.TargetResolution = targetResolution;
-            }
-
-            if (Globals.Database.FullScreen != mFullscreenCheckbox.IsChecked)
-            {
-                Globals.Database.FullScreen = mFullscreenCheckbox.IsChecked;
-                shouldReset = true;
-            }
-
-            if (mFpsList.SelectedItem.Text == Strings.Settings.UnlimitedFps)
-            {
-                newFps = -1;
-            }
-            else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps30)
-            {
-                newFps = 1;
-            }
-            else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps60)
-            {
-                newFps = 2;
-            }
-            else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps90)
-            {
-                newFps = 3;
-            }
-            else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps120)
-            {
-                newFps = 4;
-            }
-
-            if (newFps != Globals.Database.TargetFps)
-            {
-                shouldReset = true;
-                Globals.Database.TargetFps = newFps;
-            }
-
-            // Audio Settings.
-            Globals.Database.MusicVolume = (int)mMusicSlider.Value;
-            Globals.Database.SoundVolume = (int)mSoundSlider.Value;
-            Audio.UpdateGlobalVolume();
-
-            // Control Settings.
-            Controls.ActiveControls = mKeybindingEditControls;
-            Controls.ActiveControls.Save();
-
-            // Save Preferences.
-            Globals.Database.SavePreferences();
-
-            if (shouldReset)
-            {
-                mCustomResolutionMenuItem?.Hide();
-                Graphics.Renderer.OverrideResolution = Resolution.Empty;
-                Graphics.Renderer.Init();
-            }
-
-            // Hide the currently opened window.
-            Hide();
+    private void OnKeyUp(Keys modifier, Keys key)
+    {
+        if (mKeybindingEditBtn == null)
+        {
+            return;
         }
 
-        private void SettingsCancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
+        if (key != Keys.None && !_keysDown.Remove(key))
         {
-            // Update previously saved values in order to discard changes.
-            Globals.Database.MusicVolume = mPreviousMusicVolume;
-            Globals.Database.SoundVolume = mPreviousSoundVolume;
-            Audio.UpdateGlobalVolume();
-            mKeybindingEditControls = new Controls(Controls.ActiveControls);
-
-            // Hide our current window.
-            Hide();
+            return;
         }
+
+        mKeybindingEditControls.UpdateControl(mKeybindingEditControl, mKeyEdit, modifier, key);
+        mKeybindingEditBtn.Text = Strings.Keys.FormatKeyName(modifier, key);
+
+        if (key != Keys.None)
+        {
+            foreach (var control in mKeybindingEditControls.ControlMapping)
+            {
+                if (control.Key == mKeybindingEditControl)
+                {
+                    continue;
+                }
+
+                var bindings = control.Value.Bindings;
+                for (var bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++)
+                {
+                    var binding = bindings[bindingIndex];
+
+                    if (binding.Modifier == modifier && binding.Key == key)
+                    {
+                        // Remove this mapping.
+                        mKeybindingEditControls.UpdateControl(control.Key, bindingIndex, Keys.None, Keys.None);
+
+                        // Update UI.
+                        mKeybindingBtns[control.Key][bindingIndex].Text = Strings.Keys.KeyDictionary[Enum.GetName(typeof(Keys), Keys.None).ToLower()];
+                    }
+                }
+            }
+
+            mKeybindingEditBtn.PlayHoverSound();
+        }
+
+        mKeybindingEditBtn = null;
+        _keysDown.Clear();
+        Interface.GwenInput.HandleInput = true;
+    }
+
+    // Methods.
+    public void Update()
+    {
+        if (IsVisible &&
+            mKeybindingEditBtn != null &&
+            mKeybindingListeningTimer < Timing.Global.MillisecondsUtc)
+        {
+            OnKeyUp(Keys.None, Keys.None);
+        }
+    }
+
+    public void Show(bool returnToMenu = false)
+    {
+        // Take over all input when we're in-game.
+        if (Globals.GameState == GameStates.InGame)
+        {
+            mSettingsPanel.MakeModal(true);
+        }
+
+        // Game Settings.
+        mAutoCloseWindowsCheckbox.IsChecked = Globals.Database.HideOthersOnWindowOpen;
+        mAutoToggleChatLogCheckbox.IsChecked = Globals.Database.AutoToggleChatLog;
+        mShowHealthAsPercentageCheckbox.IsChecked = Globals.Database.ShowHealthAsPercentage;
+        mShowManaAsPercentageCheckbox.IsChecked = Globals.Database.ShowManaAsPercentage;
+        mShowExperienceAsPercentageCheckbox.IsChecked = Globals.Database.ShowExperienceAsPercentage;
+        mFriendOverheadInfoCheckbox.IsChecked = Globals.Database.FriendOverheadInfo;
+        mGuildMemberOverheadInfoCheckbox.IsChecked = Globals.Database.GuildMemberOverheadInfo;
+        mMyOverheadInfoCheckbox.IsChecked = Globals.Database.MyOverheadInfo;
+        mNpcOverheadInfoCheckbox.IsChecked = Globals.Database.NpcOverheadInfo;
+        mPartyMemberOverheadInfoCheckbox.IsChecked = Globals.Database.PartyMemberOverheadInfo;
+        mPlayerOverheadInfoCheckbox.IsChecked = Globals.Database.PlayerOverheadInfo;
+        mFriendOverheadHpBarCheckbox.IsChecked = Globals.Database.FriendOverheadHpBar;
+        mGuildMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.GuildMemberOverheadHpBar;
+        mMyOverheadHpBarCheckbox.IsChecked = Globals.Database.MyOverheadHpBar;
+        mNpcOverheadHpBarCheckbox.IsChecked = Globals.Database.NpcOverheadHpBar;
+        mPartyMemberOverheadHpBarCheckbox.IsChecked = Globals.Database.PartyMemberOverheadHpBar;
+        mPlayerOverheadHpBarCheckbox.IsChecked = Globals.Database.PlayerOverheadHpBar;
+        mStickyTarget.IsChecked = Globals.Database.StickyTarget;
+        mAutoTurnToTarget.IsChecked = Globals.Database.AutoTurnToTarget;
+        mTypewriterCheckbox.IsChecked = Globals.Database.TypewriterBehavior == Enums.TypewriterBehavior.Word;
+
+        // Video Settings.
+        mFullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
+        mLightingEnabledCheckbox.IsChecked = Globals.Database.EnableLighting;
+
+        // _uiScale.Value = Globals.Database.UIScale;
+        _worldScale.Value = Globals.Database.WorldZoom;
+
+        if (Graphics.Renderer.GetValidVideoModes().Count > 0)
+        {
+            string resolutionLabel;
+            if (Graphics.Renderer.HasOverrideResolution)
+            {
+                resolutionLabel = Strings.Settings.ResolutionCustom;
+
+                if (mCustomResolutionMenuItem == null)
+                {
+                    mCustomResolutionMenuItem = mResolutionList.AddItem(Strings.Settings.ResolutionCustom);
+                }
+
+                mCustomResolutionMenuItem.Show();
+            }
+            else
+            {
+                var validVideoModes = Graphics.Renderer.GetValidVideoModes();
+                var targetResolution = Globals.Database.TargetResolution;
+                resolutionLabel = targetResolution < 0 || validVideoModes.Count <= targetResolution ? Strings.Settings.ResolutionCustom : validVideoModes[Globals.Database.TargetResolution];
+            }
+
+            mResolutionList.SelectByText(resolutionLabel);
+        }
+
+        switch (Globals.Database.TargetFps)
+        {
+            case -1: // Unlimited.
+                mFpsList.SelectByText(Strings.Settings.UnlimitedFps);
+
+                break;
+            case 0: // Vertical Sync.
+                mFpsList.SelectByText(Strings.Settings.Vsync);
+
+                break;
+            case 1: // 30 Frames per second.
+                mFpsList.SelectByText(Strings.Settings.Fps30);
+
+                break;
+            case 2: // 60 Frames per second.
+                mFpsList.SelectByText(Strings.Settings.Fps60);
+
+                break;
+            case 3: // 90 Frames per second.
+                mFpsList.SelectByText(Strings.Settings.Fps90);
+
+                break;
+            case 4: // 120 Frames per second.
+                mFpsList.SelectByText(Strings.Settings.Fps120);
+
+                break;
+            default:
+                mFpsList.SelectByText(Strings.Settings.Vsync);
+
+                break;
+        }
+
+        // Audio Settings.
+        mPreviousMusicVolume = Globals.Database.MusicVolume;
+        mPreviousSoundVolume = Globals.Database.SoundVolume;
+        mMusicSlider.Value = Globals.Database.MusicVolume;
+        mSoundSlider.Value = Globals.Database.SoundVolume;
+        mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
+        mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
+
+        // Control Settings.
+        mKeybindingEditControls = new Controls(Controls.ActiveControls);
+
+        // Settings Window is not hidden anymore.
+        mSettingsPanel.Show();
+
+        // Load every GUI element to their default state when showing up the settings window (pressed tabs, containers, etc.)
+        LoadSettingsWindow();
+
+        // Set up whether we're supposed to return to the previous menu.
+        mReturnToMenu = returnToMenu;
+    }
+
+    public bool IsVisible => !mSettingsPanel.IsHidden;
+
+    public void Hide()
+    {
+        // Hide the current window.
+        mSettingsPanel.Hide();
+        mSettingsPanel.RemoveModal();
+
+        // Return to our previous menus (or not) depending on gamestate and the method we'd been opened.
+        if (mReturnToMenu)
+        {
+            switch (Globals.GameState)
+            {
+                case GameStates.Menu:
+                    mMainMenu?.Show();
+                    break;
+
+                case GameStates.InGame:
+                    mEscapeMenu?.Show();
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            mReturnToMenu = false;
+        }
+    }
+
+    // Input Handlers
+    private void MusicSlider_ValueChanged(Base sender, EventArgs arguments)
+    {
+        mMusicLabel.Text = Strings.Settings.MusicVolume.ToString((int)mMusicSlider.Value);
+        Globals.Database.MusicVolume = (int)mMusicSlider.Value;
+        Audio.UpdateGlobalVolume();
+    }
+
+    private void SoundSlider_ValueChanged(Base sender, EventArgs arguments)
+    {
+        mSoundLabel.Text = Strings.Settings.SoundVolume.ToString((int)mSoundSlider.Value);
+        Globals.Database.SoundVolume = (int)mSoundSlider.Value;
+        Audio.UpdateGlobalVolume();
+    }
+
+    private void Key_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        EditKeyPressed((Button)sender);
+    }
+
+    private void EditKeyPressed(Button sender)
+    {
+        if (mKeybindingEditBtn == null)
+        {
+            sender.Text = Strings.Controls.Listening;
+            mKeyEdit = ((KeyValuePair<Control, int>)sender.UserData).Value;
+            mKeybindingEditControl = ((KeyValuePair<Control, int>)sender.UserData).Key;
+            mKeybindingEditBtn = sender;
+            Interface.GwenInput.HandleInput = false;
+            mKeybindingListeningTimer = Timing.Global.MillisecondsUtc + 3000;
+        }
+    }
+
+    private void KeybindingsRestoreBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        mKeybindingEditControls.ResetDefaults();
+        foreach (Control control in Enum.GetValues(typeof(Control)))
+        {
+            var controlMapping = mKeybindingEditControls.ControlMapping[control];
+            for (var bindingIndex = 0; bindingIndex < controlMapping.Bindings.Count; bindingIndex++)
+            {
+                var binding = controlMapping.Bindings[bindingIndex];
+                mKeybindingBtns[control][bindingIndex].Text = Strings.Keys.FormatKeyName(binding.Modifier, binding.Key);
+            }
+        }
+    }
+
+    private void SettingsApplyBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        var shouldReset = false;
+
+        // Game Settings.
+        Globals.Database.HideOthersOnWindowOpen = mAutoCloseWindowsCheckbox.IsChecked;
+        Globals.Database.AutoToggleChatLog = mAutoToggleChatLogCheckbox.IsChecked;
+        Globals.Database.ShowExperienceAsPercentage = mShowExperienceAsPercentageCheckbox.IsChecked;
+        Globals.Database.ShowHealthAsPercentage = mShowHealthAsPercentageCheckbox.IsChecked;
+        Globals.Database.ShowManaAsPercentage = mShowManaAsPercentageCheckbox.IsChecked;
+        Globals.Database.FriendOverheadInfo = mFriendOverheadInfoCheckbox.IsChecked;
+        Globals.Database.GuildMemberOverheadInfo = mGuildMemberOverheadInfoCheckbox.IsChecked;
+        Globals.Database.MyOverheadInfo = mMyOverheadInfoCheckbox.IsChecked;
+        Globals.Database.NpcOverheadInfo = mNpcOverheadInfoCheckbox.IsChecked;
+        Globals.Database.PartyMemberOverheadInfo = mPartyMemberOverheadInfoCheckbox.IsChecked;
+        Globals.Database.PlayerOverheadInfo = mPlayerOverheadInfoCheckbox.IsChecked;
+        Globals.Database.FriendOverheadHpBar = mFriendOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.GuildMemberOverheadHpBar = mGuildMemberOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.MyOverheadHpBar= mMyOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.NpcOverheadHpBar= mNpcOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.PartyMemberOverheadHpBar = mPartyMemberOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.PlayerOverheadHpBar = mPlayerOverheadHpBarCheckbox.IsChecked;
+        Globals.Database.StickyTarget = mStickyTarget.IsChecked;
+        Globals.Database.AutoTurnToTarget = mAutoTurnToTarget.IsChecked;
+        Globals.Database.TypewriterBehavior = mTypewriterCheckbox.IsChecked ? Enums.TypewriterBehavior.Word : Enums.TypewriterBehavior.Off;
+
+        // Video Settings.
+
+        // Globals.Database.UIScale = (float)_uiScale.Value;
+        Globals.Database.WorldZoom = (float)_worldScale.Value;
+
+        var resolution = mResolutionList.SelectedItem;
+        var validVideoModes = Graphics.Renderer.GetValidVideoModes();
+        var targetResolution = validVideoModes?.FindIndex(videoMode =>
+            string.Equals(videoMode, resolution.Text)) ?? -1;
+        var newFps = 0;
+
+        Globals.Database.EnableLighting = mLightingEnabledCheckbox.IsChecked;
+
+        if (targetResolution > -1)
+        {
+            shouldReset = Globals.Database.TargetResolution != targetResolution ||
+                          Graphics.Renderer.HasOverrideResolution;
+            Globals.Database.TargetResolution = targetResolution;
+        }
+
+        if (Globals.Database.FullScreen != mFullscreenCheckbox.IsChecked)
+        {
+            Globals.Database.FullScreen = mFullscreenCheckbox.IsChecked;
+            shouldReset = true;
+        }
+
+        if (mFpsList.SelectedItem.Text == Strings.Settings.UnlimitedFps)
+        {
+            newFps = -1;
+        }
+        else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps30)
+        {
+            newFps = 1;
+        }
+        else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps60)
+        {
+            newFps = 2;
+        }
+        else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps90)
+        {
+            newFps = 3;
+        }
+        else if (mFpsList.SelectedItem.Text == Strings.Settings.Fps120)
+        {
+            newFps = 4;
+        }
+
+        if (newFps != Globals.Database.TargetFps)
+        {
+            shouldReset = true;
+            Globals.Database.TargetFps = newFps;
+        }
+
+        // Audio Settings.
+        Globals.Database.MusicVolume = (int)mMusicSlider.Value;
+        Globals.Database.SoundVolume = (int)mSoundSlider.Value;
+        Audio.UpdateGlobalVolume();
+
+        // Control Settings.
+        Controls.ActiveControls = mKeybindingEditControls;
+        Controls.ActiveControls.Save();
+
+        // Save Preferences.
+        Globals.Database.SavePreferences();
+
+        if (shouldReset)
+        {
+            mCustomResolutionMenuItem?.Hide();
+            Graphics.Renderer.OverrideResolution = Resolution.Empty;
+            Graphics.Renderer.Init();
+        }
+
+        // Hide the currently opened window.
+        Hide();
+    }
+
+    private void SettingsCancelBtn_Clicked(Base sender, ClickedEventArgs arguments)
+    {
+        // Update previously saved values in order to discard changes.
+        Globals.Database.MusicVolume = mPreviousMusicVolume;
+        Globals.Database.SoundVolume = mPreviousSoundVolume;
+        Audio.UpdateGlobalVolume();
+        mKeybindingEditControls = new Controls(Controls.ActiveControls);
+
+        // Hide our current window.
+        Hide();
     }
 }

--- a/Intersect.Client/Items/MapItemInstance.cs
+++ b/Intersect.Client/Items/MapItemInstance.cs
@@ -3,37 +3,35 @@ using Intersect.Network.Packets.Server;
 using Newtonsoft.Json;
 
 
-namespace Intersect.Client.Items
+namespace Intersect.Client.Items;
+
+
+public partial class MapItemInstance : Item, IMapItemInstance
 {
+    /// <summary>
+    /// The Unique Id of this particular MapItemInstance so we can refer to it elsewhere.
+    /// </summary>
+    public Guid Id { get; set; }
 
-    public partial class MapItemInstance : Item, IMapItemInstance
+    public int X { get; set; }
+
+    public int Y { get; set; }
+
+    [JsonIgnore] public int TileIndex => Y * Options.MapWidth + X;
+
+    public MapItemInstance() : base()
     {
-        /// <summary>
-        /// The Unique Id of this particular MapItemInstance so we can refer to it elsewhere.
-        /// </summary>
-        public Guid Id { get; set; }
+    }
 
-        public int X { get; set; }
-
-        public int Y { get; set; }
-
-        [JsonIgnore] public int TileIndex => Y * Options.MapWidth + X;
-
-        public MapItemInstance() : base()
-        {
-        }
-
-        public MapItemInstance(int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties itemProperties) : base()
-        {
-            Id = uniqueId;
-            X = tileIndex % Options.MapWidth;
-            Y = (int)Math.Floor(tileIndex / (float)Options.MapWidth);
-            ItemId = itemId;
-            BagId = bagId;
-            Quantity = quantity;
-            ItemProperties = itemProperties;
-        }
-
+    public MapItemInstance(int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties itemProperties) : base()
+    {
+        Id = uniqueId;
+        X = tileIndex % Options.MapWidth;
+        Y = (int)Math.Floor(tileIndex / (float)Options.MapWidth);
+        ItemId = itemId;
+        BagId = bagId;
+        Quantity = quantity;
+        ItemProperties = itemProperties;
     }
 
 }

--- a/Intersect.Client/Localization/Strings.cs
+++ b/Intersect.Client/Localization/Strings.cs
@@ -7,255 +7,300 @@ using Intersect.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Intersect.Client.Localization
+namespace Intersect.Client.Localization;
+
+
+public static partial class Strings
 {
+    private const string StringsFileName = "client_strings.json";
+    private static char[] mQuantityTrimChars = new char[] { '.', '0' };
 
-    public static partial class Strings
+    public static string FormatQuantityAbbreviated(long value)
     {
-        private const string StringsFileName = "client_strings.json";
-        private static char[] mQuantityTrimChars = new char[] { '.', '0' };
-
-        public static string FormatQuantityAbbreviated(long value)
+        if (value == 0)
         {
-            if (value == 0)
+            return "";
+        }
+        else
+        {
+            double returnVal = 0;
+            var postfix = "";
+
+            // hundreds
+            if (value <= 999)
             {
-                return "";
+                returnVal = value;
+            }
+
+            // thousands
+            else if (value >= 1000 && value <= 999999)
+            {
+                returnVal = value / 1000.0;
+                postfix = Numbers.Thousands;
+            }
+
+            // millions
+            else if (value >= 1000000 && value <= 999999999)
+            {
+                returnVal = value / 1000000.0;
+                postfix = Numbers.Millions;
+            }
+
+            // billions
+            else if (value >= 1000000000 && value <= 999999999999)
+            {
+                returnVal = value / 1000000000.0;
+                postfix = Numbers.Billions;
             }
             else
             {
-                double returnVal = 0;
-                var postfix = "";
-
-                // hundreds
-                if (value <= 999)
-                {
-                    returnVal = value;
-                }
-
-                // thousands
-                else if (value >= 1000 && value <= 999999)
-                {
-                    returnVal = value / 1000.0;
-                    postfix = Numbers.Thousands;
-                }
-
-                // millions
-                else if (value >= 1000000 && value <= 999999999)
-                {
-                    returnVal = value / 1000000.0;
-                    postfix = Numbers.Millions;
-                }
-
-                // billions
-                else if (value >= 1000000000 && value <= 999999999999)
-                {
-                    returnVal = value / 1000000000.0;
-                    postfix = Numbers.Billions;
-                }
-                else
-                {
-                    return "OOB";
-                }
-
-                if (returnVal >= 10)
-                {
-                    returnVal = Math.Floor(returnVal);
-
-                    return returnVal.ToString() + postfix;
-                }
-                else
-                {
-                    returnVal = Math.Floor(returnVal * 10) / 10.0;
-
-                    return returnVal.ToString("F1")
-                               .TrimEnd(mQuantityTrimChars)
-                               .ToString()
-                               .Replace(".", Numbers.Decimal) +
-                           postfix;
-                }
-            }
-        }
-
-        private static void SynchronizeConfigurableStrings()
-        {
-            if (Options.Instance == default)
-            {
-                return;
+                return "OOB";
             }
 
-            for (var rarityCode = 0; rarityCode < Options.Instance.Items.RarityTiers.Count; rarityCode++)
+            if (returnVal >= 10)
             {
-                var rarityName = Options.Instance.Items.RarityTiers[rarityCode];
-                if (!ItemDescription.Rarity.ContainsKey(rarityName))
-                {
-                    ItemDescription.Rarity[rarityName] = $"{rarityCode}:{rarityName}";
-                }
+                returnVal = Math.Floor(returnVal);
+
+                return returnVal.ToString() + postfix;
+            }
+            else
+            {
+                returnVal = Math.Floor(returnVal * 10) / 10.0;
+
+                return returnVal.ToString("F1")
+                           .TrimEnd(mQuantityTrimChars)
+                           .ToString()
+                           .Replace(".", Numbers.Decimal) +
+                       postfix;
             }
         }
+    }
 
-        private static void PostLoad()
+    private static void SynchronizeConfigurableStrings()
+    {
+        if (Options.Instance == default)
         {
-
-            Program.OpenGLLink = Errors.OpenGlLink.ToString();
-            Program.OpenALLink = Errors.OpenAllLink.ToString();
+            return;
         }
 
-        public static void Load()
+        for (var rarityCode = 0; rarityCode < Options.Instance.Items.RarityTiers.Count; rarityCode++)
         {
-            SynchronizeConfigurableStrings();
-
-            try
+            var rarityName = Options.Instance.Items.RarityTiers[rarityCode];
+            if (!ItemDescription.Rarity.ContainsKey(rarityName))
             {
-                var serialized = new Dictionary<string, Dictionary<string, object>>();
-                serialized = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(
-                    File.ReadAllText(Path.Combine(ClientConfiguration.ResourcesDirectory, StringsFileName))
-                );
+                ItemDescription.Rarity[rarityName] = $"{rarityCode}:{rarityName}";
+            }
+        }
+    }
 
-                var rootType = typeof(Strings);
-                var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
-                var missingStrings = new List<string>();
-                foreach (var groupType in groupTypes)
+    private static void PostLoad()
+    {
+
+        Program.OpenGLLink = Errors.OpenGlLink.ToString();
+        Program.OpenALLink = Errors.OpenAllLink.ToString();
+    }
+
+    public static void Load()
+    {
+        SynchronizeConfigurableStrings();
+
+        try
+        {
+            var serialized = new Dictionary<string, Dictionary<string, object>>();
+            serialized = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(
+                File.ReadAllText(Path.Combine(ClientConfiguration.ResourcesDirectory, StringsFileName))
+            );
+
+            var rootType = typeof(Strings);
+            var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
+            var missingStrings = new List<string>();
+            foreach (var groupType in groupTypes)
+            {
+                if (!serialized.TryGetValue(groupType.Name, out var serializedGroup))
                 {
-                    if (!serialized.TryGetValue(groupType.Name, out var serializedGroup))
+                    missingStrings.Add($"{groupType.Name}");
+                    serialized[groupType.Name] = SerializeGroup(groupType);
+                    continue;
+                }
+
+                foreach (var fieldInfo in groupType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                {
+                    var fieldValue = fieldInfo.GetValue(null);
+                    if (!serializedGroup.TryGetValue(fieldInfo.Name, out var serializedValue))
                     {
-                        missingStrings.Add($"{groupType.Name}");
-                        serialized[groupType.Name] = SerializeGroup(groupType);
-                        continue;
+                        var foundKey = serializedGroup.Keys.FirstOrDefault(key => string.Equals(fieldInfo.Name, key, StringComparison.OrdinalIgnoreCase));
+                        if (foundKey != default)
+                        {
+                            _ = serializedGroup.TryGetValue(foundKey, out serializedValue);
+                        }
                     }
 
-                    foreach (var fieldInfo in groupType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                    switch (fieldValue)
                     {
-                        var fieldValue = fieldInfo.GetValue(null);
-                        if (!serializedGroup.TryGetValue(fieldInfo.Name, out var serializedValue))
-                        {
-                            var foundKey = serializedGroup.Keys.FirstOrDefault(key => string.Equals(fieldInfo.Name, key, StringComparison.OrdinalIgnoreCase));
-                            if (foundKey != default)
+                        case LocalizedString localizedString:
+                            var jsonString = (string)serializedValue;
+                            if (jsonString == default)
                             {
-                                _ = serializedGroup.TryGetValue(foundKey, out serializedValue);
+                                Log.Warn($"{groupType.Name}.{fieldInfo.Name} is null.");
+                                missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string)");
+                                serializedGroup[fieldInfo.Name] = (string)localizedString;
                             }
-                        }
+                            else
+                            {
+                                fieldInfo.SetValue(null, new LocalizedString(jsonString));
+                            }
+                            break;
 
-                        switch (fieldValue)
-                        {
-                            case LocalizedString localizedString:
-                                var jsonString = (string)serializedValue;
-                                if (jsonString == default)
+                        case Dictionary<int, LocalizedString> intDictionary:
+                            DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, intDictionary);
+                            break;
+
+                        case Dictionary<string, LocalizedString> stringDictionary:
+                            DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, stringDictionary);
+                            break;
+
+                        default:
+                            {
+                                var fieldType = fieldInfo.FieldType;
+                                if (!fieldType.IsGenericType || typeof(Dictionary<,>) != fieldType.GetGenericTypeDefinition())
                                 {
-                                    Log.Warn($"{groupType.Name}.{fieldInfo.Name} is null.");
-                                    missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string)");
-                                    serializedGroup[fieldInfo.Name] = (string)localizedString;
-                                }
-                                else
-                                {
-                                    fieldInfo.SetValue(null, new LocalizedString(jsonString));
-                                }
-                                break;
-
-                            case Dictionary<int, LocalizedString> intDictionary:
-                                DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, intDictionary);
-                                break;
-
-                            case Dictionary<string, LocalizedString> stringDictionary:
-                                DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, stringDictionary);
-                                break;
-
-                            default:
-                                {
-                                    var fieldType = fieldInfo.FieldType;
-                                    if (!fieldType.IsGenericType || typeof(Dictionary<,>) != fieldType.GetGenericTypeDefinition())
-                                    {
-                                        Log.Error(new NotSupportedException($"Unsupported localization type for {groupType.Name}.{fieldInfo.Name}: {fieldInfo.FieldType.FullName}"));
-                                        break;
-                                    }
-
-                                    var parameters = fieldType.GenericTypeArguments;
-                                    var localizedParameterType = parameters.Last();
-                                    if (localizedParameterType != typeof(LocalizedString))
-                                    {
-                                        Log.Error(new NotSupportedException($"Unsupported localization dictionary value type for {groupType.Name}.{fieldInfo.Name}: {localizedParameterType.FullName}"));
-                                        break;
-                                    }
-
-                                    _ = _methodInfoDeserializeDictionary.MakeGenericMethod(parameters.First()).Invoke(default, new object[]
-                                    {
-                                                missingStrings,
-                                                groupType,
-                                                fieldInfo,
-                                                fieldValue,
-                                                serializedGroup,
-                                                serializedValue,
-                                                fieldValue
-                                    });
+                                    Log.Error(new NotSupportedException($"Unsupported localization type for {groupType.Name}.{fieldInfo.Name}: {fieldInfo.FieldType.FullName}"));
                                     break;
                                 }
-                        }
+
+                                var parameters = fieldType.GenericTypeArguments;
+                                var localizedParameterType = parameters.Last();
+                                if (localizedParameterType != typeof(LocalizedString))
+                                {
+                                    Log.Error(new NotSupportedException($"Unsupported localization dictionary value type for {groupType.Name}.{fieldInfo.Name}: {localizedParameterType.FullName}"));
+                                    break;
+                                }
+
+                                _ = _methodInfoDeserializeDictionary.MakeGenericMethod(parameters.First()).Invoke(default, new object[]
+                                {
+                                            missingStrings,
+                                            groupType,
+                                            fieldInfo,
+                                            fieldValue,
+                                            serializedGroup,
+                                            serializedValue,
+                                            fieldValue
+                                });
+                                break;
+                            }
                     }
                 }
-
-                if (missingStrings.Count > 0)
-                {
-                    Log.Warn($"Missing strings, overwriting strings file:\n\t{string.Join(",\n\t", missingStrings)}");
-                    SaveSerialized(serialized);
-                }
-            }
-            catch (Exception exception)
-            {
-                Log.Warn(exception);
-                Save();
             }
 
-            PostLoad();
-        }
-
-        private static readonly MethodInfo _methodInfoDeserializeDictionary = typeof(Strings).GetMethod(
-                                                nameof(DeserializeDictionary),
-                                                BindingFlags.NonPublic | BindingFlags.Static
-                                            ) ?? throw new InvalidOperationException();
-
-        private static void DeserializeDictionary<TKey>(
-            List<string> missingStrings,
-            Type groupType,
-            FieldInfo fieldInfo,
-            object fieldValue,
-            Dictionary<string, object> serializedGroup,
-            object serializedValue,
-            Dictionary<TKey, LocalizedString> dictionary
-        )
-        {
-            var serializedDictionary = serializedValue as JObject;
-            var serializedField = JToken.FromObject(fieldValue);
-            if (serializedValue == default)
+            if (missingStrings.Count > 0)
             {
-                missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string dictionary)");
-                serializedGroup[fieldInfo.Name] = serializedField;
-            }
-            else
-            {
-                var keys = dictionary.Keys.ToList();
-                foreach (var key in keys)
-                {
-                    var stringKey = key.ToString();
-                    if (!serializedDictionary.TryGetValue(stringKey, out var token) || token?.Type != JTokenType.String)
-                    {
-                        missingStrings.Add($"{groupType.Name}.{fieldInfo.Name}[{key}]");
-                        serializedDictionary[stringKey] = (string)dictionary[key];
-                        continue;
-                    }
-
-                    dictionary[key] = new LocalizedString((string)token);
-                }
+                Log.Warn($"Missing strings, overwriting strings file:\n\t{string.Join(",\n\t", missingStrings)}");
+                SaveSerialized(serialized);
             }
         }
-
-        private static Dictionary<string, string> SerializeDictionary<TKey>(Dictionary<TKey, LocalizedString> localizedDictionary)
+        catch (Exception exception)
         {
-            return localizedDictionary.ToDictionary(
-                pair => pair.Key.ToString(),
-                pair => pair.Value.ToString()
+            Log.Warn(exception);
+            Save();
+        }
+
+        PostLoad();
+    }
+
+    private static readonly MethodInfo _methodInfoDeserializeDictionary = typeof(Strings).GetMethod(
+                                            nameof(DeserializeDictionary),
+                                            BindingFlags.NonPublic | BindingFlags.Static
+                                        ) ?? throw new InvalidOperationException();
+
+    private static void DeserializeDictionary<TKey>(
+        List<string> missingStrings,
+        Type groupType,
+        FieldInfo fieldInfo,
+        object fieldValue,
+        Dictionary<string, object> serializedGroup,
+        object serializedValue,
+        Dictionary<TKey, LocalizedString> dictionary
+    )
+    {
+        var serializedDictionary = serializedValue as JObject;
+        var serializedField = JToken.FromObject(fieldValue);
+        if (serializedValue == default)
+        {
+            missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string dictionary)");
+            serializedGroup[fieldInfo.Name] = serializedField;
+        }
+        else
+        {
+            var keys = dictionary.Keys.ToList();
+            foreach (var key in keys)
+            {
+                var stringKey = key.ToString();
+                if (!serializedDictionary.TryGetValue(stringKey, out var token) || token?.Type != JTokenType.String)
+                {
+                    missingStrings.Add($"{groupType.Name}.{fieldInfo.Name}[{key}]");
+                    serializedDictionary[stringKey] = (string)dictionary[key];
+                    continue;
+                }
+
+                dictionary[key] = new LocalizedString((string)token);
+            }
+        }
+    }
+
+    private static Dictionary<string, string> SerializeDictionary<TKey>(Dictionary<TKey, LocalizedString> localizedDictionary)
+    {
+        return localizedDictionary.ToDictionary(
+            pair => pair.Key.ToString(),
+            pair => pair.Value.ToString()
+        );
+    }
+
+    private static Dictionary<string, object> SerializeGroup(Type groupType)
+    {
+        var serializedGroup = new Dictionary<string, object>();
+        foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
+        {
+            switch (fieldInfo.GetValue(null))
+            {
+                case LocalizedString localizedString:
+                    serializedGroup.Add(fieldInfo.Name, localizedString.ToString());
+                    break;
+
+                case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedIntKeyDictionary));
+                    break;
+
+                case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedStringKeyDictionary));
+                    break;
+
+                case Dictionary<ChatboxTab, LocalizedString> localizedChatboxTabKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedChatboxTabKeyDictionary));
+                    break;
+            }
+        }
+        return serializedGroup;
+    }
+
+    private static void SaveSerialized(Dictionary<string, Dictionary<string, object>> serialized)
+    {
+        var languageDirectory = Path.Combine(ClientConfiguration.ResourcesDirectory);
+        if (Directory.Exists(languageDirectory))
+        {
+            File.WriteAllText(
+                Path.Combine(languageDirectory, StringsFileName),
+                JsonConvert.SerializeObject(serialized, Formatting.Indented)
             );
         }
+    }
 
-        private static Dictionary<string, object> SerializeGroup(Type groupType)
+    public static void Save()
+    {
+        var serialized = new Dictionary<string, Dictionary<string, object>>();
+        var rootType = typeof(Strings);
+        var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
+
+        foreach (var groupType in groupTypes)
         {
             var serializedGroup = new Dictionary<string, object>();
             foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
@@ -267,2246 +312,2199 @@ namespace Intersect.Client.Localization
                         break;
 
                     case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedIntKeyDictionary));
+                        serializedGroup.Add(fieldInfo.Name, localizedIntKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
                         break;
 
                     case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedStringKeyDictionary));
-                        break;
-
-                    case Dictionary<ChatboxTab, LocalizedString> localizedChatboxTabKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedChatboxTabKeyDictionary));
+                        serializedGroup.Add(fieldInfo.Name, localizedStringKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
                         break;
                 }
             }
-            return serializedGroup;
+
+            serialized.Add(groupType.Name, serializedGroup);
         }
 
-        private static void SaveSerialized(Dictionary<string, Dictionary<string, object>> serialized)
+        SaveSerialized(serialized);
+    }
+
+    public partial struct Admin
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Access = @"Access:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Access0 = @"None";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Access1 = @"Moderator";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Access2 = @"Admin";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Ban = @"Ban";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BanCaption = @"Ban {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BanPrompt = @"Banning {00} will not allow them to access this game for the duration you set!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Chronological = @"123...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ChronologicalTip = @"Order maps chronologically.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Face = @"Face:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Kick = @"Kick";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Kill = @"Kill";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapList = @"Map List:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Mute = @"Mute";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MuteCaption = @"Mute {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MutePrompt = @"Muting {00} will not allow them to chat in game for the duration you set!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"Name:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString None = @"None";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OverworldReturn = @"Leave Instance";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SetFace = @"Set Face";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SetPower = @"Set Power";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SetSprite = @"Set Sprite";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Sprite = @"Sprite:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Administration";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unban = @"Unban";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnbanCaption = @"Unban {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnbanPrompt = @"Are you sure that you want to unban {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unmute = @"Unmute";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnmuteCaption = @"Unmute {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnmutePrompt = @"Are you sure that you want to unmute {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Warp2Me = @"Warp To Me";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarpMe2 = @"Warp Me To";
+    }
+
+    public partial struct Bags
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RetrieveItem = @"Retrieve Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RetrieveItemPrompt = @"How many/much {00} would you like to retrieve?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StoreItem = @"Store Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StoreItemPrompt = @"How many/much {00} would you like to store?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Bag";
+    }
+
+    public partial struct Bank
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DepositItem = @"Deposit Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DepositItemPrompt = @"How many/much {00} would you like to deposit?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NoSpace = @"There is no space left in your bank for that item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Bank";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WithdrawItem = @"Withdraw Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WithdrawItemPrompt = @"How many/much {00} would you like to withdraw?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WithdrawItemNoSpace = @"There is no space left in your inventory for that item!";
+    }
+
+    public partial struct BanMute
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Duration = @"Duration:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FiveDays = @"5 days";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FourDays = @"4 days";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Forever = @"Indefinitely";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IncludeIp = @"Include IP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OneDay = @"1 day";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OneMonth = @"1 month";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OneWeek = @"1 week";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OneYear = @"1 year";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Okay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Reason = @"Reason:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SixMonths = @"6 months";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ThreeDays = @"3 days";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TwoDays = @"2 days";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TwoMonths = @"2 months";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TwoWeeks = @"2 weeks";
+    }
+
+    public partial struct Character
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AttackSpeed = @"Attack Speed: {00}s";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownReduction = @"Cooldown Reduction: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Equipment = @"Equipment:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ExtraBuffs = @"Extra Buffs";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ExtraExp = @"Bonus EXP: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString HealthRegen = @"Health Regen: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LevelAndClass = @"Level: {00}, Class: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Lifesteal = @"Lifesteal: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Luck = @"Luck: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ManaRegen = @"Mana Regen: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Manasteal = @"Manasteal: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Points = @"Points: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat0 = @"{00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat1 = @"{00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat2 = @"{00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat3 = @"{00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat4 = @"{00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stats = @"Stats:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Tenacity = @"Tenacity: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Character Information";
+    }
+
+    public partial struct CharacterCreation
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Class = @"Class:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Create = @"Create";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Female = @"Female";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Gender = @"Gender:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Hint = @"Customize";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Hint2 = @"Your Character";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InvalidName = @"Character name is invalid. Please use alphanumeric characters with a length between 2 and 20.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Male = @"Male";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"Name:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Create a New Character";
+    }
+
+    public partial struct CharacterSelection
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Delete = @"Delete";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DeletePrompt = @"Are you sure you want to delete {00}? This action is irreversible!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DeleteTitle = @"Delete {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Empty = @"Empty Character Slot";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Info = @"Level: {00}, Class: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Logout = @"Logout";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"{00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString New = @"New";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Play = @"Play";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Select a Character to Play";
+    }
+
+    public partial struct Chatbox
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Channel = @"Channel:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ChannelAdmin = @"admin";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Channels = new Dictionary<int, LocalizedString>
         {
-            var languageDirectory = Path.Combine(ClientConfiguration.ResourcesDirectory);
-            if (Directory.Exists(languageDirectory))
+            {0, @"local"},
+            {1, @"global"},
+            {2, @"party"},
+            {3, @"guild"}
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ClearLogButtonToolTip = @"Clear chat log messages";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<ChatboxTab, LocalizedString> ChatTabButtons = new Dictionary<ChatboxTab, LocalizedString>() {
+            { ChatboxTab.All, @"All" },
+            { ChatboxTab.Local, @"Local" },
+            { ChatboxTab.Party, @"Party" },
+            { ChatboxTab.Global, @"Global" },
+            { ChatboxTab.Guild, @"Guild" },
+            { ChatboxTab.System, @"System" },
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EnterChat = @"Click here to chat.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EnterChat1 = @"Press '{00}' to chat.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EnterChat2 = @"Press '{00}' or '{01}' to chat.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Send = @"Send";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Chat";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ToggleLogButtonToolTip = @"Toggle chat log visibility";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TooFast = @"You are chatting too fast!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnableToCopy = @"It appears you are not able to copy/paste on this platform. Please make sure you have either the 'xclip' or 'wl-clipboard' packages installed if you are running Linux.";
+    }
+
+    public partial struct Colors
+    {
+
+        public static Dictionary<int, LocalizedString> presets = new Dictionary<int, LocalizedString>
+        {
+            {0, @"Black"},
+            {1, @"White"},
+            {2, @"Pink"},
+            {3, @"Blue"},
+            {4, @"Red"},
+            {5, @"Green"},
+            {6, @"Yellow"},
+            {7, @"Orange"},
+            {8, @"Purple"},
+            {9, @"Gray"},
+            {10, @"Cyan"}
+        };
+
+    }
+
+    public partial struct Combat
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AttackWhileCastingDeny = @"You cannot attack while casting a spell.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat0 = @"Attack";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat1 = @"Ability Power";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat2 = @"Defense";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat3 = @"Magic Resist";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Stat4 = @"Speed";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarningCharacterSelect = @"You are attempting to logout while in combat! Your character will remain in-game until combat has ended. Are you sure you want to logout now?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarningExitDesktop = @"You are attempting to exit while in combat! Your character will remain in-game until combat has ended. Are you sure you want to quit now?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarningLogout = @"You are attempting to logout while in combat! Your character will remain in-game until combat has ended. Are you sure you want to logout now?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarningTitle = @"Combat Warning!";
+    }
+
+    public partial struct Controls
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<string, LocalizedString> KeyDictionary = new Dictionary<string, LocalizedString>
+        {
+            {"attackinteract", @"Attack/Interact:"},
+            {"block", @"Block:"},
+            {"autotarget", @"Auto Target:"},
+            {"enter", @"Chat:"},
+            {"hotkey0", @"Hot Key 0:"},
+            {"hotkey1", @"Hot Key 1:"},
+            {"hotkey2", @"Hot Key 2:"},
+            {"hotkey3", @"Hot Key 3:"},
+            {"hotkey4", @"Hot Key 4:"},
+            {"hotkey5", @"Hot Key 5:"},
+            {"hotkey6", @"Hot Key 6:"},
+            {"hotkey7", @"Hot Key 7:"},
+            {"hotkey8", @"Hot Key 8:"},
+            {"hotkey9", @"Hot Key 9:"},
+            {"movedown", @"Down:"},
+            {"moveleft", @"Left:"},
+            {"moveright", @"Right:"},
+            {"moveup", @"Up:"},
+            {"pickup", @"Pick Up:"},
+            {"screenshot", @"Screenshot:"},
+            {"openmenu", @"Open Menu:"},
+            {"openinventory", @"Open Inventory:"},
+            {"openquests", @"Open Quests:"},
+            {"opencharacterinfo", @"Open Character Info:"},
+            {"openparties", @"Open Parties:"},
+            {"openspells", @"Open Spells:"},
+            {"openfriends", @"Open Friends:"},
+            {"openguild", @"Open Guild:"},
+            {"opensettings", @"Open Settings:"},
+            {"opendebugger", @"Open Debugger:"},
+            {"openadminpanel", @"Open Admin Panel:"},
+            {"togglegui", @"Toggle Interface:"},
+            {"turnaround", @"Hold to turn around:"},
+            {"togglezoomin", "Toggle Zoom In:"},
+            {"holdtozoomin", "Hold to Zoom In:"},
+            {"togglezoomout", "Toggle Zoom Out:"},
+            {"holdtozoomout", "Hold to Zoom Out:"},
+            {"togglefullscreen", "Toggle Fullscreen:"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Listening = @"Listening";
+
+    }
+
+    public partial struct Crafting
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Craft = @"Craft 1";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CraftAll = @"Craft {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CraftChance = @"Chance of failure: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CraftingTime = "Crafting time: {00}s";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CraftStop = "Stop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DestroyMaterialsChance = @"Chance to destroy materials: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IncorrectResources = @"You do not have the necessary resources to craft this item.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Ingredients = @"Required:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Product = @"Crafting:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Recipes = @"Recipes:";
+    }
+
+    public partial struct Credits
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back to Main Menu";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Credits";
+
+    }
+
+    public partial struct Debug
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ControlUnderCursor = @"Control Under Cursor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DrawDebugOutlines = @"Draw Debug Outlines";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Draws = @"Draws";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EnableLayoutHotReloading = @"Enable Experimental Layout Hot Reloading";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EntitiesDrawn = @"Entities Drawn";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fps = @"FPS";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InterfaceObjects = @"Interface Objects";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KnownEntities = @"Known Entities";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KnownMaps = @"Known Maps";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LightsDrawn = @"Lights Drawn";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Map = @"Map";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapsDrawn = @"Maps Drawn";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Ping = @"Ping";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShutdownServer = @"Shutdown Server";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShutdownServerAndExit = @"Shutdown Server and Exit";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Time = @"Time";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Debug";
+    }
+
+    public partial struct EntityBox
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Exp = @"EXP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ExpValue = @"{00} / {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Friend = "Befriend";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Level = @"Lv. {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Map = @"{00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MaxLevel = @"Max Level";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NameAndLevel = @"{00}    {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Party = @"Party";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Trade = @"Trade";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital0 = @"HP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital0Value = @"{00} / {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital1 = @"MP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital1Value = @"{00} / {01}";
+    }
+
+    public partial struct Errors
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DisconnectionEvent = @"Please provide this message to your administrator: {0}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DisplayNotSupported = @"Invalid Display Configuration!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DisplayNotSupportedError = @"Fullscreen {00} resolution is not supported on this device!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString HostNotFound = @"DNS resolution error, please report this to the game administrator.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LoadFile = @"Failed to load a {00}. Please send the game administrator a copy of your errors log file in the logs directory.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LostConnection = @"Lost connection to the game server. Please make sure you're connected to the internet and try again!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotConnected = @"Not connected to the game server. Is it online?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OpenAllLink = @"https://goo.gl/Nbx6hx";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OpenGlLink = @"https://goo.gl/RSP3ts";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PasswordInvalid = @"Password is invalid. Please use alphanumeric characters with a length between 4 and 20.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ResourcesNotFound = @"The resources directory could not be found! Intersect will now close.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Error!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UsernameInvalid = @"Username is invalid. Please use alphanumeric characters with a length between 2 and 20.";
+    }
+
+    public partial struct Words
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LcaseAnimation = @"animation";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LcaseMusic = @"soundtrack";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LcaseSound = @"sound";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LcaseSprite = @"sprite";
+    }
+
+    public partial struct EventWindow
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Continue = @"Continue";
+
+    }
+
+    public partial struct ForgotPass
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Hint = @"If your account exists, we will send you a temporary password reset code.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Label = @"Enter your username or email below:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Submit = @"Submit";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Password Reset";
+    }
+
+    public partial struct Friends
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AddFriend = @"Add Friend";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AddFriendPrompt = @"Who would you like to add as a friend?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InFight = @"You are currently in a fight!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Offline = @"Offline";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RemoveFriend = @"Remove Friend";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RemoveFriendPrompt = @"Do you wish to remove {00} from your friends list?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Request = @"Friend Request";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RequestPrompt = @"{00} has sent you a friend request. Do you accept?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Friends";
+    }
+
+    public partial struct GameMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Character = @"Character Information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Friends = @"Friends";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Items = @"Inventory";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Menu = @"Open Menu";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Party = @"Party";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Quest = @"Quest Log";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Spells = @"Spell Book";
+    }
+
+    public partial struct General
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapItemStackable = @"{01} {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString None = @"None";
+    }
+
+    public partial struct Guilds
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bank = @"{00} Guild Bank";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Demote = @"Demote to {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DemotePrompt = @"Are you sure you want to demote {00} to rank {01}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DemoteTitle = @"Demote Guild Member";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Guild = @"Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildTip = @"Send {00} an invite to your guild.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Invite = @"Invite";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InviteAlreadyInGuild = @"The player you're trying to invite is already in a guild or has a pending invite.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InviteMemberPrompt = @"Who would you like to invite to {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InviteMemberTitle = @"Invite Player";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InviteRequestPrompt = @"{00} would like to invite you to join their guild, {01}. Do you accept?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InviteRequestTitle = @"Guild Invite";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Kick = @"Kick";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KickPrompt = @"Are you sure you want to kick {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KickTitle = @"Kick Guild Member";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Leave = "Leave";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LeavePrompt = @"Are you sure you want to leave your guild?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LeaveTitle = @"Leave Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotAllowedDeposit = @"You do not have permission to deposit items into {00}'s guild bank.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotAllowedSwap = @"You do not have permission to swap items within {00}'s guild bank.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotAllowedWithdraw = @"You do not have permission to withdraw from {00}'s guild bank.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotInGuild = @"You are not currently in a guild!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OfflineListEntry = @"[{00}] {01} - {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OnlineListEntry = @"[{00}] {01} - {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PM = @"PM";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Promote = @"Promote to {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PromotePrompt = @"Are you sure you want to promote {00} to rank {01}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PromoteTitle = @"Promote Guild Member";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Tooltip = @"Lv. {00} {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Transfer = @"Transfer";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TransferPrompt = @"This action will completely transfer all ownership of your guild to {00} and you will lose your rank of {01}. If you are sure you want to hand over your guild enter '{02}' below.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TransferTitle = @"Transfer Guild";
+    }
+
+    public partial struct InputBox
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString No = @"No";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Okay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Yes = @"Yes";
+    }
+
+    public partial struct MapItemWindow
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LootButton = @"Loot All";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Loot";
+    }
+
+    public partial struct Internals
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bounds = @"Bounds";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Color = @"Color";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ColorOverride = @"Color Override";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CoordinateX = @"X";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CoordinateY = @"Y";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CoordinateZ = @"Z";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ExperimentalFeatureTooltip = @"This feature is experimental and may cause issues when enabled.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GlobalItem = @"Global {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LocalItem = @"Local {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"Name";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotApplicable = @"N/A";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ResolutionXByY = @"{0}x{1}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Type = @"Type";
+    }
+
+    public partial struct Inventory
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DropItemPrompt = @"How many units of {00} would you like to discard?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DropItemTitle = @"Drop Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DropPrompt = @"Do you wish to drop the item: {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EquippedSymbol = "E";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Inventory";
+    }
+
+    public partial struct ItemContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bag = @"Bag {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bank = @"Bank {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cast = @"Cast {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Drop = @"Drop {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Equip = @"Equip {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Learn = @"Learn {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Open = @"Open {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Sell = @"Sell {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Trade = @"Offer {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unequip = @"Unequip {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Use = @"Use {00}";
+    }
+
+    public partial struct SpellContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cast = @"Cast {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Forget = @"Forget {00}";
+    }
+
+    public partial struct BankContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Withdraw = @"Withdraw {00}";
+    }
+
+    public partial struct BagContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Withdraw = @"Withdraw {00}";
+    }
+
+    public partial struct TradeContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Withdraw = @"Revoke {00}";
+    }
+
+    public partial struct ChatContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FriendInvite = @"Send Friend request to {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildInvite = @"Invite {00} to Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PartyInvite = @"Invite {00} to Party";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PM = @"Send Private Message to {00}";
+    }
+
+    public partial struct ShopContextMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Buy = @"Buy {00}";
+    }
+
+    public partial struct ItemDescription
+    {
+        // String Properties (A - Z):
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Amount = @"Amount:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AttackSpeed = @"Attack Speed:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BagSlots = @"Bag Slots:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bagged = @"Bagged";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Banked = @"Banked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BaseDamage = @"Base Damage:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BaseDamageType = @"Damage Type:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BlockAbsorption = @"Block Absorption:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BlockAmount = @"Block Amount:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BlockChance = @"Block Chance:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CastSpell = @"Casts Spell: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CritChance = @"Critical Chance:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CritMultiplier = @"Critical Multiplier:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Description = @"{00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DropOnDeath = @"Drop chance on death:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Dropped = @"Dropped";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildBanked = @"Guild Banked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ItemLimits = @"Cannot be {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Multiplier = @"{00}x";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Percentage = @"{00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RegularAndPercentage = @"{00} + {01}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ScalingPercentage = @"Scaling Percentage:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ScalingStat = @"Scaling Stat:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SingleUse = @"Single use";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Sold = @"Sold";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatGrowthRange = @"{00} to {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TeachSpell = @"Teaches Spell: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Traded = @"Traded";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TwoHand = @"2H";
+
+        // Integer Dictionaries (A - Z):
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> BonusEffects = new Dictionary<int, LocalizedString>
+        {
+            {0, @""},
+            {1, @"Cooldown Reduction:"},
+            {2, @"Lifesteal:"},
+            {3, @"Tenacity:"},
+            {4, @"Luck:"},
+            {5, @"Bonus Experience:"},
+            {6, @"Manasteal:"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> ConsumableTypes = new Dictionary<int, LocalizedString>()
+        {
+            {0, "Restores HP:"},
+            {1, "Restores MP:"},
+            {2, "Grants Experience:"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> DamageTypes = new Dictionary<int, LocalizedString>()
+        {
+            {0, @"Physical"},
+            {1, @"Magic"},
+            {2, @"True"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> ItemTypes = new Dictionary<int, LocalizedString>
+        {
+            {0, @"None"},
+            {1, @"Equipment"},
+            {2, @"Consumable"},
+            {3, @"Currency"},
+            {4, @"Spell"},
+            {5, @"Special"},
+            {6, @"Bag"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> StatCounts = new Dictionary<int, LocalizedString>
+        {
+            {0, @"Attack:"},
+            {1, @"Ability Power:"},
+            {2, @"Defense:"},
+            {3, @"Magic Resist:"},
+            {4, @"Speed:"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Stats = new Dictionary<int, LocalizedString>
+        {
+            {0, @"Attack"},
+            {1, @"Ability Power"},
+            {2, @"Defense"},
+            {3, @"Magic Resist"},
+            {4, @"Speed"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Vitals = new Dictionary<int, LocalizedString>
+        {
+            {0, @"HP:"},
+            {1, @"MP:"},
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> VitalsRegen = new Dictionary<int, LocalizedString>
+        {
+            {0, @"HP Regen:"},
+            {1, @"MP Regen:"},
+        };
+
+        // String Dictionaries (A - Z):
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<string, LocalizedString> Rarity = new Dictionary<string, LocalizedString>
+        {
+            {"None", @"None"},
+            {"Common", @"Common"},
+            {"Uncommon", @"Uncommon"},
+            {"Rare", @"Rare"},
+            {"Epic", @"Epic"},
+            {"Legendary", @"Legendary"},
+        };
+    }
+
+    public partial struct Keys
+    {
+        public static string FormatKeyName(Framework.GenericClasses.Keys modifier, Framework.GenericClasses.Keys key)
+        {
+            var formatted = KeyDictionary[Enum.GetName(typeof(Framework.GenericClasses.Keys), key).ToLower()];
+
+            if (modifier != Framework.GenericClasses.Keys.None)
             {
-                File.WriteAllText(
-                    Path.Combine(languageDirectory, StringsFileName),
-                    JsonConvert.SerializeObject(serialized, Formatting.Indented)
-                );
-            }
-        }
-
-        public static void Save()
-        {
-            var serialized = new Dictionary<string, Dictionary<string, object>>();
-            var rootType = typeof(Strings);
-            var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
-
-            foreach (var groupType in groupTypes)
-            {
-                var serializedGroup = new Dictionary<string, object>();
-                foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
-                {
-                    switch (fieldInfo.GetValue(null))
-                    {
-                        case LocalizedString localizedString:
-                            serializedGroup.Add(fieldInfo.Name, localizedString.ToString());
-                            break;
-
-                        case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
-                            serializedGroup.Add(fieldInfo.Name, localizedIntKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
-                            break;
-
-                        case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
-                            serializedGroup.Add(fieldInfo.Name, localizedStringKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
-                            break;
-                    }
-                }
-
-                serialized.Add(groupType.Name, serializedGroup);
-            }
-
-            SaveSerialized(serialized);
-        }
-
-        public partial struct Admin
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Access = @"Access:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Access0 = @"None";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Access1 = @"Moderator";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Access2 = @"Admin";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Ban = @"Ban";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BanCaption = @"Ban {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BanPrompt = @"Banning {00} will not allow them to access this game for the duration you set!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Chronological = @"123...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ChronologicalTip = @"Order maps chronologically.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Face = @"Face:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Kick = @"Kick";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Kill = @"Kill";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapList = @"Map List:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Mute = @"Mute";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MuteCaption = @"Mute {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MutePrompt = @"Muting {00} will not allow them to chat in game for the duration you set!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Name = @"Name:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString None = @"None";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OverworldReturn = @"Leave Instance";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SetFace = @"Set Face";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SetPower = @"Set Power";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SetSprite = @"Set Sprite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Sprite = @"Sprite:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Administration";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Unban = @"Unban";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnbanCaption = @"Unban {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnbanPrompt = @"Are you sure that you want to unban {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Unmute = @"Unmute";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnmuteCaption = @"Unmute {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnmutePrompt = @"Are you sure that you want to unmute {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Warp2Me = @"Warp To Me";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarpMe2 = @"Warp Me To";
-        }
-
-        public partial struct Bags
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RetrieveItem = @"Retrieve Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RetrieveItemPrompt = @"How many/much {00} would you like to retrieve?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StoreItem = @"Store Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StoreItemPrompt = @"How many/much {00} would you like to store?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Bag";
-        }
-
-        public partial struct Bank
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DepositItem = @"Deposit Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DepositItemPrompt = @"How many/much {00} would you like to deposit?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NoSpace = @"There is no space left in your bank for that item!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Bank";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WithdrawItem = @"Withdraw Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WithdrawItemPrompt = @"How many/much {00} would you like to withdraw?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WithdrawItemNoSpace = @"There is no space left in your inventory for that item!";
-        }
-
-        public partial struct BanMute
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Duration = @"Duration:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FiveDays = @"5 days";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FourDays = @"4 days";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Forever = @"Indefinitely";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IncludeIp = @"Include IP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OneDay = @"1 day";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OneMonth = @"1 month";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OneWeek = @"1 week";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OneYear = @"1 year";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Okay";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Reason = @"Reason:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SixMonths = @"6 months";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ThreeDays = @"3 days";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TwoDays = @"2 days";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TwoMonths = @"2 months";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TwoWeeks = @"2 weeks";
-        }
-
-        public partial struct Character
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AttackSpeed = @"Attack Speed: {00}s";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownReduction = @"Cooldown Reduction: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Equipment = @"Equipment:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ExtraBuffs = @"Extra Buffs";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ExtraExp = @"Bonus EXP: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString HealthRegen = @"Health Regen: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LevelAndClass = @"Level: {00}, Class: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Lifesteal = @"Lifesteal: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Luck = @"Luck: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ManaRegen = @"Mana Regen: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Manasteal = @"Manasteal: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Points = @"Points: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat0 = @"{00}: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat1 = @"{00}: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat2 = @"{00}: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat3 = @"{00}: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat4 = @"{00}: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stats = @"Stats:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Tenacity = @"Tenacity: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Character Information";
-        }
-
-        public partial struct CharacterCreation
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Class = @"Class:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Create = @"Create";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Female = @"Female";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Gender = @"Gender:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Hint = @"Customize";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Hint2 = @"Your Character";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InvalidName = @"Character name is invalid. Please use alphanumeric characters with a length between 2 and 20.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Male = @"Male";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Name = @"Name:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Create a New Character";
-        }
-
-        public partial struct CharacterSelection
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Delete = @"Delete";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DeletePrompt = @"Are you sure you want to delete {00}? This action is irreversible!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DeleteTitle = @"Delete {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Empty = @"Empty Character Slot";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Info = @"Level: {00}, Class: {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Logout = @"Logout";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Name = @"{00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString New = @"New";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Play = @"Play";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Select a Character to Play";
-        }
-
-        public partial struct Chatbox
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Channel = @"Channel:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ChannelAdmin = @"admin";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Channels = new Dictionary<int, LocalizedString>
-            {
-                {0, @"local"},
-                {1, @"global"},
-                {2, @"party"},
-                {3, @"guild"}
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ClearLogButtonToolTip = @"Clear chat log messages";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<ChatboxTab, LocalizedString> ChatTabButtons = new Dictionary<ChatboxTab, LocalizedString>() {
-                { ChatboxTab.All, @"All" },
-                { ChatboxTab.Local, @"Local" },
-                { ChatboxTab.Party, @"Party" },
-                { ChatboxTab.Global, @"Global" },
-                { ChatboxTab.Guild, @"Guild" },
-                { ChatboxTab.System, @"System" },
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EnterChat = @"Click here to chat.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EnterChat1 = @"Press '{00}' to chat.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EnterChat2 = @"Press '{00}' or '{01}' to chat.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Send = @"Send";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Chat";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ToggleLogButtonToolTip = @"Toggle chat log visibility";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TooFast = @"You are chatting too fast!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnableToCopy = @"It appears you are not able to copy/paste on this platform. Please make sure you have either the 'xclip' or 'wl-clipboard' packages installed if you are running Linux.";
-        }
-
-        public partial struct Colors
-        {
-
-            public static Dictionary<int, LocalizedString> presets = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Black"},
-                {1, @"White"},
-                {2, @"Pink"},
-                {3, @"Blue"},
-                {4, @"Red"},
-                {5, @"Green"},
-                {6, @"Yellow"},
-                {7, @"Orange"},
-                {8, @"Purple"},
-                {9, @"Gray"},
-                {10, @"Cyan"}
-            };
-
-        }
-
-        public partial struct Combat
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AttackWhileCastingDeny = @"You cannot attack while casting a spell.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat0 = @"Attack";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat1 = @"Ability Power";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat2 = @"Defense";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat3 = @"Magic Resist";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Stat4 = @"Speed";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarningCharacterSelect = @"You are attempting to logout while in combat! Your character will remain in-game until combat has ended. Are you sure you want to logout now?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarningExitDesktop = @"You are attempting to exit while in combat! Your character will remain in-game until combat has ended. Are you sure you want to quit now?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarningLogout = @"You are attempting to logout while in combat! Your character will remain in-game until combat has ended. Are you sure you want to logout now?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarningTitle = @"Combat Warning!";
-        }
-
-        public partial struct Controls
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<string, LocalizedString> KeyDictionary = new Dictionary<string, LocalizedString>
-            {
-                {"attackinteract", @"Attack/Interact:"},
-                {"block", @"Block:"},
-                {"autotarget", @"Auto Target:"},
-                {"enter", @"Chat:"},
-                {"hotkey0", @"Hot Key 0:"},
-                {"hotkey1", @"Hot Key 1:"},
-                {"hotkey2", @"Hot Key 2:"},
-                {"hotkey3", @"Hot Key 3:"},
-                {"hotkey4", @"Hot Key 4:"},
-                {"hotkey5", @"Hot Key 5:"},
-                {"hotkey6", @"Hot Key 6:"},
-                {"hotkey7", @"Hot Key 7:"},
-                {"hotkey8", @"Hot Key 8:"},
-                {"hotkey9", @"Hot Key 9:"},
-                {"movedown", @"Down:"},
-                {"moveleft", @"Left:"},
-                {"moveright", @"Right:"},
-                {"moveup", @"Up:"},
-                {"pickup", @"Pick Up:"},
-                {"screenshot", @"Screenshot:"},
-                {"openmenu", @"Open Menu:"},
-                {"openinventory", @"Open Inventory:"},
-                {"openquests", @"Open Quests:"},
-                {"opencharacterinfo", @"Open Character Info:"},
-                {"openparties", @"Open Parties:"},
-                {"openspells", @"Open Spells:"},
-                {"openfriends", @"Open Friends:"},
-                {"openguild", @"Open Guild:"},
-                {"opensettings", @"Open Settings:"},
-                {"opendebugger", @"Open Debugger:"},
-                {"openadminpanel", @"Open Admin Panel:"},
-                {"togglegui", @"Toggle Interface:"},
-                {"turnaround", @"Hold to turn around:"},
-                {"togglezoomin", "Toggle Zoom In:"},
-                {"holdtozoomin", "Hold to Zoom In:"},
-                {"togglezoomout", "Toggle Zoom Out:"},
-                {"holdtozoomout", "Hold to Zoom Out:"},
-                {"togglefullscreen", "Toggle Fullscreen:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Listening = @"Listening";
-
-        }
-
-        public partial struct Crafting
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Craft = @"Craft 1";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CraftAll = @"Craft {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CraftChance = @"Chance of failure: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CraftingTime = "Crafting time: {00}s";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CraftStop = "Stop";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DestroyMaterialsChance = @"Chance to destroy materials: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IncorrectResources = @"You do not have the necessary resources to craft this item.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Ingredients = @"Required:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Product = @"Crafting:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Recipes = @"Recipes:";
-        }
-
-        public partial struct Credits
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back to Main Menu";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Credits";
-
-        }
-
-        public partial struct Debug
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ControlUnderCursor = @"Control Under Cursor";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DrawDebugOutlines = @"Draw Debug Outlines";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Draws = @"Draws";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EnableLayoutHotReloading = @"Enable Experimental Layout Hot Reloading";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EntitiesDrawn = @"Entities Drawn";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fps = @"FPS";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InterfaceObjects = @"Interface Objects";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KnownEntities = @"Known Entities";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KnownMaps = @"Known Maps";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LightsDrawn = @"Lights Drawn";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Map = @"Map";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapsDrawn = @"Maps Drawn";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Ping = @"Ping";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShutdownServer = @"Shutdown Server";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShutdownServerAndExit = @"Shutdown Server and Exit";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Time = @"Time";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Debug";
-        }
-
-        public partial struct EntityBox
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Exp = @"EXP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ExpValue = @"{00} / {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Friend = "Befriend";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Level = @"Lv. {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Map = @"{00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MaxLevel = @"Max Level";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NameAndLevel = @"{00}    {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Party = @"Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Trade = @"Trade";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital0 = @"HP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital0Value = @"{00} / {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital1 = @"MP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital1Value = @"{00} / {01}";
-        }
-
-        public partial struct Errors
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DisconnectionEvent = @"Please provide this message to your administrator: {0}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DisplayNotSupported = @"Invalid Display Configuration!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DisplayNotSupportedError = @"Fullscreen {00} resolution is not supported on this device!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString HostNotFound = @"DNS resolution error, please report this to the game administrator.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LoadFile = @"Failed to load a {00}. Please send the game administrator a copy of your errors log file in the logs directory.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LostConnection = @"Lost connection to the game server. Please make sure you're connected to the internet and try again!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotConnected = @"Not connected to the game server. Is it online?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OpenAllLink = @"https://goo.gl/Nbx6hx";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OpenGlLink = @"https://goo.gl/RSP3ts";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PasswordInvalid = @"Password is invalid. Please use alphanumeric characters with a length between 4 and 20.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ResourcesNotFound = @"The resources directory could not be found! Intersect will now close.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Error!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UsernameInvalid = @"Username is invalid. Please use alphanumeric characters with a length between 2 and 20.";
-        }
-
-        public partial struct Words
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LcaseAnimation = @"animation";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LcaseMusic = @"soundtrack";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LcaseSound = @"sound";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LcaseSprite = @"sprite";
-        }
-
-        public partial struct EventWindow
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Continue = @"Continue";
-
-        }
-
-        public partial struct ForgotPass
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Hint = @"If your account exists, we will send you a temporary password reset code.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Label = @"Enter your username or email below:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Submit = @"Submit";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Password Reset";
-        }
-
-        public partial struct Friends
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AddFriend = @"Add Friend";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AddFriendPrompt = @"Who would you like to add as a friend?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InFight = @"You are currently in a fight!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Offline = @"Offline";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RemoveFriend = @"Remove Friend";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RemoveFriendPrompt = @"Do you wish to remove {00} from your friends list?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Request = @"Friend Request";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RequestPrompt = @"{00} has sent you a friend request. Do you accept?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Friends";
-        }
-
-        public partial struct GameMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Character = @"Character Information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Friends = @"Friends";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Items = @"Inventory";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Menu = @"Open Menu";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Party = @"Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Quest = @"Quest Log";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Spells = @"Spell Book";
-        }
-
-        public partial struct General
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapItemStackable = @"{01} {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString None = @"None";
-        }
-
-        public partial struct Guilds
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bank = @"{00} Guild Bank";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Demote = @"Demote to {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DemotePrompt = @"Are you sure you want to demote {00} to rank {01}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DemoteTitle = @"Demote Guild Member";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Guild = @"Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildTip = @"Send {00} an invite to your guild.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Invite = @"Invite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InviteAlreadyInGuild = @"The player you're trying to invite is already in a guild or has a pending invite.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InviteMemberPrompt = @"Who would you like to invite to {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InviteMemberTitle = @"Invite Player";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InviteRequestPrompt = @"{00} would like to invite you to join their guild, {01}. Do you accept?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InviteRequestTitle = @"Guild Invite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Kick = @"Kick";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KickPrompt = @"Are you sure you want to kick {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KickTitle = @"Kick Guild Member";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Leave = "Leave";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LeavePrompt = @"Are you sure you want to leave your guild?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LeaveTitle = @"Leave Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotAllowedDeposit = @"You do not have permission to deposit items into {00}'s guild bank.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotAllowedSwap = @"You do not have permission to swap items within {00}'s guild bank.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotAllowedWithdraw = @"You do not have permission to withdraw from {00}'s guild bank.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotInGuild = @"You are not currently in a guild!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OfflineListEntry = @"[{00}] {01} - {02}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OnlineListEntry = @"[{00}] {01} - {02}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PM = @"PM";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Promote = @"Promote to {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PromotePrompt = @"Are you sure you want to promote {00} to rank {01}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PromoteTitle = @"Promote Guild Member";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Tooltip = @"Lv. {00} {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Transfer = @"Transfer";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TransferPrompt = @"This action will completely transfer all ownership of your guild to {00} and you will lose your rank of {01}. If you are sure you want to hand over your guild enter '{02}' below.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TransferTitle = @"Transfer Guild";
-        }
-
-        public partial struct InputBox
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString No = @"No";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Okay";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Yes = @"Yes";
-        }
-
-        public partial struct MapItemWindow
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LootButton = @"Loot All";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Loot";
-        }
-
-        public partial struct Internals
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bounds = @"Bounds";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Color = @"Color";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ColorOverride = @"Color Override";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CoordinateX = @"X";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CoordinateY = @"Y";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CoordinateZ = @"Z";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ExperimentalFeatureTooltip = @"This feature is experimental and may cause issues when enabled.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GlobalItem = @"Global {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LocalItem = @"Local {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Name = @"Name";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotApplicable = @"N/A";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ResolutionXByY = @"{0}x{1}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Type = @"Type";
-        }
-
-        public partial struct Inventory
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DropItemPrompt = @"How many units of {00} would you like to discard?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DropItemTitle = @"Drop Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DropPrompt = @"Do you wish to drop the item: {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EquippedSymbol = "E";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Inventory";
-        }
-
-        public partial struct ItemContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bag = @"Bag {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bank = @"Bank {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cast = @"Cast {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Drop = @"Drop {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Equip = @"Equip {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Learn = @"Learn {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Open = @"Open {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Sell = @"Sell {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Trade = @"Offer {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Unequip = @"Unequip {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Use = @"Use {00}";
-        }
-
-        public partial struct SpellContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cast = @"Cast {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Forget = @"Forget {00}";
-        }
-
-        public partial struct BankContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Withdraw = @"Withdraw {00}";
-        }
-
-        public partial struct BagContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Withdraw = @"Withdraw {00}";
-        }
-
-        public partial struct TradeContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Withdraw = @"Revoke {00}";
-        }
-
-        public partial struct ChatContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FriendInvite = @"Send Friend request to {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildInvite = @"Invite {00} to Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PartyInvite = @"Invite {00} to Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PM = @"Send Private Message to {00}";
-        }
-
-        public partial struct ShopContextMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Buy = @"Buy {00}";
-        }
-
-        public partial struct ItemDescription
-        {
-            // String Properties (A - Z):
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Amount = @"Amount:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AttackSpeed = @"Attack Speed:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BagSlots = @"Bag Slots:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bagged = @"Bagged";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Banked = @"Banked";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BaseDamage = @"Base Damage:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BaseDamageType = @"Damage Type:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BlockAbsorption = @"Block Absorption:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BlockAmount = @"Block Amount:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BlockChance = @"Block Chance:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CastSpell = @"Casts Spell: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CritChance = @"Critical Chance:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CritMultiplier = @"Critical Multiplier:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Description = @"{00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DropOnDeath = @"Drop chance on death:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Dropped = @"Dropped";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildBanked = @"Guild Banked";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ItemLimits = @"Cannot be {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Multiplier = @"{00}x";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Percentage = @"{00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RegularAndPercentage = @"{00} + {01}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ScalingPercentage = @"Scaling Percentage:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ScalingStat = @"Scaling Stat:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SingleUse = @"Single use";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Sold = @"Sold";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatGrowthRange = @"{00} to {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TeachSpell = @"Teaches Spell: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Traded = @"Traded";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TwoHand = @"2H";
-
-            // Integer Dictionaries (A - Z):
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> BonusEffects = new Dictionary<int, LocalizedString>
-            {
-                {0, @""},
-                {1, @"Cooldown Reduction:"},
-                {2, @"Lifesteal:"},
-                {3, @"Tenacity:"},
-                {4, @"Luck:"},
-                {5, @"Bonus Experience:"},
-                {6, @"Manasteal:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> ConsumableTypes = new Dictionary<int, LocalizedString>()
-            {
-                {0, "Restores HP:"},
-                {1, "Restores MP:"},
-                {2, "Grants Experience:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> DamageTypes = new Dictionary<int, LocalizedString>()
-            {
-                {0, @"Physical"},
-                {1, @"Magic"},
-                {2, @"True"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> ItemTypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Equipment"},
-                {2, @"Consumable"},
-                {3, @"Currency"},
-                {4, @"Spell"},
-                {5, @"Special"},
-                {6, @"Bag"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> StatCounts = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Attack:"},
-                {1, @"Ability Power:"},
-                {2, @"Defense:"},
-                {3, @"Magic Resist:"},
-                {4, @"Speed:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Stats = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Attack"},
-                {1, @"Ability Power"},
-                {2, @"Defense"},
-                {3, @"Magic Resist"},
-                {4, @"Speed"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Vitals = new Dictionary<int, LocalizedString>
-            {
-                {0, @"HP:"},
-                {1, @"MP:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> VitalsRegen = new Dictionary<int, LocalizedString>
-            {
-                {0, @"HP Regen:"},
-                {1, @"MP Regen:"},
-            };
-
-            // String Dictionaries (A - Z):
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<string, LocalizedString> Rarity = new Dictionary<string, LocalizedString>
-            {
-                {"None", @"None"},
-                {"Common", @"Common"},
-                {"Uncommon", @"Uncommon"},
-                {"Rare", @"Rare"},
-                {"Epic", @"Epic"},
-                {"Legendary", @"Legendary"},
-            };
-        }
-
-        public partial struct Keys
-        {
-            public static string FormatKeyName(Framework.GenericClasses.Keys modifier, Framework.GenericClasses.Keys key)
-            {
-                var formatted = KeyDictionary[Enum.GetName(typeof(Framework.GenericClasses.Keys), key).ToLower()];
-
-                if (modifier != Framework.GenericClasses.Keys.None)
-                {
-                    var modifierName = KeyDictionary[Enum.GetName(typeof(Framework.GenericClasses.Keys), modifier).ToLower()];
-                    formatted = KeyNameWithModifier.ToString(modifierName, formatted);
-                }
-
-                return formatted;
+                var modifierName = KeyDictionary[Enum.GetName(typeof(Framework.GenericClasses.Keys), modifier).ToLower()];
+                formatted = KeyNameWithModifier.ToString(modifierName, formatted);
             }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<string, LocalizedString> KeyDictionary = new Dictionary<string, LocalizedString>()
-            {
-                {"a", @"A"},
-                {"add", @"Add"},
-                {"alt", @"Alt"},
-                {"apps", @"Apps"},
-                {"attn", @"Attn"},
-                {"b", @"B"},
-                {"back", @"Back"},
-                {"browserback", @"BrowserBack"},
-                {"browserfavorites", @"BrowserFavorites"},
-                {"browserforward", @"BrowserForward"},
-                {"browserhome", @"BrowserHome"},
-                {"browserrefresh", @"BrowserRefresh"},
-                {"browsersearch", @"BrowserSearch"},
-                {"browserstop", @"BrowserStop"},
-                {"c", @"C"},
-                {"cancel", @"Cancel"},
-                {"capital", @"Capital"},
-                {"capslock", @"CapsLock"},
-                {"clear", @"Clear"},
-                {"control", @"Control"},
-                {"controlkey", @"ControlKey"},
-                {"crsel", @"Crsel"},
-                {"d", @"D"},
-                {"d0", @"0"},
-                {"d1", @"1"},
-                {"d2", @"2"},
-                {"d3", @"3"},
-                {"d4", @"4"},
-                {"d5", @"5"},
-                {"d6", @"6"},
-                {"d7", @"7"},
-                {"d8", @"8"},
-                {"d9", @"9"},
-                {"decimal", @"Decimal"},
-                {"delete", @"Delete"},
-                {"divide", @"Divide"},
-                {"down", @"Down"},
-                {"e", @"E"},
-                {"end", @"End"},
-                {"enter", @"Enter"},
-                {"eraseeof", @"EraseEof"},
-                {"escape", @"Escape"},
-                {"execute", @"Execute"},
-                {"exsel", @"Exsel"},
-                {"f", @"F"},
-                {"f1", @"F1"},
-                {"f10", @"F10"},
-                {"f11", @"F11"},
-                {"f12", @"F12"},
-                {"f13", @"F13"},
-                {"f14", @"F14"},
-                {"f15", @"F15"},
-                {"f16", @"F16"},
-                {"f17", @"F17"},
-                {"f18", @"F18"},
-                {"f19", @"F19"},
-                {"f2", @"F2"},
-                {"f20", @"F20"},
-                {"f21", @"F21"},
-                {"f22", @"F22"},
-                {"f23", @"F23"},
-                {"f24", @"F24"},
-                {"f3", @"F3"},
-                {"f4", @"F4"},
-                {"f5", @"F5"},
-                {"f6", @"F6"},
-                {"f7", @"F7"},
-                {"f8", @"F8"},
-                {"f9", @"F9"},
-                {"finalmode", @"FinalMode"},
-                {"g", @"G"},
-                {"h", @"H"},
-                {"hanguelmode", @"HanguelMode"},
-                {"hangulmode", @"HangulMode"},
-                {"hanjamode", @"HanjaMode"},
-                {"help", @"Help"},
-                {"home", @"Home"},
-                {"i", @"I"},
-                {"imeaccept", @"IMEAccept"},
-                {"imeaceept", @"IMEAceept"},
-                {"imeconvert", @"IMEConvert"},
-                {"imemodechange", @"IMEModeChange"},
-                {"imenonconvert", @"IMENonconvert"},
-                {"insert", @"Insert"},
-                {"j", @"J"},
-                {"junjamode", @"JunjaMode"},
-                {"k", @"K"},
-                {"kanamode", @"KanaMode"},
-                {"kanjimode", @"KanjiMode"},
-                {"keycode", @"KeyCode"},
-                {"l", @"L"},
-                {"launchapplication1", @"LaunchApplication1"},
-                {"launchapplication2", @"LaunchApplication2"},
-                {"launchmail", @"LaunchMail"},
-                {"lbutton", @"Left Mouse"},
-                {"lcontrolkey", @"L Control"},
-                {"left", @"Left"},
-                {"linefeed", @"LineFeed"},
-                {"lmenu", @"L Menu"},
-                {"lshiftkey", @"L Shift"},
-                {"lwin", @"LWin"},
-                {"m", @"M"},
-                {"mbutton", @"Middle Mouse"},
-                {"medianexttrack", @"MediaNextTrack"},
-                {"mediaplaypause", @"MediaPlayPause"},
-                {"mediaprevioustrack", @"MediaPreviousTrack"},
-                {"mediastop", @"MediaStop"},
-                {"menu", @"Menu"},
-                {"modifiers", @"Modifiers"},
-                {"multiply", @"Multiply"},
-                {"n", @"N"},
-                {"next", @"Next"},
-                {"noname", @"NoName"},
-                {"none", @"None"},
-                {"numlock", @"NumLock"},
-                {"numpad0", @"NumPad 0"},
-                {"numpad1", @"NumPad 1"},
-                {"numpad2", @"NumPad 2"},
-                {"numpad3", @"NumPad 3"},
-                {"numpad4", @"NumPad 4"},
-                {"numpad5", @"NumPad 5"},
-                {"numpad6", @"NumPad 6"},
-                {"numpad7", @"NumPad 7"},
-                {"numpad8", @"NumPad 8"},
-                {"numpad9", @"NumPad 9"},
-                {"o", @"O"},
-                {"oem1", @"1"},
-                {"oem102", @"0"},
-                {"oem2", @"2"},
-                {"oem3", @"3"},
-                {"oem4", @"4"},
-                {"oem5", @"5"},
-                {"oem6", @"6"},
-                {"oem7", @"7"},
-                {"oem8", @"8"},
-                {"oembackslash", @"\"},
-                {"oemclear", @"OemClear"},
-                {"oemclosebrackets", @"]"},
-                {"oemcomma", @","},
-                {"oemminus", @"-"},
-                {"oemopenbrackets", @"["},
-                {"oemperiod", @"."},
-                {"oempipe", @"|"},
-                {"oemplus", @"+"},
-                {"oemquestion", @"?"},
-                {"oemquotes", @"'"},
-                {"oemsemicolon", @"OemSemicolon"},
-                {"oemtilde", @"`"},
-                {"p", @"P"},
-                {"pa1", @"Pa1"},
-                {"packet", @"Packet"},
-                {"pagedown", @"Page Down"},
-                {"pageup", @"Page Up"},
-                {"pause", @"Pause"},
-                {"play", @"Play"},
-                {"print", @"Print"},
-                {"printscreen", @"PrintScreen"},
-                {"prior", @"Prior"},
-                {"processkey", @"ProcessKey"},
-                {"q", @"Q"},
-                {"r", @"R"},
-                {"rbutton", @"Right Mouse"},
-                {"rcontrolkey", @"R Control"},
-                {"return", @"Return"},
-                {"right", @"Right"},
-                {"rmenu", @"R Menu"},
-                {"rshiftkey", @"R Shift"},
-                {"rwin", @"RWin"},
-                {"s", @"S"},
-                {"scroll", @"Scroll"},
-                {"select", @"Select"},
-                {"selectmedia", @"SelectMedia"},
-                {"separator", @"Separator"},
-                {"shift", @"Shift"},
-                {"shiftkey", @"ShiftKey"},
-                {"sleep", @"Sleep"},
-                {"snapshot", @"Snapshot"},
-                {"space", @"Space"},
-                {"subtract", @"Subtract"},
-                {"t", @"T"},
-                {"tab", @"Tab"},
-                {"u", @"U"},
-                {"up", @"Up"},
-                {"v", @"V"},
-                {"volumedown", @"VolumeDown"},
-                {"volumemute", @"VolumeMute"},
-                {"volumeup", @"VolumeUp"},
-                {"w", @"W"},
-                {"x", @"X"},
-                {"xbutton1", @"XButton1"},
-                {"xbutton2", @"XButton2"},
-                {"y", @"Y"},
-                {"z", @"Z"},
-                {"zoom", @"Zoom"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KeyNameWithModifier = @"{00} + {01}";
-
+            return formatted;
         }
 
-        public partial struct LoginWindow
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<string, LocalizedString> KeyDictionary = new Dictionary<string, LocalizedString>()
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back";
+            {"a", @"A"},
+            {"add", @"Add"},
+            {"alt", @"Alt"},
+            {"apps", @"Apps"},
+            {"attn", @"Attn"},
+            {"b", @"B"},
+            {"back", @"Back"},
+            {"browserback", @"BrowserBack"},
+            {"browserfavorites", @"BrowserFavorites"},
+            {"browserforward", @"BrowserForward"},
+            {"browserhome", @"BrowserHome"},
+            {"browserrefresh", @"BrowserRefresh"},
+            {"browsersearch", @"BrowserSearch"},
+            {"browserstop", @"BrowserStop"},
+            {"c", @"C"},
+            {"cancel", @"Cancel"},
+            {"capital", @"Capital"},
+            {"capslock", @"CapsLock"},
+            {"clear", @"Clear"},
+            {"control", @"Control"},
+            {"controlkey", @"ControlKey"},
+            {"crsel", @"Crsel"},
+            {"d", @"D"},
+            {"d0", @"0"},
+            {"d1", @"1"},
+            {"d2", @"2"},
+            {"d3", @"3"},
+            {"d4", @"4"},
+            {"d5", @"5"},
+            {"d6", @"6"},
+            {"d7", @"7"},
+            {"d8", @"8"},
+            {"d9", @"9"},
+            {"decimal", @"Decimal"},
+            {"delete", @"Delete"},
+            {"divide", @"Divide"},
+            {"down", @"Down"},
+            {"e", @"E"},
+            {"end", @"End"},
+            {"enter", @"Enter"},
+            {"eraseeof", @"EraseEof"},
+            {"escape", @"Escape"},
+            {"execute", @"Execute"},
+            {"exsel", @"Exsel"},
+            {"f", @"F"},
+            {"f1", @"F1"},
+            {"f10", @"F10"},
+            {"f11", @"F11"},
+            {"f12", @"F12"},
+            {"f13", @"F13"},
+            {"f14", @"F14"},
+            {"f15", @"F15"},
+            {"f16", @"F16"},
+            {"f17", @"F17"},
+            {"f18", @"F18"},
+            {"f19", @"F19"},
+            {"f2", @"F2"},
+            {"f20", @"F20"},
+            {"f21", @"F21"},
+            {"f22", @"F22"},
+            {"f23", @"F23"},
+            {"f24", @"F24"},
+            {"f3", @"F3"},
+            {"f4", @"F4"},
+            {"f5", @"F5"},
+            {"f6", @"F6"},
+            {"f7", @"F7"},
+            {"f8", @"F8"},
+            {"f9", @"F9"},
+            {"finalmode", @"FinalMode"},
+            {"g", @"G"},
+            {"h", @"H"},
+            {"hanguelmode", @"HanguelMode"},
+            {"hangulmode", @"HangulMode"},
+            {"hanjamode", @"HanjaMode"},
+            {"help", @"Help"},
+            {"home", @"Home"},
+            {"i", @"I"},
+            {"imeaccept", @"IMEAccept"},
+            {"imeaceept", @"IMEAceept"},
+            {"imeconvert", @"IMEConvert"},
+            {"imemodechange", @"IMEModeChange"},
+            {"imenonconvert", @"IMENonconvert"},
+            {"insert", @"Insert"},
+            {"j", @"J"},
+            {"junjamode", @"JunjaMode"},
+            {"k", @"K"},
+            {"kanamode", @"KanaMode"},
+            {"kanjimode", @"KanjiMode"},
+            {"keycode", @"KeyCode"},
+            {"l", @"L"},
+            {"launchapplication1", @"LaunchApplication1"},
+            {"launchapplication2", @"LaunchApplication2"},
+            {"launchmail", @"LaunchMail"},
+            {"lbutton", @"Left Mouse"},
+            {"lcontrolkey", @"L Control"},
+            {"left", @"Left"},
+            {"linefeed", @"LineFeed"},
+            {"lmenu", @"L Menu"},
+            {"lshiftkey", @"L Shift"},
+            {"lwin", @"LWin"},
+            {"m", @"M"},
+            {"mbutton", @"Middle Mouse"},
+            {"medianexttrack", @"MediaNextTrack"},
+            {"mediaplaypause", @"MediaPlayPause"},
+            {"mediaprevioustrack", @"MediaPreviousTrack"},
+            {"mediastop", @"MediaStop"},
+            {"menu", @"Menu"},
+            {"modifiers", @"Modifiers"},
+            {"multiply", @"Multiply"},
+            {"n", @"N"},
+            {"next", @"Next"},
+            {"noname", @"NoName"},
+            {"none", @"None"},
+            {"numlock", @"NumLock"},
+            {"numpad0", @"NumPad 0"},
+            {"numpad1", @"NumPad 1"},
+            {"numpad2", @"NumPad 2"},
+            {"numpad3", @"NumPad 3"},
+            {"numpad4", @"NumPad 4"},
+            {"numpad5", @"NumPad 5"},
+            {"numpad6", @"NumPad 6"},
+            {"numpad7", @"NumPad 7"},
+            {"numpad8", @"NumPad 8"},
+            {"numpad9", @"NumPad 9"},
+            {"o", @"O"},
+            {"oem1", @"1"},
+            {"oem102", @"0"},
+            {"oem2", @"2"},
+            {"oem3", @"3"},
+            {"oem4", @"4"},
+            {"oem5", @"5"},
+            {"oem6", @"6"},
+            {"oem7", @"7"},
+            {"oem8", @"8"},
+            {"oembackslash", @"\"},
+            {"oemclear", @"OemClear"},
+            {"oemclosebrackets", @"]"},
+            {"oemcomma", @","},
+            {"oemminus", @"-"},
+            {"oemopenbrackets", @"["},
+            {"oemperiod", @"."},
+            {"oempipe", @"|"},
+            {"oemplus", @"+"},
+            {"oemquestion", @"?"},
+            {"oemquotes", @"'"},
+            {"oemsemicolon", @"OemSemicolon"},
+            {"oemtilde", @"`"},
+            {"p", @"P"},
+            {"pa1", @"Pa1"},
+            {"packet", @"Packet"},
+            {"pagedown", @"Page Down"},
+            {"pageup", @"Page Up"},
+            {"pause", @"Pause"},
+            {"play", @"Play"},
+            {"print", @"Print"},
+            {"printscreen", @"PrintScreen"},
+            {"prior", @"Prior"},
+            {"processkey", @"ProcessKey"},
+            {"q", @"Q"},
+            {"r", @"R"},
+            {"rbutton", @"Right Mouse"},
+            {"rcontrolkey", @"R Control"},
+            {"return", @"Return"},
+            {"right", @"Right"},
+            {"rmenu", @"R Menu"},
+            {"rshiftkey", @"R Shift"},
+            {"rwin", @"RWin"},
+            {"s", @"S"},
+            {"scroll", @"Scroll"},
+            {"select", @"Select"},
+            {"selectmedia", @"SelectMedia"},
+            {"separator", @"Separator"},
+            {"shift", @"Shift"},
+            {"shiftkey", @"ShiftKey"},
+            {"sleep", @"Sleep"},
+            {"snapshot", @"Snapshot"},
+            {"space", @"Space"},
+            {"subtract", @"Subtract"},
+            {"t", @"T"},
+            {"tab", @"Tab"},
+            {"u", @"U"},
+            {"up", @"Up"},
+            {"v", @"V"},
+            {"volumedown", @"VolumeDown"},
+            {"volumemute", @"VolumeMute"},
+            {"volumeup", @"VolumeUp"},
+            {"w", @"W"},
+            {"x", @"X"},
+            {"xbutton1", @"XButton1"},
+            {"xbutton2", @"XButton2"},
+            {"y", @"Y"},
+            {"z", @"Z"},
+            {"zoom", @"Zoom"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ForgotPassword = @"Forgot Password?";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KeyNameWithModifier = @"{00} + {01}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Login = @"Login";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Password = @"Password:";
+    public partial struct LoginWindow
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SavePassword = @"Save Password";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ForgotPassword = @"Forgot Password?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Login";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Login = @"Login";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Username = @"Username:";
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Password = @"Password:";
 
-        public partial struct Main
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SavePassword = @"Save Password";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Login";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Username = @"Username:";
+    }
+
+    public partial struct Main
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GameName = @"Intersect Client";
+    }
+
+    public partial struct MainMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Credits = @"Credits";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Exit = @"Exit";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Login = @"Login";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Register = @"Register";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Settings = @"Settings";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SettingsTooltip = @"";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Start = @"Start";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Main Menu";
+    }
+
+    public partial struct Settings
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Apply = @"Apply";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AudioSettingsTab = @"Audio";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AutoCloseWindows = @"Auto-close Windows";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AutoToggleChatLog = @"Auto-toggle chat log visibility";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EnableLighting = @"Enable Light Effects";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fps120 = @"120";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fps30 = @"30";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fps60 = @"60";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fps90 = @"90";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fullscreen = @"Fullscreen";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GameSettingsTab = @"Game";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InformationSettings = @"Information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InterfaceSettings = @"Interface";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KeyBindingSettingsTab = @"Controls";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MusicVolume = @"Music Volume: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Resolution = @"Resolution:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ResolutionCustom = @"Custom Resolution";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Restore = @"Restore Defaults";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SoundVolume = @"Sound Volume: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowExperienceAsPercentage = @"Show experience as percentage";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowFriendOverheadHpBar = @"Show friends overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowFriendOverheadInformation = @"Show friends overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowGuildOverheadHpBar = @"Show guild member overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowGuildOverheadInformation = @"Show guild member overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowHealthAsPercentage = @"Show health as percentage";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowNpcOverheadHpBar = @"Show NPC overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowNpcOverheadInformation = @"Show NPC overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowManaAsPercentage = @"Show mana as percentage";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowMyOverheadHpBar = @"Show my overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowMyOverheadInformation = @"Show my overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowPartyOverheadHpBar = @"Show party member overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowPartyOverheadInformation = @"Show party member overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowPlayerOverheadHpBar = @"Show players overhead HP bar";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ShowPlayerOverheadInformation = @"Show players overhead information";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StickyTarget = @"Sticky Target";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TargetFps = @"Target FPS:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TargetingSettings = @"Targeting";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AutoTurnToTarget = @"Auto-turn to target";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Settings";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TypewriterText = @"Typewriter Text";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnlimitedFps = @"No Limit";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString VideoSettingsTab = @"Video";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vsync = @"V-Sync";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WorldScale = @"World Scale";
+    }
+
+    public partial struct Parties
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InFight = @"You are currently fighting!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InvitePrompt = @"{00} has invited you to their party. Do you accept?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Kick = @"Kick {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString KickLabel = @"Kick";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Leader = @"Leader";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LeaderTip = @"Party Leader";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Leave = @"Leave Party";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LeaveTip = @"Leave Tip";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"{00} - Lv. {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PartyInvite = @"Party Invite";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Party";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital0 = @"HP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital0Value = @"{00} / {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital1 = @"MP:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Vital1Value = @"{00} / {01}";
+    }
+
+    public partial struct QuestLog
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Abandon = @"Abandon";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AbandonPrompt = @"Are you sure that you want to quit the quest ""{00}""?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AbandonTitle = @"Abandon Quest: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Completed = @"Quest Completed";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CurrentTask = @"Current Task:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InProgress = @"Quest In Progress";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NotStarted = @"Quest Not Started";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TaskItem = @"{00}/{01} {02}(s) gathered.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TaskNpc = @"{00}/{01} {02}(s) slain.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Quest Log";
+    }
+
+    public partial struct QuestOffer
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Accept = @"Accept";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Decline = @"Decline";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Quest Offer";
+    }
+
+    public partial struct Regex
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Email =
+            @"^(([\w-]+\.)+[\w-]+|([a-zA-Z]{1}|[\w-]{2,}))@((([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])){1}|([a-zA-Z]+[\w-]+\.)+[a-zA-Z]{2,4})$";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Password = @"^[-_=\+`~!@#\$%\^&\*()\[\]{}\\|;\:'"",<\.>/\?a-zA-Z0-9]{4,64}$";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Username = @"^[a-zA-Z0-9]{2,20}$";
+    }
+
+    public partial struct Registration
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Back";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ConfirmPassword = @"Confirm Password:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Email = @"Email:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EmailInvalid = @"The email is invalid.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Password = @"Password:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PasswordMismatch = @"The passwords do not match.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Register = @"Register";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Register";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Username = @"Username:";
+    }
+
+    public partial struct ResetPass
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Back = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Code = @"Enter the reset code that was sent to you:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ConfirmPassword = @"Confirm Password:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Error = @"Error!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ErrorMessage =
+            @"The reset code was not valid, has expired, or the account does not exist!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InputCode = @"Please enter your password reset code.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NewPassword = @"New Password:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Submit = @"Submit";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Success = @"Success!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuccessMessage = @"Your password has been reset!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Password Reset";
+    }
+
+    public partial struct Server
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Connecting = @"Connecting...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Failed = @"Network Error";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString HandshakeFailure = @"Handshake Error";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Offline = @"Offline";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Online = @"Online";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ServerFull = @"Server is Full";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatusLabel = @"Server Status: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unknown = @"Unknown";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString VersionMismatch = @"Version Mismatch";
+    }
+
+    public partial struct Shop
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BuyItem = @"Buy Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BuyItemPrompt = @"How many units of {00} would you like to buy?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CannotSell = @"This shop does not accept that item!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Costs = @"Costs {00} {01}(s)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SellItem = @"Sell Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SellItemPrompt = @"How many units of {00} would you like to sell?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SellPrompt = @"Do you wish to sell the item: {00}?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SellsFor = @"Sells for {00} {01}(s)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WontBuy = @"Shop Will Not Buy This Item";
+    }
+
+    public partial struct SpellDescription
+    {
+        // String Properties (A - Z):
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Bound = @"Cannot be unlearned.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CastTime = @"Cast Time:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cooldown = @"Cooldown:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroup = @"Cooldown Group:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CritChance = @"Critical Chance:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CritMultiplier = @"Critical Multiplier:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DamageType = @"Damage Type:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Distance = @"Distance:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DoT = @"Damages over Time";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Duration = @"Duration:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Effect = @"Effect:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Friendly = @"Support Spell";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString HoT = @"Heals over Time";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreConsumedResourceBlock = @"Ignores Consumed Resources";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreCooldownReduction = @"Ignores Cooldown Reduction";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreGlobalCooldown = @"Ignores Global Cooldown";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreMapBlock = @"Ignores Map Blocks";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreResourceBlock = @"Ignores Active Resources";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreZDimension = @"Ignores Height Differences";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Instant = @"Instant";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Multiplier = @"{00}x";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Percentage = @"{00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RegularAndPercentage = @"{00} + {01}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ScalingPercentage = @"Scaling Percentage:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ScalingStat = @"Scaling Stat:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatBuff = @"Stat Buff";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Tick = @"Ticks every:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Tiles = @"{00} Tiles";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unfriendly = @"Damaging Spell";
+
+
+        // Integer Dictionaries (A - Z):
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> DamageTypes = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GameName = @"Intersect Client";
-        }
+            {0, @"Physical"},
+            {1, @"Magic"},
+            {2, @"True"},
+        };
 
-        public partial struct MainMenu
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Effects = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Credits = @"Credits";
+            {0, @""},
+            {1, @"Silence"},
+            {2, @"Stun"},
+            {3, @"Snare"},
+            {4, @"Blind"},
+            {5, @"Stealth"},
+            {6, @"Transforms"},
+            {7, @"Cleanse"},
+            {8, @"Invulnerable"},
+            {9, @"Shield"},
+            {10, @"Sleep"},
+            {11, @"On-Hit"},
+            {12, @"Taunt"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Exit = @"Exit";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Login = @"Login";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Register = @"Register";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Settings = @"Settings";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SettingsTooltip = @"";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Start = @"Start";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Main Menu";
-        }
-
-        public partial struct Settings
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> SpellTypes = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Apply = @"Apply";
+            {0, @"Combat Spell"},
+            {1, @"Warp to Map"},
+            {2, @"Warp to Target"},
+            {3, @"Dash"},
+            {4, @"Special"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AudioSettingsTab = @"Audio";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AutoCloseWindows = @"Auto-close Windows";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AutoToggleChatLog = @"Auto-toggle chat log visibility";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EnableLighting = @"Enable Light Effects";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fps120 = @"120";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fps30 = @"30";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fps60 = @"60";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fps90 = @"90";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fullscreen = @"Fullscreen";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GameSettingsTab = @"Game";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InformationSettings = @"Information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InterfaceSettings = @"Interface";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KeyBindingSettingsTab = @"Controls";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MusicVolume = @"Music Volume: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Resolution = @"Resolution:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ResolutionCustom = @"Custom Resolution";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Restore = @"Restore Defaults";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SoundVolume = @"Sound Volume: {00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowExperienceAsPercentage = @"Show experience as percentage";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowFriendOverheadHpBar = @"Show friends overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowFriendOverheadInformation = @"Show friends overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowGuildOverheadHpBar = @"Show guild member overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowGuildOverheadInformation = @"Show guild member overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowHealthAsPercentage = @"Show health as percentage";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowNpcOverheadHpBar = @"Show NPC overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowNpcOverheadInformation = @"Show NPC overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowManaAsPercentage = @"Show mana as percentage";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowMyOverheadHpBar = @"Show my overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowMyOverheadInformation = @"Show my overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPartyOverheadHpBar = @"Show party member overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPartyOverheadInformation = @"Show party member overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPlayerOverheadHpBar = @"Show players overhead HP bar";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ShowPlayerOverheadInformation = @"Show players overhead information";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StickyTarget = @"Sticky Target";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TargetFps = @"Target FPS:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TargetingSettings = @"Targeting";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AutoTurnToTarget = @"Auto-turn to target";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Settings";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TypewriterText = @"Typewriter Text";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UnlimitedFps = @"No Limit";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString VideoSettingsTab = @"Video";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vsync = @"V-Sync";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WorldScale = @"World Scale";
-        }
-
-        public partial struct Parties
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Stats = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InFight = @"You are currently fighting!";
+            {0, @"Attack"},
+            {1, @"Ability Power"},
+            {2, @"Defense"},
+            {3, @"Magic Resist"},
+            {4, @"Speed"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InvitePrompt = @"{00} has invited you to their party. Do you accept?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Kick = @"Kick {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString KickLabel = @"Kick";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Leader = @"Leader";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LeaderTip = @"Party Leader";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Leave = @"Leave Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LeaveTip = @"Leave Tip";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Name = @"{00} - Lv. {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PartyInvite = @"Party Invite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Party";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital0 = @"HP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital0Value = @"{00} / {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital1 = @"MP:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Vital1Value = @"{00} / {01}";
-        }
-
-        public partial struct QuestLog
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> StatCounts = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Abandon = @"Abandon";
+            {0, @"Attack:"},
+            {1, @"Ability Power:"},
+            {2, @"Defense:"},
+            {3, @"Magic Resist:"},
+            {4, @"Speed:"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AbandonPrompt = @"Are you sure that you want to quit the quest ""{00}""?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AbandonTitle = @"Abandon Quest: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Completed = @"Quest Completed";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CurrentTask = @"Current Task:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InProgress = @"Quest In Progress";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NotStarted = @"Quest Not Started";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TaskItem = @"{00}/{01} {02}(s) gathered.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TaskNpc = @"{00}/{01} {02}(s) slain.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Quest Log";
-        }
-
-        public partial struct QuestOffer
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> TargetTypes = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Accept = @"Accept";
+            {0, @"Self Cast"},
+            {1, @"Targetted - Range: {00} Tiles"},
+            {2, @"AOE"},
+            {3, @"Projectile - Range: {00} Tiles"},
+            {4, @"On Hit"},
+            {5, @"Trap"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Decline = @"Decline";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Quest Offer";
-        }
-
-        public partial struct Regex
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> VitalCosts = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Email =
-                @"^(([\w-]+\.)+[\w-]+|([a-zA-Z]{1}|[\w-]{2,}))@((([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\.([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])){1}|([a-zA-Z]+[\w-]+\.)+[a-zA-Z]{2,4})$";
+            {0, @"HP Cost:"},
+            {1, @"MP Cost:"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Password = @"^[-_=\+`~!@#\$%\^&\*()\[\]{}\\|;\:'"",<\.>/\?a-zA-Z0-9]{4,64}$";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Username = @"^[a-zA-Z0-9]{2,20}$";
-        }
-
-        public partial struct Registration
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> VitalDamage = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Back";
+            {0, @"HP Damage:"},
+            {1, @"MP Damage:"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ConfirmPassword = @"Confirm Password:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Email = @"Email:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EmailInvalid = @"The email is invalid.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Password = @"Password:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PasswordMismatch = @"The passwords do not match.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Register = @"Register";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Register";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Username = @"Username:";
-        }
-
-        public partial struct ResetPass
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> VitalRecovery = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Back = @"Cancel";
+            {0, @"HP Recovery:"},
+            {1, @"MP Recovery:"},
+        };
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Code = @"Enter the reset code that was sent to you:";
+    public partial struct Spells
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ForgetSpell = @"Forget Spell";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ConfirmPassword = @"Confirm Password:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ForgetSpellPrompt = @"Are you sure you want to forget {00}?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Error = @"Error!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Spells";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ErrorMessage =
-                @"The reset code was not valid, has expired, or the account does not exist!";
+    public partial struct Trading
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Accept = @"Accept";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InputCode = @"Please enter your password reset code.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InFight = @"You are currently fighting!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NewPassword = @"New Password:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OfferItem = @"Offer Item";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Submit = @"Submit";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OfferItemPrompt = @"How many units of {00} would you like to offer?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Success = @"Success!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Pending = @"Pending";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuccessMessage = @"Your password has been reset!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RequestPrompt =
+            @"{00} has invited you to trade items with them. Do you accept?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Password Reset";
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RevokeItem = @"Revoke Item";
 
-        public partial struct Server
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Connecting = @"Connecting...";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RevokeItemPrompt = @"How many units of {00} would you like to revoke?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Failed = @"Network Error";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TheirOffer = @"Their Offer:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString HandshakeFailure = @"Handshake Error";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Trading with {00}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Offline = @"Offline";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TradeRequest = @"Trading Invite";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Online = @"Online";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Value = @"Value: {00}";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ServerFull = @"Server is Full";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString YourOffer = @"Your Offer:";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatusLabel = @"Server Status: {00}";
+    public partial struct EscapeMenu
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CharacterSelect = @"Characters";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Unknown = @"Unknown";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Close = @"Close";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString VersionMismatch = @"Version Mismatch";
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ExitToDesktop = @"Desktop";
 
-        public partial struct Shop
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BuyItem = @"Buy Item";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Logout = @"Logout";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BuyItemPrompt = @"How many units of {00} would you like to buy?";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Settings = @"Settings";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CannotSell = @"This shop does not accept that item!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Menu";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Costs = @"Costs {00} {01}(s)";
+    public partial struct Numbers
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Billions = "b";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SellItem = @"Sell Item";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Comma = ",";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SellItemPrompt = @"How many units of {00} would you like to sell?";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Decimal = ".";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SellPrompt = @"Do you wish to sell the item: {00}?";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Millions = "m";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SellsFor = @"Sells for {00} {01}(s)";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Thousands = "k";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WontBuy = @"Shop Will Not Buy This Item";
-        }
+    public partial struct Update
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Checking = @"Checking for updates, please wait.";
 
-        public partial struct SpellDescription
-        {
-            // String Properties (A - Z):
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Done = @"Update complete! Launching game.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Bound = @"Cannot be unlearned.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Error = @"Update Error! Check logs for more information.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CastTime = @"Cast Time:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FilesRemaining = @"{00} Files Remaining";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cooldown = @"Cooldown:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PercentComplete = @"{00}%";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroup = @"Cooldown Group:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RemainingSize = @"{00} Left";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CritChance = @"Critical Chance:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Restart = @"Update complete! Relaunch {00} to play.";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CritMultiplier = @"Critical Multiplier:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Updating = @"Downloading updates, please wait.";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DamageType = @"Damage Type:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Distance = @"Distance:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DoT = @"Damages over Time";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Duration = @"Duration:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Effect = @"Effect:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Friendly = @"Support Spell";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString HoT = @"Heals over Time";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreConsumedResourceBlock = @"Ignores Consumed Resources";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreCooldownReduction = @"Ignores Cooldown Reduction";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreGlobalCooldown = @"Ignores Global Cooldown";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreMapBlock = @"Ignores Map Blocks";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreResourceBlock = @"Ignores Active Resources";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreZDimension = @"Ignores Height Differences";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Instant = @"Instant";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Multiplier = @"{00}x";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Percentage = @"{00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RegularAndPercentage = @"{00} + {01}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ScalingPercentage = @"Scaling Percentage:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ScalingStat = @"Scaling Stat:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatBuff = @"Stat Buff";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Tick = @"Ticks every:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Tiles = @"{00} Tiles";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Unfriendly = @"Damaging Spell";
-
-
-            // Integer Dictionaries (A - Z):
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> DamageTypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Physical"},
-                {1, @"Magic"},
-                {2, @"True"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Effects = new Dictionary<int, LocalizedString>
-            {
-                {0, @""},
-                {1, @"Silence"},
-                {2, @"Stun"},
-                {3, @"Snare"},
-                {4, @"Blind"},
-                {5, @"Stealth"},
-                {6, @"Transforms"},
-                {7, @"Cleanse"},
-                {8, @"Invulnerable"},
-                {9, @"Shield"},
-                {10, @"Sleep"},
-                {11, @"On-Hit"},
-                {12, @"Taunt"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> SpellTypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Combat Spell"},
-                {1, @"Warp to Map"},
-                {2, @"Warp to Target"},
-                {3, @"Dash"},
-                {4, @"Special"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Stats = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Attack"},
-                {1, @"Ability Power"},
-                {2, @"Defense"},
-                {3, @"Magic Resist"},
-                {4, @"Speed"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> StatCounts = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Attack:"},
-                {1, @"Ability Power:"},
-                {2, @"Defense:"},
-                {3, @"Magic Resist:"},
-                {4, @"Speed:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> TargetTypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Self Cast"},
-                {1, @"Targetted - Range: {00} Tiles"},
-                {2, @"AOE"},
-                {3, @"Projectile - Range: {00} Tiles"},
-                {4, @"On Hit"},
-                {5, @"Trap"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> VitalCosts = new Dictionary<int, LocalizedString>
-            {
-                {0, @"HP Cost:"},
-                {1, @"MP Cost:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> VitalDamage = new Dictionary<int, LocalizedString>
-            {
-                {0, @"HP Damage:"},
-                {1, @"MP Damage:"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> VitalRecovery = new Dictionary<int, LocalizedString>
-            {
-                {0, @"HP Recovery:"},
-                {1, @"MP Recovery:"},
-            };
-        }
-
-        public partial struct Spells
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ForgetSpell = @"Forget Spell";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ForgetSpellPrompt = @"Are you sure you want to forget {00}?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Spells";
-        }
-
-        public partial struct Trading
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Accept = @"Accept";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InFight = @"You are currently fighting!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OfferItem = @"Offer Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OfferItemPrompt = @"How many units of {00} would you like to offer?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Pending = @"Pending";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RequestPrompt =
-                @"{00} has invited you to trade items with them. Do you accept?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RevokeItem = @"Revoke Item";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RevokeItemPrompt = @"How many units of {00} would you like to revoke?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TheirOffer = @"Their Offer:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Trading with {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TradeRequest = @"Trading Invite";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Value = @"Value: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString YourOffer = @"Your Offer:";
-        }
-
-        public partial struct EscapeMenu
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CharacterSelect = @"Characters";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Close = @"Close";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ExitToDesktop = @"Desktop";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Logout = @"Logout";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Settings = @"Settings";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Menu";
-        }
-
-        public partial struct Numbers
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Billions = "b";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Comma = ",";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Decimal = ".";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Millions = "m";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Thousands = "k";
-        }
-
-        public partial struct Update
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Checking = @"Checking for updates, please wait.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Done = @"Update complete! Launching game.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Error = @"Update Error! Check logs for more information.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FilesRemaining = @"{00} Files Remaining";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PercentComplete = @"{00}%";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RemainingSize = @"{00} Left";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Restart = @"Update complete! Relaunch {00} to play.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Updating = @"Downloading updates, please wait.";
-        }
-
-        public partial struct GameWindow
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EntityNameAndLevel = @"{00} [Lv. {01}]";
-        }
-
+    public partial struct GameWindow
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EntityNameAndLevel = @"{00} [Lv. {01}]";
     }
 
 }

--- a/Intersect.Client/Maps/ActionMessage.cs
+++ b/Intersect.Client/Maps/ActionMessage.cs
@@ -2,45 +2,43 @@
 using Intersect.Client.General;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Maps
+namespace Intersect.Client.Maps;
+
+
+public partial class ActionMessage : IActionMessage
 {
 
-    public partial class ActionMessage : IActionMessage
+    public Color Color { get; set; } = new Color();
+
+    public IMapInstance Map { get; set; }
+
+    public string Msg { get; set; } = "";
+
+    public long TransmissionTimer { get; set; }
+
+    public int X { get; set; }
+
+    public long XOffset { get; set; }
+
+    public int Y { get; set; }
+
+    public ActionMessage(MapInstance map, int x, int y, string message, Color color)
     {
+        Map = map;
+        X = x;
+        Y = y;
+        Msg = message;
+        Color = color;
+        XOffset = Globals.Random.Next(-30, 30); //+- 16 pixels so action msg's don't overlap!
+        TransmissionTimer = Timing.Global.MillisecondsUtc + 1000;
+    }
 
-        public Color Color { get; set; } = new Color();
-
-        public IMapInstance Map { get; set; }
-
-        public string Msg { get; set; } = "";
-
-        public long TransmissionTimer { get; set; }
-
-        public int X { get; set; }
-
-        public long XOffset { get; set; }
-
-        public int Y { get; set; }
-
-        public ActionMessage(MapInstance map, int x, int y, string message, Color color)
+    public void TryRemove()
+    {
+        if (TransmissionTimer <= Timing.Global.MillisecondsUtc)
         {
-            Map = map;
-            X = x;
-            Y = y;
-            Msg = message;
-            Color = color;
-            XOffset = Globals.Random.Next(-30, 30); //+- 16 pixels so action msg's don't overlap!
-            TransmissionTimer = Timing.Global.MillisecondsUtc + 1000;
+            (Map as MapInstance).ActionMessages.Remove(this);
         }
-
-        public void TryRemove()
-        {
-            if (TransmissionTimer <= Timing.Global.MillisecondsUtc)
-            {
-                (Map as MapInstance).ActionMessages.Remove(this);
-            }
-        }
-
     }
 
 }

--- a/Intersect.Client/Maps/MapAnimation.cs
+++ b/Intersect.Client/Maps/MapAnimation.cs
@@ -3,27 +3,25 @@ using Intersect.Client.Framework.Maps;
 using Intersect.GameObjects;
 using Intersect.Enums;
 
-namespace Intersect.Client.Maps
+namespace Intersect.Client.Maps;
+
+
+public partial class MapAnimation : Animation, IMapAnimation
 {
+    public Guid Id { get; } = Guid.NewGuid();
 
-    public partial class MapAnimation : Animation, IMapAnimation
+    private Direction mDir;
+
+    private int mTileX;
+
+    private int mTileY;
+
+
+    public MapAnimation(AnimationBase animBase, int tileX, int tileY, Direction dir, Entity owner = null) : base(animBase, false, false, -1, owner)
     {
-        public Guid Id { get; } = Guid.NewGuid();
-
-        private Direction mDir;
-
-        private int mTileX;
-
-        private int mTileY;
-
-
-        public MapAnimation(AnimationBase animBase, int tileX, int tileY, Direction dir, Entity owner = null) : base(animBase, false, false, -1, owner)
-        {
-            mTileX = tileX;
-            mTileY = tileY;
-            mDir = dir;
-        }
-
+        mTileX = tileX;
+        mTileY = tileY;
+        mDir = dir;
     }
 
 }

--- a/Intersect.Client/Maps/MapGrid.cs
+++ b/Intersect.Client/Maps/MapGrid.cs
@@ -1,18 +1,17 @@
 ﻿using Intersect.Client.General;
 using Intersect.Client.Framework.Maps;
 
-namespace Intersect.Client.Maps
+namespace Intersect.Client.Maps;
+
+public partial class MapGrid : IMapGrid
 {
-    public partial class MapGrid : IMapGrid
-    {
-        /// <inheritdoc />
-        public Guid[,] Content => Globals.MapGrid;
+    /// <inheritdoc />
+    public Guid[,] Content => Globals.MapGrid;
 
-        /// <inheritdoc />
-        public long Height => Globals.MapGridHeight;
+    /// <inheritdoc />
+    public long Height => Globals.MapGridHeight;
 
-        /// <inheritdoc />
-        public long Width => Globals.MapGridWidth;
+    /// <inheritdoc />
+    public long Width => Globals.MapGridWidth;
 
-    }
 }

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -23,1369 +23,1367 @@ using Intersect.Utilities;
 using Newtonsoft.Json;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Client.Maps
+namespace Intersect.Client.Maps;
+
+
+public partial class MapInstance : MapBase, IGameObject<Guid, MapInstance>, IMapInstance
 {
 
-    public partial class MapInstance : MapBase, IGameObject<Guid, MapInstance>, IMapInstance
+    //Client Only Values
+    public delegate void MapLoadedDelegate(MapInstance map);
+
+    //Map State Variables
+    public static Dictionary<Guid, long> MapRequests { get; set; } = new Dictionary<Guid, long>();
+
+    public static MapLoadedDelegate OnMapLoaded { get; set; }
+
+    private static MapControllers sLookup;
+
+    public List<IWeatherParticle> _removeParticles { get; set; } = new List<IWeatherParticle>();
+
+    //Weather
+    public List<IWeatherParticle> _weatherParticles { get; set; } = new List<IWeatherParticle>();
+
+    private long _weatherParticleSpawnTime;
+
+    //Action Msg's
+    public List<IActionMessage> ActionMessages { get; set; } = new List<IActionMessage>();
+
+    IReadOnlyList<IActionMessage> IMapInstance.ActionMessages => ActionMessages;
+
+    //Attribute Sounds
+    public List<IMapSound> AttributeSounds { get; set; } = new List<IMapSound>();
+
+    IReadOnlyList<IMapSound> IMapInstance.AttributeSounds => AttributeSounds;
+
+    //Map Animations
+    public ConcurrentDictionary<Guid, MapAnimation> LocalAnimations { get; set; } = new ConcurrentDictionary<Guid, MapAnimation>();
+
+    IReadOnlyList<IMapAnimation> IMapInstance.Animations => LocalAnimations.Values.ToList();
+
+    public Dictionary<Guid, Entity> LocalEntities { get; set; } = new Dictionary<Guid, Entity>();
+
+    IReadOnlyList<IEntity> IMapInstance.Entities => LocalEntities.Values.ToList();
+
+    //Map Critters
+    public Dictionary<Guid, Critter> LocalCritters { get; set; } = new Dictionary<Guid, Critter>();
+
+    IReadOnlyList<IEntity> IMapInstance.Critters => LocalCritters.Values.ToList();
+
+    //Map Players/Events/Npcs
+    public List<Guid> LocalEntitiesToDispose { get; set; } = new List<Guid>();
+
+    //Map Items
+    public Dictionary<int, List<IMapItemInstance>> MapItems { get; set; } = new Dictionary<int, List<IMapItemInstance>>();
+
+    IReadOnlyList<IMapItemInstance> IMapInstance.Items => MapItems.Values.SelectMany(x => x).ToList();
+
+    //Map Attributes
+    private Dictionary<GameObjects.Maps.MapAttribute, Animation> mAttributeAnimInstances = new Dictionary<GameObjects.Maps.MapAttribute, Animation>();
+    private Dictionary<GameObjects.Maps.MapAttribute, Entity> mAttributeCritterInstances = new Dictionary<GameObjects.Maps.MapAttribute, Entity>();
+
+    protected float mCurFogIntensity;
+
+    private List<Event> mEvents = new List<Event>();
+
+    protected float mFogCurrentX;
+
+    protected float mFogCurrentY;
+
+    //Fog Variables
+    protected long mFogUpdateTime = -1;
+
+    //Update Timer
+    private long mLastUpdateTime;
+
+    protected float mOverlayIntensity;
+
+    //Overlay Image Variables
+    protected long mOverlayUpdateTime = -1;
+
+    protected float mPanoramaIntensity;
+
+    //Panorama Variables
+    protected long mPanoramaUpdateTime = -1;
+
+    private bool mTexturesFound = false;
+
+    private Dictionary<string, Dictionary<object, GameTileBuffer[]>> mTileBufferDict = new Dictionary<string, Dictionary<object, GameTileBuffer[]>>(); //[Layer][?][?]
+
+    private Dictionary<string, GameTileBuffer[][]> mTileBuffers = new Dictionary<string, GameTileBuffer[][]>(); //[Layer][Autotile Frame][Buffer Index]
+
+    //Initialization
+    public MapInstance(Guid id) : base(id)
     {
-
-        //Client Only Values
-        public delegate void MapLoadedDelegate(MapInstance map);
-
-        //Map State Variables
-        public static Dictionary<Guid, long> MapRequests { get; set; } = new Dictionary<Guid, long>();
-
-        public static MapLoadedDelegate OnMapLoaded { get; set; }
-
-        private static MapControllers sLookup;
-
-        public List<IWeatherParticle> _removeParticles { get; set; } = new List<IWeatherParticle>();
-
-        //Weather
-        public List<IWeatherParticle> _weatherParticles { get; set; } = new List<IWeatherParticle>();
-
-        private long _weatherParticleSpawnTime;
-
-        //Action Msg's
-        public List<IActionMessage> ActionMessages { get; set; } = new List<IActionMessage>();
-
-        IReadOnlyList<IActionMessage> IMapInstance.ActionMessages => ActionMessages;
-
-        //Attribute Sounds
-        public List<IMapSound> AttributeSounds { get; set; } = new List<IMapSound>();
-
-        IReadOnlyList<IMapSound> IMapInstance.AttributeSounds => AttributeSounds;
-
-        //Map Animations
-        public ConcurrentDictionary<Guid, MapAnimation> LocalAnimations { get; set; } = new ConcurrentDictionary<Guid, MapAnimation>();
-
-        IReadOnlyList<IMapAnimation> IMapInstance.Animations => LocalAnimations.Values.ToList();
-
-        public Dictionary<Guid, Entity> LocalEntities { get; set; } = new Dictionary<Guid, Entity>();
-
-        IReadOnlyList<IEntity> IMapInstance.Entities => LocalEntities.Values.ToList();
-
-        //Map Critters
-        public Dictionary<Guid, Critter> LocalCritters { get; set; } = new Dictionary<Guid, Critter>();
-
-        IReadOnlyList<IEntity> IMapInstance.Critters => LocalCritters.Values.ToList();
-
-        //Map Players/Events/Npcs
-        public List<Guid> LocalEntitiesToDispose { get; set; } = new List<Guid>();
-
-        //Map Items
-        public Dictionary<int, List<IMapItemInstance>> MapItems { get; set; } = new Dictionary<int, List<IMapItemInstance>>();
-
-        IReadOnlyList<IMapItemInstance> IMapInstance.Items => MapItems.Values.SelectMany(x => x).ToList();
-
-        //Map Attributes
-        private Dictionary<GameObjects.Maps.MapAttribute, Animation> mAttributeAnimInstances = new Dictionary<GameObjects.Maps.MapAttribute, Animation>();
-        private Dictionary<GameObjects.Maps.MapAttribute, Entity> mAttributeCritterInstances = new Dictionary<GameObjects.Maps.MapAttribute, Entity>();
-
-        protected float mCurFogIntensity;
-
-        private List<Event> mEvents = new List<Event>();
-
-        protected float mFogCurrentX;
-
-        protected float mFogCurrentY;
-
-        //Fog Variables
-        protected long mFogUpdateTime = -1;
-
-        //Update Timer
-        private long mLastUpdateTime;
-
-        protected float mOverlayIntensity;
-
-        //Overlay Image Variables
-        protected long mOverlayUpdateTime = -1;
-
-        protected float mPanoramaIntensity;
-
-        //Panorama Variables
-        protected long mPanoramaUpdateTime = -1;
-
-        private bool mTexturesFound = false;
-
-        private Dictionary<string, Dictionary<object, GameTileBuffer[]>> mTileBufferDict = new Dictionary<string, Dictionary<object, GameTileBuffer[]>>(); //[Layer][?][?]
-
-        private Dictionary<string, GameTileBuffer[][]> mTileBuffers = new Dictionary<string, GameTileBuffer[][]>(); //[Layer][Autotile Frame][Buffer Index]
-
-        //Initialization
-        public MapInstance(Guid id) : base(id)
+        mTileBuffers.Clear();
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
         {
-            mTileBuffers.Clear();
+            mTileBufferDict.Add(layer, new Dictionary<object, GameTileBuffer[]>());
+            mTileBuffers.Add(layer, new GameTileBuffer[3][]); //3 autotile frames per layer
+        }
+    }
+
+    public bool IsLoaded { get; private set; }
+
+    //Camera Locking Variables
+    public bool[] CameraHolds { get; set; } = new bool[4];
+
+    //World Position
+    public int GridX { get; set; }
+
+    public int GridY { get; set; }
+
+    //Map Sounds
+    public IMapSound BackgroundSound { get; set; }
+
+    public new static MapControllers Lookup => sLookup ?? (sLookup = new MapControllers(MapBase.Lookup));
+
+    //Load
+    public void Load(string json)
+    {
+        LocalEntitiesToDispose.AddRange(LocalEntities.Keys.ToArray());
+        JsonConvert.PopulateObject(
+            json, this, new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace }
+        );
+
+        IsLoaded = true;
+        Autotiles = new MapAutotiles(this);
+        OnMapLoaded -= HandleMapLoaded;
+        OnMapLoaded += HandleMapLoaded;
+        MapRequests.Remove(Id);
+    }
+
+    public void LoadTileData(byte[] packet)
+    {
+        Layers = JsonConvert.DeserializeObject<Dictionary<string, Tile[,]>>(LZ4.UnPickleString(packet), mJsonSerializerSettings);
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            if (!Layers.ContainsKey(layer))
+            {
+                Layers.Add(layer, new Tile[Options.MapWidth, Options.MapHeight]);
+            }
+        }
+    }
+
+    private void CacheTextures()
+    {
+        if (mTexturesFound == false && GameContentManager.Current.TilesetsLoaded)
+        {
             foreach (var layer in Options.Instance.MapOpts.Layers.All)
             {
-                mTileBufferDict.Add(layer, new Dictionary<object, GameTileBuffer[]>());
-                mTileBuffers.Add(layer, new GameTileBuffer[3][]); //3 autotile frames per layer
-            }
-        }
-
-        public bool IsLoaded { get; private set; }
-
-        //Camera Locking Variables
-        public bool[] CameraHolds { get; set; } = new bool[4];
-
-        //World Position
-        public int GridX { get; set; }
-
-        public int GridY { get; set; }
-
-        //Map Sounds
-        public IMapSound BackgroundSound { get; set; }
-
-        public new static MapControllers Lookup => sLookup ?? (sLookup = new MapControllers(MapBase.Lookup));
-
-        //Load
-        public void Load(string json)
-        {
-            LocalEntitiesToDispose.AddRange(LocalEntities.Keys.ToArray());
-            JsonConvert.PopulateObject(
-                json, this, new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace }
-            );
-
-            IsLoaded = true;
-            Autotiles = new MapAutotiles(this);
-            OnMapLoaded -= HandleMapLoaded;
-            OnMapLoaded += HandleMapLoaded;
-            MapRequests.Remove(Id);
-        }
-
-        public void LoadTileData(byte[] packet)
-        {
-            Layers = JsonConvert.DeserializeObject<Dictionary<string, Tile[,]>>(LZ4.UnPickleString(packet), mJsonSerializerSettings);
-            foreach (var layer in Options.Instance.MapOpts.Layers.All)
-            {
-                if (!Layers.ContainsKey(layer))
+                for (var x = 0; x < Options.MapWidth; x++)
                 {
-                    Layers.Add(layer, new Tile[Options.MapWidth, Options.MapHeight]);
-                }
-            }
-        }
-
-        private void CacheTextures()
-        {
-            if (mTexturesFound == false && GameContentManager.Current.TilesetsLoaded)
-            {
-                foreach (var layer in Options.Instance.MapOpts.Layers.All)
-                {
-                    for (var x = 0; x < Options.MapWidth; x++)
+                    for (var y = 0; y < Options.MapHeight; y++)
                     {
-                        for (var y = 0; y < Options.MapHeight; y++)
+                        var tileset = TilesetBase.Get(Layers[layer][x, y].TilesetId);
+                        if (tileset != null)
                         {
-                            var tileset = TilesetBase.Get(Layers[layer][x, y].TilesetId);
-                            if (tileset != null)
-                            {
-                                var tilesetTex = Globals.ContentManager.GetTexture(
-                                    Framework.Content.TextureType.Tileset, tileset.Name
-                                );
-
-                                Layers[layer][x, y].TilesetTex = tilesetTex;
-                            }
-                        }
-                    }
-                }
-
-                mTexturesFound = true;
-            }
-        }
-
-        //Updating
-        public void Update(bool isLocal)
-        {
-            if (isLocal)
-            {
-                mLastUpdateTime = Timing.Global.Milliseconds + 10000;
-                UpdateMapAttributes();
-                if (BackgroundSound == null && !TextUtils.IsNone(Sound))
-                {
-                    BackgroundSound = Audio.AddMapSound(Sound, -1, -1, Id, true, 0, 10);
-                }
-
-                foreach (var anim in LocalAnimations)
-                {
-                    if (anim.Value.Disposed())
-                    {
-                        LocalAnimations.TryRemove(anim.Key, out MapAnimation removed);
-                    }
-                    else
-                    {
-                        anim.Value.Update();
-                    }
-                }
-
-                foreach (var en in LocalEntities)
-                {
-                    if (en.Value == null)
-                    {
-                        continue;
-                    }
-
-                    en.Value.Update();
-                }
-
-                foreach (var critter in mAttributeCritterInstances)
-                {
-                    if (critter.Value == null)
-                    {
-                        continue;
-                    }
-
-                    critter.Value.Update();
-                }
-
-                for (var i = 0; i < LocalEntitiesToDispose.Count; i++)
-                {
-                    LocalEntities.Remove(LocalEntitiesToDispose[i]);
-                }
-
-                LocalEntitiesToDispose.Clear();
-            }
-            else
-            {
-                if (Timing.Global.Milliseconds > mLastUpdateTime)
-                {
-                    Dispose();
-                }
-
-                HideActiveAnimations();
-            }
-        }
-
-        public bool InView()
-        {
-            var myMap = Globals.Me.MapInstance;
-            if (Globals.MapGridWidth == 0 || Globals.MapGridHeight == 0 || myMap == null)
-            {
-                return true;
-            }
-
-            var gridX = myMap.GridX;
-            var gridY = myMap.GridY;
-            for (var x = gridX - 1; x <= gridX + 1; x++)
-            {
-                for (var y = gridY - 1; y <= gridY + 1; y++)
-                {
-                    if (x >= 0 && x < Globals.MapGridWidth && y >= 0 && y < Globals.MapGridHeight)
-                    {
-                        if (Globals.MapGrid[x, y] == Id)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private void HandleMapLoaded(MapInstance map)
-        {
-            //See if this new map is on the same grid as us
-            var updatedBuffers = new HashSet<GameTileBuffer>();
-            if (map != this && Globals.GridMaps.Contains(map.Id) && Globals.GridMaps.Contains(Id) && IsLoaded)
-            {
-                var surroundingMaps = GenerateAutotileGrid();
-                if (map.GridX == GridX - 1)
-                {
-                    if (map.GridY == GridY - 1)
-                    {
-                        //Check Northwest
-                        updatedBuffers.UnionWith(CheckAutotile(0, 0, surroundingMaps));
-                    }
-                    else if (map.GridY == GridY)
-                    {
-                        //Check West
-                        for (var y = 0; y < Options.MapHeight; y++)
-                        {
-                            updatedBuffers.UnionWith(CheckAutotile(0, y, surroundingMaps));
-                        }
-                    }
-                    else if (map.GridY == GridY + 1)
-                    {
-                        //Check Southwest
-                        updatedBuffers.UnionWith(CheckAutotile(0, Options.MapHeight - 1, surroundingMaps));
-                    }
-                }
-                else if (map.GridX == GridX)
-                {
-                    if (map.GridY == GridY - 1)
-                    {
-                        //Check North
-                        for (var x = 0; x < Options.MapWidth; x++)
-                        {
-                            updatedBuffers.UnionWith(CheckAutotile(x, 0, surroundingMaps));
-                        }
-                    }
-                    else if (map.GridY == GridY + 1)
-                    {
-                        //Check South
-                        for (var x = 0; x < Options.MapWidth; x++)
-                        {
-                            updatedBuffers.UnionWith(CheckAutotile(x, Options.MapHeight - 1, surroundingMaps));
-                        }
-                    }
-                }
-                else if (map.GridX == GridX + 1)
-                {
-                    if (map.GridY == GridY - 1)
-                    {
-                        //Check Northeast
-                        updatedBuffers.UnionWith(
-                            CheckAutotile(Options.MapWidth - 1, Options.MapHeight, surroundingMaps)
-                        );
-                    }
-                    else if (map.GridY == GridY)
-                    {
-                        //Check East
-                        for (var y = 0; y < Options.MapHeight; y++)
-                        {
-                            updatedBuffers.UnionWith(CheckAutotile(Options.MapWidth - 1, y, surroundingMaps));
-                        }
-                    }
-                    else if (map.GridY == GridY + 1)
-                    {
-                        //Check Southeast
-                        updatedBuffers.UnionWith(
-                            CheckAutotile(Options.MapWidth - 1, Options.MapHeight - 1, surroundingMaps)
-                        );
-                    }
-                }
-
-                //Along with edges we need to recalculate ALL cliffs :(
-                foreach (var layer in Options.Instance.MapOpts.Layers.All)
-                {
-                    for (var x = 0; x < Options.MapWidth; x++)
-                    {
-                        for (var y = 0; y < Options.MapHeight; y++)
-                        {
-                            if (Layers[layer][x, y].Autotile == MapAutotiles.AUTOTILE_CLIFF)
-                            {
-                                updatedBuffers.UnionWith(CheckAutotile(x, y, surroundingMaps));
-                            }
-                        }
-                    }
-                }
-            }
-
-            foreach (var buffer in updatedBuffers)
-            {
-                buffer.SetData();
-            }
-        }
-
-        private GameTileBuffer[] CheckAutotile(int x, int y, MapBase[,] surroundingMaps)
-        {
-            var updated = new List<GameTileBuffer>();
-            foreach (var layer in Options.Instance.MapOpts.Layers.All)
-            {
-                if (Autotiles.UpdateAutoTile(x, y, layer, surroundingMaps))
-                {
-                    //Find the VBO, update it.
-                    var tileBuffer = mTileBufferDict[layer];
-                    var tile = Layers[layer][x, y];
-                    if (tile.TilesetTex == null)
-                    {
-                        continue;
-                    }
-
-                    var tilesetTex = (GameTexture)tile.TilesetTex;
-                    if (tile.X < 0 || tile.Y < 0)
-                    {
-                        continue;
-                    }
-
-                    if (tile.X * Options.TileWidth >= tilesetTex.GetWidth() ||
-                        tile.Y * Options.TileHeight >= tilesetTex.GetHeight())
-                    {
-                        continue;
-                    }
-
-                    var platformTex = tilesetTex.GetTexture();
-                    if (tileBuffer.ContainsKey(platformTex))
-                    {
-                        for (var autotileFrame = 0; autotileFrame < 3; autotileFrame++)
-                        {
-                            var buffer = tileBuffer[platformTex][autotileFrame];
-                            var xoffset = GetX();
-                            var yoffset = GetY();
-                            DrawAutoTile(
-                                layer, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, 1, x, y,
-                                autotileFrame, tilesetTex, buffer, true
-                            ); //Top Left
-
-                            DrawAutoTile(
-                                layer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                y * Options.TileHeight + yoffset, 2, x, y, autotileFrame, tilesetTex, buffer, true
+                            var tilesetTex = Globals.ContentManager.GetTexture(
+                                Framework.Content.TextureType.Tileset, tileset.Name
                             );
 
-                            DrawAutoTile(
-                                layer, x * Options.TileWidth + xoffset,
-                                y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, autotileFrame,
-                                tilesetTex, buffer, true
-                            );
-
-                            DrawAutoTile(
-                                layer, +x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, autotileFrame,
-                                tilesetTex, buffer, true
-                            );
-
-                            if (!updated.Contains(buffer))
-                            {
-                                updated.Add(buffer);
-                            }
+                            Layers[layer][x, y].TilesetTex = tilesetTex;
                         }
                     }
                 }
             }
 
-            return updated.ToArray();
+            mTexturesFound = true;
         }
+    }
 
-        //Helper Functions
-        public MapBase[,] GenerateAutotileGrid()
+    //Updating
+    public void Update(bool isLocal)
+    {
+        if (isLocal)
         {
-            var mapBase = new MapBase[3, 3];
-            if (Globals.MapGrid != null && Globals.GridMaps.Contains(Id))
+            mLastUpdateTime = Timing.Global.Milliseconds + 10000;
+            UpdateMapAttributes();
+            if (BackgroundSound == null && !TextUtils.IsNone(Sound))
             {
-                for (var x = -1; x <= 1; x++)
+                BackgroundSound = Audio.AddMapSound(Sound, -1, -1, Id, true, 0, 10);
+            }
+
+            foreach (var anim in LocalAnimations)
+            {
+                if (anim.Value.Disposed())
                 {
-                    for (var y = -1; y <= 1; y++)
-                    {
-                        var x1 = GridX + x;
-                        var y1 = GridY + y;
-                        if (x1 >= 0 && y1 >= 0 && x1 < Globals.MapGridWidth && y1 < Globals.MapGridHeight)
-                        {
-                            if (x == 0 && y == 0)
-                            {
-                                mapBase[x + 1, y + 1] = this;
-                            }
-                            else
-                            {
-                                mapBase[x + 1, y + 1] = Lookup.Get<MapInstance>(Globals.MapGrid[x1, y1]);
-                            }
-                        }
-                    }
+                    LocalAnimations.TryRemove(anim.Key, out MapAnimation removed);
                 }
-            }
-            else
-            {
-                Debug.WriteLine("Returning null mapgrid for map " + Name);
-            }
-
-            return mapBase;
-        }
-
-        public float X => GetX();
-
-        //Retreives the X Position of the Left side of the map in world space.
-        public float GetX()
-        {
-            return GridX * Options.MapWidth * Options.TileWidth;
-        }
-
-        public float Y => GetY();
-
-        //Retreives the Y Position of the Top side of the map in world space.
-        public float GetY()
-        {
-            return GridY * Options.MapHeight * Options.TileHeight;
-        }
-
-        //Attribute References
-        private void UpdateMapAttributes()
-        {
-            var width = Options.MapWidth;
-            var height = Options.MapHeight;
-            for (var y = 0; y < height; y++)
-            {
-                for (var x = 0; x < width; x++)
+                else
                 {
-                    var att = Attributes[x, y];
-                    if (att == null)
-                    {
-                        continue;
-                    }
-
-                    if (att.Type == MapAttribute.Animation)
-                    {
-                        var anim = AnimationBase.Get(((MapAnimationAttribute)att).AnimationId);
-                        if (anim == null)
-                        {
-                            continue;
-                        }
-
-                        if (!mAttributeAnimInstances.ContainsKey(att))
-                        {
-                            var animInstance = new Animation(anim, true);
-                            animInstance.SetPosition(
-                                GetX() + x * Options.TileWidth + Options.TileWidth / 2,
-                                GetY() + y * Options.TileHeight + Options.TileHeight / 2, x, y, Id, 0
-                            );
-
-                            mAttributeAnimInstances.Add(att, animInstance);
-                        }
-
-                        mAttributeAnimInstances[att].Update();
-                    }
-
-
-                    if (att.Type == MapAttribute.Critter)
-                    {
-                        var critterAttribute = ((MapCritterAttribute)att);
-                        var sprite = critterAttribute.Sprite;
-                        var anim = AnimationBase.Get(critterAttribute.AnimationId);
-                        if (anim == null && TextUtils.IsNone(sprite))
-                        {
-                            continue;
-                        }
-
-                        if (!mAttributeCritterInstances.ContainsKey(att))
-                        {
-                            var critter = new Critter(this, (byte)x, (byte)y, critterAttribute);
-                            LocalCritters.Add(critter.Id, critter);
-                            mAttributeCritterInstances.Add(att, critter);
-                        }
-
-                        mAttributeCritterInstances[att].Update();
-                    }
+                    anim.Value.Update();
                 }
             }
-        }
 
-        private void ClearMapAttributes()
-        {
-            foreach (var attributeInstance in mAttributeAnimInstances)
+            foreach (var en in LocalEntities)
             {
-                attributeInstance.Value.Dispose();
+                if (en.Value == null)
+                {
+                    continue;
+                }
+
+                en.Value.Update();
             }
 
             foreach (var critter in mAttributeCritterInstances)
             {
-                critter.Value.Dispose();
+                if (critter.Value == null)
+                {
+                    continue;
+                }
+
+                critter.Value.Update();
             }
 
-            LocalCritters.Clear();
-            mAttributeCritterInstances.Clear();
-            mAttributeAnimInstances.Clear();
+            for (var i = 0; i < LocalEntitiesToDispose.Count; i++)
+            {
+                LocalEntities.Remove(LocalEntitiesToDispose[i]);
+            }
+
+            LocalEntitiesToDispose.Clear();
+        }
+        else
+        {
+            if (Timing.Global.Milliseconds > mLastUpdateTime)
+            {
+                Dispose();
+            }
+
+            HideActiveAnimations();
+        }
+    }
+
+    public bool InView()
+    {
+        var myMap = Globals.Me.MapInstance;
+        if (Globals.MapGridWidth == 0 || Globals.MapGridHeight == 0 || myMap == null)
+        {
+            return true;
         }
 
-        //Sound Functions
-        public void CreateMapSounds()
+        var gridX = myMap.GridX;
+        var gridY = myMap.GridY;
+        for (var x = gridX - 1; x <= gridX + 1; x++)
         {
-            ClearAttributeSounds();
-            for (var x = 0; x < Options.MapWidth; ++x)
+            for (var y = gridY - 1; y <= gridY + 1; y++)
             {
-                for (var y = 0; y < Options.MapHeight; ++y)
+                if (x >= 0 && x < Globals.MapGridWidth && y >= 0 && y < Globals.MapGridHeight)
                 {
-                    var attribute = Attributes?[x, y];
-                    if (attribute?.Type != MapAttribute.Sound)
+                    if (Globals.MapGrid[x, y] == Id)
                     {
-                        continue;
+                        return true;
                     }
+                }
+            }
+        }
 
-                    if (TextUtils.IsNone(((MapSoundAttribute)attribute).File))
+        return false;
+    }
+
+    private void HandleMapLoaded(MapInstance map)
+    {
+        //See if this new map is on the same grid as us
+        var updatedBuffers = new HashSet<GameTileBuffer>();
+        if (map != this && Globals.GridMaps.Contains(map.Id) && Globals.GridMaps.Contains(Id) && IsLoaded)
+        {
+            var surroundingMaps = GenerateAutotileGrid();
+            if (map.GridX == GridX - 1)
+            {
+                if (map.GridY == GridY - 1)
+                {
+                    //Check Northwest
+                    updatedBuffers.UnionWith(CheckAutotile(0, 0, surroundingMaps));
+                }
+                else if (map.GridY == GridY)
+                {
+                    //Check West
+                    for (var y = 0; y < Options.MapHeight; y++)
                     {
-                        continue;
+                        updatedBuffers.UnionWith(CheckAutotile(0, y, surroundingMaps));
                     }
-
-                    var sound = Audio.AddMapSound(
-                        ((MapSoundAttribute)attribute).File, x, y, Id, true, ((MapSoundAttribute)attribute).LoopInterval, ((MapSoundAttribute)attribute).Distance
+                }
+                else if (map.GridY == GridY + 1)
+                {
+                    //Check Southwest
+                    updatedBuffers.UnionWith(CheckAutotile(0, Options.MapHeight - 1, surroundingMaps));
+                }
+            }
+            else if (map.GridX == GridX)
+            {
+                if (map.GridY == GridY - 1)
+                {
+                    //Check North
+                    for (var x = 0; x < Options.MapWidth; x++)
+                    {
+                        updatedBuffers.UnionWith(CheckAutotile(x, 0, surroundingMaps));
+                    }
+                }
+                else if (map.GridY == GridY + 1)
+                {
+                    //Check South
+                    for (var x = 0; x < Options.MapWidth; x++)
+                    {
+                        updatedBuffers.UnionWith(CheckAutotile(x, Options.MapHeight - 1, surroundingMaps));
+                    }
+                }
+            }
+            else if (map.GridX == GridX + 1)
+            {
+                if (map.GridY == GridY - 1)
+                {
+                    //Check Northeast
+                    updatedBuffers.UnionWith(
+                        CheckAutotile(Options.MapWidth - 1, Options.MapHeight, surroundingMaps)
                     );
-
-                    AttributeSounds?.Add(sound);
                 }
-            }
-        }
-
-        private void ClearAttributeSounds()
-        {
-            AttributeSounds?.ForEach(Audio.StopSound);
-            AttributeSounds?.Clear();
-        }
-
-        //Animations
-        public void AddTileAnimation(Guid animId, int tileX, int tileY, Direction dir = Direction.None, IEntity owner = null)
-        {
-            var animBase = AnimationBase.Get(animId);
-            if (animBase == null)
-            {
-                return;
-            }
-
-            var anim = new MapAnimation(animBase, tileX, tileY, dir, owner as Entity);
-            LocalAnimations.TryAdd(anim.Id, anim);
-            anim.SetPosition(
-                GetX() + tileX * Options.TileWidth + Options.TileWidth / 2,
-                GetY() + tileY * Options.TileHeight + Options.TileHeight / 2, tileX, tileY, Id, dir
-            );
-        }
-
-        private void HideActiveAnimations()
-        {
-            LocalEntities?.Values.ToList().ForEach(entity => entity?.ClearAnimations(null));
-            foreach (var anim in LocalAnimations)
-            {
-                anim.Value?.Dispose();
-            }
-            LocalAnimations?.Clear();
-            ClearMapAttributes();
-        }
-
-        public void BuildVBOs()
-        {
-            foreach (var layer in Options.Instance.MapOpts.Layers.All)
-            {
-                mTileBuffers[layer] = DrawMapLayer(layer, GetX(), GetY());
-                for (var y = 0; y < 3; y++)
+                else if (map.GridY == GridY)
                 {
-                    for (var z = 0; z < mTileBuffers[layer][y].Length; z++)
+                    //Check East
+                    for (var y = 0; y < Options.MapHeight; y++)
                     {
-                        mTileBuffers[layer][y][z].SetData();
+                        updatedBuffers.UnionWith(CheckAutotile(Options.MapWidth - 1, y, surroundingMaps));
                     }
                 }
+                else if (map.GridY == GridY + 1)
+                {
+                    //Check Southeast
+                    updatedBuffers.UnionWith(
+                        CheckAutotile(Options.MapWidth - 1, Options.MapHeight - 1, surroundingMaps)
+                    );
+                }
             }
-        }
 
-        public void DestroyVBOs()
-        {
+            //Along with edges we need to recalculate ALL cliffs :(
             foreach (var layer in Options.Instance.MapOpts.Layers.All)
             {
-                for (var y = 0; y < 3; y++)
+                for (var x = 0; x < Options.MapWidth; x++)
                 {
-                    if (mTileBuffers[layer][y] != null)
+                    for (var y = 0; y < Options.MapHeight; y++)
                     {
-                        for (var z = 0; z < mTileBuffers[layer][y].Length; z++)
+                        if (Layers[layer][x, y].Autotile == MapAutotiles.AUTOTILE_CLIFF)
                         {
-                            mTileBuffers[layer][y][z].Dispose();
+                            updatedBuffers.UnionWith(CheckAutotile(x, y, surroundingMaps));
                         }
                     }
                 }
-                mTileBufferDict[layer]?.Clear();
             }
-            mTileBuffers = null;
         }
 
-        //Rendering/Drawing Code
-        public void Draw(int layer = 0) //Lower, Middle, Upper
+        foreach (var buffer in updatedBuffers)
         {
-            if (!IsLoaded)
-            {
-                return;
-            }
+            buffer.SetData();
+        }
+    }
 
-            CacheTextures();
-            if (!mTexturesFound)
+    private GameTileBuffer[] CheckAutotile(int x, int y, MapBase[,] surroundingMaps)
+    {
+        var updated = new List<GameTileBuffer>();
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            if (Autotiles.UpdateAutoTile(x, y, layer, surroundingMaps))
             {
-                return;
-            }
-
-            if (mTileBuffers[Options.Instance.MapOpts.Layers.All[0]][0] == null)
-            {
-                BuildVBOs();
-            }
-
-            var drawLayers = Options.Instance.MapOpts.Layers.LowerLayers;
-
-            if (layer == 1)
-            {
-                drawLayers = Options.Instance.MapOpts.Layers.MiddleLayers;
-            }
-
-            if (layer == 2)
-            {
-                drawLayers = Options.Instance.MapOpts.Layers.UpperLayers;
-            }
-
-            foreach (var drawLayer in drawLayers)
-            {
-                if (mTileBuffers[drawLayer][Globals.AnimFrame] != null)
+                //Find the VBO, update it.
+                var tileBuffer = mTileBufferDict[layer];
+                var tile = Layers[layer][x, y];
+                if (tile.TilesetTex == null)
                 {
-                    for (var i = 0; i < mTileBuffers[drawLayer][Globals.AnimFrame].Length; i++)
+                    continue;
+                }
+
+                var tilesetTex = (GameTexture)tile.TilesetTex;
+                if (tile.X < 0 || tile.Y < 0)
+                {
+                    continue;
+                }
+
+                if (tile.X * Options.TileWidth >= tilesetTex.GetWidth() ||
+                    tile.Y * Options.TileHeight >= tilesetTex.GetHeight())
+                {
+                    continue;
+                }
+
+                var platformTex = tilesetTex.GetTexture();
+                if (tileBuffer.ContainsKey(platformTex))
+                {
+                    for (var autotileFrame = 0; autotileFrame < 3; autotileFrame++)
                     {
-                        Graphics.Renderer.DrawTileBuffer(mTileBuffers[drawLayer][Globals.AnimFrame][i]);
+                        var buffer = tileBuffer[platformTex][autotileFrame];
+                        var xoffset = GetX();
+                        var yoffset = GetY();
+                        DrawAutoTile(
+                            layer, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, 1, x, y,
+                            autotileFrame, tilesetTex, buffer, true
+                        ); //Top Left
+
+                        DrawAutoTile(
+                            layer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                            y * Options.TileHeight + yoffset, 2, x, y, autotileFrame, tilesetTex, buffer, true
+                        );
+
+                        DrawAutoTile(
+                            layer, x * Options.TileWidth + xoffset,
+                            y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, autotileFrame,
+                            tilesetTex, buffer, true
+                        );
+
+                        DrawAutoTile(
+                            layer, +x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                            y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, autotileFrame,
+                            tilesetTex, buffer, true
+                        );
+
+                        if (!updated.Contains(buffer))
+                        {
+                            updated.Add(buffer);
+                        }
                     }
                 }
             }
         }
 
-        public void DrawItemsAndLights()
+        return updated.ToArray();
+    }
+
+    //Helper Functions
+    public MapBase[,] GenerateAutotileGrid()
+    {
+        var mapBase = new MapBase[3, 3];
+        if (Globals.MapGrid != null && Globals.GridMaps.Contains(Id))
         {
-            // Calculate tile and map item dimensions.
-            var tileWidth = Options.TileWidth;
-            var tileHeight = Options.TileHeight;
-            var mapItemWidth = Options.Instance.MapOpts.MapItemWidth;
-            var mapItemHeight = Options.Instance.MapOpts.MapItemHeight;
-
-            // Draw map items.
-            foreach (var (key, tileItems) in MapItems)
+            for (var x = -1; x <= 1; x++)
             {
-                // Calculate tile coordinates.
-                var tileX = key % Options.MapWidth;
-                var tileY = (int)Math.Floor(key / (float)Options.MapWidth);
+                for (var y = -1; y <= 1; y++)
+                {
+                    var x1 = GridX + x;
+                    var y1 = GridY + y;
+                    if (x1 >= 0 && y1 >= 0 && x1 < Globals.MapGridWidth && y1 < Globals.MapGridHeight)
+                    {
+                        if (x == 0 && y == 0)
+                        {
+                            mapBase[x + 1, y + 1] = this;
+                        }
+                        else
+                        {
+                            mapBase[x + 1, y + 1] = Lookup.Get<MapInstance>(Globals.MapGrid[x1, y1]);
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            Debug.WriteLine("Returning null mapgrid for map " + Name);
+        }
 
+        return mapBase;
+    }
+
+    public float X => GetX();
+
+    //Retreives the X Position of the Left side of the map in world space.
+    public float GetX()
+    {
+        return GridX * Options.MapWidth * Options.TileWidth;
+    }
+
+    public float Y => GetY();
+
+    //Retreives the Y Position of the Top side of the map in world space.
+    public float GetY()
+    {
+        return GridY * Options.MapHeight * Options.TileHeight;
+    }
+
+    //Attribute References
+    private void UpdateMapAttributes()
+    {
+        var width = Options.MapWidth;
+        var height = Options.MapHeight;
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var att = Attributes[x, y];
+                if (att == null)
+                {
+                    continue;
+                }
+
+                if (att.Type == MapAttribute.Animation)
+                {
+                    var anim = AnimationBase.Get(((MapAnimationAttribute)att).AnimationId);
+                    if (anim == null)
+                    {
+                        continue;
+                    }
+
+                    if (!mAttributeAnimInstances.ContainsKey(att))
+                    {
+                        var animInstance = new Animation(anim, true);
+                        animInstance.SetPosition(
+                            GetX() + x * Options.TileWidth + Options.TileWidth / 2,
+                            GetY() + y * Options.TileHeight + Options.TileHeight / 2, x, y, Id, 0
+                        );
+
+                        mAttributeAnimInstances.Add(att, animInstance);
+                    }
+
+                    mAttributeAnimInstances[att].Update();
+                }
+
+
+                if (att.Type == MapAttribute.Critter)
+                {
+                    var critterAttribute = ((MapCritterAttribute)att);
+                    var sprite = critterAttribute.Sprite;
+                    var anim = AnimationBase.Get(critterAttribute.AnimationId);
+                    if (anim == null && TextUtils.IsNone(sprite))
+                    {
+                        continue;
+                    }
+
+                    if (!mAttributeCritterInstances.ContainsKey(att))
+                    {
+                        var critter = new Critter(this, (byte)x, (byte)y, critterAttribute);
+                        LocalCritters.Add(critter.Id, critter);
+                        mAttributeCritterInstances.Add(att, critter);
+                    }
+
+                    mAttributeCritterInstances[att].Update();
+                }
+            }
+        }
+    }
+
+    private void ClearMapAttributes()
+    {
+        foreach (var attributeInstance in mAttributeAnimInstances)
+        {
+            attributeInstance.Value.Dispose();
+        }
+
+        foreach (var critter in mAttributeCritterInstances)
+        {
+            critter.Value.Dispose();
+        }
+
+        LocalCritters.Clear();
+        mAttributeCritterInstances.Clear();
+        mAttributeAnimInstances.Clear();
+    }
+
+    //Sound Functions
+    public void CreateMapSounds()
+    {
+        ClearAttributeSounds();
+        for (var x = 0; x < Options.MapWidth; ++x)
+        {
+            for (var y = 0; y < Options.MapHeight; ++y)
+            {
+                var attribute = Attributes?[x, y];
+                if (attribute?.Type != MapAttribute.Sound)
+                {
+                    continue;
+                }
+
+                if (TextUtils.IsNone(((MapSoundAttribute)attribute).File))
+                {
+                    continue;
+                }
+
+                var sound = Audio.AddMapSound(
+                    ((MapSoundAttribute)attribute).File, x, y, Id, true, ((MapSoundAttribute)attribute).LoopInterval, ((MapSoundAttribute)attribute).Distance
+                );
+
+                AttributeSounds?.Add(sound);
+            }
+        }
+    }
+
+    private void ClearAttributeSounds()
+    {
+        AttributeSounds?.ForEach(Audio.StopSound);
+        AttributeSounds?.Clear();
+    }
+
+    //Animations
+    public void AddTileAnimation(Guid animId, int tileX, int tileY, Direction dir = Direction.None, IEntity owner = null)
+    {
+        var animBase = AnimationBase.Get(animId);
+        if (animBase == null)
+        {
+            return;
+        }
+
+        var anim = new MapAnimation(animBase, tileX, tileY, dir, owner as Entity);
+        LocalAnimations.TryAdd(anim.Id, anim);
+        anim.SetPosition(
+            GetX() + tileX * Options.TileWidth + Options.TileWidth / 2,
+            GetY() + tileY * Options.TileHeight + Options.TileHeight / 2, tileX, tileY, Id, dir
+        );
+    }
+
+    private void HideActiveAnimations()
+    {
+        LocalEntities?.Values.ToList().ForEach(entity => entity?.ClearAnimations(null));
+        foreach (var anim in LocalAnimations)
+        {
+            anim.Value?.Dispose();
+        }
+        LocalAnimations?.Clear();
+        ClearMapAttributes();
+    }
+
+    public void BuildVBOs()
+    {
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            mTileBuffers[layer] = DrawMapLayer(layer, GetX(), GetY());
+            for (var y = 0; y < 3; y++)
+            {
+                for (var z = 0; z < mTileBuffers[layer][y].Length; z++)
+                {
+                    mTileBuffers[layer][y][z].SetData();
+                }
+            }
+        }
+    }
+
+    public void DestroyVBOs()
+    {
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            for (var y = 0; y < 3; y++)
+            {
+                if (mTileBuffers[layer][y] != null)
+                {
+                    for (var z = 0; z < mTileBuffers[layer][y].Length; z++)
+                    {
+                        mTileBuffers[layer][y][z].Dispose();
+                    }
+                }
+            }
+            mTileBufferDict[layer]?.Clear();
+        }
+        mTileBuffers = null;
+    }
+
+    //Rendering/Drawing Code
+    public void Draw(int layer = 0) //Lower, Middle, Upper
+    {
+        if (!IsLoaded)
+        {
+            return;
+        }
+
+        CacheTextures();
+        if (!mTexturesFound)
+        {
+            return;
+        }
+
+        if (mTileBuffers[Options.Instance.MapOpts.Layers.All[0]][0] == null)
+        {
+            BuildVBOs();
+        }
+
+        var drawLayers = Options.Instance.MapOpts.Layers.LowerLayers;
+
+        if (layer == 1)
+        {
+            drawLayers = Options.Instance.MapOpts.Layers.MiddleLayers;
+        }
+
+        if (layer == 2)
+        {
+            drawLayers = Options.Instance.MapOpts.Layers.UpperLayers;
+        }
+
+        foreach (var drawLayer in drawLayers)
+        {
+            if (mTileBuffers[drawLayer][Globals.AnimFrame] != null)
+            {
+                for (var i = 0; i < mTileBuffers[drawLayer][Globals.AnimFrame].Length; i++)
+                {
+                    Graphics.Renderer.DrawTileBuffer(mTileBuffers[drawLayer][Globals.AnimFrame][i]);
+                }
+            }
+        }
+    }
+
+    public void DrawItemsAndLights()
+    {
+        // Calculate tile and map item dimensions.
+        var tileWidth = Options.TileWidth;
+        var tileHeight = Options.TileHeight;
+        var mapItemWidth = Options.Instance.MapOpts.MapItemWidth;
+        var mapItemHeight = Options.Instance.MapOpts.MapItemHeight;
+
+        // Draw map items.
+        foreach (var (key, tileItems) in MapItems)
+        {
+            // Calculate tile coordinates.
+            var tileX = key % Options.MapWidth;
+            var tileY = (int)Math.Floor(key / (float)Options.MapWidth);
+
+            // Loop through this in reverse to match client/server display and pick-up order.
+            for (var index = tileItems.Count - 1; index >= 0; index--)
+            {
+                // Set up all information we need to draw this name.
+                var itemBase = ItemBase.Get(tileItems[index].ItemId);
+                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, itemBase.Icon);
+
+                if (itemTex == null)
+                {
+                    continue;
+                }
+
+                var x = X + tileX * tileWidth;
+                var y = Y + tileY * tileHeight;
+                var centerX = x + (tileWidth / 2);
+                var centerY = y + (tileHeight / 2);
+                var textureXPosition = centerX - (mapItemWidth / 2);
+                var textureYPosition = centerY - (mapItemHeight / 2);
+
+                // Draw the item texture.
+                Graphics.DrawGameTexture(
+                    itemTex,
+                    new FloatRect(0, 0, itemTex.Width, itemTex.Height),
+                    new FloatRect(textureXPosition, textureYPosition, mapItemWidth, mapItemHeight),
+                    itemBase.Color
+                );
+            }
+        }
+
+        //Add lights to our darkness texture
+        foreach (var light in Lights)
+        {
+            double w = light.Size;
+            var x = GetX() + (light.TileX * tileWidth + light.OffsetX) + tileWidth / 2f;
+            var y = GetY() + (light.TileY * tileHeight + light.OffsetY) + tileHeight / 2f;
+            Graphics.AddLight((int)x, (int)y, (int)w, light.Intensity, light.Expand, light.Color);
+        }
+    }
+
+    /// <summary>
+    /// Draws all names of the items on the tile the user is hovering over.
+    /// </summary>
+    public void DrawItemNames()
+    {
+        if (Interface.Interface.MouseHitGui())
+        {
+            return;
+        }
+        // Get where our mouse is located and convert it to a tile based location.
+        var mousePos = Graphics.ConvertToWorldPoint(
+                Globals.InputManager.GetMousePosition()
+        );
+        var x = (int)(mousePos.X - (int)GetX()) / Options.TileWidth;
+        var y = (int)(mousePos.Y - (int)GetY()) / Options.TileHeight;
+        var mapId = Id;
+
+        // Is this an actual location on this map?
+        if (Globals.Me.TryGetRealLocation(ref x, ref y, ref mapId) && mapId == Id)
+        {
+            // Apparently it is! Do we have any items to render here?
+            var tileItems = new List<IMapItemInstance>();
+            if (MapItems.TryGetValue(y * Options.MapWidth + x, out tileItems))
+            {
+                var baseOffset = 0;
                 // Loop through this in reverse to match client/server display and pick-up order.
                 for (var index = tileItems.Count - 1; index >= 0; index--)
                 {
                     // Set up all information we need to draw this name.
                     var itemBase = ItemBase.Get(tileItems[index].ItemId);
-                    var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, itemBase.Icon);
-
-                    if (itemTex == null)
+                    var name = tileItems[index].Base.Name;
+                    var quantity = tileItems[index].Quantity;
+                    var rarity = itemBase.Rarity;
+                    if (tileItems[index].Quantity > 1)
                     {
-                        continue;
+                        name = Localization.Strings.General.MapItemStackable.ToString(name, Strings.FormatQuantityAbbreviated(quantity));
+                    }
+                    var color = CustomColors.Items.MapRarities.ContainsKey(rarity)
+                        ? CustomColors.Items.MapRarities[rarity]
+                        : new LabelColor(Color.White, Color.Black, new Color(100, 0, 0, 0));
+                    var textSize = Graphics.Renderer.MeasureText(name, Graphics.EntityNameFont, 1);
+                    var offsetY = (baseOffset * textSize.Y);
+                    var destX = GetX() + (int)Math.Ceiling(((x * Options.TileWidth) + (Options.TileWidth / 2)) - (textSize.X / 2));
+                    var destY = GetY() + (int)Math.Ceiling(((y * Options.TileHeight) - ((Options.TileHeight / 3) + textSize.Y))) - offsetY;
+
+                    // Do we need to draw a background?
+                    if (color.Background != Color.Transparent)
+                    {
+                        Graphics.DrawGameTexture(
+                            Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
+                            new FloatRect(destX - 4, destY, textSize.X + 8, textSize.Y), color.Background
+                        );
                     }
 
-                    var x = X + tileX * tileWidth;
-                    var y = Y + tileY * tileHeight;
-                    var centerX = x + (tileWidth / 2);
-                    var centerY = y + (tileHeight / 2);
-                    var textureXPosition = centerX - (mapItemWidth / 2);
-                    var textureYPosition = centerY - (mapItemHeight / 2);
+                    // Finaly, draw the actual name!
+                    Graphics.Renderer.DrawString(name, Graphics.EntityNameFont, destX, destY, 1, color.Name, true, null, color.Outline);
 
-                    // Draw the item texture.
-                    Graphics.DrawGameTexture(
-                        itemTex,
-                        new FloatRect(0, 0, itemTex.Width, itemTex.Height),
-                        new FloatRect(textureXPosition, textureYPosition, mapItemWidth, mapItemHeight),
-                        itemBase.Color
-                    );
+                    baseOffset++;
                 }
             }
+        }
+    }
 
-            //Add lights to our darkness texture
-            foreach (var light in Lights)
-            {
-                double w = light.Size;
-                var x = GetX() + (light.TileX * tileWidth + light.OffsetX) + tileWidth / 2f;
-                var y = GetY() + (light.TileY * tileHeight + light.OffsetY) + tileHeight / 2f;
-                Graphics.AddLight((int)x, (int)y, (int)w, light.Intensity, light.Expand, light.Color);
-            }
+    private void DrawAutoTile(
+        string layerName,
+        float destX,
+        float destY,
+        int quarterNum,
+        int x,
+        int y,
+        int forceFrame,
+        GameTexture tileset,
+        GameTileBuffer buffer,
+        bool update = false
+    )
+    {
+        int yOffset = 0, xOffset = 0;
+
+        // calculate the offset
+        switch (Layers[layerName][x, y].Autotile)
+        {
+            case MapAutotiles.AUTOTILE_WATERFALL:
+                yOffset = (forceFrame - 1) * Options.TileHeight;
+
+                break;
+
+            case MapAutotiles.AUTOTILE_ANIM:
+                xOffset = forceFrame * Options.TileWidth * 2;
+
+                break;
+
+            case MapAutotiles.AUTOTILE_ANIM_XP:
+                xOffset = forceFrame * Options.TileWidth * 3;
+
+                break;
+
+            case MapAutotiles.AUTOTILE_CLIFF:
+                yOffset = -Options.TileHeight;
+
+                break;
         }
 
-        /// <summary>
-        /// Draws all names of the items on the tile the user is hovering over.
-        /// </summary>
-        public void DrawItemNames()
+        if (update)
         {
-            if (Interface.Interface.MouseHitGui())
+            if (!buffer.UpdateTile(
+                tileset, destX, destY,
+                Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
+                Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
+                Options.TileWidth / 2, Options.TileHeight / 2
+            ))
             {
-                return;
+                throw new Exception("Failed to update tile to VBO!");
             }
-            // Get where our mouse is located and convert it to a tile based location.
-            var mousePos = Graphics.ConvertToWorldPoint(
-                    Globals.InputManager.GetMousePosition()
-            );
-            var x = (int)(mousePos.X - (int)GetX()) / Options.TileWidth;
-            var y = (int)(mousePos.Y - (int)GetY()) / Options.TileHeight;
-            var mapId = Id;
-
-            // Is this an actual location on this map?
-            if (Globals.Me.TryGetRealLocation(ref x, ref y, ref mapId) && mapId == Id)
+        }
+        else
+        {
+            if (!buffer.AddTile(
+                tileset, destX, destY,
+                Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
+                Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
+                Options.TileWidth / 2, Options.TileHeight / 2
+            ))
             {
-                // Apparently it is! Do we have any items to render here?
-                var tileItems = new List<IMapItemInstance>();
-                if (MapItems.TryGetValue(y * Options.MapWidth + x, out tileItems))
-                {
-                    var baseOffset = 0;
-                    // Loop through this in reverse to match client/server display and pick-up order.
-                    for (var index = tileItems.Count - 1; index >= 0; index--)
-                    {
-                        // Set up all information we need to draw this name.
-                        var itemBase = ItemBase.Get(tileItems[index].ItemId);
-                        var name = tileItems[index].Base.Name;
-                        var quantity = tileItems[index].Quantity;
-                        var rarity = itemBase.Rarity;
-                        if (tileItems[index].Quantity > 1)
-                        {
-                            name = Localization.Strings.General.MapItemStackable.ToString(name, Strings.FormatQuantityAbbreviated(quantity));
-                        }
-                        var color = CustomColors.Items.MapRarities.ContainsKey(rarity)
-                            ? CustomColors.Items.MapRarities[rarity]
-                            : new LabelColor(Color.White, Color.Black, new Color(100, 0, 0, 0));
-                        var textSize = Graphics.Renderer.MeasureText(name, Graphics.EntityNameFont, 1);
-                        var offsetY = (baseOffset * textSize.Y);
-                        var destX = GetX() + (int)Math.Ceiling(((x * Options.TileWidth) + (Options.TileWidth / 2)) - (textSize.X / 2));
-                        var destY = GetY() + (int)Math.Ceiling(((y * Options.TileHeight) - ((Options.TileHeight / 3) + textSize.Y))) - offsetY;
+                throw new Exception("Failed to add tile to VBO!");
+            }
+        }
+    }
 
-                        // Do we need to draw a background?
-                        if (color.Background != Color.Transparent)
+    private GameTileBuffer[][] DrawMapLayer(string layerName, float xoffset = 0, float yoffset = 0)
+    {
+        var tileBuffers = new Dictionary<object, GameTileBuffer[]>();
+
+        if (!Layers.ContainsKey(layerName))
+        {
+            return null;
+        }
+
+        for (var x = 0; x < Options.MapWidth; x++)
+        {
+            for (var y = 0; y < Options.MapHeight; y++)
+            {
+                var tile = Layers[layerName][x, y];
+                if (tile.TilesetTex == null)
+                {
+                    continue;
+                }
+
+                var tilesetTex = (GameTexture)tile.TilesetTex;
+
+                if (tile.X < 0 || tile.Y < 0)
+                {
+                    continue;
+                }
+
+                if (tile.X * Options.TileWidth >= tilesetTex.GetWidth() ||
+                    tile.Y * Options.TileHeight >= tilesetTex.GetHeight())
+                {
+                    continue;
+                }
+
+                var platformTex = tilesetTex.GetTexture();
+
+                GameTileBuffer[] buffers = null;
+                if (tileBuffers.ContainsKey(platformTex))
+                {
+                    buffers = tileBuffers[platformTex];
+                }
+                else
+                {
+                    buffers = new GameTileBuffer[3];
+                    for (var i = 0; i < 3; i++)
+                    {
+                        buffers[i] = Graphics.Renderer.CreateTileBuffer();
+                    }
+
+                    tileBuffers.Add(platformTex, buffers);
+                }
+
+                switch (Autotiles.Layers[layerName][x, y].RenderState)
+                {
+                    case MapAutotiles.RENDER_STATE_NORMAL:
+                        for (var i = 0; i < 3; i++)
                         {
-                            Graphics.DrawGameTexture(
-                                Graphics.Renderer.GetWhiteTexture(), new FloatRect(0, 0, 1, 1),
-                                new FloatRect(destX - 4, destY, textSize.X + 8, textSize.Y), color.Background
+                            var buffer = buffers[i];
+                            if (!buffer.AddTile(
+                                tilesetTex, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset,
+                                Layers[layerName][x, y].X * Options.TileWidth,
+                                Layers[layerName][x, y].Y * Options.TileHeight, Options.TileWidth,
+                                Options.TileHeight
+                            ))
+                            {
+                                throw new Exception("Failed to add VBO!");
+                            }
+                        }
+
+                        break;
+                    case MapAutotiles.RENDER_STATE_AUTOTILE:
+                        for (var i = 0; i < 3; i++)
+                        {
+                            DrawAutoTile(
+                                layerName, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, 1, x, y,
+                                i, tilesetTex, buffers[i]
+                            );
+
+                            DrawAutoTile(
+                                layerName, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                                y * Options.TileHeight + yoffset, 2, x, y, i, tilesetTex, buffers[i]
+                            );
+
+                            DrawAutoTile(
+                                layerName, x * Options.TileWidth + xoffset,
+                                y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, i, tilesetTex,
+                                buffers[i]
+                            );
+
+                            DrawAutoTile(
+                                layerName, +x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                                y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, i, tilesetTex,
+                                buffers[i]
                             );
                         }
 
-                        // Finaly, draw the actual name!
-                        Graphics.Renderer.DrawString(name, Graphics.EntityNameFont, destX, destY, 1, color.Name, true, null, color.Outline);
-
-                        baseOffset++;
-                    }
+                        break;
                 }
             }
         }
 
-        private void DrawAutoTile(
-            string layerName,
-            float destX,
-            float destY,
-            int quarterNum,
-            int x,
-            int y,
-            int forceFrame,
-            GameTexture tileset,
-            GameTileBuffer buffer,
-            bool update = false
-        )
+        var outputBuffers = new GameTileBuffer[3][];
+        for (var i = 0; i < 3; i++)
         {
-            int yOffset = 0, xOffset = 0;
-
-            // calculate the offset
-            switch (Layers[layerName][x, y].Autotile)
-            {
-                case MapAutotiles.AUTOTILE_WATERFALL:
-                    yOffset = (forceFrame - 1) * Options.TileHeight;
-
-                    break;
-
-                case MapAutotiles.AUTOTILE_ANIM:
-                    xOffset = forceFrame * Options.TileWidth * 2;
-
-                    break;
-
-                case MapAutotiles.AUTOTILE_ANIM_XP:
-                    xOffset = forceFrame * Options.TileWidth * 3;
-
-                    break;
-
-                case MapAutotiles.AUTOTILE_CLIFF:
-                    yOffset = -Options.TileHeight;
-
-                    break;
-            }
-
-            if (update)
-            {
-                if (!buffer.UpdateTile(
-                    tileset, destX, destY,
-                    Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
-                    Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
-                    Options.TileWidth / 2, Options.TileHeight / 2
-                ))
-                {
-                    throw new Exception("Failed to update tile to VBO!");
-                }
-            }
-            else
-            {
-                if (!buffer.AddTile(
-                    tileset, destX, destY,
-                    Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
-                    Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
-                    Options.TileWidth / 2, Options.TileHeight / 2
-                ))
-                {
-                    throw new Exception("Failed to add tile to VBO!");
-                }
-            }
+            outputBuffers[i] = new GameTileBuffer[tileBuffers.Count];
         }
 
-        private GameTileBuffer[][] DrawMapLayer(string layerName, float xoffset = 0, float yoffset = 0)
+        var valueArrays = tileBuffers.Values.ToArray();
+        for (var x = 0; x < valueArrays.Length; x++)
         {
-            var tileBuffers = new Dictionary<object, GameTileBuffer[]>();
-
-            if (!Layers.ContainsKey(layerName))
-            {
-                return null;
-            }
-
-            for (var x = 0; x < Options.MapWidth; x++)
-            {
-                for (var y = 0; y < Options.MapHeight; y++)
-                {
-                    var tile = Layers[layerName][x, y];
-                    if (tile.TilesetTex == null)
-                    {
-                        continue;
-                    }
-
-                    var tilesetTex = (GameTexture)tile.TilesetTex;
-
-                    if (tile.X < 0 || tile.Y < 0)
-                    {
-                        continue;
-                    }
-
-                    if (tile.X * Options.TileWidth >= tilesetTex.GetWidth() ||
-                        tile.Y * Options.TileHeight >= tilesetTex.GetHeight())
-                    {
-                        continue;
-                    }
-
-                    var platformTex = tilesetTex.GetTexture();
-
-                    GameTileBuffer[] buffers = null;
-                    if (tileBuffers.ContainsKey(platformTex))
-                    {
-                        buffers = tileBuffers[platformTex];
-                    }
-                    else
-                    {
-                        buffers = new GameTileBuffer[3];
-                        for (var i = 0; i < 3; i++)
-                        {
-                            buffers[i] = Graphics.Renderer.CreateTileBuffer();
-                        }
-
-                        tileBuffers.Add(platformTex, buffers);
-                    }
-
-                    switch (Autotiles.Layers[layerName][x, y].RenderState)
-                    {
-                        case MapAutotiles.RENDER_STATE_NORMAL:
-                            for (var i = 0; i < 3; i++)
-                            {
-                                var buffer = buffers[i];
-                                if (!buffer.AddTile(
-                                    tilesetTex, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset,
-                                    Layers[layerName][x, y].X * Options.TileWidth,
-                                    Layers[layerName][x, y].Y * Options.TileHeight, Options.TileWidth,
-                                    Options.TileHeight
-                                ))
-                                {
-                                    throw new Exception("Failed to add VBO!");
-                                }
-                            }
-
-                            break;
-                        case MapAutotiles.RENDER_STATE_AUTOTILE:
-                            for (var i = 0; i < 3; i++)
-                            {
-                                DrawAutoTile(
-                                    layerName, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, 1, x, y,
-                                    i, tilesetTex, buffers[i]
-                                );
-
-                                DrawAutoTile(
-                                    layerName, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                    y * Options.TileHeight + yoffset, 2, x, y, i, tilesetTex, buffers[i]
-                                );
-
-                                DrawAutoTile(
-                                    layerName, x * Options.TileWidth + xoffset,
-                                    y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, i, tilesetTex,
-                                    buffers[i]
-                                );
-
-                                DrawAutoTile(
-                                    layerName, +x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                    y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, i, tilesetTex,
-                                    buffers[i]
-                                );
-                            }
-
-                            break;
-                    }
-                }
-            }
-
-            var outputBuffers = new GameTileBuffer[3][];
             for (var i = 0; i < 3; i++)
             {
-                outputBuffers[i] = new GameTileBuffer[tileBuffers.Count];
+                outputBuffers[i][x] = valueArrays[x][i];
             }
-
-            var valueArrays = tileBuffers.Values.ToArray();
-            for (var x = 0; x < valueArrays.Length; x++)
-            {
-                for (var i = 0; i < 3; i++)
-                {
-                    outputBuffers[i][x] = valueArrays[x][i];
-                }
-            }
-
-            mTileBufferDict[layerName] = tileBuffers;
-
-            return outputBuffers;
         }
 
-        /// <summary>
-        /// Draws the fog over the game view.
-        /// </summary>
-        public void DrawFog()
-        {
-            // Exit early if the player or map data is not available, or if there is no fog texture.
-            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || string.IsNullOrWhiteSpace(Fog))
-            {
-                return;
-            }
+        mTileBufferDict[layerName] = tileBuffers;
 
-            // Get fog texture and exit early if it is not available.
+        return outputBuffers;
+    }
+
+    /// <summary>
+    /// Draws the fog over the game view.
+    /// </summary>
+    public void DrawFog()
+    {
+        // Exit early if the player or map data is not available, or if there is no fog texture.
+        if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null || string.IsNullOrWhiteSpace(Fog))
+        {
+            return;
+        }
+
+        // Get fog texture and exit early if it is not available.
+        var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
+        if (fogTex == null)
+        {
+            return;
+        }
+
+        // Calculate elapsed time since the last update and set maximum value for elapsedTime to
+        // prevent large jumps in fog intensity (1 second maximum).
+        float elapsedTime = Math.Min(Timing.Global.MillisecondsUtc - mFogUpdateTime, 1000);
+        mFogUpdateTime = Timing.Global.MillisecondsUtc;
+
+        // Update fog intensity based on whether the player is on the current map or not.
+        mCurFogIntensity = Id == Globals.Me.MapId
+            ? Math.Min(1, mCurFogIntensity + elapsedTime / 2000f)
+            : Math.Max(0, mCurFogIntensity - elapsedTime / 2000f);
+
+        // Calculate the number of times the fog texture needs to be drawn to cover the map area.
+        var xCount = Options.MapWidth * Options.TileWidth * 3 / fogTex.Width;
+        var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.Height;
+
+        // Update the fog texture's position based on its speed and elapsed time.
+        mFogCurrentX += elapsedTime / 1000f * FogXSpeed * 2;
+        mFogCurrentY += elapsedTime / 1000f * FogYSpeed * 2;
+
+        // Handle cases where the fog texture's position goes out of bounds.
+        mFogCurrentX %= fogTex.Width;
+        mFogCurrentY %= fogTex.Height;
+
+        // Round the fog texture's position to the nearest integer value.
+        var drawX = (float)Math.Round(mFogCurrentX);
+        var drawY = (float)Math.Round(mFogCurrentY);
+
+        for (var x = -1; x <= xCount; x++)
+        {
+            for (var y = -1; y <= yCount; y++)
+            {
+                Graphics.DrawGameTexture(
+                    fogTex, new FloatRect(0, 0, fogTex.Width, fogTex.Height),
+                    new FloatRect(
+                        X - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
+                        Y - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY,
+                        fogTex.Width, fogTex.Height
+                    ), new Color((byte)(FogTransparency * mCurFogIntensity), 255, 255, 255)
+                );
+            }
+        }
+    }
+
+    //Weather
+    public void DrawWeather()
+    {
+        if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null)
+        {
+            return;
+        }
+
+        var anim = AnimationBase.Get(WeatherAnimationId);
+
+        if (anim == null || WeatherIntensity == 0)
+        {
+            return;
+        }
+
+        _removeParticles.Clear();
+
+        if ((WeatherXSpeed != 0 || WeatherYSpeed != 0) && Globals.Me.MapInstance == this)
+        {
+            if (Timing.Global.MillisecondsUtc > _weatherParticleSpawnTime)
+            {
+                _weatherParticles.Add(new WeatherParticle(_removeParticles, WeatherXSpeed, WeatherYSpeed, anim));
+                var spawnTime = 25 + (int)(475 * (1f - WeatherIntensity / 100f));
+                spawnTime = (int)(spawnTime *
+                                   (480000f /
+                                    (Graphics.Renderer.GetScreenWidth() * Graphics.Renderer.GetScreenHeight())));
+
+                _weatherParticleSpawnTime = Timing.Global.MillisecondsUtc + spawnTime;
+            }
+        }
+
+        //Process and draw each weather particle
+        foreach (var w in _weatherParticles)
+        {
+            w.Update();
+        }
+
+        //Remove all old particles from the weather particles list from the removeparticles list.
+        foreach (var r in _removeParticles)
+        {
+            r.Dispose();
+            _weatherParticles.Remove(r);
+        }
+    }
+
+    private void ClearWeather()
+    {
+        foreach (var r in _weatherParticles)
+        {
+            r.Dispose();
+        }
+
+        _weatherParticles.Clear();
+    }
+
+    public void GridSwitched()
+    {
+        mPanoramaIntensity = 1f;
+        mCurFogIntensity = 1f;
+    }
+
+    public void DrawPanorama()
+    {
+        float ecTime = Timing.Global.MillisecondsUtc - mPanoramaUpdateTime;
+        mPanoramaUpdateTime = Timing.Global.MillisecondsUtc;
+        if (Id == Globals.Me.MapId)
+        {
+            if (mPanoramaIntensity != 1)
+            {
+                mPanoramaIntensity += ecTime / 2000f;
+                if (mPanoramaIntensity > 1)
+                {
+                    mPanoramaIntensity = 1;
+                }
+            }
+        }
+        else
+        {
+            if (mPanoramaIntensity != 0)
+            {
+                mPanoramaIntensity -= ecTime / 2000f;
+                if (mPanoramaIntensity < 0)
+                {
+                    mPanoramaIntensity = 0;
+                }
+            }
+        }
+
+        var imageTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, Panorama);
+        if (imageTex != null)
+        {
+            Graphics.DrawFullScreenTexture(imageTex, mPanoramaIntensity);
+        }
+    }
+
+    public void DrawOverlayGraphic()
+    {
+        float ecTime = Timing.Global.MillisecondsUtc - mOverlayUpdateTime;
+        mOverlayUpdateTime = Timing.Global.MillisecondsUtc;
+        if (Id == Globals.Me.MapId)
+        {
+            if (mOverlayIntensity != 1)
+            {
+                mOverlayIntensity += ecTime / 2000f;
+                if (mOverlayIntensity > 1)
+                {
+                    mOverlayIntensity = 1;
+                }
+            }
+        }
+        else
+        {
+            if (mOverlayIntensity != 0)
+            {
+                mOverlayIntensity -= ecTime / 2000f;
+                if (mOverlayIntensity < 0)
+                {
+                    mOverlayIntensity = 0;
+                }
+            }
+        }
+
+        var imageTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, OverlayGraphic);
+        if (imageTex != null)
+        {
+            Graphics.DrawFullScreenTexture(imageTex, mOverlayIntensity);
+        }
+    }
+
+    public void CompareEffects(IMapInstance oldMap)
+    {
+        // Return if the old map is not a MapInstance.
+        if (!(oldMap is MapInstance tempMap))
+        {
+            return;
+        }
+
+        // Check if fog is the same.
+        if (tempMap.Fog == Fog)
+        {
+            // Get fog texture.
             var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
             if (fogTex == null)
             {
                 return;
             }
 
-            // Calculate elapsed time since the last update and set maximum value for elapsedTime to
-            // prevent large jumps in fog intensity (1 second maximum).
-            float elapsedTime = Math.Min(Timing.Global.MillisecondsUtc - mFogUpdateTime, 1000);
-            mFogUpdateTime = Timing.Global.MillisecondsUtc;
+            // Copy over fog values.
+            mFogUpdateTime = tempMap.mFogUpdateTime;
+            var ratio = (float)tempMap.FogTransparency / FogTransparency;
+            mCurFogIntensity = ratio * tempMap.mCurFogIntensity;
+            mFogCurrentX = tempMap.mFogCurrentX;
+            mFogCurrentY = tempMap.mFogCurrentY;
 
-            // Update fog intensity based on whether the player is on the current map or not.
-            mCurFogIntensity = Id == Globals.Me.MapId
-                ? Math.Min(1, mCurFogIntensity + elapsedTime / 2000f)
-                : Math.Max(0, mCurFogIntensity - elapsedTime / 2000f);
+            // Calculate displacement of current map compared to old map.
+            float dx = X - oldMap.X;
+            float dy = Y - oldMap.Y;
 
-            // Calculate the number of times the fog texture needs to be drawn to cover the map area.
-            var xCount = Options.MapWidth * Options.TileWidth * 3 / fogTex.Width;
-            var yCount = Options.MapHeight * Options.TileHeight * 3 / fogTex.Height;
+            // Update fog position based on displacement.
+            mFogCurrentX += (Options.TileWidth * Options.MapWidth % fogTex.Width) * -Math.Sign(dx);
+            mFogCurrentY += (Options.TileHeight * Options.MapHeight % fogTex.Height) * -Math.Sign(dy);
 
-            // Update the fog texture's position based on its speed and elapsed time.
-            mFogCurrentX += elapsedTime / 1000f * FogXSpeed * 2;
-            mFogCurrentY += elapsedTime / 1000f * FogYSpeed * 2;
-
-            // Handle cases where the fog texture's position goes out of bounds.
-            mFogCurrentX %= fogTex.Width;
-            mFogCurrentY %= fogTex.Height;
-
-            // Round the fog texture's position to the nearest integer value.
-            var drawX = (float)Math.Round(mFogCurrentX);
-            var drawY = (float)Math.Round(mFogCurrentY);
-
-            for (var x = -1; x <= xCount; x++)
-            {
-                for (var y = -1; y <= yCount; y++)
-                {
-                    Graphics.DrawGameTexture(
-                        fogTex, new FloatRect(0, 0, fogTex.Width, fogTex.Height),
-                        new FloatRect(
-                            X - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
-                            Y - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY,
-                            fogTex.Width, fogTex.Height
-                        ), new Color((byte)(FogTransparency * mCurFogIntensity), 255, 255, 255)
-                    );
-                }
-            }
+            // Reset fog intensity of old map.
+            tempMap.mCurFogIntensity = 0;
         }
 
-        //Weather
-        public void DrawWeather()
+        // Check if panorama is the same.
+        if (tempMap.Panorama == Panorama)
         {
-            if (Globals.Me == null || Lookup.Get(Globals.Me.MapId) == null)
-            {
-                return;
-            }
-
-            var anim = AnimationBase.Get(WeatherAnimationId);
-
-            if (anim == null || WeatherIntensity == 0)
-            {
-                return;
-            }
-
-            _removeParticles.Clear();
-
-            if ((WeatherXSpeed != 0 || WeatherYSpeed != 0) && Globals.Me.MapInstance == this)
-            {
-                if (Timing.Global.MillisecondsUtc > _weatherParticleSpawnTime)
-                {
-                    _weatherParticles.Add(new WeatherParticle(_removeParticles, WeatherXSpeed, WeatherYSpeed, anim));
-                    var spawnTime = 25 + (int)(475 * (1f - WeatherIntensity / 100f));
-                    spawnTime = (int)(spawnTime *
-                                       (480000f /
-                                        (Graphics.Renderer.GetScreenWidth() * Graphics.Renderer.GetScreenHeight())));
-
-                    _weatherParticleSpawnTime = Timing.Global.MillisecondsUtc + spawnTime;
-                }
-            }
-
-            //Process and draw each weather particle
-            foreach (var w in _weatherParticles)
-            {
-                w.Update();
-            }
-
-            //Remove all old particles from the weather particles list from the removeparticles list.
-            foreach (var r in _removeParticles)
-            {
-                r.Dispose();
-                _weatherParticles.Remove(r);
-            }
+            // Copy over panorama values.
+            mPanoramaIntensity = tempMap.mPanoramaIntensity;
+            mPanoramaUpdateTime = tempMap.mPanoramaUpdateTime;
+            // Reset panorama intensity of old map.
+            tempMap.mPanoramaIntensity = 0;
         }
 
-        private void ClearWeather()
+        // Check if overlay graphic is the same.
+        if (tempMap.OverlayGraphic == OverlayGraphic)
         {
-            foreach (var r in _weatherParticles)
-            {
-                r.Dispose();
-            }
-
-            _weatherParticles.Clear();
+            // Copy over overlay graphic values.
+            mOverlayIntensity = tempMap.mOverlayIntensity;
+            mOverlayUpdateTime = tempMap.mOverlayUpdateTime;
+            // Reset overlay graphic intensity of old map.
+            tempMap.mOverlayIntensity = 0;
         }
+    }
 
-        public void GridSwitched()
+    public void DrawActionMsgs()
+    {
+        for (var n = ActionMessages.Count - 1; n > -1; n--)
         {
-            mPanoramaIntensity = 1f;
-            mCurFogIntensity = 1f;
+            var y = (int)Math.Ceiling(
+                GetY() +
+                ActionMessages[n].Y * Options.TileHeight -
+                Options.TileHeight *
+                2 *
+                (1000 - (ActionMessages[n].TransmissionTimer - Timing.Global.MillisecondsUtc)) /
+                1000
+            );
+
+            var x = (int)Math.Ceiling(GetX() + ActionMessages[n].X * Options.TileWidth + ActionMessages[n].XOffset);
+            var textWidth = Graphics.Renderer.MeasureText(ActionMessages[n].Msg, Graphics.ActionMsgFont, 1).X;
+            Graphics.Renderer.DrawString(
+                ActionMessages[n].Msg, Graphics.ActionMsgFont, x - textWidth / 2f, y, 1, ActionMessages[n].Color,
+                true, null, new Color(40, 40, 40)
+            );
+
+            //Try to remove
+            ActionMessages[n].TryRemove();
         }
+    }
 
-        public void DrawPanorama()
+    //Events
+    public void AddEvent(Guid evtId, EventEntityPacket packet)
+    {
+        if (IsLoaded)
         {
-            float ecTime = Timing.Global.MillisecondsUtc - mPanoramaUpdateTime;
-            mPanoramaUpdateTime = Timing.Global.MillisecondsUtc;
-            if (Id == Globals.Me.MapId)
+            if (LocalEntities.ContainsKey(evtId))
             {
-                if (mPanoramaIntensity != 1)
-                {
-                    mPanoramaIntensity += ecTime / 2000f;
-                    if (mPanoramaIntensity > 1)
-                    {
-                        mPanoramaIntensity = 1;
-                    }
-                }
+                LocalEntities[evtId].Load(packet);
             }
             else
             {
-                if (mPanoramaIntensity != 0)
-                {
-                    mPanoramaIntensity -= ecTime / 2000f;
-                    if (mPanoramaIntensity < 0)
-                    {
-                        mPanoramaIntensity = 0;
-                    }
-                }
-            }
-
-            var imageTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, Panorama);
-            if (imageTex != null)
-            {
-                Graphics.DrawFullScreenTexture(imageTex, mPanoramaIntensity);
-            }
-        }
-
-        public void DrawOverlayGraphic()
-        {
-            float ecTime = Timing.Global.MillisecondsUtc - mOverlayUpdateTime;
-            mOverlayUpdateTime = Timing.Global.MillisecondsUtc;
-            if (Id == Globals.Me.MapId)
-            {
-                if (mOverlayIntensity != 1)
-                {
-                    mOverlayIntensity += ecTime / 2000f;
-                    if (mOverlayIntensity > 1)
-                    {
-                        mOverlayIntensity = 1;
-                    }
-                }
-            }
-            else
-            {
-                if (mOverlayIntensity != 0)
-                {
-                    mOverlayIntensity -= ecTime / 2000f;
-                    if (mOverlayIntensity < 0)
-                    {
-                        mOverlayIntensity = 0;
-                    }
-                }
-            }
-
-            var imageTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Image, OverlayGraphic);
-            if (imageTex != null)
-            {
-                Graphics.DrawFullScreenTexture(imageTex, mOverlayIntensity);
-            }
-        }
-
-        public void CompareEffects(IMapInstance oldMap)
-        {
-            // Return if the old map is not a MapInstance.
-            if (!(oldMap is MapInstance tempMap))
-            {
-                return;
-            }
-
-            // Check if fog is the same.
-            if (tempMap.Fog == Fog)
-            {
-                // Get fog texture.
-                var fogTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Fog, Fog);
-                if (fogTex == null)
-                {
-                    return;
-                }
-
-                // Copy over fog values.
-                mFogUpdateTime = tempMap.mFogUpdateTime;
-                var ratio = (float)tempMap.FogTransparency / FogTransparency;
-                mCurFogIntensity = ratio * tempMap.mCurFogIntensity;
-                mFogCurrentX = tempMap.mFogCurrentX;
-                mFogCurrentY = tempMap.mFogCurrentY;
-
-                // Calculate displacement of current map compared to old map.
-                float dx = X - oldMap.X;
-                float dy = Y - oldMap.Y;
-
-                // Update fog position based on displacement.
-                mFogCurrentX += (Options.TileWidth * Options.MapWidth % fogTex.Width) * -Math.Sign(dx);
-                mFogCurrentY += (Options.TileHeight * Options.MapHeight % fogTex.Height) * -Math.Sign(dy);
-
-                // Reset fog intensity of old map.
-                tempMap.mCurFogIntensity = 0;
-            }
-
-            // Check if panorama is the same.
-            if (tempMap.Panorama == Panorama)
-            {
-                // Copy over panorama values.
-                mPanoramaIntensity = tempMap.mPanoramaIntensity;
-                mPanoramaUpdateTime = tempMap.mPanoramaUpdateTime;
-                // Reset panorama intensity of old map.
-                tempMap.mPanoramaIntensity = 0;
-            }
-
-            // Check if overlay graphic is the same.
-            if (tempMap.OverlayGraphic == OverlayGraphic)
-            {
-                // Copy over overlay graphic values.
-                mOverlayIntensity = tempMap.mOverlayIntensity;
-                mOverlayUpdateTime = tempMap.mOverlayUpdateTime;
-                // Reset overlay graphic intensity of old map.
-                tempMap.mOverlayIntensity = 0;
-            }
-        }
-
-        public void DrawActionMsgs()
-        {
-            for (var n = ActionMessages.Count - 1; n > -1; n--)
-            {
-                var y = (int)Math.Ceiling(
-                    GetY() +
-                    ActionMessages[n].Y * Options.TileHeight -
-                    Options.TileHeight *
-                    2 *
-                    (1000 - (ActionMessages[n].TransmissionTimer - Timing.Global.MillisecondsUtc)) /
-                    1000
-                );
-
-                var x = (int)Math.Ceiling(GetX() + ActionMessages[n].X * Options.TileWidth + ActionMessages[n].XOffset);
-                var textWidth = Graphics.Renderer.MeasureText(ActionMessages[n].Msg, Graphics.ActionMsgFont, 1).X;
-                Graphics.Renderer.DrawString(
-                    ActionMessages[n].Msg, Graphics.ActionMsgFont, x - textWidth / 2f, y, 1, ActionMessages[n].Color,
-                    true, null, new Color(40, 40, 40)
-                );
-
-                //Try to remove
-                ActionMessages[n].TryRemove();
-            }
-        }
-
-        //Events
-        public void AddEvent(Guid evtId, EventEntityPacket packet)
-        {
-            if (IsLoaded)
-            {
-                if (LocalEntities.ContainsKey(evtId))
-                {
-                    LocalEntities[evtId].Load(packet);
-                }
-                else
-                {
-                    var evt = new Event(evtId, packet);
-                    LocalEntities.Add(evtId, evt);
-                    mEvents.Add(evt);
-                }
-            }
-        }
-
-        public new static MapInstance Get(Guid id)
-        {
-            return MapInstance.Lookup.Get<MapInstance>(id);
-        }
-
-        public static bool TryGet(Guid id, out MapInstance instance)
-        {
-            instance = MapInstance.Lookup.Get<MapInstance>(id);
-            if (instance == null)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public override void Delete()
-        {
-            if (Lookup != null)
-            {
-                Lookup.Delete(this);
-            }
-        }
-
-        //Dispose
-        public void Dispose(bool prep = true, bool killentities = true)
-        {
-            IsLoaded = false;
-            OnMapLoaded -= HandleMapLoaded;
-
-            foreach (var evt in mEvents)
-            {
-                evt.Dispose();
-            }
-
-            mEvents.Clear();
-
-            if (killentities)
-            {
-                foreach (var en in Globals.Entities)
-                {
-                    if (en.Value.MapId == Id)
-                    {
-                        Globals.EntitiesToDispose.Add(en.Key);
-                    }
-                }
-
-                foreach (var en in LocalEntities)
-                {
-                    en.Value.Dispose();
-                }
-            }
-
-            HideActiveAnimations();
-            ClearWeather();
-            ClearMapAttributes();
-            ClearAttributeSounds();
-            DestroyVBOs();
-            Delete();
-        }
-
-        public static bool MapNotRequested(Guid mapId)
-        {
-            if (!MapRequests.TryGetValue(mapId, out var nextRequest))
-            {
-                return true;
-            }
-
-            return nextRequest < Timing.Global.Milliseconds;
-        }
-
-        public static void UpdateMapRequestTime(params Guid[] mapIds)
-        {
-            foreach (var mapId in mapIds)
-            {
-                if (mapId == default)
-                {
-                    continue;
-                }
-
-                MapRequests[mapId] = Timing.Global.Milliseconds + 2000;
+                var evt = new Event(evtId, packet);
+                LocalEntities.Add(evtId, evt);
+                mEvents.Add(evt);
             }
         }
     }
 
+    public new static MapInstance Get(Guid id)
+    {
+        return MapInstance.Lookup.Get<MapInstance>(id);
+    }
+
+    public static bool TryGet(Guid id, out MapInstance instance)
+    {
+        instance = MapInstance.Lookup.Get<MapInstance>(id);
+        if (instance == null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public override void Delete()
+    {
+        if (Lookup != null)
+        {
+            Lookup.Delete(this);
+        }
+    }
+
+    //Dispose
+    public void Dispose(bool prep = true, bool killentities = true)
+    {
+        IsLoaded = false;
+        OnMapLoaded -= HandleMapLoaded;
+
+        foreach (var evt in mEvents)
+        {
+            evt.Dispose();
+        }
+
+        mEvents.Clear();
+
+        if (killentities)
+        {
+            foreach (var en in Globals.Entities)
+            {
+                if (en.Value.MapId == Id)
+                {
+                    Globals.EntitiesToDispose.Add(en.Key);
+                }
+            }
+
+            foreach (var en in LocalEntities)
+            {
+                en.Value.Dispose();
+            }
+        }
+
+        HideActiveAnimations();
+        ClearWeather();
+        ClearMapAttributes();
+        ClearAttributeSounds();
+        DestroyVBOs();
+        Delete();
+    }
+
+    public static bool MapNotRequested(Guid mapId)
+    {
+        if (!MapRequests.TryGetValue(mapId, out var nextRequest))
+        {
+            return true;
+        }
+
+        return nextRequest < Timing.Global.Milliseconds;
+    }
+
+    public static void UpdateMapRequestTime(params Guid[] mapIds)
+    {
+        foreach (var mapId in mapIds)
+        {
+            if (mapId == default)
+            {
+                continue;
+            }
+
+            MapRequests[mapId] = Timing.Global.Milliseconds + 2000;
+        }
+    }
 }

--- a/Intersect.Client/Maps/WeatherParticle.cs
+++ b/Intersect.Client/Maps/WeatherParticle.cs
@@ -7,155 +7,153 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Client.Maps
+namespace Intersect.Client.Maps;
+
+
+public partial class WeatherParticle : IWeatherParticle
 {
 
-    public partial class WeatherParticle : IWeatherParticle
+    private List<IWeatherParticle> _RemoveParticle;
+
+    private Animation animInstance;
+
+    private Rectangle bounds;
+
+    private float cameraSpawnX;
+
+    private float cameraSpawnY;
+
+    private int originalX;
+
+    private int originalY;
+
+    private Point partSize;
+
+    private long TransmittionTimer;
+
+    public float X { get; set; }
+
+    private int xVelocity;
+
+    public float Y { get; set; }
+
+    private int yVelocity;
+
+    public WeatherParticle(List<IWeatherParticle> RemoveParticle, int xvelocity, int yvelocity, AnimationBase anim)
     {
+        TransmittionTimer = Timing.Global.MillisecondsUtc;
+        bounds = new Rectangle(0, 0, Graphics.Renderer.GetScreenWidth(), Graphics.Renderer.GetScreenHeight());
 
-        private List<IWeatherParticle> _RemoveParticle;
+        xVelocity = xvelocity;
+        yVelocity = yvelocity;
 
-        private Animation animInstance;
+        animInstance = new Animation(anim, true, false);
+        var animSize = animInstance.CalculateAnimationSize();
+        partSize = animSize;
 
-        private Rectangle bounds;
-
-        private float cameraSpawnX;
-
-        private float cameraSpawnY;
-
-        private int originalX;
-
-        private int originalY;
-
-        private Point partSize;
-
-        private long TransmittionTimer;
-
-        public float X { get; set; }
-
-        private int xVelocity;
-
-        public float Y { get; set; }
-
-        private int yVelocity;
-
-        public WeatherParticle(List<IWeatherParticle> RemoveParticle, int xvelocity, int yvelocity, AnimationBase anim)
+        if (xVelocity > 0)
         {
-            TransmittionTimer = Timing.Global.MillisecondsUtc;
-            bounds = new Rectangle(0, 0, Graphics.Renderer.GetScreenWidth(), Graphics.Renderer.GetScreenHeight());
+            originalX = Globals.Random.Next(
+                -Graphics.Renderer.GetScreenWidth() / 4 - animSize.X,
+                Graphics.Renderer.GetScreenWidth() + animSize.X
+            );
+        }
+        else if (xVelocity < 0)
+        {
+            originalX = Globals.Random.Next(
+                animSize.X, (int)(Graphics.Renderer.GetScreenWidth() * 1.25f) + animSize.X
+            );
+        }
+        else
+        {
+            originalX = Globals.Random.Next(-animSize.X, Graphics.Renderer.GetScreenWidth() + animSize.X);
+        }
 
-            xVelocity = xvelocity;
-            yVelocity = yvelocity;
-
-            animInstance = new Animation(anim, true, false);
-            var animSize = animInstance.CalculateAnimationSize();
-            partSize = animSize;
-
+        if (yVelocity > 0)
+        {
+            originalY = -animSize.Y;
+        }
+        else if (yVelocity < 0)
+        {
+            originalY = Graphics.Renderer.GetScreenHeight() + animSize.Y;
+        }
+        else
+        {
+            originalY = Globals.Random.Next(-animSize.Y, Graphics.Renderer.GetScreenHeight() + animSize.Y);
             if (xVelocity > 0)
             {
-                originalX = Globals.Random.Next(
-                    -Graphics.Renderer.GetScreenWidth() / 4 - animSize.X,
-                    Graphics.Renderer.GetScreenWidth() + animSize.X
-                );
+                originalX = -animSize.X;
             }
             else if (xVelocity < 0)
             {
-                originalX = Globals.Random.Next(
-                    animSize.X, (int)(Graphics.Renderer.GetScreenWidth() * 1.25f) + animSize.X
-                );
+                originalX = Graphics.Renderer.GetScreenWidth();
             }
-            else
-            {
-                originalX = Globals.Random.Next(-animSize.X, Graphics.Renderer.GetScreenWidth() + animSize.X);
-            }
-
-            if (yVelocity > 0)
-            {
-                originalY = -animSize.Y;
-            }
-            else if (yVelocity < 0)
-            {
-                originalY = Graphics.Renderer.GetScreenHeight() + animSize.Y;
-            }
-            else
-            {
-                originalY = Globals.Random.Next(-animSize.Y, Graphics.Renderer.GetScreenHeight() + animSize.Y);
-                if (xVelocity > 0)
-                {
-                    originalX = -animSize.X;
-                }
-                else if (xVelocity < 0)
-                {
-                    originalX = Graphics.Renderer.GetScreenWidth();
-                }
-            }
-
-            if (originalX < 0)
-            {
-                bounds.X = originalX;
-                bounds.Width += Math.Abs(originalX);
-            }
-
-            if (originalY < 0)
-            {
-                bounds.Y = originalY;
-                bounds.Height += Math.Abs(originalY);
-            }
-
-            if (originalY > Graphics.Renderer.GetScreenHeight())
-            {
-                bounds.Height = originalY;
-            }
-
-            if (originalX > Graphics.Renderer.GetScreenWidth())
-            {
-                bounds.Width = originalX;
-            }
-
-            bounds.X -= animSize.X;
-            bounds.Width += animSize.X * 2;
-            bounds.Y -= animSize.Y;
-            bounds.Height += animSize.Y * 2;
-
-            X = originalX;
-            Y = originalY;
-            cameraSpawnX = Graphics.Renderer.GetView().Left;
-            cameraSpawnY = Graphics.Renderer.GetView().Top;
-            _RemoveParticle = RemoveParticle;
         }
 
-        public void Update()
+        if (originalX < 0)
         {
-            //Check if out of bounds
-            var newBounds = new Rectangle(
-                bounds.X + ((int)Graphics.Renderer.GetView().Left - (int)cameraSpawnX),
-                bounds.Y + ((int)Graphics.Renderer.GetView().Top - (int)cameraSpawnY), bounds.Width, bounds.Height
-            );
-
-            if (!newBounds.IntersectsWith(new Rectangle((int)X, (int)Y, partSize.X, partSize.Y)))
-            {
-                _RemoveParticle.Add(this);
-            }
-            else
-            {
-                var timeScale = (Timing.Global.MillisecondsUtc - TransmittionTimer) / 10f;
-                X = originalX + xVelocity * timeScale;
-                Y = originalY + yVelocity * timeScale;
-                animInstance.SetPosition(cameraSpawnX + X, cameraSpawnY + Y, -1, -1, Guid.Empty, Direction.None, 0);
-                animInstance.Update();
-            }
+            bounds.X = originalX;
+            bounds.Width += Math.Abs(originalX);
         }
 
-        public void Dispose()
+        if (originalY < 0)
         {
-            animInstance.Dispose();
+            bounds.Y = originalY;
+            bounds.Height += Math.Abs(originalY);
         }
 
-        ~WeatherParticle()
+        if (originalY > Graphics.Renderer.GetScreenHeight())
         {
-            Dispose();
+            bounds.Height = originalY;
         }
 
+        if (originalX > Graphics.Renderer.GetScreenWidth())
+        {
+            bounds.Width = originalX;
+        }
+
+        bounds.X -= animSize.X;
+        bounds.Width += animSize.X * 2;
+        bounds.Y -= animSize.Y;
+        bounds.Height += animSize.Y * 2;
+
+        X = originalX;
+        Y = originalY;
+        cameraSpawnX = Graphics.Renderer.GetView().Left;
+        cameraSpawnY = Graphics.Renderer.GetView().Top;
+        _RemoveParticle = RemoveParticle;
+    }
+
+    public void Update()
+    {
+        //Check if out of bounds
+        var newBounds = new Rectangle(
+            bounds.X + ((int)Graphics.Renderer.GetView().Left - (int)cameraSpawnX),
+            bounds.Y + ((int)Graphics.Renderer.GetView().Top - (int)cameraSpawnY), bounds.Width, bounds.Height
+        );
+
+        if (!newBounds.IntersectsWith(new Rectangle((int)X, (int)Y, partSize.X, partSize.Y)))
+        {
+            _RemoveParticle.Add(this);
+        }
+        else
+        {
+            var timeScale = (Timing.Global.MillisecondsUtc - TransmittionTimer) / 10f;
+            X = originalX + xVelocity * timeScale;
+            Y = originalY + yVelocity * timeScale;
+            animInstance.SetPosition(cameraSpawnX + X, cameraSpawnY + Y, -1, -1, Guid.Empty, Direction.None, 0);
+            animInstance.Update();
+        }
+    }
+
+    public void Dispose()
+    {
+        animInstance.Dispose();
+    }
+
+    ~WeatherParticle()
+    {
+        Dispose();
     }
 
 }

--- a/Intersect.Client/MonoGame/Audio/MonoAudioInstance.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoAudioInstance.cs
@@ -1,18 +1,16 @@
 ﻿using Intersect.Client.Framework.Audio;
 
-namespace Intersect.Client.MonoGame.Audio
+namespace Intersect.Client.MonoGame.Audio;
+
+
+public abstract partial class MonoAudioInstance<TSource> : GameAudioInstance where TSource : GameAudioSource
 {
 
-    public abstract partial class MonoAudioInstance<TSource> : GameAudioInstance where TSource : GameAudioSource
+    /// <inheritdoc />
+    protected MonoAudioInstance(GameAudioSource source) : base(source)
     {
-
-        /// <inheritdoc />
-        protected MonoAudioInstance(GameAudioSource source) : base(source)
-        {
-        }
-
-        public new TSource Source => base.Source as TSource ?? throw new InvalidOperationException();
-
     }
+
+    public new TSource Source => base.Source as TSource ?? throw new InvalidOperationException();
 
 }

--- a/Intersect.Client/MonoGame/Audio/MonoMusicInstance.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoMusicInstance.cs
@@ -2,142 +2,140 @@
 
 using Microsoft.Xna.Framework.Audio;
 
-namespace Intersect.Client.MonoGame.Audio
+namespace Intersect.Client.MonoGame.Audio;
+
+
+public partial class MonoMusicInstance : MonoAudioInstance<MonoMusicSource>
 {
 
-    public partial class MonoMusicInstance : MonoAudioInstance<MonoMusicSource>
+    public static MonoMusicInstance Instance = null;
+
+    private readonly DynamicSoundEffectInstance mSong;
+
+    private readonly MonoMusicSource mSource;
+
+    private bool mDisposed;
+
+    private int mVolume;
+
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public MonoMusicInstance(MonoMusicSource source) : base(source)
     {
-
-        public static MonoMusicInstance Instance = null;
-
-        private readonly DynamicSoundEffectInstance mSong;
-
-        private readonly MonoMusicSource mSource;
-
-        private bool mDisposed;
-
-        private int mVolume;
-
-        // ReSharper disable once SuggestBaseTypeForParameter
-        public MonoMusicInstance(MonoMusicSource source) : base(source)
+        //Only allow one music player at a time
+        if (Instance != null)
         {
-            //Only allow one music player at a time
-            if (Instance != null)
-            {
-                Instance.Stop();
-                Instance.Dispose();
-                Instance = null;
-            }
-
-            Instance = this;
-            mSource = source;
-
-
-            mSong = source.LoadSong();
+            Instance.Stop();
+            Instance.Dispose();
+            Instance = null;
         }
 
-        public override AudioInstanceState State
+        Instance = this;
+        mSource = source;
+
+
+        mSong = source.LoadSong();
+    }
+
+    public override AudioInstanceState State
+    {
+        get
         {
-            get
+            if (mSong == null || mSong.IsDisposed)
             {
-                if (mSong == null || mSong.IsDisposed)
-                {
+                return AudioInstanceState.Disposed;
+            }
+
+            switch (mSong.State)
+            {
+                case SoundState.Playing:
+                    return AudioInstanceState.Playing;
+                case SoundState.Paused:
+                    return AudioInstanceState.Paused;
+                case SoundState.Stopped:
+                    return AudioInstanceState.Stopped;
+                default:
                     return AudioInstanceState.Disposed;
-                }
-
-                switch (mSong.State)
-                {
-                    case SoundState.Playing:
-                        return AudioInstanceState.Playing;
-                    case SoundState.Paused:
-                        return AudioInstanceState.Paused;
-                    case SoundState.Stopped:
-                        return AudioInstanceState.Stopped;
-                    default:
-                        return AudioInstanceState.Disposed;
-                }
             }
         }
+    }
 
-        public override void Play()
+    public override void Play()
+    {
+        if (mSong != null && !mSong.IsDisposed)
         {
-            if (mSong != null && !mSong.IsDisposed)
-            {
-                mSong.Play();
-            }
+            mSong.Play();
         }
+    }
 
-        public override void Pause()
+    public override void Pause()
+    {
+        if (mSong != null && !mSong.IsDisposed)
         {
-            if (mSong != null && !mSong.IsDisposed)
-            {
-                mSong.Pause();
-            }
+            mSong.Pause();
         }
+    }
 
-        public override void Stop()
+    public override void Stop()
+    {
+        if (mSong != null && !mSong.IsDisposed)
         {
-            if (mSong != null && !mSong.IsDisposed)
-            {
-                mSong.Stop();
-            }
+            mSong.Stop();
         }
+    }
 
-        public override void SetVolume(int volume, bool isMusic = false)
+    public override void SetVolume(int volume, bool isMusic = false)
+    {
+        if (mSong != null && !mSong.IsDisposed)
         {
-            if (mSong != null && !mSong.IsDisposed)
-            {
-                mVolume = volume;
-                try
-                {
-                    mSong.Volume = mVolume * (Globals.Database.MusicVolume / 100f) / 100f;
-                }
-                catch (NullReferenceException)
-                {
-                    // song changed while changing volume
-                }
-                catch (Exception)
-                {
-                    // device not ready
-                }
-            }
-        }
-
-        public override int GetVolume()
-        {
-            return mVolume;
-        }
-
-        protected override void InternalLoopSet()
-        {
-            if (mSong != null)
-            {
-                //mSong.IsLooped = IsLooping;
-            }
-        }
-
-        public override void Dispose()
-        {
-            mDisposed = true;
+            mVolume = volume;
             try
             {
-                mSong?.Stop();
-                //Closing the source will lock the processing thread and then properly dispose of the song.
-                mSource.Close();
+                mSong.Volume = mVolume * (Globals.Database.MusicVolume / 100f) / 100f;
             }
-            catch
+            catch (NullReferenceException)
             {
-                /* This is just to catch any B.S. errors that MonoGame shouldn't be throwing to us. */
+                // song changed while changing volume
+            }
+            catch (Exception)
+            {
+                // device not ready
             }
         }
+    }
 
-        ~MonoMusicInstance()
+    public override int GetVolume()
+    {
+        return mVolume;
+    }
+
+    protected override void InternalLoopSet()
+    {
+        if (mSong != null)
         {
-            mDisposed = true;
-
-            //We don't want to call MediaPlayer.Stop() here because it's static and another song has likely started playing.
+            //mSong.IsLooped = IsLooping;
         }
+    }
 
+    public override void Dispose()
+    {
+        mDisposed = true;
+        try
+        {
+            mSong?.Stop();
+            //Closing the source will lock the processing thread and then properly dispose of the song.
+            mSource.Close();
+        }
+        catch
+        {
+            /* This is just to catch any B.S. errors that MonoGame shouldn't be throwing to us. */
+        }
+    }
+
+    ~MonoMusicInstance()
+    {
+        mDisposed = true;
+
+        //We don't want to call MediaPlayer.Stop() here because it's static and another song has likely started playing.
     }
 
 }

--- a/Intersect.Client/MonoGame/Audio/MonoMusicSource.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoMusicSource.cs
@@ -9,219 +9,217 @@ using Microsoft.Xna.Framework.Audio;
 
 using NVorbis;
 
-namespace Intersect.Client.MonoGame.Audio
+namespace Intersect.Client.MonoGame.Audio;
+
+
+public partial class MonoMusicSource : GameAudioSource
 {
+    private readonly string mPath;
+    private readonly string mRealPath;
+    private readonly Func<Stream> mCreateStream;
 
-    public partial class MonoMusicSource : GameAudioSource
+    public VorbisReader Reader { get; set; }
+    public DynamicSoundEffectInstance Instance { get; set; }
+
+
+    private static Thread mUnderlyingThread;
+    private static object mInstanceLock = new object();
+    private static MonoMusicSource mActiveSource;
+
+    public MonoMusicSource(string path, string realPath, string name = default)
     {
-        private readonly string mPath;
-        private readonly string mRealPath;
-        private readonly Func<Stream> mCreateStream;
+        Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
+        mPath = path;
+        mRealPath = realPath;
 
-        public VorbisReader Reader { get; set; }
-        public DynamicSoundEffectInstance Instance { get; set; }
+        InitializeThread();
+    }
 
+    public MonoMusicSource(Func<Stream> createStream, string name = default)
+    {
+        Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
+        mCreateStream = createStream;
 
-        private static Thread mUnderlyingThread;
-        private static object mInstanceLock = new object();
-        private static MonoMusicSource mActiveSource;
+        InitializeThread();
+    }
 
-        public MonoMusicSource(string path, string realPath, string name = default)
+    private void InitializeThread()
+    {
+        //if (mUnderlyingThread == null)
+        //{
+        //    mUnderlyingThread = new Thread(EnsureBuffersFilled)
+        //    {
+        //        Priority = ThreadPriority.Lowest,
+        //        IsBackground = true
+        //    };
+
+        //    mUnderlyingThread.Start();
+        //}
+    }
+
+    public override GameAudioInstance CreateInstance()
+    {
+        return new MonoMusicInstance(this);
+    }
+
+    public DynamicSoundEffectInstance LoadSong()
+    {
+        lock (mInstanceLock)
         {
-            Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
-            mPath = path;
-            mRealPath = realPath;
-
-            InitializeThread();
-        }
-
-        public MonoMusicSource(Func<Stream> createStream, string name = default)
-        {
-            Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
-            mCreateStream = createStream;
-
-            InitializeThread();
-        }
-
-        private void InitializeThread()
-        {
-            //if (mUnderlyingThread == null)
-            //{
-            //    mUnderlyingThread = new Thread(EnsureBuffersFilled)
-            //    {
-            //        Priority = ThreadPriority.Lowest,
-            //        IsBackground = true
-            //    };
-
-            //    mUnderlyingThread.Start();
-            //}
-        }
-
-        public override GameAudioInstance CreateInstance()
-        {
-            return new MonoMusicInstance(this);
-        }
-
-        public DynamicSoundEffectInstance LoadSong()
-        {
-            lock (mInstanceLock)
+            try
             {
-                try
+                if (!string.IsNullOrWhiteSpace(mRealPath))
                 {
-                    if (!string.IsNullOrWhiteSpace(mRealPath))
+
+                    if (Reader == null)
                     {
-
-                        if (Reader == null)
+                        // Do we have this cached?
+                        if (Globals.ContentManager.MusicPacks != null && Globals.ContentManager.MusicPacks.Contains(Path.GetFileName(mRealPath)))
                         {
-                            // Do we have this cached?
-                            if (Globals.ContentManager.MusicPacks != null && Globals.ContentManager.MusicPacks.Contains(Path.GetFileName(mRealPath)))
-                            {
-                                // Read from cache, but close reader when we're done with it!
-                                Reader = new VorbisReader(Globals.ContentManager.MusicPacks.GetAsset(Path.GetFileName(mRealPath)), true);
-                            }
-                            else if (mCreateStream != null)
-                            {
-                                Reader = new VorbisReader(mCreateStream(), true);
-                            }
-                            else
-                            {
-                                Reader = new VorbisReader(mRealPath);
-                            }
+                            // Read from cache, but close reader when we're done with it!
+                            Reader = new VorbisReader(Globals.ContentManager.MusicPacks.GetAsset(Path.GetFileName(mRealPath)), true);
                         }
-
-                        if (Instance != null)
+                        else if (mCreateStream != null)
                         {
-                            Instance.Dispose();
-                            Instance = null;
+                            Reader = new VorbisReader(mCreateStream(), true);
                         }
-
-                        Instance = new DynamicSoundEffectInstance(
-                            Reader.SampleRate, Reader.Channels == 1 ? AudioChannels.Mono : AudioChannels.Stereo
-                        );
-
-                        Instance.BufferNeeded += Instance_BufferNeeded;
-                        mActiveSource = this;
-                        return Instance;
-
+                        else
+                        {
+                            Reader = new VorbisReader(mRealPath);
+                        }
                     }
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(exception, $"Error loading '{mPath}'.");
-                    ChatboxMsg.AddMessage(
-                        new ChatboxMsg(
-                            $"{Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSound)} [{mPath}]", new Color(0xBF, 0x0, 0x0), Enums.ChatMessageType.Error
-                        )
+
+                    if (Instance != null)
+                    {
+                        Instance.Dispose();
+                        Instance = null;
+                    }
+
+                    Instance = new DynamicSoundEffectInstance(
+                        Reader.SampleRate, Reader.Channels == 1 ? AudioChannels.Mono : AudioChannels.Stereo
                     );
+
+                    Instance.BufferNeeded += Instance_BufferNeeded;
+                    mActiveSource = this;
+                    return Instance;
+
                 }
             }
-            mActiveSource = this;
-            return null;
-        }
-
-        public void Close()
-        {
-            lock (mInstanceLock)
+            catch (Exception exception)
             {
-                Reader?.Dispose();
-                Reader = null;
-
-                Instance?.Dispose();
-                Instance = null;
-
-                mActiveSource = null;
+                Log.Error(exception, $"Error loading '{mPath}'.");
+                ChatboxMsg.AddMessage(
+                    new ChatboxMsg(
+                        $"{Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSound)} [{mPath}]", new Color(0xBF, 0x0, 0x0), Enums.ChatMessageType.Error
+                    )
+                );
             }
         }
+        mActiveSource = this;
+        return null;
+    }
 
-        private static void EnsureBuffersFilled()
+    public void Close()
+    {
+        lock (mInstanceLock)
         {
-            var buffers = 3;
-            var samples = 44100;
-            var updateRate = 10;
+            Reader?.Dispose();
+            Reader = null;
 
-            while (Globals.IsRunning)
-            {
-                Thread.Sleep((int)(1000 / Math.Max(updateRate,1)));
-                lock (mInstanceLock)
-                {
-                    if (mActiveSource != null)
-                    {
-                        var reader = mActiveSource.Reader;
-                        var soundInstance = mActiveSource.Instance;
+            Instance?.Dispose();
+            Instance = null;
 
-                        if (reader != null && soundInstance != null && !soundInstance.IsDisposed) {
-                            float[] sampleBuffer = null;
-                            while (soundInstance.PendingBufferCount < buffers)
-                            {
-                                if (sampleBuffer == null)
-                                    sampleBuffer = new float[samples];
-
-                                var read = reader.ReadSamples(sampleBuffer, 0, sampleBuffer.Length);
-                                if (read == 0)
-                                {
-                                    reader.DecodedPosition = 0;
-                                    continue;
-                                }
-
-                                var dataBuffer = new byte[read << 1];
-                                for (var sampleIndex = 0; sampleIndex < read; ++sampleIndex)
-                                {
-                                    var sample = (short)MathHelper.Clamp(sampleBuffer[sampleIndex] * 32767f, short.MinValue, short.MaxValue);
-                                    var sampleData = BitConverter.GetBytes(sample);
-                                    for (var sampleByteIndex = 0; sampleByteIndex < sampleData.Length; ++sampleByteIndex)
-                                        dataBuffer[(sampleIndex << 1) + sampleByteIndex] = sampleData[sampleByteIndex];
-                                }
-
-                                soundInstance.SubmitBuffer(dataBuffer, 0, read << 1);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        private void Instance_BufferNeeded(object sender, EventArgs e)
-        {
-            var buffers = 3;
-            var samples = 44100;
-            var updateRate = 10;
-
-            var reader = Reader;
-            var soundInstance = Instance;
-
-            if (reader != null && soundInstance != null && !soundInstance.IsDisposed)
-            {
-                float[] sampleBuffer = null;
-                while (soundInstance.PendingBufferCount < buffers)
-                {
-                    if (sampleBuffer == null)
-                        sampleBuffer = new float[samples];
-
-                    var read = reader.ReadSamples(sampleBuffer, 0, sampleBuffer.Length);
-                    if (read == 0)
-                    {
-                        reader.DecodedPosition = 0;
-                        continue;
-                    }
-
-                    var dataBuffer = new byte[read << 1];
-                    for (var sampleIndex = 0; sampleIndex < read; ++sampleIndex)
-                    {
-                        var sample = (short)MathHelper.Clamp(sampleBuffer[sampleIndex] * 32767f, short.MinValue, short.MaxValue);
-                        var sampleData = BitConverter.GetBytes(sample);
-                        for (var sampleByteIndex = 0; sampleByteIndex < sampleData.Length; ++sampleByteIndex)
-                            dataBuffer[(sampleIndex << 1) + sampleByteIndex] = sampleData[sampleByteIndex];
-                    }
-
-                    soundInstance.SubmitBuffer(dataBuffer, 0, read << 1);
-                }
-            }
-        }
-
-        ~MonoMusicSource()
-        {
-            Close();
+            mActiveSource = null;
         }
     }
 
+    private static void EnsureBuffersFilled()
+    {
+        var buffers = 3;
+        var samples = 44100;
+        var updateRate = 10;
+
+        while (Globals.IsRunning)
+        {
+            Thread.Sleep((int)(1000 / Math.Max(updateRate,1)));
+            lock (mInstanceLock)
+            {
+                if (mActiveSource != null)
+                {
+                    var reader = mActiveSource.Reader;
+                    var soundInstance = mActiveSource.Instance;
+
+                    if (reader != null && soundInstance != null && !soundInstance.IsDisposed) {
+                        float[] sampleBuffer = null;
+                        while (soundInstance.PendingBufferCount < buffers)
+                        {
+                            if (sampleBuffer == null)
+                                sampleBuffer = new float[samples];
+
+                            var read = reader.ReadSamples(sampleBuffer, 0, sampleBuffer.Length);
+                            if (read == 0)
+                            {
+                                reader.DecodedPosition = 0;
+                                continue;
+                            }
+
+                            var dataBuffer = new byte[read << 1];
+                            for (var sampleIndex = 0; sampleIndex < read; ++sampleIndex)
+                            {
+                                var sample = (short)MathHelper.Clamp(sampleBuffer[sampleIndex] * 32767f, short.MinValue, short.MaxValue);
+                                var sampleData = BitConverter.GetBytes(sample);
+                                for (var sampleByteIndex = 0; sampleByteIndex < sampleData.Length; ++sampleByteIndex)
+                                    dataBuffer[(sampleIndex << 1) + sampleByteIndex] = sampleData[sampleByteIndex];
+                            }
+
+                            soundInstance.SubmitBuffer(dataBuffer, 0, read << 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void Instance_BufferNeeded(object sender, EventArgs e)
+    {
+        var buffers = 3;
+        var samples = 44100;
+        var updateRate = 10;
+
+        var reader = Reader;
+        var soundInstance = Instance;
+
+        if (reader != null && soundInstance != null && !soundInstance.IsDisposed)
+        {
+            float[] sampleBuffer = null;
+            while (soundInstance.PendingBufferCount < buffers)
+            {
+                if (sampleBuffer == null)
+                    sampleBuffer = new float[samples];
+
+                var read = reader.ReadSamples(sampleBuffer, 0, sampleBuffer.Length);
+                if (read == 0)
+                {
+                    reader.DecodedPosition = 0;
+                    continue;
+                }
+
+                var dataBuffer = new byte[read << 1];
+                for (var sampleIndex = 0; sampleIndex < read; ++sampleIndex)
+                {
+                    var sample = (short)MathHelper.Clamp(sampleBuffer[sampleIndex] * 32767f, short.MinValue, short.MaxValue);
+                    var sampleData = BitConverter.GetBytes(sample);
+                    for (var sampleByteIndex = 0; sampleByteIndex < sampleData.Length; ++sampleByteIndex)
+                        dataBuffer[(sampleIndex << 1) + sampleByteIndex] = sampleData[sampleByteIndex];
+                }
+
+                soundInstance.SubmitBuffer(dataBuffer, 0, read << 1);
+            }
+        }
+    }
+
+    ~MonoMusicSource()
+    {
+        Close();
+    }
 }

--- a/Intersect.Client/MonoGame/Audio/MonoSoundInstance.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoSoundInstance.cs
@@ -2,126 +2,124 @@
 
 using Microsoft.Xna.Framework.Audio;
 
-namespace Intersect.Client.MonoGame.Audio
+namespace Intersect.Client.MonoGame.Audio;
+
+
+public partial class MonoSoundInstance : MonoAudioInstance<MonoSoundSource>
 {
 
-    public partial class MonoSoundInstance : MonoAudioInstance<MonoSoundSource>
+    private readonly SoundEffectInstance mInstance;
+
+    private bool mDisposed;
+
+    private int mVolume;
+
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public MonoSoundInstance(MonoSoundSource source) : base(source)
     {
+        mInstance = Source.Effect?.CreateInstance();
+    }
 
-        private readonly SoundEffectInstance mInstance;
-
-        private bool mDisposed;
-
-        private int mVolume;
-
-        // ReSharper disable once SuggestBaseTypeForParameter
-        public MonoSoundInstance(MonoSoundSource source) : base(source)
-        {
-            mInstance = Source.Effect?.CreateInstance();
-        }
-
-        public override AudioInstanceState State
-        {
-            get
-            {
-                if (mDisposed || mInstance == null)
-                {
-                    return AudioInstanceState.Disposed;
-                }
-
-                switch (mInstance.State)
-                {
-                    case SoundState.Playing:
-                        return AudioInstanceState.Playing;
-                    case SoundState.Stopped:
-                        return AudioInstanceState.Stopped;
-                    case SoundState.Paused:
-                        return AudioInstanceState.Paused;
-                    default:
-                        return AudioInstanceState.Disposed;
-                }
-            }
-        }
-
-        public override void Play()
-        {
-            //This can fail due to null reference exceptions or sound limits, or any other number of reasons
-            //I'm adding a catch-all so that maybe it stops crashing games :/
-            try
-            {
-                mInstance?.Play();
-            }
-            catch (Exception ex)
-            {
-                Logging.Log.Debug(ex, "Error trying to play sound in MonoSoundInstance.Play()");
-            }
-        }
-
-        public override void Pause()
-        {
-            mInstance?.Pause();
-        }
-
-        public override void Stop()
-        {
-            mInstance?.Stop();
-        }
-
-        public override void SetVolume(int volume, bool isMusic = false)
-        {
-            mVolume = volume;
-            try
-            {
-                if (mInstance != null)
-                {
-                    mInstance.Volume = mVolume * (float) (Globals.Database.SoundVolume / 100f) / 100f;
-                }
-            }
-            catch (NullReferenceException)
-            {
-                // song changed while changing volume
-            }
-            catch (Exception)
-            {
-                // device not ready
-            }
-        }
-
-        public override int GetVolume()
-        {
-            return mVolume;
-        }
-
-        protected override void InternalLoopSet()
-        {
-            if (mInstance != null)
-            {
-                mInstance.IsLooped = IsLooping;
-            }
-        }
-
-        public override void Dispose()
+    public override AudioInstanceState State
+    {
+        get
         {
             if (mDisposed || mInstance == null)
             {
-                return;
+                return AudioInstanceState.Disposed;
             }
 
-            mDisposed = true;
-            if (mInstance.State != SoundState.Stopped)
+            switch (mInstance.State)
             {
-                mInstance.Stop();
+                case SoundState.Playing:
+                    return AudioInstanceState.Playing;
+                case SoundState.Stopped:
+                    return AudioInstanceState.Stopped;
+                case SoundState.Paused:
+                    return AudioInstanceState.Paused;
+                default:
+                    return AudioInstanceState.Disposed;
             }
-
-            mInstance.Dispose();
-            Source.ReleaseEffect();
         }
+    }
 
-        ~MonoSoundInstance()
+    public override void Play()
+    {
+        //This can fail due to null reference exceptions or sound limits, or any other number of reasons
+        //I'm adding a catch-all so that maybe it stops crashing games :/
+        try
         {
-            Dispose();
+            mInstance?.Play();
+        }
+        catch (Exception ex)
+        {
+            Logging.Log.Debug(ex, "Error trying to play sound in MonoSoundInstance.Play()");
+        }
+    }
+
+    public override void Pause()
+    {
+        mInstance?.Pause();
+    }
+
+    public override void Stop()
+    {
+        mInstance?.Stop();
+    }
+
+    public override void SetVolume(int volume, bool isMusic = false)
+    {
+        mVolume = volume;
+        try
+        {
+            if (mInstance != null)
+            {
+                mInstance.Volume = mVolume * (float) (Globals.Database.SoundVolume / 100f) / 100f;
+            }
+        }
+        catch (NullReferenceException)
+        {
+            // song changed while changing volume
+        }
+        catch (Exception)
+        {
+            // device not ready
+        }
+    }
+
+    public override int GetVolume()
+    {
+        return mVolume;
+    }
+
+    protected override void InternalLoopSet()
+    {
+        if (mInstance != null)
+        {
+            mInstance.IsLooped = IsLooping;
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (mDisposed || mInstance == null)
+        {
+            return;
         }
 
+        mDisposed = true;
+        if (mInstance.State != SoundState.Stopped)
+        {
+            mInstance.Stop();
+        }
+
+        mInstance.Dispose();
+        Source.ReleaseEffect();
+    }
+
+    ~MonoSoundInstance()
+    {
+        Dispose();
     }
 
 }

--- a/Intersect.Client/MonoGame/Audio/MonoSoundSource.cs
+++ b/Intersect.Client/MonoGame/Audio/MonoSoundSource.cs
@@ -6,102 +6,100 @@ using Intersect.Logging;
 
 using Microsoft.Xna.Framework.Audio;
 
-namespace Intersect.Client.MonoGame.Audio
+namespace Intersect.Client.MonoGame.Audio;
+
+
+public partial class MonoSoundSource : GameAudioSource
 {
+    private readonly string mPath;
+    private readonly string mRealPath;
+    private Func<Stream> mCreateStream;
 
-    public partial class MonoSoundSource : GameAudioSource
+    private int mInstanceCount;
+
+    private SoundEffect mSound;
+
+    public MonoSoundSource(string path, string realPath, string name = default)
     {
-        private readonly string mPath;
-        private readonly string mRealPath;
-        private Func<Stream> mCreateStream;
+        
+        mPath = path;
+        mRealPath = realPath;
+        Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
+    }
 
-        private int mInstanceCount;
+    public MonoSoundSource(Func<Stream> createStream, string name = default)
+    {
+        mCreateStream = createStream;
+        Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
+    }
 
-        private SoundEffect mSound;
-
-        public MonoSoundSource(string path, string realPath, string name = default)
+    public SoundEffect Effect
+    {
+        get
         {
-            
-            mPath = path;
-            mRealPath = realPath;
-            Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
-        }
-
-        public MonoSoundSource(Func<Stream> createStream, string name = default)
-        {
-            mCreateStream = createStream;
-            Name = string.IsNullOrWhiteSpace(name) ? string.Empty : name;
-        }
-
-        public SoundEffect Effect
-        {
-            get
+            if (mSound == null)
             {
-                if (mSound == null)
-                {
-                    LoadSound();
-                }
-
-                return mSound;
-            }
-        }
-
-        public override GameAudioInstance CreateInstance()
-        {
-            mInstanceCount++;
-
-            return new MonoSoundInstance(this);
-        }
-
-        public void ReleaseEffect()
-        {
-            if (--mInstanceCount > 0)
-            {
-                return;
+                LoadSound();
             }
 
-            mSound?.Dispose();
-            mSound = null;
+            return mSound;
+        }
+    }
+
+    public override GameAudioInstance CreateInstance()
+    {
+        mInstanceCount++;
+
+        return new MonoSoundInstance(this);
+    }
+
+    public void ReleaseEffect()
+    {
+        if (--mInstanceCount > 0)
+        {
+            return;
         }
 
-        private void LoadSound()
+        mSound?.Dispose();
+        mSound = null;
+    }
+
+    private void LoadSound()
+    {
+        try
         {
-            try
+            if (mCreateStream != null)
             {
-                if (mCreateStream != null)
+                using (var stream = mCreateStream())
                 {
-                    using (var stream = mCreateStream())
-                    {
-                        mSound = SoundEffect.FromStream(stream);
-                    }
-                }
-                else if (Globals.ContentManager.SoundPacks != null && Globals.ContentManager.SoundPacks.Contains(mRealPath))
-                {
-                    using (var stream = Globals.ContentManager.SoundPacks.GetAsset(mRealPath))
-                    {
-                        mSound = SoundEffect.FromStream(stream);
-                    }
-                }
-                else
-                {
-                    using (var fileStream = new FileStream(mRealPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                    {
-                        mSound = SoundEffect.FromStream(fileStream);
-                    }  
-
+                    mSound = SoundEffect.FromStream(stream);
                 }
             }
-            catch (Exception exception)
+            else if (Globals.ContentManager.SoundPacks != null && Globals.ContentManager.SoundPacks.Contains(mRealPath))
             {
-                Log.Error(exception, $"Error loading '{mPath}'.");
-                ChatboxMsg.AddMessage(
-                    new ChatboxMsg(
-                        $"{Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSound)} [{mPath}]",
-                        new Color(0xBF, 0x0, 0x0),  Enums.ChatMessageType.Error
-                    )
-                );
+                using (var stream = Globals.ContentManager.SoundPacks.GetAsset(mRealPath))
+                {
+                    mSound = SoundEffect.FromStream(stream);
+                }
             }
+            else
+            {
+                using (var fileStream = new FileStream(mRealPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    mSound = SoundEffect.FromStream(fileStream);
+                }  
 
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, $"Error loading '{mPath}'.");
+            ChatboxMsg.AddMessage(
+                new ChatboxMsg(
+                    $"{Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSound)} [{mPath}]",
+                    new Color(0xBF, 0x0, 0x0),  Enums.ChatMessageType.Error
+                )
+            );
         }
 
     }

--- a/Intersect.Client/MonoGame/Database/MonoDatabase.cs
+++ b/Intersect.Client/MonoGame/Database/MonoDatabase.cs
@@ -4,53 +4,52 @@ using Intersect.Logging;
 
 using Microsoft.Win32;
 
-namespace Intersect.Client.MonoGame.Database
+namespace Intersect.Client.MonoGame.Database;
+
+public partial class MonoDatabase : GameDatabase
 {
-    public partial class MonoDatabase : GameDatabase
+    private RegistryKey OpenOrCreateKeyPath(RegistryKey root, params string[] keyPath) =>
+        keyPath.Aggregate(root, (current, nextName) => current?.CreateSubKey(nextName, true));
+
+    private RegistryKey GetInstanceKey() => OpenOrCreateKeyPath(
+        Registry.CurrentUser,
+        "Software",
+        "IntersectClient",
+        $"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}"
+    );
+
+    public override void DeletePreference(string key)
     {
-        private RegistryKey OpenOrCreateKeyPath(RegistryKey root, params string[] keyPath) =>
-            keyPath.Aggregate(root, (current, nextName) => current?.CreateSubKey(nextName, true));
-
-        private RegistryKey GetInstanceKey() => OpenOrCreateKeyPath(
-            Registry.CurrentUser,
-            "Software",
-            "IntersectClient",
-            $"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}"
-        );
-
-        public override void DeletePreference(string key)
+        try
         {
-            try
-            {
-                var instanceKey = GetInstanceKey();
-                instanceKey?.DeleteValue(key);
-            }
-            catch (Exception exception)
-            {
+            var instanceKey = GetInstanceKey();
+            instanceKey?.DeleteValue(key);
+        }
+        catch (Exception exception)
+        {
 #if DEBUG
-                Log.Error(exception);
+            Log.Error(exception);
 #endif
-            }
         }
-
-        public override bool HasPreference(string key) => GetInstanceKey()?.GetValue(key) != default;
-
-        public override void SavePreference<TValue>(string key, TValue value)
-        {
-            try
-            {
-                var instanceKey = GetInstanceKey();
-                instanceKey.SetValue(key, Convert.ToString(value));
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Log.Error($"Unable to save preference {key} in the registry.");
-                throw;
-            }
-        }
-
-        public override string LoadPreference(string key) => GetInstanceKey()?.GetValue(key) as string ?? string.Empty;
-
-        public override bool LoadConfig() => ClientConfiguration.LoadAndSave() != default;
     }
+
+    public override bool HasPreference(string key) => GetInstanceKey()?.GetValue(key) != default;
+
+    public override void SavePreference<TValue>(string key, TValue value)
+    {
+        try
+        {
+            var instanceKey = GetInstanceKey();
+            instanceKey.SetValue(key, Convert.ToString(value));
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Log.Error($"Unable to save preference {key} in the registry.");
+            throw;
+        }
+    }
+
+    public override string LoadPreference(string key) => GetInstanceKey()?.GetValue(key) as string ?? string.Empty;
+
+    public override bool LoadConfig() => ClientConfiguration.LoadAndSave() != default;
 }

--- a/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client/MonoGame/File Management/MonoContentManager.cs
@@ -10,373 +10,371 @@ using Intersect.Logging;
 
 using Newtonsoft.Json.Linq;
 
-namespace Intersect.Client.MonoGame.File_Management
+namespace Intersect.Client.MonoGame.File_Management;
+
+
+public partial class MonoContentManager : GameContentManager
 {
 
-    public partial class MonoContentManager : GameContentManager
+    public MonoContentManager()
     {
+        Init(this);
 
-        public MonoContentManager()
+        var rootPath = Path.GetFullPath(ClientConfiguration.ResourcesDirectory);
+
+        if (!Directory.Exists(rootPath))
         {
-            Init(this);
+            Log.Error(Strings.Errors.ResourcesNotFound);
 
-            var rootPath = Path.GetFullPath(ClientConfiguration.ResourcesDirectory);
-
-            if (!Directory.Exists(rootPath))
-            {
-                Log.Error(Strings.Errors.ResourcesNotFound);
-
-                Environment.Exit(1);
-            }
-
-            ContentWatcher = new ContentWatcher(rootPath);
+            Environment.Exit(1);
         }
 
-        //Graphic Loading
-        public override void LoadTilesets(string[] tilesetnames)
+        ContentWatcher = new ContentWatcher(rootPath);
+    }
+
+    //Graphic Loading
+    public override void LoadTilesets(string[] tilesetnames)
+    {
+        mTilesetDict.Clear();
+
+        IEnumerable<string> tilesetFiles = Array.Empty<string>();
+
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets");
+        if (!Directory.Exists(dir))
         {
-            mTilesetDict.Clear();
-
-            IEnumerable<string> tilesetFiles = Array.Empty<string>();
-
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets");
-            if (!Directory.Exists(dir))
-            {
-                if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-            }
-            else
-            {
-                tilesetFiles = Directory.GetFiles(dir).Select(f => Path.GetFileName(f));
-            }
-
-            foreach (var t in tilesetnames)
-            {
-                var realFilename = tilesetFiles.FirstOrDefault(file => t.Equals(file, StringComparison.InvariantCultureIgnoreCase)) ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(t) &&
-                    (!string.IsNullOrWhiteSpace(realFilename) ||
-                     GameTexturePacks.GetFrame(Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t.ToLower())) != null) &&
-                    !mTilesetDict.ContainsKey(t.ToLower()))
-                {
-                    mTilesetDict.Add(
-                        t.ToLower(), Core.Graphics.Renderer.LoadTexture(Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t), Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", realFilename))
-                    );
-                }
-            }
-
-            TilesetsLoaded = true;
-        }
-
-        public override void LoadTexturePacks()
-        {
-            mTexturePackDict.Clear();
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "packs");
-            if (!Directory.Exists(dir))
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
             {
                 Directory.CreateDirectory(dir);
             }
+        }
+        else
+        {
+            tilesetFiles = Directory.GetFiles(dir).Select(f => Path.GetFileName(f));
+        }
 
-            var items = Directory.GetFiles(dir, "*.meta");
-            for (var i = 0; i < items.Length; i++)
+        foreach (var t in tilesetnames)
+        {
+            var realFilename = tilesetFiles.FirstOrDefault(file => t.Equals(file, StringComparison.InvariantCultureIgnoreCase)) ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(t) &&
+                (!string.IsNullOrWhiteSpace(realFilename) ||
+                 GameTexturePacks.GetFrame(Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t.ToLower())) != null) &&
+                !mTilesetDict.ContainsKey(t.ToLower()))
             {
-                var json = GzipCompression.ReadDecompressedString(items[i]);
-                var obj = JObject.Parse(json);
-                var frames = (JArray) obj["frames"];
-                var img = obj["meta"]["image"].ToString();
-                if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img)))
+                mTilesetDict.Add(
+                    t.ToLower(), Core.Graphics.Renderer.LoadTexture(Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", t), Path.Combine(ClientConfiguration.ResourcesDirectory, "tilesets", realFilename))
+                );
+            }
+        }
+
+        TilesetsLoaded = true;
+    }
+
+    public override void LoadTexturePacks()
+    {
+        mTexturePackDict.Clear();
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "packs");
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var items = Directory.GetFiles(dir, "*.meta");
+        for (var i = 0; i < items.Length; i++)
+        {
+            var json = GzipCompression.ReadDecompressedString(items[i]);
+            var obj = JObject.Parse(json);
+            var frames = (JArray) obj["frames"];
+            var img = obj["meta"]["image"].ToString();
+            if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img)))
+            {
+                var platformText = Core.Graphics.Renderer.LoadTexture(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img));
+                if (platformText != null)
                 {
-                    var platformText = Core.Graphics.Renderer.LoadTexture(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", img));
-                    if (platformText != null)
+                    foreach (var frame in frames)
                     {
-                        foreach (var frame in frames)
-                        {
-                            var filename = frame["filename"].ToString();
-                            var sourceRect = new Rectangle(
-                                int.Parse(frame["frame"]["x"].ToString()), int.Parse(frame["frame"]["y"].ToString()),
-                                int.Parse(frame["frame"]["w"].ToString()), int.Parse(frame["frame"]["h"].ToString())
-                            );
+                        var filename = frame["filename"].ToString();
+                        var sourceRect = new Rectangle(
+                            int.Parse(frame["frame"]["x"].ToString()), int.Parse(frame["frame"]["y"].ToString()),
+                            int.Parse(frame["frame"]["w"].ToString()), int.Parse(frame["frame"]["h"].ToString())
+                        );
 
-                            var rotated = bool.Parse(frame["rotated"].ToString());
-                            var sourceSize = new Rectangle(
-                                int.Parse(frame["spriteSourceSize"]["x"].ToString()),
-                                int.Parse(frame["spriteSourceSize"]["y"].ToString()),
-                                int.Parse(frame["spriteSourceSize"]["w"].ToString()),
-                                int.Parse(frame["spriteSourceSize"]["h"].ToString())
-                            );
+                        var rotated = bool.Parse(frame["rotated"].ToString());
+                        var sourceSize = new Rectangle(
+                            int.Parse(frame["spriteSourceSize"]["x"].ToString()),
+                            int.Parse(frame["spriteSourceSize"]["y"].ToString()),
+                            int.Parse(frame["spriteSourceSize"]["w"].ToString()),
+                            int.Parse(frame["spriteSourceSize"]["h"].ToString())
+                        );
 
-                            GameTexturePacks.AddFrame(
-                                new GameTexturePackFrame(filename, sourceRect, rotated, sourceSize, platformText)
-                            );
-                        }
+                        GameTexturePacks.AddFrame(
+                            new GameTexturePackFrame(filename, sourceRect, rotated, sourceSize, platformText)
+                        );
                     }
                 }
             }
         }
+    }
 
-        public void LoadTextureGroup(string directory, Dictionary<string, IAsset> dict)
+    public void LoadTextureGroup(string directory, Dictionary<string, IAsset> dict)
+    {
+        dict.Clear();
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, directory);
+        if (!Directory.Exists(dir))
         {
-            dict.Clear();
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, directory);
-            if (!Directory.Exists(dir))
-            {
-                if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-            }
-            else
-            {
-                var items = Directory.GetFiles(dir, "*.png");
-                for (var i = 0; i < items.Length; i++)
-                {
-                    var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
-                    dict.Add(filename, Core.Graphics.Renderer.LoadTexture(Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))));
-                }
-            }
-
-            var packItems = GameTexturePacks.GetFolderFrames(directory);
-            if (packItems != null)
-            {
-                foreach (var itm in packItems)
-                {
-                    var filename = Path.GetFileName(itm.Filename.ToLower().Replace("\\", "/"));
-                    if (!dict.ContainsKey(filename))
-                    {
-                        dict.Add(filename, Core.Graphics.Renderer.LoadTexture(Path.Combine(dir, filename), Path.Combine(dir, Path.Combine(dir, filename))));
-                    }
-                }
-            }
-        }
-
-        public override void LoadItems()
-        {
-            LoadTextureGroup("items", mItemDict);
-        }
-
-        public override void LoadEntities()
-        {
-            LoadTextureGroup("entities", mEntityDict);
-        }
-
-        public override void LoadSpells()
-        {
-            LoadTextureGroup("spells", mSpellDict);
-        }
-
-        public override void LoadAnimations()
-        {
-            LoadTextureGroup("animations", mAnimationDict);
-        }
-
-        public override void LoadFaces()
-        {
-            LoadTextureGroup("faces", mFaceDict);
-        }
-
-        public override void LoadImages()
-        {
-            LoadTextureGroup("images", mImageDict);
-        }
-
-        public override void LoadFogs()
-        {
-            LoadTextureGroup("fogs", mFogDict);
-        }
-
-        public override void LoadResources()
-        {
-            LoadTextureGroup(ClientConfiguration.ResourcesDirectory, mResourceDict);
-        }
-
-        public override void LoadPaperdolls()
-        {
-            LoadTextureGroup("paperdolls", mPaperdollDict);
-        }
-
-        public override void LoadGui()
-        {
-            LoadTextureGroup("gui", mGuiDict);
-        }
-
-        public override void LoadMisc()
-        {
-            LoadTextureGroup("misc", mMiscDict);
-        }
-
-        public override void LoadFonts()
-        {
-            mFontDict.Clear();
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "fonts");
-            if (!Directory.Exists(dir))
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
             {
                 Directory.CreateDirectory(dir);
             }
-
-            var items = Directory.GetFiles(dir, "*.xnb");
+        }
+        else
+        {
+            var items = Directory.GetFiles(dir, "*.png");
             for (var i = 0; i < items.Length; i++)
             {
                 var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
-                var font = Core.Graphics.Renderer.LoadFont(Path.Combine(dir, filename));
-                if (mFontDict.IndexOf(font) == -1)
-                {
-                    mFontDict.Add(font);
-                }
+                dict.Add(filename, Core.Graphics.Renderer.LoadTexture(Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))));
             }
         }
 
-        public override void LoadShaders()
+        var packItems = GameTexturePacks.GetFolderFrames(directory);
+        if (packItems != null)
         {
-            mShaderDict.Clear();
-
-            const string shaderPrefix = "Intersect.Client.Resources.Shaders.";
-            var availableShaders = typeof(MonoContentManager).Assembly
-                .GetManifestResourceNames()
-                .Where(resourceName =>
-                    resourceName.StartsWith(shaderPrefix)
-                    && resourceName.EndsWith(".xnb")
-                ).ToArray();
-
-            for (var i = 0; i < availableShaders.Length; i++)
+            foreach (var itm in packItems)
             {
-                var resourceFullName = availableShaders[i];
-                var shaderNameWithoutExtension = resourceFullName.Substring(0, resourceFullName.Length - 4);
-                var shaderName = shaderNameWithoutExtension.Substring(shaderPrefix.Length);
-                mShaderDict.Add(shaderName, Core.Graphics.Renderer.LoadShader(resourceFullName));
+                var filename = Path.GetFileName(itm.Filename.ToLower().Replace("\\", "/"));
+                if (!dict.ContainsKey(filename))
+                {
+                    dict.Add(filename, Core.Graphics.Renderer.LoadTexture(Path.Combine(dir, filename), Path.Combine(dir, Path.Combine(dir, filename))));
+                }
+            }
+        }
+    }
+
+    public override void LoadItems()
+    {
+        LoadTextureGroup("items", mItemDict);
+    }
+
+    public override void LoadEntities()
+    {
+        LoadTextureGroup("entities", mEntityDict);
+    }
+
+    public override void LoadSpells()
+    {
+        LoadTextureGroup("spells", mSpellDict);
+    }
+
+    public override void LoadAnimations()
+    {
+        LoadTextureGroup("animations", mAnimationDict);
+    }
+
+    public override void LoadFaces()
+    {
+        LoadTextureGroup("faces", mFaceDict);
+    }
+
+    public override void LoadImages()
+    {
+        LoadTextureGroup("images", mImageDict);
+    }
+
+    public override void LoadFogs()
+    {
+        LoadTextureGroup("fogs", mFogDict);
+    }
+
+    public override void LoadResources()
+    {
+        LoadTextureGroup(ClientConfiguration.ResourcesDirectory, mResourceDict);
+    }
+
+    public override void LoadPaperdolls()
+    {
+        LoadTextureGroup("paperdolls", mPaperdollDict);
+    }
+
+    public override void LoadGui()
+    {
+        LoadTextureGroup("gui", mGuiDict);
+    }
+
+    public override void LoadMisc()
+    {
+        LoadTextureGroup("misc", mMiscDict);
+    }
+
+    public override void LoadFonts()
+    {
+        mFontDict.Clear();
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "fonts");
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var items = Directory.GetFiles(dir, "*.xnb");
+        for (var i = 0; i < items.Length; i++)
+        {
+            var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
+            var font = Core.Graphics.Renderer.LoadFont(Path.Combine(dir, filename));
+            if (mFontDict.IndexOf(font) == -1)
+            {
+                mFontDict.Add(font);
+            }
+        }
+    }
+
+    public override void LoadShaders()
+    {
+        mShaderDict.Clear();
+
+        const string shaderPrefix = "Intersect.Client.Resources.Shaders.";
+        var availableShaders = typeof(MonoContentManager).Assembly
+            .GetManifestResourceNames()
+            .Where(resourceName =>
+                resourceName.StartsWith(shaderPrefix)
+                && resourceName.EndsWith(".xnb")
+            ).ToArray();
+
+        for (var i = 0; i < availableShaders.Length; i++)
+        {
+            var resourceFullName = availableShaders[i];
+            var shaderNameWithoutExtension = resourceFullName.Substring(0, resourceFullName.Length - 4);
+            var shaderName = shaderNameWithoutExtension.Substring(shaderPrefix.Length);
+            mShaderDict.Add(shaderName, Core.Graphics.Renderer.LoadShader(resourceFullName));
+        }
+    }
+
+    public override void LoadSounds()
+    {
+        mSoundDict.Clear();
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "sounds");
+        if (!Directory.Exists(dir))
+        {
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+        else
+        {
+            var items = Directory.GetFiles(dir, "*.wav");
+            for (var i = 0; i < items.Length; i++)
+            {
+                var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
+                mSoundDict.Add(
+                    RemoveExtension(filename),
+                    new MonoSoundSource(
+                        Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))
+                    )
+                );
             }
         }
 
-        public override void LoadSounds()
+        // If we have a sound index file, load from it!
+        if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "sound.index")))
         {
-            mSoundDict.Clear();
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "sounds");
-            if (!Directory.Exists(dir))
+            SoundPacks = new AssetPacker(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "sound.index"), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs"));
+            foreach(var item in SoundPacks.FileList)
             {
-                if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
+                if (!mSoundDict.ContainsKey(RemoveExtension(item).ToLower()))
                 {
-                    Directory.CreateDirectory(dir);
-                }
-            }
-            else
-            {
-                var items = Directory.GetFiles(dir, "*.wav");
-                for (var i = 0; i < items.Length; i++)
-                {
-                    var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
                     mSoundDict.Add(
-                        RemoveExtension(filename),
-                        new MonoSoundSource(
-                            Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))
-                        )
+                        RemoveExtension(item).ToLower(),
+                        new MonoSoundSource(item, item)
                     );
                 }
             }
-
-            // If we have a sound index file, load from it!
-            if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "sound.index")))
-            {
-                SoundPacks = new AssetPacker(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "sound.index"), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs"));
-                foreach(var item in SoundPacks.FileList)
-                {
-                    if (!mSoundDict.ContainsKey(RemoveExtension(item).ToLower()))
-                    {
-                        mSoundDict.Add(
-                            RemoveExtension(item).ToLower(),
-                            new MonoSoundSource(item, item)
-                        );
-                    }
-                }
-            }
-            
         }
+        
+    }
 
-        public override void LoadMusic()
+    public override void LoadMusic()
+    {
+        mMusicDict.Clear();
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "music");
+        if (!Directory.Exists(dir))
         {
-            mMusicDict.Clear();
-            var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, "music");
-            if (!Directory.Exists(dir))
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
             {
-                if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-            }
-            else
-            {
-                var items = Directory.GetFiles(dir, "*.ogg");
-                for (var i = 0; i < items.Length; i++)
-                {
-                    var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
-                    mMusicDict.Add(RemoveExtension(filename), new MonoMusicSource(Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))));
-                }
-            }
-
-            // If we have a music index file, load from it!
-            if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "music.index")))
-            {
-                MusicPacks = new AssetPacker(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "music.index"), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs"));
-                foreach (var item in MusicPacks.FileList)
-                {
-                    if (!mMusicDict.ContainsKey(RemoveExtension(item).ToLower()))
-                    {
-                        mMusicDict.Add(
-                            RemoveExtension(item).ToLower(),
-                            new MonoMusicSource(item, item)
-                        );
-                    }
-                }
+                Directory.CreateDirectory(dir);
             }
         }
-
-        /// <inheritdoc />
-        protected override TAsset Load<TAsset>(
-            Dictionary<string, IAsset> lookup,
-            ContentTypes contentType,
-            string name,
-            Func<Stream> createStream
-        )
+        else
         {
-            switch (contentType)
+            var items = Directory.GetFiles(dir, "*.ogg");
+            for (var i = 0; i < items.Length; i++)
             {
-                case ContentTypes.Animation:
-                case ContentTypes.Entity:
-                case ContentTypes.Face:
-                case ContentTypes.Fog:
-                case ContentTypes.Image:
-                case ContentTypes.Interface:
-                case ContentTypes.Item:
-                case ContentTypes.Miscellaneous:
-                case ContentTypes.Paperdoll:
-                case ContentTypes.Resource:
-                case ContentTypes.Spell:
-                case ContentTypes.TexturePack:
-                case ContentTypes.TileSet:
-                    var asset = Core.Graphics.Renderer.LoadTexture(name, createStream) as TAsset;
-                    lookup?.Add(name, asset);
-                    return asset;
-
-                case ContentTypes.Font:
-                    throw new NotImplementedException();
-
-                case ContentTypes.Shader:
-                    throw new NotImplementedException();
-
-                case ContentTypes.Music:
-                    var music = new MonoMusicSource(createStream) as TAsset;
-                    lookup?.Add(RemoveExtension(name), music);
-                    return music;
-
-                case ContentTypes.Sound:
-                    var sound = new MonoSoundSource(createStream, name) as TAsset;
-                    lookup?.Add(RemoveExtension(name), sound);
-                    return sound;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentType), contentType, null);
+                var filename = items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar).ToLower();
+                mMusicDict.Add(RemoveExtension(filename), new MonoMusicSource(Path.Combine(dir, filename), Path.Combine(dir, items[i].Replace(dir, "").TrimStart(Path.DirectorySeparatorChar))));
             }
         }
 
+        // If we have a music index file, load from it!
+        if (File.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "music.index")))
+        {
+            MusicPacks = new AssetPacker(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs", "music.index"), Path.Combine(ClientConfiguration.ResourcesDirectory, "packs"));
+            foreach (var item in MusicPacks.FileList)
+            {
+                if (!mMusicDict.ContainsKey(RemoveExtension(item).ToLower()))
+                {
+                    mMusicDict.Add(
+                        RemoveExtension(item).ToLower(),
+                        new MonoMusicSource(item, item)
+                    );
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override TAsset Load<TAsset>(
+        Dictionary<string, IAsset> lookup,
+        ContentTypes contentType,
+        string name,
+        Func<Stream> createStream
+    )
+    {
+        switch (contentType)
+        {
+            case ContentTypes.Animation:
+            case ContentTypes.Entity:
+            case ContentTypes.Face:
+            case ContentTypes.Fog:
+            case ContentTypes.Image:
+            case ContentTypes.Interface:
+            case ContentTypes.Item:
+            case ContentTypes.Miscellaneous:
+            case ContentTypes.Paperdoll:
+            case ContentTypes.Resource:
+            case ContentTypes.Spell:
+            case ContentTypes.TexturePack:
+            case ContentTypes.TileSet:
+                var asset = Core.Graphics.Renderer.LoadTexture(name, createStream) as TAsset;
+                lookup?.Add(name, asset);
+                return asset;
+
+            case ContentTypes.Font:
+                throw new NotImplementedException();
+
+            case ContentTypes.Shader:
+                throw new NotImplementedException();
+
+            case ContentTypes.Music:
+                var music = new MonoMusicSource(createStream) as TAsset;
+                lookup?.Add(RemoveExtension(name), music);
+                return music;
+
+            case ContentTypes.Sound:
+                var sound = new MonoSoundSource(createStream, name) as TAsset;
+                lookup?.Add(RemoveExtension(name), sound);
+                return sound;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentType), contentType, null);
+        }
     }
 
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoFont.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoFont.cs
@@ -5,35 +5,33 @@ using Intersect.Logging;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client.MonoGame.Graphics
+namespace Intersect.Client.MonoGame.Graphics;
+
+
+public partial class MonoFont : GameFont
 {
 
-    public partial class MonoFont : GameFont
+    private SpriteFont mFont;
+
+    public MonoFont(string fontName, string fileName, int fontSize, ContentManager contentManager) : base(
+        fontName, fontSize
+    )
     {
-
-        private SpriteFont mFont;
-
-        public MonoFont(string fontName, string fileName, int fontSize, ContentManager contentManager) : base(
-            fontName, fontSize
-        )
+        try
         {
-            try
-            {
-                var extensionlessFileName = GameContentManager.RemoveExtension(fileName);
-                var resolvedFileName = Path.Combine(Environment.CurrentDirectory, extensionlessFileName);
-                mFont = contentManager.Load<SpriteFont>(resolvedFileName);
-            }
-            catch (Exception ex)
-            {
-                Log.Trace(ex);
-            }
+            var extensionlessFileName = GameContentManager.RemoveExtension(fileName);
+            var resolvedFileName = Path.Combine(Environment.CurrentDirectory, extensionlessFileName);
+            mFont = contentManager.Load<SpriteFont>(resolvedFileName);
         }
-
-        public override object GetFont()
+        catch (Exception ex)
         {
-            return mFont;
+            Log.Trace(ex);
         }
+    }
 
+    public override object GetFont()
+    {
+        return mFont;
     }
 
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderTexture.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderTexture.cs
@@ -3,101 +3,99 @@ using Intersect.Client.Framework.Graphics;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client.MonoGame.Graphics
+namespace Intersect.Client.MonoGame.Graphics;
+
+
+public partial class MonoRenderTexture : GameRenderTexture
 {
 
-    public partial class MonoRenderTexture : GameRenderTexture
+    private GraphicsDevice mGraphicsDevice;
+
+    private int mHeight;
+
+    private RenderTarget2D mRenderTexture;
+
+    private int mWidth;
+
+    public MonoRenderTexture(GraphicsDevice graphicsDevice, int width, int height) : base(width, height)
     {
+        mRenderTexture = new RenderTarget2D(
+            graphicsDevice,
+            width,
+            height,
+            mipMap: false,
+            preferredFormat: graphicsDevice.PresentationParameters.BackBufferFormat,
+            preferredDepthFormat: graphicsDevice.PresentationParameters.DepthStencilFormat,
+            /* For whatever reason if this isn't zero everything breaks in .NET 7 on MacOS and most Windows devices */
+            preferredMultiSampleCount: 0, // graphicsDevice.PresentationParameters.MultiSampleCount,
+            usage: RenderTargetUsage.PreserveContents
+        );
 
-        private GraphicsDevice mGraphicsDevice;
+        RenderTextureCount++;
+        mGraphicsDevice = graphicsDevice;
+        mWidth = width;
+        mHeight = height;
+    }
 
-        private int mHeight;
+    public override string GetName()
+    {
+        return "";
+    }
 
-        private RenderTarget2D mRenderTexture;
+    public override int GetWidth()
+    {
+        return mWidth;
+    }
 
-        private int mWidth;
+    public override int GetHeight()
+    {
+        return mHeight;
+    }
 
-        public MonoRenderTexture(GraphicsDevice graphicsDevice, int width, int height) : base(width, height)
+    public override object GetTexture()
+    {
+        return mRenderTexture;
+    }
+
+    public override Color GetPixel(int x1, int y1)
+    {
+        var pixel = new Microsoft.Xna.Framework.Color[1];
+        mRenderTexture.GetData(0, new Rectangle(x1, y1, 1, 1), pixel, 0, 1);
+
+        return new Color(pixel[0].A, pixel[0].R, pixel[0].G, pixel[0].B);
+    }
+
+    public override GameTexturePackFrame GetTexturePackFrame()
+    {
+        return null;
+    }
+
+    public override bool Begin()
+    {
+        return true;
+    }
+
+    public override void End()
+    {
+        ((MonoRenderer) Core.Graphics.Renderer).EndSpriteBatch();
+    }
+
+    public override void Clear(Color color)
+    {
+        ((MonoRenderer) Core.Graphics.Renderer).EndSpriteBatch();
+        mGraphicsDevice.SetRenderTarget(mRenderTexture);
+        mGraphicsDevice.Clear(MonoRenderer.ConvertColor(color));
+        mGraphicsDevice.SetRenderTarget(null);
+    }
+
+    public override void Dispose()
+    {
+        if (mRenderTexture != null)
         {
-            mRenderTexture = new RenderTarget2D(
-                graphicsDevice,
-                width,
-                height,
-                mipMap: false,
-                preferredFormat: graphicsDevice.PresentationParameters.BackBufferFormat,
-                preferredDepthFormat: graphicsDevice.PresentationParameters.DepthStencilFormat,
-                /* For whatever reason if this isn't zero everything breaks in .NET 7 on MacOS and most Windows devices */
-                preferredMultiSampleCount: 0, // graphicsDevice.PresentationParameters.MultiSampleCount,
-                usage: RenderTargetUsage.PreserveContents
-            );
-
-            RenderTextureCount++;
-            mGraphicsDevice = graphicsDevice;
-            mWidth = width;
-            mHeight = height;
+            mRenderTexture.Dispose();
+            mRenderTexture = null;
+            RenderTextureCount--;
         }
-
-        public override string GetName()
-        {
-            return "";
-        }
-
-        public override int GetWidth()
-        {
-            return mWidth;
-        }
-
-        public override int GetHeight()
-        {
-            return mHeight;
-        }
-
-        public override object GetTexture()
-        {
-            return mRenderTexture;
-        }
-
-        public override Color GetPixel(int x1, int y1)
-        {
-            var pixel = new Microsoft.Xna.Framework.Color[1];
-            mRenderTexture.GetData(0, new Rectangle(x1, y1, 1, 1), pixel, 0, 1);
-
-            return new Color(pixel[0].A, pixel[0].R, pixel[0].G, pixel[0].B);
-        }
-
-        public override GameTexturePackFrame GetTexturePackFrame()
-        {
-            return null;
-        }
-
-        public override bool Begin()
-        {
-            return true;
-        }
-
-        public override void End()
-        {
-            ((MonoRenderer) Core.Graphics.Renderer).EndSpriteBatch();
-        }
-
-        public override void Clear(Color color)
-        {
-            ((MonoRenderer) Core.Graphics.Renderer).EndSpriteBatch();
-            mGraphicsDevice.SetRenderTarget(mRenderTexture);
-            mGraphicsDevice.Clear(MonoRenderer.ConvertColor(color));
-            mGraphicsDevice.SetRenderTarget(null);
-        }
-
-        public override void Dispose()
-        {
-            if (mRenderTexture != null)
-            {
-                mRenderTexture.Dispose();
-                mRenderTexture = null;
-                RenderTextureCount--;
-            }
-        }
-
     }
 
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoRenderer.cs
@@ -17,1013 +17,1011 @@ using Microsoft.Xna.Framework.Graphics;
 using MathHelper = Intersect.Utilities.MathHelper;
 using XNARectangle = Microsoft.Xna.Framework.Rectangle;
 using XNAColor = Microsoft.Xna.Framework.Color;
-namespace Intersect.Client.MonoGame.Graphics
+namespace Intersect.Client.MonoGame.Graphics;
+
+
+public class MonoRenderer : GameRenderer
 {
 
-    public class MonoRenderer : GameRenderer
+    private readonly List<MonoTexture> mAllTextures = new List<MonoTexture>();
+
+    private BasicEffect mBasicEffect;
+
+    private ContentManager mContentManager;
+
+    private GameBlendModes mCurrentBlendmode = GameBlendModes.None;
+
+    private GameShader mCurrentShader;
+
+    private FloatRect mCurrentSpriteView;
+
+    private GameRenderTexture mCurrentTarget;
+
+    private FloatRect mCurrentView;
+
+    private BlendState mCutoutState;
+
+    private int mDisplayHeight;
+
+    private bool mDisplayModeChanged;
+
+    private int mDisplayWidth;
+
+    private int mFps;
+
+    private int mFpsCount;
+
+    private long mFpsTimer;
+
+    private long mFsChangedTimer = -1;
+
+    private Game mGame;
+
+    private GameWindow mGameWindow;
+
+    private GraphicsDeviceManager mGraphics;
+
+    private GraphicsDevice mGraphicsDevice;
+
+    private bool mInitialized;
+
+    private bool mInitializing;
+
+    private BlendState mMultiplyState;
+
+    private BlendState mNormalState;
+
+    private DisplayMode mOldDisplayMode;
+
+    RasterizerState mRasterizerState = new RasterizerState { ScissorTestEnable = true };
+
+    private int mScreenHeight;
+
+    private RenderTarget2D mScreenshotRenderTarget;
+
+    private int mScreenWidth;
+
+    private SpriteBatch mSpriteBatch;
+
+    private bool mSpriteBatchBegan;
+
+    private List<string>? _validVideoModes;
+
+    private GameTexture? mWhiteTexture;
+
+    public MonoRenderer(GraphicsDeviceManager graphics, ContentManager contentManager, Game monoGame)
     {
+        mGame = monoGame;
+        mGraphics = graphics;
+        mContentManager = contentManager;
 
-        private readonly List<MonoTexture> mAllTextures = new List<MonoTexture>();
-
-        private BasicEffect mBasicEffect;
-
-        private ContentManager mContentManager;
-
-        private GameBlendModes mCurrentBlendmode = GameBlendModes.None;
-
-        private GameShader mCurrentShader;
-
-        private FloatRect mCurrentSpriteView;
-
-        private GameRenderTexture mCurrentTarget;
-
-        private FloatRect mCurrentView;
-
-        private BlendState mCutoutState;
-
-        private int mDisplayHeight;
-
-        private bool mDisplayModeChanged;
-
-        private int mDisplayWidth;
-
-        private int mFps;
-
-        private int mFpsCount;
-
-        private long mFpsTimer;
-
-        private long mFsChangedTimer = -1;
-
-        private Game mGame;
-
-        private GameWindow mGameWindow;
-
-        private GraphicsDeviceManager mGraphics;
-
-        private GraphicsDevice mGraphicsDevice;
-
-        private bool mInitialized;
-
-        private bool mInitializing;
-
-        private BlendState mMultiplyState;
-
-        private BlendState mNormalState;
-
-        private DisplayMode mOldDisplayMode;
-
-        RasterizerState mRasterizerState = new RasterizerState { ScissorTestEnable = true };
-
-        private int mScreenHeight;
-
-        private RenderTarget2D mScreenshotRenderTarget;
-
-        private int mScreenWidth;
-
-        private SpriteBatch mSpriteBatch;
-
-        private bool mSpriteBatchBegan;
-
-        private List<string>? _validVideoModes;
-
-        private GameTexture? mWhiteTexture;
-
-        public MonoRenderer(GraphicsDeviceManager graphics, ContentManager contentManager, Game monoGame)
+        mNormalState = new BlendState
         {
-            mGame = monoGame;
-            mGraphics = graphics;
-            mContentManager = contentManager;
+            ColorSourceBlend = Blend.SourceAlpha,
+            AlphaSourceBlend = Blend.One,
+            ColorDestinationBlend = Blend.InverseSourceAlpha,
+            AlphaDestinationBlend = Blend.One,
+            ColorBlendFunction = BlendFunction.Add,
+            AlphaBlendFunction = BlendFunction.Add,
+        };
 
-            mNormalState = new BlendState
-            {
-                ColorSourceBlend = Blend.SourceAlpha,
-                AlphaSourceBlend = Blend.One,
-                ColorDestinationBlend = Blend.InverseSourceAlpha,
-                AlphaDestinationBlend = Blend.One,
-                ColorBlendFunction = BlendFunction.Add,
-                AlphaBlendFunction = BlendFunction.Add,
-            };
-
-            mMultiplyState = new BlendState
-            {
-                ColorBlendFunction = BlendFunction.Add,
-                ColorSourceBlend = Blend.DestinationColor,
-                ColorDestinationBlend = Blend.Zero
-            };
-
-            mCutoutState = new BlendState
-            {
-                ColorBlendFunction = BlendFunction.Add,
-                ColorSourceBlend = Blend.Zero,
-                ColorDestinationBlend = Blend.InverseSourceAlpha,
-                AlphaBlendFunction = BlendFunction.Add,
-                AlphaSourceBlend = Blend.Zero,
-                AlphaDestinationBlend = Blend.InverseSourceAlpha
-            };
-
-            mGameWindow = monoGame.Window;
-        }
-
-        public IList<string> ValidVideoModes => GetValidVideoModes();
-
-        public void UpdateGraphicsState(int width, int height, bool initial = false)
+        mMultiplyState = new BlendState
         {
-            var currentDisplayMode = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode;
+            ColorBlendFunction = BlendFunction.Add,
+            ColorSourceBlend = Blend.DestinationColor,
+            ColorDestinationBlend = Blend.Zero
+        };
 
-            if (Globals.Database.FullScreen)
+        mCutoutState = new BlendState
+        {
+            ColorBlendFunction = BlendFunction.Add,
+            ColorSourceBlend = Blend.Zero,
+            ColorDestinationBlend = Blend.InverseSourceAlpha,
+            AlphaBlendFunction = BlendFunction.Add,
+            AlphaSourceBlend = Blend.Zero,
+            AlphaDestinationBlend = Blend.InverseSourceAlpha
+        };
+
+        mGameWindow = monoGame.Window;
+    }
+
+    public IList<string> ValidVideoModes => GetValidVideoModes();
+
+    public void UpdateGraphicsState(int width, int height, bool initial = false)
+    {
+        var currentDisplayMode = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode;
+
+        if (Globals.Database.FullScreen)
+        {
+            var supported = false;
+            foreach (var mode in mGraphics.GraphicsDevice.Adapter.SupportedDisplayModes)
             {
-                var supported = false;
-                foreach (var mode in mGraphics.GraphicsDevice.Adapter.SupportedDisplayModes)
+                if (mode.Width == width && mode.Height == height)
                 {
-                    if (mode.Width == width && mode.Height == height)
-                    {
-                        supported = true;
-                    }
-                }
-
-                if (!supported)
-                {
-                    Globals.Database.FullScreen = false;
-                    Globals.Database.SavePreferences();
-                    Interface.Interface.ShowError(
-                        Strings.Errors.DisplayNotSupportedError.ToString(
-                            Strings.Internals.ResolutionXByY.ToString(width, height)
-                        ),
-                        Strings.Errors.DisplayNotSupported
-                    );
+                    supported = true;
                 }
             }
 
-            var fsChanged = mGraphics.IsFullScreen != Globals.Database.FullScreen && !Globals.Database.FullScreen;
-
-            mGraphics.IsFullScreen = Globals.Database.FullScreen;
-            if (fsChanged)
+            if (!supported)
             {
-                mGraphics.ApplyChanges();
-            }
-
-            mScreenWidth = width;
-            mScreenHeight = height;
-            mGraphics.PreferredBackBufferWidth = width;
-            mGraphics.PreferredBackBufferHeight = height;
-            mGraphics.SynchronizeWithVerticalRetrace = Globals.Database.TargetFps == 0;
-
-            if (Globals.Database.TargetFps == 1)
-            {
-                mGame.TargetElapsedTime = new TimeSpan(333333);
-            }
-            else if (Globals.Database.TargetFps == 2)
-            {
-                mGame.TargetElapsedTime = new TimeSpan(333333 / 2);
-            }
-            else if (Globals.Database.TargetFps == 3)
-            {
-                mGame.TargetElapsedTime = new TimeSpan(333333 / 3);
-            }
-            else if (Globals.Database.TargetFps == 4)
-            {
-                mGame.TargetElapsedTime = new TimeSpan(333333 / 4);
-            }
-
-            mGame.IsFixedTimeStep = Globals.Database.TargetFps > 0;
-
-            mGraphics.ApplyChanges();
-
-            mDisplayWidth = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode.Width;
-            mDisplayHeight = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height;
-            if (fsChanged || initial)
-            {
-                var displayBounds = Sdl2.GetDisplayBounds();
-                var currentDisplayBounds = displayBounds[0];
-                mGameWindow.Position = new Microsoft.Xna.Framework.Point(
-                    currentDisplayBounds.x + (currentDisplayBounds.w - mScreenWidth) / 2,
-                    currentDisplayBounds.y + (currentDisplayBounds.h - mScreenHeight) / 2
+                Globals.Database.FullScreen = false;
+                Globals.Database.SavePreferences();
+                Interface.Interface.ShowError(
+                    Strings.Errors.DisplayNotSupportedError.ToString(
+                        Strings.Internals.ResolutionXByY.ToString(width, height)
+                    ),
+                    Strings.Errors.DisplayNotSupported
                 );
             }
-
-            mOldDisplayMode = currentDisplayMode;
-            if (fsChanged)
-            {
-                mFsChangedTimer = Timing.Global.MillisecondsUtc + 1000;
-            }
-
-            if (fsChanged)
-            {
-                mDisplayModeChanged = true;
-            }
         }
 
-        public void CreateWhiteTexture()
+        var fsChanged = mGraphics.IsFullScreen != Globals.Database.FullScreen && !Globals.Database.FullScreen;
+
+        mGraphics.IsFullScreen = Globals.Database.FullScreen;
+        if (fsChanged)
         {
-            var texture = new Texture2D(mGraphicsDevice, 1, 1);
-            texture.SetData(new[] { XNAColor.White });
-            mWhiteTexture = MonoTexture.CreateFromTexture2D(texture, "white_1px_1px");
+            mGraphics.ApplyChanges();
         }
 
-        public override bool Begin()
+        mScreenWidth = width;
+        mScreenHeight = height;
+        mGraphics.PreferredBackBufferWidth = width;
+        mGraphics.PreferredBackBufferHeight = height;
+        mGraphics.SynchronizeWithVerticalRetrace = Globals.Database.TargetFps == 0;
+
+        if (Globals.Database.TargetFps == 1)
         {
-            if (mFsChangedTimer > -1 && mFsChangedTimer < Timing.Global.MillisecondsUtc)
-            {
-                mGraphics.PreferredBackBufferWidth--;
-                mGraphics.ApplyChanges();
-                mGraphics.PreferredBackBufferWidth++;
-                mGraphics.ApplyChanges();
-                mFsChangedTimer = -1;
-            }
-
-            if (mGameWindow.ClientBounds.Width != 0 &&
-                mGameWindow.ClientBounds.Height != 0 &&
-                (mGameWindow.ClientBounds.Width != mScreenWidth || mGameWindow.ClientBounds.Height != mScreenHeight) &&
-                !mGraphics.IsFullScreen)
-            {
-                if (mOldDisplayMode != mGraphics.GraphicsDevice.DisplayMode)
-                {
-                    mDisplayModeChanged = true;
-                }
-
-                UpdateGraphicsState(mScreenWidth, mScreenHeight);
-            }
-
-            return RecreateSpriteBatch();
+            mGame.TargetElapsedTime = new TimeSpan(333333);
+        }
+        else if (Globals.Database.TargetFps == 2)
+        {
+            mGame.TargetElapsedTime = new TimeSpan(333333 / 2);
+        }
+        else if (Globals.Database.TargetFps == 3)
+        {
+            mGame.TargetElapsedTime = new TimeSpan(333333 / 3);
+        }
+        else if (Globals.Database.TargetFps == 4)
+        {
+            mGame.TargetElapsedTime = new TimeSpan(333333 / 4);
         }
 
-        protected override bool RecreateSpriteBatch()
-        {
-            if (mSpriteBatchBegan)
-            {
-                EndSpriteBatch();
-            }
+        mGame.IsFixedTimeStep = Globals.Database.TargetFps > 0;
 
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true, null);
-            return true;
-        }
+        mGraphics.ApplyChanges();
 
-        public Pointf GetMouseOffset()
+        mDisplayWidth = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode.Width;
+        mDisplayHeight = mGraphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height;
+        if (fsChanged || initial)
         {
-            return new Pointf(
-                mGraphics.PreferredBackBufferWidth / (float)mGameWindow.ClientBounds.Width,
-                mGraphics.PreferredBackBufferHeight / (float)mGameWindow.ClientBounds.Height
+            var displayBounds = Sdl2.GetDisplayBounds();
+            var currentDisplayBounds = displayBounds[0];
+            mGameWindow.Position = new Microsoft.Xna.Framework.Point(
+                currentDisplayBounds.x + (currentDisplayBounds.w - mScreenWidth) / 2,
+                currentDisplayBounds.y + (currentDisplayBounds.h - mScreenHeight) / 2
             );
         }
 
-        private void StartSpritebatch(
-            FloatRect view,
-            GameBlendModes mode = GameBlendModes.None,
-            GameShader shader = null,
-            GameRenderTexture target = null,
-            bool forced = false,
-            RasterizerState rs = null,
-            bool drawImmediate = false
-        )
+        mOldDisplayMode = currentDisplayMode;
+        if (fsChanged)
         {
-            var viewsDiff = view.X != mCurrentSpriteView.X ||
-                            view.Y != mCurrentSpriteView.Y ||
-                            view.Width != mCurrentSpriteView.Width ||
-                            view.Height != mCurrentSpriteView.Height;
+            mFsChangedTimer = Timing.Global.MillisecondsUtc + 1000;
+        }
 
-            if (mode != mCurrentBlendmode ||
-                shader != mCurrentShader ||
-                shader != null && shader.ValuesChanged() ||
-                target != mCurrentTarget ||
-                viewsDiff ||
-                forced ||
-                drawImmediate ||
-                !mSpriteBatchBegan)
+        if (fsChanged)
+        {
+            mDisplayModeChanged = true;
+        }
+    }
+
+    public void CreateWhiteTexture()
+    {
+        var texture = new Texture2D(mGraphicsDevice, 1, 1);
+        texture.SetData(new[] { XNAColor.White });
+        mWhiteTexture = MonoTexture.CreateFromTexture2D(texture, "white_1px_1px");
+    }
+
+    public override bool Begin()
+    {
+        if (mFsChangedTimer > -1 && mFsChangedTimer < Timing.Global.MillisecondsUtc)
+        {
+            mGraphics.PreferredBackBufferWidth--;
+            mGraphics.ApplyChanges();
+            mGraphics.PreferredBackBufferWidth++;
+            mGraphics.ApplyChanges();
+            mFsChangedTimer = -1;
+        }
+
+        if (mGameWindow.ClientBounds.Width != 0 &&
+            mGameWindow.ClientBounds.Height != 0 &&
+            (mGameWindow.ClientBounds.Width != mScreenWidth || mGameWindow.ClientBounds.Height != mScreenHeight) &&
+            !mGraphics.IsFullScreen)
+        {
+            if (mOldDisplayMode != mGraphics.GraphicsDevice.DisplayMode)
             {
-                if (mSpriteBatchBegan)
-                {
-                    mSpriteBatch.End();
-                }
-
-                if (target != null)
-                {
-                    mGraphicsDevice?.SetRenderTarget((RenderTarget2D)target.GetTexture());
-                }
-                else
-                {
-                    mGraphicsDevice?.SetRenderTarget(mScreenshotRenderTarget);
-                }
-
-                var blend = mNormalState;
-                Effect useEffect = null;
-
-                switch (mode)
-                {
-                    case GameBlendModes.None:
-                        blend = mNormalState;
-
-                        break;
-
-                    case GameBlendModes.Alpha:
-                        blend = BlendState.AlphaBlend;
-
-                        break;
-
-                    case GameBlendModes.Multiply:
-                        blend = mMultiplyState;
-
-                        break;
-
-                    case GameBlendModes.Add:
-                        blend = BlendState.Additive;
-
-                        break;
-
-                    case GameBlendModes.Opaque:
-                        blend = BlendState.Opaque;
-
-                        break;
-
-                    case GameBlendModes.Cutout:
-                        blend = mCutoutState;
-
-                        break;
-                }
-
-                if (shader != null)
-                {
-                    useEffect = (Effect)shader.GetShader();
-                    shader.ResetChanged();
-                }
-
-                mSpriteBatch.Begin(
-                    drawImmediate ? SpriteSortMode.Immediate : SpriteSortMode.Deferred,
-                    blend,
-                    SamplerState.PointClamp,
-                    null,
-                    rs,
-                    useEffect,
-                    CreateViewMatrix(view)
-                );
-
-                mCurrentSpriteView = view;
-                mCurrentBlendmode = mode;
-                mCurrentShader = shader;
-                mCurrentTarget = target;
-                mSpriteBatchBegan = true;
+                mDisplayModeChanged = true;
             }
+
+            UpdateGraphicsState(mScreenWidth, mScreenHeight);
         }
 
-        public override bool DisplayModeChanged()
+        return RecreateSpriteBatch();
+    }
+
+    protected override bool RecreateSpriteBatch()
+    {
+        if (mSpriteBatchBegan)
         {
-            var changed = mDisplayModeChanged;
-            mDisplayModeChanged = false;
-
-            return changed;
+            EndSpriteBatch();
         }
 
-        public void EndSpriteBatch()
+        StartSpritebatch(mCurrentView, GameBlendModes.None, null, null, true, null);
+        return true;
+    }
+
+    public Pointf GetMouseOffset()
+    {
+        return new Pointf(
+            mGraphics.PreferredBackBufferWidth / (float)mGameWindow.ClientBounds.Width,
+            mGraphics.PreferredBackBufferHeight / (float)mGameWindow.ClientBounds.Height
+        );
+    }
+
+    private void StartSpritebatch(
+        FloatRect view,
+        GameBlendModes mode = GameBlendModes.None,
+        GameShader shader = null,
+        GameRenderTexture target = null,
+        bool forced = false,
+        RasterizerState rs = null,
+        bool drawImmediate = false
+    )
+    {
+        var viewsDiff = view.X != mCurrentSpriteView.X ||
+                        view.Y != mCurrentSpriteView.Y ||
+                        view.Width != mCurrentSpriteView.Width ||
+                        view.Height != mCurrentSpriteView.Height;
+
+        if (mode != mCurrentBlendmode ||
+            shader != mCurrentShader ||
+            shader != null && shader.ValuesChanged() ||
+            target != mCurrentTarget ||
+            viewsDiff ||
+            forced ||
+            drawImmediate ||
+            !mSpriteBatchBegan)
         {
             if (mSpriteBatchBegan)
             {
                 mSpriteBatch.End();
             }
 
-            mSpriteBatchBegan = false;
-        }
-
-        public static XNAColor ConvertColor(Color clr)
-        {
-            return new XNAColor(clr.R, clr.G, clr.B, clr.A);
-        }
-
-        public override void Clear(Color color)
-        {
-            mGraphicsDevice.Clear(ConvertColor(color));
-        }
-
-        public override void DrawTileBuffer(GameTileBuffer buffer)
-        {
-            EndSpriteBatch();
-            if (mGraphicsDevice == null || buffer == null)
+            if (target != null)
             {
-                return;
-            }
-
-            mGraphicsDevice.SetRenderTarget(mScreenshotRenderTarget);
-            mGraphicsDevice.BlendState = mNormalState;
-            mGraphicsDevice.RasterizerState = RasterizerState.CullCounterClockwise;
-            mGraphicsDevice.SamplerStates[0] = SamplerState.PointClamp;
-            mGraphicsDevice.DepthStencilState = DepthStencilState.None;
-            ((MonoTileBuffer)buffer).Draw(mBasicEffect, mCurrentView);
-        }
-
-        public override void Close()
-        {
-        }
-
-        public override GameTexture GetWhiteTexture()
-        {
-            return mWhiteTexture;
-        }
-
-        public ContentManager GetContentManager()
-        {
-            return mContentManager;
-        }
-
-        public override GameRenderTexture CreateRenderTexture(int width, int height)
-        {
-            return new MonoRenderTexture(mGraphicsDevice, width, height);
-        }
-
-        public override void DrawString(
-            string text,
-            GameFont gameFont,
-            float x,
-            float y,
-            float fontScale,
-            Color fontColor,
-            bool worldPos = true,
-            GameRenderTexture renderTexture = null,
-            Color borderColor = null
-        )
-        {
-            var font = (SpriteFont)gameFont?.GetFont();
-            if (font == null)
-            {
-                return;
-            }
-
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, null);
-            foreach (var chr in text)
-            {
-                if (!font.Characters.Contains(chr))
-                {
-                    text = text.Replace(chr, ' ');
-                }
-            }
-
-            if (borderColor != null && borderColor != Color.Transparent)
-            {
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x, y - 1), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x - 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x + 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x, y + 1), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-            }
-
-            mSpriteBatch.DrawString(font, text, new Vector2(x, y), ConvertColor(fontColor));
-        }
-
-        public override void DrawString(
-            string text,
-            GameFont gameFont,
-            float x,
-            float y,
-            float fontScale,
-            Color fontColor,
-            bool worldPos,
-            GameRenderTexture renderTexture,
-            FloatRect clipRect,
-            Color borderColor = null
-        )
-        {
-            if (gameFont == null)
-            {
-                return;
-            }
-
-            x += mCurrentView.X;
-            y += mCurrentView.Y;
-
-            var font = (SpriteFont)gameFont.GetFont();
-            if (font == null)
-            {
-                return;
-            }
-
-            var clr = ConvertColor(fontColor);
-
-            //Copy the current scissor rect so we can restore it after
-            var currentRect = mSpriteBatch.GraphicsDevice.ScissorRectangle;
-            StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, mRasterizerState, true);
-
-            //Set the current scissor rectangle
-            mSpriteBatch.GraphicsDevice.ScissorRectangle = new XNARectangle(
-                (int)clipRect.X, (int)clipRect.Y, (int)clipRect.Width, (int)clipRect.Height
-            );
-
-            foreach (var chr in text)
-            {
-                if (!font.Characters.Contains(chr))
-                {
-                    text = text.Replace(chr, ' ');
-                }
-            }
-
-            if (borderColor != null && borderColor != Color.Transparent)
-            {
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x, y - 1), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x - 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x + 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-
-                mSpriteBatch.DrawString(
-                    font, text, new Vector2(x, y + 1), ConvertColor(borderColor), 0f, Vector2.Zero,
-                    new Vector2(fontScale, fontScale), SpriteEffects.None, 0
-                );
-            }
-
-            mSpriteBatch.DrawString(
-                font, text, new Vector2(x, y), clr, 0f, Vector2.Zero, new Vector2(fontScale, fontScale),
-                SpriteEffects.None, 0
-            );
-
-            EndSpriteBatch();
-
-            //Reset scissor rectangle to the saved value
-            mSpriteBatch.GraphicsDevice.ScissorRectangle = currentRect;
-        }
-
-        public override GameTileBuffer CreateTileBuffer()
-        {
-            return new MonoTileBuffer(mGraphicsDevice);
-        }
-
-        public override void DrawTexture(
-            GameTexture tex,
-            float sx,
-            float sy,
-            float sw,
-            float sh,
-            float tx,
-            float ty,
-            float tw,
-            float th,
-            Color renderColor,
-            GameRenderTexture renderTarget = null,
-            GameBlendModes blendMode = GameBlendModes.None,
-            GameShader shader = null,
-            float rotationDegrees = 0,
-            bool isUi = false,
-            bool drawImmediate = false
-        )
-        {
-            var texture = tex?.GetTexture();
-            if (texture == null)
-            {
-                return;
-            }
-
-            var packRotated = false;
-
-            var pack = tex.GetTexturePackFrame();
-            if (pack != null)
-            {
-                if (pack.Rotated)
-                {
-                    rotationDegrees -= 90;
-                    var z = tw;
-                    tw = th;
-                    th = z;
-
-                    z = sx;
-                    sx = pack.Rect.Right - sy - sh;
-                    sy = pack.Rect.Top + z;
-
-                    z = sw;
-                    sw = sh;
-                    sh = z;
-                    packRotated = true;
-                }
-                else
-                {
-                    sx += pack.Rect.X;
-                    sy += pack.Rect.Y;
-                }
-            }
-
-            var origin = Vector2.Zero;
-            if (Math.Abs(rotationDegrees) > 0.01)
-            {
-                rotationDegrees = (float)(Math.PI / 180 * rotationDegrees);
-                origin = new Vector2(sw / 2f, sh / 2f);
-
-                //TODO: Optimize in terms of memory AND performance.
-                var pnt = new Pointf(0, 0);
-                var pnt1 = new Pointf(tw, 0);
-                var pnt2 = new Pointf(0, th);
-                var cntr = new Pointf(tw / 2, th / 2);
-
-                var pntMod = Rotate(pnt, cntr, rotationDegrees);
-                var pntMod2 = Rotate(pnt1, cntr, rotationDegrees);
-                var pntMod3 = Rotate(pnt2, cntr, rotationDegrees);
-
-                var width = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod2.X, pntMod2.Y));
-                var height = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod3.X, pntMod3.Y));
-
-                if (packRotated)
-                {
-                    (width, height) = (height, width);
-                }
-
-                tx += width / 2f;
-                ty += height / 2f;
-            }
-
-            // Cache the result of ConvertColor(renderColor) in a temporary variable.
-            var color = ConvertColor(renderColor);
-
-            // Use a single Draw method to avoid duplicating code.
-            void Draw(FloatRect currentView, GameRenderTexture targetObject)
-            {
-                StartSpritebatch(currentView, blendMode, shader, targetObject, false, null, drawImmediate);
-
-                mSpriteBatch.Draw((Texture2D)texture, new Vector2(tx, ty),
-                    new XNARectangle((int)sx, (int)sy, (int)sw, (int)sh), color, rotationDegrees, origin,
-                    new Vector2(tw / sw, th / sh), SpriteEffects.None, 0);
-            }
-
-            if (renderTarget == null)
-            {
-                if (isUi)
-                {
-                    tx += mCurrentView.X;
-                    ty += mCurrentView.Y;
-                }
-
-                Draw(mCurrentView, null);
+                mGraphicsDevice?.SetRenderTarget((RenderTarget2D)target.GetTexture());
             }
             else
             {
-                Draw(new FloatRect(0, 0, renderTarget.GetWidth(), renderTarget.GetHeight()), renderTarget);
+                mGraphicsDevice?.SetRenderTarget(mScreenshotRenderTarget);
+            }
+
+            var blend = mNormalState;
+            Effect useEffect = null;
+
+            switch (mode)
+            {
+                case GameBlendModes.None:
+                    blend = mNormalState;
+
+                    break;
+
+                case GameBlendModes.Alpha:
+                    blend = BlendState.AlphaBlend;
+
+                    break;
+
+                case GameBlendModes.Multiply:
+                    blend = mMultiplyState;
+
+                    break;
+
+                case GameBlendModes.Add:
+                    blend = BlendState.Additive;
+
+                    break;
+
+                case GameBlendModes.Opaque:
+                    blend = BlendState.Opaque;
+
+                    break;
+
+                case GameBlendModes.Cutout:
+                    blend = mCutoutState;
+
+                    break;
+            }
+
+            if (shader != null)
+            {
+                useEffect = (Effect)shader.GetShader();
+                shader.ResetChanged();
+            }
+
+            mSpriteBatch.Begin(
+                drawImmediate ? SpriteSortMode.Immediate : SpriteSortMode.Deferred,
+                blend,
+                SamplerState.PointClamp,
+                null,
+                rs,
+                useEffect,
+                CreateViewMatrix(view)
+            );
+
+            mCurrentSpriteView = view;
+            mCurrentBlendmode = mode;
+            mCurrentShader = shader;
+            mCurrentTarget = target;
+            mSpriteBatchBegan = true;
+        }
+    }
+
+    public override bool DisplayModeChanged()
+    {
+        var changed = mDisplayModeChanged;
+        mDisplayModeChanged = false;
+
+        return changed;
+    }
+
+    public void EndSpriteBatch()
+    {
+        if (mSpriteBatchBegan)
+        {
+            mSpriteBatch.End();
+        }
+
+        mSpriteBatchBegan = false;
+    }
+
+    public static XNAColor ConvertColor(Color clr)
+    {
+        return new XNAColor(clr.R, clr.G, clr.B, clr.A);
+    }
+
+    public override void Clear(Color color)
+    {
+        mGraphicsDevice.Clear(ConvertColor(color));
+    }
+
+    public override void DrawTileBuffer(GameTileBuffer buffer)
+    {
+        EndSpriteBatch();
+        if (mGraphicsDevice == null || buffer == null)
+        {
+            return;
+        }
+
+        mGraphicsDevice.SetRenderTarget(mScreenshotRenderTarget);
+        mGraphicsDevice.BlendState = mNormalState;
+        mGraphicsDevice.RasterizerState = RasterizerState.CullCounterClockwise;
+        mGraphicsDevice.SamplerStates[0] = SamplerState.PointClamp;
+        mGraphicsDevice.DepthStencilState = DepthStencilState.None;
+        ((MonoTileBuffer)buffer).Draw(mBasicEffect, mCurrentView);
+    }
+
+    public override void Close()
+    {
+    }
+
+    public override GameTexture GetWhiteTexture()
+    {
+        return mWhiteTexture;
+    }
+
+    public ContentManager GetContentManager()
+    {
+        return mContentManager;
+    }
+
+    public override GameRenderTexture CreateRenderTexture(int width, int height)
+    {
+        return new MonoRenderTexture(mGraphicsDevice, width, height);
+    }
+
+    public override void DrawString(
+        string text,
+        GameFont gameFont,
+        float x,
+        float y,
+        float fontScale,
+        Color fontColor,
+        bool worldPos = true,
+        GameRenderTexture renderTexture = null,
+        Color borderColor = null
+    )
+    {
+        var font = (SpriteFont)gameFont?.GetFont();
+        if (font == null)
+        {
+            return;
+        }
+
+        StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, null);
+        foreach (var chr in text)
+        {
+            if (!font.Characters.Contains(chr))
+            {
+                text = text.Replace(chr, ' ');
             }
         }
 
-        private static double GetDistance(double x1, double y1, double x2, double y2)
+        if (borderColor != null && borderColor != Color.Transparent)
         {
-            var a2 = Math.Pow(x2 - x1, 2);
-            var b2 = Math.Pow(y2 - y1, 2);
-            var root = Math.Sqrt(a2 + b2);
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x, y - 1), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
 
-            return root;
-        }
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x - 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
 
-        private Pointf Rotate(Pointf pnt, Pointf ctr, float angle)
-        {
-            return new Pointf(
-                (float)(pnt.X + ctr.X * Math.Cos(angle) - ctr.Y * Math.Sin(angle)),
-                (float)(pnt.Y + ctr.X * Math.Sin(angle) + ctr.Y * Math.Cos(angle))
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x + 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
+
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x, y + 1), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
             );
         }
 
-        public override void End()
+        mSpriteBatch.DrawString(font, text, new Vector2(x, y), ConvertColor(fontColor));
+    }
+
+    public override void DrawString(
+        string text,
+        GameFont gameFont,
+        float x,
+        float y,
+        float fontScale,
+        Color fontColor,
+        bool worldPos,
+        GameRenderTexture renderTexture,
+        FloatRect clipRect,
+        Color borderColor = null
+    )
+    {
+        if (gameFont == null)
         {
-            EndSpriteBatch();
-            mFpsCount++;
-            if (mFpsTimer < Timing.Global.MillisecondsUtc)
+            return;
+        }
+
+        x += mCurrentView.X;
+        y += mCurrentView.Y;
+
+        var font = (SpriteFont)gameFont.GetFont();
+        if (font == null)
+        {
+            return;
+        }
+
+        var clr = ConvertColor(fontColor);
+
+        //Copy the current scissor rect so we can restore it after
+        var currentRect = mSpriteBatch.GraphicsDevice.ScissorRectangle;
+        StartSpritebatch(mCurrentView, GameBlendModes.None, null, renderTexture, false, mRasterizerState, true);
+
+        //Set the current scissor rectangle
+        mSpriteBatch.GraphicsDevice.ScissorRectangle = new XNARectangle(
+            (int)clipRect.X, (int)clipRect.Y, (int)clipRect.Width, (int)clipRect.Height
+        );
+
+        foreach (var chr in text)
+        {
+            if (!font.Characters.Contains(chr))
             {
-                mFps = mFpsCount;
-                mFpsCount = 0;
-                mFpsTimer = Timing.Global.MillisecondsUtc + 1000;
-                mGameWindow.Title = Strings.Main.GameName;
+                text = text.Replace(chr, ' ');
+            }
+        }
+
+        if (borderColor != null && borderColor != Color.Transparent)
+        {
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x, y - 1), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
+
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x - 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
+
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x + 1, y), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
+
+            mSpriteBatch.DrawString(
+                font, text, new Vector2(x, y + 1), ConvertColor(borderColor), 0f, Vector2.Zero,
+                new Vector2(fontScale, fontScale), SpriteEffects.None, 0
+            );
+        }
+
+        mSpriteBatch.DrawString(
+            font, text, new Vector2(x, y), clr, 0f, Vector2.Zero, new Vector2(fontScale, fontScale),
+            SpriteEffects.None, 0
+        );
+
+        EndSpriteBatch();
+
+        //Reset scissor rectangle to the saved value
+        mSpriteBatch.GraphicsDevice.ScissorRectangle = currentRect;
+    }
+
+    public override GameTileBuffer CreateTileBuffer()
+    {
+        return new MonoTileBuffer(mGraphicsDevice);
+    }
+
+    public override void DrawTexture(
+        GameTexture tex,
+        float sx,
+        float sy,
+        float sw,
+        float sh,
+        float tx,
+        float ty,
+        float tw,
+        float th,
+        Color renderColor,
+        GameRenderTexture renderTarget = null,
+        GameBlendModes blendMode = GameBlendModes.None,
+        GameShader shader = null,
+        float rotationDegrees = 0,
+        bool isUi = false,
+        bool drawImmediate = false
+    )
+    {
+        var texture = tex?.GetTexture();
+        if (texture == null)
+        {
+            return;
+        }
+
+        var packRotated = false;
+
+        var pack = tex.GetTexturePackFrame();
+        if (pack != null)
+        {
+            if (pack.Rotated)
+            {
+                rotationDegrees -= 90;
+                var z = tw;
+                tw = th;
+                th = z;
+
+                z = sx;
+                sx = pack.Rect.Right - sy - sh;
+                sy = pack.Rect.Top + z;
+
+                z = sw;
+                sw = sh;
+                sh = z;
+                packRotated = true;
+            }
+            else
+            {
+                sx += pack.Rect.X;
+                sy += pack.Rect.Y;
+            }
+        }
+
+        var origin = Vector2.Zero;
+        if (Math.Abs(rotationDegrees) > 0.01)
+        {
+            rotationDegrees = (float)(Math.PI / 180 * rotationDegrees);
+            origin = new Vector2(sw / 2f, sh / 2f);
+
+            //TODO: Optimize in terms of memory AND performance.
+            var pnt = new Pointf(0, 0);
+            var pnt1 = new Pointf(tw, 0);
+            var pnt2 = new Pointf(0, th);
+            var cntr = new Pointf(tw / 2, th / 2);
+
+            var pntMod = Rotate(pnt, cntr, rotationDegrees);
+            var pntMod2 = Rotate(pnt1, cntr, rotationDegrees);
+            var pntMod3 = Rotate(pnt2, cntr, rotationDegrees);
+
+            var width = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod2.X, pntMod2.Y));
+            var height = (int)Math.Round(GetDistance(pntMod.X, pntMod.Y, pntMod3.X, pntMod3.Y));
+
+            if (packRotated)
+            {
+                (width, height) = (height, width);
             }
 
-            foreach (var texture in mAllTextures)
+            tx += width / 2f;
+            ty += height / 2f;
+        }
+
+        // Cache the result of ConvertColor(renderColor) in a temporary variable.
+        var color = ConvertColor(renderColor);
+
+        // Use a single Draw method to avoid duplicating code.
+        void Draw(FloatRect currentView, GameRenderTexture targetObject)
+        {
+            StartSpritebatch(currentView, blendMode, shader, targetObject, false, null, drawImmediate);
+
+            mSpriteBatch.Draw((Texture2D)texture, new Vector2(tx, ty),
+                new XNARectangle((int)sx, (int)sy, (int)sw, (int)sh), color, rotationDegrees, origin,
+                new Vector2(tw / sw, th / sh), SpriteEffects.None, 0);
+        }
+
+        if (renderTarget == null)
+        {
+            if (isUi)
             {
-                texture?.Update();
-            }
-        }
-
-        public override int GetFps()
-        {
-            return mFps;
-        }
-
-        public override int GetScreenHeight()
-        {
-            return mScreenHeight;
-        }
-
-        public override int GetScreenWidth()
-        {
-            return mScreenWidth;
-        }
-
-        public override string GetResolutionString()
-        {
-            return mScreenWidth + "x" + mScreenHeight;
-        }
-
-        public Resolution[] GetAllowedResolutions()
-        {
-            var allowedResolutions = new[]
-                {
-                    new Resolution(800, 600), new Resolution(1024, 768), new Resolution(1024, 720),
-                    new Resolution(1280, 720), new Resolution(1280, 768), new Resolution(1280, 1024),
-                    new Resolution(1360, 768), new Resolution(1366, 768), new Resolution(1440, 1050),
-                    new Resolution(1440, 900), new Resolution(1600, 900), new Resolution(1680, 1050),
-                    new Resolution(1920, 1080),
-                }.Concat(
-                    mGraphicsDevice.Adapter.SupportedDisplayModes
-                        .Select(displayMode => new Resolution(displayMode.Width, displayMode.Height))
-                        .Where(resolution => resolution is { X: >= 800, Y: >= 480 })
-                )
-                .Distinct()
-                .Order()
-                .ToArray();
-
-            if (Steam.SteamDeck)
-            {
-                allowedResolutions = new[]
-                {
-                    new Resolution(mGraphicsDevice.DisplayMode.Width, mGraphicsDevice.DisplayMode.Height),
-                };
+                tx += mCurrentView.X;
+                ty += mCurrentView.Y;
             }
 
-            return allowedResolutions;
+            Draw(mCurrentView, null);
+        }
+        else
+        {
+            Draw(new FloatRect(0, 0, renderTarget.GetWidth(), renderTarget.GetHeight()), renderTarget);
+        }
+    }
+
+    private static double GetDistance(double x1, double y1, double x2, double y2)
+    {
+        var a2 = Math.Pow(x2 - x1, 2);
+        var b2 = Math.Pow(y2 - y1, 2);
+        var root = Math.Sqrt(a2 + b2);
+
+        return root;
+    }
+
+    private Pointf Rotate(Pointf pnt, Pointf ctr, float angle)
+    {
+        return new Pointf(
+            (float)(pnt.X + ctr.X * Math.Cos(angle) - ctr.Y * Math.Sin(angle)),
+            (float)(pnt.Y + ctr.X * Math.Sin(angle) + ctr.Y * Math.Cos(angle))
+        );
+    }
+
+    public override void End()
+    {
+        EndSpriteBatch();
+        mFpsCount++;
+        if (mFpsTimer < Timing.Global.MillisecondsUtc)
+        {
+            mFps = mFpsCount;
+            mFpsCount = 0;
+            mFpsTimer = Timing.Global.MillisecondsUtc + 1000;
+            mGameWindow.Title = Strings.Main.GameName;
         }
 
-        public override List<string> GetValidVideoModes()
+        foreach (var texture in mAllTextures)
         {
-            if (_validVideoModes != null)
+            texture?.Update();
+        }
+    }
+
+    public override int GetFps()
+    {
+        return mFps;
+    }
+
+    public override int GetScreenHeight()
+    {
+        return mScreenHeight;
+    }
+
+    public override int GetScreenWidth()
+    {
+        return mScreenWidth;
+    }
+
+    public override string GetResolutionString()
+    {
+        return mScreenWidth + "x" + mScreenHeight;
+    }
+
+    public Resolution[] GetAllowedResolutions()
+    {
+        var allowedResolutions = new[]
             {
-                return _validVideoModes;
-            }
+                new Resolution(800, 600), new Resolution(1024, 768), new Resolution(1024, 720),
+                new Resolution(1280, 720), new Resolution(1280, 768), new Resolution(1280, 1024),
+                new Resolution(1360, 768), new Resolution(1366, 768), new Resolution(1440, 1050),
+                new Resolution(1440, 900), new Resolution(1600, 900), new Resolution(1680, 1050),
+                new Resolution(1920, 1080),
+            }.Concat(
+                mGraphicsDevice.Adapter.SupportedDisplayModes
+                    .Select(displayMode => new Resolution(displayMode.Width, displayMode.Height))
+                    .Where(resolution => resolution is { X: >= 800, Y: >= 480 })
+            )
+            .Distinct()
+            .Order()
+            .ToArray();
 
-            _validVideoModes = new List<string>();
-
-            var allowedResolutions = GetAllowedResolutions();
-
-            var displayWidth = mGraphicsDevice.DisplayMode?.Width;
-            var displayHeight = mGraphicsDevice.DisplayMode?.Height;
-
-            foreach (var resolution in allowedResolutions)
+        if (Steam.SteamDeck)
+        {
+            allowedResolutions = new[]
             {
-                if (resolution.X > displayWidth)
-                {
-                    continue;
-                }
+                new Resolution(mGraphicsDevice.DisplayMode.Width, mGraphicsDevice.DisplayMode.Height),
+            };
+        }
 
-                if (resolution.Y > displayHeight)
-                {
-                    continue;
-                }
+        return allowedResolutions;
+    }
 
-                _validVideoModes.Add(resolution.ToString());
-            }
-
+    public override List<string> GetValidVideoModes()
+    {
+        if (_validVideoModes != null)
+        {
             return _validVideoModes;
         }
 
-        public override FloatRect GetView()
-        {
-            return mCurrentView;
-        }
+        _validVideoModes = new List<string>();
 
-        public override void Init()
+        var allowedResolutions = GetAllowedResolutions();
+
+        var displayWidth = mGraphicsDevice.DisplayMode?.Width;
+        var displayHeight = mGraphicsDevice.DisplayMode?.Height;
+
+        foreach (var resolution in allowedResolutions)
         {
-            if (mInitializing)
+            if (resolution.X > displayWidth)
             {
-                return;
+                continue;
             }
 
-            mInitializing = true;
-
-            var database = Globals.Database;
-            var validVideoModes = GetValidVideoModes();
-
-            if (database.TargetResolution < 0)
+            if (resolution.Y > displayHeight)
             {
-                var allowedResolutions = GetAllowedResolutions();
-                var currentDisplayMode = mGraphicsDevice.Adapter.CurrentDisplayMode;
-                var defaultResolution = allowedResolutions.LastOrDefault(
-                    allowedResolution => currentDisplayMode.Width != allowedResolution.X &&
-                                         currentDisplayMode.Width ==
-                                         allowedResolution.X * currentDisplayMode.Height / allowedResolution.Y
+                continue;
+            }
+
+            _validVideoModes.Add(resolution.ToString());
+        }
+
+        return _validVideoModes;
+    }
+
+    public override FloatRect GetView()
+    {
+        return mCurrentView;
+    }
+
+    public override void Init()
+    {
+        if (mInitializing)
+        {
+            return;
+        }
+
+        mInitializing = true;
+
+        var database = Globals.Database;
+        var validVideoModes = GetValidVideoModes();
+
+        if (database.TargetResolution < 0)
+        {
+            var allowedResolutions = GetAllowedResolutions();
+            var currentDisplayMode = mGraphicsDevice.Adapter.CurrentDisplayMode;
+            var defaultResolution = allowedResolutions.LastOrDefault(
+                allowedResolution => currentDisplayMode.Width != allowedResolution.X &&
+                                     currentDisplayMode.Width ==
+                                     allowedResolution.X * currentDisplayMode.Height / allowedResolution.Y
+            );
+
+            if (defaultResolution == default)
+            {
+                defaultResolution = allowedResolutions.LastOrDefault(
+                    allowedResolution => allowedResolution.X * 9 / 16 == allowedResolution.Y &&
+                                         allowedResolution.X < currentDisplayMode.Width &&
+                                         allowedResolution.Y < currentDisplayMode.Height
+                );
+            }
+
+            if (defaultResolution != default)
+            {
+                database.TargetResolution = allowedResolutions.IndexOf(defaultResolution);
+            }
+        }
+
+        var targetResolution = MathHelper.Clamp(database.TargetResolution, 0, validVideoModes.Count - 1);
+
+        if (targetResolution != database.TargetResolution)
+        {
+            Debug.Assert(database != default, "database != null");
+            database.TargetResolution = targetResolution;
+            database.SavePreference("Resolution", database.TargetResolution.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var targetVideoMode = validVideoModes[targetResolution];
+        if (!string.IsNullOrWhiteSpace(targetVideoMode) && Resolution.TryParse(targetVideoMode, out var resolution))
+        {
+            PreferredResolution = resolution;
+        }
+
+        mGraphics.PreferredBackBufferWidth = PreferredResolution.X;
+        mGraphics.PreferredBackBufferHeight = PreferredResolution.Y;
+
+        UpdateGraphicsState(ActiveResolution.X, ActiveResolution.Y, true);
+
+        if (mWhiteTexture == null)
+        {
+            CreateWhiteTexture();
+        }
+
+        mInitializing = false;
+    }
+
+    public void Init(GraphicsDevice graphicsDevice)
+    {
+        mGraphicsDevice = graphicsDevice;
+        mBasicEffect = new BasicEffect(mGraphicsDevice);
+        mBasicEffect.LightingEnabled = false;
+        mBasicEffect.TextureEnabled = true;
+        mSpriteBatch = new SpriteBatch(mGraphicsDevice);
+    }
+
+    public override GameFont LoadFont(string filename)
+    {
+        // Get font size from filename, format should be name_size.xnb or whatever
+        var name = GameContentManager.RemoveExtension(filename)
+            .Replace(Path.Combine(ClientConfiguration.ResourcesDirectory, "fonts"), "")
+            .TrimStart(Path.DirectorySeparatorChar);
+
+        // Split the name into parts
+        var parts = name.Split('_');
+
+        // Check if the font size can be extracted
+        if (parts.Length < 1 || !int.TryParse(parts[parts.Length - 1], out var size))
+        {
+            return null;
+        }
+
+        // Concatenate the parts of the name except the last one to get the full name
+        name = string.Join("_", parts.Take(parts.Length - 1));
+
+        // Return a new MonoFont with the extracted name and size
+        return new MonoFont(name, filename, size, mContentManager);
+    }
+
+    public override GameShader LoadShader(string shaderName)
+    {
+        return new MonoShader(shaderName, mContentManager);
+    }
+
+    public override GameTexture LoadTexture(string filename, string realFilename)
+    {
+        var packFrame = GameTexturePacks.GetFrame(filename);
+        if (packFrame != null)
+        {
+            var tx = new MonoTexture(mGraphicsDevice, filename, packFrame);
+            mAllTextures.Add(tx);
+
+            return tx;
+        }
+
+        var tex = new MonoTexture(mGraphicsDevice, filename, realFilename);
+        mAllTextures.Add(tex);
+
+        return tex;
+    }
+
+    /// <inheritdoc />
+    public override GameTexture LoadTexture(string assetName, Func<Stream> createStream) =>
+        new MonoTexture(mGraphicsDevice, assetName, createStream);
+
+    public override Pointf MeasureText(string text, GameFont gameFont, float fontScale)
+    {
+        var font = (SpriteFont)gameFont?.GetFont();
+        if (font == null)
+        {
+            return Pointf.Empty;
+        }
+
+        foreach (var chr in text)
+        {
+            if (!font.Characters.Contains(chr))
+            {
+                text = text.Replace(chr, ' ');
+            }
+        }
+
+        var size = font.MeasureString(text);
+
+        return new Pointf(size.X * fontScale, size.Y * fontScale);
+    }
+
+    private Matrix CreateViewMatrix(FloatRect view)
+    {
+        return Matrix.CreateRotationZ(0f) *
+               Matrix.CreateTranslation(-view.X, -view.Y, 0) *
+               Matrix.CreateScale(new Vector3(_scale));
+    }
+
+    public override void SetView(FloatRect view)
+    {
+        mCurrentView = view;
+
+        Matrix.CreateOrthographicOffCenter(0, view.Width, view.Height, 0, 0f, -1, out var projection);
+        projection.M41 += -0.5f * projection.M11;
+        projection.M42 += -0.5f * projection.M22;
+        mBasicEffect.Projection = projection;
+        mBasicEffect.View = CreateViewMatrix(view);
+    }
+
+    public override bool BeginScreenshot()
+    {
+        if (mGraphicsDevice == null)
+        {
+            return false;
+        }
+
+        mScreenshotRenderTarget = new RenderTarget2D(
+            mGraphicsDevice,
+            mScreenWidth,
+            mScreenHeight,
+            mipMap: false,
+            preferredFormat: mGraphicsDevice.PresentationParameters.BackBufferFormat,
+            preferredDepthFormat: mGraphicsDevice.PresentationParameters.DepthStencilFormat,
+            /* For whatever reason if this isn't zero everything breaks in .NET 7 on MacOS and most Windows devices */
+            preferredMultiSampleCount: 0, // mGraphicsDevice.PresentationParameters.MultiSampleCount,
+            usage: RenderTargetUsage.PreserveContents
+        );
+
+        return true;
+    }
+
+    public override void EndScreenshot()
+    {
+        if (mScreenshotRenderTarget == null)
+        {
+            return;
+        }
+
+        ScreenshotRequests.ForEach(
+            screenshotRequestStream =>
+            {
+                if (screenshotRequestStream == null)
+                {
+                    return;
+                }
+
+                mScreenshotRenderTarget.SaveAsPng(
+                    screenshotRequestStream, mScreenshotRenderTarget.Width, mScreenshotRenderTarget.Height
                 );
 
-                if (defaultResolution == default)
-                {
-                    defaultResolution = allowedResolutions.LastOrDefault(
-                        allowedResolution => allowedResolution.X * 9 / 16 == allowedResolution.Y &&
-                                             allowedResolution.X < currentDisplayMode.Width &&
-                                             allowedResolution.Y < currentDisplayMode.Height
-                    );
-                }
-
-                if (defaultResolution != default)
-                {
-                    database.TargetResolution = allowedResolutions.IndexOf(defaultResolution);
-                }
+                screenshotRequestStream.Close();
             }
+        );
 
-            var targetResolution = MathHelper.Clamp(database.TargetResolution, 0, validVideoModes.Count - 1);
+        ScreenshotRequests.Clear();
 
-            if (targetResolution != database.TargetResolution)
-            {
-                Debug.Assert(database != default, "database != null");
-                database.TargetResolution = targetResolution;
-                database.SavePreference("Resolution", database.TargetResolution.ToString(CultureInfo.InvariantCulture));
-            }
-
-            var targetVideoMode = validVideoModes[targetResolution];
-            if (!string.IsNullOrWhiteSpace(targetVideoMode) && Resolution.TryParse(targetVideoMode, out var resolution))
-            {
-                PreferredResolution = resolution;
-            }
-
-            mGraphics.PreferredBackBufferWidth = PreferredResolution.X;
-            mGraphics.PreferredBackBufferHeight = PreferredResolution.Y;
-
-            UpdateGraphicsState(ActiveResolution.X, ActiveResolution.Y, true);
-
-            if (mWhiteTexture == null)
-            {
-                CreateWhiteTexture();
-            }
-
-            mInitializing = false;
-        }
-
-        public void Init(GraphicsDevice graphicsDevice)
+        if (mGraphicsDevice == null)
         {
-            mGraphicsDevice = graphicsDevice;
-            mBasicEffect = new BasicEffect(mGraphicsDevice);
-            mBasicEffect.LightingEnabled = false;
-            mBasicEffect.TextureEnabled = true;
-            mSpriteBatch = new SpriteBatch(mGraphicsDevice);
+            return;
         }
 
-        public override GameFont LoadFont(string filename)
+        var skippedFrame = mScreenshotRenderTarget;
+        mScreenshotRenderTarget = null;
+        mGraphicsDevice.SetRenderTarget(null);
+
+        if (!Begin())
         {
-            // Get font size from filename, format should be name_size.xnb or whatever
-            var name = GameContentManager.RemoveExtension(filename)
-                .Replace(Path.Combine(ClientConfiguration.ResourcesDirectory, "fonts"), "")
-                .TrimStart(Path.DirectorySeparatorChar);
-
-            // Split the name into parts
-            var parts = name.Split('_');
-
-            // Check if the font size can be extracted
-            if (parts.Length < 1 || !int.TryParse(parts[parts.Length - 1], out var size))
-            {
-                return null;
-            }
-
-            // Concatenate the parts of the name except the last one to get the full name
-            name = string.Join("_", parts.Take(parts.Length - 1));
-
-            // Return a new MonoFont with the extracted name and size
-            return new MonoFont(name, filename, size, mContentManager);
+            return;
         }
 
-        public override GameShader LoadShader(string shaderName)
-        {
-            return new MonoShader(shaderName, mContentManager);
-        }
-
-        public override GameTexture LoadTexture(string filename, string realFilename)
-        {
-            var packFrame = GameTexturePacks.GetFrame(filename);
-            if (packFrame != null)
-            {
-                var tx = new MonoTexture(mGraphicsDevice, filename, packFrame);
-                mAllTextures.Add(tx);
-
-                return tx;
-            }
-
-            var tex = new MonoTexture(mGraphicsDevice, filename, realFilename);
-            mAllTextures.Add(tex);
-
-            return tex;
-        }
-
-        /// <inheritdoc />
-        public override GameTexture LoadTexture(string assetName, Func<Stream> createStream) =>
-            new MonoTexture(mGraphicsDevice, assetName, createStream);
-
-        public override Pointf MeasureText(string text, GameFont gameFont, float fontScale)
-        {
-            var font = (SpriteFont)gameFont?.GetFont();
-            if (font == null)
-            {
-                return Pointf.Empty;
-            }
-
-            foreach (var chr in text)
-            {
-                if (!font.Characters.Contains(chr))
-                {
-                    text = text.Replace(chr, ' ');
-                }
-            }
-
-            var size = font.MeasureString(text);
-
-            return new Pointf(size.X * fontScale, size.Y * fontScale);
-        }
-
-        private Matrix CreateViewMatrix(FloatRect view)
-        {
-            return Matrix.CreateRotationZ(0f) *
-                   Matrix.CreateTranslation(-view.X, -view.Y, 0) *
-                   Matrix.CreateScale(new Vector3(_scale));
-        }
-
-        public override void SetView(FloatRect view)
-        {
-            mCurrentView = view;
-
-            Matrix.CreateOrthographicOffCenter(0, view.Width, view.Height, 0, 0f, -1, out var projection);
-            projection.M41 += -0.5f * projection.M11;
-            projection.M42 += -0.5f * projection.M22;
-            mBasicEffect.Projection = projection;
-            mBasicEffect.View = CreateViewMatrix(view);
-        }
-
-        public override bool BeginScreenshot()
-        {
-            if (mGraphicsDevice == null)
-            {
-                return false;
-            }
-
-            mScreenshotRenderTarget = new RenderTarget2D(
-                mGraphicsDevice,
-                mScreenWidth,
-                mScreenHeight,
-                mipMap: false,
-                preferredFormat: mGraphicsDevice.PresentationParameters.BackBufferFormat,
-                preferredDepthFormat: mGraphicsDevice.PresentationParameters.DepthStencilFormat,
-                /* For whatever reason if this isn't zero everything breaks in .NET 7 on MacOS and most Windows devices */
-                preferredMultiSampleCount: 0, // mGraphicsDevice.PresentationParameters.MultiSampleCount,
-                usage: RenderTargetUsage.PreserveContents
-            );
-
-            return true;
-        }
-
-        public override void EndScreenshot()
-        {
-            if (mScreenshotRenderTarget == null)
-            {
-                return;
-            }
-
-            ScreenshotRequests.ForEach(
-                screenshotRequestStream =>
-                {
-                    if (screenshotRequestStream == null)
-                    {
-                        return;
-                    }
-
-                    mScreenshotRenderTarget.SaveAsPng(
-                        screenshotRequestStream, mScreenshotRenderTarget.Width, mScreenshotRenderTarget.Height
-                    );
-
-                    screenshotRequestStream.Close();
-                }
-            );
-
-            ScreenshotRequests.Clear();
-
-            if (mGraphicsDevice == null)
-            {
-                return;
-            }
-
-            var skippedFrame = mScreenshotRenderTarget;
-            mScreenshotRenderTarget = null;
-            mGraphicsDevice.SetRenderTarget(null);
-
-            if (!Begin())
-            {
-                return;
-            }
-
-            mSpriteBatch?.Draw(skippedFrame, new XNARectangle(), XNAColor.White);
-            End();
-        }
-
+        mSpriteBatch?.Draw(skippedFrame, new XNARectangle(), XNAColor.White);
+        End();
     }
 
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoShader.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoShader.cs
@@ -6,100 +6,98 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client.MonoGame.Graphics
+namespace Intersect.Client.MonoGame.Graphics;
+
+
+public partial class MonoShader : GameShader
 {
 
-    public partial class MonoShader : GameShader
+    private Effect mShader;
+
+    private bool mValuesChanged = false;
+
+    private Dictionary<string, Color> Colors = new Dictionary<string, Color>();
+
+    private Dictionary<string, float> Floats = new Dictionary<string, float>();
+
+    public MonoShader(string shaderName, ContentManager contentManager) : base(shaderName)
     {
-
-        private Effect mShader;
-
-        private bool mValuesChanged = false;
-
-        private Dictionary<string, Color> Colors = new Dictionary<string, Color>();
-
-        private Dictionary<string, float> Floats = new Dictionary<string, float>();
-
-        public MonoShader(string shaderName, ContentManager contentManager) : base(shaderName)
+        using (var resourceStream = typeof(MonoShader).Assembly.GetManifestResourceStream(shaderName))
         {
-            using (var resourceStream = typeof(MonoShader).Assembly.GetManifestResourceStream(shaderName))
-            {
-                var extractedPath = FileSystemHelper.WriteToTemporaryFolder(shaderName, resourceStream);
-                mShader = contentManager.Load<Effect>(Path.ChangeExtension(extractedPath, null));
-            }
+            var extractedPath = FileSystemHelper.WriteToTemporaryFolder(shaderName, resourceStream);
+            mShader = contentManager.Load<Effect>(Path.ChangeExtension(extractedPath, null));
         }
+    }
 
-        public override void SetFloat(string key, float val)
+    public override void SetFloat(string key, float val)
+    {
+        if (!Floats.ContainsKey(key))
         {
-            if (!Floats.ContainsKey(key))
+            Floats.Add(key, val);
+            mValuesChanged = true;
+        }
+        else
+        {
+            if (Floats[key] != val)
             {
-                Floats.Add(key, val);
+                Floats[key] = val;
                 mValuesChanged = true;
             }
-            else
-            {
-                if (Floats[key] != val)
-                {
-                    Floats[key] = val;
-                    mValuesChanged = true;
-                }
-            }
         }
+    }
 
-        public override void SetInt(string key, int val)
+    public override void SetInt(string key, int val)
+    {
+        //throw new NotImplementedException();
+    }
+
+    public override void SetColor(string key, Color val)
+    {
+        if (!Colors.ContainsKey(key))
         {
-            //throw new NotImplementedException();
+            Colors.Add(key, val);
+            mValuesChanged = true;
         }
-
-        public override void SetColor(string key, Color val)
+        else
         {
-            if (!Colors.ContainsKey(key))
+            if (Colors[key].A != val.A || Colors[key].R != val.R || Colors[key].G != val.G || Colors[key].B != val.B)
             {
-                Colors.Add(key, val);
+                Colors[key] = val;
                 mValuesChanged = true;
             }
-            else
-            {
-                if (Colors[key].A != val.A || Colors[key].R != val.R || Colors[key].G != val.G || Colors[key].B != val.B)
-                {
-                    Colors[key] = val;
-                    mValuesChanged = true;
-                }
-            }
         }
+    }
 
-        public override void SetVector2(string key, Pointf val)
+    public override void SetVector2(string key, Pointf val)
+    {
+        //throw new NotImplementedException();
+    }
+
+    public override bool ValuesChanged()
+    {
+        return mValuesChanged;
+    }
+
+    public override void ResetChanged()
+    {
+        mValuesChanged = false;
+
+        //Set Pending
+        foreach (var clr in Colors)
         {
-            //throw new NotImplementedException();
+            var vec = new Vector4(clr.Value.R / 255f, clr.Value.G / 255f, clr.Value.B / 255f, clr.Value.A / 255f);
+            mShader.Parameters[clr.Key].SetValue(vec);
         }
 
-        public override bool ValuesChanged()
+        foreach (var f in Floats)
         {
-            return mValuesChanged;
+            mShader.Parameters[f.Key].SetValue(f.Value);
         }
+    }
 
-        public override void ResetChanged()
-        {
-            mValuesChanged = false;
-
-            //Set Pending
-            foreach (var clr in Colors)
-            {
-                var vec = new Vector4(clr.Value.R / 255f, clr.Value.G / 255f, clr.Value.B / 255f, clr.Value.A / 255f);
-                mShader.Parameters[clr.Key].SetValue(vec);
-            }
-
-            foreach (var f in Floats)
-            {
-                mShader.Parameters[f.Key].SetValue(f.Value);
-            }
-        }
-
-        public override object GetShader()
-        {
-            return mShader;
-        }
-
+    public override object GetShader()
+    {
+        return mShader;
     }
 
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoTexture.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoTexture.cs
@@ -9,290 +9,289 @@ using Intersect.Utilities;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client.MonoGame.Graphics
+namespace Intersect.Client.MonoGame.Graphics;
+
+public partial class MonoTexture : GameTexture
 {
-    public partial class MonoTexture : GameTexture
+    private GraphicsDevice mGraphicsDevice;
+
+    private int mHeight = -1;
+
+    private long mLastAccessTime;
+
+    private bool mLoadError;
+
+    private string mName = "";
+
+    private GameTexturePackFrame mPackFrame;
+
+    private readonly string mPath = "";
+
+    private readonly string mRealPath = "";
+
+    private Texture2D mTexture;
+
+    private int mWidth = -1;
+
+    private readonly Func<Stream> CreateStream;
+
+    private bool _doNotFree = false;
+
+    private MonoTexture(Texture2D texture2D, string assetName)
     {
-        private GraphicsDevice mGraphicsDevice;
+        mGraphicsDevice = texture2D.GraphicsDevice;
+        mPath = assetName;
+        mName = assetName;
+        mTexture = texture2D;
+        _doNotFree = true;
+    }
 
-        private int mHeight = -1;
+    public MonoTexture(GraphicsDevice graphicsDevice, string filename, string realPath)
+    {
+        mGraphicsDevice = graphicsDevice;
+        mPath = filename;
+        mRealPath = realPath;
+        mName = Path.GetFileName(filename);
+    }
 
-        private long mLastAccessTime;
+    public MonoTexture(GraphicsDevice graphicsDevice, string assetName, Func<Stream> createStream)
+    {
+        mGraphicsDevice = graphicsDevice;
+        mPath = assetName;
+        mName = assetName;
+        CreateStream = createStream;
+    }
 
-        private bool mLoadError;
+    public MonoTexture(GraphicsDevice graphicsDevice, string filename, GameTexturePackFrame packFrame)
+    {
+        mGraphicsDevice = graphicsDevice;
+        mPath = filename;
+        mName = Path.GetFileName(filename);
+        mPackFrame = packFrame;
+        mWidth = packFrame.SourceRect.Width;
+        mHeight = packFrame.SourceRect.Height;
+    }
 
-        private string mName = "";
-
-        private GameTexturePackFrame mPackFrame;
-
-        private readonly string mPath = "";
-
-        private readonly string mRealPath = "";
-
-        private Texture2D mTexture;
-
-        private int mWidth = -1;
-
-        private readonly Func<Stream> CreateStream;
-
-        private bool _doNotFree = false;
-
-        private MonoTexture(Texture2D texture2D, string assetName)
+    private void Load(Stream stream)
+    {
+        mTexture = Texture2D.FromStream(mGraphicsDevice, stream);
+        if (mTexture == null)
         {
-            mGraphicsDevice = texture2D.GraphicsDevice;
-            mPath = assetName;
-            mName = assetName;
-            mTexture = texture2D;
-            _doNotFree = true;
+            throw new InvalidDataException("Failed to load texture, received no data.");
         }
 
-        public MonoTexture(GraphicsDevice graphicsDevice, string filename, string realPath)
+        mWidth = mTexture.Width;
+        mHeight = mTexture.Height;
+        mLoadError = false;
+    }
+
+    public void LoadTexture()
+    {
+        if (mTexture != null)
         {
-            mGraphicsDevice = graphicsDevice;
-            mPath = filename;
-            mRealPath = realPath;
-            mName = Path.GetFileName(filename);
+            return;
         }
 
-        public MonoTexture(GraphicsDevice graphicsDevice, string assetName, Func<Stream> createStream)
+        if (CreateStream != null)
         {
-            mGraphicsDevice = graphicsDevice;
-            mPath = assetName;
-            mName = assetName;
-            CreateStream = createStream;
-        }
-
-        public MonoTexture(GraphicsDevice graphicsDevice, string filename, GameTexturePackFrame packFrame)
-        {
-            mGraphicsDevice = graphicsDevice;
-            mPath = filename;
-            mName = Path.GetFileName(filename);
-            mPackFrame = packFrame;
-            mWidth = packFrame.SourceRect.Width;
-            mHeight = packFrame.SourceRect.Height;
-        }
-
-        private void Load(Stream stream)
-        {
-            mTexture = Texture2D.FromStream(mGraphicsDevice, stream);
-            if (mTexture == null)
+            using (var stream = CreateStream())
             {
-                throw new InvalidDataException("Failed to load texture, received no data.");
-            }
-
-            mWidth = mTexture.Width;
-            mHeight = mTexture.Height;
-            mLoadError = false;
-        }
-
-        public void LoadTexture()
-        {
-            if (mTexture != null)
-            {
+                Load(stream);
                 return;
             }
+        }
 
-            if (CreateStream != null)
+        if (mPackFrame != null)
+        {
+            ((MonoTexture) mPackFrame.PackTexture)?.LoadTexture();
+
+            return;
+        }
+
+        mLoadError = true;
+        if (string.IsNullOrWhiteSpace(mRealPath))
+        {
+            Log.Error("Invalid texture path (empty/null).");
+
+            return;
+        }
+
+        var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
+
+        if (!File.Exists(mRealPath))
+        {
+            Log.Error($"Texture does not exist: {relativePath}");
+
+            return;
+        }
+
+        using (var fileStream = File.Open(mRealPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            try
             {
-                using (var stream = CreateStream())
+                if (Path.GetExtension(mPath) == ".asset")
                 {
-                    Load(stream);
-                    return;
-                }
-            }
-
-            if (mPackFrame != null)
-            {
-                ((MonoTexture) mPackFrame.PackTexture)?.LoadTexture();
-
-                return;
-            }
-
-            mLoadError = true;
-            if (string.IsNullOrWhiteSpace(mRealPath))
-            {
-                Log.Error("Invalid texture path (empty/null).");
-
-                return;
-            }
-
-            var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
-
-            if (!File.Exists(mRealPath))
-            {
-                Log.Error($"Texture does not exist: {relativePath}");
-
-                return;
-            }
-
-            using (var fileStream = File.Open(mRealPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                try
-                {
-                    if (Path.GetExtension(mPath) == ".asset")
+                    using (var gzip = GzipCompression.CreateDecompressedFileStream(fileStream))
                     {
-                        using (var gzip = GzipCompression.CreateDecompressedFileStream(fileStream))
-                        {
-                            Load(gzip);
-                        }
+                        Load(gzip);
                     }
-                    else
-                    {
-                        Load(fileStream);
-                    }
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(
-                        exception,
-                        $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
-                    );
-
-                    ChatboxMsg.AddMessage(
-                        new ChatboxMsg(
-                            Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSprite) + " [" + mName + "]",
-                            new Color(0xBF, 0x0, 0x0), Enums.ChatMessageType.Error
-                        )
-                    );
-                }
-            }
-        }
-
-        public void ResetAccessTime()
-        {
-            mLastAccessTime = Timing.Global.MillisecondsUtc + 15000;
-        }
-
-        public override string GetName()
-        {
-            return mName;
-        }
-
-        public override int GetWidth()
-        {
-            ResetAccessTime();
-            if (mWidth != -1)
-            {
-                return mWidth;
-            }
-
-            if (mTexture == null)
-            {
-                LoadTexture();
-            }
-
-            if (mLoadError)
-            {
-                mWidth = 0;
-            }
-
-            return mWidth;
-        }
-
-        public override int GetHeight()
-        {
-            ResetAccessTime();
-            if (mHeight != -1)
-            {
-                return mHeight;
-            }
-
-            if (mTexture == null)
-            {
-                LoadTexture();
-            }
-
-            if (mLoadError)
-            {
-                mHeight = 0;
-            }
-
-            return mHeight;
-        }
-
-        public override object GetTexture()
-        {
-            if (mPackFrame != null)
-            {
-                return mPackFrame.PackTexture.GetTexture();
-            }
-
-            ResetAccessTime();
-
-            if (mTexture == null)
-            {
-                LoadTexture();
-            }
-
-            return mTexture;
-        }
-
-        public override Color GetPixel(int x1, int y1)
-        {
-            if (mTexture == null)
-            {
-                LoadTexture();
-            }
-
-            if (mLoadError)
-            {
-                return Color.White;
-            }
-
-            var tex = mTexture;
-
-            var pack = GetTexturePackFrame();
-            if (pack != null)
-            {
-                tex = (Texture2D) mPackFrame.PackTexture.GetTexture();
-                if (pack.Rotated)
-                {
-                    var z = x1;
-                    x1 = pack.Rect.Right - y1 - pack.Rect.Height;
-                    y1 = pack.Rect.Top + z;
                 }
                 else
                 {
-                    x1 += pack.Rect.X;
-                    y1 += pack.Rect.Y;
+                    Load(fileStream);
                 }
             }
-
-            var pixel = new Microsoft.Xna.Framework.Color[1];
-            tex?.GetData(0, new Rectangle(x1, y1, 1, 1), pixel, 0, 1);
-
-            return new Color(pixel[0].A, pixel[0].R, pixel[0].G, pixel[0].B);
-        }
-
-        public override GameTexturePackFrame GetTexturePackFrame()
-        {
-            return mPackFrame;
-        }
-
-        public void Update()
-        {
-            if (_doNotFree)
+            catch (Exception exception)
             {
-                return;
-            }
+                Log.Error(
+                    exception,
+                    $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
+                );
 
-            if (mTexture == null)
-            {
-                return;
+                ChatboxMsg.AddMessage(
+                    new ChatboxMsg(
+                        Strings.Errors.LoadFile.ToString(Strings.Words.LcaseSprite) + " [" + mName + "]",
+                        new Color(0xBF, 0x0, 0x0), Enums.ChatMessageType.Error
+                    )
+                );
             }
-
-            if (mLastAccessTime >= Timing.Global.MillisecondsUtc)
-            {
-                return;
-            }
-
-            mTexture.Dispose();
-            mTexture = null;
         }
+    }
 
-        public static MonoTexture CreateFromTexture2D(Texture2D texture2D, string assetName)
+    public void ResetAccessTime()
+    {
+        mLastAccessTime = Timing.Global.MillisecondsUtc + 15000;
+    }
+
+    public override string GetName()
+    {
+        return mName;
+    }
+
+    public override int GetWidth()
+    {
+        ResetAccessTime();
+        if (mWidth != -1)
         {
-            return new MonoTexture(texture2D, assetName);
+            return mWidth;
         }
+
+        if (mTexture == null)
+        {
+            LoadTexture();
+        }
+
+        if (mLoadError)
+        {
+            mWidth = 0;
+        }
+
+        return mWidth;
+    }
+
+    public override int GetHeight()
+    {
+        ResetAccessTime();
+        if (mHeight != -1)
+        {
+            return mHeight;
+        }
+
+        if (mTexture == null)
+        {
+            LoadTexture();
+        }
+
+        if (mLoadError)
+        {
+            mHeight = 0;
+        }
+
+        return mHeight;
+    }
+
+    public override object GetTexture()
+    {
+        if (mPackFrame != null)
+        {
+            return mPackFrame.PackTexture.GetTexture();
+        }
+
+        ResetAccessTime();
+
+        if (mTexture == null)
+        {
+            LoadTexture();
+        }
+
+        return mTexture;
+    }
+
+    public override Color GetPixel(int x1, int y1)
+    {
+        if (mTexture == null)
+        {
+            LoadTexture();
+        }
+
+        if (mLoadError)
+        {
+            return Color.White;
+        }
+
+        var tex = mTexture;
+
+        var pack = GetTexturePackFrame();
+        if (pack != null)
+        {
+            tex = (Texture2D) mPackFrame.PackTexture.GetTexture();
+            if (pack.Rotated)
+            {
+                var z = x1;
+                x1 = pack.Rect.Right - y1 - pack.Rect.Height;
+                y1 = pack.Rect.Top + z;
+            }
+            else
+            {
+                x1 += pack.Rect.X;
+                y1 += pack.Rect.Y;
+            }
+        }
+
+        var pixel = new Microsoft.Xna.Framework.Color[1];
+        tex?.GetData(0, new Rectangle(x1, y1, 1, 1), pixel, 0, 1);
+
+        return new Color(pixel[0].A, pixel[0].R, pixel[0].G, pixel[0].B);
+    }
+
+    public override GameTexturePackFrame GetTexturePackFrame()
+    {
+        return mPackFrame;
+    }
+
+    public void Update()
+    {
+        if (_doNotFree)
+        {
+            return;
+        }
+
+        if (mTexture == null)
+        {
+            return;
+        }
+
+        if (mLastAccessTime >= Timing.Global.MillisecondsUtc)
+        {
+            return;
+        }
+
+        mTexture.Dispose();
+        mTexture = null;
+    }
+
+    public static MonoTexture CreateFromTexture2D(Texture2D texture2D, string assetName)
+    {
+        return new MonoTexture(texture2D, assetName);
     }
 }

--- a/Intersect.Client/MonoGame/Graphics/MonoTileBuffer.cs
+++ b/Intersect.Client/MonoGame/Graphics/MonoTileBuffer.cs
@@ -4,286 +4,284 @@ using Intersect.Client.Framework.Graphics;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client.Classes.MonoGame.Graphics
+namespace Intersect.Client.Classes.MonoGame.Graphics;
+
+
+public partial class MonoTileBuffer : GameTileBuffer
 {
 
-    public partial class MonoTileBuffer : GameTileBuffer
+    private bool disposed;
+
+    private IndexBuffer indexBuffer;
+
+    private List<short> indices = new List<short>();
+
+    private GraphicsDevice mGraphicsDevice;
+
+    private bool updatesPending = false;
+
+    private VertexBuffer vertexBuffer;
+
+    private int vertexCount;
+
+    private Dictionary<Tuple<float, float>, int> verticeDict = new Dictionary<Tuple<float, float>, int>();
+
+    private List<VertexPositionTexture> vertices = new List<VertexPositionTexture>();
+
+    public MonoTileBuffer(GraphicsDevice device)
     {
+        mGraphicsDevice = device;
+    }
 
-        private bool disposed;
+    public override bool Supported { get; } = true;
 
-        private IndexBuffer indexBuffer;
+    public override GameTexture Texture { get; protected set; }
 
-        private List<short> indices = new List<short>();
-
-        private GraphicsDevice mGraphicsDevice;
-
-        private bool updatesPending = false;
-
-        private VertexBuffer vertexBuffer;
-
-        private int vertexCount;
-
-        private Dictionary<Tuple<float, float>, int> verticeDict = new Dictionary<Tuple<float, float>, int>();
-
-        private List<VertexPositionTexture> vertices = new List<VertexPositionTexture>();
-
-        public MonoTileBuffer(GraphicsDevice device)
+    public override bool AddTile(GameTexture tex, float x, float y, int srcX, int srcY, int srcW, int srcH)
+    {
+        var platformTex = tex?.GetTexture();
+        if (platformTex == null)
         {
-            mGraphicsDevice = device;
+            return false;
         }
 
-        public override bool Supported { get; } = true;
-
-        public override GameTexture Texture { get; protected set; }
-
-        public override bool AddTile(GameTexture tex, float x, float y, int srcX, int srcY, int srcW, int srcH)
+        if (Texture == null)
         {
-            var platformTex = tex?.GetTexture();
-            if (platformTex == null)
+            Texture = tex;
+        }
+        else if (Texture.GetTexture() != platformTex)
+        {
+            return false;
+        }
+
+        if (vertexBuffer != null)
+        {
+            return false;
+        }
+
+        var rotated = false;
+        var pack = tex.GetTexturePackFrame();
+        if (pack != null)
+        {
+            if (pack.Rotated)
             {
-                return false;
-            }
+                rotated = true;
 
-            if (Texture == null)
-            {
-                Texture = tex;
-            }
-            else if (Texture.GetTexture() != platformTex)
-            {
-                return false;
-            }
+                var z = srcX;
+                srcX = pack.Rect.Right - srcY - srcH;
+                srcY = pack.Rect.Top + z;
 
-            if (vertexBuffer != null)
-            {
-                return false;
-            }
-
-            var rotated = false;
-            var pack = tex.GetTexturePackFrame();
-            if (pack != null)
-            {
-                if (pack.Rotated)
-                {
-                    rotated = true;
-
-                    var z = srcX;
-                    srcX = pack.Rect.Right - srcY - srcH;
-                    srcY = pack.Rect.Top + z;
-
-                    z = srcW;
-                    srcW = srcH;
-                    srcH = z;
-                }
-                else
-                {
-                    srcX += pack.Rect.X;
-                    srcY += pack.Rect.Y;
-                }
-            }
-
-            var texture = (Texture2D) tex.GetTexture();
-
-            var textureSizeX = 1f / texture.Width;
-            var textureSizeY = 1f / texture.Height;
-
-            var left = srcX * textureSizeX;
-            var right = (srcX + srcW) * textureSizeX;
-            var bottom = (srcY + srcH) * textureSizeY;
-            var top = srcY * textureSizeY;
-
-            verticeDict.Add(new Tuple<float, float>(x, y), vertices.Count);
-
-            if (rotated)
-            {
-                vertices.Add(new VertexPositionTexture(new Vector3(x, y + srcH, 0), new Vector2(left, top)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(right, top)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y + srcH, 0), new Vector2(left, bottom)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, bottom)));
+                z = srcW;
+                srcW = srcH;
+                srcH = z;
             }
             else
             {
-                vertices.Add(new VertexPositionTexture(new Vector3(x, y + srcH, 0), new Vector2(left, bottom)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(left, top)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y + srcH, 0), new Vector2(right, bottom)));
-                vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, top)));
+                srcX += pack.Rect.X;
+                srcY += pack.Rect.Y;
             }
+        }
 
-            indices.Add((short) vertexCount);
-            indices.Add((short) (vertexCount + 1));
-            indices.Add((short) (vertexCount + 2));
+        var texture = (Texture2D) tex.GetTexture();
 
-            indices.Add((short) (vertexCount + 2));
-            indices.Add((short) (vertexCount + 1));
-            indices.Add((short) (vertexCount + 3));
+        var textureSizeX = 1f / texture.Width;
+        var textureSizeY = 1f / texture.Height;
 
-            vertexCount += 4;
+        var left = srcX * textureSizeX;
+        var right = (srcX + srcW) * textureSizeX;
+        var bottom = (srcY + srcH) * textureSizeY;
+        var top = srcY * textureSizeY;
 
+        verticeDict.Add(new Tuple<float, float>(x, y), vertices.Count);
+
+        if (rotated)
+        {
+            vertices.Add(new VertexPositionTexture(new Vector3(x, y + srcH, 0), new Vector2(left, top)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(right, top)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y + srcH, 0), new Vector2(left, bottom)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, bottom)));
+        }
+        else
+        {
+            vertices.Add(new VertexPositionTexture(new Vector3(x, y + srcH, 0), new Vector2(left, bottom)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(left, top)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y + srcH, 0), new Vector2(right, bottom)));
+            vertices.Add(new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, top)));
+        }
+
+        indices.Add((short) vertexCount);
+        indices.Add((short) (vertexCount + 1));
+        indices.Add((short) (vertexCount + 2));
+
+        indices.Add((short) (vertexCount + 2));
+        indices.Add((short) (vertexCount + 1));
+        indices.Add((short) (vertexCount + 3));
+
+        vertexCount += 4;
+
+        return true;
+    }
+
+    public void Draw(BasicEffect basicEffect, FloatRect view)
+    {
+        if (vertexBuffer != null && !disposed)
+        {
+            mGraphicsDevice.SetVertexBuffer(vertexBuffer);
+            mGraphicsDevice.Indices = indexBuffer;
+
+            basicEffect.Texture = (Texture2D) Texture.GetTexture();
+            foreach (var pass in basicEffect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                mGraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertexCount / 2);
+            }
+        }
+    }
+
+    public override bool SetData()
+    {
+        if (vertexBuffer != null && !updatesPending)
+        {
+            return false;
+        }
+
+        if (vertices.Count == 0)
+        {
             return true;
         }
 
-        public void Draw(BasicEffect basicEffect, FloatRect view)
+        TileBufferCount++;
+        if (vertexBuffer == null)
         {
-            if (vertexBuffer != null && !disposed)
-            {
-                mGraphicsDevice.SetVertexBuffer(vertexBuffer);
-                mGraphicsDevice.Indices = indexBuffer;
+            vertexBuffer = new VertexBuffer(
+                mGraphicsDevice, typeof(VertexPositionTexture), vertices.Count, BufferUsage.WriteOnly
+            );
 
-                basicEffect.Texture = (Texture2D) Texture.GetTexture();
-                foreach (var pass in basicEffect.CurrentTechnique.Passes)
-                {
-                    pass.Apply();
-                    mGraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertexCount / 2);
-                }
-            }
+            indexBuffer = new IndexBuffer(mGraphicsDevice, typeof(short), indices.Count, BufferUsage.WriteOnly);
         }
 
-        public override bool SetData()
+        vertexBuffer.SetData(vertices.ToArray());
+        if (!updatesPending)
         {
-            if (vertexBuffer != null && !updatesPending)
-            {
-                return false;
-            }
-
-            if (vertices.Count == 0)
-            {
-                return true;
-            }
-
-            TileBufferCount++;
-            if (vertexBuffer == null)
-            {
-                vertexBuffer = new VertexBuffer(
-                    mGraphicsDevice, typeof(VertexPositionTexture), vertices.Count, BufferUsage.WriteOnly
-                );
-
-                indexBuffer = new IndexBuffer(mGraphicsDevice, typeof(short), indices.Count, BufferUsage.WriteOnly);
-            }
-
-            vertexBuffer.SetData(vertices.ToArray());
-            if (!updatesPending)
-            {
-                indexBuffer.SetData(indices.ToArray());
-            }
-
-            updatesPending = false;
-
-            return true;
+            indexBuffer.SetData(indices.ToArray());
         }
 
-        public override void Dispose()
+        updatesPending = false;
+
+        return true;
+    }
+
+    public override void Dispose()
+    {
+        vertexBuffer?.Dispose();
+        vertexBuffer = null;
+        indexBuffer?.Dispose();
+        indexBuffer = null;
+        TileBufferCount--;
+        disposed = true;
+    }
+
+    public override bool UpdateTile(GameTexture tex, float x, float y, int srcX, int srcY, int srcW, int srcH)
+    {
+        var key = new Tuple<float, float>(x, y);
+        var vertexIndex = -1;
+        if (verticeDict.ContainsKey(key))
         {
-            vertexBuffer?.Dispose();
-            vertexBuffer = null;
-            indexBuffer?.Dispose();
-            indexBuffer = null;
-            TileBufferCount--;
-            disposed = true;
+            vertexIndex = verticeDict[key];
         }
 
-        public override bool UpdateTile(GameTexture tex, float x, float y, int srcX, int srcY, int srcW, int srcH)
+        if (vertexIndex == -1)
         {
-            var key = new Tuple<float, float>(x, y);
-            var vertexIndex = -1;
-            if (verticeDict.ContainsKey(key))
+            return false;
+        }
+
+        var platformTex = tex?.GetTexture();
+        if (platformTex == null)
+        {
+            return false;
+        }
+
+        if (tex == null)
+        {
+            return false;
+        }
+
+        if (tex.GetTexture() != platformTex)
+        {
+            return false;
+        }
+
+        if (vertexBuffer == null)
+        {
+            return false;
+        }
+
+        var pack = tex.GetTexturePackFrame();
+
+        var rotated = false;
+        if (pack != null)
+        {
+            if (pack.Rotated)
             {
-                vertexIndex = verticeDict[key];
-            }
+                rotated = true;
 
-            if (vertexIndex == -1)
-            {
-                return false;
-            }
+                var z = srcX;
+                srcX = pack.Rect.Right - srcY - srcH;
+                srcY = pack.Rect.Top + z;
 
-            var platformTex = tex?.GetTexture();
-            if (platformTex == null)
-            {
-                return false;
-            }
-
-            if (tex == null)
-            {
-                return false;
-            }
-
-            if (tex.GetTexture() != platformTex)
-            {
-                return false;
-            }
-
-            if (vertexBuffer == null)
-            {
-                return false;
-            }
-
-            var pack = tex.GetTexturePackFrame();
-
-            var rotated = false;
-            if (pack != null)
-            {
-                if (pack.Rotated)
-                {
-                    rotated = true;
-
-                    var z = srcX;
-                    srcX = pack.Rect.Right - srcY - srcH;
-                    srcY = pack.Rect.Top + z;
-
-                    z = srcW;
-                    srcW = srcH;
-                    srcH = z;
-                }
-                else
-                {
-                    srcX += pack.Rect.X;
-                    srcY += pack.Rect.Y;
-                }
-            }
-
-            var texture = (Texture2D) tex.GetTexture();
-
-            var textureSizeX = 1f / texture.Width;
-            var textureSizeY = 1f / texture.Height;
-
-            var left = srcX * textureSizeX;
-            var right = (srcX + srcW) * textureSizeX;
-            var bottom = (srcY + srcH) * textureSizeY;
-            var top = srcY * textureSizeY;
-
-            if (rotated)
-            {
-                vertices[vertexIndex++] = new VertexPositionTexture(
-                    new Vector3(x, y + srcH, 0), new Vector2(left, top)
-                );
-
-                vertices[vertexIndex++] = new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(right, top));
-                vertices[vertexIndex++] = new VertexPositionTexture(
-                    new Vector3(x + srcW, y + srcH, 0), new Vector2(left, bottom)
-                );
-
-                vertices[vertexIndex] = new VertexPositionTexture(
-                    new Vector3(x + srcW, y, 0), new Vector2(right, bottom)
-                );
+                z = srcW;
+                srcW = srcH;
+                srcH = z;
             }
             else
             {
-                vertices[vertexIndex++] = new VertexPositionTexture(
-                    new Vector3(x, y + srcH, 0), new Vector2(left, bottom)
-                );
-
-                vertices[vertexIndex++] = new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(left, top));
-                vertices[vertexIndex++] = new VertexPositionTexture(
-                    new Vector3(x + srcW, y + srcH, 0), new Vector2(right, bottom)
-                );
-
-                vertices[vertexIndex] = new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, top));
+                srcX += pack.Rect.X;
+                srcY += pack.Rect.Y;
             }
-
-            updatesPending = true;
-
-            return true;
         }
 
+        var texture = (Texture2D) tex.GetTexture();
+
+        var textureSizeX = 1f / texture.Width;
+        var textureSizeY = 1f / texture.Height;
+
+        var left = srcX * textureSizeX;
+        var right = (srcX + srcW) * textureSizeX;
+        var bottom = (srcY + srcH) * textureSizeY;
+        var top = srcY * textureSizeY;
+
+        if (rotated)
+        {
+            vertices[vertexIndex++] = new VertexPositionTexture(
+                new Vector3(x, y + srcH, 0), new Vector2(left, top)
+            );
+
+            vertices[vertexIndex++] = new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(right, top));
+            vertices[vertexIndex++] = new VertexPositionTexture(
+                new Vector3(x + srcW, y + srcH, 0), new Vector2(left, bottom)
+            );
+
+            vertices[vertexIndex] = new VertexPositionTexture(
+                new Vector3(x + srcW, y, 0), new Vector2(right, bottom)
+            );
+        }
+        else
+        {
+            vertices[vertexIndex++] = new VertexPositionTexture(
+                new Vector3(x, y + srcH, 0), new Vector2(left, bottom)
+            );
+
+            vertices[vertexIndex++] = new VertexPositionTexture(new Vector3(x, y, 0), new Vector2(left, top));
+            vertices[vertexIndex++] = new VertexPositionTexture(
+                new Vector3(x + srcW, y + srcH, 0), new Vector2(right, bottom)
+            );
+
+            vertices[vertexIndex] = new VertexPositionTexture(new Vector3(x + srcW, y, 0), new Vector2(right, top));
+        }
+
+        updatesPending = true;
+
+        return true;
     }
 
 }

--- a/Intersect.Client/MonoGame/Input/MonoClipboard.cs
+++ b/Intersect.Client/MonoGame/Input/MonoClipboard.cs
@@ -1,20 +1,19 @@
 using Intersect.Client.Framework.Input;
 using Intersect.Client.MonoGame.NativeInterop;
 
-namespace Intersect.Client.MonoGame.Input
+namespace Intersect.Client.MonoGame.Input;
+
+public partial class MonoClipboard : GameClipboard
 {
-    public partial class MonoClipboard : GameClipboard
-    {
-        /// <inheritdoc />
-        public override void SetText(string data) => Sdl2.SDL_SetClipboardText(data);
+    /// <inheritdoc />
+    public override void SetText(string data) => Sdl2.SDL_SetClipboardText(data);
 
-        /// <inheritdoc />
-        public override string GetText() => Sdl2.SDL_GetClipboardText();
+    /// <inheritdoc />
+    public override string GetText() => Sdl2.SDL_GetClipboardText();
 
-        /// <inheritdoc />
-        public override bool IsEmpty => string.IsNullOrEmpty(GetText());
+    /// <inheritdoc />
+    public override bool IsEmpty => string.IsNullOrEmpty(GetText());
 
-        /// <inheritdoc />
-        public override bool IsEnabled => Sdl2.IsClipboardSupported;
-    }
+    /// <inheritdoc />
+    public override bool IsEnabled => Sdl2.IsClipboardSupported;
 }

--- a/Intersect.Client/MonoGame/Input/MonoInput.cs
+++ b/Intersect.Client/MonoGame/Input/MonoInput.cs
@@ -14,447 +14,445 @@ using Microsoft.Xna.Framework.Input;
 using Keys = Intersect.Client.Framework.GenericClasses.Keys;
 using Rectangle = Intersect.Client.Framework.GenericClasses.Rectangle;
 
-namespace Intersect.Client.MonoGame.Input
+namespace Intersect.Client.MonoGame.Input;
+
+
+public partial class MonoInput : GameInput
 {
 
-    public partial class MonoInput : GameInput
+    private Dictionary<Keys, Microsoft.Xna.Framework.Input.Keys> mKeyDictionary;
+
+    private KeyboardState mLastKeyboardState;
+
+    private MouseState mLastMouseState;
+
+    private int mMouseX;
+
+    private int mMouseY;
+
+    private int mMouseVScroll;
+
+    private int mMouseHScroll;
+
+    private Game mMyGame;
+
+    private readonly GamePadCapabilities[] _gamePadCapabilities =
+        new GamePadCapabilities[GamePad.MaximumGamePadCount];
+
+    private GamePadState _lastGamePadState;
+
+    private int _activeGamePad;
+
+    private bool _keyboardOpened;
+
+    public MonoInput(Game myGame)
     {
-
-        private Dictionary<Keys, Microsoft.Xna.Framework.Input.Keys> mKeyDictionary;
-
-        private KeyboardState mLastKeyboardState;
-
-        private MouseState mLastMouseState;
-
-        private int mMouseX;
-
-        private int mMouseY;
-
-        private int mMouseVScroll;
-
-        private int mMouseHScroll;
-
-        private Game mMyGame;
-
-        private readonly GamePadCapabilities[] _gamePadCapabilities =
-            new GamePadCapabilities[GamePad.MaximumGamePadCount];
-
-        private GamePadState _lastGamePadState;
-
-        private int _activeGamePad;
-
-        private bool _keyboardOpened;
-
-        public MonoInput(Game myGame)
+        myGame.Window.TextInput += Window_TextInput;
+        mMyGame = myGame;
+        mKeyDictionary = new Dictionary<Keys, Microsoft.Xna.Framework.Input.Keys>();
+        foreach (Keys key in Enum.GetValues(typeof(Keys)))
         {
-            myGame.Window.TextInput += Window_TextInput;
-            mMyGame = myGame;
-            mKeyDictionary = new Dictionary<Keys, Microsoft.Xna.Framework.Input.Keys>();
-            foreach (Keys key in Enum.GetValues(typeof(Keys)))
+            if (!mKeyDictionary.ContainsKey(key))
             {
-                if (!mKeyDictionary.ContainsKey(key))
+                foreach (Microsoft.Xna.Framework.Input.Keys monoKey in Enum.GetValues(
+                    typeof(Microsoft.Xna.Framework.Input.Keys)
+                ))
                 {
-                    foreach (Microsoft.Xna.Framework.Input.Keys monoKey in Enum.GetValues(
-                        typeof(Microsoft.Xna.Framework.Input.Keys)
-                    ))
+                    if (key == Keys.Shift)
                     {
-                        if (key == Keys.Shift)
+                        mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.LeftShift);
+
+                        break;
+                    }
+
+                    if (key == Keys.Control || key == Keys.LControlKey)
+                    {
+                        mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.LeftControl);
+
+                        break;
+                    }
+
+                    if (key == Keys.RControlKey)
+                    {
+                        mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.RightControl);
+
+                        break;
+                    }
+
+                    if (key == Keys.Return)
+                    {
+                        mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.Enter);
+
+                        break;
+                    }
+                    else
+                    {
+                        if (key.ToString() == monoKey.ToString())
                         {
-                            mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.LeftShift);
+                            mKeyDictionary.Add(key, monoKey);
 
                             break;
                         }
-
-                        if (key == Keys.Control || key == Keys.LControlKey)
-                        {
-                            mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.LeftControl);
-
-                            break;
-                        }
-
-                        if (key == Keys.RControlKey)
-                        {
-                            mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.RightControl);
-
-                            break;
-                        }
-
-                        if (key == Keys.Return)
-                        {
-                            mKeyDictionary.Add(key, Microsoft.Xna.Framework.Input.Keys.Enter);
-
-                            break;
-                        }
-                        else
-                        {
-                            if (key.ToString() == monoKey.ToString())
-                            {
-                                mKeyDictionary.Add(key, monoKey);
-
-                                break;
-                            }
-                        }
                     }
                 }
-
-                if (!mKeyDictionary.ContainsKey(key))
-                {
-                    Debug.WriteLine("Mono does not have a key to match: " + key);
-                }
             }
 
-            InputHandler.FocusChanged += InputHandlerOnFocusChanged;
-        }
-
-        private void InputHandlerOnFocusChanged(Base? control, FocusSource focusSource)
-        {
-            if (control == default)
+            if (!mKeyDictionary.ContainsKey(key))
             {
-                return;
-            }
-
-            if (focusSource == FocusSource.Mouse)
-            {
-                return;
-            }
-
-            Vector2 center = new(
-                (control.BoundsGlobal.Left + control.BoundsGlobal.Right) / 2f,
-                (control.BoundsGlobal.Bottom + control.BoundsGlobal.Top) / 2f
-            );
-
-            Mouse.SetPosition((int)center.X, (int)center.Y);
-            var mouseState = Mouse.GetState();
-            Interface.Interface.GwenInput.ProcessMessage(
-                new GwenInputMessage(IntersectInput.InputEvent.MouseMove, new Pointf(mouseState.X, mouseState.Y), (int)MouseButtons.None, Keys.Alt)
-            );
-        }
-
-        private void Window_TextInput(object sender, TextInputEventArgs e)
-        {
-            Interface.Interface.GwenInput.ProcessMessage(
-                new GwenInputMessage(
-                    IntersectInput.InputEvent.TextEntered, GetMousePosition(), (int) MouseButtons.None, Keys.Alt, false,
-                    false, false, e.Character.ToString()
-                )
-            );
-        }
-
-        public override bool MouseButtonDown(MouseButtons mb)
-        {
-            switch (mb)
-            {
-                case MouseButtons.Left:
-                    return mLastMouseState.LeftButton == ButtonState.Pressed;
-                case MouseButtons.Right:
-                    return mLastMouseState.RightButton == ButtonState.Pressed;
-                case MouseButtons.Middle:
-                    return mLastMouseState.MiddleButton == ButtonState.Pressed;
-                case MouseButtons.X1:
-                    return mLastMouseState.XButton1 == ButtonState.Pressed;
-                case MouseButtons.X2:
-                    return mLastMouseState.XButton2 == ButtonState.Pressed;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mb), mb, null);
+                Debug.WriteLine("Mono does not have a key to match: " + key);
             }
         }
 
-        public override bool KeyDown(Keys key)
-        {
-            if (mKeyDictionary.ContainsKey(key))
-            {
-                if (mLastKeyboardState.IsKeyDown(mKeyDictionary[key]))
-                {
-                    return true;
-                }
-            }
+        InputHandler.FocusChanged += InputHandlerOnFocusChanged;
+    }
 
-            return false;
+    private void InputHandlerOnFocusChanged(Base? control, FocusSource focusSource)
+    {
+        if (control == default)
+        {
+            return;
         }
 
-        public override Pointf GetMousePosition()
+        if (focusSource == FocusSource.Mouse)
         {
-            return new Pointf(mMouseX, mMouseY);
+            return;
         }
 
-        private void CheckMouseButton(Keys modifier, ButtonState bs, MouseButtons mb)
+        Vector2 center = new(
+            (control.BoundsGlobal.Left + control.BoundsGlobal.Right) / 2f,
+            (control.BoundsGlobal.Bottom + control.BoundsGlobal.Top) / 2f
+        );
+
+        Mouse.SetPosition((int)center.X, (int)center.Y);
+        var mouseState = Mouse.GetState();
+        Interface.Interface.GwenInput.ProcessMessage(
+            new GwenInputMessage(IntersectInput.InputEvent.MouseMove, new Pointf(mouseState.X, mouseState.Y), (int)MouseButtons.None, Keys.Alt)
+        );
+    }
+
+    private void Window_TextInput(object sender, TextInputEventArgs e)
+    {
+        Interface.Interface.GwenInput.ProcessMessage(
+            new GwenInputMessage(
+                IntersectInput.InputEvent.TextEntered, GetMousePosition(), (int) MouseButtons.None, Keys.Alt, false,
+                false, false, e.Character.ToString()
+            )
+        );
+    }
+
+    public override bool MouseButtonDown(MouseButtons mb)
+    {
+        switch (mb)
         {
-            if (Globals.GameState == GameStates.Intro)
-            {
-                return; //No mouse input allowed while showing intro slides
-            }
-
-            if (bs == ButtonState.Pressed && !MouseButtonDown(mb))
-            {
-                Interface.Interface.GwenInput.ProcessMessage(
-                    new GwenInputMessage(IntersectInput.InputEvent.MouseDown, GetMousePosition(), (int) mb, Keys.Alt)
-                );
-
-                Core.Input.OnMouseDown(modifier, mb);
-            }
-            else if (bs == ButtonState.Released && MouseButtonDown(mb))
-            {
-                Interface.Interface.GwenInput.ProcessMessage(
-                    new GwenInputMessage(IntersectInput.InputEvent.MouseUp, GetMousePosition(), (int) mb, Keys.Alt)
-                );
-
-                Core.Input.OnMouseUp(modifier, mb);
-            }
-        }
-
-        private void CheckMouseScrollWheel(int scrlVValue, int scrlHValue)
-        {
-            Pointf p = new Pointf(0, 0);
-
-            if (scrlVValue != mMouseVScroll || scrlHValue != mMouseHScroll)
-            {
-                p = new Pointf(scrlHValue - mMouseHScroll, scrlVValue - mMouseVScroll);
-
-                Interface.Interface.GwenInput.ProcessMessage(
-                    new GwenInputMessage(IntersectInput.InputEvent.MouseScroll, p, (int)MouseButtons.Middle, Keys.Alt)
-                );
-
-                mMouseVScroll = scrlVValue;
-                mMouseHScroll = scrlHValue;
-            }
-        }
-
-        public override void Update(TimeSpan elapsed)
-        {
-            if (mMyGame.IsActive)
-            {
-                if (_keyboardOpened)
-                {
-                    Steam.PumpEvents();
-                }
-
-                var gamePadCapabilities = Enumerable.Range(0, GamePad.MaximumGamePadCount)
-                    .Select(GamePad.GetCapabilities)
-                    .ToArray();
-
-                Array.Copy(
-                    gamePadCapabilities,
-                    _gamePadCapabilities,
-                    Math.Min(gamePadCapabilities.Length, _gamePadCapabilities.Length)
-                );
-
-                var gamePadState = Enumerable
-                    .Range(0, GamePad.MaximumGamePadCount)
-                    .Select(GamePad.GetState)
-                    .Skip(_activeGamePad)
-                    .FirstOrDefault(gamePad => gamePad.IsConnected);
-
-                if (gamePadState.IsConnected)
-                {
-                    var deltaX = (int)(gamePadState.ThumbSticks.Right.X * elapsed.TotalSeconds * 1000);
-                    var deltaY = (int)(-gamePadState.ThumbSticks.Right.Y * elapsed.TotalSeconds * 1000);
-
-                    var temporaryMouseState = Mouse.GetState();
-                    Mouse.SetPosition(temporaryMouseState.X + deltaX, temporaryMouseState.Y + deltaY);
-                }
-
-                var keyboardState = Keyboard.GetState();
-                var mouseState = Mouse.GetState();
-
-                if (mouseState.X != mMouseX || mouseState.Y != mMouseY)
-                {
-                    mMouseX = (int)(mouseState.X * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().X);
-                    mMouseY = (int)(mouseState.Y * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().Y);
-                    Interface.Interface.GwenInput.ProcessMessage(
-                        new GwenInputMessage(
-                            IntersectInput.InputEvent.MouseMove, GetMousePosition(), (int)MouseButtons.None, Keys.Alt
-                        )
-                    );
-                }
-
-                if (gamePadState.IsConnected)
-                {
-                    var leftMouseButton = gamePadState.Buttons.A == ButtonState.Released
-                        ? mouseState.LeftButton
-                        : ButtonState.Pressed;
-
-                    var rightMouseButton = gamePadState.Buttons.B == ButtonState.Released
-                        ? mouseState.RightButton
-                        : ButtonState.Pressed;
-
-                    mouseState = new MouseState(
-                        mouseState.X,
-                        mouseState.Y,
-                        mouseState.ScrollWheelValue,
-                        leftMouseButton,
-                        mouseState.MiddleButton,
-                        rightMouseButton,
-                        mouseState.XButton1,
-                        mouseState.XButton2,
-                        mouseState.HorizontalScrollWheelValue
-                    );
-
-                    var gamePadKeys = Enum.GetValues<Buttons>()
-                        .Where(gamePadState.IsButtonDown)
-                        .Select(
-                            button => button switch
-                            {
-                                Buttons.None => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.DPadUp => Microsoft.Xna.Framework.Input.Keys.Up,
-                                Buttons.DPadDown => Microsoft.Xna.Framework.Input.Keys.Down,
-                                Buttons.DPadLeft => Microsoft.Xna.Framework.Input.Keys.Left,
-                                Buttons.DPadRight => Microsoft.Xna.Framework.Input.Keys.Right,
-                                Buttons.Start => Microsoft.Xna.Framework.Input.Keys.Escape,
-                                Buttons.Back => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftStick => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightStick => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftShoulder => Microsoft.Xna.Framework.Input.Keys.Back,
-                                Buttons.RightShoulder => Microsoft.Xna.Framework.Input.Keys.Tab,
-                                Buttons.BigButton => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.A => Microsoft.Xna.Framework.Input.Keys.Enter,
-                                Buttons.B => Microsoft.Xna.Framework.Input.Keys.Back,
-                                Buttons.X => Microsoft.Xna.Framework.Input.Keys.E,
-                                Buttons.Y => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftThumbstickLeft => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightTrigger => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftTrigger => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightThumbstickUp => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightThumbstickDown => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightThumbstickRight => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.RightThumbstickLeft => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftThumbstickUp => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftThumbstickDown => Microsoft.Xna.Framework.Input.Keys.None,
-                                Buttons.LeftThumbstickRight => Microsoft.Xna.Framework.Input.Keys.None,
-                                _ => throw new ArgumentOutOfRangeException(nameof(button), button, null)
-                            }
-                        );
-
-                    keyboardState = new KeyboardState(
-                        keyboardState.GetPressedKeys().Concat(gamePadKeys).ToArray(),
-                        keyboardState.CapsLock,
-                        keyboardState.NumLock
-                    );
-                }
-
-                // Get what modifier key we're currently pressing.
-                var modifier = GetPressedModifier(keyboardState);
-
-                //Check for state changes in the left mouse button
-                CheckMouseButton(modifier, mouseState.LeftButton, MouseButtons.Left);
-                CheckMouseButton(modifier, mouseState.RightButton, MouseButtons.Right);
-                CheckMouseButton(modifier, mouseState.MiddleButton, MouseButtons.Middle);
-                CheckMouseButton(modifier, mouseState.XButton1, MouseButtons.X1);
-                CheckMouseButton(modifier, mouseState.XButton2, MouseButtons.X2);
-
-                CheckMouseScrollWheel(mouseState.ScrollWheelValue, mouseState.HorizontalScrollWheelValue);
-
-                foreach (var key in mKeyDictionary)
-                {
-                    if (keyboardState.IsKeyDown(key.Value) && !mLastKeyboardState.IsKeyDown(key.Value))
-                    {
-                        Log.Diagnostic("{0} -> {1}", key.Key, key.Value);
-                        Interface.Interface.GwenInput.ProcessMessage(
-                            new GwenInputMessage(
-                                IntersectInput.InputEvent.KeyDown, GetMousePosition(), (int) MouseButtons.None, key.Key
-                            )
-                        );
-
-                        Core.Input.OnKeyPressed(modifier, key.Key);
-                    }
-                    else if (!keyboardState.IsKeyDown(key.Value) && mLastKeyboardState.IsKeyDown(key.Value))
-                    {
-                        Interface.Interface.GwenInput.ProcessMessage(
-                            new GwenInputMessage(
-                                IntersectInput.InputEvent.KeyUp, GetMousePosition(), (int) MouseButtons.None, key.Key
-                            )
-                        );
-
-                        Core.Input.OnKeyReleased(modifier, key.Key);
-                    }
-                }
-
-                mLastKeyboardState = keyboardState;
-                mLastMouseState = mouseState;
-                _lastGamePadState = gamePadState;
-            }
-            else
-            {
-                var modifier = GetPressedModifier(mLastKeyboardState);
-
-                foreach (var key in mKeyDictionary)
-                {
-                    if (mLastKeyboardState.IsKeyDown(key.Value))
-                    {
-                        Interface.Interface.GwenInput.ProcessMessage(
-                            new GwenInputMessage(
-                                IntersectInput.InputEvent.KeyUp, GetMousePosition(), (int) MouseButtons.None, key.Key
-                            )
-                        );
-
-                        Core.Input.OnKeyReleased(modifier, key.Key);
-                    }
-                }
-
-                CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Left);
-                CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Right);
-                CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Middle);
-                CheckMouseButton(modifier, ButtonState.Released, MouseButtons.X1);
-                CheckMouseButton(modifier, ButtonState.Released, MouseButtons.X2);
-                mLastKeyboardState = new KeyboardState();
-                mLastMouseState = new MouseState();
-            }
-        }
-
-        public Keys GetPressedModifier(KeyboardState state)
-        {
-            var modifier = Keys.None;
-            if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftControl) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightControl))
-            {
-                modifier = Keys.Control;
-            }
-
-            if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift))
-            {
-                modifier = Keys.Shift;
-            }
-
-            if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftAlt) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightAlt))
-            {
-                modifier = Keys.Alt;
-            }
-
-            return modifier;
-        }
-        public override void OpenKeyboard(
-            KeyboardType type,
-            string text,
-            bool autoCorrection,
-            bool multiLine,
-            bool secure
-        )
-        {
-            return; //no on screen keyboard for pc clients
-        }
-
-        public override void OpenKeyboard(
-            KeyboardType keyboardType,
-            Action<string?> inputHandler,
-            string description,
-            string text,
-            bool multiline = false,
-            uint maxLength = 1024,
-            Rectangle? inputBounds = default
-        )
-        {
-            if (!Steam.SteamDeck)
-            {
-                return;
-            }
-
-            _keyboardOpened = Steam.ShowKeyboard(
-                inputHandler,
-                description,
-                existingInput: text,
-                keyboardType == KeyboardType.Password,
-                maxLength,
-                inputBounds
-            );
+            case MouseButtons.Left:
+                return mLastMouseState.LeftButton == ButtonState.Pressed;
+            case MouseButtons.Right:
+                return mLastMouseState.RightButton == ButtonState.Pressed;
+            case MouseButtons.Middle:
+                return mLastMouseState.MiddleButton == ButtonState.Pressed;
+            case MouseButtons.X1:
+                return mLastMouseState.XButton1 == ButtonState.Pressed;
+            case MouseButtons.X2:
+                return mLastMouseState.XButton2 == ButtonState.Pressed;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mb), mb, null);
         }
     }
 
+    public override bool KeyDown(Keys key)
+    {
+        if (mKeyDictionary.ContainsKey(key))
+        {
+            if (mLastKeyboardState.IsKeyDown(mKeyDictionary[key]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public override Pointf GetMousePosition()
+    {
+        return new Pointf(mMouseX, mMouseY);
+    }
+
+    private void CheckMouseButton(Keys modifier, ButtonState bs, MouseButtons mb)
+    {
+        if (Globals.GameState == GameStates.Intro)
+        {
+            return; //No mouse input allowed while showing intro slides
+        }
+
+        if (bs == ButtonState.Pressed && !MouseButtonDown(mb))
+        {
+            Interface.Interface.GwenInput.ProcessMessage(
+                new GwenInputMessage(IntersectInput.InputEvent.MouseDown, GetMousePosition(), (int) mb, Keys.Alt)
+            );
+
+            Core.Input.OnMouseDown(modifier, mb);
+        }
+        else if (bs == ButtonState.Released && MouseButtonDown(mb))
+        {
+            Interface.Interface.GwenInput.ProcessMessage(
+                new GwenInputMessage(IntersectInput.InputEvent.MouseUp, GetMousePosition(), (int) mb, Keys.Alt)
+            );
+
+            Core.Input.OnMouseUp(modifier, mb);
+        }
+    }
+
+    private void CheckMouseScrollWheel(int scrlVValue, int scrlHValue)
+    {
+        Pointf p = new Pointf(0, 0);
+
+        if (scrlVValue != mMouseVScroll || scrlHValue != mMouseHScroll)
+        {
+            p = new Pointf(scrlHValue - mMouseHScroll, scrlVValue - mMouseVScroll);
+
+            Interface.Interface.GwenInput.ProcessMessage(
+                new GwenInputMessage(IntersectInput.InputEvent.MouseScroll, p, (int)MouseButtons.Middle, Keys.Alt)
+            );
+
+            mMouseVScroll = scrlVValue;
+            mMouseHScroll = scrlHValue;
+        }
+    }
+
+    public override void Update(TimeSpan elapsed)
+    {
+        if (mMyGame.IsActive)
+        {
+            if (_keyboardOpened)
+            {
+                Steam.PumpEvents();
+            }
+
+            var gamePadCapabilities = Enumerable.Range(0, GamePad.MaximumGamePadCount)
+                .Select(GamePad.GetCapabilities)
+                .ToArray();
+
+            Array.Copy(
+                gamePadCapabilities,
+                _gamePadCapabilities,
+                Math.Min(gamePadCapabilities.Length, _gamePadCapabilities.Length)
+            );
+
+            var gamePadState = Enumerable
+                .Range(0, GamePad.MaximumGamePadCount)
+                .Select(GamePad.GetState)
+                .Skip(_activeGamePad)
+                .FirstOrDefault(gamePad => gamePad.IsConnected);
+
+            if (gamePadState.IsConnected)
+            {
+                var deltaX = (int)(gamePadState.ThumbSticks.Right.X * elapsed.TotalSeconds * 1000);
+                var deltaY = (int)(-gamePadState.ThumbSticks.Right.Y * elapsed.TotalSeconds * 1000);
+
+                var temporaryMouseState = Mouse.GetState();
+                Mouse.SetPosition(temporaryMouseState.X + deltaX, temporaryMouseState.Y + deltaY);
+            }
+
+            var keyboardState = Keyboard.GetState();
+            var mouseState = Mouse.GetState();
+
+            if (mouseState.X != mMouseX || mouseState.Y != mMouseY)
+            {
+                mMouseX = (int)(mouseState.X * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().X);
+                mMouseY = (int)(mouseState.Y * ((MonoRenderer)Core.Graphics.Renderer).GetMouseOffset().Y);
+                Interface.Interface.GwenInput.ProcessMessage(
+                    new GwenInputMessage(
+                        IntersectInput.InputEvent.MouseMove, GetMousePosition(), (int)MouseButtons.None, Keys.Alt
+                    )
+                );
+            }
+
+            if (gamePadState.IsConnected)
+            {
+                var leftMouseButton = gamePadState.Buttons.A == ButtonState.Released
+                    ? mouseState.LeftButton
+                    : ButtonState.Pressed;
+
+                var rightMouseButton = gamePadState.Buttons.B == ButtonState.Released
+                    ? mouseState.RightButton
+                    : ButtonState.Pressed;
+
+                mouseState = new MouseState(
+                    mouseState.X,
+                    mouseState.Y,
+                    mouseState.ScrollWheelValue,
+                    leftMouseButton,
+                    mouseState.MiddleButton,
+                    rightMouseButton,
+                    mouseState.XButton1,
+                    mouseState.XButton2,
+                    mouseState.HorizontalScrollWheelValue
+                );
+
+                var gamePadKeys = Enum.GetValues<Buttons>()
+                    .Where(gamePadState.IsButtonDown)
+                    .Select(
+                        button => button switch
+                        {
+                            Buttons.None => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.DPadUp => Microsoft.Xna.Framework.Input.Keys.Up,
+                            Buttons.DPadDown => Microsoft.Xna.Framework.Input.Keys.Down,
+                            Buttons.DPadLeft => Microsoft.Xna.Framework.Input.Keys.Left,
+                            Buttons.DPadRight => Microsoft.Xna.Framework.Input.Keys.Right,
+                            Buttons.Start => Microsoft.Xna.Framework.Input.Keys.Escape,
+                            Buttons.Back => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftStick => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightStick => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftShoulder => Microsoft.Xna.Framework.Input.Keys.Back,
+                            Buttons.RightShoulder => Microsoft.Xna.Framework.Input.Keys.Tab,
+                            Buttons.BigButton => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.A => Microsoft.Xna.Framework.Input.Keys.Enter,
+                            Buttons.B => Microsoft.Xna.Framework.Input.Keys.Back,
+                            Buttons.X => Microsoft.Xna.Framework.Input.Keys.E,
+                            Buttons.Y => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftThumbstickLeft => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightTrigger => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftTrigger => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightThumbstickUp => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightThumbstickDown => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightThumbstickRight => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.RightThumbstickLeft => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftThumbstickUp => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftThumbstickDown => Microsoft.Xna.Framework.Input.Keys.None,
+                            Buttons.LeftThumbstickRight => Microsoft.Xna.Framework.Input.Keys.None,
+                            _ => throw new ArgumentOutOfRangeException(nameof(button), button, null)
+                        }
+                    );
+
+                keyboardState = new KeyboardState(
+                    keyboardState.GetPressedKeys().Concat(gamePadKeys).ToArray(),
+                    keyboardState.CapsLock,
+                    keyboardState.NumLock
+                );
+            }
+
+            // Get what modifier key we're currently pressing.
+            var modifier = GetPressedModifier(keyboardState);
+
+            //Check for state changes in the left mouse button
+            CheckMouseButton(modifier, mouseState.LeftButton, MouseButtons.Left);
+            CheckMouseButton(modifier, mouseState.RightButton, MouseButtons.Right);
+            CheckMouseButton(modifier, mouseState.MiddleButton, MouseButtons.Middle);
+            CheckMouseButton(modifier, mouseState.XButton1, MouseButtons.X1);
+            CheckMouseButton(modifier, mouseState.XButton2, MouseButtons.X2);
+
+            CheckMouseScrollWheel(mouseState.ScrollWheelValue, mouseState.HorizontalScrollWheelValue);
+
+            foreach (var key in mKeyDictionary)
+            {
+                if (keyboardState.IsKeyDown(key.Value) && !mLastKeyboardState.IsKeyDown(key.Value))
+                {
+                    Log.Diagnostic("{0} -> {1}", key.Key, key.Value);
+                    Interface.Interface.GwenInput.ProcessMessage(
+                        new GwenInputMessage(
+                            IntersectInput.InputEvent.KeyDown, GetMousePosition(), (int) MouseButtons.None, key.Key
+                        )
+                    );
+
+                    Core.Input.OnKeyPressed(modifier, key.Key);
+                }
+                else if (!keyboardState.IsKeyDown(key.Value) && mLastKeyboardState.IsKeyDown(key.Value))
+                {
+                    Interface.Interface.GwenInput.ProcessMessage(
+                        new GwenInputMessage(
+                            IntersectInput.InputEvent.KeyUp, GetMousePosition(), (int) MouseButtons.None, key.Key
+                        )
+                    );
+
+                    Core.Input.OnKeyReleased(modifier, key.Key);
+                }
+            }
+
+            mLastKeyboardState = keyboardState;
+            mLastMouseState = mouseState;
+            _lastGamePadState = gamePadState;
+        }
+        else
+        {
+            var modifier = GetPressedModifier(mLastKeyboardState);
+
+            foreach (var key in mKeyDictionary)
+            {
+                if (mLastKeyboardState.IsKeyDown(key.Value))
+                {
+                    Interface.Interface.GwenInput.ProcessMessage(
+                        new GwenInputMessage(
+                            IntersectInput.InputEvent.KeyUp, GetMousePosition(), (int) MouseButtons.None, key.Key
+                        )
+                    );
+
+                    Core.Input.OnKeyReleased(modifier, key.Key);
+                }
+            }
+
+            CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Left);
+            CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Right);
+            CheckMouseButton(modifier, ButtonState.Released, MouseButtons.Middle);
+            CheckMouseButton(modifier, ButtonState.Released, MouseButtons.X1);
+            CheckMouseButton(modifier, ButtonState.Released, MouseButtons.X2);
+            mLastKeyboardState = new KeyboardState();
+            mLastMouseState = new MouseState();
+        }
+    }
+
+    public Keys GetPressedModifier(KeyboardState state)
+    {
+        var modifier = Keys.None;
+        if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftControl) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightControl))
+        {
+            modifier = Keys.Control;
+        }
+
+        if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift))
+        {
+            modifier = Keys.Shift;
+        }
+
+        if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftAlt) || state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightAlt))
+        {
+            modifier = Keys.Alt;
+        }
+
+        return modifier;
+    }
+    public override void OpenKeyboard(
+        KeyboardType type,
+        string text,
+        bool autoCorrection,
+        bool multiLine,
+        bool secure
+    )
+    {
+        return; //no on screen keyboard for pc clients
+    }
+
+    public override void OpenKeyboard(
+        KeyboardType keyboardType,
+        Action<string?> inputHandler,
+        string description,
+        string text,
+        bool multiline = false,
+        uint maxLength = 1024,
+        Rectangle? inputBounds = default
+    )
+    {
+        if (!Steam.SteamDeck)
+        {
+            return;
+        }
+
+        _keyboardOpened = Steam.ShowKeyboard(
+            inputHandler,
+            description,
+            existingInput: text,
+            keyboardType == KeyboardType.Password,
+            maxLength,
+            inputBounds
+        );
+    }
 }

--- a/Intersect.Client/MonoGame/NativeInterop/DllLoader.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/DllLoader.cs
@@ -1,129 +1,128 @@
 using System.Runtime.InteropServices;
 
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public abstract class DllLoader
 {
-    public abstract class DllLoader
+    public static readonly DllLoader PlatformLoader;
+
+    static DllLoader()
     {
-        public static readonly DllLoader PlatformLoader;
-
-        static DllLoader()
+        switch (PlatformHelper.CurrentPlatform)
         {
-            switch (PlatformHelper.CurrentPlatform)
-            {
-                case Platform.Unknown:
-                    PlatformLoader = new UnixDllLoader();
-                    break;
+            case Platform.Unknown:
+                PlatformLoader = new UnixDllLoader();
+                break;
 
-                case Platform.Linux:
-                    PlatformLoader = new LinuxDllLoader();
-                    break;
+            case Platform.Linux:
+                PlatformLoader = new LinuxDllLoader();
+                break;
 
-                case Platform.MacOS:
-                    PlatformLoader = new MacDllLoader();
-                    break;
+            case Platform.MacOS:
+                PlatformLoader = new MacDllLoader();
+                break;
 
-                case Platform.Windows:
-                    PlatformLoader = new WindowsDllLoader();
-                    break;
+            case Platform.Windows:
+                PlatformLoader = new WindowsDllLoader();
+                break;
 
-                default: throw new IndexOutOfRangeException();
-            }
+            default: throw new IndexOutOfRangeException();
+        }
+    }
+
+    public abstract IntPtr LoadLibrary(string libraryName);
+
+    protected abstract IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName);
+
+    public virtual TDelegate LoadFunction<TDelegate>(IntPtr libraryHandle, string functionName)
+    {
+        var functionPointer = LoadFunctionPointer(libraryHandle, functionName);
+        return functionPointer == default
+            ? default
+            : Marshal.GetDelegateForFunctionPointer<TDelegate>(functionPointer);
+    }
+
+    private sealed class WindowsDllLoader : DllLoader
+    {
+        [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+
+        [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr LoadLibraryW(string lpszLib);
+
+        public override IntPtr LoadLibrary(string libraryName)
+        {
+            return LoadLibraryW(libraryName);
         }
 
-        public abstract IntPtr LoadLibrary(string libraryName);
-
-        protected abstract IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName);
-
-        public virtual TDelegate LoadFunction<TDelegate>(IntPtr libraryHandle, string functionName)
+        protected override IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName)
         {
-            var functionPointer = LoadFunctionPointer(libraryHandle, functionName);
-            return functionPointer == default
-                ? default
-                : Marshal.GetDelegateForFunctionPointer<TDelegate>(functionPointer);
+            return GetProcAddress(libraryHandle, functionName);
+        }
+    }
+
+    private sealed class MacDllLoader : UnixDllLoader
+    {
+        public MacDllLoader() : base(dlopen, dlsym) { }
+
+        [DllImport("/usr/lib/libSystem.dylib")]
+        private static extern IntPtr dlopen(string path, int flags);
+
+        [DllImport("/usr/lib/libSystem.dylib")]
+        private static extern IntPtr dlsym(IntPtr handle, string symbol);
+    }
+
+    private sealed class LinuxDllLoader : UnixDllLoader
+    {
+        public LinuxDllLoader() : base(dlopen, dlsym) { }
+
+        [DllImport("libdl.so.2")]
+        private static extern IntPtr dlopen(string path, int flags);
+
+        [DllImport("libdl.so.2")]
+        private static extern IntPtr dlsym(IntPtr handle, string symbol);
+    }
+
+    private class UnixDllLoader : DllLoader
+    {
+        protected const int RTLD_LAZY = 0x0001;
+
+        private readonly dlopen_d _dlopen;
+        private readonly dlsym_d _dlsym;
+
+        protected UnixDllLoader(dlopen_d dlopen, dlsym_d dlsym)
+        {
+            _dlopen = dlopen;
+            _dlsym = dlsym;
         }
 
-        private sealed class WindowsDllLoader : DllLoader
+        public UnixDllLoader() : this(dlopen, dlsym) { }
+
+        [DllImport("libdl")]
+        private static extern IntPtr dlopen(string path, int flags);
+
+        [DllImport("libdl")]
+        private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        public override IntPtr LoadLibrary(string libraryName)
         {
-            [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
-            private static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+            var result = _dlopen(libraryName, RTLD_LAZY);
 
-            [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
-            private static extern IntPtr LoadLibraryW(string lpszLib);
-
-            public override IntPtr LoadLibrary(string libraryName)
+            if (result == default)
             {
-                return LoadLibraryW(libraryName);
+                result = _dlopen(Path.Combine(Environment.CurrentDirectory, libraryName), RTLD_LAZY);
             }
 
-            protected override IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName)
-            {
-                return GetProcAddress(libraryHandle, functionName);
-            }
+            return result;
         }
 
-        private sealed class MacDllLoader : UnixDllLoader
+        protected override IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName)
         {
-            public MacDllLoader() : base(dlopen, dlsym) { }
-
-            [DllImport("/usr/lib/libSystem.dylib")]
-            private static extern IntPtr dlopen(string path, int flags);
-
-            [DllImport("/usr/lib/libSystem.dylib")]
-            private static extern IntPtr dlsym(IntPtr handle, string symbol);
+            return _dlsym(libraryHandle, functionName);
         }
 
-        private sealed class LinuxDllLoader : UnixDllLoader
-        {
-            public LinuxDllLoader() : base(dlopen, dlsym) { }
+        protected delegate IntPtr dlopen_d(string path, int flags);
 
-            [DllImport("libdl.so.2")]
-            private static extern IntPtr dlopen(string path, int flags);
-
-            [DllImport("libdl.so.2")]
-            private static extern IntPtr dlsym(IntPtr handle, string symbol);
-        }
-
-        private class UnixDllLoader : DllLoader
-        {
-            protected const int RTLD_LAZY = 0x0001;
-
-            private readonly dlopen_d _dlopen;
-            private readonly dlsym_d _dlsym;
-
-            protected UnixDllLoader(dlopen_d dlopen, dlsym_d dlsym)
-            {
-                _dlopen = dlopen;
-                _dlsym = dlsym;
-            }
-
-            public UnixDllLoader() : this(dlopen, dlsym) { }
-
-            [DllImport("libdl")]
-            private static extern IntPtr dlopen(string path, int flags);
-
-            [DllImport("libdl")]
-            private static extern IntPtr dlsym(IntPtr handle, string symbol);
-
-            public override IntPtr LoadLibrary(string libraryName)
-            {
-                var result = _dlopen(libraryName, RTLD_LAZY);
-
-                if (result == default)
-                {
-                    result = _dlopen(Path.Combine(Environment.CurrentDirectory, libraryName), RTLD_LAZY);
-                }
-
-                return result;
-            }
-
-            protected override IntPtr LoadFunctionPointer(IntPtr libraryHandle, string functionName)
-            {
-                return _dlsym(libraryHandle, functionName);
-            }
-
-            protected delegate IntPtr dlopen_d(string path, int flags);
-
-            protected delegate IntPtr dlsym_d(IntPtr handle, string symbol);
-        }
+        protected delegate IntPtr dlsym_d(IntPtr handle, string symbol);
     }
 }

--- a/Intersect.Client/MonoGame/NativeInterop/FunctionLoader.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/FunctionLoader.cs
@@ -1,70 +1,69 @@
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public sealed class FunctionLoader
 {
-    public sealed class FunctionLoader
+    private readonly IntPtr _libraryHandle;
+
+    private FunctionLoader(IntPtr libraryHandle)
     {
-        private readonly IntPtr _libraryHandle;
+        _libraryHandle = libraryHandle;
+    }
 
-        private FunctionLoader(IntPtr libraryHandle)
+    public FunctionLoader(string name) : this(DllLoader.PlatformLoader.LoadLibrary(name))
+    {
+    }
+
+    public FunctionLoader(KnownLibrary knownLibrary) : this(ResolveKnownLibrary(knownLibrary))
+    {
+    }
+
+    public TDelegate LoadFunction<TDelegate>(string functionName)
+    {
+        return DllLoader.PlatformLoader.LoadFunction<TDelegate>(_libraryHandle, functionName);
+    }
+
+    private static string ResolveKnownLibrary(KnownLibrary knownLibrary)
+    {
+        switch (knownLibrary)
         {
-            _libraryHandle = libraryHandle;
-        }
+            case KnownLibrary.OpenAL:
+                switch (PlatformHelper.CurrentPlatform)
+                {
+                    /* Fall-back to Linux if the platform is unknown */
+                    case Platform.Unknown:
+                    case Platform.Linux:
+                        return "libopenal.so.1";
 
-        public FunctionLoader(string name) : this(DllLoader.PlatformLoader.LoadLibrary(name))
-        {
-        }
+                    case Platform.MacOS: return "libopenal.1.dylib";
+                    case Platform.Windows: return "soft_oal.dll";
+                    default: throw new IndexOutOfRangeException();
+                }
 
-        public FunctionLoader(KnownLibrary knownLibrary) : this(ResolveKnownLibrary(knownLibrary))
-        {
-        }
+            case KnownLibrary.SDL2:
+                switch (PlatformHelper.CurrentPlatform)
+                {
+                    /* Fall-back to Linux if the platform is unknown */
+                    case Platform.Unknown:
+                    case Platform.Linux:
+                        return "libSDL2-2.0.so.0";
 
-        public TDelegate LoadFunction<TDelegate>(string functionName)
-        {
-            return DllLoader.PlatformLoader.LoadFunction<TDelegate>(_libraryHandle, functionName);
-        }
+                    case Platform.MacOS: return "libSDL2.dylib";
+                    case Platform.Windows: return "SDL2.dll";
+                    default: throw new IndexOutOfRangeException();
+                }
 
-        private static string ResolveKnownLibrary(KnownLibrary knownLibrary)
-        {
-            switch (knownLibrary)
-            {
-                case KnownLibrary.OpenAL:
-                    switch (PlatformHelper.CurrentPlatform)
-                    {
-                        /* Fall-back to Linux if the platform is unknown */
-                        case Platform.Unknown:
-                        case Platform.Linux:
-                            return "libopenal.so.1";
+            case KnownLibrary.steam_api:
+                return PlatformHelper.CurrentPlatform switch
+                {
+                    Platform.Unknown => "libsteam_api.so",
+                    Platform.Linux => "libsteam_api.so",
+                    Platform.MacOS => "libsteam_api.dylib",
+                    Platform.Windows => "steam_api64.dll",
+                    _ => throw new IndexOutOfRangeException(),
+                };
 
-                        case Platform.MacOS: return "libopenal.1.dylib";
-                        case Platform.Windows: return "soft_oal.dll";
-                        default: throw new IndexOutOfRangeException();
-                    }
-
-                case KnownLibrary.SDL2:
-                    switch (PlatformHelper.CurrentPlatform)
-                    {
-                        /* Fall-back to Linux if the platform is unknown */
-                        case Platform.Unknown:
-                        case Platform.Linux:
-                            return "libSDL2-2.0.so.0";
-
-                        case Platform.MacOS: return "libSDL2.dylib";
-                        case Platform.Windows: return "SDL2.dll";
-                        default: throw new IndexOutOfRangeException();
-                    }
-
-                case KnownLibrary.steam_api:
-                    return PlatformHelper.CurrentPlatform switch
-                    {
-                        Platform.Unknown => "libsteam_api.so",
-                        Platform.Linux => "libsteam_api.so",
-                        Platform.MacOS => "libsteam_api.dylib",
-                        Platform.Windows => "steam_api64.dll",
-                        _ => throw new IndexOutOfRangeException(),
-                    };
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(knownLibrary), knownLibrary, null);
-            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(knownLibrary), knownLibrary, null);
         }
     }
 }

--- a/Intersect.Client/MonoGame/NativeInterop/KnownLibrary.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/KnownLibrary.cs
@@ -1,9 +1,8 @@
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public enum KnownLibrary
 {
-    public enum KnownLibrary
-    {
-        OpenAL,
-        SDL2,
-        steam_api,
-    }
+    OpenAL,
+    SDL2,
+    steam_api,
 }

--- a/Intersect.Client/MonoGame/NativeInterop/Platform.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/Platform.cs
@@ -1,10 +1,9 @@
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public enum Platform
 {
-    public enum Platform
-    {
-        Unknown,
-        Linux,
-        MacOS,
-        Windows
-    }
+    Unknown,
+    Linux,
+    MacOS,
+    Windows
 }

--- a/Intersect.Client/MonoGame/NativeInterop/PlatformHelper.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/PlatformHelper.cs
@@ -1,29 +1,28 @@
 using System.Runtime.InteropServices;
 
-namespace Intersect.Client.MonoGame.NativeInterop
-{
-    public static class PlatformHelper
-    {
-        public static readonly Platform CurrentPlatform;
+namespace Intersect.Client.MonoGame.NativeInterop;
 
-        static PlatformHelper()
+public static class PlatformHelper
+{
+    public static readonly Platform CurrentPlatform;
+
+    static PlatformHelper()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                CurrentPlatform = Platform.Windows;
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                CurrentPlatform = Platform.MacOS;
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                CurrentPlatform = Platform.Linux;
-            }
-            else
-            {
-                CurrentPlatform = Platform.Unknown;
-            }
+            CurrentPlatform = Platform.Windows;
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            CurrentPlatform = Platform.MacOS;
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            CurrentPlatform = Platform.Linux;
+        }
+        else
+        {
+            CurrentPlatform = Platform.Unknown;
         }
     }
 }

--- a/Intersect.Client/MonoGame/NativeInterop/Sdl2.Rect.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/Sdl2.Rect.cs
@@ -1,10 +1,9 @@
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public struct SDL_Rect
 {
-    public struct SDL_Rect
-    {
-        public int x;
-        public int y;
-        public int w;
-        public int h;
-    }
+    public int x;
+    public int y;
+    public int w;
+    public int h;
 }

--- a/Intersect.Client/MonoGame/NativeInterop/Sdl2.Video.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/Sdl2.Video.cs
@@ -1,59 +1,58 @@
 using System.Runtime.InteropServices;
 
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public partial class Sdl2
 {
-    public partial class Sdl2
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int SDL_GetNumVideoDisplays_d();
+
+    public static SDL_GetNumVideoDisplays_d SDL_GetNumVideoDisplays =
+        Loader.Functions.LoadFunction<SDL_GetNumVideoDisplays_d>(nameof(SDL_GetNumVideoDisplays));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate int SDL_GetDisplayBounds_d(int displayIndex, SDL_Rect * rect);
+    
+    private static SDL_GetDisplayBounds_d SDL_GetDisplayBounds_f =
+        Loader.Functions.LoadFunction<SDL_GetDisplayBounds_d>(nameof(SDL_GetDisplayBounds));
+
+    public static SDL_Rect SDL_GetDisplayBounds(int displayIndex)
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate int SDL_GetNumVideoDisplays_d();
-
-        public static SDL_GetNumVideoDisplays_d SDL_GetNumVideoDisplays =
-            Loader.Functions.LoadFunction<SDL_GetNumVideoDisplays_d>(nameof(SDL_GetNumVideoDisplays));
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private unsafe delegate int SDL_GetDisplayBounds_d(int displayIndex, SDL_Rect * rect);
-        
-        private static SDL_GetDisplayBounds_d SDL_GetDisplayBounds_f =
-            Loader.Functions.LoadFunction<SDL_GetDisplayBounds_d>(nameof(SDL_GetDisplayBounds));
-
-        public static SDL_Rect SDL_GetDisplayBounds(int displayIndex)
+        if (TryGetDisplayBounds(displayIndex, out var bounds))
         {
-            if (TryGetDisplayBounds(displayIndex, out var bounds))
+            return bounds;
+        }
+
+        throw new Exception(SDL_GetError());
+    }
+
+    public static unsafe bool TryGetDisplayBounds(int displayIndex, out SDL_Rect bounds)
+    {
+        fixed (SDL_Rect* boundsPointer = &bounds)
+        {
+            return SDL_GetDisplayBounds_f(displayIndex, boundsPointer) == 0;
+        }
+    }
+    
+    public static SDL_Rect[] GetDisplayBounds()
+    {
+        var displayCount = SDL_GetNumVideoDisplays();
+        if (displayCount < 1)
+        {
+            throw new Exception(SDL_GetError());
+        }
+
+        var displayBounds = new SDL_Rect[displayCount];
+        for (var displayIndex = 0; displayIndex < displayCount; ++displayIndex)
+        {
+            if (TryGetDisplayBounds(displayIndex, out displayBounds[displayIndex]))
             {
-                return bounds;
+                continue;
             }
 
             throw new Exception(SDL_GetError());
         }
 
-        public static unsafe bool TryGetDisplayBounds(int displayIndex, out SDL_Rect bounds)
-        {
-            fixed (SDL_Rect* boundsPointer = &bounds)
-            {
-                return SDL_GetDisplayBounds_f(displayIndex, boundsPointer) == 0;
-            }
-        }
-        
-        public static SDL_Rect[] GetDisplayBounds()
-        {
-            var displayCount = SDL_GetNumVideoDisplays();
-            if (displayCount < 1)
-            {
-                throw new Exception(SDL_GetError());
-            }
-
-            var displayBounds = new SDL_Rect[displayCount];
-            for (var displayIndex = 0; displayIndex < displayCount; ++displayIndex)
-            {
-                if (TryGetDisplayBounds(displayIndex, out displayBounds[displayIndex]))
-                {
-                    continue;
-                }
-
-                throw new Exception(SDL_GetError());
-            }
-
-            return displayBounds;
-        }
+        return displayBounds;
     }
 }

--- a/Intersect.Client/MonoGame/NativeInterop/Sdl2.cs
+++ b/Intersect.Client/MonoGame/NativeInterop/Sdl2.cs
@@ -1,88 +1,87 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Intersect.Client.MonoGame.NativeInterop
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public static partial class Sdl2
 {
-    public static partial class Sdl2
+    private static class Loader
     {
-        private static class Loader
-        {
-            internal static readonly FunctionLoader Functions = new FunctionLoader(KnownLibrary.SDL2);
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private unsafe delegate byte* SDL_GetError_d();
-
-        private static SDL_GetError_d SDL_GetError_f = Loader.Functions.LoadFunction<SDL_GetError_d>(nameof(SDL_GetError));
-
-        public static unsafe string SDL_GetError()
-        {
-            if (SDL_GetError_f == default)
-            {
-                throw new PlatformNotSupportedException();
-            }
-            
-            var textBytes = SDL_GetError_f();
-            var endTextBytes = textBytes;
-            while (*endTextBytes != default)
-            {
-                ++endTextBytes;
-            }
-
-            var text = Encoding.UTF8.GetString(textBytes, (int)(endTextBytes - textBytes));
-            return text;
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private unsafe delegate void SDL_free_d(void* ptr);
-
-        private static SDL_free_d SDL_free = Loader.Functions.LoadFunction<SDL_free_d>(nameof(SDL_free));
-        
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private unsafe delegate byte* SDL_GetClipboardText_d();
-
-        private static SDL_GetClipboardText_d SDL_GetClipboardText_f =
-            Loader.Functions.LoadFunction<SDL_GetClipboardText_d>(nameof(SDL_GetClipboardText));
-
-        public static unsafe string SDL_GetClipboardText()
-        {
-            if (SDL_GetClipboardText_f == default || SDL_free == default)
-            {
-                throw new PlatformNotSupportedException();
-            }
-            
-            var textBytes = SDL_GetClipboardText_f();
-            var endTextBytes = textBytes;
-            while (*endTextBytes != default)
-            {
-                ++endTextBytes;
-            }
-
-            var text = Encoding.UTF8.GetString(textBytes, (int)(endTextBytes - textBytes));
-            SDL_free(textBytes);
-            return text;
-        }
-        
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private unsafe delegate int SDL_SetClipboardText_d(byte* text);
-
-        private static SDL_SetClipboardText_d SDL_SetClipboardText_f =
-            Loader.Functions.LoadFunction<SDL_SetClipboardText_d>(nameof(SDL_SetClipboardText));
-
-        public static unsafe bool SDL_SetClipboardText(string text)
-        {
-            if (SDL_SetClipboardText_f == default)
-            {
-                throw new PlatformNotSupportedException();
-            }
-            
-            fixed (byte* textBytes = Encoding.UTF8.GetBytes(text))
-            {
-                return SDL_SetClipboardText_f(textBytes) == 0;
-            }
-        }
-
-        public static bool IsClipboardSupported => SDL_GetClipboardText_f != default &&
-                                                   SDL_SetClipboardText_f != default && SDL_free != default;
+        internal static readonly FunctionLoader Functions = new FunctionLoader(KnownLibrary.SDL2);
     }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate byte* SDL_GetError_d();
+
+    private static SDL_GetError_d SDL_GetError_f = Loader.Functions.LoadFunction<SDL_GetError_d>(nameof(SDL_GetError));
+
+    public static unsafe string SDL_GetError()
+    {
+        if (SDL_GetError_f == default)
+        {
+            throw new PlatformNotSupportedException();
+        }
+        
+        var textBytes = SDL_GetError_f();
+        var endTextBytes = textBytes;
+        while (*endTextBytes != default)
+        {
+            ++endTextBytes;
+        }
+
+        var text = Encoding.UTF8.GetString(textBytes, (int)(endTextBytes - textBytes));
+        return text;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate void SDL_free_d(void* ptr);
+
+    private static SDL_free_d SDL_free = Loader.Functions.LoadFunction<SDL_free_d>(nameof(SDL_free));
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate byte* SDL_GetClipboardText_d();
+
+    private static SDL_GetClipboardText_d SDL_GetClipboardText_f =
+        Loader.Functions.LoadFunction<SDL_GetClipboardText_d>(nameof(SDL_GetClipboardText));
+
+    public static unsafe string SDL_GetClipboardText()
+    {
+        if (SDL_GetClipboardText_f == default || SDL_free == default)
+        {
+            throw new PlatformNotSupportedException();
+        }
+        
+        var textBytes = SDL_GetClipboardText_f();
+        var endTextBytes = textBytes;
+        while (*endTextBytes != default)
+        {
+            ++endTextBytes;
+        }
+
+        var text = Encoding.UTF8.GetString(textBytes, (int)(endTextBytes - textBytes));
+        SDL_free(textBytes);
+        return text;
+    }
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate int SDL_SetClipboardText_d(byte* text);
+
+    private static SDL_SetClipboardText_d SDL_SetClipboardText_f =
+        Loader.Functions.LoadFunction<SDL_SetClipboardText_d>(nameof(SDL_SetClipboardText));
+
+    public static unsafe bool SDL_SetClipboardText(string text)
+    {
+        if (SDL_SetClipboardText_f == default)
+        {
+            throw new PlatformNotSupportedException();
+        }
+        
+        fixed (byte* textBytes = Encoding.UTF8.GetBytes(text))
+        {
+            return SDL_SetClipboardText_f(textBytes) == 0;
+        }
+    }
+
+    public static bool IsClipboardSupported => SDL_GetClipboardText_f != default &&
+                                               SDL_SetClipboardText_f != default && SDL_free != default;
 }

--- a/Intersect.Client/MonoGame/Network/MonoSocket.cs
+++ b/Intersect.Client/MonoGame/Network/MonoSocket.cs
@@ -17,260 +17,259 @@ using Intersect.Client.Localization;
 using Intersect.Network.Packets.Unconnected.Client;
 using Intersect.Rsa;
 
-namespace Intersect.Client.MonoGame.Network
+namespace Intersect.Client.MonoGame.Network;
+
+internal partial class MonoSocket : GameSocket
 {
-    internal partial class MonoSocket : GameSocket
-    {
-        internal static NetworkFactory? NetworkFactory { get; set; }
+    internal static NetworkFactory? NetworkFactory { get; set; }
 
-        private static readonly NetworkFactory DefaultNetworkFactory =
-            (context, parameters, handlePacket, _) =>
+    private static readonly NetworkFactory DefaultNetworkFactory =
+        (context, parameters, handlePacket, _) =>
+        {
+            var config = new NetworkConfiguration(
+                ClientConfiguration.Instance.Host,
+                ClientConfiguration.Instance.Port
+            );
+            return new ClientNetwork(context, config, parameters)
             {
-                var config = new NetworkConfiguration(
-                    ClientConfiguration.Instance.Host,
-                    ClientConfiguration.Instance.Port
-                );
-                return new ClientNetwork(context, config, parameters)
-                {
-                    Handler = handlePacket,
-                };
+                Handler = handlePacket,
             };
+        };
 
-        /// <summary>
-        /// Interval between status pings in ms (e.g. full, bad version, etc.)
-        /// </summary>
+    /// <summary>
+    /// Interval between status pings in ms (e.g. full, bad version, etc.)
+    /// </summary>
 #if DEBUG
-        private const long ServerStatusPingInterval = 1_000;
+    private const long ServerStatusPingInterval = 1_000;
 #else
-        private const long ServerStatusPingInterval = 15_000;
+    private const long ServerStatusPingInterval = 15_000;
 #endif
 
-        private const string AsymmetricKeyManifestResourceName = "Intersect.Client.network.handshake.bkey.pub";
+    private const string AsymmetricKeyManifestResourceName = "Intersect.Client.network.handshake.bkey.pub";
 
-        private IClient? _network;
+    private IClient? _network;
 
-        public override IClient Network
+    public override IClient Network
+    {
+        get
         {
-            get
+            if (_network != default)
             {
-                if (_network != default)
-                {
-                    return _network;
-                }
-
-                using var asymmetricKeyStream =
-                    typeof(MonoSocket).Assembly.GetManifestResourceStream(AsymmetricKeyManifestResourceName);
-                if (asymmetricKeyStream == default)
-                {
-                    throw new MissingManifestResourceException(
-                        $"Unable to get manifest resource stream for '{AsymmetricKeyManifestResourceName}'"
-                    );
-                }
-
-                var rsaKey = new RsaKey(asymmetricKeyStream);
-                var network = (NetworkFactory ?? DefaultNetworkFactory).Invoke(
-                    Context,
-                    rsaKey.Parameters,
-                    AddPacketToQueue,
-                    default
-                );
-
-                network.OnConnected += OnConnected;
-                network.OnDisconnected += OnDisconnected;
-                network.OnConnectionDenied += (sender, connectionEventArgs) => OnConnectionFailed(sender, connectionEventArgs, true);
-                _network = network as IClient;
-                Debug.Assert(_network != default);
                 return _network;
             }
+
+            using var asymmetricKeyStream =
+                typeof(MonoSocket).Assembly.GetManifestResourceStream(AsymmetricKeyManifestResourceName);
+            if (asymmetricKeyStream == default)
+            {
+                throw new MissingManifestResourceException(
+                    $"Unable to get manifest resource stream for '{AsymmetricKeyManifestResourceName}'"
+                );
+            }
+
+            var rsaKey = new RsaKey(asymmetricKeyStream);
+            var network = (NetworkFactory ?? DefaultNetworkFactory).Invoke(
+                Context,
+                rsaKey.Parameters,
+                AddPacketToQueue,
+                default
+            );
+
+            network.OnConnected += OnConnected;
+            network.OnDisconnected += OnDisconnected;
+            network.OnConnectionDenied += (sender, connectionEventArgs) => OnConnectionFailed(sender, connectionEventArgs, true);
+            _network = network as IClient;
+            Debug.Assert(_network != default);
+            return _network;
+        }
+    }
+
+    private static readonly ConcurrentQueue<KeyValuePair<IConnection, IPacket>> PacketQueue = new();
+
+    private IClientContext Context { get; }
+
+    private long _nextServerStatusPing;
+
+    private string? _lastHost;
+    private int? _lastPort;
+    private IPEndPoint? _lastEndpoint;
+    private volatile bool _resolvingHost;
+
+    private static readonly HashSet<string> UnresolvableHostNames = new();
+
+    public static MonoSocket Instance { get; private set; } = default!;
+
+    internal MonoSocket(IClientContext context)
+    {
+        Context = context;
+        Instance = this;
+    }
+
+    public override bool IsConnected => Network.IsConnected;
+
+    public override int Ping => Network.Ping;
+
+    private bool TryResolveEndPoint([NotNullWhen(true)] out IPEndPoint? endPoint)
+    {
+        var currentHost = ClientConfiguration.Instance.Host;
+        if (UnresolvableHostNames.Contains(currentHost))
+        {
+            endPoint = default;
+            return false;
         }
 
-        private static readonly ConcurrentQueue<KeyValuePair<IConnection, IPacket>> PacketQueue = new();
-
-        private IClientContext Context { get; }
-
-        private long _nextServerStatusPing;
-
-        private string? _lastHost;
-        private int? _lastPort;
-        private IPEndPoint? _lastEndpoint;
-        private volatile bool _resolvingHost;
-
-        private static readonly HashSet<string> UnresolvableHostNames = new();
-
-        public static MonoSocket Instance { get; private set; } = default!;
-
-        internal MonoSocket(IClientContext context)
+        if (!string.Equals(_lastHost, currentHost))
         {
-            Context = context;
-            Instance = this;
+            _lastHost = currentHost;
+            _lastEndpoint = default;
         }
 
-        public override bool IsConnected => Network.IsConnected;
-
-        public override int Ping => Network.Ping;
-
-        private bool TryResolveEndPoint([NotNullWhen(true)] out IPEndPoint? endPoint)
+        var currentPort = ClientConfiguration.Instance.Port;
+        if (_lastPort != currentPort)
         {
-            var currentHost = ClientConfiguration.Instance.Host;
-            if (UnresolvableHostNames.Contains(currentHost))
-            {
-                endPoint = default;
-                return false;
-            }
-
-            if (!string.Equals(_lastHost, currentHost))
-            {
-                _lastHost = currentHost;
-                _lastEndpoint = default;
-            }
-
-            var currentPort = ClientConfiguration.Instance.Port;
-            if (_lastPort != currentPort)
-            {
-                _lastPort = currentPort;
-                _lastEndpoint = default;
-            }
-
-            if (string.IsNullOrWhiteSpace(_lastHost))
-            {
-                endPoint = default;
-                return false;
-            }
-
-            if (_lastEndpoint != default)
-            {
-                endPoint = _lastEndpoint;
-                return true;
-            }
-
-            try
-            {
-                var address = Dns.GetHostAddresses(_lastHost).FirstOrDefault();
-                var port = _lastPort;
-                if (address == default || !port.HasValue)
-                {
-                    endPoint = default;
-                    return false;
-                }
-
-                endPoint = new IPEndPoint(address, port.Value);
-                _lastEndpoint = endPoint;
-                return true;
-            }
-            catch (SocketException socketException)
-            {
-                if (socketException.SocketErrorCode != SocketError.HostNotFound)
-                {
-                    throw;
-                }
-
-                UnresolvableHostNames.Add(_lastHost);
-                Interface.Interface.ShowError(Strings.Errors.HostNotFound);
-                Log.Error(socketException, $"Failed to resolve host: '{_lastHost}'");
-                endPoint = default;
-                return false;
-            }
+            _lastPort = currentPort;
+            _lastEndpoint = default;
         }
 
-        public override void Connect(string host, int port)
+        if (string.IsNullOrWhiteSpace(_lastHost))
         {
-            if (!Network.Connect())
-            {
-                Log.Error("An error occurred while attempting to connect.");
-            }
+            endPoint = default;
+            return false;
         }
 
-        public override void SendPacket(object packet)
+        if (_lastEndpoint != default)
         {
-            if (packet is not IntersectPacket intersectPacket)
-            {
-                return;
-            }
-
-            _network?.Send(intersectPacket);
-        }
-
-        public static bool AddPacketToQueue(IConnection connection, IPacket packet)
-        {
-            if (packet is AbstractTimedPacket timedPacket)
-            {
-                Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
-            }
-
-            PacketQueue.Enqueue(new KeyValuePair<IConnection, IPacket>(connection, packet));
-
+            endPoint = _lastEndpoint;
             return true;
         }
 
-        public override void Update()
+        try
         {
-            while (PacketQueue.TryDequeue(out KeyValuePair<IConnection, IPacket> dequeued))
+            var address = Dns.GetHostAddresses(_lastHost).FirstOrDefault();
+            var port = _lastPort;
+            if (address == default || !port.HasValue)
             {
-                OnDataReceived(dequeued.Value);
+                endPoint = default;
+                return false;
             }
 
+            endPoint = new IPEndPoint(address, port.Value);
+            _lastEndpoint = endPoint;
+            return true;
+        }
+        catch (SocketException socketException)
+        {
+            if (socketException.SocketErrorCode != SocketError.HostNotFound)
+            {
+                throw;
+            }
+
+            UnresolvableHostNames.Add(_lastHost);
+            Interface.Interface.ShowError(Strings.Errors.HostNotFound);
+            Log.Error(socketException, $"Failed to resolve host: '{_lastHost}'");
+            endPoint = default;
+            return false;
+        }
+    }
+
+    public override void Connect(string host, int port)
+    {
+        if (!Network.Connect())
+        {
+            Log.Error("An error occurred while attempting to connect.");
+        }
+    }
+
+    public override void SendPacket(object packet)
+    {
+        if (packet is not IntersectPacket intersectPacket)
+        {
+            return;
+        }
+
+        _network?.Send(intersectPacket);
+    }
+
+    public static bool AddPacketToQueue(IConnection connection, IPacket packet)
+    {
+        if (packet is AbstractTimedPacket timedPacket)
+        {
+            Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
+        }
+
+        PacketQueue.Enqueue(new KeyValuePair<IConnection, IPacket>(connection, packet));
+
+        return true;
+    }
+
+    public override void Update()
+    {
+        while (PacketQueue.TryDequeue(out KeyValuePair<IConnection, IPacket> dequeued))
+        {
+            OnDataReceived(dequeued.Value);
+        }
+
+        // ReSharper disable once InvertIf
+        if (Globals.GameState == GameStates.Menu)
+        {
+            var now = Timing.Global.MillisecondsUtc;
             // ReSharper disable once InvertIf
-            if (Globals.GameState == GameStates.Menu)
+            if (_nextServerStatusPing <= now || MainMenu.LastNetworkStatusChangeTime < 0)
             {
-                var now = Timing.Global.MillisecondsUtc;
-                // ReSharper disable once InvertIf
-                if (_nextServerStatusPing <= now || MainMenu.LastNetworkStatusChangeTime < 0)
+                if (!_resolvingHost)
                 {
-                    if (!_resolvingHost)
-                    {
-                        _resolvingHost = true;
-                        Task.Run(
-                            () =>
+                    _resolvingHost = true;
+                    Task.Run(
+                        () =>
+                        {
+                            try
                             {
-                                try
+                                if (TryResolveEndPoint(out var serverEndpoint))
                                 {
-                                    if (TryResolveEndPoint(out var serverEndpoint))
+                                    var network = Network;
+                                    if (network == default)
                                     {
-                                        var network = Network;
-                                        if (network == default)
-                                        {
-                                            Log.Info("No network created to poll for server status.");
-                                        }
-                                        else
-                                        {
-                                            network.SendUnconnected(serverEndpoint, new ServerStatusRequestPacket());
-                                        }
+                                        Log.Info("No network created to poll for server status.");
                                     }
-                                    else if (!UnresolvableHostNames.Contains(_lastHost))
+                                    else
                                     {
-                                        Log.Info($"Unable to resolve '{_lastHost}:{_lastPort}'");
+                                        network.SendUnconnected(serverEndpoint, new ServerStatusRequestPacket());
                                     }
                                 }
-                                catch (Exception exception)
+                                else if (!UnresolvableHostNames.Contains(_lastHost))
                                 {
-                                    Log.Error(exception);
+                                    Log.Info($"Unable to resolve '{_lastHost}:{_lastPort}'");
                                 }
-
-                                _resolvingHost = false;
                             }
-                        );
-                    }
+                            catch (Exception exception)
+                            {
+                                Log.Error(exception);
+                            }
 
-                    if (MainMenu.LastNetworkStatusChangeTime + ServerStatusPingInterval < now)
-                    {
-                        MainMenu.SetNetworkStatus(NetworkStatus.Offline);
-                    }
-
-                    _nextServerStatusPing = now + ServerStatusPingInterval;
+                            _resolvingHost = false;
+                        }
+                    );
                 }
+
+                if (MainMenu.LastNetworkStatusChangeTime + ServerStatusPingInterval < now)
+                {
+                    MainMenu.SetNetworkStatus(NetworkStatus.Offline);
+                }
+
+                _nextServerStatusPing = now + ServerStatusPingInterval;
             }
         }
+    }
 
-        public override void Disconnect(string reason)
-        {
-            Network.Disconnect(reason);
-        }
+    public override void Disconnect(string reason)
+    {
+        Network.Disconnect(reason);
+    }
 
-        public override void Dispose()
-        {
-            _network?.Close();
-            _network?.Dispose();
-            _network = default;
-        }
+    public override void Dispose()
+    {
+        _network?.Close();
+        _network?.Dispose();
+        _network = default;
     }
 }

--- a/Intersect.Client/Networking/NetworkStatus.cs
+++ b/Intersect.Client/Networking/NetworkStatus.cs
@@ -1,48 +1,46 @@
 ﻿using Intersect.Client.Localization;
 using Intersect.Network;
 
-namespace Intersect.Client.Networking
+namespace Intersect.Client.Networking;
+
+
+public static partial class NetworkStatusExtensions
 {
 
-    public static partial class NetworkStatusExtensions
+    public static string ToLocalizedString(this NetworkStatus networkStatus)
     {
-
-        public static string ToLocalizedString(this NetworkStatus networkStatus)
+        switch (networkStatus)
         {
-            switch (networkStatus)
-            {
-                case NetworkStatus.Unknown:
-                    return Strings.Server.Unknown;
+            case NetworkStatus.Unknown:
+                return Strings.Server.Unknown;
 
-                case NetworkStatus.Connecting:
-                    return Strings.Server.Connecting;
+            case NetworkStatus.Connecting:
+                return Strings.Server.Connecting;
 
-                case NetworkStatus.Online:
-                    return Strings.Server.Online;
+            case NetworkStatus.Online:
+                return Strings.Server.Online;
 
-                case NetworkStatus.Offline:
-                    return Strings.Server.Offline;
+            case NetworkStatus.Offline:
+                return Strings.Server.Offline;
 
-                case NetworkStatus.Failed:
-                    return Strings.Server.Failed;
+            case NetworkStatus.Failed:
+                return Strings.Server.Failed;
 
-                case NetworkStatus.VersionMismatch:
-                    return Strings.Server.VersionMismatch;
+            case NetworkStatus.VersionMismatch:
+                return Strings.Server.VersionMismatch;
 
-                case NetworkStatus.ServerFull:
-                    return Strings.Server.ServerFull;
+            case NetworkStatus.ServerFull:
+                return Strings.Server.ServerFull;
 
-                case NetworkStatus.HandshakeFailure:
-                    return Strings.Server.HandshakeFailure;
+            case NetworkStatus.HandshakeFailure:
+                return Strings.Server.HandshakeFailure;
 
-                case NetworkStatus.Quitting:
-                    return "";
+            case NetworkStatus.Quitting:
+                return "";
 
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(networkStatus), networkStatus, null);
-            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(networkStatus), networkStatus, null);
         }
-
     }
 
 }

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -26,927 +26,842 @@ using Intersect.Framework;
 using Intersect.Models;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Client.Networking
+namespace Intersect.Client.Networking;
+
+
+internal sealed partial class PacketHandler
 {
-
-    internal sealed partial class PacketHandler
+    private sealed partial class VirtualPacketSender : IPacketSender
     {
-        private sealed partial class VirtualPacketSender : IPacketSender
+        public IApplicationContext ApplicationContext { get; }
+
+        public INetwork Network => Networking.Network.Socket.Network;
+
+        public VirtualPacketSender(IApplicationContext applicationContext) =>
+            ApplicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
+        
+        #region Implementation of IPacketSender
+
+        /// <inheritdoc />
+        public bool Send(IPacket packet)
         {
-            public IApplicationContext ApplicationContext { get; }
-
-            public INetwork Network => Networking.Network.Socket.Network;
-
-            public VirtualPacketSender(IApplicationContext applicationContext) =>
-                ApplicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
-            
-            #region Implementation of IPacketSender
-
-            /// <inheritdoc />
-            public bool Send(IPacket packet)
+            if (packet is IntersectPacket intersectPacket)
             {
-                if (packet is IntersectPacket intersectPacket)
-                {
-                    Networking.Network.SendPacket(intersectPacket);
-                    return true;
-                }
-
-                return false;
+                Networking.Network.SendPacket(intersectPacket);
+                return true;
             }
 
-            #endregion
+            return false;
         }
 
-        public long Ping { get; set; } = 0;
+        #endregion
+    }
 
-        public long PingTime { get; set; }
+    public long Ping { get; set; } = 0;
 
-        public IClientContext Context { get; }
+    public long PingTime { get; set; }
 
-        public Logger Logger => Context.Logger;
+    public IClientContext Context { get; }
 
-        public PacketHandlerRegistry Registry { get; }
+    public Logger Logger => Context.Logger;
 
-        public IPacketSender VirtualSender { get; }
+    public PacketHandlerRegistry Registry { get; }
 
-        public PacketHandler(IClientContext context, PacketHandlerRegistry packetHandlerRegistry)
+    public IPacketSender VirtualSender { get; }
+
+    public PacketHandler(IClientContext context, PacketHandlerRegistry packetHandlerRegistry)
+    {
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
+
+        if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
         {
-            Context = context ?? throw new ArgumentNullException(nameof(context));
-            Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
-
-            if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
-            {
-                throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
-            }
-
-            if (!Registry.TryRegisterAvailableTypeHandlers(GetType().Assembly))
-            {
-                throw new InvalidOperationException("Failed to register type handlers, see logs for more details.");
-            }
-
-            VirtualSender = new VirtualPacketSender(context);
+            throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
         }
 
-        public bool HandlePacket(IPacket packet)
+        if (!Registry.TryRegisterAvailableTypeHandlers(GetType().Assembly))
         {
-            if (packet is AbstractTimedPacket timedPacket)
-            {
-                Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
-            }
-
-            if (!(packet is IntersectPacket))
-            {
-                return false;
-            }
-
-            if (!packet.IsValid)
-            {
-                return false;
-            }
-
-            if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
-            {
-                Logger.Error($"No registered handler for {packet.GetType().FullName}!");
-
-                return false;
-            }
-
-            if (Registry.TryGetPreprocessors(packet, out var preprocessors))
-            {
-                if (!preprocessors.All(preprocessor => preprocessor.Handle(VirtualSender, packet)))
-                {
-                    // Preprocessors are intended to be silent filter functions
-                    return false;
-                }
-            }
-
-            if (Registry.TryGetPreHooks(packet, out var preHooks))
-            {
-                if (!preHooks.All(hook => hook.Handle(VirtualSender, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            if (!handler(VirtualSender, packet))
-            {
-                return false;
-            }
-
-            if (Registry.TryGetPostHooks(packet, out var postHooks))
-            {
-                if (!postHooks.All(hook => hook.Handle(VirtualSender, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            return true;
+            throw new InvalidOperationException("Failed to register type handlers, see logs for more details.");
         }
 
-        //PingPacket
-        public void HandlePacket(IPacketSender packetSender, PingPacket packet)
+        VirtualSender = new VirtualPacketSender(context);
+    }
+
+    public bool HandlePacket(IPacket packet)
+    {
+        if (packet is AbstractTimedPacket timedPacket)
         {
-            if (!packet.RequestingReply)
+            Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
+        }
+
+        if (!(packet is IntersectPacket))
+        {
+            return false;
+        }
+
+        if (!packet.IsValid)
+        {
+            return false;
+        }
+
+        if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+        {
+            Logger.Error($"No registered handler for {packet.GetType().FullName}!");
+
+            return false;
+        }
+
+        if (Registry.TryGetPreprocessors(packet, out var preprocessors))
+        {
+            if (!preprocessors.All(preprocessor => preprocessor.Handle(VirtualSender, packet)))
+            {
+                // Preprocessors are intended to be silent filter functions
+                return false;
+            }
+        }
+
+        if (Registry.TryGetPreHooks(packet, out var preHooks))
+        {
+            if (!preHooks.All(hook => hook.Handle(VirtualSender, packet)))
+            {
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
+                return false;
+            }
+        }
+
+        if (!handler(VirtualSender, packet))
+        {
+            return false;
+        }
+
+        if (Registry.TryGetPostHooks(packet, out var postHooks))
+        {
+            if (!postHooks.All(hook => hook.Handle(VirtualSender, packet)))
+            {
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    //PingPacket
+    public void HandlePacket(IPacketSender packetSender, PingPacket packet)
+    {
+        if (!packet.RequestingReply)
+        {
+            return;
+        }
+
+        PacketSender.SendPing();
+        PingTime = Timing.Global.Milliseconds;
+    }
+
+    //ConfigPacket
+    public void HandlePacket(IPacketSender packetSender, ConfigPacket packet)
+    {
+        Log.Debug("Received configuration from server.");
+        Options.LoadFromServer(packet.Config);
+        Globals.WaitingOnServer = false;
+        MainMenu.HandleReceivedConfiguration();
+        try
+        {
+            Strings.Load();
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+        Graphics.InitInGame();
+    }
+
+    //JoinGamePacket
+    public void HandlePacket(IPacketSender packetSender, JoinGamePacket packet)
+    {
+        Main.JoinGame();
+        Globals.JoiningGame = true;
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MapAreaPacket packet)
+    {
+        foreach (var map in packet.Maps)
+        {
+            HandleMap(packetSender, map);
+        }
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MapAreaIdsPacket packet)
+    {
+        // TODO: Background all of this?
+        List<ObjectCacheKey<MapBase>> cacheKeys = new(packet.MapIds.Length);
+        List<MapPacket> loadedCachedMaps = new(packet.MapIds.Length);
+        foreach (var mapId in packet.MapIds)
+        {
+            if (ObjectDataDiskCache<MapBase>.TryLoad(mapId, out var cacheData))
+            {
+                ObjectCacheKey<MapBase> cacheKey = new(cacheData.Id);
+                var deserializedCachedPacket = MessagePacker.Instance.Deserialize<MapPacket>(cacheData.Data, silent: true);
+                if (deserializedCachedPacket != default)
+                {
+                    cacheKey = new ObjectCacheKey<MapBase>(
+                        cacheData.Id,
+                        cacheData.Checksum,
+                        cacheData.Version
+                    );
+                    cacheKeys.Add(cacheKey);
+                    loadedCachedMaps.Add(deserializedCachedPacket);
+                    continue;
+                }
+
+                Log.Warn($"Failed to deserialized cached data for {cacheKey}, will fetch again");
+            }
+
+            cacheKeys.Add(new ObjectCacheKey<MapBase>(new Id<MapBase>(mapId)));
+        }
+
+        PacketSender.SendNeedMap(cacheKeys.ToArray());
+
+        foreach (var cachedMap in loadedCachedMaps)
+        {
+            HandleMap(packetSender, cachedMap, skipSave: true);
+        }
+    }
+
+    private void HandleMap(IPacketSender packetSender, MapPacket packet, bool skipSave = false)
+    {
+        var mapId = packet.MapId;
+
+        if (!skipSave)
+        {
+            ObjectCacheData<MapBase> cacheData = new()
+            {
+                Id = new Id<MapBase>(mapId),
+                Data = (packet as IntersectPacket).Data,
+                Version = packet.CacheVersion,
+            };
+            ObjectCacheKey<MapBase> cacheKey = new(new Id<MapBase>(mapId), cacheData.Checksum, cacheData.Version);
+
+            if (!ObjectDataDiskCache<MapBase>.TrySave(cacheData))
+            {
+                Log.Warn($"Failed to save cache for {cacheKey}");
+            }
+        }
+
+        MapInstance.UpdateMapRequestTime(packet.MapId);
+        
+        if (MapInstance.TryGet(mapId, out var mapInstance))
+        {
+            if (packet.Revision == mapInstance.Revision)
             {
                 return;
             }
 
-            PacketSender.SendPing();
-            PingTime = Timing.Global.Milliseconds;
+            mapInstance.Dispose(false, false);
         }
 
-        //ConfigPacket
-        public void HandlePacket(IPacketSender packetSender, ConfigPacket packet)
+        mapInstance = new MapInstance(mapId);
+        MapInstance.Lookup.Set(mapId, mapInstance);
+        lock (mapInstance.MapLock)
         {
-            Log.Debug("Received configuration from server.");
-            Options.LoadFromServer(packet.Config);
-            Globals.WaitingOnServer = false;
-            MainMenu.HandleReceivedConfiguration();
-            try
+            mapInstance.Load(packet.Data);
+            mapInstance.LoadTileData(packet.TileData);
+            mapInstance.AttributeData = packet.AttributeData;
+            mapInstance.CreateMapSounds();
+            if (mapId == Globals.Me.MapId)
             {
-                Strings.Load();
+                Audio.PlayMusic(mapInstance.Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
             }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-            Graphics.InitInGame();
-        }
 
-        //JoinGamePacket
-        public void HandlePacket(IPacketSender packetSender, JoinGamePacket packet)
-        {
-            Main.JoinGame();
-            Globals.JoiningGame = true;
-        }
+            mapInstance.GridX = packet.GridX;
+            mapInstance.GridY = packet.GridY;
+            mapInstance.CameraHolds = packet.CameraHolds;
+            mapInstance.Autotiles.InitAutotiles(mapInstance.GenerateAutotileGrid());
 
-        public void HandlePacket(IPacketSender packetSender, MapAreaPacket packet)
-        {
-            foreach (var map in packet.Maps)
+            if (Globals.PendingEvents.ContainsKey(mapId))
             {
-                HandleMap(packetSender, map);
-            }
-        }
-
-        public void HandlePacket(IPacketSender packetSender, MapAreaIdsPacket packet)
-        {
-            // TODO: Background all of this?
-            List<ObjectCacheKey<MapBase>> cacheKeys = new(packet.MapIds.Length);
-            List<MapPacket> loadedCachedMaps = new(packet.MapIds.Length);
-            foreach (var mapId in packet.MapIds)
-            {
-                if (ObjectDataDiskCache<MapBase>.TryLoad(mapId, out var cacheData))
+                foreach (var evt in Globals.PendingEvents[mapId])
                 {
-                    ObjectCacheKey<MapBase> cacheKey = new(cacheData.Id);
-                    var deserializedCachedPacket = MessagePacker.Instance.Deserialize<MapPacket>(cacheData.Data, silent: true);
-                    if (deserializedCachedPacket != default)
+                    mapInstance.AddEvent(evt.Key, evt.Value);
+                }
+
+                Globals.PendingEvents[mapId].Clear();
+            }
+        }
+
+        MapInstance.OnMapLoaded?.Invoke(mapInstance);
+    }
+
+    //MapPacket
+    public void HandlePacket(IPacketSender packetSender, MapPacket packet)
+    {
+        HandleMap(packetSender, packet);
+        Globals.Me.FetchNewMaps();
+    }
+
+    //PlayerEntityPacket
+    public void HandlePacket(IPacketSender packetSender, PlayerEntityPacket packet)
+    {
+        var en = Globals.GetEntity(packet.EntityId, EntityType.Player);
+        if (en != null)
+        {
+            en.Load(packet);
+            if (packet.IsSelf)
+            {
+                Globals.Me = (Player) Globals.Entities[packet.EntityId];
+            }
+        }
+        else
+        {
+            Globals.Entities.Add(packet.EntityId, new Player(packet.EntityId, packet));
+            if (packet.IsSelf)
+            {
+                Globals.Me = (Player) Globals.Entities[packet.EntityId];
+            }
+        }
+    }
+
+    //NpcEntityPacket
+    public void HandlePacket(IPacketSender packetSender, NpcEntityPacket packet)
+    {
+        var en = Globals.GetEntity(packet.EntityId, EntityType.GlobalEntity);
+        if (en != null)
+        {
+            en.Load(packet);
+            en.Aggression = packet.Aggression;
+        }
+        else
+        {
+            var entity = new Entity(packet.EntityId, packet, EntityType.GlobalEntity)
+            {
+                Aggression = packet.Aggression,
+            };
+            Globals.Entities.Add(entity.Id, entity);
+        }
+    }
+
+    //ResourceEntityPacket
+    public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
+    {
+        var en = Globals.GetEntity(packet.EntityId, EntityType.Resource);
+        if (en != null)
+        {
+            en.Load(packet);
+        }
+        else
+        {
+            var entity = new Resource(packet.EntityId, packet);
+            Globals.Entities.Add(entity.Id, entity);
+        }
+    }
+
+    //ProjectileEntityPacket
+    public void HandlePacket(IPacketSender packetSender, ProjectileEntityPacket packet)
+    {
+        var en = Globals.GetEntity(packet.EntityId, EntityType.Projectile);
+        if (en != null)
+        {
+            en.Load(packet);
+        }
+        else
+        {
+            var entity = new Projectile(packet.EntityId, packet);
+            Globals.Entities.Add(entity.Id, entity);
+        }
+    }
+
+    //EventEntityPacket
+    public void HandlePacket(IPacketSender packetSender, EventEntityPacket packet)
+    {
+        var map = MapInstance.Get(packet.MapId);
+        if (map != null)
+        {
+            map?.AddEvent(packet.EntityId, packet);
+        }
+        else
+        {
+            var dict = Globals.PendingEvents.ContainsKey(packet.MapId)
+                ? Globals.PendingEvents[packet.MapId]
+                : new Dictionary<Guid, EventEntityPacket>();
+
+            if (dict.ContainsKey(packet.EntityId))
+            {
+                dict[packet.EntityId] = packet;
+            }
+            else
+            {
+                dict.Add(packet.EntityId, packet);
+            }
+
+            if (!Globals.PendingEvents.ContainsKey(packet.MapId))
+            {
+                Globals.PendingEvents.Add(packet.MapId, dict);
+            }
+        }
+    }
+
+    //MapEntitiesPacket
+    public void HandlePacket(IPacketSender packetSender, MapEntitiesPacket packet)
+    {
+        var mapEntities = new Dictionary<Guid, List<Guid>>();
+        foreach (var pkt in packet.MapEntities)
+        {
+            HandlePacket(pkt);
+
+            if (!mapEntities.ContainsKey(pkt.MapId))
+            {
+                mapEntities.Add(pkt.MapId, new List<Guid>());
+            }
+
+            mapEntities[pkt.MapId].Add(pkt.EntityId);
+        }
+
+        //Remove any entities on the map that shouldn't be there anymore!
+        foreach (var entities in mapEntities)
+        {
+            foreach (var entity in Globals.Entities)
+            {
+                if (entity.Value.MapId == entities.Key && !entities.Value.Contains(entity.Key))
+                {
+                    if (!Globals.EntitiesToDispose.Contains(entity.Key) && entity.Value != Globals.Me && !(entity.Value is Projectile))
                     {
-                        cacheKey = new ObjectCacheKey<MapBase>(
-                            cacheData.Id,
-                            cacheData.Checksum,
-                            cacheData.Version
-                        );
-                        cacheKeys.Add(cacheKey);
-                        loadedCachedMaps.Add(deserializedCachedPacket);
-                        continue;
+                        Globals.EntitiesToDispose.Add(entity.Key);
                     }
-
-                    Log.Warn($"Failed to deserialized cached data for {cacheKey}, will fetch again");
-                }
-
-                cacheKeys.Add(new ObjectCacheKey<MapBase>(new Id<MapBase>(mapId)));
-            }
-
-            PacketSender.SendNeedMap(cacheKeys.ToArray());
-
-            foreach (var cachedMap in loadedCachedMaps)
-            {
-                HandleMap(packetSender, cachedMap, skipSave: true);
-            }
-        }
-
-        private void HandleMap(IPacketSender packetSender, MapPacket packet, bool skipSave = false)
-        {
-            var mapId = packet.MapId;
-
-            if (!skipSave)
-            {
-                ObjectCacheData<MapBase> cacheData = new()
-                {
-                    Id = new Id<MapBase>(mapId),
-                    Data = (packet as IntersectPacket).Data,
-                    Version = packet.CacheVersion,
-                };
-                ObjectCacheKey<MapBase> cacheKey = new(new Id<MapBase>(mapId), cacheData.Checksum, cacheData.Version);
-
-                if (!ObjectDataDiskCache<MapBase>.TrySave(cacheData))
-                {
-                    Log.Warn($"Failed to save cache for {cacheKey}");
-                }
-            }
-
-            MapInstance.UpdateMapRequestTime(packet.MapId);
-            
-            if (MapInstance.TryGet(mapId, out var mapInstance))
-            {
-                if (packet.Revision == mapInstance.Revision)
-                {
-                    return;
-                }
-
-                mapInstance.Dispose(false, false);
-            }
-
-            mapInstance = new MapInstance(mapId);
-            MapInstance.Lookup.Set(mapId, mapInstance);
-            lock (mapInstance.MapLock)
-            {
-                mapInstance.Load(packet.Data);
-                mapInstance.LoadTileData(packet.TileData);
-                mapInstance.AttributeData = packet.AttributeData;
-                mapInstance.CreateMapSounds();
-                if (mapId == Globals.Me.MapId)
-                {
-                    Audio.PlayMusic(mapInstance.Music, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-                }
-
-                mapInstance.GridX = packet.GridX;
-                mapInstance.GridY = packet.GridY;
-                mapInstance.CameraHolds = packet.CameraHolds;
-                mapInstance.Autotiles.InitAutotiles(mapInstance.GenerateAutotileGrid());
-
-                if (Globals.PendingEvents.ContainsKey(mapId))
-                {
-                    foreach (var evt in Globals.PendingEvents[mapId])
-                    {
-                        mapInstance.AddEvent(evt.Key, evt.Value);
-                    }
-
-                    Globals.PendingEvents[mapId].Clear();
-                }
-            }
-
-            MapInstance.OnMapLoaded?.Invoke(mapInstance);
-        }
-
-        //MapPacket
-        public void HandlePacket(IPacketSender packetSender, MapPacket packet)
-        {
-            HandleMap(packetSender, packet);
-            Globals.Me.FetchNewMaps();
-        }
-
-        //PlayerEntityPacket
-        public void HandlePacket(IPacketSender packetSender, PlayerEntityPacket packet)
-        {
-            var en = Globals.GetEntity(packet.EntityId, EntityType.Player);
-            if (en != null)
-            {
-                en.Load(packet);
-                if (packet.IsSelf)
-                {
-                    Globals.Me = (Player) Globals.Entities[packet.EntityId];
-                }
-            }
-            else
-            {
-                Globals.Entities.Add(packet.EntityId, new Player(packet.EntityId, packet));
-                if (packet.IsSelf)
-                {
-                    Globals.Me = (Player) Globals.Entities[packet.EntityId];
                 }
             }
         }
+    }
 
-        //NpcEntityPacket
-        public void HandlePacket(IPacketSender packetSender, NpcEntityPacket packet)
+    // MapInstanceChanged Packet
+    public void HandlePacket(IPacketSender packetSender, MapInstanceChangedPacket packet)
+    {
+        var disposingEntities = new List<Guid>();
+        foreach (var pkt in packet.EntitiesToDispose)
         {
-            var en = Globals.GetEntity(packet.EntityId, EntityType.GlobalEntity);
-            if (en != null)
-            {
-                en.Load(packet);
-                en.Aggression = packet.Aggression;
-            }
-            else
-            {
-                var entity = new Entity(packet.EntityId, packet, EntityType.GlobalEntity)
-                {
-                    Aggression = packet.Aggression,
-                };
-                Globals.Entities.Add(entity.Id, entity);
-            }
+            HandlePacket(pkt);
+            disposingEntities.Add(pkt.EntityId);
         }
 
-        //ResourceEntityPacket
-        public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
+        foreach (var entity in disposingEntities)
         {
-            var en = Globals.GetEntity(packet.EntityId, EntityType.Resource);
-            if (en != null)
-            {
-                en.Load(packet);
-            }
-            else
-            {
-                var entity = new Resource(packet.EntityId, packet);
-                Globals.Entities.Add(entity.Id, entity);
-            }
+            Globals.EntitiesToDispose.Add(entity);
         }
 
-        //ProjectileEntityPacket
-        public void HandlePacket(IPacketSender packetSender, ProjectileEntityPacket packet)
+        foreach (var mapId in packet.MapIdsToRefresh)
         {
-            var en = Globals.GetEntity(packet.EntityId, EntityType.Projectile);
-            if (en != null)
-            {
-                en.Load(packet);
-            }
-            else
-            {
-                var entity = new Projectile(packet.EntityId, packet);
-                Globals.Entities.Add(entity.Id, entity);
-            }
-        }
-
-        //EventEntityPacket
-        public void HandlePacket(IPacketSender packetSender, EventEntityPacket packet)
-        {
-            var map = MapInstance.Get(packet.MapId);
+            var map = MapInstance.Get(mapId);
             if (map != null)
             {
-                map?.AddEvent(packet.EntityId, packet);
-            }
-            else
-            {
-                var dict = Globals.PendingEvents.ContainsKey(packet.MapId)
-                    ? Globals.PendingEvents[packet.MapId]
-                    : new Dictionary<Guid, EventEntityPacket>();
-
-                if (dict.ContainsKey(packet.EntityId))
-                {
-                    dict[packet.EntityId] = packet;
-                }
-                else
-                {
-                    dict.Add(packet.EntityId, packet);
-                }
-
-                if (!Globals.PendingEvents.ContainsKey(packet.MapId))
-                {
-                    Globals.PendingEvents.Add(packet.MapId, dict);
-                }
+                Globals.EntitiesToDispose.AddRange(map.LocalEntities.Values
+                    .ToList()
+                    .Select(en => en.Id));
             }
         }
+    }
 
-        //MapEntitiesPacket
-        public void HandlePacket(IPacketSender packetSender, MapEntitiesPacket packet)
+    //EntityPositionPacket
+    public void HandlePacket(IPacketSender packetSender, EntityPositionPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        Entity en;
+        if (type != EntityType.Event)
         {
-            var mapEntities = new Dictionary<Guid, List<Guid>>();
-            foreach (var pkt in packet.MapEntities)
-            {
-                HandlePacket(pkt);
-
-                if (!mapEntities.ContainsKey(pkt.MapId))
-                {
-                    mapEntities.Add(pkt.MapId, new List<Guid>());
-                }
-
-                mapEntities[pkt.MapId].Add(pkt.EntityId);
-            }
-
-            //Remove any entities on the map that shouldn't be there anymore!
-            foreach (var entities in mapEntities)
-            {
-                foreach (var entity in Globals.Entities)
-                {
-                    if (entity.Value.MapId == entities.Key && !entities.Value.Contains(entity.Key))
-                    {
-                        if (!Globals.EntitiesToDispose.Contains(entity.Key) && entity.Value != Globals.Me && !(entity.Value is Projectile))
-                        {
-                            Globals.EntitiesToDispose.Add(entity.Key);
-                        }
-                    }
-                }
-            }
-        }
-
-        // MapInstanceChanged Packet
-        public void HandlePacket(IPacketSender packetSender, MapInstanceChangedPacket packet)
-        {
-            var disposingEntities = new List<Guid>();
-            foreach (var pkt in packet.EntitiesToDispose)
-            {
-                HandlePacket(pkt);
-                disposingEntities.Add(pkt.EntityId);
-            }
-
-            foreach (var entity in disposingEntities)
-            {
-                Globals.EntitiesToDispose.Add(entity);
-            }
-
-            foreach (var mapId in packet.MapIdsToRefresh)
-            {
-                var map = MapInstance.Get(mapId);
-                if (map != null)
-                {
-                    Globals.EntitiesToDispose.AddRange(map.LocalEntities.Values
-                        .ToList()
-                        .Select(en => en.Id));
-                }
-            }
-        }
-
-        //EntityPositionPacket
-        public void HandlePacket(IPacketSender packetSender, EntityPositionPacket packet)
-        {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            Entity en;
-            if (type != EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                if (MapInstance.Get(mapId) == null)
-                {
-                    return;
-                }
-
-                if (!MapInstance.Get(mapId).LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = MapInstance.Get(mapId).LocalEntities[id];
-            }
-
-            if (en == Globals.Me)
-            {
-                Log.Debug($"received epp: {Timing.Global.Milliseconds}");
-            }
-
-            if (en == Globals.Me &&
-                (Globals.Me.DashQueue.Count > 0 || Globals.Me.DashTimer > Timing.Global.Milliseconds))
+            if (!Globals.Entities.ContainsKey(id))
             {
                 return;
             }
 
-            if (en == Globals.Me && Globals.Me.MapId != mapId)
-            {
-                Globals.Me.MapId = mapId;
-                Globals.NeedsMaps = true;
-                Globals.Me.FetchNewMaps();
-            }
-            else
-            {
-                en.MapId = mapId;
-            }
-
-            en.X = packet.X;
-            en.Y = packet.Y;
-            en.Dir = (Direction)packet.Direction;
-            en.Passable = packet.Passable;
-            en.HideName = packet.HideName;
+            en = Globals.Entities[id];
         }
-
-        //EntityLeftPacket
-        public void HandlePacket(IPacketSender packetSender, EntityLeftPacket packet)
+        else
         {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            if (id == Globals.Me?.Id && type < EntityType.Event)
+            if (MapInstance.Get(mapId) == null)
             {
                 return;
             }
 
-            if (type != EntityType.Event)
+            if (!MapInstance.Get(mapId).LocalEntities.ContainsKey(id))
             {
-                if (Globals.Entities?.ContainsKey(id) ?? false)
-                {
-                    Globals.EntitiesToDispose?.Add(id);
-                }
+                return;
             }
-            else
-            {
-                var map = MapInstance.Get(mapId);
-                if (map?.LocalEntities?.ContainsKey(id) ?? false)
-                {
-                    map.LocalEntities[id]?.Dispose();
-                    map.LocalEntities[id] = null;
-                    map.LocalEntities.Remove(id);
-                }
-            }
+
+            en = MapInstance.Get(mapId).LocalEntities[id];
         }
 
-        //ChatMsgPacket
-        public void HandlePacket(IPacketSender packetSender, ChatMsgPacket packet)
+        if (en == Globals.Me)
         {
-            ChatboxMsg.AddMessage(
-                new ChatboxMsg(
-                    packet.Message ?? "", new Color(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Type,
-                    packet.Target
+            Log.Debug($"received epp: {Timing.Global.Milliseconds}");
+        }
+
+        if (en == Globals.Me &&
+            (Globals.Me.DashQueue.Count > 0 || Globals.Me.DashTimer > Timing.Global.Milliseconds))
+        {
+            return;
+        }
+
+        if (en == Globals.Me && Globals.Me.MapId != mapId)
+        {
+            Globals.Me.MapId = mapId;
+            Globals.NeedsMaps = true;
+            Globals.Me.FetchNewMaps();
+        }
+        else
+        {
+            en.MapId = mapId;
+        }
+
+        en.X = packet.X;
+        en.Y = packet.Y;
+        en.Dir = (Direction)packet.Direction;
+        en.Passable = packet.Passable;
+        en.HideName = packet.HideName;
+    }
+
+    //EntityLeftPacket
+    public void HandlePacket(IPacketSender packetSender, EntityLeftPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        if (id == Globals.Me?.Id && type < EntityType.Event)
+        {
+            return;
+        }
+
+        if (type != EntityType.Event)
+        {
+            if (Globals.Entities?.ContainsKey(id) ?? false)
+            {
+                Globals.EntitiesToDispose?.Add(id);
+            }
+        }
+        else
+        {
+            var map = MapInstance.Get(mapId);
+            if (map?.LocalEntities?.ContainsKey(id) ?? false)
+            {
+                map.LocalEntities[id]?.Dispose();
+                map.LocalEntities[id] = null;
+                map.LocalEntities.Remove(id);
+            }
+        }
+    }
+
+    //ChatMsgPacket
+    public void HandlePacket(IPacketSender packetSender, ChatMsgPacket packet)
+    {
+        ChatboxMsg.AddMessage(
+            new ChatboxMsg(
+                packet.Message ?? "", new Color(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Type,
+                packet.Target
+            )
+        );
+    }
+
+    //AnnouncementPacket
+    public void HandlePacket(IPacketSender packetSender, AnnouncementPacket packet)
+    {
+        Interface.Interface.GameUi.AnnouncementWindow.ShowAnnouncement(packet.Message, packet.Duration);   
+    }
+
+    //ActionMsgPackets
+    public void HandlePacket(IPacketSender packetSender, ActionMsgPackets packet)
+    {
+        foreach (var pkt in packet.Packets)
+        {
+            HandlePacket(pkt);
+        }
+    }
+
+    //ActionMsgPacket
+    public void HandlePacket(IPacketSender packetSender, ActionMsgPacket packet)
+    {
+        var map = MapInstance.Get(packet.MapId);
+        if (map != null)
+        {
+            map.ActionMessages.Add(
+                new ActionMessage(
+                    map, packet.X, packet.Y, packet.Message,
+                    new Color(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B)
                 )
             );
         }
+    }
 
-        //AnnouncementPacket
-        public void HandlePacket(IPacketSender packetSender, AnnouncementPacket packet)
+    //GameDataPacket
+    public void HandlePacket(IPacketSender packetSender, GameDataPacket packet)
+    {
+        foreach (var pkt in packet.GameObjects)
         {
-            Interface.Interface.GameUi.AnnouncementWindow.ShowAnnouncement(packet.Message, packet.Duration);   
+            HandlePacket(pkt);
         }
 
-        //ActionMsgPackets
-        public void HandlePacket(IPacketSender packetSender, ActionMsgPackets packet)
+        CustomColors.Load(packet.ColorsJson);
+        Globals.HasGameData = true;
+    }
+
+    //MapListPacket
+    public void HandlePacket(IPacketSender packetSender, MapListPacket packet)
+    {
+        MapList.List.JsonData = packet.MapListData;
+        MapList.List.PostLoad(MapBase.Lookup, false, true);
+
+        //TODO ? If admin window is open update it
+    }
+
+    //EntityMovementPackets
+    public void HandlePacket(IPacketSender packetSender, EntityMovementPackets packet)
+    {
+        if (packet.GlobalMovements != null)
         {
-            foreach (var pkt in packet.Packets)
+            foreach (var pkt in packet.GlobalMovements)
             {
                 HandlePacket(pkt);
             }
         }
 
-        //ActionMsgPacket
-        public void HandlePacket(IPacketSender packetSender, ActionMsgPacket packet)
+        if (packet.LocalMovements != null)
         {
-            var map = MapInstance.Get(packet.MapId);
-            if (map != null)
-            {
-                map.ActionMessages.Add(
-                    new ActionMessage(
-                        map, packet.X, packet.Y, packet.Message,
-                        new Color(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B)
-                    )
-                );
-            }
-        }
-
-        //GameDataPacket
-        public void HandlePacket(IPacketSender packetSender, GameDataPacket packet)
-        {
-            foreach (var pkt in packet.GameObjects)
+            foreach (var pkt in packet.LocalMovements)
             {
                 HandlePacket(pkt);
             }
-
-            CustomColors.Load(packet.ColorsJson);
-            Globals.HasGameData = true;
         }
+    }
 
-        //MapListPacket
-        public void HandlePacket(IPacketSender packetSender, MapListPacket packet)
+    //EntityMovePacket
+    public void HandlePacket(IPacketSender packetSender, EntityMovePacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        Entity en;
+        if (type < EntityType.Event)
         {
-            MapList.List.JsonData = packet.MapListData;
-            MapList.List.PostLoad(MapBase.Lookup, false, true);
-
-            //TODO ? If admin window is open update it
-        }
-
-        //EntityMovementPackets
-        public void HandlePacket(IPacketSender packetSender, EntityMovementPackets packet)
-        {
-            if (packet.GlobalMovements != null)
+            if (!Globals.Entities.ContainsKey(id))
             {
-                foreach (var pkt in packet.GlobalMovements)
-                {
-                    HandlePacket(pkt);
-                }
+                return;
             }
 
-            if (packet.LocalMovements != null)
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var gameMap = MapInstance.Get(mapId);
+            if (gameMap == null)
             {
-                foreach (var pkt in packet.LocalMovements)
-                {
-                    HandlePacket(pkt);
-                }
+                return;
+            }
+
+            if (!gameMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = gameMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        var entityMap = MapInstance.Get(en.MapId);
+        if (entityMap == null)
+        {
+            return;
+        }
+
+        if (en is Player && Options.Combat.MovementCancelsCast)
+        {
+            en.CastTime = 0;
+        }
+
+        if (en.Dashing != null || en.DashQueue.Count > 0)
+        {
+            return;
+        }
+
+        var map = mapId;
+        var x = packet.X;
+        var y = packet.Y;
+        Direction dir = (Direction)packet.Direction;
+        var correction = packet.Correction;
+        if ((en.MapId != map || en.X != x || en.Y != y) &&
+            (en != Globals.Me || en == Globals.Me && correction) &&
+            en.Dashing == null)
+        {
+            en.MapId = map;
+            en.X = x;
+            en.Y = y;
+            en.Dir = dir;
+            if (en is Player p)
+            {
+                p.MoveDir = dir;
+            }
+            en.IsMoving = true;
+
+            switch (en.Dir)
+            {
+                case Direction.Up:
+                    en.OffsetY = Options.TileWidth;
+                    en.OffsetX = 0;
+
+                    break;
+                case Direction.Down:
+                    en.OffsetY = -Options.TileWidth;
+                    en.OffsetX = 0;
+
+                    break;
+                case Direction.Left:
+                    en.OffsetY = 0;
+                    en.OffsetX = Options.TileWidth;
+
+                    break;
+                case Direction.Right:
+                    en.OffsetY = 0;
+                    en.OffsetX = -Options.TileWidth;
+
+                    break;
+                case Direction.UpLeft:
+                    en.OffsetY = Options.TileHeight;
+                    en.OffsetX = Options.TileWidth;
+
+                    break;
+                case Direction.UpRight:
+                    en.OffsetY = Options.TileHeight;
+                    en.OffsetX = -Options.TileWidth;
+
+                    break;
+                case Direction.DownLeft:
+                    en.OffsetY = -Options.TileHeight;
+                    en.OffsetX = Options.TileWidth;
+
+                    break;
+                case Direction.DownRight:
+                    en.OffsetY = -Options.TileHeight;
+                    en.OffsetX = -Options.TileWidth;
+
+                    break;
             }
         }
 
-        //EntityMovePacket
-        public void HandlePacket(IPacketSender packetSender, EntityMovePacket packet)
+        // Set the Z-Dimension if the player has moved up or down a dimension.
+        if (entityMap.Attributes[en.X, en.Y] != null &&
+            entityMap.Attributes[en.X, en.Y].Type == MapAttribute.ZDimension)
         {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            Entity en;
-            if (type < EntityType.Event)
+            if (((MapZDimensionAttribute) entityMap.Attributes[en.X, en.Y]).GatewayTo > 0)
             {
-                if (!Globals.Entities.ContainsKey(id))
+                en.Z = (byte) (((MapZDimensionAttribute) entityMap.Attributes[en.X, en.Y]).GatewayTo - 1);
+            }
+        }
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MapEntityVitalsPacket packet)
+    {
+        // Get our map, cancel out if it doesn't exist.
+        var map = MapInstance.Get(packet.MapId);
+        if (map == null)
+        {
+            return;
+        }
+
+        foreach (var en in packet.EntityUpdates)
+        {
+            Entity entity = null;
+
+            if (en.Type < EntityType.Event)
+            {
+                if (!Globals.Entities.ContainsKey(en.Id))
                 {
                     return;
                 }
 
-                en = Globals.Entities[id];
+                entity = Globals.Entities[en.Id];
             }
             else
             {
-                var gameMap = MapInstance.Get(mapId);
-                if (gameMap == null)
+                if (!map.LocalEntities.ContainsKey(en.Id))
                 {
                     return;
                 }
 
-                if (!gameMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = gameMap.LocalEntities[id];
+                entity = map.LocalEntities[en.Id];
             }
 
-            if (en == null)
+            if (entity == null)
             {
                 return;
             }
 
-            var entityMap = MapInstance.Get(en.MapId);
-            if (entityMap == null)
-            {
-                return;
-            }
+            entity.Vital = en.Vitals;
+            entity.MaxVital = en.MaxVitals;
 
-            if (en is Player && Options.Combat.MovementCancelsCast)
+            if (entity == Globals.Me)
             {
-                en.CastTime = 0;
-            }
-
-            if (en.Dashing != null || en.DashQueue.Count > 0)
-            {
-                return;
-            }
-
-            var map = mapId;
-            var x = packet.X;
-            var y = packet.Y;
-            Direction dir = (Direction)packet.Direction;
-            var correction = packet.Correction;
-            if ((en.MapId != map || en.X != x || en.Y != y) &&
-                (en != Globals.Me || en == Globals.Me && correction) &&
-                en.Dashing == null)
-            {
-                en.MapId = map;
-                en.X = x;
-                en.Y = y;
-                en.Dir = dir;
-                if (en is Player p)
+                if (en.CombatTimeRemaining > 0)
                 {
-                    p.MoveDir = dir;
-                }
-                en.IsMoving = true;
-
-                switch (en.Dir)
-                {
-                    case Direction.Up:
-                        en.OffsetY = Options.TileWidth;
-                        en.OffsetX = 0;
-
-                        break;
-                    case Direction.Down:
-                        en.OffsetY = -Options.TileWidth;
-                        en.OffsetX = 0;
-
-                        break;
-                    case Direction.Left:
-                        en.OffsetY = 0;
-                        en.OffsetX = Options.TileWidth;
-
-                        break;
-                    case Direction.Right:
-                        en.OffsetY = 0;
-                        en.OffsetX = -Options.TileWidth;
-
-                        break;
-                    case Direction.UpLeft:
-                        en.OffsetY = Options.TileHeight;
-                        en.OffsetX = Options.TileWidth;
-
-                        break;
-                    case Direction.UpRight:
-                        en.OffsetY = Options.TileHeight;
-                        en.OffsetX = -Options.TileWidth;
-
-                        break;
-                    case Direction.DownLeft:
-                        en.OffsetY = -Options.TileHeight;
-                        en.OffsetX = Options.TileWidth;
-
-                        break;
-                    case Direction.DownRight:
-                        en.OffsetY = -Options.TileHeight;
-                        en.OffsetX = -Options.TileWidth;
-
-                        break;
-                }
-            }
-
-            // Set the Z-Dimension if the player has moved up or down a dimension.
-            if (entityMap.Attributes[en.X, en.Y] != null &&
-                entityMap.Attributes[en.X, en.Y].Type == MapAttribute.ZDimension)
-            {
-                if (((MapZDimensionAttribute) entityMap.Attributes[en.X, en.Y]).GatewayTo > 0)
-                {
-                    en.Z = (byte) (((MapZDimensionAttribute) entityMap.Attributes[en.X, en.Y]).GatewayTo - 1);
+                    Globals.Me.CombatTimer = Timing.Global.Milliseconds + en.CombatTimeRemaining;
                 }
             }
         }
+    }
 
-        public void HandlePacket(IPacketSender packetSender, MapEntityVitalsPacket packet)
+    public void HandlePacket(IPacketSender packetSender, MapEntityStatusPacket packet)
+    {
+        // Get our map, cancel out if it doesn't exist.
+        var map = MapInstance.Get(packet.MapId);
+        if (map == null)
         {
-            // Get our map, cancel out if it doesn't exist.
-            var map = MapInstance.Get(packet.MapId);
-            if (map == null)
-            {
-                return;
-            }
-
-            foreach (var en in packet.EntityUpdates)
-            {
-                Entity entity = null;
-
-                if (en.Type < EntityType.Event)
-                {
-                    if (!Globals.Entities.ContainsKey(en.Id))
-                    {
-                        return;
-                    }
-
-                    entity = Globals.Entities[en.Id];
-                }
-                else
-                {
-                    if (!map.LocalEntities.ContainsKey(en.Id))
-                    {
-                        return;
-                    }
-
-                    entity = map.LocalEntities[en.Id];
-                }
-
-                if (entity == null)
-                {
-                    return;
-                }
-
-                entity.Vital = en.Vitals;
-                entity.MaxVital = en.MaxVitals;
-
-                if (entity == Globals.Me)
-                {
-                    if (en.CombatTimeRemaining > 0)
-                    {
-                        Globals.Me.CombatTimer = Timing.Global.Milliseconds + en.CombatTimeRemaining;
-                    }
-                }
-            }
+            return;
         }
 
-        public void HandlePacket(IPacketSender packetSender, MapEntityStatusPacket packet)
+        foreach (var en in packet.EntityUpdates)
         {
-            // Get our map, cancel out if it doesn't exist.
-            var map = MapInstance.Get(packet.MapId);
-            if (map == null)
+            Entity entity = null;
+
+            if (en.Type < EntityType.Event)
             {
-                return;
-            }
-
-            foreach (var en in packet.EntityUpdates)
-            {
-                Entity entity = null;
-
-                if (en.Type < EntityType.Event)
-                {
-                    if (!Globals.Entities.ContainsKey(en.Id))
-                    {
-                        return;
-                    }
-
-                    entity = Globals.Entities[en.Id];
-                }
-                else
-                {
-                    if (!map.LocalEntities.ContainsKey(en.Id))
-                    {
-                        return;
-                    }
-
-                    entity = map.LocalEntities[en.Id];
-                }
-
-                if (entity == null)
+                if (!Globals.Entities.ContainsKey(en.Id))
                 {
                     return;
                 }
 
-                //Update status effects
-                entity.Status.Clear();
-                foreach (var status in en.Statuses)
-                {
-                    var instance = new Status(
-                        status.SpellId, status.Type, status.TransformSprite, status.TimeRemaining, status.TotalDuration
-                    );
-
-                    entity.Status.Add(instance);
-
-                    if (instance.Type == SpellEffect.Stun || instance.Type == SpellEffect.Silence)
-                    {
-                        entity.CastTime = 0;
-                    }
-                    else if (instance.Type == SpellEffect.Shield)
-                    {
-                        instance.Shield = status.VitalShields;
-                    }
-                }
-
-                entity.SortStatuses();
-
-                if (Interface.Interface.GameUi != null)
-                {
-                    //If its you or your target, update the entity box.
-                    if (en.Id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
-                    {
-                        Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
-                    }
-                    else if (en.Id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
-                    {
-                        Globals.Me.TargetBox.ShouldUpdateStatuses = true;
-                    }
-                }
-            }
-        }
-
-        //EntityVitalsPacket
-        public void HandlePacket(IPacketSender packetSender, EntityVitalsPacket packet)
-        {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            Entity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = Globals.Entities[id];
+                entity = Globals.Entities[en.Id];
             }
             else
             {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
+                if (!map.LocalEntities.ContainsKey(en.Id))
                 {
                     return;
                 }
 
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = entityMap.LocalEntities[id];
+                entity = map.LocalEntities[en.Id];
             }
 
-            if (en == null)
+            if (entity == null)
             {
                 return;
-            }
-
-            en.Vital = packet.Vitals;
-            en.MaxVital = packet.MaxVitals;
-
-            if (en == Globals.Me)
-            {
-                if (packet.CombatTimeRemaining > 0)
-                {
-                    Globals.Me.CombatTimer = Timing.Global.Milliseconds + packet.CombatTimeRemaining;
-                }
             }
 
             //Update status effects
-            en.Status.Clear();
-            foreach (var status in packet.StatusEffects)
+            entity.Status.Clear();
+            foreach (var status in en.Statuses)
             {
                 var instance = new Status(
                     status.SpellId, status.Type, status.TransformSprite, status.TimeRemaining, status.TotalDuration
                 );
 
-                en.Status.Add(instance);
+                entity.Status.Add(instance);
 
                 if (instance.Type == SpellEffect.Stun || instance.Type == SpellEffect.Silence)
                 {
-                    en.CastTime = 0;
+                    entity.CastTime = 0;
                 }
                 else if (instance.Type == SpellEffect.Shield)
                 {
@@ -954,547 +869,659 @@ namespace Intersect.Client.Networking
                 }
             }
 
-            en.SortStatuses();
+            entity.SortStatuses();
 
             if (Interface.Interface.GameUi != null)
             {
                 //If its you or your target, update the entity box.
-                if (id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
+                if (en.Id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
                 {
                     Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
                 }
-                else if (id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
+                else if (en.Id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
                 {
                     Globals.Me.TargetBox.ShouldUpdateStatuses = true;
                 }
             }
         }
+    }
 
-        //EntityStatsPacket
-        public void HandlePacket(IPacketSender packetSender, EntityStatsPacket packet)
+    //EntityVitalsPacket
+    public void HandlePacket(IPacketSender packetSender, EntityVitalsPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        Entity en = null;
+        if (type < EntityType.Event)
         {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            Entity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
-                {
-                    return;
-                }
-
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = entityMap.LocalEntities[id];
-            }
-
-            if (en == null)
+            if (!Globals.Entities.ContainsKey(id))
             {
                 return;
             }
 
-            en.Stat = packet.Stats;
+            en = Globals.Entities[id];
         }
-
-        //EntityDirectionPacket
-        public void HandlePacket(IPacketSender packetSender, EntityDirectionPacket packet)
+        else
         {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            Entity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
-                {
-                    return;
-                }
-
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = entityMap.LocalEntities[id];
-            }
-
-            if (en == null)
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
             {
                 return;
             }
 
-            en.Dir = (Direction)packet.Direction;
-        }
-
-        //EntityAttackPacket
-        public void HandlePacket(IPacketSender packetSender, EntityAttackPacket packet)
-        {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            var attackTimer = packet.AttackTimer;
-
-            Entity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
-                {
-                    return;
-                }
-
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = entityMap.LocalEntities[id];
-            }
-
-            if (en == null)
+            if (!entityMap.LocalEntities.ContainsKey(id))
             {
                 return;
             }
 
-            var isSelf = en == Globals.Me;
-            en.IsBlocking = packet.IsBlocking;
+            en = entityMap.LocalEntities[id];
+        }
 
-            if (attackTimer > -1)
+        if (en == null)
+        {
+            return;
+        }
+
+        en.Vital = packet.Vitals;
+        en.MaxVital = packet.MaxVitals;
+
+        if (en == Globals.Me)
+        {
+            if (packet.CombatTimeRemaining > 0)
             {
-                en.AttackTimer = Timing.Global.Milliseconds + attackTimer;
-                if (!isSelf)
-                {
-                    en.AttackTime = attackTimer;
-                }
+                Globals.Me.CombatTimer = Timing.Global.Milliseconds + packet.CombatTimeRemaining;
             }
         }
 
-        //EntityDiePacket
-        public void HandlePacket(IPacketSender packetSender, EntityDiePacket packet)
+        //Update status effects
+        en.Status.Clear();
+        foreach (var status in packet.StatusEffects)
         {
-            var id = packet.Id;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            
-            Entity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
-                }
-                
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
-                {
-                    return;
-                }
-
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                {
-                    return;
-                }
-
-                en = entityMap.LocalEntities[id];
-            }
-
-            if (en == null)
-            {
-                return;
-            }
-
-            en.ClearAnimations(null);
-        }
-
-        //EventDialogPacket
-        public void HandlePacket(IPacketSender packetSender, EventDialogPacket packet)
-        {
-            var ed = new Dialog();
-            ed.Prompt = packet.Prompt;
-            ed.Face = packet.Face;
-            if (packet.Type != 0)
-            {
-                ed.Opt1 = packet.Responses[0];
-                ed.Opt2 = packet.Responses[1];
-                ed.Opt3 = packet.Responses[2];
-                ed.Opt4 = packet.Responses[3];
-            }
-
-            ed.EventId = packet.EventId;
-            Globals.EventDialogs.Add(ed);
-        }
-
-        //InputVariablePacket
-        public void HandlePacket(IPacketSender packetSender, InputVariablePacket packet)
-        {
-            var type = InputBox.InputType.NumericInput;
-            switch (packet.Type)
-            {
-                case VariableDataType.String:
-                    type = InputBox.InputType.TextInput;
-
-                    break;
-                case VariableDataType.Integer:
-                case VariableDataType.Number:
-                    type = InputBox.InputType.NumericInput;
-
-                    break;
-                case VariableDataType.Boolean:
-                    type = InputBox.InputType.YesNo;
-
-                    break;
-            }
-
-            var iBox = new InputBox(
-                packet.Title, packet.Prompt, true, type, PacketSender.SendEventInputVariable,
-                PacketSender.SendEventInputVariableCancel, packet.EventId
+            var instance = new Status(
+                status.SpellId, status.Type, status.TransformSprite, status.TimeRemaining, status.TotalDuration
             );
+
+            en.Status.Add(instance);
+
+            if (instance.Type == SpellEffect.Stun || instance.Type == SpellEffect.Silence)
+            {
+                en.CastTime = 0;
+            }
+            else if (instance.Type == SpellEffect.Shield)
+            {
+                instance.Shield = status.VitalShields;
+            }
         }
 
-        //ErrorMessagePacket
-        public void HandlePacket(IPacketSender packetSender, ErrorMessagePacket packet)
-        {
-            Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
-            Globals.WaitingOnServer = false;
-            Interface.Interface.ShowError(packet.Header, packet.Error);
-            Interface.Interface.MenuUi?.Reset();
-        }
+        en.SortStatuses();
 
-        //MapItemsPacket
-        public void HandlePacket(IPacketSender packetSender, MapItemsPacket packet)
+        if (Interface.Interface.GameUi != null)
         {
-            var map = MapInstance.Get(packet.MapId);
-            if (map == null)
+            //If its you or your target, update the entity box.
+            if (id == Globals.Me.Id && Interface.Interface.GameUi.PlayerStatusWindow != null)
+            {
+                Interface.Interface.GameUi.PlayerStatusWindow.ShouldUpdateStatuses = true;
+            }
+            else if (id == Globals.Me.TargetIndex && Globals.Me.TargetBox != null)
+            {
+                Globals.Me.TargetBox.ShouldUpdateStatuses = true;
+            }
+        }
+    }
+
+    //EntityStatsPacket
+    public void HandlePacket(IPacketSender packetSender, EntityStatsPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
             {
                 return;
             }
 
-            map.MapItems.Clear();
-            foreach(var item in packet.Items)
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
             {
-                var mapItem = new MapItemInstance(item.TileIndex,item.Id, item.ItemId, item.BagId, item.Quantity, item.Properties);
-                
-                if (!map.MapItems.ContainsKey(mapItem.TileIndex))
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        en.Stat = packet.Stats;
+    }
+
+    //EntityDirectionPacket
+    public void HandlePacket(IPacketSender packetSender, EntityDirectionPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        en.Dir = (Direction)packet.Direction;
+    }
+
+    //EntityAttackPacket
+    public void HandlePacket(IPacketSender packetSender, EntityAttackPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        var attackTimer = packet.AttackTimer;
+
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        var isSelf = en == Globals.Me;
+        en.IsBlocking = packet.IsBlocking;
+
+        if (attackTimer > -1)
+        {
+            en.AttackTimer = Timing.Global.Milliseconds + attackTimer;
+            if (!isSelf)
+            {
+                en.AttackTime = attackTimer;
+            }
+        }
+    }
+
+    //EntityDiePacket
+    public void HandlePacket(IPacketSender packetSender, EntityDiePacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
+            {
+                return;
+            }
+            
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        en.ClearAnimations(null);
+    }
+
+    //EventDialogPacket
+    public void HandlePacket(IPacketSender packetSender, EventDialogPacket packet)
+    {
+        var ed = new Dialog();
+        ed.Prompt = packet.Prompt;
+        ed.Face = packet.Face;
+        if (packet.Type != 0)
+        {
+            ed.Opt1 = packet.Responses[0];
+            ed.Opt2 = packet.Responses[1];
+            ed.Opt3 = packet.Responses[2];
+            ed.Opt4 = packet.Responses[3];
+        }
+
+        ed.EventId = packet.EventId;
+        Globals.EventDialogs.Add(ed);
+    }
+
+    //InputVariablePacket
+    public void HandlePacket(IPacketSender packetSender, InputVariablePacket packet)
+    {
+        var type = InputBox.InputType.NumericInput;
+        switch (packet.Type)
+        {
+            case VariableDataType.String:
+                type = InputBox.InputType.TextInput;
+
+                break;
+            case VariableDataType.Integer:
+            case VariableDataType.Number:
+                type = InputBox.InputType.NumericInput;
+
+                break;
+            case VariableDataType.Boolean:
+                type = InputBox.InputType.YesNo;
+
+                break;
+        }
+
+        var iBox = new InputBox(
+            packet.Title, packet.Prompt, true, type, PacketSender.SendEventInputVariable,
+            PacketSender.SendEventInputVariableCancel, packet.EventId
+        );
+    }
+
+    //ErrorMessagePacket
+    public void HandlePacket(IPacketSender packetSender, ErrorMessagePacket packet)
+    {
+        Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
+        Globals.WaitingOnServer = false;
+        Interface.Interface.ShowError(packet.Header, packet.Error);
+        Interface.Interface.MenuUi?.Reset();
+    }
+
+    //MapItemsPacket
+    public void HandlePacket(IPacketSender packetSender, MapItemsPacket packet)
+    {
+        var map = MapInstance.Get(packet.MapId);
+        if (map == null)
+        {
+            return;
+        }
+
+        map.MapItems.Clear();
+        foreach(var item in packet.Items)
+        {
+            var mapItem = new MapItemInstance(item.TileIndex,item.Id, item.ItemId, item.BagId, item.Quantity, item.Properties);
+            
+            if (!map.MapItems.ContainsKey(mapItem.TileIndex))
+            {
+                map.MapItems.Add(mapItem.TileIndex, new List<IMapItemInstance>());
+            }
+
+            map.MapItems[mapItem.TileIndex].Add(mapItem);
+        }
+    }
+
+    //MapItemUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, MapItemUpdatePacket packet)
+    {
+        var map = MapInstance.Get(packet.MapId);
+        if (map == null)
+        {
+            return;
+        }
+
+        // Are we deleting this item?
+        if (packet.ItemId == Guid.Empty)
+        {
+            // Find our item based on our unique Id and remove it.
+            foreach(var location in map.MapItems.Keys)
+            {
+                var tempItem = map.MapItems[location].Where(item => item.Id == packet.Id).SingleOrDefault();
+                if (tempItem != null)
                 {
-                    map.MapItems.Add(mapItem.TileIndex, new List<IMapItemInstance>());
+                    map.MapItems[location].Remove(tempItem);
                 }
-
-                map.MapItems[mapItem.TileIndex].Add(mapItem);
             }
         }
-
-        //MapItemUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, MapItemUpdatePacket packet)
+        else
         {
-            var map = MapInstance.Get(packet.MapId);
-            if (map == null)
+            if (!map.MapItems.ContainsKey(packet.TileIndex))
             {
-                return;
+                map.MapItems.Add(packet.TileIndex, new List<IMapItemInstance>());
             }
 
-            // Are we deleting this item?
-            if (packet.ItemId == Guid.Empty)
+            // Check if the item already exists, if it does replace it. Otherwise just add it.
+            var mapItem = new MapItemInstance(packet.TileIndex, packet.Id, packet.ItemId, packet.BagId, packet.Quantity, packet.Properties);
+            if (map.MapItems[packet.TileIndex].Any(item => item.Id == mapItem.Id))
             {
-                // Find our item based on our unique Id and remove it.
-                foreach(var location in map.MapItems.Keys)
+                for (var index = 0; index < map.MapItems[packet.TileIndex].Count; index++)
                 {
-                    var tempItem = map.MapItems[location].Where(item => item.Id == packet.Id).SingleOrDefault();
-                    if (tempItem != null)
+                    if (map.MapItems[packet.TileIndex][index].Id == mapItem.Id)
                     {
-                        map.MapItems[location].Remove(tempItem);
+                        map.MapItems[packet.TileIndex][index] = mapItem;
                     }
                 }
             }
             else
             {
-                if (!map.MapItems.ContainsKey(packet.TileIndex))
+                // Reverse the array again to match server, add item.. then  reverse again to get the right render order.
+                map.MapItems[packet.TileIndex].Add(mapItem);
+            } 
+        }
+    }
+
+    //InventoryPacket
+    public void HandlePacket(IPacketSender packetSender, InventoryPacket packet)
+    {
+        foreach (var inv in packet.Slots)
+        {
+            HandlePacket(inv);
+        }
+    }
+
+    //InventoryUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, InventoryUpdatePacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.Inventory[packet.Slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
+            Globals.Me.InventoryUpdatedDelegate?.Invoke();
+        }
+    }
+
+    //SpellsPacket
+    public void HandlePacket(IPacketSender packetSender, SpellsPacket packet)
+    {
+        foreach (var spl in packet.Slots)
+        {
+            HandlePacket(spl);
+        }
+    }
+
+    //SpellUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, SpellUpdatePacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.Spells[packet.Slot].Load(packet.SpellId);
+        }
+    }
+
+    //EquipmentPacket
+    public void HandlePacket(IPacketSender packetSender, EquipmentPacket packet)
+    {
+        var entityId = packet.EntityId;
+        if (Globals.Entities.ContainsKey(entityId))
+        {
+            var entity = Globals.Entities[entityId];
+            if (entity != null)
+            {
+                if (entity == Globals.Me && packet.InventorySlots != null)
                 {
-                    map.MapItems.Add(packet.TileIndex, new List<IMapItemInstance>());
+                    entity.MyEquipment = packet.InventorySlots;
                 }
-
-                // Check if the item already exists, if it does replace it. Otherwise just add it.
-                var mapItem = new MapItemInstance(packet.TileIndex, packet.Id, packet.ItemId, packet.BagId, packet.Quantity, packet.Properties);
-                if (map.MapItems[packet.TileIndex].Any(item => item.Id == mapItem.Id))
+                else if (packet.ItemIds != null)
                 {
-                    for (var index = 0; index < map.MapItems[packet.TileIndex].Count; index++)
-                    {
-                        if (map.MapItems[packet.TileIndex][index].Id == mapItem.Id)
-                        {
-                            map.MapItems[packet.TileIndex][index] = mapItem;
-                        }
-                    }
+                    entity.Equipment = packet.ItemIds;
                 }
-                else
+            }
+        }
+    }
+
+    //StatPointsPacket
+    public void HandlePacket(IPacketSender packetSender, StatPointsPacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.StatPoints = packet.Points;
+        }
+    }
+
+    //HotbarPacket
+    public void HandlePacket(IPacketSender packetSender, HotbarPacket packet)
+    {
+        for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
+        {
+            if (Globals.Me == null)
+            {
+                Log.Debug("Can't set hotbar, Globals.Me is null!");
+
+                break;
+            }
+
+            if (Globals.Me.Hotbar == null)
+            {
+                Log.Debug("Can't set hotbar, hotbar is null!");
+
+                break;
+            }
+
+            var hotbarEntry = Globals.Me.Hotbar[i];
+            hotbarEntry.Load(packet.SlotData[i]);
+        }
+    }
+
+    //CharacterCreationPacket
+    public void HandlePacket(IPacketSender packetSender, CharacterCreationPacket packet)
+    {
+        Globals.WaitingOnServer = false;
+        Interface.Interface.MenuUi.MainMenu.NotifyOpenCharacterCreation();
+    }
+
+    //AdminPanelPacket
+    public void HandlePacket(IPacketSender packetSender, AdminPanelPacket packet)
+    {
+        Interface.Interface.GameUi.NotifyOpenAdminWindow();
+    }
+
+    //SpellCastPacket
+    public void HandlePacket(IPacketSender packetSender, SpellCastPacket packet)
+    {
+        var entityId = packet.EntityId;
+        var spellId = packet.SpellId;
+        if (SpellBase.Get(spellId) != null && Globals.Entities.ContainsKey(entityId))
+        {
+            Globals.Entities[entityId].CastTime = Timing.Global.Milliseconds + SpellBase.Get(spellId).CastDuration;
+            Globals.Entities[entityId].SpellCast = spellId;
+        }
+    }
+
+    //SpellCooldownPacket
+    public void HandlePacket(IPacketSender packetSender, SpellCooldownPacket packet)
+    {
+        foreach (var cd in packet.SpellCds)
+        {
+            var time = Timing.Global.Milliseconds + cd.Value;
+            if (!Globals.Me.SpellCooldowns.ContainsKey(cd.Key))
+            {
+                Globals.Me.SpellCooldowns.Add(cd.Key, time);
+            }
+            else
+            {
+                Globals.Me.SpellCooldowns[cd.Key] = time;
+            }
+        }
+    }
+
+    //ItemCooldownPacket
+    public void HandlePacket(IPacketSender packetSender, ItemCooldownPacket packet)
+    {
+        foreach (var cd in packet.ItemCds)
+        {
+            var time = Timing.Global.Milliseconds + cd.Value;
+            if (!Globals.Me.ItemCooldowns.ContainsKey(cd.Key))
+            {
+                Globals.Me.ItemCooldowns.Add(cd.Key, time);
+            }
+            else
+            {
+                Globals.Me.ItemCooldowns[cd.Key] = time;
+            }
+        }
+    }
+
+    //GlobalCooldownPacket
+    public void HandlePacket(IPacketSender packetSender, GlobalCooldownPacket packet)
+    {
+        Globals.Me.GlobalCooldown = Timing.Global.Milliseconds + packet.GlobalCooldown;
+    }
+
+    //ExperiencePacket
+    public void HandlePacket(IPacketSender packetSender, ExperiencePacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.Experience = packet.Experience;
+            Globals.Me.ExperienceToNextLevel = packet.ExperienceToNextLevel;
+        }
+    }
+
+    //ProjectileDeadPacket
+    public void HandlePacket(IPacketSender packetSender, ProjectileDeadPacket packet)
+    {
+        if (packet.ProjectileDeaths != null)
+        {
+            foreach (var projDeath in packet.ProjectileDeaths)
+            {
+                if (Globals.Entities.ContainsKey(projDeath) && Globals.Entities[projDeath] is Projectile)
                 {
-                    // Reverse the array again to match server, add item.. then  reverse again to get the right render order.
-                    map.MapItems[packet.TileIndex].Add(mapItem);
-                } 
+                    Globals.EntitiesToDispose?.Add(projDeath);
+                }
             }
         }
-
-        //InventoryPacket
-        public void HandlePacket(IPacketSender packetSender, InventoryPacket packet)
+        if (packet.SpawnDeaths != null)
         {
-            foreach (var inv in packet.Slots)
+            foreach (var spawnDeath in packet.SpawnDeaths)
             {
-                HandlePacket(inv);
+                if (Globals.Entities.ContainsKey(spawnDeath.Key) && Globals.Entities[spawnDeath.Key] is Projectile projectile)
+                {
+                    projectile.SpawnDead(spawnDeath.Value);
+                }
             }
         }
+    }
 
-        //InventoryUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, InventoryUpdatePacket packet)
+    //PlayAnimationPackets
+    public void HandlePacket(IPacketSender sender, PlayAnimationPackets packet)
+    {
+        foreach (var pkt in packet.Packets)
         {
-            if (Globals.Me != null)
+            HandlePacket(pkt);
+        }
+    }
+
+    //PlayAnimationPacket
+    public void HandlePacket(IPacketSender packetSender, PlayAnimationPacket packet)
+    {
+        var mapId = packet.MapId;
+        var animId = packet.AnimationId;
+        var targetType = packet.TargetType;
+        var entityId = packet.EntityId;
+        if (targetType == -1)
+        {
+            var map = MapInstance.Get(mapId);
+            if (map != null)
             {
-                Globals.Me.Inventory[packet.Slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
-                Globals.Me.InventoryUpdatedDelegate?.Invoke();
+                map.AddTileAnimation(animId, packet.X, packet.Y, packet.Direction);
             }
         }
-
-        //SpellsPacket
-        public void HandlePacket(IPacketSender packetSender, SpellsPacket packet)
+        else if (targetType == 1)
         {
-            foreach (var spl in packet.Slots)
-            {
-                HandlePacket(spl);
-            }
-        }
-
-        //SpellUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, SpellUpdatePacket packet)
-        {
-            if (Globals.Me != null)
-            {
-                Globals.Me.Spells[packet.Slot].Load(packet.SpellId);
-            }
-        }
-
-        //EquipmentPacket
-        public void HandlePacket(IPacketSender packetSender, EquipmentPacket packet)
-        {
-            var entityId = packet.EntityId;
             if (Globals.Entities.ContainsKey(entityId))
             {
-                var entity = Globals.Entities[entityId];
-                if (entity != null)
+                if (Globals.Entities[entityId] != null && !Globals.EntitiesToDispose.Contains(entityId))
                 {
-                    if (entity == Globals.Me && packet.InventorySlots != null)
+                    var animBase = AnimationBase.Get(animId);
+                    if (animBase != null)
                     {
-                        entity.MyEquipment = packet.InventorySlots;
-                    }
-                    else if (packet.ItemIds != null)
-                    {
-                        entity.Equipment = packet.ItemIds;
-                    }
-                }
-            }
-        }
+                        var animInstance = new Animation(
+                            animBase, false, packet.Direction != Direction.None, -1, Globals.Entities[entityId]
+                        );
 
-        //StatPointsPacket
-        public void HandlePacket(IPacketSender packetSender, StatPointsPacket packet)
-        {
-            if (Globals.Me != null)
-            {
-                Globals.Me.StatPoints = packet.Points;
-            }
-        }
+                        if (packet.Direction > Direction.None)
+                        {
+                            animInstance.SetDir(packet.Direction);
+                        }
 
-        //HotbarPacket
-        public void HandlePacket(IPacketSender packetSender, HotbarPacket packet)
-        {
-            for (var i = 0; i < Options.Instance.PlayerOpts.HotbarSlotCount; i++)
-            {
-                if (Globals.Me == null)
-                {
-                    Log.Debug("Can't set hotbar, Globals.Me is null!");
-
-                    break;
-                }
-
-                if (Globals.Me.Hotbar == null)
-                {
-                    Log.Debug("Can't set hotbar, hotbar is null!");
-
-                    break;
-                }
-
-                var hotbarEntry = Globals.Me.Hotbar[i];
-                hotbarEntry.Load(packet.SlotData[i]);
-            }
-        }
-
-        //CharacterCreationPacket
-        public void HandlePacket(IPacketSender packetSender, CharacterCreationPacket packet)
-        {
-            Globals.WaitingOnServer = false;
-            Interface.Interface.MenuUi.MainMenu.NotifyOpenCharacterCreation();
-        }
-
-        //AdminPanelPacket
-        public void HandlePacket(IPacketSender packetSender, AdminPanelPacket packet)
-        {
-            Interface.Interface.GameUi.NotifyOpenAdminWindow();
-        }
-
-        //SpellCastPacket
-        public void HandlePacket(IPacketSender packetSender, SpellCastPacket packet)
-        {
-            var entityId = packet.EntityId;
-            var spellId = packet.SpellId;
-            if (SpellBase.Get(spellId) != null && Globals.Entities.ContainsKey(entityId))
-            {
-                Globals.Entities[entityId].CastTime = Timing.Global.Milliseconds + SpellBase.Get(spellId).CastDuration;
-                Globals.Entities[entityId].SpellCast = spellId;
-            }
-        }
-
-        //SpellCooldownPacket
-        public void HandlePacket(IPacketSender packetSender, SpellCooldownPacket packet)
-        {
-            foreach (var cd in packet.SpellCds)
-            {
-                var time = Timing.Global.Milliseconds + cd.Value;
-                if (!Globals.Me.SpellCooldowns.ContainsKey(cd.Key))
-                {
-                    Globals.Me.SpellCooldowns.Add(cd.Key, time);
-                }
-                else
-                {
-                    Globals.Me.SpellCooldowns[cd.Key] = time;
-                }
-            }
-        }
-
-        //ItemCooldownPacket
-        public void HandlePacket(IPacketSender packetSender, ItemCooldownPacket packet)
-        {
-            foreach (var cd in packet.ItemCds)
-            {
-                var time = Timing.Global.Milliseconds + cd.Value;
-                if (!Globals.Me.ItemCooldowns.ContainsKey(cd.Key))
-                {
-                    Globals.Me.ItemCooldowns.Add(cd.Key, time);
-                }
-                else
-                {
-                    Globals.Me.ItemCooldowns[cd.Key] = time;
-                }
-            }
-        }
-
-        //GlobalCooldownPacket
-        public void HandlePacket(IPacketSender packetSender, GlobalCooldownPacket packet)
-        {
-            Globals.Me.GlobalCooldown = Timing.Global.Milliseconds + packet.GlobalCooldown;
-        }
-
-        //ExperiencePacket
-        public void HandlePacket(IPacketSender packetSender, ExperiencePacket packet)
-        {
-            if (Globals.Me != null)
-            {
-                Globals.Me.Experience = packet.Experience;
-                Globals.Me.ExperienceToNextLevel = packet.ExperienceToNextLevel;
-            }
-        }
-
-        //ProjectileDeadPacket
-        public void HandlePacket(IPacketSender packetSender, ProjectileDeadPacket packet)
-        {
-            if (packet.ProjectileDeaths != null)
-            {
-                foreach (var projDeath in packet.ProjectileDeaths)
-                {
-                    if (Globals.Entities.ContainsKey(projDeath) && Globals.Entities[projDeath] is Projectile)
-                    {
-                        Globals.EntitiesToDispose?.Add(projDeath);
-                    }
-                }
-            }
-            if (packet.SpawnDeaths != null)
-            {
-                foreach (var spawnDeath in packet.SpawnDeaths)
-                {
-                    if (Globals.Entities.ContainsKey(spawnDeath.Key) && Globals.Entities[spawnDeath.Key] is Projectile projectile)
-                    {
-                        projectile.SpawnDead(spawnDeath.Value);
+                        Globals.Entities[entityId].Animations.Add(animInstance);
                     }
                 }
             }
         }
-
-        //PlayAnimationPackets
-        public void HandlePacket(IPacketSender sender, PlayAnimationPackets packet)
+        else if (targetType == 2)
         {
-            foreach (var pkt in packet.Packets)
+            var map = MapInstance.Get(mapId);
+            if (map != null)
             {
-                HandlePacket(pkt);
-            }
-        }
-
-        //PlayAnimationPacket
-        public void HandlePacket(IPacketSender packetSender, PlayAnimationPacket packet)
-        {
-            var mapId = packet.MapId;
-            var animId = packet.AnimationId;
-            var targetType = packet.TargetType;
-            var entityId = packet.EntityId;
-            if (targetType == -1)
-            {
-                var map = MapInstance.Get(mapId);
-                if (map != null)
+                if (map.LocalEntities.ContainsKey(entityId))
                 {
-                    map.AddTileAnimation(animId, packet.X, packet.Y, packet.Direction);
-                }
-            }
-            else if (targetType == 1)
-            {
-                if (Globals.Entities.ContainsKey(entityId))
-                {
-                    if (Globals.Entities[entityId] != null && !Globals.EntitiesToDispose.Contains(entityId))
+                    if (map.LocalEntities[entityId] != null)
                     {
                         var animBase = AnimationBase.Get(animId);
                         if (animBase != null)
                         {
                             var animInstance = new Animation(
-                                animBase, false, packet.Direction != Direction.None, -1, Globals.Entities[entityId]
+                                animBase, false, packet.Direction == Direction.None, -1,
+                                map.LocalEntities[entityId]
                             );
 
                             if (packet.Direction > Direction.None)
@@ -1502,672 +1529,643 @@ namespace Intersect.Client.Networking
                                 animInstance.SetDir(packet.Direction);
                             }
 
-                            Globals.Entities[entityId].Animations.Add(animInstance);
-                        }
-                    }
-                }
-            }
-            else if (targetType == 2)
-            {
-                var map = MapInstance.Get(mapId);
-                if (map != null)
-                {
-                    if (map.LocalEntities.ContainsKey(entityId))
-                    {
-                        if (map.LocalEntities[entityId] != null)
-                        {
-                            var animBase = AnimationBase.Get(animId);
-                            if (animBase != null)
-                            {
-                                var animInstance = new Animation(
-                                    animBase, false, packet.Direction == Direction.None, -1,
-                                    map.LocalEntities[entityId]
-                                );
-
-                                if (packet.Direction > Direction.None)
-                                {
-                                    animInstance.SetDir(packet.Direction);
-                                }
-
-                                map.LocalEntities[entityId].Animations.Add(animInstance);
-                            }
+                            map.LocalEntities[entityId].Animations.Add(animInstance);
                         }
                     }
                 }
             }
         }
+    }
 
-        //HoldPlayerPacket
-        public void HandlePacket(IPacketSender packetSender, HoldPlayerPacket packet)
+    //HoldPlayerPacket
+    public void HandlePacket(IPacketSender packetSender, HoldPlayerPacket packet)
+    {
+        var eventId = packet.EventId;
+        var mapId = packet.MapId;
+        if (!packet.Releasing)
         {
-            var eventId = packet.EventId;
-            var mapId = packet.MapId;
-            if (!packet.Releasing)
+            if (!Globals.EventHolds.ContainsKey(eventId))
             {
-                if (!Globals.EventHolds.ContainsKey(eventId))
+                Globals.EventHolds.Add(eventId, mapId);
+            }
+        }
+        else
+        {
+            if (Globals.EventHolds.ContainsKey(eventId))
+            {
+                Globals.EventHolds.Remove(eventId);
+            }
+        }
+    }
+
+    //PlayMusicPacket
+    public void HandlePacket(IPacketSender packetSender, PlayMusicPacket packet)
+    {
+        Audio.PlayMusic(packet.BGM, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
+    }
+
+    //StopMusicPacket
+    public void HandlePacket(IPacketSender packetSender, StopMusicPacket packet)
+    {
+        Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
+    }
+
+    //PlaySoundPacket
+    public void HandlePacket(IPacketSender packetSender, PlaySoundPacket packet)
+    {
+        Audio.AddGameSound(packet.Sound, false);
+    }
+
+    //StopSoundsPacket
+    public void HandlePacket(IPacketSender packetSender, StopSoundsPacket packet)
+    {
+        Audio.StopAllSounds();
+    }
+
+    //ShowPicturePacket
+    public void HandlePacket(IPacketSender packetSender, ShowPicturePacket packet)
+    {
+        PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
+        packet.ReceiveTime = Timing.Global.Milliseconds;
+        Globals.Picture = packet;
+    }
+
+    //HidePicturePacket
+    public void HandlePacket(IPacketSender packetSender, HidePicturePacket packet)
+    {
+        PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
+        Globals.Picture = null;
+    }
+
+    //ShopPacket
+    public void HandlePacket(IPacketSender packetSender, ShopPacket packet)
+    {
+        if (Interface.Interface.GameUi == null)
+        {
+            throw new ArgumentNullException(nameof(Interface.Interface.GameUi));
+        }
+
+        if (packet == null)
+        {
+            throw new ArgumentNullException(nameof(packet));
+        }
+
+        if (packet.ShopData != null)
+        {
+            Globals.GameShop = new ShopBase();
+            Globals.GameShop.Load(packet.ShopData);
+            Interface.Interface.GameUi.NotifyOpenShop();
+        }
+        else
+        {
+            Globals.GameShop = null;
+            Interface.Interface.GameUi.NotifyCloseShop();
+        }
+    }
+
+    //CraftingTablePacket
+    public void HandlePacket(IPacketSender packetSender, CraftingTablePacket packet)
+    {
+        if (!packet.Close)
+        {
+            Globals.ActiveCraftingTable = new CraftingTableBase();
+            Globals.ActiveCraftingTable.Load(packet.TableData);
+            Interface.Interface.GameUi.NotifyOpenCraftingTable(packet.JournalMode);
+        }
+        else
+        {
+            Interface.Interface.GameUi.NotifyCloseCraftingTable();
+        }
+    }
+
+    //BankPacket
+    public void HandlePacket(IPacketSender packetSender, BankPacket packet)
+    {
+        if (!packet.Close)
+        {
+            Globals.GuildBank = packet.Guild;
+            Globals.Bank = new Item[packet.Slots];
+            foreach (var itm in packet.Items)
+            {
+                HandlePacket(itm);
+            }
+            Globals.BankSlots = packet.Slots;
+            Interface.Interface.GameUi.NotifyOpenBank();
+        }
+        else
+        {
+            Interface.Interface.GameUi.NotifyCloseBank();
+        }
+    }
+
+    //BankUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, BankUpdatePacket packet)
+    {
+        var slot = packet.Slot;
+        if (packet.ItemId != Guid.Empty)
+        {
+            Globals.Bank[slot] = new Item();
+            Globals.Bank[slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
+        }
+        else
+        {
+            Globals.Bank[slot] = null;
+        }
+    }
+
+    //GameObjectPacket
+    public void HandlePacket(IPacketSender packetSender, GameObjectPacket packet)
+    {
+        var type = packet.Type;
+        var id = packet.Id;
+        var another = packet.AnotherFollowing;
+        var deleted = packet.Deleted;
+        var json = "";
+        if (!deleted)
+        {
+            json = packet.Data;
+        }
+
+        switch (type)
+        {
+            case GameObjectType.Map:
+                //Handled in a different packet
+                break;
+            case GameObjectType.Tileset:
+                var obj = new TilesetBase(id);
+                obj.Load(json);
+                TilesetBase.Lookup.Set(id, obj);
+                if (Globals.HasGameData && !another)
                 {
-                    Globals.EventHolds.Add(eventId, mapId);
-                }
-            }
-            else
-            {
-                if (Globals.EventHolds.ContainsKey(eventId))
-                {
-                    Globals.EventHolds.Remove(eventId);
-                }
-            }
-        }
-
-        //PlayMusicPacket
-        public void HandlePacket(IPacketSender packetSender, PlayMusicPacket packet)
-        {
-            Audio.PlayMusic(packet.BGM, ClientConfiguration.Instance.MusicFadeTimer, ClientConfiguration.Instance.MusicFadeTimer, true);
-        }
-
-        //StopMusicPacket
-        public void HandlePacket(IPacketSender packetSender, StopMusicPacket packet)
-        {
-            Audio.StopMusic(ClientConfiguration.Instance.MusicFadeTimer);
-        }
-
-        //PlaySoundPacket
-        public void HandlePacket(IPacketSender packetSender, PlaySoundPacket packet)
-        {
-            Audio.AddGameSound(packet.Sound, false);
-        }
-
-        //StopSoundsPacket
-        public void HandlePacket(IPacketSender packetSender, StopSoundsPacket packet)
-        {
-            Audio.StopAllSounds();
-        }
-
-        //ShowPicturePacket
-        public void HandlePacket(IPacketSender packetSender, ShowPicturePacket packet)
-        {
-            PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
-            packet.ReceiveTime = Timing.Global.Milliseconds;
-            Globals.Picture = packet;
-        }
-
-        //HidePicturePacket
-        public void HandlePacket(IPacketSender packetSender, HidePicturePacket packet)
-        {
-            PacketSender.SendClosePicture(Globals.Picture?.EventId ?? Guid.Empty);
-            Globals.Picture = null;
-        }
-
-        //ShopPacket
-        public void HandlePacket(IPacketSender packetSender, ShopPacket packet)
-        {
-            if (Interface.Interface.GameUi == null)
-            {
-                throw new ArgumentNullException(nameof(Interface.Interface.GameUi));
-            }
-
-            if (packet == null)
-            {
-                throw new ArgumentNullException(nameof(packet));
-            }
-
-            if (packet.ShopData != null)
-            {
-                Globals.GameShop = new ShopBase();
-                Globals.GameShop.Load(packet.ShopData);
-                Interface.Interface.GameUi.NotifyOpenShop();
-            }
-            else
-            {
-                Globals.GameShop = null;
-                Interface.Interface.GameUi.NotifyCloseShop();
-            }
-        }
-
-        //CraftingTablePacket
-        public void HandlePacket(IPacketSender packetSender, CraftingTablePacket packet)
-        {
-            if (!packet.Close)
-            {
-                Globals.ActiveCraftingTable = new CraftingTableBase();
-                Globals.ActiveCraftingTable.Load(packet.TableData);
-                Interface.Interface.GameUi.NotifyOpenCraftingTable(packet.JournalMode);
-            }
-            else
-            {
-                Interface.Interface.GameUi.NotifyCloseCraftingTable();
-            }
-        }
-
-        //BankPacket
-        public void HandlePacket(IPacketSender packetSender, BankPacket packet)
-        {
-            if (!packet.Close)
-            {
-                Globals.GuildBank = packet.Guild;
-                Globals.Bank = new Item[packet.Slots];
-                foreach (var itm in packet.Items)
-                {
-                    HandlePacket(itm);
-                }
-                Globals.BankSlots = packet.Slots;
-                Interface.Interface.GameUi.NotifyOpenBank();
-            }
-            else
-            {
-                Interface.Interface.GameUi.NotifyCloseBank();
-            }
-        }
-
-        //BankUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, BankUpdatePacket packet)
-        {
-            var slot = packet.Slot;
-            if (packet.ItemId != Guid.Empty)
-            {
-                Globals.Bank[slot] = new Item();
-                Globals.Bank[slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
-            }
-            else
-            {
-                Globals.Bank[slot] = null;
-            }
-        }
-
-        //GameObjectPacket
-        public void HandlePacket(IPacketSender packetSender, GameObjectPacket packet)
-        {
-            var type = packet.Type;
-            var id = packet.Id;
-            var another = packet.AnotherFollowing;
-            var deleted = packet.Deleted;
-            var json = "";
-            if (!deleted)
-            {
-                json = packet.Data;
-            }
-
-            switch (type)
-            {
-                case GameObjectType.Map:
-                    //Handled in a different packet
-                    break;
-                case GameObjectType.Tileset:
-                    var obj = new TilesetBase(id);
-                    obj.Load(json);
-                    TilesetBase.Lookup.Set(id, obj);
-                    if (Globals.HasGameData && !another)
-                    {
-                        Globals.ContentManager.LoadTilesets(TilesetBase.GetNameList());
-                    }
-
-                    break;
-                case GameObjectType.Event:
-                    //Clients don't store event data, im an idiot.
-                    break;
-                default:
-                    var lookup = type.GetLookup();
-                    if (deleted)
-                    {
-                        lookup.Get(id)?.Delete();
-                    }
-                    else
-                    {
-                        lookup.DeleteAt(id);
-                        var item = lookup.AddNew(type.GetObjectType(), id);
-                        item.Load(json);
-                    }
-
-                    break;
-            }
-        }
-
-        //EntityDashPacket
-        public void HandlePacket(IPacketSender packetSender, EntityDashPacket packet)
-        {
-            if (Globals.Entities.ContainsKey(packet.EntityId))
-            {
-                Globals.Entities[packet.EntityId]
-                    .DashQueue.Enqueue(
-                        new Dash(
-                            Globals.Entities[packet.EntityId] as Entity, packet.EndMapId, packet.EndX, packet.EndY,
-                            packet.DashTime, packet.Direction
-                        )
-                    );
-            }
-        }
-
-        //MapGridPacket
-        public void HandlePacket(IPacketSender packetSender, MapGridPacket packet)
-        {
-            Globals.MapGridWidth = packet.Grid.GetLength(0);
-            Globals.MapGridHeight = packet.Grid.GetLength(1);
-            var clearKnownMaps = packet.ClearKnownMaps;
-            Globals.MapGrid = new Guid[Globals.MapGridWidth, Globals.MapGridHeight];
-            if (clearKnownMaps)
-            {
-                foreach (var map in MapInstance.Lookup.Values.ToArray())
-                {
-                    ((MapInstance) map).Dispose();
-                }
-            }
-
-            Globals.NeedsMaps = true;
-            Globals.GridMaps.Clear();
-            for (var x = 0; x < Globals.MapGridWidth; x++)
-            {
-                for (var y = 0; y < Globals.MapGridHeight; y++)
-                {
-                    Globals.MapGrid[x, y] = packet.Grid[x, y];
-                    if (Globals.MapGrid[x, y] != Guid.Empty)
-                    {
-                        Globals.GridMaps.Add(Globals.MapGrid[x, y]);
-                        // MapInstance.UpdateMapRequestTime(Globals.MapGrid[x, y]);
-                    }
-                }
-            }
-
-            if (Globals.Me != null)
-            {
-                Globals.Me.FetchNewMaps();
-            }
-
-            Graphics.GridSwitched = true;
-        }
-
-        //TimePacket
-        public void HandlePacket(IPacketSender packetSender, TimePacket packet)
-        {
-            Time.LoadTime(
-                packet.Time, Color.FromArgb(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Rate
-            );
-        }
-
-        //PartyPacket
-        public void HandlePacket(IPacketSender packetSender, PartyPacket packet)
-        {
-            if (Globals.Me == null || Globals.Me.Party == null)
-            {
-                return;
-            }
-
-            Globals.Me.Party.Clear();
-            for (var i = 0; i < packet.MemberData.Length; i++)
-            {
-                var mem = packet.MemberData[i];
-                Globals.Me.Party.Add(new PartyMember(mem.Id, mem.Name, mem.Vital, mem.MaxVital, mem.Level));
-            }
-        }
-
-        //PartyUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, PartyUpdatePacket packet)
-        {
-            var index = packet.MemberIndex;
-            if (index < Globals.Me.Party.Count)
-            {
-                var mem = packet.MemberData;
-                Globals.Me.Party[index] = new PartyMember(mem.Id, mem.Name, mem.Vital, mem.MaxVital, mem.Level);
-            }
-        }
-
-        //PartyInvitePacket
-        public void HandlePacket(IPacketSender packetSender, PartyInvitePacket packet)
-        {
-            var iBox = new InputBox(
-                Strings.Parties.PartyInvite, Strings.Parties.InvitePrompt.ToString(packet.LeaderName), true,
-                InputBox.InputType.YesNo, PacketSender.SendPartyAccept, PacketSender.SendPartyDecline, packet.LeaderId
-            );
-        }
-
-        //ChatBubblePacket
-        public void HandlePacket(IPacketSender packetSender, ChatBubblePacket packet)
-        {
-            var id = packet.EntityId;
-            var type = packet.Type;
-            var mapId = packet.MapId;
-            IEntity en = null;
-            if (type < EntityType.Event)
-            {
-                if (!Globals.Entities.ContainsKey(id))
-                {
-                    return;
+                    Globals.ContentManager.LoadTilesets(TilesetBase.GetNameList());
                 }
 
-                en = Globals.Entities[id];
-            }
-            else
-            {
-                var entityMap = MapInstance.Get(mapId);
-                if (entityMap == null)
+                break;
+            case GameObjectType.Event:
+                //Clients don't store event data, im an idiot.
+                break;
+            default:
+                var lookup = type.GetLookup();
+                if (deleted)
                 {
-                    return;
+                    lookup.Get(id)?.Delete();
+                }
+                else
+                {
+                    lookup.DeleteAt(id);
+                    var item = lookup.AddNew(type.GetObjectType(), id);
+                    item.Load(json);
                 }
 
-                if (!entityMap.LocalEntities.ContainsKey(id))
-                    return;
-                {
-                }
-
-                en = entityMap.LocalEntities[id];
-            }
-
-            if (en == null)
-            {
-                return;
-            }
-
-            en.AddChatBubble(packet.Text);
+                break;
         }
+    }
 
-        //QuestOfferPacket
-        public void HandlePacket(IPacketSender packetSender, QuestOfferPacket packet)
+    //EntityDashPacket
+    public void HandlePacket(IPacketSender packetSender, EntityDashPacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.EntityId))
         {
-            if (!Globals.QuestOffers.Contains(packet.QuestId))
-            {
-                Globals.QuestOffers.Add(packet.QuestId);
-            }
-        }
-
-        //QuestProgressPacket
-        public void HandlePacket(IPacketSender packetSender, QuestProgressPacket packet)
-        {
-            if (Globals.Me != null)
-            {
-                foreach (var quest in packet.Quests)
-                {
-                    if (quest.Value == null)
-                    {
-                        if (Globals.Me.QuestProgress.ContainsKey(quest.Key))
-                        {
-                            Globals.Me.QuestProgress.Remove(quest.Key);
-                        }
-                    }
-                    else
-                    {
-                        if (Globals.Me.QuestProgress.ContainsKey(quest.Key))
-                        {
-                            Globals.Me.QuestProgress[quest.Key] = new QuestProgress(quest.Value);
-                        }
-                        else
-                        {
-                            Globals.Me.QuestProgress.Add(quest.Key, new QuestProgress(quest.Value));
-                        }
-                    }
-                }
-
-                Globals.Me.HiddenQuests = packet.HiddenQuests;
-
-                if (Interface.Interface.GameUi != null)
-                {
-                    Interface.Interface.GameUi.NotifyQuestsUpdated();
-                }
-            }
-        }
-
-        //TradePacket
-        public void HandlePacket(IPacketSender packetSender, TradePacket packet)
-        {
-            if (!string.IsNullOrEmpty(packet.TradePartner))
-            {
-                Globals.Trade = new Item[2, Options.MaxInvItems];
-
-                //Gotta initialize the trade values
-                for (var x = 0; x < 2; x++)
-                {
-                    for (var y = 0; y < Options.MaxInvItems; y++)
-                    {
-                        Globals.Trade[x, y] = new Item();
-                    }
-                }
-
-                Interface.Interface.GameUi.NotifyOpenTrading(packet.TradePartner);
-            }
-            else
-            {
-                Interface.Interface.GameUi.NotifyCloseTrading();
-            }
-        }
-
-        //TradeUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, TradeUpdatePacket packet)
-        {
-            var side = 0;
-
-            if (packet.TraderId != Globals.Me.Id)
-            {
-                side = 1;
-            }
-
-            var slot = packet.Slot;
-            if (packet.ItemId == Guid.Empty)
-            {
-                Globals.Trade[side, slot] = null;
-            }
-            else
-            {
-                Globals.Trade[side, slot] = new Item();
-                Globals.Trade[side, slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
-            }
-        }
-
-        //TradeRequestPacket
-        public void HandlePacket(IPacketSender packetSender, TradeRequestPacket packet)
-        {
-            var iBox = new InputBox(
-                Strings.Trading.TradeRequest, Strings.Trading.RequestPrompt.ToString(packet.PartnerName), true,
-                InputBox.InputType.YesNo, PacketSender.SendTradeRequestAccept, PacketSender.SendTradeRequestDecline,
-                packet.PartnerId
-            );
-        }
-
-        //NpcAggressionPacket
-        public void HandlePacket(IPacketSender packetSender, NpcAggressionPacket packet)
-        {
-            if (Globals.Entities.ContainsKey(packet.EntityId))
-            {
-                Globals.Entities[packet.EntityId].Aggression = packet.Aggression;
-            }
-        }
-
-        //PlayerDeathPacket
-        public void HandlePacket(IPacketSender packetSender, PlayerDeathPacket packet)
-        {
-            if (Globals.Entities.ContainsKey(packet.PlayerId))
-            {
-                //Clear all dashes.
-                Globals.Entities[packet.PlayerId].DashQueue.Clear();
-                Globals.Entities[packet.PlayerId].Dashing = null;
-                Globals.Entities[packet.PlayerId].DashTimer = 0;
-            }
-        }
-
-        //EntityZDimensionPacket
-        public void HandlePacket(IPacketSender packetSender, EntityZDimensionPacket packet)
-        {
-            if (Globals.Entities.ContainsKey(packet.EntityId))
-            {
-                Globals.Entities[packet.EntityId].Z = packet.Level;
-            }
-        }
-
-        //BagPacket
-        public void HandlePacket(IPacketSender packetSender, BagPacket packet)
-        {
-            if (!packet.Close)
-            {
-                Globals.Bag = new Item[packet.Slots];
-                Interface.Interface.GameUi.NotifyOpenBag();
-            }
-            else
-            {
-                Interface.Interface.GameUi.NotifyCloseBag();
-            }
-        }
-
-        //BagUpdatePacket
-        public void HandlePacket(IPacketSender packetSender, BagUpdatePacket packet)
-        {
-            if (packet.ItemId == Guid.Empty)
-            {
-                Globals.Bag[packet.Slot] = null;
-            }
-            else
-            {
-                Globals.Bag[packet.Slot] = new Item();
-                Globals.Bag[packet.Slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
-            }
-        }
-
-        //MoveRoutePacket
-        public void HandlePacket(IPacketSender packetSender, MoveRoutePacket packet)
-        {
-            Globals.MoveRouteActive = packet.Active;
-        }
-
-        //FriendsPacket
-        public void HandlePacket(IPacketSender packetSender, FriendsPacket packet)
-        {
-            Globals.Me?.Friends.Clear();
-
-            foreach (var friend in packet.OnlineFriends)
-            {
-                var f = new FriendInstance()
-                {
-                    Name = friend.Key,
-                    Map = friend.Value,
-                    Online = true
-                };
-
-                Globals.Me?.Friends.Add(f);
-            }
-
-            foreach (var friend in packet.OfflineFriends)
-            {
-                var f = new FriendInstance()
-                {
-                    Name = friend,
-                    Online = false
-                };
-
-                Globals.Me?.Friends.Add(f);
-            }
-
-            Interface.Interface.GameUi?.NotifyUpdateFriendsList();
-        }
-
-        //FriendRequestPacket
-        public void HandlePacket(IPacketSender packetSender, FriendRequestPacket packet)
-        {
-            var iBox = new InputBox(
-                Strings.Friends.Request, Strings.Friends.RequestPrompt.ToString(packet.FriendName), true,
-                InputBox.InputType.YesNo, PacketSender.SendFriendRequestAccept, PacketSender.SendFriendRequestDecline,
-                packet.FriendId
-            );
-        }
-
-        //CharactersPacket
-        public void HandlePacket(IPacketSender packetSender, CharactersPacket packet)
-        {
-            var characters = new List<Character>();
-
-            foreach (var chr in packet.Characters)
-            {
-                characters.Add(
-                    new Character(chr.Id, chr.Name, chr.Sprite, chr.Face, chr.Level, chr.ClassName, chr.Equipment)
+            Globals.Entities[packet.EntityId]
+                .DashQueue.Enqueue(
+                    new Dash(
+                        Globals.Entities[packet.EntityId] as Entity, packet.EndMapId, packet.EndX, packet.EndY,
+                        packet.DashTime, packet.Direction
+                    )
                 );
-            }
+        }
+    }
 
-            if (packet.FreeSlot)
+    //MapGridPacket
+    public void HandlePacket(IPacketSender packetSender, MapGridPacket packet)
+    {
+        Globals.MapGridWidth = packet.Grid.GetLength(0);
+        Globals.MapGridHeight = packet.Grid.GetLength(1);
+        var clearKnownMaps = packet.ClearKnownMaps;
+        Globals.MapGrid = new Guid[Globals.MapGridWidth, Globals.MapGridHeight];
+        if (clearKnownMaps)
+        {
+            foreach (var map in MapInstance.Lookup.Values.ToArray())
             {
-                characters.Add(null);
+                ((MapInstance) map).Dispose();
             }
-
-            Globals.WaitingOnServer = false;
-            Interface.Interface.MenuUi.MainMenu.NotifyOpenCharacterSelection(characters);
         }
 
-        //PasswordResetResultPacket
-        public void HandlePacket(IPacketSender packetSender, PasswordResetResultPacket packet)
+        Globals.NeedsMaps = true;
+        Globals.GridMaps.Clear();
+        for (var x = 0; x < Globals.MapGridWidth; x++)
         {
-            if (packet.Succeeded)
+            for (var y = 0; y < Globals.MapGridHeight; y++)
             {
-                // Show Success Message and Open Login Screen
-                Interface.Interface.ShowError(Strings.ResetPass.Success, Strings.ResetPass.SuccessMessage);
-                Interface.Interface.MenuUi.MainMenu.NotifyOpenLogin();
-            }
-            else
-            {
-                Interface.Interface.ShowError(Strings.ResetPass.Error, Strings.ResetPass.ErrorMessage);
-            }
-
-            Globals.WaitingOnServer = false;
-        }
-
-        //TargetOverridePacket
-        public void HandlePacket(IPacketSender packetSender, TargetOverridePacket packet)
-        {
-            if (Globals.Entities.ContainsKey(packet.TargetId))
-            { 
-                Globals.Me.TryTarget(Globals.Entities[packet.TargetId] as Entity, true);
+                Globals.MapGrid[x, y] = packet.Grid[x, y];
+                if (Globals.MapGrid[x, y] != Guid.Empty)
+                {
+                    Globals.GridMaps.Add(Globals.MapGrid[x, y]);
+                    // MapInstance.UpdateMapRequestTime(Globals.MapGrid[x, y]);
+                }
             }
         }
 
-        //EnteringGamePacket
-        public void HandlePacket(IPacketSender packetSender, EnteringGamePacket packet)
+        if (Globals.Me != null)
         {
-            //Fade out, we're finally loading the game world!
-            Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
+            Globals.Me.FetchNewMaps();
         }
 
-        //CancelCastPacket
-        public void HandlePacket(IPacketSender packetSender, CancelCastPacket packet)
+        Graphics.GridSwitched = true;
+    }
+
+    //TimePacket
+    public void HandlePacket(IPacketSender packetSender, TimePacket packet)
+    {
+        Time.LoadTime(
+            packet.Time, Color.FromArgb(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Rate
+        );
+    }
+
+    //PartyPacket
+    public void HandlePacket(IPacketSender packetSender, PartyPacket packet)
+    {
+        if (Globals.Me == null || Globals.Me.Party == null)
         {
-            if (Globals.Entities.ContainsKey(packet.EntityId))
-            {
-                Globals.Entities[packet.EntityId].CastTime = 0;
-                Globals.Entities[packet.EntityId].SpellCast = Guid.Empty;
-            }
+            return;
         }
 
-        //GuildPacket
-        public void HandlePacket(IPacketSender packetSender, GuildPacket packet)
+        Globals.Me.Party.Clear();
+        for (var i = 0; i < packet.MemberData.Length; i++)
         {
-            if (Globals.Me == null || Globals.Me.Guild == null)
+            var mem = packet.MemberData[i];
+            Globals.Me.Party.Add(new PartyMember(mem.Id, mem.Name, mem.Vital, mem.MaxVital, mem.Level));
+        }
+    }
+
+    //PartyUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, PartyUpdatePacket packet)
+    {
+        var index = packet.MemberIndex;
+        if (index < Globals.Me.Party.Count)
+        {
+            var mem = packet.MemberData;
+            Globals.Me.Party[index] = new PartyMember(mem.Id, mem.Name, mem.Vital, mem.MaxVital, mem.Level);
+        }
+    }
+
+    //PartyInvitePacket
+    public void HandlePacket(IPacketSender packetSender, PartyInvitePacket packet)
+    {
+        var iBox = new InputBox(
+            Strings.Parties.PartyInvite, Strings.Parties.InvitePrompt.ToString(packet.LeaderName), true,
+            InputBox.InputType.YesNo, PacketSender.SendPartyAccept, PacketSender.SendPartyDecline, packet.LeaderId
+        );
+    }
+
+    //ChatBubblePacket
+    public void HandlePacket(IPacketSender packetSender, ChatBubblePacket packet)
+    {
+        var id = packet.EntityId;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+        IEntity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
             {
                 return;
             }
 
-            Globals.Me.GuildMembers = packet.Members.OrderByDescending(m => m.Online).ThenBy(m => m.Rank).ThenBy(m => m.Name).ToArray();
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
 
-            Interface.Interface.GameUi.NotifyUpdateGuildList();
+            if (!entityMap.LocalEntities.ContainsKey(id))
+                return;
+            {
+            }
+
+            en = entityMap.LocalEntities[id];
         }
 
-
-        //GuildInvitePacket
-        public void HandlePacket(IPacketSender packetSender, GuildInvitePacket packet)
+        if (en == null)
         {
-            var iBox = new InputBox(
-                Strings.Guilds.InviteRequestTitle, Strings.Guilds.InviteRequestPrompt.ToString(packet.Inviter, packet.GuildName), true,
-                InputBox.InputType.YesNo, PacketSender.SendGuildInviteAccept, PacketSender.SendGuildInviteDecline,
-                null
+            return;
+        }
+
+        en.AddChatBubble(packet.Text);
+    }
+
+    //QuestOfferPacket
+    public void HandlePacket(IPacketSender packetSender, QuestOfferPacket packet)
+    {
+        if (!Globals.QuestOffers.Contains(packet.QuestId))
+        {
+            Globals.QuestOffers.Add(packet.QuestId);
+        }
+    }
+
+    //QuestProgressPacket
+    public void HandlePacket(IPacketSender packetSender, QuestProgressPacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            foreach (var quest in packet.Quests)
+            {
+                if (quest.Value == null)
+                {
+                    if (Globals.Me.QuestProgress.ContainsKey(quest.Key))
+                    {
+                        Globals.Me.QuestProgress.Remove(quest.Key);
+                    }
+                }
+                else
+                {
+                    if (Globals.Me.QuestProgress.ContainsKey(quest.Key))
+                    {
+                        Globals.Me.QuestProgress[quest.Key] = new QuestProgress(quest.Value);
+                    }
+                    else
+                    {
+                        Globals.Me.QuestProgress.Add(quest.Key, new QuestProgress(quest.Value));
+                    }
+                }
+            }
+
+            Globals.Me.HiddenQuests = packet.HiddenQuests;
+
+            if (Interface.Interface.GameUi != null)
+            {
+                Interface.Interface.GameUi.NotifyQuestsUpdated();
+            }
+        }
+    }
+
+    //TradePacket
+    public void HandlePacket(IPacketSender packetSender, TradePacket packet)
+    {
+        if (!string.IsNullOrEmpty(packet.TradePartner))
+        {
+            Globals.Trade = new Item[2, Options.MaxInvItems];
+
+            //Gotta initialize the trade values
+            for (var x = 0; x < 2; x++)
+            {
+                for (var y = 0; y < Options.MaxInvItems; y++)
+                {
+                    Globals.Trade[x, y] = new Item();
+                }
+            }
+
+            Interface.Interface.GameUi.NotifyOpenTrading(packet.TradePartner);
+        }
+        else
+        {
+            Interface.Interface.GameUi.NotifyCloseTrading();
+        }
+    }
+
+    //TradeUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, TradeUpdatePacket packet)
+    {
+        var side = 0;
+
+        if (packet.TraderId != Globals.Me.Id)
+        {
+            side = 1;
+        }
+
+        var slot = packet.Slot;
+        if (packet.ItemId == Guid.Empty)
+        {
+            Globals.Trade[side, slot] = null;
+        }
+        else
+        {
+            Globals.Trade[side, slot] = new Item();
+            Globals.Trade[side, slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
+        }
+    }
+
+    //TradeRequestPacket
+    public void HandlePacket(IPacketSender packetSender, TradeRequestPacket packet)
+    {
+        var iBox = new InputBox(
+            Strings.Trading.TradeRequest, Strings.Trading.RequestPrompt.ToString(packet.PartnerName), true,
+            InputBox.InputType.YesNo, PacketSender.SendTradeRequestAccept, PacketSender.SendTradeRequestDecline,
+            packet.PartnerId
+        );
+    }
+
+    //NpcAggressionPacket
+    public void HandlePacket(IPacketSender packetSender, NpcAggressionPacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.EntityId))
+        {
+            Globals.Entities[packet.EntityId].Aggression = packet.Aggression;
+        }
+    }
+
+    //PlayerDeathPacket
+    public void HandlePacket(IPacketSender packetSender, PlayerDeathPacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.PlayerId))
+        {
+            //Clear all dashes.
+            Globals.Entities[packet.PlayerId].DashQueue.Clear();
+            Globals.Entities[packet.PlayerId].Dashing = null;
+            Globals.Entities[packet.PlayerId].DashTimer = 0;
+        }
+    }
+
+    //EntityZDimensionPacket
+    public void HandlePacket(IPacketSender packetSender, EntityZDimensionPacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.EntityId))
+        {
+            Globals.Entities[packet.EntityId].Z = packet.Level;
+        }
+    }
+
+    //BagPacket
+    public void HandlePacket(IPacketSender packetSender, BagPacket packet)
+    {
+        if (!packet.Close)
+        {
+            Globals.Bag = new Item[packet.Slots];
+            Interface.Interface.GameUi.NotifyOpenBag();
+        }
+        else
+        {
+            Interface.Interface.GameUi.NotifyCloseBag();
+        }
+    }
+
+    //BagUpdatePacket
+    public void HandlePacket(IPacketSender packetSender, BagUpdatePacket packet)
+    {
+        if (packet.ItemId == Guid.Empty)
+        {
+            Globals.Bag[packet.Slot] = null;
+        }
+        else
+        {
+            Globals.Bag[packet.Slot] = new Item();
+            Globals.Bag[packet.Slot].Load(packet.ItemId, packet.Quantity, packet.BagId, packet.Properties);
+        }
+    }
+
+    //MoveRoutePacket
+    public void HandlePacket(IPacketSender packetSender, MoveRoutePacket packet)
+    {
+        Globals.MoveRouteActive = packet.Active;
+    }
+
+    //FriendsPacket
+    public void HandlePacket(IPacketSender packetSender, FriendsPacket packet)
+    {
+        Globals.Me?.Friends.Clear();
+
+        foreach (var friend in packet.OnlineFriends)
+        {
+            var f = new FriendInstance()
+            {
+                Name = friend.Key,
+                Map = friend.Value,
+                Online = true
+            };
+
+            Globals.Me?.Friends.Add(f);
+        }
+
+        foreach (var friend in packet.OfflineFriends)
+        {
+            var f = new FriendInstance()
+            {
+                Name = friend,
+                Online = false
+            };
+
+            Globals.Me?.Friends.Add(f);
+        }
+
+        Interface.Interface.GameUi?.NotifyUpdateFriendsList();
+    }
+
+    //FriendRequestPacket
+    public void HandlePacket(IPacketSender packetSender, FriendRequestPacket packet)
+    {
+        var iBox = new InputBox(
+            Strings.Friends.Request, Strings.Friends.RequestPrompt.ToString(packet.FriendName), true,
+            InputBox.InputType.YesNo, PacketSender.SendFriendRequestAccept, PacketSender.SendFriendRequestDecline,
+            packet.FriendId
+        );
+    }
+
+    //CharactersPacket
+    public void HandlePacket(IPacketSender packetSender, CharactersPacket packet)
+    {
+        var characters = new List<Character>();
+
+        foreach (var chr in packet.Characters)
+        {
+            characters.Add(
+                new Character(chr.Id, chr.Name, chr.Sprite, chr.Face, chr.Level, chr.ClassName, chr.Equipment)
             );
         }
 
-        public void HandlePacket(IPacketSender packetSender, FadePacket packet)
+        if (packet.FreeSlot)
         {
-            switch (packet.FadeType)
-            {
-                case GameObjects.Events.FadeType.None:
-                    Fade.Cancel(packet.WaitForCompletion);
-                    break;
-                case GameObjects.Events.FadeType.FadeIn:
-                    Fade.FadeIn(packet.DurationMs, packet.WaitForCompletion);
-                    break;
-                case GameObjects.Events.FadeType.FadeOut:
-                    Fade.FadeOut(packet.DurationMs, packet.WaitForCompletion);
-                    break;
-            }
+            characters.Add(null);
         }
 
+        Globals.WaitingOnServer = false;
+        Interface.Interface.MenuUi.MainMenu.NotifyOpenCharacterSelection(characters);
+    }
+
+    //PasswordResetResultPacket
+    public void HandlePacket(IPacketSender packetSender, PasswordResetResultPacket packet)
+    {
+        if (packet.Succeeded)
+        {
+            // Show Success Message and Open Login Screen
+            Interface.Interface.ShowError(Strings.ResetPass.Success, Strings.ResetPass.SuccessMessage);
+            Interface.Interface.MenuUi.MainMenu.NotifyOpenLogin();
+        }
+        else
+        {
+            Interface.Interface.ShowError(Strings.ResetPass.Error, Strings.ResetPass.ErrorMessage);
+        }
+
+        Globals.WaitingOnServer = false;
+    }
+
+    //TargetOverridePacket
+    public void HandlePacket(IPacketSender packetSender, TargetOverridePacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.TargetId))
+        { 
+            Globals.Me.TryTarget(Globals.Entities[packet.TargetId] as Entity, true);
+        }
+    }
+
+    //EnteringGamePacket
+    public void HandlePacket(IPacketSender packetSender, EnteringGamePacket packet)
+    {
+        //Fade out, we're finally loading the game world!
+        Fade.FadeOut(ClientConfiguration.Instance.FadeDurationMs);
+    }
+
+    //CancelCastPacket
+    public void HandlePacket(IPacketSender packetSender, CancelCastPacket packet)
+    {
+        if (Globals.Entities.ContainsKey(packet.EntityId))
+        {
+            Globals.Entities[packet.EntityId].CastTime = 0;
+            Globals.Entities[packet.EntityId].SpellCast = Guid.Empty;
+        }
+    }
+
+    //GuildPacket
+    public void HandlePacket(IPacketSender packetSender, GuildPacket packet)
+    {
+        if (Globals.Me == null || Globals.Me.Guild == null)
+        {
+            return;
+        }
+
+        Globals.Me.GuildMembers = packet.Members.OrderByDescending(m => m.Online).ThenBy(m => m.Rank).ThenBy(m => m.Name).ToArray();
+
+        Interface.Interface.GameUi.NotifyUpdateGuildList();
+    }
+
+
+    //GuildInvitePacket
+    public void HandlePacket(IPacketSender packetSender, GuildInvitePacket packet)
+    {
+        var iBox = new InputBox(
+            Strings.Guilds.InviteRequestTitle, Strings.Guilds.InviteRequestPrompt.ToString(packet.Inviter, packet.GuildName), true,
+            InputBox.InputType.YesNo, PacketSender.SendGuildInviteAccept, PacketSender.SendGuildInviteDecline,
+            null
+        );
+    }
+
+    public void HandlePacket(IPacketSender packetSender, FadePacket packet)
+    {
+        switch (packet.FadeType)
+        {
+            case GameObjects.Events.FadeType.None:
+                Fade.Cancel(packet.WaitForCompletion);
+                break;
+            case GameObjects.Events.FadeType.FadeIn:
+                Fade.FadeIn(packet.DurationMs, packet.WaitForCompletion);
+                break;
+            case GameObjects.Events.FadeType.FadeOut:
+                Fade.FadeOut(packet.DurationMs, packet.WaitForCompletion);
+                break;
+        }
     }
 
 }

--- a/Intersect.Client/Networking/PacketSender.cs
+++ b/Intersect.Client/Networking/PacketSender.cs
@@ -9,497 +9,495 @@ using Intersect.Models;
 using Intersect.Network.Packets.Client;
 using AdminAction = Intersect.Admin.Actions.AdminAction;
 
-namespace Intersect.Client.Networking
+namespace Intersect.Client.Networking;
+
+
+public static partial class PacketSender
 {
 
-    public static partial class PacketSender
+    public static void SendPing()
     {
+        Network.SendPacket(new PingPacket { Responding = true });
+    }
 
-        public static void SendPing()
+    public static void SendLogin(string username, string password)
+    {
+        Network.SendPacket(new LoginPacket(username, password));
+    }
+
+    public static void SendLogout(bool characterSelect = false)
+    {
+        Network.SendPacket(new LogoutPacket(characterSelect));
+    }
+
+    public static void SendNeedMap(params ObjectCacheKey<MapBase>[] cacheKeys)
+    {
+        var validMapCacheKeys = cacheKeys
+            .Where(cacheKey => cacheKey != default && MapInstance.MapNotRequested(cacheKey.Id.Guid))
+            .Where(
+                cacheKey => string.IsNullOrWhiteSpace(cacheKey.Checksum) ||
+                            string.IsNullOrWhiteSpace(cacheKey.Version) ||
+                            !MapInstance.TryGet(cacheKey.Id.Guid, out _)
+            )
+            .ToArray();
+        if (validMapCacheKeys.Length < 1)
         {
-            Network.SendPacket(new PingPacket { Responding = true });
+            return;
         }
 
-        public static void SendLogin(string username, string password)
+        Network.SendPacket(new GetObjectData<MapBase>(validMapCacheKeys));
+        MapInstance.UpdateMapRequestTime(validMapCacheKeys.Select(cacheKey => cacheKey.Id.Guid).ToArray());
+    }
+
+    public static void SendNeedMap(params Guid[] mapIds)
+    {
+        var validMapIds = mapIds.Where(
+                mapId => mapId != default && !MapInstance.TryGet(mapId, out _) && MapInstance.MapNotRequested(mapId)
+            )
+            .ToArray();
+        if (validMapIds.Length < 1)
         {
-            Network.SendPacket(new LoginPacket(username, password));
+            return;
         }
 
-        public static void SendLogout(bool characterSelect = false)
+        Network.SendPacket(
+            new GetObjectData<MapBase>(
+                validMapIds.Select(id => new ObjectCacheKey<MapBase>(new Id<MapBase>(id))).ToArray()
+            )
+        );
+        MapInstance.UpdateMapRequestTime(validMapIds);
+    }
+
+    public static void SendNeedMapForGrid(MapInstance? mapInstance = default)
+    {
+        if (mapInstance == default && !MapInstance.TryGet(Globals.Me.MapId, out mapInstance))
         {
-            Network.SendPacket(new LogoutPacket(characterSelect));
+            return;
         }
 
-        public static void SendNeedMap(params ObjectCacheKey<MapBase>[] cacheKeys)
+        var gridX = mapInstance.GridX;
+        var gridY = mapInstance.GridY;
+        var minX = Math.Max(0, gridX - 1);
+        var minY = Math.Max(0, gridY - 1);
+        var maxX = Math.Min(Globals.MapGridWidth, gridX + 2);
+        var maxY = Math.Min(Globals.MapGridHeight, gridY + 2);
+
+        List<Guid> idsToFetch = new(9);
+
+        for (int x = minX; x < maxX; x++)
         {
-            var validMapCacheKeys = cacheKeys
-                .Where(cacheKey => cacheKey != default && MapInstance.MapNotRequested(cacheKey.Id.Guid))
-                .Where(
-                    cacheKey => string.IsNullOrWhiteSpace(cacheKey.Checksum) ||
-                                string.IsNullOrWhiteSpace(cacheKey.Version) ||
-                                !MapInstance.TryGet(cacheKey.Id.Guid, out _)
-                )
-                .ToArray();
-            if (validMapCacheKeys.Length < 1)
+            for (int y = minY; y < maxY; y++)
             {
-                return;
-            }
-
-            Network.SendPacket(new GetObjectData<MapBase>(validMapCacheKeys));
-            MapInstance.UpdateMapRequestTime(validMapCacheKeys.Select(cacheKey => cacheKey.Id.Guid).ToArray());
-        }
-
-        public static void SendNeedMap(params Guid[] mapIds)
-        {
-            var validMapIds = mapIds.Where(
-                    mapId => mapId != default && !MapInstance.TryGet(mapId, out _) && MapInstance.MapNotRequested(mapId)
-                )
-                .ToArray();
-            if (validMapIds.Length < 1)
-            {
-                return;
-            }
-
-            Network.SendPacket(
-                new GetObjectData<MapBase>(
-                    validMapIds.Select(id => new ObjectCacheKey<MapBase>(new Id<MapBase>(id))).ToArray()
-                )
-            );
-            MapInstance.UpdateMapRequestTime(validMapIds);
-        }
-
-        public static void SendNeedMapForGrid(MapInstance? mapInstance = default)
-        {
-            if (mapInstance == default && !MapInstance.TryGet(Globals.Me.MapId, out mapInstance))
-            {
-                return;
-            }
-
-            var gridX = mapInstance.GridX;
-            var gridY = mapInstance.GridY;
-            var minX = Math.Max(0, gridX - 1);
-            var minY = Math.Max(0, gridY - 1);
-            var maxX = Math.Min(Globals.MapGridWidth, gridX + 2);
-            var maxY = Math.Min(Globals.MapGridHeight, gridY + 2);
-
-            List<Guid> idsToFetch = new(9);
-
-            for (int x = minX; x < maxX; x++)
-            {
-                for (int y = minY; y < maxY; y++)
+                var mapId = Globals.MapGrid[x, y];
+                if (mapId == Guid.Empty)
                 {
-                    var mapId = Globals.MapGrid[x, y];
-                    if (mapId == Guid.Empty)
-                    {
-                        continue;
-                    }
-
-                    idsToFetch.Add(mapId);
+                    continue;
                 }
-            }
 
-            SendNeedMap(idsToFetch.ToArray());
-        }
-
-        public static void SendMove()
-        {
-            Network.SendPacket(new MovePacket(Globals.Me.MapId, Globals.Me.X, Globals.Me.Y, Globals.Me.Dir));
-        }
-
-        public static void SendChatMsg(string msg, byte channel)
-        {
-            Network.SendPacket(new ChatMsgPacket(msg, channel));
-        }
-
-        public static void SendAttack(Guid targetId)
-        {
-            Network.SendPacket(new AttackPacket(targetId));
-        }
-
-        public static void SendBlock(bool blocking)
-        {
-            Network.SendPacket(new BlockPacket(blocking));
-        }
-
-        public static void SendDirection(Direction dir)
-        {
-            Network.SendPacket(new DirectionPacket(dir));
-        }
-
-        public static void SendEnterGame()
-        {
-            Network.SendPacket(new EnterGamePacket());
-        }
-
-        public static void SendActivateEvent(Guid eventId)
-        {
-            Network.SendPacket(new ActivateEventPacket(eventId));
-        }
-
-        public static void SendEventResponse(byte response, Dialog ed)
-        {
-            Globals.EventDialogs.Remove(ed);
-            Network.SendPacket(new EventResponsePacket(ed.EventId, response));
-        }
-
-        public static void SendEventInputVariable(object sender, EventArgs e)
-        {
-            Network.SendPacket(
-                new EventInputVariablePacket(
-                    (Guid) ((InputBox) sender).UserData, (int) ((InputBox) sender).Value, ((InputBox) sender).TextValue
-                )
-            );
-        }
-
-        public static void SendEventInputVariableCancel(object sender, EventArgs e)
-        {
-            Network.SendPacket(
-                new EventInputVariablePacket(
-                    (Guid) ((InputBox) sender).UserData, (int) ((InputBox) sender).Value, ((InputBox) sender).TextValue,
-                    true
-                )
-            );
-        }
-
-        public static void SendCreateAccount(string username, string password, string email)
-        {
-            Network.SendPacket(new CreateAccountPacket(username.Trim(), password.Trim(), email.Trim()));
-        }
-
-        public static void SendCreateCharacter(string name, Guid classId, int sprite)
-        {
-            Network.SendPacket(new CreateCharacterPacket(name, classId, sprite));
-        }
-
-        public static void SendPickupItem(Guid mapId, int tileIndex, Guid uniqueId)
-        {
-            Network.SendPacket(new PickupItemPacket(mapId, tileIndex, uniqueId));
-        }
-
-        public static void SendSwapInvItems(int item1, int item2)
-        {
-            Network.SendPacket(new SwapInvItemsPacket(item1, item2));
-        }
-
-        public static void SendDropItem(int slot, int amount)
-        {
-            Network.SendPacket(new DropItemPacket(slot, amount));
-        }
-
-        public static void SendUseItem(int slot, Guid targetId)
-        {
-            Network.SendPacket(new UseItemPacket(slot, targetId));
-        }
-
-        public static void SendSwapSpells(int spell1, int spell2)
-        {
-            Network.SendPacket(new SwapSpellsPacket(spell1, spell2));
-        }
-
-        public static void SendForgetSpell(int slot)
-        {
-            Network.SendPacket(new ForgetSpellPacket(slot));
-        }
-
-        public static void SendUseSpell(int slot, Guid targetId)
-        {
-            Network.SendPacket(new UseSpellPacket(slot, targetId));
-        }
-
-        public static void SendUnequipItem(int slot)
-        {
-            Network.SendPacket(new UnequipItemPacket(slot));
-        }
-
-        public static void SendUpgradeStat(byte stat)
-        {
-            Network.SendPacket(new UpgradeStatPacket(stat));
-        }
-
-        public static void SendHotbarUpdate(int hotbarSlot, sbyte type, int itemIndex)
-        {
-            Network.SendPacket(new HotbarUpdatePacket(hotbarSlot, type, itemIndex));
-        }
-
-        public static void SendHotbarSwap(int index, int swapIndex)
-        {
-            Network.SendPacket(new HotbarSwapPacket(index, swapIndex));
-        }
-
-        public static void SendOpenAdminWindow()
-        {
-            Network.SendPacket(new OpenAdminWindowPacket());
-        }
-
-        //Admin Action Packet Should be Here
-
-        public static void SendSellItem(int slot, int amount)
-        {
-            Network.SendPacket(new SellItemPacket(slot, amount));
-        }
-
-        public static void SendBuyItem(int slot, int amount)
-        {
-            Network.SendPacket(new BuyItemPacket(slot, amount));
-        }
-
-        public static void SendCloseShop()
-        {
-            Network.SendPacket(new CloseShopPacket());
-        }
-
-        public static void SendDepositItem(int slot, int amount, int bankSlot = -1)
-        {
-            Network.SendPacket(new DepositItemPacket(slot, amount, bankSlot));
-        }
-
-        public static void SendWithdrawItem(int slot, int amount, int invSlot = -1)
-        {
-            Network.SendPacket(new WithdrawItemPacket(slot, amount, invSlot));
-        }
-
-        public static void SendCloseBank()
-        {
-            Network.SendPacket(new CloseBankPacket());
-        }
-
-        public static void SendCloseCrafting()
-        {
-            Network.SendPacket(new CloseCraftingPacket());
-        }
-
-        public static void SendMoveBankItems(int slot1, int slot2)
-        {
-            Network.SendPacket(new SwapBankItemsPacket(slot1, slot2));
-        }
-
-        public static void SendCraftItem(Guid id, int count)
-        {
-            Network.SendPacket(new CraftItemPacket(id, count));
-        }
-
-        public static void SendPartyInvite(Guid targetId)
-        {
-            Network.SendPacket(new PartyInvitePacket(targetId));
-        }
-
-        public static void SendPartyInvite(string target)
-        {
-            Network.SendPacket(new PartyInvitePacket(target));
-        }
-
-        public static void SendPartyKick(Guid targetId)
-        {
-            Network.SendPacket(new PartyKickPacket(targetId));
-        }
-
-        public static void SendPartyLeave()
-        {
-            Network.SendPacket(new PartyLeavePacket());
-        }
-
-        public static void SendPartyAccept(object sender, EventArgs e)
-        {
-            Network.SendPacket(new PartyInviteResponsePacket((Guid) ((InputBox) sender).UserData, true));
-        }
-
-        public static void SendPartyDecline(object sender, EventArgs e)
-        {
-            Network.SendPacket(new PartyInviteResponsePacket((Guid) ((InputBox) sender).UserData, false));
-        }
-
-        public static void SendAcceptQuest(Guid questId)
-        {
-            Network.SendPacket(new QuestResponsePacket(questId, true));
-        }
-
-        public static void SendDeclineQuest(Guid questId)
-        {
-            Network.SendPacket(new QuestResponsePacket(questId, false));
-        }
-
-        public static void SendAbandonQuest(Guid questId)
-        {
-            Network.SendPacket(new AbandonQuestPacket(questId));
-        }
-
-        public static void SendTradeRequest(Guid targetId)
-        {
-            Network.SendPacket(new TradeRequestPacket(targetId));
-        }
-
-        public static void SendOfferTradeItem(int slot, int amount)
-        {
-            Network.SendPacket(new OfferTradeItemPacket(slot, amount));
-        }
-
-        public static void SendRevokeTradeItem(int slot, int amount)
-        {
-            Network.SendPacket(new RevokeTradeItemPacket(slot, amount));
-        }
-
-        public static void SendAcceptTrade()
-        {
-            Network.SendPacket(new AcceptTradePacket());
-        }
-
-        public static void SendDeclineTrade()
-        {
-            Network.SendPacket(new DeclineTradePacket());
-        }
-
-        public static void SendTradeRequestAccept(object sender, EventArgs e)
-        {
-            Network.SendPacket(new TradeRequestResponsePacket((Guid) ((InputBox) sender).UserData, true));
-        }
-
-        public static void SendTradeRequestDecline(object sender, EventArgs e)
-        {
-            Network.SendPacket(new TradeRequestResponsePacket((Guid) ((InputBox) sender).UserData, false));
-        }
-
-        public static void SendStoreBagItem(int invSlot, int amount, int bagSlot)
-        {
-            Network.SendPacket(new StoreBagItemPacket(invSlot, amount, bagSlot));
-        }
-
-        public static void SendRetrieveBagItem(int bagSlot, int amount, int invSlot)
-        {
-            Network.SendPacket(new RetrieveBagItemPacket(bagSlot, amount, invSlot));
-        }
-
-        public static void SendCloseBag()
-        {
-            Network.SendPacket(new CloseBagPacket());
-        }
-
-        public static void SendMoveBagItems(int slot1, int slot2)
-        {
-            Network.SendPacket(new SwapBagItemsPacket(slot1, slot2));
-        }
-
-        public static void SendRequestFriends()
-        {
-            Network.SendPacket(new RequestFriendsPacket());
-        }
-
-        public static void SendAddFriend(string name)
-        {
-            Network.SendPacket(new UpdateFriendsPacket(name, true));
-        }
-
-        public static void SendRemoveFriend(string name)
-        {
-            Network.SendPacket(new UpdateFriendsPacket(name, false));
-        }
-
-        public static void SendFriendRequestAccept(Object sender, EventArgs e)
-        {
-            Network.SendPacket(new FriendRequestResponsePacket((Guid) ((InputBox) sender).UserData, true));
-        }
-
-        public static void SendFriendRequestDecline(Object sender, EventArgs e)
-        {
-            Network.SendPacket(new FriendRequestResponsePacket((Guid) ((InputBox) sender).UserData, false));
-        }
-
-        public static void SendSelectCharacter(Guid charId)
-        {
-            Network.SendPacket(new SelectCharacterPacket(charId));
-        }
-
-        public static void SendDeleteCharacter(Guid charId)
-        {
-            Network.SendPacket(new DeleteCharacterPacket(charId));
-        }
-
-        public static void SendNewCharacter()
-        {
-            Network.SendPacket(new NewCharacterPacket());
-        }
-
-        public static void SendRequestPasswordReset(string nameEmail)
-        {
-            Network.SendPacket(new RequestPasswordResetPacket(nameEmail));
-        }
-
-        public static void SendResetPassword(string nameEmail, string code, string hashedPass)
-        {
-            Network.SendPacket(new ResetPasswordPacket(nameEmail, code, hashedPass));
-        }
-
-        public static void SendAdminAction(AdminAction action)
-        {
-            Network.SendPacket(new AdminActionPacket(action));
-        }
-
-        public static void SendBumpEvent(Guid mapId, Guid eventId)
-        {
-            Network.SendPacket(new BumpPacket(mapId, eventId));
-        }
-
-        public static void SendRequestGuild()
-        {
-            Network.SendPacket(new RequestGuildPacket());
-        }
-
-        public static void SendGuildInviteAccept(Object sender, EventArgs e)
-        {
-            Network.SendPacket(new GuildInviteAcceptPacket());
-        }
-
-        public static void SendGuildInviteDecline(Object sender, EventArgs e)
-        {
-            Network.SendPacket(new GuildInviteDeclinePacket());
-        }
-
-        public static void SendInviteGuild(string name)
-        {
-            Network.SendPacket(new UpdateGuildMemberPacket(Guid.Empty, name, Enums.GuildMemberUpdateAction.Invite));
-        }
-
-        public static void SendLeaveGuild()
-        {
-            Network.SendPacket(new GuildLeavePacket());
-        }
-
-        public static void SendKickGuildMember(Guid id)
-        {
-            Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Remove));
-        }
-        public static void SendPromoteGuildMember(Guid id, int rank)
-        {
-            Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Promote, rank));
-        }
-
-        public static void SendDemoteGuildMember(Guid id, int rank)
-        {
-            Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Demote, rank));
-        }
-
-        public static void SendTransferGuild(Guid id)
-        {
-            Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Transfer));
-        }
-      
-        public static void SendClosePicture(Guid eventId)
-        {
-            if (eventId != Guid.Empty)
-            {
-                Network.SendPacket(new PictureClosedPacket(eventId));
+                idsToFetch.Add(mapId);
             }
         }
 
-        public static void SendFadeCompletePacket()
-        {
-            Network.SendPacket(new FadeCompletePacket());
-        }
+        SendNeedMap(idsToFetch.ToArray());
+    }
 
-        public static void SendTarget(Guid targetId)
-        {
-            Network.SendPacket(new TargetPacket(targetId));
-        }
+    public static void SendMove()
+    {
+        Network.SendPacket(new MovePacket(Globals.Me.MapId, Globals.Me.X, Globals.Me.Y, Globals.Me.Dir));
+    }
 
+    public static void SendChatMsg(string msg, byte channel)
+    {
+        Network.SendPacket(new ChatMsgPacket(msg, channel));
+    }
+
+    public static void SendAttack(Guid targetId)
+    {
+        Network.SendPacket(new AttackPacket(targetId));
+    }
+
+    public static void SendBlock(bool blocking)
+    {
+        Network.SendPacket(new BlockPacket(blocking));
+    }
+
+    public static void SendDirection(Direction dir)
+    {
+        Network.SendPacket(new DirectionPacket(dir));
+    }
+
+    public static void SendEnterGame()
+    {
+        Network.SendPacket(new EnterGamePacket());
+    }
+
+    public static void SendActivateEvent(Guid eventId)
+    {
+        Network.SendPacket(new ActivateEventPacket(eventId));
+    }
+
+    public static void SendEventResponse(byte response, Dialog ed)
+    {
+        Globals.EventDialogs.Remove(ed);
+        Network.SendPacket(new EventResponsePacket(ed.EventId, response));
+    }
+
+    public static void SendEventInputVariable(object sender, EventArgs e)
+    {
+        Network.SendPacket(
+            new EventInputVariablePacket(
+                (Guid) ((InputBox) sender).UserData, (int) ((InputBox) sender).Value, ((InputBox) sender).TextValue
+            )
+        );
+    }
+
+    public static void SendEventInputVariableCancel(object sender, EventArgs e)
+    {
+        Network.SendPacket(
+            new EventInputVariablePacket(
+                (Guid) ((InputBox) sender).UserData, (int) ((InputBox) sender).Value, ((InputBox) sender).TextValue,
+                true
+            )
+        );
+    }
+
+    public static void SendCreateAccount(string username, string password, string email)
+    {
+        Network.SendPacket(new CreateAccountPacket(username.Trim(), password.Trim(), email.Trim()));
+    }
+
+    public static void SendCreateCharacter(string name, Guid classId, int sprite)
+    {
+        Network.SendPacket(new CreateCharacterPacket(name, classId, sprite));
+    }
+
+    public static void SendPickupItem(Guid mapId, int tileIndex, Guid uniqueId)
+    {
+        Network.SendPacket(new PickupItemPacket(mapId, tileIndex, uniqueId));
+    }
+
+    public static void SendSwapInvItems(int item1, int item2)
+    {
+        Network.SendPacket(new SwapInvItemsPacket(item1, item2));
+    }
+
+    public static void SendDropItem(int slot, int amount)
+    {
+        Network.SendPacket(new DropItemPacket(slot, amount));
+    }
+
+    public static void SendUseItem(int slot, Guid targetId)
+    {
+        Network.SendPacket(new UseItemPacket(slot, targetId));
+    }
+
+    public static void SendSwapSpells(int spell1, int spell2)
+    {
+        Network.SendPacket(new SwapSpellsPacket(spell1, spell2));
+    }
+
+    public static void SendForgetSpell(int slot)
+    {
+        Network.SendPacket(new ForgetSpellPacket(slot));
+    }
+
+    public static void SendUseSpell(int slot, Guid targetId)
+    {
+        Network.SendPacket(new UseSpellPacket(slot, targetId));
+    }
+
+    public static void SendUnequipItem(int slot)
+    {
+        Network.SendPacket(new UnequipItemPacket(slot));
+    }
+
+    public static void SendUpgradeStat(byte stat)
+    {
+        Network.SendPacket(new UpgradeStatPacket(stat));
+    }
+
+    public static void SendHotbarUpdate(int hotbarSlot, sbyte type, int itemIndex)
+    {
+        Network.SendPacket(new HotbarUpdatePacket(hotbarSlot, type, itemIndex));
+    }
+
+    public static void SendHotbarSwap(int index, int swapIndex)
+    {
+        Network.SendPacket(new HotbarSwapPacket(index, swapIndex));
+    }
+
+    public static void SendOpenAdminWindow()
+    {
+        Network.SendPacket(new OpenAdminWindowPacket());
+    }
+
+    //Admin Action Packet Should be Here
+
+    public static void SendSellItem(int slot, int amount)
+    {
+        Network.SendPacket(new SellItemPacket(slot, amount));
+    }
+
+    public static void SendBuyItem(int slot, int amount)
+    {
+        Network.SendPacket(new BuyItemPacket(slot, amount));
+    }
+
+    public static void SendCloseShop()
+    {
+        Network.SendPacket(new CloseShopPacket());
+    }
+
+    public static void SendDepositItem(int slot, int amount, int bankSlot = -1)
+    {
+        Network.SendPacket(new DepositItemPacket(slot, amount, bankSlot));
+    }
+
+    public static void SendWithdrawItem(int slot, int amount, int invSlot = -1)
+    {
+        Network.SendPacket(new WithdrawItemPacket(slot, amount, invSlot));
+    }
+
+    public static void SendCloseBank()
+    {
+        Network.SendPacket(new CloseBankPacket());
+    }
+
+    public static void SendCloseCrafting()
+    {
+        Network.SendPacket(new CloseCraftingPacket());
+    }
+
+    public static void SendMoveBankItems(int slot1, int slot2)
+    {
+        Network.SendPacket(new SwapBankItemsPacket(slot1, slot2));
+    }
+
+    public static void SendCraftItem(Guid id, int count)
+    {
+        Network.SendPacket(new CraftItemPacket(id, count));
+    }
+
+    public static void SendPartyInvite(Guid targetId)
+    {
+        Network.SendPacket(new PartyInvitePacket(targetId));
+    }
+
+    public static void SendPartyInvite(string target)
+    {
+        Network.SendPacket(new PartyInvitePacket(target));
+    }
+
+    public static void SendPartyKick(Guid targetId)
+    {
+        Network.SendPacket(new PartyKickPacket(targetId));
+    }
+
+    public static void SendPartyLeave()
+    {
+        Network.SendPacket(new PartyLeavePacket());
+    }
+
+    public static void SendPartyAccept(object sender, EventArgs e)
+    {
+        Network.SendPacket(new PartyInviteResponsePacket((Guid) ((InputBox) sender).UserData, true));
+    }
+
+    public static void SendPartyDecline(object sender, EventArgs e)
+    {
+        Network.SendPacket(new PartyInviteResponsePacket((Guid) ((InputBox) sender).UserData, false));
+    }
+
+    public static void SendAcceptQuest(Guid questId)
+    {
+        Network.SendPacket(new QuestResponsePacket(questId, true));
+    }
+
+    public static void SendDeclineQuest(Guid questId)
+    {
+        Network.SendPacket(new QuestResponsePacket(questId, false));
+    }
+
+    public static void SendAbandonQuest(Guid questId)
+    {
+        Network.SendPacket(new AbandonQuestPacket(questId));
+    }
+
+    public static void SendTradeRequest(Guid targetId)
+    {
+        Network.SendPacket(new TradeRequestPacket(targetId));
+    }
+
+    public static void SendOfferTradeItem(int slot, int amount)
+    {
+        Network.SendPacket(new OfferTradeItemPacket(slot, amount));
+    }
+
+    public static void SendRevokeTradeItem(int slot, int amount)
+    {
+        Network.SendPacket(new RevokeTradeItemPacket(slot, amount));
+    }
+
+    public static void SendAcceptTrade()
+    {
+        Network.SendPacket(new AcceptTradePacket());
+    }
+
+    public static void SendDeclineTrade()
+    {
+        Network.SendPacket(new DeclineTradePacket());
+    }
+
+    public static void SendTradeRequestAccept(object sender, EventArgs e)
+    {
+        Network.SendPacket(new TradeRequestResponsePacket((Guid) ((InputBox) sender).UserData, true));
+    }
+
+    public static void SendTradeRequestDecline(object sender, EventArgs e)
+    {
+        Network.SendPacket(new TradeRequestResponsePacket((Guid) ((InputBox) sender).UserData, false));
+    }
+
+    public static void SendStoreBagItem(int invSlot, int amount, int bagSlot)
+    {
+        Network.SendPacket(new StoreBagItemPacket(invSlot, amount, bagSlot));
+    }
+
+    public static void SendRetrieveBagItem(int bagSlot, int amount, int invSlot)
+    {
+        Network.SendPacket(new RetrieveBagItemPacket(bagSlot, amount, invSlot));
+    }
+
+    public static void SendCloseBag()
+    {
+        Network.SendPacket(new CloseBagPacket());
+    }
+
+    public static void SendMoveBagItems(int slot1, int slot2)
+    {
+        Network.SendPacket(new SwapBagItemsPacket(slot1, slot2));
+    }
+
+    public static void SendRequestFriends()
+    {
+        Network.SendPacket(new RequestFriendsPacket());
+    }
+
+    public static void SendAddFriend(string name)
+    {
+        Network.SendPacket(new UpdateFriendsPacket(name, true));
+    }
+
+    public static void SendRemoveFriend(string name)
+    {
+        Network.SendPacket(new UpdateFriendsPacket(name, false));
+    }
+
+    public static void SendFriendRequestAccept(Object sender, EventArgs e)
+    {
+        Network.SendPacket(new FriendRequestResponsePacket((Guid) ((InputBox) sender).UserData, true));
+    }
+
+    public static void SendFriendRequestDecline(Object sender, EventArgs e)
+    {
+        Network.SendPacket(new FriendRequestResponsePacket((Guid) ((InputBox) sender).UserData, false));
+    }
+
+    public static void SendSelectCharacter(Guid charId)
+    {
+        Network.SendPacket(new SelectCharacterPacket(charId));
+    }
+
+    public static void SendDeleteCharacter(Guid charId)
+    {
+        Network.SendPacket(new DeleteCharacterPacket(charId));
+    }
+
+    public static void SendNewCharacter()
+    {
+        Network.SendPacket(new NewCharacterPacket());
+    }
+
+    public static void SendRequestPasswordReset(string nameEmail)
+    {
+        Network.SendPacket(new RequestPasswordResetPacket(nameEmail));
+    }
+
+    public static void SendResetPassword(string nameEmail, string code, string hashedPass)
+    {
+        Network.SendPacket(new ResetPasswordPacket(nameEmail, code, hashedPass));
+    }
+
+    public static void SendAdminAction(AdminAction action)
+    {
+        Network.SendPacket(new AdminActionPacket(action));
+    }
+
+    public static void SendBumpEvent(Guid mapId, Guid eventId)
+    {
+        Network.SendPacket(new BumpPacket(mapId, eventId));
+    }
+
+    public static void SendRequestGuild()
+    {
+        Network.SendPacket(new RequestGuildPacket());
+    }
+
+    public static void SendGuildInviteAccept(Object sender, EventArgs e)
+    {
+        Network.SendPacket(new GuildInviteAcceptPacket());
+    }
+
+    public static void SendGuildInviteDecline(Object sender, EventArgs e)
+    {
+        Network.SendPacket(new GuildInviteDeclinePacket());
+    }
+
+    public static void SendInviteGuild(string name)
+    {
+        Network.SendPacket(new UpdateGuildMemberPacket(Guid.Empty, name, Enums.GuildMemberUpdateAction.Invite));
+    }
+
+    public static void SendLeaveGuild()
+    {
+        Network.SendPacket(new GuildLeavePacket());
+    }
+
+    public static void SendKickGuildMember(Guid id)
+    {
+        Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Remove));
+    }
+    public static void SendPromoteGuildMember(Guid id, int rank)
+    {
+        Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Promote, rank));
+    }
+
+    public static void SendDemoteGuildMember(Guid id, int rank)
+    {
+        Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Demote, rank));
+    }
+
+    public static void SendTransferGuild(Guid id)
+    {
+        Network.SendPacket(new UpdateGuildMemberPacket(id, null, Enums.GuildMemberUpdateAction.Transfer));
+    }
+  
+    public static void SendClosePicture(Guid eventId)
+    {
+        if (eventId != Guid.Empty)
+        {
+            Network.SendPacket(new PictureClosedPacket(eventId));
+        }
+    }
+
+    public static void SendFadeCompletePacket()
+    {
+        Network.SendPacket(new FadeCompletePacket());
+    }
+
+    public static void SendTarget(Guid targetId)
+    {
+        Network.SendPacket(new TargetPacket(targetId));
     }
 
 }

--- a/Intersect.Client/Plugins/Audio/AudioManager.cs
+++ b/Intersect.Client/Plugins/Audio/AudioManager.cs
@@ -2,29 +2,28 @@
 using Intersect.Client.Framework.Core.Sounds;
 using Intersect.Client.Framework.Entities;
 
-namespace Intersect.Client.Plugins.Audio
+namespace Intersect.Client.Plugins.Audio;
+
+public partial class AudioManager : IAudioManager
 {
-    public partial class AudioManager : IAudioManager
-    {
-        /// <inheritdoc />
-        public IMapSound PlayMapSound(string filename, int x, int y, Guid mapId, bool loop, int loopInterval, int distance, IEntity parent = null) => Core.Audio.AddMapSound(filename, x, y, mapId, loop, loopInterval, distance, parent);
+    /// <inheritdoc />
+    public IMapSound PlayMapSound(string filename, int x, int y, Guid mapId, bool loop, int loopInterval, int distance, IEntity parent = null) => Core.Audio.AddMapSound(filename, x, y, mapId, loop, loopInterval, distance, parent);
 
-        /// <inheritdoc />
-        public ISound PlaySound(string filename, bool loop) => Core.Audio.AddGameSound(filename, loop);
+    /// <inheritdoc />
+    public ISound PlaySound(string filename, bool loop) => Core.Audio.AddGameSound(filename, loop);
 
-        /// <inheritdoc />
-        public void StopSound(ISound sound) => Core.Audio.StopSound(sound as IMapSound);
+    /// <inheritdoc />
+    public void StopSound(ISound sound) => Core.Audio.StopSound(sound as IMapSound);
 
-        /// <inheritdoc />
-        public void StopSound(IMapSound sound) => Core.Audio.StopSound(sound);
+    /// <inheritdoc />
+    public void StopSound(IMapSound sound) => Core.Audio.StopSound(sound);
 
-        /// <inheritdoc />
-        public void StopAllSounds() => Core.Audio.StopAllSounds();
+    /// <inheritdoc />
+    public void StopAllSounds() => Core.Audio.StopAllSounds();
 
-        /// <inheritdoc />
-        public void PlayMusic(string filename, int fadeout = 0, int fadein = 0, bool loop = false) => Core.Audio.PlayMusic(filename, fadeout, fadein, loop);
+    /// <inheritdoc />
+    public void PlayMusic(string filename, int fadeout = 0, int fadein = 0, bool loop = false) => Core.Audio.PlayMusic(filename, fadeout, fadein, loop);
 
-        /// <inheritdoc />
-        public void StopMusic(int fadeout = 0) => Core.Audio.StopMusic(fadeout);
-    }
+    /// <inheritdoc />
+    public void StopMusic(int fadeout = 0) => Core.Audio.StopMusic(fadeout);
 }

--- a/Intersect.Client/Plugins/Contexts/ClientPluginContext.cs
+++ b/Intersect.Client/Plugins/Contexts/ClientPluginContext.cs
@@ -14,80 +14,79 @@ using Intersect.Plugins;
 using Intersect.Plugins.Contexts;
 using Intersect.Plugins.Interfaces;
 
-namespace Intersect.Client.Plugins.Contexts
+namespace Intersect.Client.Plugins.Contexts;
+
+/// <summary>
+/// Implementation of <see cref="IClientPluginContext"/>.
+/// </summary>
+internal sealed partial class ClientPluginContext : PluginContext<ClientPluginContext, IClientLifecycleHelper>,
+    IClientPluginContext
 {
     /// <summary>
-    /// Implementation of <see cref="IClientPluginContext"/>.
+    /// <see cref="IPluginContext"/> factory that creates instances of <see cref="IClientPluginContext"/>.
     /// </summary>
-    internal sealed partial class ClientPluginContext : PluginContext<ClientPluginContext, IClientLifecycleHelper>,
-        IClientPluginContext
+    internal sealed partial class Factory : IFactory<IPluginContext>
     {
-        /// <summary>
-        /// <see cref="IPluginContext"/> factory that creates instances of <see cref="IClientPluginContext"/>.
-        /// </summary>
-        internal sealed partial class Factory : IFactory<IPluginContext>
+        /// <inheritdoc />
+        public IPluginContext Create(params object[] args)
         {
-            /// <inheritdoc />
-            public IPluginContext Create(params object[] args)
+            if (args.Length != 2)
             {
-                if (args.Length != 2)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(args), $"{nameof(args)} should have 2 arguments.");
-                }
-
-                if (!(args[0] is Plugin plugin))
-                {
-                    throw new ArgumentException($@"First argument needs to be non-null and of type {nameof(Plugin)}.");
-                }
-
-                if (!(args[1] is IPacketHelper packetHelper))
-                {
-                    throw new ArgumentException($@"Second argument needs to be non-null and of type {nameof(IPacketHelper)}.");
-                }
-
-                return new ClientPluginContext(plugin, packetHelper);
+                throw new ArgumentOutOfRangeException(nameof(args), $"{nameof(args)} should have 2 arguments.");
             }
+
+            if (!(args[0] is Plugin plugin))
+            {
+                throw new ArgumentException($@"First argument needs to be non-null and of type {nameof(Plugin)}.");
+            }
+
+            if (!(args[1] is IPacketHelper packetHelper))
+            {
+                throw new ArgumentException($@"Second argument needs to be non-null and of type {nameof(IPacketHelper)}.");
+            }
+
+            return new ClientPluginContext(plugin, packetHelper);
         }
-
-        /// <inheritdoc />
-        private ClientPluginContext(Plugin plugin, IPacketHelper packetHelper) : base(plugin)
-        {
-            Lifecycle = new ClientLifecycleHelper(this);
-            Network = new ClientNetworkHelper(packetHelper);
-        }
-
-        /// <inheritdoc />
-        public IContentManager ContentManager => Globals.ContentManager ??
-                                                 throw new InvalidOperationException(
-                                                     @"Tried accessing the content manager before it was created."
-                                                 );
-
-        /// <inheritdoc />
-        public IGameRenderer Graphics => Core.Graphics.Renderer ??
-                                                 throw new InvalidOperationException(
-                                                     @"Tried accessing the game renderer before it was created."
-                                                 );
-
-        /// <inheritdoc />
-        public IAudioManager Audio { get; } = new AudioManager();
-
-        /// <inheritdoc />
-        public override IClientLifecycleHelper Lifecycle { get; }
-        
-        /// <inheritdoc />
-        public IClientNetworkHelper Network { get; }
-
-        /// <inheritdoc />
-        public IGameInput Input => Globals.InputManager ??
-                                                 throw new InvalidOperationException(
-                                                     @"Tried accessing the input manager before it was created."
-                                                 );
-        /// <inheritdoc />
-        public Options Options => Options.Instance ??
-                                                 throw new InvalidOperationException(
-                                                     @"Tried accessing the options instance before it was created."
-                                                 );
-
-        public IMapGrid MapGrid { get; } = new MapGrid();
     }
+
+    /// <inheritdoc />
+    private ClientPluginContext(Plugin plugin, IPacketHelper packetHelper) : base(plugin)
+    {
+        Lifecycle = new ClientLifecycleHelper(this);
+        Network = new ClientNetworkHelper(packetHelper);
+    }
+
+    /// <inheritdoc />
+    public IContentManager ContentManager => Globals.ContentManager ??
+                                             throw new InvalidOperationException(
+                                                 @"Tried accessing the content manager before it was created."
+                                             );
+
+    /// <inheritdoc />
+    public IGameRenderer Graphics => Core.Graphics.Renderer ??
+                                             throw new InvalidOperationException(
+                                                 @"Tried accessing the game renderer before it was created."
+                                             );
+
+    /// <inheritdoc />
+    public IAudioManager Audio { get; } = new AudioManager();
+
+    /// <inheritdoc />
+    public override IClientLifecycleHelper Lifecycle { get; }
+    
+    /// <inheritdoc />
+    public IClientNetworkHelper Network { get; }
+
+    /// <inheritdoc />
+    public IGameInput Input => Globals.InputManager ??
+                                             throw new InvalidOperationException(
+                                                 @"Tried accessing the input manager before it was created."
+                                             );
+    /// <inheritdoc />
+    public Options Options => Options.Instance ??
+                                             throw new InvalidOperationException(
+                                                 @"Tried accessing the options instance before it was created."
+                                             );
+
+    public IMapGrid MapGrid { get; } = new MapGrid();
 }

--- a/Intersect.Client/Plugins/Helpers/ClientLifecycleHelper.cs
+++ b/Intersect.Client/Plugins/Helpers/ClientLifecycleHelper.cs
@@ -5,60 +5,59 @@ using Intersect.Client.Interface;
 using Intersect.Client.Plugins.Interfaces;
 using Intersect.Plugins.Helpers;
 
-namespace Intersect.Client.Plugins.Helpers
+namespace Intersect.Client.Plugins.Helpers;
+
+/// <inheritdoc cref="IClientLifecycleHelper"/>
+internal sealed partial class ClientLifecycleHelper : ContextHelper<IClientPluginContext>, IClientLifecycleHelper
 {
-    /// <inheritdoc cref="IClientLifecycleHelper"/>
-    internal sealed partial class ClientLifecycleHelper : ContextHelper<IClientPluginContext>, IClientLifecycleHelper
+    /// <inheritdoc />
+    public event LifecycleChangeStateHandler LifecycleChangeState;
+
+    /// <inheritdoc />
+    public event GameUpdateHandler GameUpdate;
+
+    /// <inheritdoc />
+    public event GameDrawHandler GameDraw;
+
+    internal ClientLifecycleHelper(IClientPluginContext context) : base(context)
     {
-        /// <inheritdoc />
-        public event LifecycleChangeStateHandler LifecycleChangeState;
+        Globals.ClientLifecycleHelpers.Add(this);
+    }
 
-        /// <inheritdoc />
-        public event GameUpdateHandler GameUpdate;
+    ~ClientLifecycleHelper()
+    {
+        Globals.ClientLifecycleHelpers.Remove(this);
+    }
 
-        /// <inheritdoc />
-        public event GameDrawHandler GameDraw;
+    /// <inheritdoc />
+    public IMutableInterface Interface =>
+        Client.Interface.Interface.MenuUi ?? Client.Interface.Interface.GameUi as IMutableInterface;
 
-        internal ClientLifecycleHelper(IClientPluginContext context) : base(context)
-        {
-            Globals.ClientLifecycleHelpers.Add(this);
-        }
+    /// <inheritdoc />
+    public void OnLifecycleChangeState(GameStates state)
+    {
+        var lifecycleChangeStateArgs = new LifecycleChangeStateArgs(state);
+        LifecycleChangeState?.Invoke(Context, lifecycleChangeStateArgs);
+    }
 
-        ~ClientLifecycleHelper()
-        {
-            Globals.ClientLifecycleHelpers.Remove(this);
-        }
+    /// <inheritdoc />
+    public void OnGameUpdate(GameStates state, IPlayer player, Dictionary<Guid, IEntity> knownEntities, TimeSpan deltaTime)
+    {
+        var GameUpdateArgs = new GameUpdateArgs(state, player, knownEntities, deltaTime);
+        GameUpdate?.Invoke(Context, GameUpdateArgs);
+    }
 
-        /// <inheritdoc />
-        public IMutableInterface Interface =>
-            Client.Interface.Interface.MenuUi ?? Client.Interface.Interface.GameUi as IMutableInterface;
+    /// <inheritdoc />
+    public void OnGameDraw(DrawStates state, TimeSpan deltaTime)
+    {
+        var gameDrawArgs = new GameDrawArgs(state, deltaTime);
+        GameDraw?.Invoke(Context, gameDrawArgs);
+    }
 
-        /// <inheritdoc />
-        public void OnLifecycleChangeState(GameStates state)
-        {
-            var lifecycleChangeStateArgs = new LifecycleChangeStateArgs(state);
-            LifecycleChangeState?.Invoke(Context, lifecycleChangeStateArgs);
-        }
-
-        /// <inheritdoc />
-        public void OnGameUpdate(GameStates state, IPlayer player, Dictionary<Guid, IEntity> knownEntities, TimeSpan deltaTime)
-        {
-            var GameUpdateArgs = new GameUpdateArgs(state, player, knownEntities, deltaTime);
-            GameUpdate?.Invoke(Context, GameUpdateArgs);
-        }
-
-        /// <inheritdoc />
-        public void OnGameDraw(DrawStates state, TimeSpan deltaTime)
-        {
-            var gameDrawArgs = new GameDrawArgs(state, deltaTime);
-            GameDraw?.Invoke(Context, gameDrawArgs);
-        }
-
-        /// <inheritdoc />
-        public void OnGameDraw(DrawStates state, IEntity entity, TimeSpan deltaTime)
-        {
-            var gameDrawArgs = new GameDrawArgs(state, entity, deltaTime);
-            GameDraw?.Invoke(Context, gameDrawArgs);
-        }
+    /// <inheritdoc />
+    public void OnGameDraw(DrawStates state, IEntity entity, TimeSpan deltaTime)
+    {
+        var gameDrawArgs = new GameDrawArgs(state, entity, deltaTime);
+        GameDraw?.Invoke(Context, gameDrawArgs);
     }
 }

--- a/Intersect.Client/Plugins/Helpers/ClientNetworkHelper.cs
+++ b/Intersect.Client/Plugins/Helpers/ClientNetworkHelper.cs
@@ -3,33 +3,32 @@ using Intersect.Client.MonoGame.Network;
 using Intersect.Network;
 using Intersect.Plugins.Interfaces;
 
-namespace Intersect.Client.Plugins.Helpers
+namespace Intersect.Client.Plugins.Helpers;
+
+/// <summary>
+/// Implementation if <see cref="IClientNetworkHelper"/>.
+/// </summary>
+public sealed partial class ClientNetworkHelper : IClientNetworkHelper
 {
-    /// <summary>
-    /// Implementation if <see cref="IClientNetworkHelper"/>.
-    /// </summary>
-    public sealed partial class ClientNetworkHelper : IClientNetworkHelper
+    private static IClient Client => MonoSocket.Instance.Network; // TODO: Single player wrapper
+
+    public ClientNetworkHelper(IPacketHelper packetHelper)
     {
-        private static IClient Client => MonoSocket.Instance.Network; // TODO: Single player wrapper
-
-        public ClientNetworkHelper(IPacketHelper packetHelper)
-        {
-            PacketHelper = packetHelper ?? throw new ArgumentNullException(nameof(packetHelper));
-            PacketSender = new PluginPacketSender(PacketHelper);
-        }
-        
-        private IPacketHelper PacketHelper { get; }
-
-        /// <inheritdoc />
-        public bool IsConnected => Client?.IsConnected ?? false;
-
-        /// <inheritdoc />
-        public bool IsServerOnline => Client?.IsServerOnline ?? false;
-
-        /// <inheritdoc />
-        public IPacketSender PacketSender { get; }
-
-        /// <inheritdoc />
-        public ConnectionStatistics Statistics => Client?.Connection?.Statistics;
+        PacketHelper = packetHelper ?? throw new ArgumentNullException(nameof(packetHelper));
+        PacketSender = new PluginPacketSender(PacketHelper);
     }
+    
+    private IPacketHelper PacketHelper { get; }
+
+    /// <inheritdoc />
+    public bool IsConnected => Client?.IsConnected ?? false;
+
+    /// <inheritdoc />
+    public bool IsServerOnline => Client?.IsServerOnline ?? false;
+
+    /// <inheritdoc />
+    public IPacketSender PacketSender { get; }
+
+    /// <inheritdoc />
+    public ConnectionStatistics Statistics => Client?.Connection?.Statistics;
 }

--- a/Intersect.Client/Program.cs
+++ b/Intersect.Client/Program.cs
@@ -11,303 +11,301 @@ using Intersect.Extensions;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Client
+namespace Intersect.Client;
+
+/// <summary>
+///     The main class.
+/// </summary>
+static class Program
 {
+    public static string OpenALLink { get; set; }= string.Empty;
+
+    public static string OpenGLLink { get; set; }= string.Empty;
+
     /// <summary>
-    ///     The main class.
+    ///     The main entry point for the application.
     /// </summary>
-    static class Program
+    [STAThread]
+    internal static void Main(string[] args)
     {
-        public static string OpenALLink { get; set; }= string.Empty;
+        var waitForDebugger = args.Contains("--debugger");
 
-        public static string OpenGLLink { get; set; }= string.Empty;
-
-        /// <summary>
-        ///     The main entry point for the application.
-        /// </summary>
-        [STAThread]
-        internal static void Main(string[] args)
+        while (waitForDebugger && !Debugger.IsAttached)
         {
-            var waitForDebugger = args.Contains("--debugger");
+            System.Console.WriteLine("Waiting for debugger, sleeping 5000ms...");
+            Thread.Sleep(5000);
+        }
 
-            while (waitForDebugger && !Debugger.IsAttached)
-            {
-                System.Console.WriteLine("Waiting for debugger, sleeping 5000ms...");
-                Thread.Sleep(5000);
-            }
+        CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 
-            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+        ExportDependencies();
+        Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, "MonoGame.Framework.Client.dll"));
 
-            ExportDependencies();
-            Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, "MonoGame.Framework.Client.dll"));
-
+        try
+        {
+            var type = Type.GetType("Intersect.Client.Core.Bootstrapper", true);
+            Debug.Assert(type != null, "type != null");
+            var method = type.GetMethod("Start");
+            Debug.Assert(method != null, "method != null");
+            method.Invoke(null, new object[] { args });
+        }
+        catch (NoSuitableGraphicsDeviceException noSuitableGraphicsDeviceException)
+        {
             try
             {
-                var type = Type.GetType("Intersect.Client.Core.Bootstrapper", true);
-                Debug.Assert(type != null, "type != null");
-                var method = type.GetMethod("Start");
-                Debug.Assert(method != null, "method != null");
-                method.Invoke(null, new object[] { args });
-            }
-            catch (NoSuitableGraphicsDeviceException noSuitableGraphicsDeviceException)
-            {
-                try
-                {
-                    var message = noSuitableGraphicsDeviceException.AsFullStackString();
-                    Console.Error.WriteLine(message);
-                    File.WriteAllText("graphics-error.txt", message);
-                }
-                catch (Exception exception)
-                {
-                    Console.Error.WriteLine(exception);
-                }
-                finally
-                {
-                    if (!string.IsNullOrEmpty(OpenGLLink))
-                    {
-                        BrowserUtils.Open(OpenGLLink);
-                    }
-
-                    Environment.Exit(-1);
-                }
-            }
-            catch (NoAudioHardwareException noAudioHardwareException)
-            {
-                try
-                {
-                    var message = noAudioHardwareException.AsFullStackString();
-                    Console.Error.WriteLine(message);
-                    File.WriteAllText("audio-error.txt", message);
-                }
-                catch (Exception exception)
-                {
-                    Console.Error.WriteLine(exception);
-                }
-                finally
-                {
-                    if (!string.IsNullOrEmpty(OpenALLink))
-                    {
-                        BrowserUtils.Open(OpenALLink);
-                    }
-
-                    Environment.Exit(-1);
-                }
+                var message = noSuitableGraphicsDeviceException.AsFullStackString();
+                Console.Error.WriteLine(message);
+                File.WriteAllText("graphics-error.txt", message);
             }
             catch (Exception exception)
             {
-                ClientContext.DispatchUnhandledException(exception, true, true);
+                Console.Error.WriteLine(exception);
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(OpenGLLink))
+                {
+                    BrowserUtils.Open(OpenGLLink);
+                }
+
+                Environment.Exit(-1);
             }
         }
-
-        private static void ClearDlls()
+        catch (NoAudioHardwareException noAudioHardwareException)
         {
-            //Delete any files that exist
-            DeleteIfExists("libopenal.so.1");
-            DeleteIfExists("libSDL2-2.0.so.0");
-            DeleteIfExists("SDL2.dll");
-            DeleteIfExists("soft_oal.dll");
-            DeleteIfExists("libopenal.1.dylib");
-            DeleteIfExists("libSDL2-2.0.0.dylib");
-            DeleteIfExists("openal32.dll");
-            DeleteIfExists("MonoGame.Framework.Client.dll.config");
-            DeleteIfExists("MonoGame.Framework.Client.dll");
-
-            DeleteIfExists("libsdkencryptedappticket.dylib");
-            DeleteIfExists("libsteam_api.dylib");
-            DeleteIfExists("libsdkencryptedappticket.so");
-            DeleteIfExists("libsteam_api.so");
-            DeleteIfExists("sdkencryptedappticket64.dll");
-            DeleteIfExists("steam_api64.dll");
-        }
-
-        private static string ReadProcessOutput(string name)
-        {
-            Debug.Assert(name != null, "name != null");
-            var processStartInfo = new ProcessStartInfo
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                FileName = name
-            };
-
             try
             {
-
-                using (var p = new Process { StartInfo = processStartInfo })
-                {
-                    p.Start();
-
-                    // Do not wait for the child process to exit before
-                    // reading to the end of its redirected stream.
-                    // p.WaitForExit();
-                    // Read the output stream first and then wait.
-                    var output = p.StandardOutput.ReadToEnd();
-                    p.WaitForExit();
-                    output = output.Trim();
-
-                    return output;
-                }
+                var message = noAudioHardwareException.AsFullStackString();
+                Console.Error.WriteLine(message);
+                File.WriteAllText("audio-error.txt", message);
             }
             catch (Exception exception)
             {
-                Log.Warn(exception);
-                return string.Empty;
+                Console.Error.WriteLine(exception);
             }
-        }
-
-        private static void ExportDependencies()
-        {
-            // Delete any files that exist
-            ClearDlls();
-
-            var os = Environment.OSVersion;
-            var platformId = os.Platform;
-            if (platformId == PlatformID.Unix)
+            finally
             {
-                var unixName = ReadProcessOutput("uname");
-                if (unixName?.Contains("Darwin") ?? false)
+                if (!string.IsNullOrEmpty(OpenALLink))
                 {
-                    platformId = PlatformID.MacOSX;
+                    BrowserUtils.Open(OpenALLink);
                 }
-            }
 
-            if (!Environment.Is64BitProcess)
+                Environment.Exit(-1);
+            }
+        }
+        catch (Exception exception)
+        {
+            ClientContext.DispatchUnhandledException(exception, true, true);
+        }
+    }
+
+    private static void ClearDlls()
+    {
+        //Delete any files that exist
+        DeleteIfExists("libopenal.so.1");
+        DeleteIfExists("libSDL2-2.0.so.0");
+        DeleteIfExists("SDL2.dll");
+        DeleteIfExists("soft_oal.dll");
+        DeleteIfExists("libopenal.1.dylib");
+        DeleteIfExists("libSDL2-2.0.0.dylib");
+        DeleteIfExists("openal32.dll");
+        DeleteIfExists("MonoGame.Framework.Client.dll.config");
+        DeleteIfExists("MonoGame.Framework.Client.dll");
+
+        DeleteIfExists("libsdkencryptedappticket.dylib");
+        DeleteIfExists("libsteam_api.dylib");
+        DeleteIfExists("libsdkencryptedappticket.so");
+        DeleteIfExists("libsteam_api.so");
+        DeleteIfExists("sdkencryptedappticket64.dll");
+        DeleteIfExists("steam_api64.dll");
+    }
+
+    private static string ReadProcessOutput(string name)
+    {
+        Debug.Assert(name != null, "name != null");
+        var processStartInfo = new ProcessStartInfo
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            FileName = name
+        };
+
+        try
+        {
+
+            using (var p = new Process { StartInfo = processStartInfo })
             {
-                throw new PlatformNotSupportedException("x86 (32-bit) systems are not supported.");
-            }
+                p.Start();
 
-            switch (platformId)
+                // Do not wait for the child process to exit before
+                // reading to the end of its redirected stream.
+                // p.WaitForExit();
+                // Read the output stream first and then wait.
+                var output = p.StandardOutput.ReadToEnd();
+                p.WaitForExit();
+                output = output.Trim();
+
+                return output;
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Warn(exception);
+            return string.Empty;
+        }
+    }
+
+    private static void ExportDependencies()
+    {
+        // Delete any files that exist
+        ClearDlls();
+
+        var os = Environment.OSVersion;
+        var platformId = os.Platform;
+        if (platformId == PlatformID.Unix)
+        {
+            var unixName = ReadProcessOutput("uname");
+            if (unixName?.Contains("Darwin") ?? false)
             {
-                case PlatformID.Win32NT:
-                case PlatformID.Win32S:
-                case PlatformID.Win32Windows:
-                case PlatformID.WinCE:
-                    ExportDependency("SDL2.dll", "x64");
-                    ExportDependency("soft_oal.dll", "x64");
-                    if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
-                    {
-                        ExportDependency("sdkencryptedappticket64.dll", "runtimes/win-x64/native");
-                        ExportDependency("steam_api64.dll", "runtimes/win-x64/native");
-                    }
-                    break;
-
-                case PlatformID.MacOSX:
-                    ExportDependency("libopenal.1.dylib");
-                    ExportDependency("libSDL2.dylib");
-                    ExportDependency("openal32.dll");
-                    ExportDependency("MonoGame.Framework.dll.config", nameoverride: "MonoGame.Framework.Client.dll.config");
-                    if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
-                    {
-                        ExportDependency("libsdkencryptedappticket.dylib", "runtimes/osx/native");
-                        ExportDependency("libsteam_api.dylib", "runtimes/osx/native");
-                    }
-                    break;
-
-                case PlatformID.Xbox:
-                    break;
-
-                case PlatformID.Unix:
-                default:
-                    ExportDependency("libopenal.so.1");
-                    ExportDependency("libSDL2-2.0.so.0");
-                    ExportDependency("openal32.dll");
-                    ExportDependency("MonoGame.Framework.dll.config", nameoverride: "MonoGame.Framework.Client.dll.config");
-                    if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
-                    {
-                        ExportDependency("libsdkencryptedappticket.so", "runtimes/linux-x64/native");
-                        ExportDependency("libsteam_api.so", "runtimes/linux-x64/native");
-                    }
-                    break;
+                platformId = PlatformID.MacOSX;
             }
-
-            ExportDependency("MonoGame.Framework.dll", "", "MonoGame.Framework.Client.dll");
         }
 
-        private static void ExportDependency(string filename, string? folder = default, string? nameoverride = default)
+        if (!Environment.Is64BitProcess)
         {
-            /* If it failed it means the file already exists and can't be deleted for whatever reason. */
-            var path = string.IsNullOrEmpty(nameoverride) ? filename : nameoverride;
-            if (!DeleteIfExists(path))
-            {
-                return;
-            }
+            throw new PlatformNotSupportedException("x86 (32-bit) systems are not supported.");
+        }
 
+        switch (platformId)
+        {
+            case PlatformID.Win32NT:
+            case PlatformID.Win32S:
+            case PlatformID.Win32Windows:
+            case PlatformID.WinCE:
+                ExportDependency("SDL2.dll", "x64");
+                ExportDependency("soft_oal.dll", "x64");
+                if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
+                {
+                    ExportDependency("sdkencryptedappticket64.dll", "runtimes/win-x64/native");
+                    ExportDependency("steam_api64.dll", "runtimes/win-x64/native");
+                }
+                break;
+
+            case PlatformID.MacOSX:
+                ExportDependency("libopenal.1.dylib");
+                ExportDependency("libSDL2.dylib");
+                ExportDependency("openal32.dll");
+                ExportDependency("MonoGame.Framework.dll.config", nameoverride: "MonoGame.Framework.Client.dll.config");
+                if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
+                {
+                    ExportDependency("libsdkencryptedappticket.dylib", "runtimes/osx/native");
+                    ExportDependency("libsteam_api.dylib", "runtimes/osx/native");
+                }
+                break;
+
+            case PlatformID.Xbox:
+                break;
+
+            case PlatformID.Unix:
+            default:
+                ExportDependency("libopenal.so.1");
+                ExportDependency("libSDL2-2.0.so.0");
+                ExportDependency("openal32.dll");
+                ExportDependency("MonoGame.Framework.dll.config", nameoverride: "MonoGame.Framework.Client.dll.config");
+                if (Steam.SupportedAttribute.IsPresent(typeof(Program).Assembly))
+                {
+                    ExportDependency("libsdkencryptedappticket.so", "runtimes/linux-x64/native");
+                    ExportDependency("libsteam_api.so", "runtimes/linux-x64/native");
+                }
+                break;
+        }
+
+        ExportDependency("MonoGame.Framework.dll", "", "MonoGame.Framework.Client.dll");
+    }
+
+    private static void ExportDependency(string filename, string? folder = default, string? nameoverride = default)
+    {
+        /* If it failed it means the file already exists and can't be deleted for whatever reason. */
+        var path = string.IsNullOrEmpty(nameoverride) ? filename : nameoverride;
+        if (!DeleteIfExists(path))
+        {
+            return;
+        }
+
+        Debug.Assert(filename != null, "filename != null");
+
+        var assembly = Assembly.GetExecutingAssembly();
+        var cleanFolder = folder?.Trim().Replace('/', '.').Replace('\\', '.').Replace('-', '_') ?? string.Empty;
+        if (cleanFolder.Length > 0)
+        {
+            cleanFolder += '.';
+        }
+        var resourceName = $"Intersect.Client.Resources.{cleanFolder}{filename}";
+
+        if (assembly.GetManifestResourceNames().Contains(resourceName))
+        {
+            Console.WriteLine($@"Resource: {resourceName}");
+            using var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+            Debug.Assert(resourceStream != null, "resourceStream != null");
+            using var fileStream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            var data = new byte[resourceStream.Length];
+            resourceStream.Read(data, 0, (int)resourceStream.Length);
+            fileStream.Write(data, 0, data.Length);
+        }
+        else
+        {
+            Log.Warn($"Was looking for '{resourceName}' but only the following resources were found:\n{string.Join("\n\t", assembly.GetManifestResourceNames())}");
+            var resourceStream = assembly.GetManifestResourceStream("Intersect Client.g.resources");
+            Debug.Assert(resourceStream != null, "resourceStream != null");
+            var resources = new ResourceSet(resourceStream);
+
+            path = Path.Combine(ClientConfiguration.ResourcesDirectory, folder, filename.Split('.')[0].Split('-')[0]);
+
+            path = path.ToLower();
+
+            var enumerator = resources.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                Console.WriteLine(enumerator.Key);
+                if (enumerator.Key == null || enumerator.Key.ToString().Trim() != path.Trim())
+                {
+                    continue;
+                }
+
+                using var fs = new FileStream(
+                    string.IsNullOrEmpty(nameoverride) ? filename : nameoverride, FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite
+                );
+                var memoryStream = (UnmanagedMemoryStream)enumerator.Value;
+                if (memoryStream == null)
+                {
+                    continue;
+                }
+
+                var data = new byte[memoryStream.Length];
+                var read = memoryStream.Read(data, 0, (int)memoryStream.Length);
+                Debug.Assert(read == memoryStream.Length);
+                fs.Write(data, 0, read);
+            }
+        }
+    }
+
+    private static bool DeleteIfExists(string filename)
+    {
+        try
+        {
             Debug.Assert(filename != null, "filename != null");
-
-            var assembly = Assembly.GetExecutingAssembly();
-            var cleanFolder = folder?.Trim().Replace('/', '.').Replace('\\', '.').Replace('-', '_') ?? string.Empty;
-            if (cleanFolder.Length > 0)
+            if (File.Exists(filename))
             {
-                cleanFolder += '.';
+                File.Delete(filename);
             }
-            var resourceName = $"Intersect.Client.Resources.{cleanFolder}{filename}";
 
-            if (assembly.GetManifestResourceNames().Contains(resourceName))
-            {
-                Console.WriteLine($@"Resource: {resourceName}");
-                using var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
-                Debug.Assert(resourceStream != null, "resourceStream != null");
-                using var fileStream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
-                var data = new byte[resourceStream.Length];
-                resourceStream.Read(data, 0, (int)resourceStream.Length);
-                fileStream.Write(data, 0, data.Length);
-            }
-            else
-            {
-                Log.Warn($"Was looking for '{resourceName}' but only the following resources were found:\n{string.Join("\n\t", assembly.GetManifestResourceNames())}");
-                var resourceStream = assembly.GetManifestResourceStream("Intersect Client.g.resources");
-                Debug.Assert(resourceStream != null, "resourceStream != null");
-                var resources = new ResourceSet(resourceStream);
-
-                path = Path.Combine(ClientConfiguration.ResourcesDirectory, folder, filename.Split('.')[0].Split('-')[0]);
-
-                path = path.ToLower();
-
-                var enumerator = resources.GetEnumerator();
-                while (enumerator.MoveNext())
-                {
-                    Console.WriteLine(enumerator.Key);
-                    if (enumerator.Key == null || enumerator.Key.ToString().Trim() != path.Trim())
-                    {
-                        continue;
-                    }
-
-                    using var fs = new FileStream(
-                        string.IsNullOrEmpty(nameoverride) ? filename : nameoverride, FileMode.OpenOrCreate,
-                        FileAccess.ReadWrite
-                    );
-                    var memoryStream = (UnmanagedMemoryStream)enumerator.Value;
-                    if (memoryStream == null)
-                    {
-                        continue;
-                    }
-
-                    var data = new byte[memoryStream.Length];
-                    var read = memoryStream.Read(data, 0, (int)memoryStream.Length);
-                    Debug.Assert(read == memoryStream.Length);
-                    fs.Write(data, 0, read);
-                }
-            }
+            return true;
         }
-
-        private static bool DeleteIfExists(string filename)
+        catch
         {
-            try
-            {
-                Debug.Assert(filename != null, "filename != null");
-                if (File.Exists(filename))
-                {
-                    File.Delete(filename);
-                }
-
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            return false;
         }
-
     }
 
 }

--- a/Intersect.Client/Spells/Spell.cs
+++ b/Intersect.Client/Spells/Spell.cs
@@ -1,25 +1,23 @@
-﻿namespace Intersect.Client.Spells
+﻿namespace Intersect.Client.Spells;
+
+
+public partial class Spell
 {
 
-    public partial class Spell
+    public Guid Id { get; set; }
+
+    public Spell Clone()
     {
+        var newSpell = new Spell() {
+            Id = Id
+        };
 
-        public Guid Id { get; set; }
+        return newSpell;
+    }
 
-        public Spell Clone()
-        {
-            var newSpell = new Spell() {
-                Id = Id
-            };
-
-            return newSpell;
-        }
-
-        public void Load(Guid spellId)
-        {
-            Id = spellId;
-        }
-
+    public void Load(Guid spellId)
+    {
+        Id = spellId;
     }
 
 }

--- a/Intersect.Client/Utilities/MathHelper.cs
+++ b/Intersect.Client/Utilities/MathHelper.cs
@@ -1,64 +1,62 @@
-﻿namespace Intersect.Client.Utilities
+﻿namespace Intersect.Client.Utilities;
+
+
+public static partial class MathHelper
 {
 
-    public static partial class MathHelper
+    public static double Lerp(double value1, double value2, double amount)
     {
+        return value1 + (value2 - value1) * amount;
+    }
 
-        public static double Lerp(double value1, double value2, double amount)
-        {
-            return value1 + (value2 - value1) * amount;
-        }
+    public static double Clamp(double value, double min, double max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static double Clamp(double value, double min, double max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static float Clamp(float value, float min, float max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static float Clamp(float value, float min, float max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static int Clamp(int value, int min, int max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static int Clamp(int value, int min, int max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static long Clamp(long value, long min, long max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static long Clamp(long value, long min, long max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static short Clamp(short value, short min, short max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static short Clamp(short value, short min, short max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static byte Clamp(byte value, byte min, byte max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static byte Clamp(byte value, byte min, byte max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static uint Clamp(uint value, uint min, uint max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static uint Clamp(uint value, uint min, uint max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static ulong Clamp(ulong value, ulong min, ulong max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static ulong Clamp(ulong value, ulong min, ulong max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
+    public static ushort Clamp(ushort value, ushort min, ushort max)
+    {
+        return value < min ? min : value > max ? max : value;
+    }
 
-        public static ushort Clamp(ushort value, ushort min, ushort max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
-
-        public static sbyte Clamp(sbyte value, sbyte min, sbyte max)
-        {
-            return value < min ? min : value > max ? max : value;
-        }
-
+    public static sbyte Clamp(sbyte value, sbyte min, sbyte max)
+    {
+        return value < min ? min : value > max ? max : value;
     }
 
 }


### PR DESCRIPTION
**Context:** File-scoped namespaces _were introduced in C# 10.0, which was released as part of .NET 6_. This feature allows developers to declare namespaces at the top of a file without enclosing them in a curly brace block, effectively making the namespace applicable to the entire file. Converting namespaces to file-scoped namespaces in C# promotes cleaner, more organized code that is easier to read, maintain, and scale as the project grows. It aligns with modern coding practices and helps prevent potential namespace conflicts, contributing to overall code quality and developer productivity.