### PR TITLE
chore: converts editor namespaces to file-scoped namespaces

### DIFF
--- a/Intersect.Editor/Configuration/ToolCursor.cs
+++ b/Intersect.Editor/Configuration/ToolCursor.cs
@@ -1,62 +1,61 @@
 ﻿using Newtonsoft.Json;
 using Intersect.Editor.General;
 
-namespace Intersect.Editor.Configuration
+namespace Intersect.Editor.Configuration;
+
+public sealed class ToolCursor
 {
-    public sealed class ToolCursor
+    public Point CursorClickPoint { get; set; }
+
+    private static readonly Dictionary<EditingTool, ToolCursor> _toolCursorDict;
+
+    public static IReadOnlyDictionary<EditingTool, ToolCursor> ToolCursorDict => _toolCursorDict;
+
+    static ToolCursor()
     {
-        public Point CursorClickPoint { get; set; }
-
-        private static readonly Dictionary<EditingTool, ToolCursor> _toolCursorDict;
-
-        public static IReadOnlyDictionary<EditingTool, ToolCursor> ToolCursorDict => _toolCursorDict;
-
-        static ToolCursor()
+        _toolCursorDict = new Dictionary<EditingTool, ToolCursor>
         {
-            _toolCursorDict = new Dictionary<EditingTool, ToolCursor>
-            {
-                { EditingTool.Brush, new ToolCursor() },
-                { EditingTool.Dropper, new ToolCursor() },
-                { EditingTool.Erase, new ToolCursor() },
-                { EditingTool.Fill, new ToolCursor() },
-                { EditingTool.Rectangle, new ToolCursor() },
-                { EditingTool.Selection, new ToolCursor() }
-            };
+            { EditingTool.Brush, new ToolCursor() },
+            { EditingTool.Dropper, new ToolCursor() },
+            { EditingTool.Erase, new ToolCursor() },
+            { EditingTool.Fill, new ToolCursor() },
+            { EditingTool.Rectangle, new ToolCursor() },
+            { EditingTool.Selection, new ToolCursor() }
+        };
+    }
+
+    public static void Load()
+    {
+        const string cursorFolder = "resources/cursors/";
+
+        if (!Directory.Exists(cursorFolder))
+        {
+            return;
         }
 
-        public static void Load()
+        foreach (EditingTool tool in Enum.GetValues(typeof(EditingTool)))
         {
-            const string cursorFolder = "resources/cursors/";
+            var fileName = $"{cursorFolder}editor_{tool.ToString().ToLowerInvariant()}.json";
+            ToolCursor toolCursor;
 
-            if (!Directory.Exists(cursorFolder))
+            if (File.Exists(fileName))
             {
-                return;
-            }
-
-            foreach (EditingTool tool in Enum.GetValues(typeof(EditingTool)))
-            {
-                var fileName = $"{cursorFolder}editor_{tool.ToString().ToLowerInvariant()}.json";
-                ToolCursor toolCursor;
-
-                if (File.Exists(fileName))
+                if (!_toolCursorDict.TryGetValue(tool, out toolCursor))
                 {
-                    if (!_toolCursorDict.TryGetValue(tool, out toolCursor))
-                    {
-                        continue;
-                    }
-
-                    var json = File.ReadAllText(fileName);
-                    toolCursor = JsonConvert.DeserializeObject<ToolCursor>(json);
-                }
-                else
-                {
-                    toolCursor = new ToolCursor();
-                    var json = JsonConvert.SerializeObject(toolCursor);
-                    File.WriteAllText(fileName, json);
+                    continue;
                 }
 
-                _toolCursorDict[tool] = toolCursor;
+                var json = File.ReadAllText(fileName);
+                toolCursor = JsonConvert.DeserializeObject<ToolCursor>(json);
             }
+            else
+            {
+                toolCursor = new ToolCursor();
+                var json = JsonConvert.SerializeObject(toolCursor);
+                File.WriteAllText(fileName, json);
+            }
+
+            _toolCursorDict[tool] = toolCursor;
         }
     }
 }

--- a/Intersect.Editor/Content/ContentManager.cs
+++ b/Intersect.Editor/Content/ContentManager.cs
@@ -9,654 +9,652 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Editor.Content
+namespace Intersect.Editor.Content;
+
+
+public static partial class GameContentManager
 {
 
-    public static partial class GameContentManager
+    public enum TextureType
     {
 
-        public enum TextureType
+        Tileset = 0,
+
+        Item,
+
+        Entity,
+
+        Spell,
+
+        Animation,
+
+        Face,
+
+        Image,
+
+        Fog,
+
+        Resource,
+
+        Paperdoll,
+
+        Gui,
+
+        Misc,
+
+    }
+
+    //Game Content
+    public static List<Texture> AllTextures { get; } = new List<Texture>();
+
+    public static List<Texture> FogTextures = new List<Texture>();
+
+    static IDictionary<string, Texture> sAnimationDict = new Dictionary<string, Texture>();
+
+    //MonoGame Content Manager
+    private static ContentManager sContentManger;
+
+    static IDictionary<string, Texture> sEntityDict = new Dictionary<string, Texture>();
+
+    private static string sErrorString = "";
+
+    static IDictionary<string, Texture> sFaceDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sFogDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sGuiDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sImageDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sItemDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sMiscDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, object> sMusicDict = new Dictionary<string, object>();
+
+    static IDictionary<string, Texture> sPaperdollDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sResourceDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Effect> sShaderDict = new Dictionary<string, Effect>();
+
+    static IDictionary<string, object> sSoundDict = new Dictionary<string, object>();
+
+    static IDictionary<string, Texture> sSpellDict = new Dictionary<string, Texture>();
+
+    static IDictionary<string, Texture> sTilesetDict = new Dictionary<string, Texture>();
+
+    public static List<Texture> TilesetTextures = new List<Texture>();
+
+    public static string[] MusicNames => sMusicDict?.Keys.ToArray();
+
+    public static string[] SmartSortedMusicNames => SmartSort(MusicNames);
+
+    public static string[] SoundNames => sSoundDict?.Keys.ToArray();
+
+    public static string[] SmartSortedSoundNames => SmartSort(SoundNames);
+
+    //Resource Downloader
+    public static void CheckForResources()
+    {
+        if (!Directory.Exists("resources"))
         {
-
-            Tileset = 0,
-
-            Item,
-
-            Entity,
-
-            Spell,
-
-            Animation,
-
-            Face,
-
-            Image,
-
-            Fog,
-
-            Resource,
-
-            Paperdoll,
-
-            Gui,
-
-            Misc,
-
-        }
-
-        //Game Content
-        public static List<Texture> AllTextures { get; } = new List<Texture>();
-
-        public static List<Texture> FogTextures = new List<Texture>();
-
-        static IDictionary<string, Texture> sAnimationDict = new Dictionary<string, Texture>();
-
-        //MonoGame Content Manager
-        private static ContentManager sContentManger;
-
-        static IDictionary<string, Texture> sEntityDict = new Dictionary<string, Texture>();
-
-        private static string sErrorString = "";
-
-        static IDictionary<string, Texture> sFaceDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sFogDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sGuiDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sImageDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sItemDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sMiscDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, object> sMusicDict = new Dictionary<string, object>();
-
-        static IDictionary<string, Texture> sPaperdollDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sResourceDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Effect> sShaderDict = new Dictionary<string, Effect>();
-
-        static IDictionary<string, object> sSoundDict = new Dictionary<string, object>();
-
-        static IDictionary<string, Texture> sSpellDict = new Dictionary<string, Texture>();
-
-        static IDictionary<string, Texture> sTilesetDict = new Dictionary<string, Texture>();
-
-        public static List<Texture> TilesetTextures = new List<Texture>();
-
-        public static string[] MusicNames => sMusicDict?.Keys.ToArray();
-
-        public static string[] SmartSortedMusicNames => SmartSort(MusicNames);
-
-        public static string[] SoundNames => sSoundDict?.Keys.ToArray();
-
-        public static string[] SmartSortedSoundNames => SmartSort(SoundNames);
-
-        //Resource Downloader
-        public static void CheckForResources()
-        {
-            if (!Directory.Exists("resources"))
-            {
-                MessageBox.Show(
-                    Strings.Errors.resourcesnotfound, Strings.Errors.resourcesnotfoundtitle, MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-
-                Environment.Exit(1);
-            }
-        }
-
-        public static void LoadEditorContent()
-        {
-            //Start by creating a MonoGame Content Manager
-            //We create a dummy game service so we can load up a content manager.
-            var container = new GameServiceContainer();
-            container.AddService(
-                typeof(IGraphicsDeviceService), new DummyGraphicsDeviceManager(Core.Graphics.GetGraphicsDevice())
+            MessageBox.Show(
+                Strings.Errors.resourcesnotfound, Strings.Errors.resourcesnotfoundtitle, MessageBoxButtons.OK,
+                MessageBoxIcon.Error
             );
 
-            sContentManger = new ContentManager(container, "");
-            LoadEntities();
-            LoadSpells();
-            LoadAnimations();
-            LoadImages();
-            LoadFogs();
-            LoadResources();
-            LoadPaperdolls();
-            LoadGui();
-            LoadFaces();
-            LoadItems();
-            LoadMisc();
-            LoadShaders();
-            LoadSounds();
-            LoadMusic();
+            Environment.Exit(1);
+        }
+    }
+
+    public static void LoadEditorContent()
+    {
+        //Start by creating a MonoGame Content Manager
+        //We create a dummy game service so we can load up a content manager.
+        var container = new GameServiceContainer();
+        container.AddService(
+            typeof(IGraphicsDeviceService), new DummyGraphicsDeviceManager(Core.Graphics.GetGraphicsDevice())
+        );
+
+        sContentManger = new ContentManager(container, "");
+        LoadEntities();
+        LoadSpells();
+        LoadAnimations();
+        LoadImages();
+        LoadFogs();
+        LoadResources();
+        LoadPaperdolls();
+        LoadGui();
+        LoadFaces();
+        LoadItems();
+        LoadMisc();
+        LoadShaders();
+        LoadSounds();
+        LoadMusic();
+    }
+
+    public static void Update()
+    {
+        for (var i = 0; i < AllTextures.Count; i++)
+        {
+            AllTextures[i].Update();
+        }
+    }
+
+    //Loading Game Resources
+    public static void LoadTextureGroup(string directory, IDictionary<string, Texture> dict)
+    {
+        dict.Clear();
+        if (!Directory.Exists("resources/" + directory))
+        {
+            Directory.CreateDirectory("resources/" + directory);
         }
 
-        public static void Update()
+        var items = Directory.GetFiles("resources/" + directory, "*.png");
+        for (var i = 0; i < items.Length; i++)
         {
-            for (var i = 0; i < AllTextures.Count; i++)
-            {
-                AllTextures[i].Update();
-            }
+            var filename = items[i].Replace("resources/" + directory + "\\", "").ToLower();
+            dict.Add(filename, new Texture("resources/" + directory + "/" + filename));
+        }
+    }
+
+    public static void LoadTilesets()
+    {
+        if (!Directory.Exists("resources/tilesets"))
+        {
+            Directory.CreateDirectory("resources/tilesets");
         }
 
-        //Loading Game Resources
-        public static void LoadTextureGroup(string directory, IDictionary<string, Texture> dict)
+        var tilesets = Directory.GetFiles("resources/tilesets", "*.png");
+        var tilesetWarning = false;
+        var suppressTilesetWarning = Preferences.LoadPreference("SuppressTextureWarning");
+        if (suppressTilesetWarning != "" && Convert.ToBoolean(suppressTilesetWarning))
         {
-            dict.Clear();
-            if (!Directory.Exists("resources/" + directory))
-            {
-                Directory.CreateDirectory("resources/" + directory);
-            }
-
-            var items = Directory.GetFiles("resources/" + directory, "*.png");
-            for (var i = 0; i < items.Length; i++)
-            {
-                var filename = items[i].Replace("resources/" + directory + "\\", "").ToLower();
-                dict.Add(filename, new Texture("resources/" + directory + "/" + filename));
-            }
+            tilesetWarning = true;
         }
 
-        public static void LoadTilesets()
+        var newTilesets = new List<string>();
+        Array.Sort(tilesets, new AlphanumComparatorFast());
+        if (tilesets.Length > 0)
         {
-            if (!Directory.Exists("resources/tilesets"))
+            var tilesetBaseList = TilesetBase.Names;
+            for (var i = 0; i < tilesets.Length; i++)
             {
-                Directory.CreateDirectory("resources/tilesets");
-            }
-
-            var tilesets = Directory.GetFiles("resources/tilesets", "*.png");
-            var tilesetWarning = false;
-            var suppressTilesetWarning = Preferences.LoadPreference("SuppressTextureWarning");
-            if (suppressTilesetWarning != "" && Convert.ToBoolean(suppressTilesetWarning))
-            {
-                tilesetWarning = true;
-            }
-
-            var newTilesets = new List<string>();
-            Array.Sort(tilesets, new AlphanumComparatorFast());
-            if (tilesets.Length > 0)
-            {
-                var tilesetBaseList = TilesetBase.Names;
-                for (var i = 0; i < tilesets.Length; i++)
+                tilesets[i] = tilesets[i].Replace("resources/tilesets\\", "");
+                if (tilesetBaseList.Length > 0)
                 {
-                    tilesets[i] = tilesets[i].Replace("resources/tilesets\\", "");
-                    if (tilesetBaseList.Length > 0)
+                    for (var x = 0; x < tilesetBaseList.Length; x++)
                     {
-                        for (var x = 0; x < tilesetBaseList.Length; x++)
+                        if (tilesetBaseList[x].ToLower() == tilesets[i].ToLower())
                         {
-                            if (tilesetBaseList[x].ToLower() == tilesets[i].ToLower())
-                            {
-                                break;
-                            }
-
-                            if (x != tilesetBaseList.Length - 1)
-                            {
-                                continue;
-                            }
-
-                            newTilesets.Add(tilesets[i]);
+                            break;
                         }
-                    }
-                    else
-                    {
+
+                        if (x != tilesetBaseList.Length - 1)
+                        {
+                            continue;
+                        }
+
                         newTilesets.Add(tilesets[i]);
                     }
                 }
-            }
-
-            sTilesetDict.Clear();
-            TilesetTextures.Clear();
-            var badTilesets = new List<string>();
-            for (var i = 0; i < TilesetBase.Lookup.Count; i++)
-            {
-                var tileset = TilesetBase.Get(TilesetBase.IdFromList(i));
-                if (File.Exists("resources/tilesets/" + tileset.Name))
+                else
                 {
-                    try
-                    {
-                        sTilesetDict[tileset.Name.ToLower()] = new Texture("resources/tilesets/" + tileset.Name);
-                        TilesetTextures.Add(sTilesetDict[tileset.Name.ToLower()]);
-                    }
-                    catch (Exception exception)
-                    {
-                        Log.Error($"Fake methods! ({tileset.Name})");
-                        if (exception.InnerException != null)
-                        {
-                            Log.Error(exception.InnerException);
-                        }
-
-                        Log.Error(exception);
-
-                        throw;
-                    }
-
-                    if (!tilesetWarning)
-                    {
-                        using (var img = Image.FromFile("resources/tilesets/" + tileset.Name))
-                        {
-                            if (img.Width > 2048 || img.Height > 2048)
-                            {
-                                badTilesets.Add(tileset.Name);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (badTilesets.Count > 0)
-            {
-                MessageBox.Show(
-                    "One or more tilesets is too large and likely won't load for your players on older machines! We recommmend that no graphic is larger than 2048 pixels in width or height.\n\nFaulting tileset(s): " +
-                    string.Join(",", badTilesets.ToArray()), "Large Tileset Warning!", MessageBoxButtons.OK,
-                    MessageBoxIcon.Exclamation
-                );
-            }
-
-            if (newTilesets.Count > 0)
-            {
-                PacketSender.SendNewTilesets(newTilesets.ToArray());
-            }
-        }
-
-        private static void LoadItems()
-        {
-            LoadTextureGroup("items", sItemDict);
-        }
-
-        private static void LoadEntities()
-        {
-            LoadTextureGroup("entities", sEntityDict);
-        }
-
-        private static void LoadSpells()
-        {
-            LoadTextureGroup("spells", sSpellDict);
-        }
-
-        private static void LoadAnimations()
-        {
-            LoadTextureGroup("animations", sAnimationDict);
-        }
-
-        private static void LoadFaces()
-        {
-            LoadTextureGroup("faces", sFaceDict);
-        }
-
-        private static void LoadImages()
-        {
-            LoadTextureGroup("images", sImageDict);
-        }
-
-        private static void LoadGui()
-        {
-            LoadTextureGroup("gui", sGuiDict);
-        }
-
-        private static void LoadFogs()
-        {
-            LoadTextureGroup("fogs", sFogDict);
-            FogTextures.Clear();
-            FogTextures.AddRange(sFogDict.Values.ToArray());
-        }
-
-        private static void LoadResources()
-        {
-            LoadTextureGroup("resources", sResourceDict);
-        }
-
-        private static void LoadPaperdolls()
-        {
-            LoadTextureGroup("paperdolls", sPaperdollDict);
-        }
-
-        private static void LoadMisc()
-        {
-            LoadTextureGroup("misc", sMiscDict);
-        }
-
-        public static void LoadShaders()
-        {
-            sShaderDict.Clear();
-
-            const string shaderPrefix = "Intersect.Editor.Resources.Shaders.";
-            var availableShaders = typeof(GameContentManager).Assembly
-                .GetManifestResourceNames()
-                .Where(resourceName =>
-                    resourceName.StartsWith(shaderPrefix)
-                    && resourceName.EndsWith(".xnb")
-                ).ToArray();
-
-            for (var i = 0; i < availableShaders.Length; i++)
-            {
-                var resourceFullName = availableShaders[i];
-                var shaderName = resourceFullName.Substring(shaderPrefix.Length);
-
-                using (var resourceStream = typeof(GameContentManager).Assembly.GetManifestResourceStream(resourceFullName))
-                {
-                    var extractedPath = FileSystemHelper.WriteToTemporaryFolder(resourceFullName, resourceStream);
-                    var shader = sContentManger.Load<Effect>(Path.ChangeExtension(extractedPath, null));
-                    sShaderDict.Add(shaderName, shader);
+                    newTilesets.Add(tilesets[i]);
                 }
             }
         }
 
-        public static void LoadSounds()
+        sTilesetDict.Clear();
+        TilesetTextures.Clear();
+        var badTilesets = new List<string>();
+        for (var i = 0; i < TilesetBase.Lookup.Count; i++)
         {
-            sSoundDict.Clear();
-            if (!Directory.Exists("resources/" + "sounds"))
+            var tileset = TilesetBase.Get(TilesetBase.IdFromList(i));
+            if (File.Exists("resources/tilesets/" + tileset.Name))
             {
-                Directory.CreateDirectory("resources/" + "sounds");
-            }
-
-            var items = Directory.GetFiles("resources/" + "sounds", "*.wav");
-            for (var i = 0; i < items.Length; i++)
-            {
-                var filename = items[i].Replace("resources/" + "sounds" + "\\", "").ToLower();
-                sSoundDict.Add(filename, null); //TODO Sound Playback
-            }
-        }
-
-        public static void LoadMusic()
-        {
-            sMusicDict.Clear();
-            if (!Directory.Exists("resources/" + "music"))
-            {
-                Directory.CreateDirectory("resources/" + "music");
-            }
-
-            var items = Directory.GetFiles("resources/" + "music", "*.ogg");
-            for (var i = 0; i < items.Length; i++)
-            {
-                var filename = items[i].Replace("resources/" + "music" + "\\", "").ToLower();
-                sMusicDict.Add(filename, null); //TODO Music Playback
-            }
-        }
-
-        public static string RemoveExtension(string fileName)
-        {
-            var fileExtPos = fileName.LastIndexOf(".");
-            if (fileExtPos >= 0)
-            {
-                fileName = fileName.Substring(0, fileExtPos);
-            }
-
-            return fileName;
-        }
-
-        //Retreiving Game Resources
-        //Content Getters
-        public static Texture2D GetTexture(TextureType type, string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return null;
-            }
-
-            IDictionary<string, Texture> textureDict = null;
-            switch (type)
-            {
-                case TextureType.Tileset:
-                    textureDict = sTilesetDict;
-
-                    break;
-                case TextureType.Item:
-                    textureDict = sItemDict;
-
-                    break;
-                case TextureType.Entity:
-                    textureDict = sEntityDict;
-
-                    break;
-                case TextureType.Spell:
-                    textureDict = sSpellDict;
-
-                    break;
-                case TextureType.Animation:
-                    textureDict = sAnimationDict;
-
-                    break;
-                case TextureType.Face:
-                    textureDict = sFaceDict;
-
-                    break;
-                case TextureType.Image:
-                    textureDict = sImageDict;
-
-                    break;
-                case TextureType.Fog:
-                    textureDict = sFogDict;
-
-                    break;
-                case TextureType.Resource:
-                    textureDict = sResourceDict;
-
-                    break;
-                case TextureType.Paperdoll:
-                    textureDict = sPaperdollDict;
-
-                    break;
-                case TextureType.Gui:
-                    textureDict = sGuiDict;
-
-                    break;
-                case TextureType.Misc:
-                    textureDict = sMiscDict;
-
-                    break;
-                default:
-                    return null;
-            }
-
-            if (textureDict == null)
-            {
-                return null;
-            }
-
-            if (textureDict == sTilesetDict
-            ) //When assigning name in tilebase base we force it to be lowercase.. so lets save some processing time here..
-            {
-                return textureDict.TryGetValue(name, out var texture1) ? texture1.GetTexture() : null;
-            }
-
-            return textureDict.TryGetValue(name.ToLower(), out var texture) ? texture.GetTexture() : null;
-        }
-
-        public static Effect GetShader(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                Log.Error("Tried to load shader with null name.");
-
-                return null;
-            }
-
-            if (sShaderDict == null)
-            {
-                return null;
-            }
-
-            return sShaderDict.TryGetValue(name.ToLower(), out var effect) ? effect : null;
-        }
-
-        public static object GetMusic(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                Log.Error("Tried to load music with null name.");
-
-                return null;
-            }
-
-            if (sMusicDict == null)
-            {
-                return null;
-            }
-
-            return sMusicDict.TryGetValue(name.ToLower(), out var music) ? music : null;
-        }
-
-        public static object GetSound(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                Log.Error("Tried to load sound with null name.");
-
-                return null;
-            }
-
-            if (sSoundDict == null)
-            {
-                return null;
-            }
-
-            return sSoundDict.TryGetValue(name.ToLower(), out var sound) ? sound : null;
-        }
-
-        public static string[] GetSmartSortedTextureNames(TextureType type)
-        {
-            return SmartSort(GetTextureNames(type));
-        }
-
-        //Getting Filenames
-        public static string[] GetTextureNames(TextureType type)
-        {
-            IDictionary<string, Texture> textureDict = null;
-            switch (type)
-            {
-                case TextureType.Tileset:
-                    textureDict = sTilesetDict;
-
-                    break;
-                case TextureType.Item:
-                    textureDict = sItemDict;
-
-                    break;
-                case TextureType.Entity:
-                    textureDict = sEntityDict;
-
-                    break;
-                case TextureType.Spell:
-                    textureDict = sSpellDict;
-
-                    break;
-                case TextureType.Animation:
-                    textureDict = sAnimationDict;
-
-                    break;
-                case TextureType.Face:
-                    textureDict = sFaceDict;
-
-                    break;
-                case TextureType.Image:
-                    textureDict = sImageDict;
-
-                    break;
-                case TextureType.Fog:
-                    textureDict = sFogDict;
-
-                    break;
-                case TextureType.Resource:
-                    textureDict = sResourceDict;
-
-                    break;
-                case TextureType.Paperdoll:
-                    textureDict = sPaperdollDict;
-
-                    break;
-                case TextureType.Gui:
-                    textureDict = sGuiDict;
-
-                    break;
-                case TextureType.Misc:
-                    textureDict = sMiscDict;
-
-                    break;
-                default:
-                    return null;
-            }
-
-            var keys = textureDict?.Keys.ToArray();
-            if (keys != null)
-            {
-                Array.Sort(keys, new AlphanumComparatorFast());
-            }
-
-            return textureDict?.Keys.ToArray();
-        }
-
-        private static readonly char[] OverridesDelimiter = new[] { '_' };
-
-        public static IEnumerable<string> GetOverridesFor(TextureType textureType, string filterState, string filterBase = default)
-        {
-            return GetTextureNames(textureType)
-                /* By using SelectMany() instead of Select() we do not have to then filter out null */
-                .SelectMany(sprite =>
+                try
                 {
-                    // Trim .png
-                    var baseName = Path.GetFileNameWithoutExtension(sprite);
-
-                    var searchState = $"_{filterState}";
-                    var indexOfState = baseName.IndexOf(searchState);
-                    if (indexOfState < 1 || baseName.Length <= indexOfState + searchState.Length)
+                    sTilesetDict[tileset.Name.ToLower()] = new Texture("resources/tilesets/" + tileset.Name);
+                    TilesetTextures.Add(sTilesetDict[tileset.Name.ToLower()]);
+                }
+                catch (Exception exception)
+                {
+                    Log.Error($"Fake methods! ({tileset.Name})");
+                    if (exception.InnerException != null)
                     {
-                        return Array.Empty<string>();
+                        Log.Error(exception.InnerException);
                     }
 
-                    var customPart = baseName[(indexOfState + searchState.Length + 1)..].Trim();
-                    if (string.IsNullOrWhiteSpace(customPart))
-                    {
-                        return Array.Empty<string>();
-                    }
+                    Log.Error(exception);
 
-                    if (string.IsNullOrWhiteSpace(filterBase))
-                    {
-                        return new[] { customPart };
-                    }
+                    throw;
+                }
 
-                    var basePart = baseName[0..indexOfState].Trim();
-                    if (string.Equals(filterBase.Trim(), basePart, StringComparison.Ordinal))
+                if (!tilesetWarning)
+                {
+                    using (var img = Image.FromFile("resources/tilesets/" + tileset.Name))
                     {
-                        return new[] { customPart };
+                        if (img.Width > 2048 || img.Height > 2048)
+                        {
+                            badTilesets.Add(tileset.Name);
+                        }
                     }
-
-                    return Array.Empty<string>();
-                })
-                /* Find only distinct values, don't show duplicates */
-                .Distinct();
+                }
+            }
         }
 
-        private static string[] SmartSort(string[] strings)
+        if (badTilesets.Count > 0)
         {
-            var sortedStrings = strings ?? new string[] { };
-            Array.Sort(sortedStrings, new AlphanumComparator());
-
-            return sortedStrings;
+            MessageBox.Show(
+                "One or more tilesets is too large and likely won't load for your players on older machines! We recommmend that no graphic is larger than 2048 pixels in width or height.\n\nFaulting tileset(s): " +
+                string.Join(",", badTilesets.ToArray()), "Large Tileset Warning!", MessageBoxButtons.OK,
+                MessageBoxIcon.Exclamation
+            );
         }
 
+        if (newTilesets.Count > 0)
+        {
+            PacketSender.SendNewTilesets(newTilesets.ToArray());
+        }
     }
 
-    internal partial class DummyGraphicsDeviceManager : IGraphicsDeviceService
+    private static void LoadItems()
     {
+        LoadTextureGroup("items", sItemDict);
+    }
 
-        public DummyGraphicsDeviceManager(GraphicsDevice graphicsDevice)
+    private static void LoadEntities()
+    {
+        LoadTextureGroup("entities", sEntityDict);
+    }
+
+    private static void LoadSpells()
+    {
+        LoadTextureGroup("spells", sSpellDict);
+    }
+
+    private static void LoadAnimations()
+    {
+        LoadTextureGroup("animations", sAnimationDict);
+    }
+
+    private static void LoadFaces()
+    {
+        LoadTextureGroup("faces", sFaceDict);
+    }
+
+    private static void LoadImages()
+    {
+        LoadTextureGroup("images", sImageDict);
+    }
+
+    private static void LoadGui()
+    {
+        LoadTextureGroup("gui", sGuiDict);
+    }
+
+    private static void LoadFogs()
+    {
+        LoadTextureGroup("fogs", sFogDict);
+        FogTextures.Clear();
+        FogTextures.AddRange(sFogDict.Values.ToArray());
+    }
+
+    private static void LoadResources()
+    {
+        LoadTextureGroup("resources", sResourceDict);
+    }
+
+    private static void LoadPaperdolls()
+    {
+        LoadTextureGroup("paperdolls", sPaperdollDict);
+    }
+
+    private static void LoadMisc()
+    {
+        LoadTextureGroup("misc", sMiscDict);
+    }
+
+    public static void LoadShaders()
+    {
+        sShaderDict.Clear();
+
+        const string shaderPrefix = "Intersect.Editor.Resources.Shaders.";
+        var availableShaders = typeof(GameContentManager).Assembly
+            .GetManifestResourceNames()
+            .Where(resourceName =>
+                resourceName.StartsWith(shaderPrefix)
+                && resourceName.EndsWith(".xnb")
+            ).ToArray();
+
+        for (var i = 0; i < availableShaders.Length; i++)
         {
-            GraphicsDevice = graphicsDevice;
+            var resourceFullName = availableShaders[i];
+            var shaderName = resourceFullName.Substring(shaderPrefix.Length);
+
+            using (var resourceStream = typeof(GameContentManager).Assembly.GetManifestResourceStream(resourceFullName))
+            {
+                var extractedPath = FileSystemHelper.WriteToTemporaryFolder(resourceFullName, resourceStream);
+                var shader = sContentManger.Load<Effect>(Path.ChangeExtension(extractedPath, null));
+                sShaderDict.Add(shaderName, shader);
+            }
+        }
+    }
+
+    public static void LoadSounds()
+    {
+        sSoundDict.Clear();
+        if (!Directory.Exists("resources/" + "sounds"))
+        {
+            Directory.CreateDirectory("resources/" + "sounds");
         }
 
-        public GraphicsDevice GraphicsDevice { get; private set; }
-
-        // Not used but required that these be here:
-        public event EventHandler<EventArgs> DeviceCreated;
-
-        public event EventHandler<EventArgs> DeviceDisposing;
-
-        public event EventHandler<EventArgs> DeviceReset;
-
-        public event EventHandler<EventArgs> DeviceResetting;
-
+        var items = Directory.GetFiles("resources/" + "sounds", "*.wav");
+        for (var i = 0; i < items.Length; i++)
+        {
+            var filename = items[i].Replace("resources/" + "sounds" + "\\", "").ToLower();
+            sSoundDict.Add(filename, null); //TODO Sound Playback
+        }
     }
+
+    public static void LoadMusic()
+    {
+        sMusicDict.Clear();
+        if (!Directory.Exists("resources/" + "music"))
+        {
+            Directory.CreateDirectory("resources/" + "music");
+        }
+
+        var items = Directory.GetFiles("resources/" + "music", "*.ogg");
+        for (var i = 0; i < items.Length; i++)
+        {
+            var filename = items[i].Replace("resources/" + "music" + "\\", "").ToLower();
+            sMusicDict.Add(filename, null); //TODO Music Playback
+        }
+    }
+
+    public static string RemoveExtension(string fileName)
+    {
+        var fileExtPos = fileName.LastIndexOf(".");
+        if (fileExtPos >= 0)
+        {
+            fileName = fileName.Substring(0, fileExtPos);
+        }
+
+        return fileName;
+    }
+
+    //Retreiving Game Resources
+    //Content Getters
+    public static Texture2D GetTexture(TextureType type, string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        IDictionary<string, Texture> textureDict = null;
+        switch (type)
+        {
+            case TextureType.Tileset:
+                textureDict = sTilesetDict;
+
+                break;
+            case TextureType.Item:
+                textureDict = sItemDict;
+
+                break;
+            case TextureType.Entity:
+                textureDict = sEntityDict;
+
+                break;
+            case TextureType.Spell:
+                textureDict = sSpellDict;
+
+                break;
+            case TextureType.Animation:
+                textureDict = sAnimationDict;
+
+                break;
+            case TextureType.Face:
+                textureDict = sFaceDict;
+
+                break;
+            case TextureType.Image:
+                textureDict = sImageDict;
+
+                break;
+            case TextureType.Fog:
+                textureDict = sFogDict;
+
+                break;
+            case TextureType.Resource:
+                textureDict = sResourceDict;
+
+                break;
+            case TextureType.Paperdoll:
+                textureDict = sPaperdollDict;
+
+                break;
+            case TextureType.Gui:
+                textureDict = sGuiDict;
+
+                break;
+            case TextureType.Misc:
+                textureDict = sMiscDict;
+
+                break;
+            default:
+                return null;
+        }
+
+        if (textureDict == null)
+        {
+            return null;
+        }
+
+        if (textureDict == sTilesetDict
+        ) //When assigning name in tilebase base we force it to be lowercase.. so lets save some processing time here..
+        {
+            return textureDict.TryGetValue(name, out var texture1) ? texture1.GetTexture() : null;
+        }
+
+        return textureDict.TryGetValue(name.ToLower(), out var texture) ? texture.GetTexture() : null;
+    }
+
+    public static Effect GetShader(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Log.Error("Tried to load shader with null name.");
+
+            return null;
+        }
+
+        if (sShaderDict == null)
+        {
+            return null;
+        }
+
+        return sShaderDict.TryGetValue(name.ToLower(), out var effect) ? effect : null;
+    }
+
+    public static object GetMusic(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Log.Error("Tried to load music with null name.");
+
+            return null;
+        }
+
+        if (sMusicDict == null)
+        {
+            return null;
+        }
+
+        return sMusicDict.TryGetValue(name.ToLower(), out var music) ? music : null;
+    }
+
+    public static object GetSound(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Log.Error("Tried to load sound with null name.");
+
+            return null;
+        }
+
+        if (sSoundDict == null)
+        {
+            return null;
+        }
+
+        return sSoundDict.TryGetValue(name.ToLower(), out var sound) ? sound : null;
+    }
+
+    public static string[] GetSmartSortedTextureNames(TextureType type)
+    {
+        return SmartSort(GetTextureNames(type));
+    }
+
+    //Getting Filenames
+    public static string[] GetTextureNames(TextureType type)
+    {
+        IDictionary<string, Texture> textureDict = null;
+        switch (type)
+        {
+            case TextureType.Tileset:
+                textureDict = sTilesetDict;
+
+                break;
+            case TextureType.Item:
+                textureDict = sItemDict;
+
+                break;
+            case TextureType.Entity:
+                textureDict = sEntityDict;
+
+                break;
+            case TextureType.Spell:
+                textureDict = sSpellDict;
+
+                break;
+            case TextureType.Animation:
+                textureDict = sAnimationDict;
+
+                break;
+            case TextureType.Face:
+                textureDict = sFaceDict;
+
+                break;
+            case TextureType.Image:
+                textureDict = sImageDict;
+
+                break;
+            case TextureType.Fog:
+                textureDict = sFogDict;
+
+                break;
+            case TextureType.Resource:
+                textureDict = sResourceDict;
+
+                break;
+            case TextureType.Paperdoll:
+                textureDict = sPaperdollDict;
+
+                break;
+            case TextureType.Gui:
+                textureDict = sGuiDict;
+
+                break;
+            case TextureType.Misc:
+                textureDict = sMiscDict;
+
+                break;
+            default:
+                return null;
+        }
+
+        var keys = textureDict?.Keys.ToArray();
+        if (keys != null)
+        {
+            Array.Sort(keys, new AlphanumComparatorFast());
+        }
+
+        return textureDict?.Keys.ToArray();
+    }
+
+    private static readonly char[] OverridesDelimiter = new[] { '_' };
+
+    public static IEnumerable<string> GetOverridesFor(TextureType textureType, string filterState, string filterBase = default)
+    {
+        return GetTextureNames(textureType)
+            /* By using SelectMany() instead of Select() we do not have to then filter out null */
+            .SelectMany(sprite =>
+            {
+                // Trim .png
+                var baseName = Path.GetFileNameWithoutExtension(sprite);
+
+                var searchState = $"_{filterState}";
+                var indexOfState = baseName.IndexOf(searchState);
+                if (indexOfState < 1 || baseName.Length <= indexOfState + searchState.Length)
+                {
+                    return Array.Empty<string>();
+                }
+
+                var customPart = baseName[(indexOfState + searchState.Length + 1)..].Trim();
+                if (string.IsNullOrWhiteSpace(customPart))
+                {
+                    return Array.Empty<string>();
+                }
+
+                if (string.IsNullOrWhiteSpace(filterBase))
+                {
+                    return new[] { customPart };
+                }
+
+                var basePart = baseName[0..indexOfState].Trim();
+                if (string.Equals(filterBase.Trim(), basePart, StringComparison.Ordinal))
+                {
+                    return new[] { customPart };
+                }
+
+                return Array.Empty<string>();
+            })
+            /* Find only distinct values, don't show duplicates */
+            .Distinct();
+    }
+
+    private static string[] SmartSort(string[] strings)
+    {
+        var sortedStrings = strings ?? new string[] { };
+        Array.Sort(sortedStrings, new AlphanumComparator());
+
+        return sortedStrings;
+    }
+
+}
+
+internal partial class DummyGraphicsDeviceManager : IGraphicsDeviceService
+{
+
+    public DummyGraphicsDeviceManager(GraphicsDevice graphicsDevice)
+    {
+        GraphicsDevice = graphicsDevice;
+    }
+
+    public GraphicsDevice GraphicsDevice { get; private set; }
+
+    // Not used but required that these be here:
+    public event EventHandler<EventArgs> DeviceCreated;
+
+    public event EventHandler<EventArgs> DeviceDisposing;
+
+    public event EventHandler<EventArgs> DeviceReset;
+
+    public event EventHandler<EventArgs> DeviceResetting;
 
 }

--- a/Intersect.Editor/Content/Texture.cs
+++ b/Intersect.Editor/Content/Texture.cs
@@ -6,192 +6,191 @@ using Microsoft.Xna.Framework.Graphics;
 
 using Graphics = Intersect.Editor.Core.Graphics;
 
-namespace Intersect.Editor.Content
+namespace Intersect.Editor.Content;
+
+public partial class Texture
 {
-    public partial class Texture
+    private readonly string mPath;
+
+    private long mLastAccessTime;
+
+    private bool mLoadError;
+
+    private int mWidth = -1;
+
+    private int mHeight = -1;
+
+    private Texture2D mTexture;
+
+    public Texture(string path)
     {
-        private readonly string mPath;
+        mPath = path;
+        GameContentManager.AllTextures.Add(this);
+    }
 
-        private long mLastAccessTime;
-
-        private bool mLoadError;
-
-        private int mWidth = -1;
-
-        private int mHeight = -1;
-
-        private Texture2D mTexture;
-
-        public Texture(string path)
+    public void LoadTexture()
+    {
+        mLoadError = true;
+        if (string.IsNullOrWhiteSpace(mPath))
         {
-            mPath = path;
-            GameContentManager.AllTextures.Add(this);
+            Log.Error("Invalid texture path (empty/null).");
+
+            return;
         }
 
-        public void LoadTexture()
+        var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
+
+        if (!File.Exists(mPath))
         {
-            mLoadError = true;
-            if (string.IsNullOrWhiteSpace(mPath))
+            Log.Error($"Texture does not exist: {relativePath}");
+
+            return;
+        }
+
+        using (var fileStream = File.Open(mPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            try
             {
-                Log.Error("Invalid texture path (empty/null).");
-
-                return;
-            }
-
-            var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
-
-            if (!File.Exists(mPath))
-            {
-                Log.Error($"Texture does not exist: {relativePath}");
-
-                return;
-            }
-
-            using (var fileStream = File.Open(mPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                try
+                mTexture = Texture2D.FromStream(Graphics.GetGraphicsDevice(), fileStream);
+                if (mTexture == null)
                 {
-                    mTexture = Texture2D.FromStream(Graphics.GetGraphicsDevice(), fileStream);
-                    if (mTexture == null)
-                    {
-                        Log.Error($"Failed to load texture due to unknown error: {relativePath}");
+                    Log.Error($"Failed to load texture due to unknown error: {relativePath}");
 
-                        return;
-                    }
+                    return;
+                }
 
-                    mWidth = mTexture.Width;
-                    mHeight = mTexture.Height;
-                    mLoadError = false;
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(
-                        exception,
-                        $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
-                    );
-                }
+                mWidth = mTexture.Width;
+                mHeight = mTexture.Height;
+                mLoadError = false;
+            }
+            catch (Exception exception)
+            {
+                Log.Error(
+                    exception,
+                    $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
+                );
             }
         }
+    }
 
-        public string GetPath() => mPath;
+    public string GetPath() => mPath;
 
-        public void ResetAccessTime()
+    public void ResetAccessTime()
+    {
+        mLastAccessTime = Timing.Global.MillisecondsUtc + 15000;
+    }
+
+    public int GetWidth()
+    {
+        ResetAccessTime();
+        if (mWidth != -1)
         {
-            mLastAccessTime = Timing.Global.MillisecondsUtc + 15000;
-        }
-
-        public int GetWidth()
-        {
-            ResetAccessTime();
-            if (mWidth != -1)
-            {
-                return mWidth;
-            }
-
-            if (mTexture == null)
-            {
-                GetDimensions();
-            }
-
-            if (mLoadError)
-            {
-                mWidth = 0;
-            }
-
             return mWidth;
         }
 
-        public int GetHeight()
+        if (mTexture == null)
         {
-            ResetAccessTime();
-            if (mHeight != -1)
-            {
-                return mHeight;
-            }
+            GetDimensions();
+        }
 
-            if (mTexture == null)
-            {
-                GetDimensions();
-            }
+        if (mLoadError)
+        {
+            mWidth = 0;
+        }
 
-            if (mLoadError)
-            {
-                mHeight = 0;
-            }
+        return mWidth;
+    }
 
+    public int GetHeight()
+    {
+        ResetAccessTime();
+        if (mHeight != -1)
+        {
             return mHeight;
         }
 
-        public Texture2D GetTexture()
+        if (mTexture == null)
         {
-            ResetAccessTime();
-            if (mTexture == null)
-            {
-                LoadTexture();
-            }
-
-            return mTexture;
+            GetDimensions();
         }
 
-        public void GetDimensions()
+        if (mLoadError)
         {
-            mLoadError = true;
-            if (string.IsNullOrWhiteSpace(mPath))
+            mHeight = 0;
+        }
+
+        return mHeight;
+    }
+
+    public Texture2D GetTexture()
+    {
+        ResetAccessTime();
+        if (mTexture == null)
+        {
+            LoadTexture();
+        }
+
+        return mTexture;
+    }
+
+    public void GetDimensions()
+    {
+        mLoadError = true;
+        if (string.IsNullOrWhiteSpace(mPath))
+        {
+            Log.Error("Invalid texture path (empty/null).");
+
+            return;
+        }
+
+        var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
+
+        if (!File.Exists(mPath))
+        {
+            Log.Error($"Texture does not exist: {relativePath}");
+
+            return;
+        }
+
+        using (var fileStream = File.Open(mPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            try
             {
-                Log.Error("Invalid texture path (empty/null).");
-
-                return;
-            }
-
-            var relativePath = FileSystemHelper.RelativePath(Directory.GetCurrentDirectory(), mPath);
-
-            if (!File.Exists(mPath))
-            {
-                Log.Error($"Texture does not exist: {relativePath}");
-
-                return;
-            }
-
-            using (var fileStream = File.Open(mPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                try
+                var img = System.Drawing.Image.FromStream(fileStream, false, false);
+                if (img == null)
                 {
-                    var img = System.Drawing.Image.FromStream(fileStream, false, false);
-                    if (img == null)
-                    {
-                        Log.Error($"Failed to load texture due to unknown error: {relativePath}");
+                    Log.Error($"Failed to load texture due to unknown error: {relativePath}");
 
-                        return;
-                    }
+                    return;
+                }
 
-                    mWidth = img.Width;
-                    mHeight = img.Height;
-                    mLoadError = false;
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(
-                        exception,
-                        $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
-                    );
-                }
+                mWidth = img.Width;
+                mHeight = img.Height;
+                mLoadError = false;
+            }
+            catch (Exception exception)
+            {
+                Log.Error(
+                    exception,
+                    $"Failed to load texture ({FileSystemHelper.FormatSize(fileStream.Length)}): {relativePath}"
+                );
             }
         }
+    }
 
-        public void Update()
+    public void Update()
+    {
+        if (mTexture == null)
         {
-            if (mTexture == null)
-            {
-                return;
-            }
-
-            if (mLastAccessTime >= Timing.Global.MillisecondsUtc)
-            {
-                return;
-            }
-
-            mTexture.Dispose();
-            mTexture = null;
+            return;
         }
+
+        if (mLastAccessTime >= Timing.Global.MillisecondsUtc)
+        {
+            return;
+        }
+
+        mTexture.Dispose();
+        mTexture = null;
     }
 }

--- a/Intersect.Editor/Content/TexturePacker.cs
+++ b/Intersect.Editor/Content/TexturePacker.cs
@@ -6,748 +6,746 @@ using Newtonsoft.Json.Linq;
 using Graphics = System.Drawing.Graphics;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
-namespace Intersect.Editor.Classes.ContentManagement
+namespace Intersect.Editor.Classes.ContentManagement;
+
+
+public partial class TexturePacker
 {
 
-    public partial class TexturePacker
+    public enum FreeRectChoiceHeuristic
     {
 
-        public enum FreeRectChoiceHeuristic
+        RectBestShortSideFit,
+
+        ///< -BSSF: Positions the rectangle against the short side of a free rectangle into which it fits the best.
+        RectBestLongSideFit,
+
+        ///< -BLSF: Positions the rectangle against the long side of a free rectangle into which it fits the best.
+        RectBestAreaFit,
+
+        ///< -BAF: Positions the rectangle into the smallest free rect into which it fits.
+        RectBottomLeftRule,
+
+        ///< -BL: Does the Tetris placement.
+        RectContactPointRule ///< -CP: Choosest the placement where the rectangle touches other rects as much as possible.
+
+    };
+
+    public bool allowRotations;
+
+    public int binHeight = 0;
+
+    public int binWidth = 0;
+
+    public List<Rectangle> freeRectangles = new List<Rectangle>();
+
+    public Dictionary<Texture, Rectangle> textures = new Dictionary<Texture, Rectangle>();
+
+    public List<Rectangle> usedRectangles = new List<Rectangle>();
+
+    public TexturePacker(string resourcesDirectory, int width, int height, bool rotations = true)
+    {
+        ResourcesDirectory = resourcesDirectory;
+        Init(width, height, rotations);
+    }
+
+    public string ResourcesDirectory { get; private set; }
+
+    public void Init(int width, int height, bool rotations = true)
+    {
+        binWidth = width;
+        binHeight = height;
+        allowRotations = rotations;
+
+        var n = new Rectangle();
+        n.X = 0;
+        n.Y = 0;
+        n.Width = width;
+        n.Height = height;
+
+        usedRectangles.Clear();
+
+        freeRectangles.Clear();
+        freeRectangles.Add(n);
+    }
+
+    public bool InsertTex(Texture tex)
+    {
+        var rect = Insert(tex.GetWidth(), tex.GetHeight(), FreeRectChoiceHeuristic.RectBestAreaFit);
+        if (rect.Height > 0)
         {
-
-            RectBestShortSideFit,
-
-            ///< -BSSF: Positions the rectangle against the short side of a free rectangle into which it fits the best.
-            RectBestLongSideFit,
-
-            ///< -BLSF: Positions the rectangle against the long side of a free rectangle into which it fits the best.
-            RectBestAreaFit,
-
-            ///< -BAF: Positions the rectangle into the smallest free rect into which it fits.
-            RectBottomLeftRule,
-
-            ///< -BL: Does the Tetris placement.
-            RectContactPointRule ///< -CP: Choosest the placement where the rectangle touches other rects as much as possible.
-
-        };
-
-        public bool allowRotations;
-
-        public int binHeight = 0;
-
-        public int binWidth = 0;
-
-        public List<Rectangle> freeRectangles = new List<Rectangle>();
-
-        public Dictionary<Texture, Rectangle> textures = new Dictionary<Texture, Rectangle>();
-
-        public List<Rectangle> usedRectangles = new List<Rectangle>();
-
-        public TexturePacker(string resourcesDirectory, int width, int height, bool rotations = true)
-        {
-            ResourcesDirectory = resourcesDirectory;
-            Init(width, height, rotations);
-        }
-
-        public string ResourcesDirectory { get; private set; }
-
-        public void Init(int width, int height, bool rotations = true)
-        {
-            binWidth = width;
-            binHeight = height;
-            allowRotations = rotations;
-
-            var n = new Rectangle();
-            n.X = 0;
-            n.Y = 0;
-            n.Width = width;
-            n.Height = height;
-
-            usedRectangles.Clear();
-
-            freeRectangles.Clear();
-            freeRectangles.Add(n);
-        }
-
-        public bool InsertTex(Texture tex)
-        {
-            var rect = Insert(tex.GetWidth(), tex.GetHeight(), FreeRectChoiceHeuristic.RectBestAreaFit);
-            if (rect.Height > 0)
-            {
-                textures.Add(tex, rect);
-
-                return true;
-            }
-
-            return false;
-        }
-
-        public void Export(int index)
-        {
-            //TODO: Trim Edges
-            var img = new Bitmap(binWidth, binHeight);
-            var maxUsedWidth = 0;
-            var maxUsedHeight = 0;
-            var g = Graphics.FromImage(img);
-            var frames = new JArray();
-
-            foreach (var tex in textures)
-            {
-                var t = Image.FromFile(tex.Key.GetPath());
-
-                var frame = new JObject
-                {
-                    { "filename", tex.Key.GetPath() }
-                };
-
-                frame["spriteSourceSize"] = new JObject
-                {
-                    ["x"] = 0,
-                    ["y"] = 0,
-                    ["w"] = t.Width,
-                    ["h"] = t.Height
-                };
-
-                frame["sourceSize"] = new JObject
-                {
-                    ["w"] = t.Width,
-                    ["h"] = t.Height
-                };
-
-                if (tex.Value.Width == t.Height && tex.Value.Height == t.Width && t.Width != t.Height)
-                {
-                    //Rotated
-                    t.RotateFlip(RotateFlipType.Rotate90FlipNone);
-                    frame["rotated"] = true;
-                }
-                else
-                {
-                    frame["rotated"] = false;
-                }
-
-                g.DrawImage(
-                    t,
-                    new RectangleF(tex.Value.X, tex.Value.Y, tex.Value.Width, tex.Value.Height),
-                    new RectangleF(0, 0, t.Width, t.Height),
-                    GraphicsUnit.Pixel
-                );
-
-                frame["frame"] = new JObject
-                {
-                    ["x"] = tex.Value.X,
-                    ["y"] = tex.Value.Y,
-                    ["w"] = tex.Value.Width,
-                    ["h"] = tex.Value.Height
-                };
-
-                if (tex.Value.Right > maxUsedWidth)
-                {
-                    maxUsedWidth = tex.Value.Right;
-                }
-
-                if (tex.Value.Bottom > maxUsedHeight)
-                {
-                    maxUsedHeight = tex.Value.Bottom;
-                }
-
-                t.Dispose();
-
-                frames.Add(frame);
-            }
-
-            g.Dispose();
-
-            if (maxUsedWidth > 0 && maxUsedHeight > 0)
-            {
-                var croppedImg = new Bitmap(maxUsedWidth, maxUsedHeight);
-                var g1 = Graphics.FromImage(croppedImg);
-                g1.DrawImage(
-                    img, new RectangleF(0, 0, maxUsedWidth, maxUsedHeight),
-                    new RectangleF(0, 0, maxUsedWidth, maxUsedHeight), GraphicsUnit.Pixel
-                );
-
-                g1.Dispose();
-                var size = new JObject
-                {
-                    ["w"] = croppedImg.Width,
-                    ["h"] = croppedImg.Height
-                };
-
-                var assetPath = Path.Combine(ResourcesDirectory, "packs", "graphics" + index + ".asset");
-                using (var stream = GzipCompression.CreateCompressedFileStream(assetPath))
-                {
-                    croppedImg.Save(stream, ImageFormat.Png);
-                }
-
-                croppedImg.Dispose();
-
-                //Create Metadata
-                var jobj = new JObject();
-                jobj.Add(new JProperty("frames", frames));
-
-                var meta = new JObject();
-                meta["image"] = "graphics" + index + ".asset";
-                meta["size"] = size;
-                jobj.Add(new JProperty("meta", meta));
-
-                var metaPath = Path.Combine(ResourcesDirectory, "packs", "graphics" + index + ".meta");
-
-                //Save Metadata
-                GzipCompression.WriteCompressedString(metaPath, jobj.ToString());
-            }
-
-            img.Dispose();
-        }
-
-        public Rectangle Insert(int width, int height, FreeRectChoiceHeuristic method)
-        {
-            var newNode = new Rectangle();
-            var score1 = 0; // Unused in this function. We don't need to know the score after finding the position.
-            var score2 = 0;
-            switch (method)
-            {
-                case FreeRectChoiceHeuristic.RectBestShortSideFit:
-                    newNode = FindPositionForNewNodeBestShortSideFit(width, height, ref score1, ref score2);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBottomLeftRule:
-                    newNode = FindPositionForNewNodeBottomLeft(width, height, ref score1, ref score2);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectContactPointRule:
-                    newNode = FindPositionForNewNodeContactPoint(width, height, ref score1);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBestLongSideFit:
-                    newNode = FindPositionForNewNodeBestLongSideFit(width, height, ref score2, ref score1);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBestAreaFit:
-                    newNode = FindPositionForNewNodeBestAreaFit(width, height, ref score1, ref score2);
-
-                    break;
-            }
-
-            if (newNode.Height == 0)
-            {
-                return newNode;
-            }
-
-            var numRectanglesToProcess = freeRectangles.Count;
-            for (var i = 0; i < numRectanglesToProcess; ++i)
-            {
-                if (SplitFreeNode(freeRectangles[i], ref newNode))
-                {
-                    freeRectangles.RemoveAt(i);
-                    --i;
-                    --numRectanglesToProcess;
-                }
-            }
-
-            PruneFreeList();
-
-            usedRectangles.Add(newNode);
-
-            return newNode;
-        }
-
-        public void Insert(List<Rectangle> rects, List<Rectangle> dst, FreeRectChoiceHeuristic method)
-        {
-            dst.Clear();
-
-            while (rects.Count > 0)
-            {
-                var bestScore1 = int.MaxValue;
-                var bestScore2 = int.MaxValue;
-                var bestRectIndex = -1;
-                var bestNode = new Rectangle();
-
-                for (var i = 0; i < rects.Count; ++i)
-                {
-                    var score1 = 0;
-                    var score2 = 0;
-                    var newNode = ScoreRect(
-                        (int)rects[i].Width, (int)rects[i].Height, method, ref score1, ref score2
-                    );
-
-                    if (score1 < bestScore1 || score1 == bestScore1 && score2 < bestScore2)
-                    {
-                        bestScore1 = score1;
-                        bestScore2 = score2;
-                        bestNode = newNode;
-                        bestRectIndex = i;
-                    }
-                }
-
-                if (bestRectIndex == -1)
-                {
-                    return;
-                }
-
-                PlaceRect(bestNode);
-                rects.RemoveAt(bestRectIndex);
-            }
-        }
-
-        void PlaceRect(Rectangle node)
-        {
-            var numRectanglesToProcess = freeRectangles.Count;
-            for (var i = 0; i < numRectanglesToProcess; ++i)
-            {
-                if (SplitFreeNode(freeRectangles[i], ref node))
-                {
-                    freeRectangles.RemoveAt(i);
-                    --i;
-                    --numRectanglesToProcess;
-                }
-            }
-
-            PruneFreeList();
-
-            usedRectangles.Add(node);
-        }
-
-        Rectangle ScoreRect(int width, int height, FreeRectChoiceHeuristic method, ref int score1, ref int score2)
-        {
-            var newNode = new Rectangle();
-            score1 = int.MaxValue;
-            score2 = int.MaxValue;
-            switch (method)
-            {
-                case FreeRectChoiceHeuristic.RectBestShortSideFit:
-                    newNode = FindPositionForNewNodeBestShortSideFit(width, height, ref score1, ref score2);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBottomLeftRule:
-                    newNode = FindPositionForNewNodeBottomLeft(width, height, ref score1, ref score2);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectContactPointRule:
-                    newNode = FindPositionForNewNodeContactPoint(width, height, ref score1);
-                    score1 = -score1; // Reverse since we are minimizing, but for contact point score bigger is better.
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBestLongSideFit:
-                    newNode = FindPositionForNewNodeBestLongSideFit(width, height, ref score2, ref score1);
-
-                    break;
-                case FreeRectChoiceHeuristic.RectBestAreaFit:
-                    newNode = FindPositionForNewNodeBestAreaFit(width, height, ref score1, ref score2);
-
-                    break;
-            }
-
-            // Cannot fit the current rectangle.
-            if (newNode.Height == 0)
-            {
-                score1 = int.MaxValue;
-                score2 = int.MaxValue;
-            }
-
-            return newNode;
-        }
-
-        /// Computes the ratio of used surface area.
-        public float Occupancy()
-        {
-            ulong usedSurfaceArea = 0;
-            for (var i = 0; i < usedRectangles.Count; ++i)
-            {
-                usedSurfaceArea += (uint)usedRectangles[i].Width * (uint)usedRectangles[i].Height;
-            }
-
-            return (float)usedSurfaceArea / (binWidth * binHeight);
-        }
-
-        Rectangle FindPositionForNewNodeBottomLeft(int width, int height, ref int bestY, ref int bestX)
-        {
-            var bestNode = new Rectangle();
-
-            //memset(bestNode, 0, sizeof(Rect));
-
-            bestY = int.MaxValue;
-
-            for (var i = 0; i < freeRectangles.Count; ++i)
-            {
-                // Try to place the rectangle in upright (non-flipped) orientation.
-                if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
-                {
-                    var topSideY = (int)freeRectangles[i].Y + height;
-                    if (topSideY < bestY || topSideY == bestY && freeRectangles[i].X < bestX)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = width;
-                        bestNode.Height = height;
-                        bestY = topSideY;
-                        bestX = (int)freeRectangles[i].X;
-                    }
-                }
-
-                if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
-                {
-                    var topSideY = (int)freeRectangles[i].Y + width;
-                    if (topSideY < bestY || topSideY == bestY && freeRectangles[i].X < bestX)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = height;
-                        bestNode.Height = width;
-                        bestY = topSideY;
-                        bestX = (int)freeRectangles[i].X;
-                    }
-                }
-            }
-
-            return bestNode;
-        }
-
-        Rectangle FindPositionForNewNodeBestShortSideFit(
-            int width,
-            int height,
-            ref int bestShortSideFit,
-            ref int bestLongSideFit
-        )
-        {
-            var bestNode = new Rectangle();
-
-            //memset(&bestNode, 0, sizeof(Rect));
-
-            bestShortSideFit = int.MaxValue;
-
-            for (var i = 0; i < freeRectangles.Count; ++i)
-            {
-                // Try to place the rectangle in upright (non-flipped) orientation.
-                if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
-                {
-                    var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
-                    var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
-                    var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
-                    var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
-
-                    if (shortSideFit < bestShortSideFit ||
-                        shortSideFit == bestShortSideFit && longSideFit < bestLongSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = width;
-                        bestNode.Height = height;
-                        bestShortSideFit = shortSideFit;
-                        bestLongSideFit = longSideFit;
-                    }
-                }
-
-                if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
-                {
-                    var flippedLeftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
-                    var flippedLeftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
-                    var flippedShortSideFit = Math.Min(flippedLeftoverHoriz, flippedLeftoverVert);
-                    var flippedLongSideFit = Math.Max(flippedLeftoverHoriz, flippedLeftoverVert);
-
-                    if (flippedShortSideFit < bestShortSideFit ||
-                        flippedShortSideFit == bestShortSideFit && flippedLongSideFit < bestLongSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = height;
-                        bestNode.Height = width;
-                        bestShortSideFit = flippedShortSideFit;
-                        bestLongSideFit = flippedLongSideFit;
-                    }
-                }
-            }
-
-            return bestNode;
-        }
-
-        Rectangle FindPositionForNewNodeBestLongSideFit(
-            int width,
-            int height,
-            ref int bestShortSideFit,
-            ref int bestLongSideFit
-        )
-        {
-            var bestNode = new Rectangle();
-
-            //memset(&bestNode, 0, sizeof(Rect));
-
-            bestLongSideFit = int.MaxValue;
-
-            for (var i = 0; i < freeRectangles.Count; ++i)
-            {
-                // Try to place the rectangle in upright (non-flipped) orientation.
-                if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
-                {
-                    var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
-                    var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
-                    var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
-                    var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
-
-                    if (longSideFit < bestLongSideFit ||
-                        longSideFit == bestLongSideFit && shortSideFit < bestShortSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = width;
-                        bestNode.Height = height;
-                        bestShortSideFit = shortSideFit;
-                        bestLongSideFit = longSideFit;
-                    }
-                }
-
-                if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
-                {
-                    var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
-                    var leftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
-                    var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
-                    var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
-
-                    if (longSideFit < bestLongSideFit ||
-                        longSideFit == bestLongSideFit && shortSideFit < bestShortSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = height;
-                        bestNode.Height = width;
-                        bestShortSideFit = shortSideFit;
-                        bestLongSideFit = longSideFit;
-                    }
-                }
-            }
-
-            return bestNode;
-        }
-
-        Rectangle FindPositionForNewNodeBestAreaFit(
-            int width,
-            int height,
-            ref int bestAreaFit,
-            ref int bestShortSideFit
-        )
-        {
-            var bestNode = new Rectangle();
-
-            //memset(&bestNode, 0, sizeof(Rect));
-
-            bestAreaFit = int.MaxValue;
-
-            for (var i = 0; i < freeRectangles.Count; ++i)
-            {
-                var areaFit = (int)freeRectangles[i].Width * (int)freeRectangles[i].Height - width * height;
-
-                // Try to place the rectangle in upright (non-flipped) orientation.
-                if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
-                {
-                    var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
-                    var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
-                    var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
-
-                    if (areaFit < bestAreaFit || areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = width;
-                        bestNode.Height = height;
-                        bestShortSideFit = shortSideFit;
-                        bestAreaFit = areaFit;
-                    }
-                }
-
-                if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
-                {
-                    var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
-                    var leftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
-                    var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
-
-                    if (areaFit < bestAreaFit || areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
-                    {
-                        bestNode.X = freeRectangles[i].X;
-                        bestNode.Y = freeRectangles[i].Y;
-                        bestNode.Width = height;
-                        bestNode.Height = width;
-                        bestShortSideFit = shortSideFit;
-                        bestAreaFit = areaFit;
-                    }
-                }
-            }
-
-            return bestNode;
-        }
-
-        /// Returns 0 if the two intervals i1 and i2 are disjoint, or the length of their overlap otherwise.
-        int CommonIntervalLength(int i1start, int i1end, int i2start, int i2end)
-        {
-            if (i1end < i2start || i2end < i1start)
-            {
-                return 0;
-            }
-
-            return Math.Min(i1end, i2end) - Math.Max(i1start, i2start);
-        }
-
-        int ContactPointScoreNode(int x, int y, int width, int height)
-        {
-            var score = 0;
-
-            if (x == 0 || x + width == binWidth)
-            {
-                score += height;
-            }
-
-            if (y == 0 || y + height == binHeight)
-            {
-                score += width;
-            }
-
-            for (var i = 0; i < usedRectangles.Count; ++i)
-            {
-                if (usedRectangles[i].X == x + width || usedRectangles[i].X + usedRectangles[i].Width == x)
-                {
-                    score += CommonIntervalLength(
-                        (int)usedRectangles[i].Y, (int)usedRectangles[i].Y + (int)usedRectangles[i].Height, y,
-                        y + height
-                    );
-                }
-
-                if (usedRectangles[i].Y == y + height || usedRectangles[i].Y + usedRectangles[i].Height == y)
-                {
-                    score += CommonIntervalLength(
-                        (int)usedRectangles[i].X, (int)usedRectangles[i].X + (int)usedRectangles[i].Width, x,
-                        x + width
-                    );
-                }
-            }
-
-            return score;
-        }
-
-        Rectangle FindPositionForNewNodeContactPoint(int width, int height, ref int bestContactScore)
-        {
-            var bestNode = new Rectangle();
-
-            //memset(&bestNode, 0, sizeof(Rect));
-
-            bestContactScore = -1;
-
-            for (var i = 0; i < freeRectangles.Count; ++i)
-            {
-                // Try to place the rectangle in upright (non-flipped) orientation.
-                if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
-                {
-                    var score = ContactPointScoreNode(
-                        (int)freeRectangles[i].X, (int)freeRectangles[i].Y, width, height
-                    );
-
-                    if (score > bestContactScore)
-                    {
-                        bestNode.X = (int)freeRectangles[i].X;
-                        bestNode.Y = (int)freeRectangles[i].Y;
-                        bestNode.Width = width;
-                        bestNode.Height = height;
-                        bestContactScore = score;
-                    }
-                }
-
-                if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
-                {
-                    var score = ContactPointScoreNode(
-                        (int)freeRectangles[i].X, (int)freeRectangles[i].Y, height, width
-                    );
-
-                    if (score > bestContactScore)
-                    {
-                        bestNode.X = (int)freeRectangles[i].X;
-                        bestNode.Y = (int)freeRectangles[i].Y;
-                        bestNode.Width = height;
-                        bestNode.Height = width;
-                        bestContactScore = score;
-                    }
-                }
-            }
-
-            return bestNode;
-        }
-
-        bool SplitFreeNode(Rectangle freeNode, ref Rectangle usedNode)
-        {
-            // Test with SAT if the rectangles even intersect.
-            if (usedNode.X >= freeNode.X + freeNode.Width ||
-                usedNode.X + usedNode.Width <= freeNode.X ||
-                usedNode.Y >= freeNode.Y + freeNode.Height ||
-                usedNode.Y + usedNode.Height <= freeNode.Y)
-            {
-                return false;
-            }
-
-            if (usedNode.X < freeNode.X + freeNode.Width && usedNode.X + usedNode.Width > freeNode.X)
-            {
-                // New node at the top side of the used node.
-                if (usedNode.Y > freeNode.Y && usedNode.Y < freeNode.Y + freeNode.Height)
-                {
-                    var newNode = freeNode;
-                    newNode.Height = usedNode.Y - newNode.Y;
-                    freeRectangles.Add(newNode);
-                }
-
-                // New node at the bottom side of the used node.
-                if (usedNode.Y + usedNode.Height < freeNode.Y + freeNode.Height)
-                {
-                    var newNode = freeNode;
-                    newNode.Y = usedNode.Y + usedNode.Height;
-                    newNode.Height = freeNode.Y + freeNode.Height - (usedNode.Y + usedNode.Height);
-                    freeRectangles.Add(newNode);
-                }
-            }
-
-            if (usedNode.Y < freeNode.Y + freeNode.Height && usedNode.Y + usedNode.Height > freeNode.Y)
-            {
-                // New node at the left side of the used node.
-                if (usedNode.X > freeNode.X && usedNode.X < freeNode.X + freeNode.Width)
-                {
-                    var newNode = freeNode;
-                    newNode.Width = usedNode.X - newNode.X;
-                    freeRectangles.Add(newNode);
-                }
-
-                // New node at the right side of the used node.
-                if (usedNode.X + usedNode.Width < freeNode.X + freeNode.Width)
-                {
-                    var newNode = freeNode;
-                    newNode.X = usedNode.X + usedNode.Width;
-                    newNode.Width = freeNode.X + freeNode.Width - (usedNode.X + usedNode.Width);
-                    freeRectangles.Add(newNode);
-                }
-            }
+            textures.Add(tex, rect);
 
             return true;
         }
 
-        void PruneFreeList()
+        return false;
+    }
+
+    public void Export(int index)
+    {
+        //TODO: Trim Edges
+        var img = new Bitmap(binWidth, binHeight);
+        var maxUsedWidth = 0;
+        var maxUsedHeight = 0;
+        var g = Graphics.FromImage(img);
+        var frames = new JArray();
+
+        foreach (var tex in textures)
         {
-            for (var i = 0; i < freeRectangles.Count; ++i)
-                for (var j = i + 1; j < freeRectangles.Count; ++j)
+            var t = Image.FromFile(tex.Key.GetPath());
+
+            var frame = new JObject
+            {
+                { "filename", tex.Key.GetPath() }
+            };
+
+            frame["spriteSourceSize"] = new JObject
+            {
+                ["x"] = 0,
+                ["y"] = 0,
+                ["w"] = t.Width,
+                ["h"] = t.Height
+            };
+
+            frame["sourceSize"] = new JObject
+            {
+                ["w"] = t.Width,
+                ["h"] = t.Height
+            };
+
+            if (tex.Value.Width == t.Height && tex.Value.Height == t.Width && t.Width != t.Height)
+            {
+                //Rotated
+                t.RotateFlip(RotateFlipType.Rotate90FlipNone);
+                frame["rotated"] = true;
+            }
+            else
+            {
+                frame["rotated"] = false;
+            }
+
+            g.DrawImage(
+                t,
+                new RectangleF(tex.Value.X, tex.Value.Y, tex.Value.Width, tex.Value.Height),
+                new RectangleF(0, 0, t.Width, t.Height),
+                GraphicsUnit.Pixel
+            );
+
+            frame["frame"] = new JObject
+            {
+                ["x"] = tex.Value.X,
+                ["y"] = tex.Value.Y,
+                ["w"] = tex.Value.Width,
+                ["h"] = tex.Value.Height
+            };
+
+            if (tex.Value.Right > maxUsedWidth)
+            {
+                maxUsedWidth = tex.Value.Right;
+            }
+
+            if (tex.Value.Bottom > maxUsedHeight)
+            {
+                maxUsedHeight = tex.Value.Bottom;
+            }
+
+            t.Dispose();
+
+            frames.Add(frame);
+        }
+
+        g.Dispose();
+
+        if (maxUsedWidth > 0 && maxUsedHeight > 0)
+        {
+            var croppedImg = new Bitmap(maxUsedWidth, maxUsedHeight);
+            var g1 = Graphics.FromImage(croppedImg);
+            g1.DrawImage(
+                img, new RectangleF(0, 0, maxUsedWidth, maxUsedHeight),
+                new RectangleF(0, 0, maxUsedWidth, maxUsedHeight), GraphicsUnit.Pixel
+            );
+
+            g1.Dispose();
+            var size = new JObject
+            {
+                ["w"] = croppedImg.Width,
+                ["h"] = croppedImg.Height
+            };
+
+            var assetPath = Path.Combine(ResourcesDirectory, "packs", "graphics" + index + ".asset");
+            using (var stream = GzipCompression.CreateCompressedFileStream(assetPath))
+            {
+                croppedImg.Save(stream, ImageFormat.Png);
+            }
+
+            croppedImg.Dispose();
+
+            //Create Metadata
+            var jobj = new JObject();
+            jobj.Add(new JProperty("frames", frames));
+
+            var meta = new JObject();
+            meta["image"] = "graphics" + index + ".asset";
+            meta["size"] = size;
+            jobj.Add(new JProperty("meta", meta));
+
+            var metaPath = Path.Combine(ResourcesDirectory, "packs", "graphics" + index + ".meta");
+
+            //Save Metadata
+            GzipCompression.WriteCompressedString(metaPath, jobj.ToString());
+        }
+
+        img.Dispose();
+    }
+
+    public Rectangle Insert(int width, int height, FreeRectChoiceHeuristic method)
+    {
+        var newNode = new Rectangle();
+        var score1 = 0; // Unused in this function. We don't need to know the score after finding the position.
+        var score2 = 0;
+        switch (method)
+        {
+            case FreeRectChoiceHeuristic.RectBestShortSideFit:
+                newNode = FindPositionForNewNodeBestShortSideFit(width, height, ref score1, ref score2);
+
+                break;
+            case FreeRectChoiceHeuristic.RectBottomLeftRule:
+                newNode = FindPositionForNewNodeBottomLeft(width, height, ref score1, ref score2);
+
+                break;
+            case FreeRectChoiceHeuristic.RectContactPointRule:
+                newNode = FindPositionForNewNodeContactPoint(width, height, ref score1);
+
+                break;
+            case FreeRectChoiceHeuristic.RectBestLongSideFit:
+                newNode = FindPositionForNewNodeBestLongSideFit(width, height, ref score2, ref score1);
+
+                break;
+            case FreeRectChoiceHeuristic.RectBestAreaFit:
+                newNode = FindPositionForNewNodeBestAreaFit(width, height, ref score1, ref score2);
+
+                break;
+        }
+
+        if (newNode.Height == 0)
+        {
+            return newNode;
+        }
+
+        var numRectanglesToProcess = freeRectangles.Count;
+        for (var i = 0; i < numRectanglesToProcess; ++i)
+        {
+            if (SplitFreeNode(freeRectangles[i], ref newNode))
+            {
+                freeRectangles.RemoveAt(i);
+                --i;
+                --numRectanglesToProcess;
+            }
+        }
+
+        PruneFreeList();
+
+        usedRectangles.Add(newNode);
+
+        return newNode;
+    }
+
+    public void Insert(List<Rectangle> rects, List<Rectangle> dst, FreeRectChoiceHeuristic method)
+    {
+        dst.Clear();
+
+        while (rects.Count > 0)
+        {
+            var bestScore1 = int.MaxValue;
+            var bestScore2 = int.MaxValue;
+            var bestRectIndex = -1;
+            var bestNode = new Rectangle();
+
+            for (var i = 0; i < rects.Count; ++i)
+            {
+                var score1 = 0;
+                var score2 = 0;
+                var newNode = ScoreRect(
+                    (int)rects[i].Width, (int)rects[i].Height, method, ref score1, ref score2
+                );
+
+                if (score1 < bestScore1 || score1 == bestScore1 && score2 < bestScore2)
                 {
-                    if (IsContainedIn(freeRectangles[i], freeRectangles[j]))
-                    {
-                        freeRectangles.RemoveAt(i);
-                        --i;
-
-                        break;
-                    }
-
-                    if (IsContainedIn(freeRectangles[j], freeRectangles[i]))
-                    {
-                        freeRectangles.RemoveAt(j);
-                        --j;
-                    }
+                    bestScore1 = score1;
+                    bestScore2 = score2;
+                    bestNode = newNode;
+                    bestRectIndex = i;
                 }
-        }
+            }
 
-        bool IsContainedIn(Rectangle a, Rectangle b)
+            if (bestRectIndex == -1)
+            {
+                return;
+            }
+
+            PlaceRect(bestNode);
+            rects.RemoveAt(bestRectIndex);
+        }
+    }
+
+    void PlaceRect(Rectangle node)
+    {
+        var numRectanglesToProcess = freeRectangles.Count;
+        for (var i = 0; i < numRectanglesToProcess; ++i)
         {
-            return a.X >= b.X && a.Y >= b.Y && a.X + a.Width <= b.X + b.Width && a.Y + a.Height <= b.Y + b.Height;
+            if (SplitFreeNode(freeRectangles[i], ref node))
+            {
+                freeRectangles.RemoveAt(i);
+                --i;
+                --numRectanglesToProcess;
+            }
         }
 
+        PruneFreeList();
+
+        usedRectangles.Add(node);
+    }
+
+    Rectangle ScoreRect(int width, int height, FreeRectChoiceHeuristic method, ref int score1, ref int score2)
+    {
+        var newNode = new Rectangle();
+        score1 = int.MaxValue;
+        score2 = int.MaxValue;
+        switch (method)
+        {
+            case FreeRectChoiceHeuristic.RectBestShortSideFit:
+                newNode = FindPositionForNewNodeBestShortSideFit(width, height, ref score1, ref score2);
+
+                break;
+            case FreeRectChoiceHeuristic.RectBottomLeftRule:
+                newNode = FindPositionForNewNodeBottomLeft(width, height, ref score1, ref score2);
+
+                break;
+            case FreeRectChoiceHeuristic.RectContactPointRule:
+                newNode = FindPositionForNewNodeContactPoint(width, height, ref score1);
+                score1 = -score1; // Reverse since we are minimizing, but for contact point score bigger is better.
+
+                break;
+            case FreeRectChoiceHeuristic.RectBestLongSideFit:
+                newNode = FindPositionForNewNodeBestLongSideFit(width, height, ref score2, ref score1);
+
+                break;
+            case FreeRectChoiceHeuristic.RectBestAreaFit:
+                newNode = FindPositionForNewNodeBestAreaFit(width, height, ref score1, ref score2);
+
+                break;
+        }
+
+        // Cannot fit the current rectangle.
+        if (newNode.Height == 0)
+        {
+            score1 = int.MaxValue;
+            score2 = int.MaxValue;
+        }
+
+        return newNode;
+    }
+
+    /// Computes the ratio of used surface area.
+    public float Occupancy()
+    {
+        ulong usedSurfaceArea = 0;
+        for (var i = 0; i < usedRectangles.Count; ++i)
+        {
+            usedSurfaceArea += (uint)usedRectangles[i].Width * (uint)usedRectangles[i].Height;
+        }
+
+        return (float)usedSurfaceArea / (binWidth * binHeight);
+    }
+
+    Rectangle FindPositionForNewNodeBottomLeft(int width, int height, ref int bestY, ref int bestX)
+    {
+        var bestNode = new Rectangle();
+
+        //memset(bestNode, 0, sizeof(Rect));
+
+        bestY = int.MaxValue;
+
+        for (var i = 0; i < freeRectangles.Count; ++i)
+        {
+            // Try to place the rectangle in upright (non-flipped) orientation.
+            if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
+            {
+                var topSideY = (int)freeRectangles[i].Y + height;
+                if (topSideY < bestY || topSideY == bestY && freeRectangles[i].X < bestX)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = width;
+                    bestNode.Height = height;
+                    bestY = topSideY;
+                    bestX = (int)freeRectangles[i].X;
+                }
+            }
+
+            if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
+            {
+                var topSideY = (int)freeRectangles[i].Y + width;
+                if (topSideY < bestY || topSideY == bestY && freeRectangles[i].X < bestX)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = height;
+                    bestNode.Height = width;
+                    bestY = topSideY;
+                    bestX = (int)freeRectangles[i].X;
+                }
+            }
+        }
+
+        return bestNode;
+    }
+
+    Rectangle FindPositionForNewNodeBestShortSideFit(
+        int width,
+        int height,
+        ref int bestShortSideFit,
+        ref int bestLongSideFit
+    )
+    {
+        var bestNode = new Rectangle();
+
+        //memset(&bestNode, 0, sizeof(Rect));
+
+        bestShortSideFit = int.MaxValue;
+
+        for (var i = 0; i < freeRectangles.Count; ++i)
+        {
+            // Try to place the rectangle in upright (non-flipped) orientation.
+            if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
+            {
+                var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
+                var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
+                var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
+                var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
+
+                if (shortSideFit < bestShortSideFit ||
+                    shortSideFit == bestShortSideFit && longSideFit < bestLongSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = width;
+                    bestNode.Height = height;
+                    bestShortSideFit = shortSideFit;
+                    bestLongSideFit = longSideFit;
+                }
+            }
+
+            if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
+            {
+                var flippedLeftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
+                var flippedLeftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
+                var flippedShortSideFit = Math.Min(flippedLeftoverHoriz, flippedLeftoverVert);
+                var flippedLongSideFit = Math.Max(flippedLeftoverHoriz, flippedLeftoverVert);
+
+                if (flippedShortSideFit < bestShortSideFit ||
+                    flippedShortSideFit == bestShortSideFit && flippedLongSideFit < bestLongSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = height;
+                    bestNode.Height = width;
+                    bestShortSideFit = flippedShortSideFit;
+                    bestLongSideFit = flippedLongSideFit;
+                }
+            }
+        }
+
+        return bestNode;
+    }
+
+    Rectangle FindPositionForNewNodeBestLongSideFit(
+        int width,
+        int height,
+        ref int bestShortSideFit,
+        ref int bestLongSideFit
+    )
+    {
+        var bestNode = new Rectangle();
+
+        //memset(&bestNode, 0, sizeof(Rect));
+
+        bestLongSideFit = int.MaxValue;
+
+        for (var i = 0; i < freeRectangles.Count; ++i)
+        {
+            // Try to place the rectangle in upright (non-flipped) orientation.
+            if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
+            {
+                var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
+                var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
+                var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
+                var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
+
+                if (longSideFit < bestLongSideFit ||
+                    longSideFit == bestLongSideFit && shortSideFit < bestShortSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = width;
+                    bestNode.Height = height;
+                    bestShortSideFit = shortSideFit;
+                    bestLongSideFit = longSideFit;
+                }
+            }
+
+            if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
+            {
+                var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
+                var leftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
+                var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
+                var longSideFit = Math.Max(leftoverHoriz, leftoverVert);
+
+                if (longSideFit < bestLongSideFit ||
+                    longSideFit == bestLongSideFit && shortSideFit < bestShortSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = height;
+                    bestNode.Height = width;
+                    bestShortSideFit = shortSideFit;
+                    bestLongSideFit = longSideFit;
+                }
+            }
+        }
+
+        return bestNode;
+    }
+
+    Rectangle FindPositionForNewNodeBestAreaFit(
+        int width,
+        int height,
+        ref int bestAreaFit,
+        ref int bestShortSideFit
+    )
+    {
+        var bestNode = new Rectangle();
+
+        //memset(&bestNode, 0, sizeof(Rect));
+
+        bestAreaFit = int.MaxValue;
+
+        for (var i = 0; i < freeRectangles.Count; ++i)
+        {
+            var areaFit = (int)freeRectangles[i].Width * (int)freeRectangles[i].Height - width * height;
+
+            // Try to place the rectangle in upright (non-flipped) orientation.
+            if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
+            {
+                var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - width);
+                var leftoverVert = Math.Abs((int)freeRectangles[i].Height - height);
+                var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
+
+                if (areaFit < bestAreaFit || areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = width;
+                    bestNode.Height = height;
+                    bestShortSideFit = shortSideFit;
+                    bestAreaFit = areaFit;
+                }
+            }
+
+            if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
+            {
+                var leftoverHoriz = Math.Abs((int)freeRectangles[i].Width - height);
+                var leftoverVert = Math.Abs((int)freeRectangles[i].Height - width);
+                var shortSideFit = Math.Min(leftoverHoriz, leftoverVert);
+
+                if (areaFit < bestAreaFit || areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
+                {
+                    bestNode.X = freeRectangles[i].X;
+                    bestNode.Y = freeRectangles[i].Y;
+                    bestNode.Width = height;
+                    bestNode.Height = width;
+                    bestShortSideFit = shortSideFit;
+                    bestAreaFit = areaFit;
+                }
+            }
+        }
+
+        return bestNode;
+    }
+
+    /// Returns 0 if the two intervals i1 and i2 are disjoint, or the length of their overlap otherwise.
+    int CommonIntervalLength(int i1start, int i1end, int i2start, int i2end)
+    {
+        if (i1end < i2start || i2end < i1start)
+        {
+            return 0;
+        }
+
+        return Math.Min(i1end, i2end) - Math.Max(i1start, i2start);
+    }
+
+    int ContactPointScoreNode(int x, int y, int width, int height)
+    {
+        var score = 0;
+
+        if (x == 0 || x + width == binWidth)
+        {
+            score += height;
+        }
+
+        if (y == 0 || y + height == binHeight)
+        {
+            score += width;
+        }
+
+        for (var i = 0; i < usedRectangles.Count; ++i)
+        {
+            if (usedRectangles[i].X == x + width || usedRectangles[i].X + usedRectangles[i].Width == x)
+            {
+                score += CommonIntervalLength(
+                    (int)usedRectangles[i].Y, (int)usedRectangles[i].Y + (int)usedRectangles[i].Height, y,
+                    y + height
+                );
+            }
+
+            if (usedRectangles[i].Y == y + height || usedRectangles[i].Y + usedRectangles[i].Height == y)
+            {
+                score += CommonIntervalLength(
+                    (int)usedRectangles[i].X, (int)usedRectangles[i].X + (int)usedRectangles[i].Width, x,
+                    x + width
+                );
+            }
+        }
+
+        return score;
+    }
+
+    Rectangle FindPositionForNewNodeContactPoint(int width, int height, ref int bestContactScore)
+    {
+        var bestNode = new Rectangle();
+
+        //memset(&bestNode, 0, sizeof(Rect));
+
+        bestContactScore = -1;
+
+        for (var i = 0; i < freeRectangles.Count; ++i)
+        {
+            // Try to place the rectangle in upright (non-flipped) orientation.
+            if (freeRectangles[i].Width >= width && freeRectangles[i].Height >= height)
+            {
+                var score = ContactPointScoreNode(
+                    (int)freeRectangles[i].X, (int)freeRectangles[i].Y, width, height
+                );
+
+                if (score > bestContactScore)
+                {
+                    bestNode.X = (int)freeRectangles[i].X;
+                    bestNode.Y = (int)freeRectangles[i].Y;
+                    bestNode.Width = width;
+                    bestNode.Height = height;
+                    bestContactScore = score;
+                }
+            }
+
+            if (allowRotations && freeRectangles[i].Width >= height && freeRectangles[i].Height >= width)
+            {
+                var score = ContactPointScoreNode(
+                    (int)freeRectangles[i].X, (int)freeRectangles[i].Y, height, width
+                );
+
+                if (score > bestContactScore)
+                {
+                    bestNode.X = (int)freeRectangles[i].X;
+                    bestNode.Y = (int)freeRectangles[i].Y;
+                    bestNode.Width = height;
+                    bestNode.Height = width;
+                    bestContactScore = score;
+                }
+            }
+        }
+
+        return bestNode;
+    }
+
+    bool SplitFreeNode(Rectangle freeNode, ref Rectangle usedNode)
+    {
+        // Test with SAT if the rectangles even intersect.
+        if (usedNode.X >= freeNode.X + freeNode.Width ||
+            usedNode.X + usedNode.Width <= freeNode.X ||
+            usedNode.Y >= freeNode.Y + freeNode.Height ||
+            usedNode.Y + usedNode.Height <= freeNode.Y)
+        {
+            return false;
+        }
+
+        if (usedNode.X < freeNode.X + freeNode.Width && usedNode.X + usedNode.Width > freeNode.X)
+        {
+            // New node at the top side of the used node.
+            if (usedNode.Y > freeNode.Y && usedNode.Y < freeNode.Y + freeNode.Height)
+            {
+                var newNode = freeNode;
+                newNode.Height = usedNode.Y - newNode.Y;
+                freeRectangles.Add(newNode);
+            }
+
+            // New node at the bottom side of the used node.
+            if (usedNode.Y + usedNode.Height < freeNode.Y + freeNode.Height)
+            {
+                var newNode = freeNode;
+                newNode.Y = usedNode.Y + usedNode.Height;
+                newNode.Height = freeNode.Y + freeNode.Height - (usedNode.Y + usedNode.Height);
+                freeRectangles.Add(newNode);
+            }
+        }
+
+        if (usedNode.Y < freeNode.Y + freeNode.Height && usedNode.Y + usedNode.Height > freeNode.Y)
+        {
+            // New node at the left side of the used node.
+            if (usedNode.X > freeNode.X && usedNode.X < freeNode.X + freeNode.Width)
+            {
+                var newNode = freeNode;
+                newNode.Width = usedNode.X - newNode.X;
+                freeRectangles.Add(newNode);
+            }
+
+            // New node at the right side of the used node.
+            if (usedNode.X + usedNode.Width < freeNode.X + freeNode.Width)
+            {
+                var newNode = freeNode;
+                newNode.X = usedNode.X + usedNode.Width;
+                newNode.Width = freeNode.X + freeNode.Width - (usedNode.X + usedNode.Width);
+                freeRectangles.Add(newNode);
+            }
+        }
+
+        return true;
+    }
+
+    void PruneFreeList()
+    {
+        for (var i = 0; i < freeRectangles.Count; ++i)
+            for (var j = i + 1; j < freeRectangles.Count; ++j)
+            {
+                if (IsContainedIn(freeRectangles[i], freeRectangles[j]))
+                {
+                    freeRectangles.RemoveAt(i);
+                    --i;
+
+                    break;
+                }
+
+                if (IsContainedIn(freeRectangles[j], freeRectangles[i]))
+                {
+                    freeRectangles.RemoveAt(j);
+                    --j;
+                }
+            }
+    }
+
+    bool IsContainedIn(Rectangle a, Rectangle b)
+    {
+        return a.X >= b.X && a.Y >= b.Y && a.X + a.Width <= b.X + b.Width && a.Y + a.Height <= b.Y + b.Height;
     }
 
 }

--- a/Intersect.Editor/Core/Database.cs
+++ b/Intersect.Editor/Core/Database.cs
@@ -2,376 +2,374 @@ using Intersect.Configuration;
 using Intersect.Editor.Configuration;
 using Mono.Data.Sqlite;
 
-namespace Intersect.Editor
+namespace Intersect.Editor.Core;
+
+
+public static partial class Database
 {
 
-    public static partial class Database
+    private const string DB_FILENAME = "resources/mapcache.db";
+
+    private const string MAP_CACHE_DATA = "data";
+
+    private const string MAP_CACHE_ID = "id";
+
+    private const string MAP_CACHE_REVISION = "revision";
+
+    //Map Table Constants
+    private const string MAP_CACHE_TABLE = "mapcache";
+
+    private const string OPTION_ID = "id";
+
+    private const string OPTION_NAME = "name";
+
+    //Options Constants
+    private const string OPTION_TABLE = "Options";
+
+    private const string OPTION_VALUE = "value";
+
+    //Grid Variables
+    public static bool GridHideDarkness;
+
+    public static bool GridHideFog;
+
+    public static bool GridHideOverlay;
+
+    public static bool GridHideResources;
+
+    public static bool GridHideEvents;
+
+    public static int GridLightColor = System.Drawing.Color.White.ToArgb();
+
+    private static SqliteConnection sDbConnection;
+
+    //Options File
+    public static void LoadOptions()
     {
-
-        private const string DB_FILENAME = "resources/mapcache.db";
-
-        private const string MAP_CACHE_DATA = "data";
-
-        private const string MAP_CACHE_ID = "id";
-
-        private const string MAP_CACHE_REVISION = "revision";
-
-        //Map Table Constants
-        private const string MAP_CACHE_TABLE = "mapcache";
-
-        private const string OPTION_ID = "id";
-
-        private const string OPTION_NAME = "name";
-
-        //Options Constants
-        private const string OPTION_TABLE = "Options";
-
-        private const string OPTION_VALUE = "value";
-
-        //Grid Variables
-        public static bool GridHideDarkness;
-
-        public static bool GridHideFog;
-
-        public static bool GridHideOverlay;
-
-        public static bool GridHideResources;
-
-        public static bool GridHideEvents;
-
-        public static int GridLightColor = System.Drawing.Color.White.ToArgb();
-
-        private static SqliteConnection sDbConnection;
-
-        //Options File
-        public static void LoadOptions()
+        if (!Directory.Exists("resources"))
         {
-            if (!Directory.Exists("resources"))
-            {
-                Directory.CreateDirectory("resources");
-            }
-
-            /* Load configuration */
-            ClientConfiguration.LoadAndSave(ClientConfiguration.DefaultPath);
-            ToolCursor.Load();
+            Directory.CreateDirectory("resources");
         }
 
-        //Map Cache DB
-        public static void InitMapCache()
+        /* Load configuration */
+        ClientConfiguration.LoadAndSave(ClientConfiguration.DefaultPath);
+        ToolCursor.Load();
+    }
+
+    //Map Cache DB
+    public static void InitMapCache()
+    {
+        if (!Directory.Exists("resources"))
         {
-            if (!Directory.Exists("resources"))
-            {
-                Directory.CreateDirectory("resources");
-            }
-
-            SqliteConnection.SetConfig(SQLiteConfig.Serialized);
-            if (!File.Exists(DB_FILENAME))
-            {
-                CreateDatabase();
-            }
-
-            if (sDbConnection == null)
-            {
-                sDbConnection = new SqliteConnection("Data Source=" + DB_FILENAME + ",Version=3");
-                sDbConnection.Open();
-            }
-
-            GridHideDarkness = GetOptionBool("HideDarkness");
-            GridHideFog = GetOptionBool("HideFog");
-            GridHideOverlay = GetOptionBool("HideOverlay");
-            GridLightColor = GetOptionInt("LightColor");
-            GridHideResources = GetOptionBool("HideResources");
-            GridHideEvents = GetOptionBool("HideEvents");
+            Directory.CreateDirectory("resources");
         }
 
-        private static void CreateDatabase()
+        SqliteConnection.SetConfig(SQLiteConfig.Serialized);
+        if (!File.Exists(DB_FILENAME))
         {
-            sDbConnection = new SqliteConnection("Data Source=" + DB_FILENAME + ",Version=3,New=True");
+            CreateDatabase();
+        }
+
+        if (sDbConnection == null)
+        {
+            sDbConnection = new SqliteConnection("Data Source=" + DB_FILENAME + ",Version=3");
             sDbConnection.Open();
-            CreateOptionsTable();
-            CreateMapCacheTable();
         }
 
-        public static void CreateOptionsTable()
-        {
-            var cmd = "CREATE TABLE " +
-                      OPTION_TABLE +
-                      " (" +
-                      OPTION_ID +
-                      " INTEGER PRIMARY KEY," +
-                      OPTION_NAME +
-                      " TEXT UNIQUE," +
-                      OPTION_VALUE +
-                      " TEXT" +
-                      ");";
+        GridHideDarkness = GetOptionBool("HideDarkness");
+        GridHideFog = GetOptionBool("HideFog");
+        GridHideOverlay = GetOptionBool("HideOverlay");
+        GridLightColor = GetOptionInt("LightColor");
+        GridHideResources = GetOptionBool("HideResources");
+        GridHideEvents = GetOptionBool("HideEvents");
+    }
 
-            using (var createCommand = sDbConnection.CreateCommand())
+    private static void CreateDatabase()
+    {
+        sDbConnection = new SqliteConnection("Data Source=" + DB_FILENAME + ",Version=3,New=True");
+        sDbConnection.Open();
+        CreateOptionsTable();
+        CreateMapCacheTable();
+    }
+
+    public static void CreateOptionsTable()
+    {
+        var cmd = "CREATE TABLE " +
+                  OPTION_TABLE +
+                  " (" +
+                  OPTION_ID +
+                  " INTEGER PRIMARY KEY," +
+                  OPTION_NAME +
+                  " TEXT UNIQUE," +
+                  OPTION_VALUE +
+                  " TEXT" +
+                  ");";
+
+        using (var createCommand = sDbConnection.CreateCommand())
+        {
+            createCommand.CommandText = cmd;
+            createCommand.ExecuteNonQuery();
+        }
+    }
+
+    public static void SaveGridOptions()
+    {
+        SaveOption("HideDarkness", GridHideDarkness.ToString());
+        SaveOption("HideFog", GridHideFog.ToString());
+        SaveOption("HideOverlay", GridHideOverlay.ToString());
+        SaveOption("HideResources", GridHideResources.ToString());
+        SaveOption("HideEvents", GridHideEvents.ToString());
+        SaveOption("LightColor", GridLightColor.ToString());
+    }
+
+    public static void SaveOption(string name, string value)
+    {
+        var query = "INSERT OR REPLACE into " +
+                    OPTION_TABLE +
+                    " (" +
+                    OPTION_NAME +
+                    "," +
+                    OPTION_VALUE +
+                    ")" +
+                    " VALUES " +
+                    " (@" +
+                    OPTION_NAME +
+                    ",@" +
+                    OPTION_VALUE +
+                    ");";
+
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + OPTION_NAME, name));
+            cmd.Parameters.Add(new SqliteParameter("@" + OPTION_VALUE, value));
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public static string GetOptionStr(string name)
+    {
+        var query = "SELECT * from " + OPTION_TABLE + " WHERE " + OPTION_NAME + "=@" + OPTION_NAME + ";";
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + OPTION_NAME, name));
+            var dataReader = cmd.ExecuteReader();
+            while (dataReader.Read())
             {
-                createCommand.CommandText = cmd;
-                createCommand.ExecuteNonQuery();
-            }
-        }
-
-        public static void SaveGridOptions()
-        {
-            SaveOption("HideDarkness", GridHideDarkness.ToString());
-            SaveOption("HideFog", GridHideFog.ToString());
-            SaveOption("HideOverlay", GridHideOverlay.ToString());
-            SaveOption("HideResources", GridHideResources.ToString());
-            SaveOption("HideEvents", GridHideEvents.ToString());
-            SaveOption("LightColor", GridLightColor.ToString());
-        }
-
-        public static void SaveOption(string name, string value)
-        {
-            var query = "INSERT OR REPLACE into " +
-                        OPTION_TABLE +
-                        " (" +
-                        OPTION_NAME +
-                        "," +
-                        OPTION_VALUE +
-                        ")" +
-                        " VALUES " +
-                        " (@" +
-                        OPTION_NAME +
-                        ",@" +
-                        OPTION_VALUE +
-                        ");";
-
-            using (var cmd = new SqliteCommand(query, sDbConnection))
-            {
-                cmd.Parameters.Add(new SqliteParameter("@" + OPTION_NAME, name));
-                cmd.Parameters.Add(new SqliteParameter("@" + OPTION_VALUE, value));
-                cmd.ExecuteNonQuery();
-            }
-        }
-
-        public static string GetOptionStr(string name)
-        {
-            var query = "SELECT * from " + OPTION_TABLE + " WHERE " + OPTION_NAME + "=@" + OPTION_NAME + ";";
-            using (var cmd = new SqliteCommand(query, sDbConnection))
-            {
-                cmd.Parameters.Add(new SqliteParameter("@" + OPTION_NAME, name));
-                var dataReader = cmd.ExecuteReader();
-                while (dataReader.Read())
+                if (dataReader[OPTION_VALUE].GetType() != typeof(DBNull))
                 {
-                    if (dataReader[OPTION_VALUE].GetType() != typeof(DBNull))
+                    var data = (string) dataReader[OPTION_VALUE];
+
+                    return data;
+                }
+            }
+        }
+
+        return "";
+    }
+
+    public static int GetOptionInt(string name)
+    {
+        var opt = GetOptionStr(name);
+        if (opt != "")
+        {
+            return Convert.ToInt32(opt);
+        }
+
+        return -1;
+    }
+
+    public static bool GetOptionBool(string name)
+    {
+        var opt = GetOptionStr(name);
+        if (opt != "")
+        {
+            return Convert.ToBoolean(opt);
+        }
+
+        return false;
+    }
+
+    public static void CreateMapCacheTable()
+    {
+        var cmd = "CREATE TABLE " +
+                  MAP_CACHE_TABLE +
+                  " (" +
+                  MAP_CACHE_ID +
+                  " TEXT PRIMARY KEY," +
+                  MAP_CACHE_REVISION +
+                  " INTEGER," +
+                  MAP_CACHE_DATA +
+                  " BLOB" +
+                  ");";
+
+        using (var createCommand = sDbConnection.CreateCommand())
+        {
+            createCommand.CommandText = cmd;
+            createCommand.ExecuteNonQuery();
+        }
+    }
+
+    public static int[] LoadMapCache(Guid id, int revision, int w, int h)
+    {
+        var data = LoadMapCacheRaw(id, revision);
+        if (data != null)
+        {
+            using (var ms = new MemoryStream(data))
+            {
+                var bmp = new Bitmap(Image.FromStream(ms), w, h);
+
+                //Gonna do really sketchy probably broken math here -- yolo
+                var imgData = new int[bmp.Width * bmp.Height];
+
+                unsafe
+                {
+                    // lock bitmap
+                    var origdata = bmp.LockBits(
+                        new Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.ImageLockMode.ReadOnly,
+                        bmp.PixelFormat
+                    );
+
+                    var byteData = (uint*) origdata.Scan0;
+
+                    // Switch bgra -> rgba
+                    for (var i = 0; i < imgData.Length; i++)
                     {
-                        var data = (string) dataReader[OPTION_VALUE];
-
-                        return data;
-                    }
-                }
-            }
-
-            return "";
-        }
-
-        public static int GetOptionInt(string name)
-        {
-            var opt = GetOptionStr(name);
-            if (opt != "")
-            {
-                return Convert.ToInt32(opt);
-            }
-
-            return -1;
-        }
-
-        public static bool GetOptionBool(string name)
-        {
-            var opt = GetOptionStr(name);
-            if (opt != "")
-            {
-                return Convert.ToBoolean(opt);
-            }
-
-            return false;
-        }
-
-        public static void CreateMapCacheTable()
-        {
-            var cmd = "CREATE TABLE " +
-                      MAP_CACHE_TABLE +
-                      " (" +
-                      MAP_CACHE_ID +
-                      " TEXT PRIMARY KEY," +
-                      MAP_CACHE_REVISION +
-                      " INTEGER," +
-                      MAP_CACHE_DATA +
-                      " BLOB" +
-                      ");";
-
-            using (var createCommand = sDbConnection.CreateCommand())
-            {
-                createCommand.CommandText = cmd;
-                createCommand.ExecuteNonQuery();
-            }
-        }
-
-        public static int[] LoadMapCache(Guid id, int revision, int w, int h)
-        {
-            var data = LoadMapCacheRaw(id, revision);
-            if (data != null)
-            {
-                using (var ms = new MemoryStream(data))
-                {
-                    var bmp = new Bitmap(Image.FromStream(ms), w, h);
-
-                    //Gonna do really sketchy probably broken math here -- yolo
-                    var imgData = new int[bmp.Width * bmp.Height];
-
-                    unsafe
-                    {
-                        // lock bitmap
-                        var origdata = bmp.LockBits(
-                            new Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.ImageLockMode.ReadOnly,
-                            bmp.PixelFormat
-                        );
-
-                        var byteData = (uint*) origdata.Scan0;
-
-                        // Switch bgra -> rgba
-                        for (var i = 0; i < imgData.Length; i++)
-                        {
-                            byteData[i] = (byteData[i] & 0x000000ff) << 16 |
-                                          (byteData[i] & 0x0000FF00) |
-                                          (byteData[i] & 0x00FF0000) >> 16 |
-                                          (byteData[i] & 0xFF000000);
-                        }
-
-                        // copy data
-                        System.Runtime.InteropServices.Marshal.Copy(origdata.Scan0, imgData, 0, bmp.Width * bmp.Height);
-
-                        byteData = null;
-
-                        // unlock bitmap
-                        bmp.UnlockBits(origdata);
+                        byteData[i] = (byteData[i] & 0x000000ff) << 16 |
+                                      (byteData[i] & 0x0000FF00) |
+                                      (byteData[i] & 0x00FF0000) >> 16 |
+                                      (byteData[i] & 0xFF000000);
                     }
 
-                    var result = new byte[imgData.Length * sizeof(int)];
-                    Buffer.BlockCopy(imgData, 0, result, 0, result.Length);
+                    // copy data
+                    System.Runtime.InteropServices.Marshal.Copy(origdata.Scan0, imgData, 0, bmp.Width * bmp.Height);
 
-                    return imgData;
+                    byteData = null;
+
+                    // unlock bitmap
+                    bmp.UnlockBits(origdata);
                 }
-            }
 
-            return null;
+                var result = new byte[imgData.Length * sizeof(int)];
+                Buffer.BlockCopy(imgData, 0, result, 0, result.Length);
+
+                return imgData;
+            }
         }
 
-        public static Image LoadMapCacheLegacy(Guid id, int revision)
+        return null;
+    }
+
+    public static Image LoadMapCacheLegacy(Guid id, int revision)
+    {
+        var data = LoadMapCacheRaw(id, revision);
+        if (data != null)
         {
-            var data = LoadMapCacheRaw(id, revision);
-            if (data != null)
+            using (var ms = new MemoryStream(data))
             {
-                using (var ms = new MemoryStream(data))
-                {
-                    return Image.FromStream(ms);
-                }
+                return Image.FromStream(ms);
             }
-
-            return null;
         }
 
-        public static byte[] LoadMapCacheRaw(Guid id, int revision)
+        return null;
+    }
+
+    public static byte[] LoadMapCacheRaw(Guid id, int revision)
+    {
+        var query = "SELECT * from " + MAP_CACHE_TABLE + " WHERE " + MAP_CACHE_ID + "=@" + MAP_CACHE_ID;
+        if (revision > -1)
         {
-            var query = "SELECT * from " + MAP_CACHE_TABLE + " WHERE " + MAP_CACHE_ID + "=@" + MAP_CACHE_ID;
+            query += " AND " + MAP_CACHE_REVISION + "=@" + MAP_CACHE_REVISION;
+        }
+
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
             if (revision > -1)
             {
-                query += " AND " + MAP_CACHE_REVISION + "=@" + MAP_CACHE_REVISION;
+                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_REVISION, revision.ToString()));
             }
 
-            using (var cmd = new SqliteCommand(query, sDbConnection))
+            var dataReader = cmd.ExecuteReader();
+            while (dataReader.Read())
             {
-                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
-                if (revision > -1)
+                if (dataReader[MAP_CACHE_DATA].GetType() != typeof(DBNull))
                 {
-                    cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_REVISION, revision.ToString()));
+                    var data = (byte[]) dataReader[MAP_CACHE_DATA];
+
+                    return data;
                 }
-
-                var dataReader = cmd.ExecuteReader();
-                while (dataReader.Read())
-                {
-                    if (dataReader[MAP_CACHE_DATA].GetType() != typeof(DBNull))
-                    {
-                        var data = (byte[]) dataReader[MAP_CACHE_DATA];
-
-                        return data;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        public static void SaveMapCache(Guid id, int revision, byte[] data)
-        {
-            var query = "INSERT OR REPLACE into " +
-                        MAP_CACHE_TABLE +
-                        " (" +
-                        MAP_CACHE_ID +
-                        "," +
-                        MAP_CACHE_REVISION +
-                        "," +
-                        MAP_CACHE_DATA +
-                        ")" +
-                        " VALUES " +
-                        " (@" +
-                        MAP_CACHE_ID +
-                        ",@" +
-                        MAP_CACHE_REVISION +
-                        ",@" +
-                        MAP_CACHE_DATA +
-                        ");";
-
-            using (var cmd = new SqliteCommand(query, sDbConnection))
-            {
-                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
-                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_REVISION, revision));
-                if (data != null)
-                {
-                    cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, data));
-                }
-                else
-                {
-                    cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, null));
-                }
-
-                cmd.ExecuteNonQuery();
             }
         }
 
-        public static void ClearMapCache(Guid id)
-        {
-            var query = "UPDATE " +
-                        MAP_CACHE_TABLE +
-                        " SET " +
-                        MAP_CACHE_DATA +
-                        " = @" +
-                        MAP_CACHE_DATA +
-                        " WHERE " +
-                        MAP_CACHE_ID +
-                        " = @" +
-                        MAP_CACHE_ID;
+        return null;
+    }
 
-            using (var cmd = new SqliteCommand(query, sDbConnection))
+    public static void SaveMapCache(Guid id, int revision, byte[] data)
+    {
+        var query = "INSERT OR REPLACE into " +
+                    MAP_CACHE_TABLE +
+                    " (" +
+                    MAP_CACHE_ID +
+                    "," +
+                    MAP_CACHE_REVISION +
+                    "," +
+                    MAP_CACHE_DATA +
+                    ")" +
+                    " VALUES " +
+                    " (@" +
+                    MAP_CACHE_ID +
+                    ",@" +
+                    MAP_CACHE_REVISION +
+                    ",@" +
+                    MAP_CACHE_DATA +
+                    ");";
+
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_REVISION, revision));
+            if (data != null)
             {
-                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
-                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, null));
-                cmd.ExecuteNonQuery();
+                cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, data));
             }
-        }
-
-        public static void ClearAllMapCache()
-        {
-            var query = "UPDATE " + MAP_CACHE_TABLE + " SET " + MAP_CACHE_DATA + " = @" + MAP_CACHE_DATA;
-            using (var cmd = new SqliteCommand(query, sDbConnection))
+            else
             {
                 cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, null));
-                cmd.ExecuteNonQuery();
             }
-        }
 
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public static void ClearMapCache(Guid id)
+    {
+        var query = "UPDATE " +
+                    MAP_CACHE_TABLE +
+                    " SET " +
+                    MAP_CACHE_DATA +
+                    " = @" +
+                    MAP_CACHE_DATA +
+                    " WHERE " +
+                    MAP_CACHE_ID +
+                    " = @" +
+                    MAP_CACHE_ID;
+
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_ID, id.ToString()));
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, null));
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public static void ClearAllMapCache()
+    {
+        var query = "UPDATE " + MAP_CACHE_TABLE + " SET " + MAP_CACHE_DATA + " = @" + MAP_CACHE_DATA;
+        using (var cmd = new SqliteCommand(query, sDbConnection))
+        {
+            cmd.Parameters.Add(new SqliteParameter("@" + MAP_CACHE_DATA, null));
+            cmd.ExecuteNonQuery();
+        }
     }
 
 }

--- a/Intersect.Editor/Core/Graphics.cs
+++ b/Intersect.Editor/Core/Graphics.cs
@@ -16,230 +16,223 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Editor.Core
+namespace Intersect.Editor.Core;
+
+
+public static partial class Graphics
 {
 
-    public static partial class Graphics
+    //Light Stuff
+    public static byte CurrentBrightness = 100;
+
+    //Editor Viewing Rect
+    public static System.Drawing.Rectangle CurrentView;
+
+    public static RenderTarget2D DarknessTexture;
+
+    public static object GraphicsLock = new object();
+
+    public static bool HideDarkness = false;
+
+    //Fog Stuff
+    public static bool HideFog = false;
+
+    public static bool HideGrid = true;
+
+    public static bool HideOverlay = false;
+
+    //Resources
+    public static bool HideResources = false;
+
+    // Events
+    public static bool HideEvents = false;
+
+    //Advanced Editing Features
+    public static bool HideTilePreview = false;
+
+    public static Color LightColor = null;
+
+    public static BlendState MultiplyState;
+
+    //Overlay Stuff
+    public static System.Drawing.Color OverlayColor = System.Drawing.Color.Transparent;
+
+    private static BlendState sCurrentBlendmode = BlendState.NonPremultiplied;
+
+    private static Effect sCurrentShader;
+
+    private static RenderTarget2D sCurrentTarget;
+
+    private static float sFogCurrentX;
+
+    private static float sFogCurrentY;
+
+    private static long sFogUpdateTime = -1;
+
+    //MonoGame Setup/Device
+    private static GraphicsDevice sGraphicsDevice;
+
+    private static List<KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>> sLightQueue =
+        new List<KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>>();
+
+    private static SwapChainRenderTarget sMapEditorChain;
+
+    private static SwapChainRenderTarget sMapGridChain;
+
+    private static PresentationParameters sPresentationParams = new PresentationParameters();
+
+    //Screenshot RT
+    private static RenderTarget2D sScreenShotRenderTexture;
+
+    //Rendering Variables
+    private static SpriteBatch sSpriteBatch;
+
+    private static bool sSpriteBatchBegan;
+
+    private static SwapChainRenderTarget sTilesetChain;
+
+    private static RenderTarget2D sWhiteTex;
+
+    public static MapInstance TilePreviewStruct;
+
+    public static bool TilePreviewUpdated;
+
+    private static long _lastNpcPulseColorUpdate;
+
+    private static float _npcColorPulseRatio;
+
+    //Setup and Loading
+    public static void InitMonogame()
     {
-
-        //Light Stuff
-        public static byte CurrentBrightness = 100;
-
-        //Editor Viewing Rect
-        public static System.Drawing.Rectangle CurrentView;
-
-        public static RenderTarget2D DarknessTexture;
-
-        public static object GraphicsLock = new object();
-
-        public static bool HideDarkness = false;
-
-        //Fog Stuff
-        public static bool HideFog = false;
-
-        public static bool HideGrid = true;
-
-        public static bool HideOverlay = false;
-
-        //Resources
-        public static bool HideResources = false;
-
-        // Events
-        public static bool HideEvents = false;
-
-        //Advanced Editing Features
-        public static bool HideTilePreview = false;
-
-        public static Color LightColor = null;
-
-        public static BlendState MultiplyState;
-
-        //Overlay Stuff
-        public static System.Drawing.Color OverlayColor = System.Drawing.Color.Transparent;
-
-        private static BlendState sCurrentBlendmode = BlendState.NonPremultiplied;
-
-        private static Effect sCurrentShader;
-
-        private static RenderTarget2D sCurrentTarget;
-
-        private static float sFogCurrentX;
-
-        private static float sFogCurrentY;
-
-        private static long sFogUpdateTime = -1;
-
-        //MonoGame Setup/Device
-        private static GraphicsDevice sGraphicsDevice;
-
-        private static List<KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>> sLightQueue =
-            new List<KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>>();
-
-        private static SwapChainRenderTarget sMapEditorChain;
-
-        private static SwapChainRenderTarget sMapGridChain;
-
-        private static PresentationParameters sPresentationParams = new PresentationParameters();
-
-        //Screenshot RT
-        private static RenderTarget2D sScreenShotRenderTexture;
-
-        //Rendering Variables
-        private static SpriteBatch sSpriteBatch;
-
-        private static bool sSpriteBatchBegan;
-
-        private static SwapChainRenderTarget sTilesetChain;
-
-        private static RenderTarget2D sWhiteTex;
-
-        public static MapInstance TilePreviewStruct;
-
-        public static bool TilePreviewUpdated;
-
-        private static long _lastNpcPulseColorUpdate;
-
-        private static float _npcColorPulseRatio;
-
-        //Setup and Loading
-        public static void InitMonogame()
+        try
         {
-            try
-            {
-                //Create the Graphics Device
-                sPresentationParams.IsFullScreen = false;
-                sPresentationParams.BackBufferWidth = (Options.TileWidth + 2) * Options.MapWidth;
-                sPresentationParams.BackBufferHeight = (Options.TileHeight + 2) * Options.MapHeight;
-                sPresentationParams.RenderTargetUsage = RenderTargetUsage.DiscardContents;
-                sPresentationParams.PresentationInterval = PresentInterval.Immediate;
+            //Create the Graphics Device
+            sPresentationParams.IsFullScreen = false;
+            sPresentationParams.BackBufferWidth = (Options.TileWidth + 2) * Options.MapWidth;
+            sPresentationParams.BackBufferHeight = (Options.TileHeight + 2) * Options.MapHeight;
+            sPresentationParams.RenderTargetUsage = RenderTargetUsage.DiscardContents;
+            sPresentationParams.PresentationInterval = PresentInterval.Immediate;
 
-                // Create device
-                sGraphicsDevice = new GraphicsDevice(
-                    GraphicsAdapter.DefaultAdapter, GraphicsProfile.HiDef, sPresentationParams
-                );
-
-                //Define our spritebatch :D
-                sSpriteBatch = new SpriteBatch(sGraphicsDevice);
-
-                SetupWhiteTex();
-
-                //Load the rest of the graphics and audio
-                GameContentManager.LoadEditorContent();
-
-                //Create our multiplicative blending state.
-                MultiplyState = new BlendState()
-                {
-                    ColorBlendFunction = BlendFunction.Add,
-                    ColorSourceBlend = Blend.DestinationColor,
-                    ColorDestinationBlend = Blend.Zero
-                };
-            }
-            catch (Exception ex)
-            {
-                // ignored
-                MessageBox.Show("Failed to initialize MonoGame. Exception Info: " + ex + "\nClosing Now");
-                Application.Exit();
-            }
-        }
-
-        public static GraphicsDevice GetGraphicsDevice()
-        {
-            return sGraphicsDevice;
-        }
-
-        public static void SetMapGridChain(SwapChainRenderTarget chain)
-        {
-            sMapGridChain = chain;
-        }
-
-        public static void SetMapEditorChain(SwapChainRenderTarget chain)
-        {
-            sMapEditorChain = chain;
-        }
-
-        public static void SetTilesetChain(SwapChainRenderTarget chain)
-        {
-            sTilesetChain = chain;
-        }
-
-        //Resource Allocation
-        private static void SetupWhiteTex()
-        {
-            sWhiteTex = CreateRenderTexture(1, 1);
-            SetRenderTarget(sWhiteTex);
-            sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
-            SetRenderTarget(null);
-        }
-
-        public static RenderTarget2D GetWhiteTex()
-        {
-            return sWhiteTex;
-        }
-
-        public static RenderTarget2D CreateRenderTexture(int width, int height)
-        {
-            return new RenderTarget2D(
-                sGraphicsDevice, width, height, false, SurfaceFormat.Color, DepthFormat.Depth16, 0,
-                RenderTargetUsage.PreserveContents
+            // Create device
+            sGraphicsDevice = new GraphicsDevice(
+                GraphicsAdapter.DefaultAdapter, GraphicsProfile.HiDef, sPresentationParams
             );
-        }
 
-        //Rendering
-        public static void Render()
-        {
-            if (sMapEditorChain != null && !sMapEditorChain.IsContentLost && !sMapEditorChain.IsDisposed)
+            //Define our spritebatch :D
+            sSpriteBatch = new SpriteBatch(sGraphicsDevice);
+
+            SetupWhiteTex();
+
+            //Load the rest of the graphics and audio
+            GameContentManager.LoadEditorContent();
+
+            //Create our multiplicative blending state.
+            MultiplyState = new BlendState()
             {
-                lock (GraphicsLock)
+                ColorBlendFunction = BlendFunction.Add,
+                ColorSourceBlend = Blend.DestinationColor,
+                ColorDestinationBlend = Blend.Zero
+            };
+        }
+        catch (Exception ex)
+        {
+            // ignored
+            MessageBox.Show("Failed to initialize MonoGame. Exception Info: " + ex + "\nClosing Now");
+            Application.Exit();
+        }
+    }
+
+    public static GraphicsDevice GetGraphicsDevice()
+    {
+        return sGraphicsDevice;
+    }
+
+    public static void SetMapGridChain(SwapChainRenderTarget chain)
+    {
+        sMapGridChain = chain;
+    }
+
+    public static void SetMapEditorChain(SwapChainRenderTarget chain)
+    {
+        sMapEditorChain = chain;
+    }
+
+    public static void SetTilesetChain(SwapChainRenderTarget chain)
+    {
+        sTilesetChain = chain;
+    }
+
+    //Resource Allocation
+    private static void SetupWhiteTex()
+    {
+        sWhiteTex = CreateRenderTexture(1, 1);
+        SetRenderTarget(sWhiteTex);
+        sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
+        SetRenderTarget(null);
+    }
+
+    public static RenderTarget2D GetWhiteTex()
+    {
+        return sWhiteTex;
+    }
+
+    public static RenderTarget2D CreateRenderTexture(int width, int height)
+    {
+        return new RenderTarget2D(
+            sGraphicsDevice, width, height, false, SurfaceFormat.Color, DepthFormat.Depth16, 0,
+            RenderTargetUsage.PreserveContents
+        );
+    }
+
+    //Rendering
+    public static void Render()
+    {
+        if (sMapEditorChain != null && !sMapEditorChain.IsContentLost && !sMapEditorChain.IsDisposed)
+        {
+            lock (GraphicsLock)
+            {
+                SetRenderTarget(sMapEditorChain);
+                sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
+                StartSpritebatch();
+                ClearDarknessTexture(null);
+                DrawTileset();
+                DrawMapGrid();
+
+                //Draw Current Map
+                if (Globals.MapEditorWindow.picMap.Visible &&
+                    Globals.MapEditorWindow.DockPanel.ActiveDocument == Globals.MapEditorWindow &&
+                    Globals.CurrentMap != null &&
+                    Globals.MapGrid.Loaded)
                 {
-                    SetRenderTarget(sMapEditorChain);
-                    sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
-                    StartSpritebatch();
-                    ClearDarknessTexture(null);
-                    DrawTileset();
-                    DrawMapGrid();
-
-                    //Draw Current Map
-                    if (Globals.MapEditorWindow.picMap.Visible &&
-                        Globals.MapEditorWindow.DockPanel.ActiveDocument == Globals.MapEditorWindow &&
-                        Globals.CurrentMap != null &&
-                        Globals.MapGrid.Loaded)
+                    //Draw The lower maps
+                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
                     {
-                        //Draw The lower maps
-                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
                         {
-                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
                             {
-                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                                MapInstance map = null;
+                                try
                                 {
-                                    MapInstance map = null;
-                                    try
-                                    {
-                                        map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                    }
-                                    catch (Exception exception)
-                                    {
-                                        Log.Error(
-                                            $"{Globals.MapGrid.Grid.GetLength(0)}x{Globals.MapGrid.Grid.GetLength(1)} -- {x},{y}"
-                                        );
+                                    map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                                }
+                                catch (Exception exception)
+                                {
+                                    Log.Error(
+                                        $"{Globals.MapGrid.Grid.GetLength(0)}x{Globals.MapGrid.Grid.GetLength(1)} -- {x},{y}"
+                                    );
 
-                                        Log.Error(exception);
-                                    }
+                                    Log.Error(exception);
+                                }
 
-                                    if (map != null)
+                                if (map != null)
+                                {
+                                    lock (map.MapLock)
                                     {
-                                        lock (map.MapLock)
-                                        {
-                                            //Draw this map
-                                            DrawMap(
-                                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                                false, 0, null
-                                            );
-                                        }
-                                    }
-                                    else
-                                    {
-                                        DrawTransparentBorders(
-                                            x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY
+                                        //Draw this map
+                                        DrawMap(
+                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                            false, 0, null
                                         );
                                     }
                                 }
@@ -250,634 +243,319 @@ namespace Intersect.Editor.Core
                                     );
                                 }
                             }
-                        }
-
-                        //Draw the lower resources/animations
-                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                        {
-                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                            else
                             {
-                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                                {
-                                    var mapGridItem = Globals.MapGrid.Grid[x, y];
-                                    var map = MapInstance.Get(mapGridItem.MapId);
-                                    if (map == null)
-                                    {
-                                        continue;
-                                    }
+                                DrawTransparentBorders(
+                                    x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY
+                                );
+                            }
+                        }
+                    }
 
+                    //Draw the lower resources/animations
+                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                    {
+                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                        {
+                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                            {
+                                var mapGridItem = Globals.MapGrid.Grid[x, y];
+                                var map = MapInstance.Get(mapGridItem.MapId);
+                                if (map == null)
+                                {
+                                    continue;
+                                }
+
+                                lock (map.MapLock)
+                                {
+                                    DrawMapAttributes(
+                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                        false, null, false, false
+                                    );
+
+                                    DrawMapAttributes(
+                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                        false, null, false, true
+                                    );
+
+                                    DrawMapAttributes(
+                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                        false, null, true, true
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    // Draw events
+                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                    {
+                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                        {
+                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                            {
+                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                                if (map != null)
+                                {
+                                    lock (map.MapLock)
+                                    {
+                                        DrawMapEvents(
+                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                            false, null
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    //Draw The upper maps
+                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                    {
+                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                        {
+                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                            {
+                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                                if (map != null)
+                                {
+                                    lock (map.MapLock)
+                                    {
+                                        //Draw this map
+                                        DrawMap(
+                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                            false, 1, null
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    //Draw the upper resources/animations
+                    for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+                    {
+                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                        {
+                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                            {
+                                var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                                if (map != null)
+                                {
                                     lock (map.MapLock)
                                     {
                                         DrawMapAttributes(
                                             map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, null, false, false
-                                        );
-
-                                        DrawMapAttributes(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, null, false, true
-                                        );
-
-                                        DrawMapAttributes(
-                                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                            false, null, true, true
+                                            false, null, true, false
                                         );
                                     }
                                 }
                             }
                         }
-
-                        // Draw events
-                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                        {
-                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                            {
-                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                                {
-                                    var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                    if (map != null)
-                                    {
-                                        lock (map.MapLock)
-                                        {
-                                            DrawMapEvents(
-                                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                                false, null
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        //Draw The upper maps
-                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                        {
-                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                            {
-                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                                {
-                                    var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                    if (map != null)
-                                    {
-                                        lock (map.MapLock)
-                                        {
-                                            //Draw this map
-                                            DrawMap(
-                                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                                false, 1, null
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        //Draw the upper resources/animations
-                        for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                        {
-                            for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                            {
-                                if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                                {
-                                    var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                    if (map != null)
-                                    {
-                                        lock (map.MapLock)
-                                        {
-                                            DrawMapAttributes(
-                                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                                false, null, true, false
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if (!HideFog)
-                        {
-                            DrawFog(null);
-                        }
-
-                        if (!HideOverlay)
-                        {
-                            DrawMapOverlay(null);
-                        }
-
-                        if (!HideDarkness || Globals.CurrentLayer == LayerOptions.Lights)
-                        {
-                            OverlayDarkness(null);
-                        }
-
-                        if (!HideGrid)
-                        {
-                            DrawGridOverlay();
-                        }
-
-                        DrawMapBorders();
-                        DrawSelectionRect();
                     }
 
-                    EndSpriteBatch();
-                    sMapEditorChain.Present();
-                }
-            }
-        }
-
-        private static void DrawGridOverlay()
-        {
-            for (var x = 0; x < Options.MapWidth; x++)
-            {
-                DrawTexture(
-                    sWhiteTex, new RectangleF(0, 0, 1, 1),
-                    new RectangleF(
-                        CurrentView.Left + x * Options.TileWidth, CurrentView.Top, 1,
-                        Options.MapHeight * Options.TileHeight
-                    ), null
-                );
-            }
-
-            for (var y = 0; y < Options.MapHeight; y++)
-            {
-                DrawTexture(
-                    sWhiteTex, new RectangleF(0, 0, 1, 1),
-                    new RectangleF(
-                        CurrentView.Left, CurrentView.Top + y * Options.TileHeight,
-                        Options.MapWidth * Options.TileWidth, 1
-                    ), null
-                );
-            }
-        }
-
-        private static void DrawTransparentBorders(int gridX, int gridY)
-        {
-            var transTex = GameContentManager.GetTexture(GameContentManager.TextureType.Misc, "transtile.png");
-            if (transTex == null)
-            {
-                return;
-            }
-
-            var xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
-            var yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
-            for (var x = 0; x < Options.MapWidth; x++)
-            {
-                for (var y = 0; y < Options.MapHeight; y++)
-                {
-                    if (new System.Drawing.Rectangle(
-                        x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, Options.TileWidth,
-                        Options.TileHeight
-                    ).IntersectsWith(new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height)))
+                    if (!HideFog)
                     {
-                        DrawTexture(
-                            transTex, new RectangleF(0, 0, transTex.Width, transTex.Height),
-                            new RectangleF(
-                                xoffset + x * Options.TileWidth, yoffset + y * Options.TileHeight, Options.TileWidth,
-                                Options.TileHeight
-                            ), System.Drawing.Color.White, null
-                        );
+                        DrawFog(null);
                     }
+
+                    if (!HideOverlay)
+                    {
+                        DrawMapOverlay(null);
+                    }
+
+                    if (!HideDarkness || Globals.CurrentLayer == LayerOptions.Lights)
+                    {
+                        OverlayDarkness(null);
+                    }
+
+                    if (!HideGrid)
+                    {
+                        DrawGridOverlay();
+                    }
+
+                    DrawMapBorders();
+                    DrawSelectionRect();
                 }
+
+                EndSpriteBatch();
+                sMapEditorChain.Present();
             }
         }
+    }
 
-        private static void DrawAutoTile(
-            Texture2D texture,
-            string layerName,
-            int destX,
-            int destY,
-            int quarterNum,
-            int x,
-            int y,
-            MapBase map,
-            RenderTarget2D target
-        )
+    private static void DrawGridOverlay()
+    {
+        for (var x = 0; x < Options.MapWidth; x++)
         {
-            int yOffset = 0, xOffset = 0;
-
-            // calculate the offset
-            switch (map.Layers[layerName][x, y].Autotile)
-            {
-                case MapAutotiles.AUTOTILE_WATERFALL:
-                    yOffset = (Globals.WaterfallFrame - 1) * Options.TileHeight;
-
-                    break;
-                case MapAutotiles.AUTOTILE_ANIM:
-                    xOffset = Globals.AutotileFrame * Options.TileWidth * 2;
-
-                    break;
-                case MapAutotiles.AUTOTILE_ANIM_XP:
-                    xOffset = Globals.AutotileFrame * Options.TileWidth * 3;
-
-                    break;
-                case MapAutotiles.AUTOTILE_CLIFF:
-                    yOffset = -Options.TileHeight;
-
-                    break;
-            }
-
             DrawTexture(
-                texture, destX, destY,
-                (int) map.Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
-                (int) map.Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
-                Options.TileWidth / 2, Options.TileHeight / 2, target
+                sWhiteTex, new RectangleF(0, 0, 1, 1),
+                new RectangleF(
+                    CurrentView.Left + x * Options.TileWidth, CurrentView.Top, 1,
+                    Options.MapHeight * Options.TileHeight
+                ), null
             );
         }
 
-        private static void DrawMap(
-            MapInstance map,
-            int gridX,
-            int gridY,
-            bool screenShotting,
-            int layer,
-            RenderTarget2D renderTarget2D
-        )
+        for (var y = 0; y < Options.MapHeight; y++)
         {
-            var tmpMap = Globals.CurrentMap;
-            if (tmpMap == null)
-            {
-                return;
-            }
+            DrawTexture(
+                sWhiteTex, new RectangleF(0, 0, 1, 1),
+                new RectangleF(
+                    CurrentView.Left, CurrentView.Top + y * Options.TileHeight,
+                    Options.MapWidth * Options.TileWidth, 1
+                ), null
+            );
+        }
+    }
 
-            int selX = Globals.CurMapSelX,
-                selY = Globals.CurMapSelY,
-                selW = Globals.CurMapSelW,
-                selH = Globals.CurMapSelH;
+    private static void DrawTransparentBorders(int gridX, int gridY)
+    {
+        var transTex = GameContentManager.GetTexture(GameContentManager.TextureType.Misc, "transtile.png");
+        if (transTex == null)
+        {
+            return;
+        }
 
-            int x1 = 0, y1 = 0, x2 = 0, y2 = 0, xoffset = 0, yoffset = 0;
-            int dragxoffset = 0, dragyoffset = 0;
-            if (Globals.CurrentTool == EditingTool.Rectangle ||
-                Globals.CurrentTool == EditingTool.Selection)
+        var xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
+        var yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
+        for (var x = 0; x < Options.MapWidth; x++)
+        {
+            for (var y = 0; y < Options.MapHeight; y++)
             {
-                if (selW < 0)
+                if (new System.Drawing.Rectangle(
+                    x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, Options.TileWidth,
+                    Options.TileHeight
+                ).IntersectsWith(new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height)))
                 {
-                    selX -= Math.Abs(selW);
-                    selW = Math.Abs(selW);
-                }
-
-                if (selH < 0)
-                {
-                    selY -= Math.Abs(selH);
-                    selH = Math.Abs(selH);
-                }
-            }
-
-            var drawLayers = new List<string>();
-            if (layer == 0)
-            {
-                drawLayers.AddRange(Options.Instance.MapOpts.Layers.LowerLayers);
-            }
-            else
-            {
-                drawLayers.AddRange(Options.Instance.MapOpts.Layers.MiddleLayers);
-                drawLayers.AddRange(Options.Instance.MapOpts.Layers.UpperLayers);
-            }
-
-            x1 = 0;
-            x2 = Options.MapWidth;
-            y1 = 0;
-            y2 = Options.MapHeight;
-            xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
-            yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
-            if (gridX != 0 || gridY != 0)
-            {
-                tmpMap = map;
-            }
-
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            if (screenShotting)
-            {
-                xoffset -= CurrentView.Left;
-                yoffset -= CurrentView.Top;
-            }
-
-            if (gridX == 0 && gridY == 0)
-            {
-                if (Globals.Dragging)
-                {
-                    if (Globals.MouseButton == 0)
-                    {
-                        dragxoffset = Globals.TotalTileDragX - (Globals.TileDragX - Globals.CurTileX);
-                        dragyoffset = Globals.TotalTileDragY - (Globals.TileDragY - Globals.CurTileY);
-                    }
-                    else
-                    {
-                        dragxoffset = Globals.TotalTileDragX;
-                        dragyoffset = Globals.TotalTileDragY;
-                    }
-                }
-
-                if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
-                {
-                    tmpMap = TilePreviewStruct;
-                    if (TilePreviewUpdated || TilePreviewStruct == null)
-                    {
-                        if (Globals.CurrentMap != null)
-                        {
-                            lock (Globals.CurrentMap.MapLock)
-                            {
-                                TilePreviewStruct = new MapInstance(Globals.CurrentMap);
-                            }
-                        }
-
-                        //Lets Create the Preview
-                        //Mimic Mouse Down
-                        tmpMap = TilePreviewStruct;
-                        if (Globals.CurrentTool == EditingTool.Selection && Globals.Dragging)
-                        {
-                            Globals.MapEditorWindow.ProcessSelectionMovement(tmpMap, false, true);
-                        }
-                        else
-                        {
-                            if (Globals.CurrentLayer == LayerOptions.Attributes)
-                            {
-                                if (Globals.CurrentTool == EditingTool.Brush)
-                                {
-                                    Globals.MapLayersWindow.PlaceAttribute(tmpMap, Globals.CurTileX, Globals.CurTileY);
-                                }
-                                else if (Globals.CurrentTool == EditingTool.Rectangle)
-                                {
-                                    for (var x = selX; x < selX + selW + 1; x++)
-                                    {
-                                        for (var y = selY; y < selY + selH + 1; y++)
-                                        {
-                                            if (Globals.MouseButton == 0)
-                                            {
-                                                Globals.MapLayersWindow.PlaceAttribute(tmpMap, x, y);
-                                            }
-                                            else if (Globals.MouseButton == 1)
-                                            {
-                                                Globals.MapLayersWindow.RemoveAttribute(tmpMap, x, y);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            else if (Globals.CurrentLayer == LayerOptions.Lights)
-                            {
-                            }
-                            else if (Globals.CurrentLayer == LayerOptions.Events)
-                            {
-                            }
-                            else if (Globals.CurrentLayer == LayerOptions.Npcs)
-                            {
-                            }
-                            else if (Globals.CurrentTileset != null)
-                            {
-                                if (Globals.CurrentTool == EditingTool.Brush)
-                                {
-                                    if (Globals.Autotilemode == 0)
-                                    {
-                                        for (var x = 0; x <= Globals.CurSelW; x++)
-                                        {
-                                            for (var y = 0; y <= Globals.CurSelH; y++)
-                                            {
-                                                if (Globals.CurTileX + x >= 0 &&
-                                                    Globals.CurTileX + x < Options.MapWidth &&
-                                                    Globals.CurTileY + y >= 0 &&
-                                                    Globals.CurTileY + y < Options.MapHeight)
-                                                {
-                                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].TilesetId = Globals.CurrentTileset.Id;
-                                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].X = Globals.CurSelX + x;
-                                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].Y = Globals.CurSelY + y;
-                                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].Autotile = 0;
-                                                    tmpMap.Autotiles.UpdateAutoTiles(Globals.CurTileX + x, Globals.CurTileY + y, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid());
-                                                }
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].TilesetId = Globals.CurrentTileset.Id;
-                                        tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].X = Globals.CurSelX;
-                                        tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].Y = Globals.CurSelY;
-                                        tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].Autotile = (byte) Globals.Autotilemode;
-                                        tmpMap.Autotiles.UpdateAutoTiles(Globals.CurTileX, Globals.CurTileY, Globals.CurrentLayer,tmpMap.GenerateAutotileGrid());
-                                    }
-
-                                    tmpMap.Autotiles.UpdateCliffAutotiles(tmpMap, Globals.CurrentLayer);
-                                }
-                                else if (Globals.CurrentTool == EditingTool.Rectangle)
-                                {
-                                    var x = 0;
-                                    var y = 0;
-                                    for (var x0 = selX; x0 < selX + selW + 1; x0++)
-                                    {
-                                        for (var y0 = selY; y0 < selY + selH + 1; y0++)
-                                        {
-                                            x = (x0 - selX) % (Globals.CurSelW + 1);
-                                            y = (y0 - selY) % (Globals.CurSelH + 1);
-                                            if (Globals.Autotilemode == 0)
-                                            {
-                                                if (x0 >= 0 &&
-                                                    x0 < Options.MapWidth &&
-                                                    y0 >= 0 &&
-                                                    y0 < Options.MapHeight &&
-                                                    x0 < selX + selW + 1 &&
-                                                    y0 < selY + selH + 1)
-                                                {
-                                                    if (Globals.MouseButton == 0)
-                                                    {
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Globals.CurrentTileset.Id;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = Globals.CurSelX + x;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = Globals.CurSelY + y;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = (byte) Globals.Autotilemode;
-                                                    }
-                                                    else if (Globals.MouseButton == 1)
-                                                    {
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Guid.Empty;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = 0;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = 0;
-                                                        tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = 0;
-                                                    }
-
-                                                    tmpMap.Autotiles.UpdateAutoTiles(
-                                                        x0, y0, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid()
-                                                    );
-                                                }
-                                            }
-                                            else
-                                            {
-                                                if (Globals.MouseButton == 0)
-                                                {
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Globals.CurrentTileset.Id;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = Globals.CurSelX;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = Globals.CurSelY;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = (byte) Globals.Autotilemode;
-                                                }
-                                                else if (Globals.MouseButton == 1)
-                                                {
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Guid.Empty;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = 0;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = 0;
-                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = 0;
-                                                }
-
-                                                tmpMap.Autotiles.UpdateAutoTiles(
-                                                    x0, y0, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid()
-                                                );
-                                            }
-
-                                            tmpMap.Autotiles.UpdateCliffAutotiles(tmpMap, Globals.CurrentLayer);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        TilePreviewUpdated = false;
-                    }
-                }
-                else
-                {
-                    tmpMap = Globals.CurrentMap;
-                }
-            }
-
-            for (var x = x1; x < x2; x++)
-            {
-                for (var y = y1; y < y2; y++)
-                {
-                    foreach (var drawLayer in drawLayers)
-                    {
-                        if (screenShotting || Globals.MapLayersWindow.LayerVisibility[drawLayer])
-                        {
-                            if (new System.Drawing.Rectangle(
-                                x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, Options.TileWidth,
-                                Options.TileHeight
-                            ).IntersectsWith(new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height)))
-                            {
-                                var tilesetObj = TilesetBase.Get(tmpMap.Layers[drawLayer][x, y].TilesetId);
-                                try
-                                {
-                                    if (tilesetObj == null)
-                                    {
-                                        continue;
-                                    }
-                                }
-                                catch (Exception exception)
-                                {
-                                    Log.Error($"map={tmpMap != null},layer{drawLayer}.tiles={tmpMap.Layers[drawLayer] != null}");
-                                    Log.Error(exception);
-
-                                    continue;
-                                }
-
-                                var tilesetTex = GameContentManager.GetTexture(
-                                    GameContentManager.TextureType.Tileset, tilesetObj.Name
-                                );
-
-                                if (tilesetTex == null || tmpMap.Autotiles == null || tmpMap.Autotiles.Layers == null)
-                                {
-                                    continue;
-                                }
-
-                                if (tmpMap.Autotiles.Layers[drawLayer][x, y].RenderState !=
-                                    MapAutotiles.RENDER_STATE_NORMAL)
-                                {
-                                    if (tmpMap.Autotiles.Layers[drawLayer][x, y].RenderState !=
-                                        MapAutotiles.RENDER_STATE_AUTOTILE)
-                                    {
-                                        continue;
-                                    }
-
-                                    DrawAutoTile(
-                                        tilesetTex, drawLayer, x * Options.TileWidth + xoffset,
-                                        y * Options.TileHeight + yoffset, 1, x, y, tmpMap, renderTarget2D
-                                    );
-
-                                    DrawAutoTile(
-                                        tilesetTex, drawLayer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                        y * Options.TileHeight + yoffset, 2, x, y, tmpMap, renderTarget2D
-                                    );
-
-                                    DrawAutoTile(
-                                        tilesetTex, drawLayer, x * Options.TileWidth + xoffset,
-                                        y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, tmpMap,
-                                        renderTarget2D
-                                    );
-
-                                    DrawAutoTile(
-                                        tilesetTex, drawLayer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
-                                        y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, tmpMap,
-                                        renderTarget2D
-                                    );
-                                }
-                                else
-                                {
-                                    DrawTexture(
-                                        tilesetTex, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset,
-                                        tmpMap.Layers[drawLayer][x, y].X * Options.TileWidth,
-                                        tmpMap.Layers[drawLayer][x, y].Y * Options.TileHeight, Options.TileWidth,
-                                        Options.TileHeight, renderTarget2D
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (layer == 1)
-            {
-                foreach (var light in tmpMap.Lights)
-                {
-                    double w = light.Size;
-                    var x = xoffset +
-                            Options.MapWidth * Options.TileWidth -
-                            CurrentView.Left +
-                            light.TileX * Options.TileWidth +
-                            light.OffsetX +
-                            Options.TileWidth / 2;
-
-                    var y = yoffset +
-                            Options.MapHeight * Options.TileHeight -
-                            CurrentView.Top +
-                            light.TileY * Options.TileHeight +
-                            light.OffsetY +
-                            Options.TileHeight / 2;
-
-                    if (!HideDarkness)
-                    {
-                        AddLight(x, y, light, null);
-                    }
+                    DrawTexture(
+                        transTex, new RectangleF(0, 0, transTex.Width, transTex.Height),
+                        new RectangleF(
+                            xoffset + x * Options.TileWidth, yoffset + y * Options.TileHeight, Options.TileWidth,
+                            Options.TileHeight
+                        ), System.Drawing.Color.White, null
+                    );
                 }
             }
         }
+    }
 
-        private static void DrawSelectionRect()
+    private static void DrawAutoTile(
+        Texture2D texture,
+        string layerName,
+        int destX,
+        int destY,
+        int quarterNum,
+        int x,
+        int y,
+        MapBase map,
+        RenderTarget2D target
+    )
+    {
+        int yOffset = 0, xOffset = 0;
+
+        // calculate the offset
+        switch (map.Layers[layerName][x, y].Autotile)
         {
-            var tmpMap = Globals.CurrentMap;
-            if (tmpMap == null)
+            case MapAutotiles.AUTOTILE_WATERFALL:
+                yOffset = (Globals.WaterfallFrame - 1) * Options.TileHeight;
+
+                break;
+            case MapAutotiles.AUTOTILE_ANIM:
+                xOffset = Globals.AutotileFrame * Options.TileWidth * 2;
+
+                break;
+            case MapAutotiles.AUTOTILE_ANIM_XP:
+                xOffset = Globals.AutotileFrame * Options.TileWidth * 3;
+
+                break;
+            case MapAutotiles.AUTOTILE_CLIFF:
+                yOffset = -Options.TileHeight;
+
+                break;
+        }
+
+        DrawTexture(
+            texture, destX, destY,
+            (int) map.Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].X + xOffset,
+            (int) map.Autotiles.Layers[layerName][x, y].QuarterTile[quarterNum].Y + yOffset,
+            Options.TileWidth / 2, Options.TileHeight / 2, target
+        );
+    }
+
+    private static void DrawMap(
+        MapInstance map,
+        int gridX,
+        int gridY,
+        bool screenShotting,
+        int layer,
+        RenderTarget2D renderTarget2D
+    )
+    {
+        var tmpMap = Globals.CurrentMap;
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        int selX = Globals.CurMapSelX,
+            selY = Globals.CurMapSelY,
+            selW = Globals.CurMapSelW,
+            selH = Globals.CurMapSelH;
+
+        int x1 = 0, y1 = 0, x2 = 0, y2 = 0, xoffset = 0, yoffset = 0;
+        int dragxoffset = 0, dragyoffset = 0;
+        if (Globals.CurrentTool == EditingTool.Rectangle ||
+            Globals.CurrentTool == EditingTool.Selection)
+        {
+            if (selW < 0)
             {
-                return;
+                selX -= Math.Abs(selW);
+                selW = Math.Abs(selW);
             }
 
-            int selX = Globals.CurMapSelX,
-                selY = Globals.CurMapSelY,
-                selW = Globals.CurMapSelW,
-                selH = Globals.CurMapSelH;
-
-            int dragxoffset = 0, dragyoffset = 0;
-            if (Globals.CurrentTool == EditingTool.Rectangle ||
-                Globals.CurrentTool == EditingTool.Selection)
+            if (selH < 0)
             {
-                if (selW < 0)
-                {
-                    selX -= Math.Abs(selW);
-                    selW = Math.Abs(selW);
-                }
-
-                if (selH < 0)
-                {
-                    selY -= Math.Abs(selH);
-                    selH = Math.Abs(selH);
-                }
+                selY -= Math.Abs(selH);
+                selH = Math.Abs(selH);
             }
+        }
 
+        var drawLayers = new List<string>();
+        if (layer == 0)
+        {
+            drawLayers.AddRange(Options.Instance.MapOpts.Layers.LowerLayers);
+        }
+        else
+        {
+            drawLayers.AddRange(Options.Instance.MapOpts.Layers.MiddleLayers);
+            drawLayers.AddRange(Options.Instance.MapOpts.Layers.UpperLayers);
+        }
+
+        x1 = 0;
+        x2 = Options.MapWidth;
+        y1 = 0;
+        y2 = Options.MapHeight;
+        xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
+        yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
+        if (gridX != 0 || gridY != 0)
+        {
+            tmpMap = map;
+        }
+
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        if (screenShotting)
+        {
+            xoffset -= CurrentView.Left;
+            yoffset -= CurrentView.Top;
+        }
+
+        if (gridX == 0 && gridY == 0)
+        {
             if (Globals.Dragging)
             {
                 if (Globals.MouseButton == 0)
@@ -892,254 +570,564 @@ namespace Intersect.Editor.Core
                 }
             }
 
-            if (!HideTilePreview || Globals.Dragging)
+            if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
             {
                 tmpMap = TilePreviewStruct;
-                if (Globals.CurrentLayer == LayerOptions.Attributes) //Attributes
+                if (TilePreviewUpdated || TilePreviewStruct == null)
                 {
-                    var attributesTex = GameContentManager.GetTexture(
-                        GameContentManager.TextureType.Misc, "attributes.png"
-                    );
-
-                    if (attributesTex != null)
+                    if (Globals.CurrentMap != null)
                     {
-                        var whiteTextureBounds = new RectangleF(
-                            sWhiteTex.Bounds.X,
-                            sWhiteTex.Bounds.Y,
-                            sWhiteTex.Bounds.Width,
-                            sWhiteTex.Bounds.Height
-                        );
-
-                        //Draw attributes
-                        for (var x = 0; x < Options.MapWidth; x++)
+                        lock (Globals.CurrentMap.MapLock)
                         {
-                            for (var y = 0; y < Options.MapHeight; y++)
+                            TilePreviewStruct = new MapInstance(Globals.CurrentMap);
+                        }
+                    }
+
+                    //Lets Create the Preview
+                    //Mimic Mouse Down
+                    tmpMap = TilePreviewStruct;
+                    if (Globals.CurrentTool == EditingTool.Selection && Globals.Dragging)
+                    {
+                        Globals.MapEditorWindow.ProcessSelectionMovement(tmpMap, false, true);
+                    }
+                    else
+                    {
+                        if (Globals.CurrentLayer == LayerOptions.Attributes)
+                        {
+                            if (Globals.CurrentTool == EditingTool.Brush)
                             {
-                                var attr = tmpMap.Attributes[x, y];
-                                if ((attr?.Type ?? MapAttribute.Walkable) == MapAttribute.Walkable)
+                                Globals.MapLayersWindow.PlaceAttribute(tmpMap, Globals.CurTileX, Globals.CurTileY);
+                            }
+                            else if (Globals.CurrentTool == EditingTool.Rectangle)
+                            {
+                                for (var x = selX; x < selX + selW + 1; x++)
                                 {
-                                    continue;
+                                    for (var y = selY; y < selY + selH + 1; y++)
+                                    {
+                                        if (Globals.MouseButton == 0)
+                                        {
+                                            Globals.MapLayersWindow.PlaceAttribute(tmpMap, x, y);
+                                        }
+                                        else if (Globals.MouseButton == 1)
+                                        {
+                                            Globals.MapLayersWindow.RemoveAttribute(tmpMap, x, y);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else if (Globals.CurrentLayer == LayerOptions.Lights)
+                        {
+                        }
+                        else if (Globals.CurrentLayer == LayerOptions.Events)
+                        {
+                        }
+                        else if (Globals.CurrentLayer == LayerOptions.Npcs)
+                        {
+                        }
+                        else if (Globals.CurrentTileset != null)
+                        {
+                            if (Globals.CurrentTool == EditingTool.Brush)
+                            {
+                                if (Globals.Autotilemode == 0)
+                                {
+                                    for (var x = 0; x <= Globals.CurSelW; x++)
+                                    {
+                                        for (var y = 0; y <= Globals.CurSelH; y++)
+                                        {
+                                            if (Globals.CurTileX + x >= 0 &&
+                                                Globals.CurTileX + x < Options.MapWidth &&
+                                                Globals.CurTileY + y >= 0 &&
+                                                Globals.CurTileY + y < Options.MapHeight)
+                                            {
+                                                tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].TilesetId = Globals.CurrentTileset.Id;
+                                                tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].X = Globals.CurSelX + x;
+                                                tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].Y = Globals.CurSelY + y;
+                                                tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX + x, Globals.CurTileY + y].Autotile = 0;
+                                                tmpMap.Autotiles.UpdateAutoTiles(Globals.CurTileX + x, Globals.CurTileY + y, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid());
+                                            }
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].TilesetId = Globals.CurrentTileset.Id;
+                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].X = Globals.CurSelX;
+                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].Y = Globals.CurSelY;
+                                    tmpMap.Layers[Globals.CurrentLayer][Globals.CurTileX, Globals.CurTileY].Autotile = (byte) Globals.Autotilemode;
+                                    tmpMap.Autotiles.UpdateAutoTiles(Globals.CurTileX, Globals.CurTileY, Globals.CurrentLayer,tmpMap.GenerateAutotileGrid());
                                 }
 
-                                var tileBounds = new RectangleF(
-                                    CurrentView.Left + x * Options.TileWidth,
-                                    CurrentView.Top + y * Options.TileHeight,
-                                    Options.TileWidth,
-                                    Options.TileHeight
-                                );
-
-                                if (attributesTex != null)
+                                tmpMap.Autotiles.UpdateCliffAutotiles(tmpMap, Globals.CurrentLayer);
+                            }
+                            else if (Globals.CurrentTool == EditingTool.Rectangle)
+                            {
+                                var x = 0;
+                                var y = 0;
+                                for (var x0 = selX; x0 < selX + selW + 1; x0++)
                                 {
-                                    var blue = (attr is MapWarpAttribute warp && warp.ChangeInstance) ? 0 : 255;
-                                    DrawTexture(
-                                       attributesTex,
-                                       new RectangleF(
-                                           0,
-                                           ((int)tmpMap.Attributes[x, y].Type - 1) * attributesTex.Width,
-                                           attributesTex.Width,
-                                           attributesTex.Width
-                                       ),
-                                       tileBounds,
-                                       System.Drawing.Color.FromArgb(255, 255, 255, blue),
-                                       null
-                                    );
+                                    for (var y0 = selY; y0 < selY + selH + 1; y0++)
+                                    {
+                                        x = (x0 - selX) % (Globals.CurSelW + 1);
+                                        y = (y0 - selY) % (Globals.CurSelH + 1);
+                                        if (Globals.Autotilemode == 0)
+                                        {
+                                            if (x0 >= 0 &&
+                                                x0 < Options.MapWidth &&
+                                                y0 >= 0 &&
+                                                y0 < Options.MapHeight &&
+                                                x0 < selX + selW + 1 &&
+                                                y0 < selY + selH + 1)
+                                            {
+                                                if (Globals.MouseButton == 0)
+                                                {
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Globals.CurrentTileset.Id;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = Globals.CurSelX + x;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = Globals.CurSelY + y;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = (byte) Globals.Autotilemode;
+                                                }
+                                                else if (Globals.MouseButton == 1)
+                                                {
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Guid.Empty;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = 0;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = 0;
+                                                    tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = 0;
+                                                }
+
+                                                tmpMap.Autotiles.UpdateAutoTiles(
+                                                    x0, y0, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid()
+                                                );
+                                            }
+                                        }
+                                        else
+                                        {
+                                            if (Globals.MouseButton == 0)
+                                            {
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Globals.CurrentTileset.Id;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = Globals.CurSelX;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = Globals.CurSelY;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = (byte) Globals.Autotilemode;
+                                            }
+                                            else if (Globals.MouseButton == 1)
+                                            {
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].TilesetId = Guid.Empty;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].X = 0;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].Y = 0;
+                                                tmpMap.Layers[Globals.CurrentLayer][x0, y0].Autotile = 0;
+                                            }
+
+                                            tmpMap.Autotiles.UpdateAutoTiles(
+                                                x0, y0, Globals.CurrentLayer, tmpMap.GenerateAutotileGrid()
+                                            );
+                                        }
+
+                                        tmpMap.Autotiles.UpdateCliffAutotiles(tmpMap, Globals.CurrentLayer);
+                                    }
                                 }
                             }
                         }
                     }
+
+                    TilePreviewUpdated = false;
                 }
-                else if (Globals.CurrentLayer == LayerOptions.Lights) //Lights
+            }
+            else
+            {
+                tmpMap = Globals.CurrentMap;
+            }
+        }
+
+        for (var x = x1; x < x2; x++)
+        {
+            for (var y = y1; y < y2; y++)
+            {
+                foreach (var drawLayer in drawLayers)
                 {
-                }
-                else if (Globals.CurrentLayer == LayerOptions.Events) //Events
-                {
-                    for (var x = 0; x < Options.MapWidth; x++)
+                    if (screenShotting || Globals.MapLayersWindow.LayerVisibility[drawLayer])
                     {
-                        for (var y = 0; y < Options.MapHeight; y++)
+                        if (new System.Drawing.Rectangle(
+                            x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset, Options.TileWidth,
+                            Options.TileHeight
+                        ).IntersectsWith(new System.Drawing.Rectangle(0, 0, CurrentView.Width, CurrentView.Height)))
                         {
-                            if (tmpMap.FindEventAt(x, y) == null)
+                            var tilesetObj = TilesetBase.Get(tmpMap.Layers[drawLayer][x, y].TilesetId);
+                            try
+                            {
+                                if (tilesetObj == null)
+                                {
+                                    continue;
+                                }
+                            }
+                            catch (Exception exception)
+                            {
+                                Log.Error($"map={tmpMap != null},layer{drawLayer}.tiles={tmpMap.Layers[drawLayer] != null}");
+                                Log.Error(exception);
+
+                                continue;
+                            }
+
+                            var tilesetTex = GameContentManager.GetTexture(
+                                GameContentManager.TextureType.Tileset, tilesetObj.Name
+                            );
+
+                            if (tilesetTex == null || tmpMap.Autotiles == null || tmpMap.Autotiles.Layers == null)
                             {
                                 continue;
                             }
 
-                            var eventTex = GameContentManager.GetTexture(
-                                GameContentManager.TextureType.Misc, "eventicon.png"
-                            );
-
-                            if (eventTex != null)
+                            if (tmpMap.Autotiles.Layers[drawLayer][x, y].RenderState !=
+                                MapAutotiles.RENDER_STATE_NORMAL)
                             {
-                                DrawTexture(
-                                    eventTex, new RectangleF(0, 0, eventTex.Width, eventTex.Height),
-                                    new RectangleF(
-                                        CurrentView.Left + x * Options.TileWidth,
-                                        CurrentView.Top + y * Options.TileHeight, Options.TileWidth, Options.TileHeight
-                                    ), System.Drawing.Color.White, null
+                                if (tmpMap.Autotiles.Layers[drawLayer][x, y].RenderState !=
+                                    MapAutotiles.RENDER_STATE_AUTOTILE)
+                                {
+                                    continue;
+                                }
+
+                                DrawAutoTile(
+                                    tilesetTex, drawLayer, x * Options.TileWidth + xoffset,
+                                    y * Options.TileHeight + yoffset, 1, x, y, tmpMap, renderTarget2D
                                 );
-                            }
-                        }
-                    }
-                }
-                else if (Globals.CurrentLayer == LayerOptions.Npcs) //NPCS
-                {
-                    for (var i = 0; i < tmpMap.Spawns.Count; i++)
-                    {
-                        if (tmpMap.Spawns[i].X < 0 || tmpMap.Spawns[i].Y < 0)
-                        {
-                            continue;
-                        }
 
-                        var spawnTex = GameContentManager.GetTexture(
-                            GameContentManager.TextureType.Misc, "spawnicon.png"
-                        );
+                                DrawAutoTile(
+                                    tilesetTex, drawLayer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                                    y * Options.TileHeight + yoffset, 2, x, y, tmpMap, renderTarget2D
+                                );
 
-                        if (spawnTex == null)
-                        {
-                            continue;
-                        }
+                                DrawAutoTile(
+                                    tilesetTex, drawLayer, x * Options.TileWidth + xoffset,
+                                    y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 3, x, y, tmpMap,
+                                    renderTarget2D
+                                );
 
-                        // Check if the current spawn is selected
-                        var spawnColor = System.Drawing.Color.White;
-                        var selectedNpcIndex = Globals.MapLayersWindow.lstMapNpcs.SelectedIndex;
-                        if (selectedNpcIndex > -1 && selectedNpcIndex < tmpMap.Spawns.Count &&
-                            tmpMap.Spawns[i] == tmpMap.Spawns[selectedNpcIndex])
-                        {
-                            // Calculate pulsating color: adjusts denominator to change speed of pulsation.
-                            var currentTime = Timing.Global.MillisecondsUtc;
-                            if ((currentTime - _lastNpcPulseColorUpdate) >= 50) // Update every 50ms.
-                            {
-                                _npcColorPulseRatio = (float)(Math.Sin(2 * Math.PI * (currentTime / 1000.0)) + 1) / 2;
-                                _lastNpcPulseColorUpdate = currentTime;
-                            }
-                            if (FrmMapLayers.NpcPulseColor == default)
-                            {
-                                FrmMapLayers.NpcPulseColor = System.Drawing.Color.Red;
-                            }
-
-                            spawnColor = GridHelper.ColorInterpolate(spawnColor, FrmMapLayers.NpcPulseColor, _npcColorPulseRatio);
-                        }
-
-                        DrawTexture(
-                            spawnTex, new RectangleF(0, 0, spawnTex.Width, spawnTex.Height),
-                            new RectangleF(
-                                CurrentView.Left + tmpMap.Spawns[i].X * Options.TileWidth,
-                                CurrentView.Top + tmpMap.Spawns[i].Y * Options.TileHeight, Options.TileWidth,
-                                Options.TileHeight
-                            ), spawnColor
-                        );
-                    }
-                }
-            }
-
-            if (Globals.CurrentTool == EditingTool.Selection && Globals.Dragging)
-            {
-                DrawBoxOutline(
-                    CurrentView.Left + Globals.CurTileX * Options.TileWidth,
-                    CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
-                    System.Drawing.Color.White, null
-                );
-            }
-
-            if (Globals.CurrentTool == EditingTool.Rectangle ||
-                Globals.CurrentTool == EditingTool.Selection)
-            {
-                DrawBoxOutline(
-                    CurrentView.Left + (selX + dragxoffset) * Options.TileWidth,
-                    CurrentView.Top + (selY + dragyoffset) * Options.TileHeight, (selW + 1) * Options.TileWidth,
-                    (selH + 1) * Options.TileHeight, System.Drawing.Color.Blue, null
-                );
-            }
-            else
-            {
-                DrawBoxOutline(
-                    CurrentView.Left + Globals.CurTileX * Options.TileWidth,
-                    CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
-                    System.Drawing.Color.White, null
-                );
-            }
-        }
-
-        private static void DrawBoxOutline(int x, int y, int w, int h, System.Drawing.Color clr, RenderTarget2D target)
-        {
-            //Draw Top of Box
-            DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, w, 1), clr, target);
-
-            //Bottom
-            DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y + h, w, 1), clr, target);
-
-            //Left
-            DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, 1, h), clr, target);
-
-            //Right
-            DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x + w, y, 1, h), clr, target);
-        }
-
-        public static void DrawMapGrid()
-        {
-            if (sMapGridChain == null ||
-                sMapGridChain.IsContentLost ||
-                sMapGridChain.IsDisposed ||
-                Globals.MapGridWindowNew.DockPanel.ActiveDocument != Globals.MapGridWindowNew)
-            {
-                return;
-            }
-
-            EndSpriteBatch();
-            SetRenderTarget(sMapGridChain);
-            sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.FromNonPremultiplied(60, 63, 65, 255));
-            var rand = new Random();
-            var grid = Globals.MapGrid;
-            lock (Globals.MapGrid.GetMapGridLock())
-            {
-                grid.Update(sMapGridChain.Bounds);
-                for (var x = 0; x < grid.GridWidth + 2; x++)
-                {
-                    for (var y = 0; y < grid.GridHeight + 2; y++)
-                    {
-                        var renderRect = new System.Drawing.Rectangle(
-                            grid.ContentRect.X + x * grid.TileWidth, grid.ContentRect.Y + y * grid.TileHeight,
-                            grid.TileWidth, grid.TileHeight
-                        );
-
-                        if (grid.ViewRect.IntersectsWith(renderRect))
-                        {
-                            if (x == 0 ||
-                                y == 0 ||
-                                x == grid.GridWidth + 1 ||
-                                y == grid.GridHeight + 1 ||
-                                grid.Grid[x - 1, y - 1].MapId == Guid.Empty)
-                            {
-                                DrawTexture(
-                                    GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                    new RectangleF(
-                                        grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
-                                    ), System.Drawing.Color.FromArgb(45, 45, 48), sMapGridChain
+                                DrawAutoTile(
+                                    tilesetTex, drawLayer, x * Options.TileWidth + Options.TileWidth / 2 + xoffset,
+                                    y * Options.TileHeight + Options.TileHeight / 2 + yoffset, 4, x, y, tmpMap,
+                                    renderTarget2D
                                 );
                             }
                             else
                             {
-                                if (grid.Grid[x - 1, y - 1].MapId != Guid.Empty)
+                                DrawTexture(
+                                    tilesetTex, x * Options.TileWidth + xoffset, y * Options.TileHeight + yoffset,
+                                    tmpMap.Layers[drawLayer][x, y].X * Options.TileWidth,
+                                    tmpMap.Layers[drawLayer][x, y].Y * Options.TileHeight, Options.TileWidth,
+                                    Options.TileHeight, renderTarget2D
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (layer == 1)
+        {
+            foreach (var light in tmpMap.Lights)
+            {
+                double w = light.Size;
+                var x = xoffset +
+                        Options.MapWidth * Options.TileWidth -
+                        CurrentView.Left +
+                        light.TileX * Options.TileWidth +
+                        light.OffsetX +
+                        Options.TileWidth / 2;
+
+                var y = yoffset +
+                        Options.MapHeight * Options.TileHeight -
+                        CurrentView.Top +
+                        light.TileY * Options.TileHeight +
+                        light.OffsetY +
+                        Options.TileHeight / 2;
+
+                if (!HideDarkness)
+                {
+                    AddLight(x, y, light, null);
+                }
+            }
+        }
+    }
+
+    private static void DrawSelectionRect()
+    {
+        var tmpMap = Globals.CurrentMap;
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        int selX = Globals.CurMapSelX,
+            selY = Globals.CurMapSelY,
+            selW = Globals.CurMapSelW,
+            selH = Globals.CurMapSelH;
+
+        int dragxoffset = 0, dragyoffset = 0;
+        if (Globals.CurrentTool == EditingTool.Rectangle ||
+            Globals.CurrentTool == EditingTool.Selection)
+        {
+            if (selW < 0)
+            {
+                selX -= Math.Abs(selW);
+                selW = Math.Abs(selW);
+            }
+
+            if (selH < 0)
+            {
+                selY -= Math.Abs(selH);
+                selH = Math.Abs(selH);
+            }
+        }
+
+        if (Globals.Dragging)
+        {
+            if (Globals.MouseButton == 0)
+            {
+                dragxoffset = Globals.TotalTileDragX - (Globals.TileDragX - Globals.CurTileX);
+                dragyoffset = Globals.TotalTileDragY - (Globals.TileDragY - Globals.CurTileY);
+            }
+            else
+            {
+                dragxoffset = Globals.TotalTileDragX;
+                dragyoffset = Globals.TotalTileDragY;
+            }
+        }
+
+        if (!HideTilePreview || Globals.Dragging)
+        {
+            tmpMap = TilePreviewStruct;
+            if (Globals.CurrentLayer == LayerOptions.Attributes) //Attributes
+            {
+                var attributesTex = GameContentManager.GetTexture(
+                    GameContentManager.TextureType.Misc, "attributes.png"
+                );
+
+                if (attributesTex != null)
+                {
+                    var whiteTextureBounds = new RectangleF(
+                        sWhiteTex.Bounds.X,
+                        sWhiteTex.Bounds.Y,
+                        sWhiteTex.Bounds.Width,
+                        sWhiteTex.Bounds.Height
+                    );
+
+                    //Draw attributes
+                    for (var x = 0; x < Options.MapWidth; x++)
+                    {
+                        for (var y = 0; y < Options.MapHeight; y++)
+                        {
+                            var attr = tmpMap.Attributes[x, y];
+                            if ((attr?.Type ?? MapAttribute.Walkable) == MapAttribute.Walkable)
+                            {
+                                continue;
+                            }
+
+                            var tileBounds = new RectangleF(
+                                CurrentView.Left + x * Options.TileWidth,
+                                CurrentView.Top + y * Options.TileHeight,
+                                Options.TileWidth,
+                                Options.TileHeight
+                            );
+
+                            if (attributesTex != null)
+                            {
+                                var blue = (attr is MapWarpAttribute warp && warp.ChangeInstance) ? 0 : 255;
+                                DrawTexture(
+                                   attributesTex,
+                                   new RectangleF(
+                                       0,
+                                       ((int)tmpMap.Attributes[x, y].Type - 1) * attributesTex.Width,
+                                       attributesTex.Width,
+                                       attributesTex.Width
+                                   ),
+                                   tileBounds,
+                                   System.Drawing.Color.FromArgb(255, 255, 255, blue),
+                                   null
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            else if (Globals.CurrentLayer == LayerOptions.Lights) //Lights
+            {
+            }
+            else if (Globals.CurrentLayer == LayerOptions.Events) //Events
+            {
+                for (var x = 0; x < Options.MapWidth; x++)
+                {
+                    for (var y = 0; y < Options.MapHeight; y++)
+                    {
+                        if (tmpMap.FindEventAt(x, y) == null)
+                        {
+                            continue;
+                        }
+
+                        var eventTex = GameContentManager.GetTexture(
+                            GameContentManager.TextureType.Misc, "eventicon.png"
+                        );
+
+                        if (eventTex != null)
+                        {
+                            DrawTexture(
+                                eventTex, new RectangleF(0, 0, eventTex.Width, eventTex.Height),
+                                new RectangleF(
+                                    CurrentView.Left + x * Options.TileWidth,
+                                    CurrentView.Top + y * Options.TileHeight, Options.TileWidth, Options.TileHeight
+                                ), System.Drawing.Color.White, null
+                            );
+                        }
+                    }
+                }
+            }
+            else if (Globals.CurrentLayer == LayerOptions.Npcs) //NPCS
+            {
+                for (var i = 0; i < tmpMap.Spawns.Count; i++)
+                {
+                    if (tmpMap.Spawns[i].X < 0 || tmpMap.Spawns[i].Y < 0)
+                    {
+                        continue;
+                    }
+
+                    var spawnTex = GameContentManager.GetTexture(
+                        GameContentManager.TextureType.Misc, "spawnicon.png"
+                    );
+
+                    if (spawnTex == null)
+                    {
+                        continue;
+                    }
+
+                    // Check if the current spawn is selected
+                    var spawnColor = System.Drawing.Color.White;
+                    var selectedNpcIndex = Globals.MapLayersWindow.lstMapNpcs.SelectedIndex;
+                    if (selectedNpcIndex > -1 && selectedNpcIndex < tmpMap.Spawns.Count &&
+                        tmpMap.Spawns[i] == tmpMap.Spawns[selectedNpcIndex])
+                    {
+                        // Calculate pulsating color: adjusts denominator to change speed of pulsation.
+                        var currentTime = Timing.Global.MillisecondsUtc;
+                        if ((currentTime - _lastNpcPulseColorUpdate) >= 50) // Update every 50ms.
+                        {
+                            _npcColorPulseRatio = (float)(Math.Sin(2 * Math.PI * (currentTime / 1000.0)) + 1) / 2;
+                            _lastNpcPulseColorUpdate = currentTime;
+                        }
+                        if (FrmMapLayers.NpcPulseColor == default)
+                        {
+                            FrmMapLayers.NpcPulseColor = System.Drawing.Color.Red;
+                        }
+
+                        spawnColor = GridHelper.ColorInterpolate(spawnColor, FrmMapLayers.NpcPulseColor, _npcColorPulseRatio);
+                    }
+
+                    DrawTexture(
+                        spawnTex, new RectangleF(0, 0, spawnTex.Width, spawnTex.Height),
+                        new RectangleF(
+                            CurrentView.Left + tmpMap.Spawns[i].X * Options.TileWidth,
+                            CurrentView.Top + tmpMap.Spawns[i].Y * Options.TileHeight, Options.TileWidth,
+                            Options.TileHeight
+                        ), spawnColor
+                    );
+                }
+            }
+        }
+
+        if (Globals.CurrentTool == EditingTool.Selection && Globals.Dragging)
+        {
+            DrawBoxOutline(
+                CurrentView.Left + Globals.CurTileX * Options.TileWidth,
+                CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
+                System.Drawing.Color.White, null
+            );
+        }
+
+        if (Globals.CurrentTool == EditingTool.Rectangle ||
+            Globals.CurrentTool == EditingTool.Selection)
+        {
+            DrawBoxOutline(
+                CurrentView.Left + (selX + dragxoffset) * Options.TileWidth,
+                CurrentView.Top + (selY + dragyoffset) * Options.TileHeight, (selW + 1) * Options.TileWidth,
+                (selH + 1) * Options.TileHeight, System.Drawing.Color.Blue, null
+            );
+        }
+        else
+        {
+            DrawBoxOutline(
+                CurrentView.Left + Globals.CurTileX * Options.TileWidth,
+                CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
+                System.Drawing.Color.White, null
+            );
+        }
+    }
+
+    private static void DrawBoxOutline(int x, int y, int w, int h, System.Drawing.Color clr, RenderTarget2D target)
+    {
+        //Draw Top of Box
+        DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, w, 1), clr, target);
+
+        //Bottom
+        DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y + h, w, 1), clr, target);
+
+        //Left
+        DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, 1, h), clr, target);
+
+        //Right
+        DrawTexture(sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x + w, y, 1, h), clr, target);
+    }
+
+    public static void DrawMapGrid()
+    {
+        if (sMapGridChain == null ||
+            sMapGridChain.IsContentLost ||
+            sMapGridChain.IsDisposed ||
+            Globals.MapGridWindowNew.DockPanel.ActiveDocument != Globals.MapGridWindowNew)
+        {
+            return;
+        }
+
+        EndSpriteBatch();
+        SetRenderTarget(sMapGridChain);
+        sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.FromNonPremultiplied(60, 63, 65, 255));
+        var rand = new Random();
+        var grid = Globals.MapGrid;
+        lock (Globals.MapGrid.GetMapGridLock())
+        {
+            grid.Update(sMapGridChain.Bounds);
+            for (var x = 0; x < grid.GridWidth + 2; x++)
+            {
+                for (var y = 0; y < grid.GridHeight + 2; y++)
+                {
+                    var renderRect = new System.Drawing.Rectangle(
+                        grid.ContentRect.X + x * grid.TileWidth, grid.ContentRect.Y + y * grid.TileHeight,
+                        grid.TileWidth, grid.TileHeight
+                    );
+
+                    if (grid.ViewRect.IntersectsWith(renderRect))
+                    {
+                        if (x == 0 ||
+                            y == 0 ||
+                            x == grid.GridWidth + 1 ||
+                            y == grid.GridHeight + 1 ||
+                            grid.Grid[x - 1, y - 1].MapId == Guid.Empty)
+                        {
+                            DrawTexture(
+                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+                                new RectangleF(
+                                    grid.ContentRect.X + x * grid.TileWidth,
+                                    grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
+                                ), System.Drawing.Color.FromArgb(45, 45, 48), sMapGridChain
+                            );
+                        }
+                        else
+                        {
+                            if (grid.Grid[x - 1, y - 1].MapId != Guid.Empty)
+                            {
+                                if (grid.Grid[x - 1, y - 1].Tex != null &&
+                                    grid.Grid[x - 1, y - 1].Tex.Width == grid.TileWidth &&
+                                    grid.Grid[x - 1, y - 1].Tex.Height == grid.TileHeight)
                                 {
-                                    if (grid.Grid[x - 1, y - 1].Tex != null &&
-                                        grid.Grid[x - 1, y - 1].Tex.Width == grid.TileWidth &&
-                                        grid.Grid[x - 1, y - 1].Tex.Height == grid.TileHeight)
-                                    {
-                                        DrawTexture(
-                                            grid.Grid[x - 1, y - 1].Tex, grid.ContentRect.X + x * grid.TileWidth,
-                                            grid.ContentRect.Y + y * grid.TileHeight, sMapGridChain
-                                        );
-                                    }
-                                    else
-                                    {
-                                        DrawTexture(
-                                            GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                            new RectangleF(
-                                                grid.ContentRect.X + x * grid.TileWidth,
-                                                grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth,
-                                                grid.TileHeight
-                                            ), System.Drawing.Color.Green, sMapGridChain
-                                        );
-                                    }
+                                    DrawTexture(
+                                        grid.Grid[x - 1, y - 1].Tex, grid.ContentRect.X + x * grid.TileWidth,
+                                        grid.ContentRect.Y + y * grid.TileHeight, sMapGridChain
+                                    );
                                 }
                                 else
                                 {
@@ -1147,1081 +1135,1093 @@ namespace Intersect.Editor.Core
                                         GetWhiteTex(), new RectangleF(0, 0, 1, 1),
                                         new RectangleF(
                                             grid.ContentRect.X + x * grid.TileWidth,
-                                            grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
-                                        ), System.Drawing.Color.Gray, sMapGridChain
+                                            grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth,
+                                            grid.TileHeight
+                                        ), System.Drawing.Color.Green, sMapGridChain
                                     );
                                 }
                             }
-
-                            if (Globals.MapGrid.ShowLines)
+                            else
                             {
                                 DrawTexture(
                                     GetWhiteTex(), new RectangleF(0, 0, 1, 1),
                                     new RectangleF(
                                         grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, 1
-                                    ), System.Drawing.Color.DarkGray, sMapGridChain
-                                );
-
-                                DrawTexture(
-                                    GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                    new RectangleF(
-                                        grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
-                                    ), System.Drawing.Color.DarkGray, sMapGridChain
-                                );
-
-                                DrawTexture(
-                                    GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                    new RectangleF(
-                                        grid.ContentRect.X + x * grid.TileWidth + grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
-                                    ), System.Drawing.Color.DarkGray, sMapGridChain
-                                );
-
-                                DrawTexture(
-                                    GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                                    new RectangleF(
-                                        grid.ContentRect.X + x * grid.TileWidth,
-                                        grid.ContentRect.Y + y * grid.TileHeight + grid.TileHeight, grid.TileWidth, 1
-                                    ), System.Drawing.Color.DarkGray, sMapGridChain
+                                        grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, grid.TileHeight
+                                    ), System.Drawing.Color.Gray, sMapGridChain
                                 );
                             }
                         }
-                    }
-                }
-            }
 
-            EndSpriteBatch();
-            sMapGridChain.Present();
-        }
-
-        private static void SetRenderTarget(RenderTarget2D target)
-        {
-            EndSpriteBatch();
-            sGraphicsDevice.SetRenderTarget(target);
-        }
-
-        public static void DrawTileset()
-        {
-            if (sTilesetChain == null ||
-                sTilesetChain.IsContentLost ||
-                sTilesetChain.IsDisposed ||
-                Globals.MapLayersWindow.CurrentTab != LayerTabs.Tiles)
-            {
-                return;
-            }
-
-            SetRenderTarget(sTilesetChain);
-            sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
-            if (Globals.CurrentTileset != null)
-            {
-                var tilesetTex = GameContentManager.GetTexture(
-                    GameContentManager.TextureType.Tileset, Globals.CurrentTileset.Name
-                );
-
-                if (tilesetTex != null)
-                {
-                    DrawTexture(tilesetTex, 0, 0, sTilesetChain);
-                    var selX = Globals.CurSelX;
-                    var selY = Globals.CurSelY;
-                    var selW = Globals.CurSelW;
-                    var selH = Globals.CurSelH;
-                    if (selW < 0)
-                    {
-                        selX -= Math.Abs(selW);
-                        selW = Math.Abs(selW);
-                    }
-
-                    if (selH < 0)
-                    {
-                        selY -= Math.Abs(selH);
-                        selH = Math.Abs(selH);
-                    }
-
-                    DrawBoxOutline(
-                        selX * Options.TileWidth, selY * Options.TileHeight,
-                        Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight,
-                        System.Drawing.Color.White, sTilesetChain
-                    );
-                }
-            }
-
-            EndSpriteBatch();
-            sTilesetChain.Present();
-        }
-
-        private static void DrawMapBorders()
-        {
-            //Horizontal Top
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, CurrentView.Y - 1, CurrentView.Width, 3),
-                System.Drawing.Color.DimGray
-            );
-
-            //Horizontal Buttom
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(0, CurrentView.Y + Options.TileHeight * Options.MapHeight - 1, CurrentView.Width, 3),
-                System.Drawing.Color.DimGray
-            );
-
-            //Vertical Left
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(CurrentView.Left - 1, 0, 3, CurrentView.Height),
-                System.Drawing.Color.DimGray
-            );
-
-            //Vertical Right
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(CurrentView.Left + Options.TileWidth * Options.MapWidth - 1, 0, 3, CurrentView.Height),
-                System.Drawing.Color.DimGray
-            );
-
-            //Horizontal Top
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(CurrentView.Left, CurrentView.Y - 1, Options.TileWidth * Options.MapWidth, 3),
-                System.Drawing.Color.DimGray
-            );
-
-            //Horizontal Buttom
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(
-                    CurrentView.Left, CurrentView.Y + Options.TileHeight * Options.MapHeight - 1,
-                    Options.TileWidth * Options.MapWidth, 3
-                ), System.Drawing.Color.DimGray
-            );
-
-            //Vertical Left
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(CurrentView.Left - 1, CurrentView.Y, 3, Options.MapHeight * Options.TileHeight),
-                System.Drawing.Color.DimGray
-            );
-
-            //Vertical Right
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1),
-                new RectangleF(
-                    CurrentView.Left + Options.TileWidth * Options.MapWidth - 1, CurrentView.Y, 3,
-                    Options.MapHeight * Options.TileHeight
-                ), System.Drawing.Color.DimGray
-            );
-        }
-
-        private static void DrawMapAttributes(
-            MapInstance map,
-            int gridX,
-            int gridY,
-            bool screenShotting,
-            RenderTarget2D renderTarget,
-            bool upper,
-            bool alternate
-        )
-        {
-            if (!screenShotting && HideResources)
-            {
-                return;
-            }
-
-            if (screenShotting && Database.GridHideResources)
-            {
-                return;
-            }
-
-            var tmpMap = Globals.CurrentMap;
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            var x1 = 0;
-            var x2 = Options.MapWidth;
-            var y1 = 0;
-            var y2 = Options.MapHeight;
-            var xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
-            var yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
-
-            if (screenShotting)
-            {
-                xoffset -= CurrentView.Left;
-                yoffset -= CurrentView.Top;
-            }
-
-            if (gridX != 0 || gridY != 0)
-            {
-                tmpMap = map;
-            }
-            else if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
-            {
-                tmpMap = TilePreviewStruct;
-            }
-
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            for (var y = y1; y < y2; y++)
-            {
-                for (var x = x1; x < x2; x++)
-                {
-                    if (tmpMap.Attributes[x, y] == null)
-                    {
-                        continue;
-                    }
-
-                    if (tmpMap.Attributes[x, y].Type == MapAttribute.Resource && !upper && !alternate)
-                    {
-                        var resource = ResourceBase.Get(((MapResourceAttribute) tmpMap.Attributes[x, y]).ResourceId);
-                        if (resource == null)
-                        {
-                            continue;
-                        }
-
-                        if (TextUtils.IsNone(resource.Initial.Graphic))
-                        {
-                            continue;
-                        }
-
-                        if (resource.Initial.GraphicFromTileset)
-                        {
-                            var res = GameContentManager.GetTexture(
-                                GameContentManager.TextureType.Tileset, resource.Initial.Graphic
-                            );
-
-                            if (res == null)
-                            {
-                                continue;
-                            }
-
-                            float xpos = x * Options.TileWidth + xoffset;
-                            float ypos = y * Options.TileHeight + yoffset;
-                            if ((resource.Initial.Height + 1) * Options.TileHeight > Options.TileHeight)
-                            {
-                                ypos -= (resource.Initial.Height + 1) * Options.TileHeight - Options.TileHeight;
-                            }
-
-                            if ((resource.Initial.Width + 1) * Options.TileWidth > Options.TileWidth)
-                            {
-                                xpos -= ((resource.Initial.Width + 1) * Options.TileWidth - Options.TileWidth) / 2;
-                            }
-
-                            DrawTexture(
-                                res, xpos, ypos, resource.Initial.X * Options.TileWidth,
-                                resource.Initial.Y * Options.TileHeight,
-                                (resource.Initial.Width + 1) * Options.TileWidth,
-                                (resource.Initial.Height + 1) * Options.TileHeight, renderTarget
-                            );
-                        }
-                        else
-                        {
-                            var res = GameContentManager.GetTexture(
-                                GameContentManager.TextureType.Resource, resource.Initial.Graphic
-                            );
-
-                            if (res == null)
-                            {
-                                continue;
-                            }
-
-                            float xpos = x * Options.TileWidth + xoffset;
-                            float ypos = y * Options.TileHeight + yoffset;
-                            if (res.Height > Options.TileHeight)
-                            {
-                                ypos -= res.Height - Options.TileHeight;
-                            }
-
-                            if (res.Width > Options.TileWidth)
-                            {
-                                xpos -= (res.Width - Options.TileWidth) / 2;
-                            }
-
-                            DrawTexture(res, xpos, ypos, 0, 0, res.Width, res.Height, renderTarget);
-                        }
-                    }
-                    else if (tmpMap.Attributes[x, y].Type == MapAttribute.Animation)
-                    {
-                        var animation =
-                            AnimationBase.Get(((MapAnimationAttribute) tmpMap.Attributes[x, y]).AnimationId);
-
-                        if (animation != null)
-                        {
-                            float xpos = x * Options.TileWidth + xoffset + Options.TileWidth / 2;
-                            float ypos = y * Options.TileHeight + yoffset + Options.TileHeight / 2;
-                            if (tmpMap.Attributes[x, y] != null)
-                            {
-                                var animInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
-
-                                //Update if the animation isn't right!
-                                if (animInstance == null || animInstance.MyBase != animation)
-                                {
-                                    tmpMap.SetAttributeAnimation(
-                                        tmpMap.Attributes[x, y], new Animation(animation, true)
-                                    );
-                                }
-
-                                animInstance.Update();
-                                animInstance.SetPosition((int) xpos, (int) ypos, 0);
-                                animInstance.Draw(renderTarget, upper, alternate);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        private static void DrawMapEvents(
-            MapInstance map,
-            int gridX,
-            int gridY,
-            bool screenShotting,
-            RenderTarget2D renderTarget
-        )
-        {
-            if (!screenShotting && HideEvents)
-            {
-                return;
-            }
-
-            if (screenShotting && Database.GridHideEvents)
-            {
-                return;
-            }
-
-            var tmpMap = Globals.CurrentMap;
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            int x1 = 0, y1 = 0, x2 = 0, y2 = 0, xoffset = 0, yoffset = 0;
-
-            x1 = 0;
-            x2 = Options.MapWidth;
-            y1 = 0;
-            y2 = Options.MapHeight;
-            xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
-            yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
-            if (gridX != 0 || gridY != 0)
-            {
-                tmpMap = map;
-            }
-
-            if (screenShotting)
-            {
-                xoffset -= CurrentView.Left;
-                yoffset -= CurrentView.Top;
-            }
-
-            if (gridX == 0 && gridY == 0)
-            {
-                if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
-                {
-                    tmpMap = TilePreviewStruct;
-                }
-            }
-
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            for (var y = y1; y < y2; y++)
-            {
-                for (var x = x1; x < x2; x++)
-                {
-                    var tmpEvent = tmpMap.FindEventAt(x, y);
-                    if (tmpEvent == null)
-                    {
-                        continue;
-                    }
-
-                    if (tmpEvent.Pages[0].Graphic == null)
-                    {
-                        continue;
-                    }
-
-                    var tmpGraphic = tmpEvent.Pages[0].Graphic;
-                    if (TextUtils.IsNone(tmpGraphic.Filename))
-                    {
-                        continue;
-                    }
-
-                    Texture2D eventTex = null;
-                    var destinationX = x * Options.TileWidth + xoffset;
-                    var destinationY = y * Options.TileHeight + yoffset;
-                    var sourceX = 0;
-                    var sourceY = 0;
-                    var width = 0;
-                    var height = 0;
-
-                    switch (tmpGraphic.Type)
-                    {
-                        case EventGraphicType.Sprite: //Sprite
-                            eventTex = GameContentManager.GetTexture(
-                                GameContentManager.TextureType.Entity, tmpGraphic.Filename
-                            );
-                            if (eventTex == null)
-                            {
-                                continue;
-                            }
-
-                            sourceX = (int)tmpGraphic.X * (eventTex.Width / Options.Instance.Sprites.NormalFrames);
-                            sourceY = (int)tmpGraphic.Y * (eventTex.Height / Options.Instance.Sprites.Directions);
-                            width = (eventTex.Width / Options.Instance.Sprites.NormalFrames);
-                            height = (eventTex.Height / Options.Instance.Sprites.Directions);
-
-                            break;
-                        case EventGraphicType.Tileset: //Tile
-                            eventTex = GameContentManager.GetTexture(
-                                GameContentManager.TextureType.Tileset, tmpGraphic.Filename
-                            );
-                            if (eventTex == null)
-                            {
-                                continue;
-                            }
-
-                            sourceX = (int)tmpGraphic.X * Options.TileWidth;
-                            sourceY = (int)tmpGraphic.Y * Options.TileHeight;
-                            width = (tmpGraphic.Width + 1) * Options.TileWidth;
-                            height = (tmpGraphic.Height + 1) * Options.TileHeight;
-
-                            break;
-                    }
-
-                    if (height > Options.TileHeight)
-                    {
-                        destinationY -= (height - Options.TileHeight);
-                    }
-
-                    if (width > Options.TileWidth)
-                    {
-                        destinationX -= (width  - Options.TileWidth) / 2;
-                    }
-
-                    DrawTexture(eventTex, destinationX, destinationY, sourceX, sourceY, width, height, renderTarget);
-                }
-            }
-        }
-        private static void DrawMapOverlay(RenderTarget2D target)
-        {
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, 0, CurrentView.Width, CurrentView.Height),
-                System.Drawing.Color.FromArgb(
-                    Globals.CurrentMap.AHue, Globals.CurrentMap.RHue, Globals.CurrentMap.GHue, Globals.CurrentMap.BHue
-                ), target
-            );
-        }
-
-        public static Bitmap ScreenShotMap()
-        {
-            if (sScreenShotRenderTexture == null)
-            {
-                sScreenShotRenderTexture = CreateRenderTexture(
-                    Options.MapWidth * Options.TileWidth, Options.MapHeight * Options.TileHeight
-                );
-            }
-
-            SetRenderTarget(sScreenShotRenderTexture);
-            sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
-
-            if (Globals.MapGrid.Contains(Globals.CurrentMap.Id))
-            {
-                //Draw The lower maps
-                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; ++y)
-                {
-                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; ++x)
-                    {
-                        if (x < 0 || x >= Globals.MapGrid.GridWidth)
-                        {
-                            continue;
-                        }
-
-                        if (y < 0 || y >= Globals.MapGrid.GridHeight)
-                        {
-                            continue;
-                        }
-
-                        var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                        if (map == null)
-                        {
-                            continue;
-                        }
-
-                        lock (map.MapLock)
-                        {
-                            //Draw this map
-                            DrawMap(
-                                map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true, 0,
-                                sScreenShotRenderTexture
-                            );
-                        }
-                    }
-                }
-
-                //Draw the lower resources/animations
-                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                {
-                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                    {
-                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                        {
-                            var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                            if (map != null)
-                            {
-                                lock (map.MapLock)
-                                {
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
-                                        sScreenShotRenderTexture, false, false
-                                    );
-
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
-                                        sScreenShotRenderTexture, false, true
-                                    );
-
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
-                                        sScreenShotRenderTexture, true, true
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Draw events
-                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                {
-                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                    {
-                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                        {
-                            var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                            if (map != null)
-                            {
-                                lock (map.MapLock)
-                                {
-                                    DrawMapEvents(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
-                                        true, sScreenShotRenderTexture
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                //Draw The upper maps
-                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                {
-                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                    {
-                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                        {
-                            var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                            if (map != null)
-                            {
-                                lock (map.MapLock)
-                                {
-                                    //Draw this map
-                                    DrawMap(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true, 1,
-                                        sScreenShotRenderTexture
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                //Draw the upper resources/animations
-                for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
-                {
-                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                    {
-                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                        {
-                            var map = MapInstance.Get(Globals.MapGrid.Grid?[x, y]?.MapId ?? Guid.Empty);
-                            if (map != null)
-                            {
-                                lock (map.MapLock)
-                                {
-                                    DrawMapAttributes(
-                                        map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
-                                        sScreenShotRenderTexture, true, false
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            else
-            {
-                lock (Globals.CurrentMap.MapLock)
-                {
-                    //Draw this map
-                    DrawMap(Globals.CurrentMap, 0, 0, true, 0, sScreenShotRenderTexture);
-                    DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, false, false);
-                    DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, false, true);
-                    DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, true, true);
-
-                    //Draw this map
-                    DrawMap(Globals.CurrentMap, 0, 0, true, 1, sScreenShotRenderTexture);
-                    DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, true, false);
-                }
-            }
-
-            if (!Database.GridHideFog)
-            {
-                DrawFog(sScreenShotRenderTexture);
-            }
-
-            if (!Database.GridHideOverlay)
-            {
-                DrawMapOverlay(sScreenShotRenderTexture);
-            }
-
-            if (!Database.GridHideDarkness || Globals.CurrentLayer == LayerOptions.Lights)
-            {
-                ClearDarknessTexture(sScreenShotRenderTexture, true);
-                OverlayDarkness(sScreenShotRenderTexture, true);
-            }
-
-            EndSpriteBatch();
-            var data = new int[sScreenShotRenderTexture.Width * sScreenShotRenderTexture.Height];
-            sScreenShotRenderTexture.GetData(
-                0,
-                new Microsoft.Xna.Framework.Rectangle(
-                    0, 0, sScreenShotRenderTexture.Width, sScreenShotRenderTexture.Height
-                ), data, 0, sScreenShotRenderTexture.Width * sScreenShotRenderTexture.Height
-            );
-
-            var bitmap = new Bitmap(sScreenShotRenderTexture.Width, sScreenShotRenderTexture.Height);
-            var bits = bitmap.LockBits(
-                new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadWrite,
-                PixelFormat.Format32bppArgb
-            );
-
-            unsafe
-            {
-                var dstPointer = (byte*) bits.Scan0;
-                for (var y = 0; y < sScreenShotRenderTexture.Height; ++y)
-                {
-                    for (var x = 0; x < sScreenShotRenderTexture.Width; ++x)
-                    {
-                        var bitmapColor = System.Drawing.Color.FromArgb(data[y * sScreenShotRenderTexture.Width + x]);
-                        dstPointer[0] = bitmapColor.R;
-                        dstPointer[1] = bitmapColor.G;
-                        dstPointer[2] = bitmapColor.B;
-                        dstPointer[3] = bitmapColor.A;
-
-                        dstPointer += 4;
-                    }
-                }
-            }
-
-            bitmap.UnlockBits(bits);
-
-            return bitmap;
-        }
-
-        /// <summary>
-        /// Draws the fog over the map editor view.
-        /// </summary>
-        private static void DrawFog(RenderTarget2D target)
-        {
-            // Exit early if the map has no fog or if the fog texture is not available.
-            var currentMap = Globals.CurrentMap;
-            var fog = currentMap.Fog;
-            if (string.IsNullOrWhiteSpace(fog))
-            {
-                return;
-            }
-
-            // Get fog texture and exit early if it is not available.
-            var fogTex = GameContentManager.GetTexture(GameContentManager.TextureType.Fog, fog);
-            if (fogTex == null)
-            {
-                return;
-            }
-
-            // Calculate elapsed time since the last update and set maximum value for elapsedTime to
-            // prevent large jumps in fog intensity (1 second maximum).
-            float elapsedTime = Math.Min(Timing.Global.MillisecondsUtc - sFogUpdateTime, 1000);
-            sFogUpdateTime = Timing.Global.MillisecondsUtc;
-
-            // Calculate the number of times the fog texture needs to be drawn to cover the map area.
-            var xCount = Globals.MapEditorWindow.picMap.Width * Options.TileWidth / fogTex.Width;
-            var yCount = Globals.MapEditorWindow.picMap.Height * Options.TileHeight / fogTex.Height;
-
-            // Update the fog texture's position based on its speed and elapsed time.
-            sFogCurrentX += elapsedTime / 1000f * currentMap.FogXSpeed * 2;
-            sFogCurrentY += elapsedTime / 1000f * currentMap.FogYSpeed * 2;
-
-            // Handle cases where the fog texture's position goes out of bounds.
-            sFogCurrentX %= fogTex.Width;
-            sFogCurrentY %= fogTex.Height;
-
-            // Round the fog texture's position to the nearest integer value.
-            var drawX = (float)Math.Round(sFogCurrentX);
-            var drawY = (float)Math.Round(sFogCurrentY);
-
-            for (var x = 0; x <= xCount; x++)
-            {
-                for (var y = 0; y <= yCount; y++)
-                {
-                    DrawTexture(
-                        fogTex, new RectangleF(0, 0, fogTex.Width, fogTex.Height),
-                        new RectangleF(
-                            0 - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
-                            0 - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY, fogTex.Width,
-                            fogTex.Height
-                        ), System.Drawing.Color.FromArgb(currentMap.FogTransparency, 255, 255, 255), target
-                    );
-                }
-            }
-        }
-
-        //Lighting
-        private static void ClearDarknessTexture(RenderTarget2D target, bool screenShotting = false)
-        {
-            if (DarknessTexture == null)
-            {
-                DarknessTexture = CreateRenderTexture(
-                    Options.TileWidth * Options.MapWidth * 3, Options.TileHeight * Options.MapHeight * 3
-                );
-            }
-
-            SetRenderTarget(DarknessTexture);
-            sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
-            SetRenderTarget(null);
-
-            if (Globals.CurrentMap == null)
-            {
-                return;
-            }
-
-            var tmpMap = Globals.CurrentMap;
-            if (tmpMap == null)
-            {
-                return;
-            }
-
-            if (screenShotting)
-            {
-                var gridLightColor = System.Drawing.Color.FromArgb(Database.GridLightColor);
-                if (!tmpMap.IsIndoors)
-                {
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb(
-                            gridLightColor.A, gridLightColor.R, gridLightColor.G, gridLightColor.B
-                        ), DarknessTexture, BlendState.NonPremultiplied
-                    );
-                }
-                else
-                {
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb((byte) ((float) tmpMap.Brightness / 100f * 255f), 255, 255, 255),
-                        DarknessTexture, BlendState.Additive
-                    );
-                }
-            }
-            else
-            {
-                if (!tmpMap.IsIndoors && LightColor != null)
-                {
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb(LightColor.A, LightColor.R, LightColor.G, LightColor.B),
-                        DarknessTexture, BlendState.NonPremultiplied
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, 0, 32, 32),
-                        System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, DarknessTexture.Height - 32, 32, 32),
-                        System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(DarknessTexture.Width - 32, 0, 32, 32),
-                        System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
-                    );
-
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(DarknessTexture.Width - 32, DarknessTexture.Height - 32, 32, 32),
-                        System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
-                    );
-                }
-                else if (tmpMap.IsIndoors)
-                {
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb((byte) ((float) tmpMap.Brightness / 100f * 255f), 255, 255, 255),
-                        DarknessTexture, BlendState.Additive
-                    );
-                }
-                else
-                {
-                    DrawTexture(
-                        sWhiteTex, new RectangleF(0, 0, 1, 1),
-                        new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                        System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
-                    );
-                }
-            }
-
-            DrawLights(target);
-        }
-
-        private static void OverlayDarkness(RenderTarget2D target, bool screenShotting = false)
-        {
-            if (DarknessTexture == null)
-            {
-                return;
-            }
-
-            var tmpMap = Globals.CurrentMap;
-            if (TilePreviewStruct != null)
-            {
-                tmpMap = TilePreviewStruct;
-            }
-
-            DrawTexture(
-                DarknessTexture, new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
-                new RectangleF(
-                    CurrentView.Left - Options.MapWidth * Options.TileWidth,
-                    CurrentView.Top - Options.MapHeight * Options.TileHeight, DarknessTexture.Width,
-                    DarknessTexture.Height
-                ), System.Drawing.Color.FromArgb(255, 255, 255, 255), target, MultiplyState
-            );
-
-            ////Draw Light Attribute Icons
-            if (Globals.CurrentLayer != LayerOptions.Lights)
-            {
-                return;
-            }
-
-            if (!screenShotting)
-            {
-                for (var x = 0; x < Options.MapWidth; x++)
-                {
-                    for (var y = 0; y < Options.MapHeight; y++)
-                    {
-                        if (tmpMap.FindLightAt(x, y) == null)
-                        {
-                            continue;
-                        }
-
-                        var lightTex = GameContentManager.GetTexture(
-                            GameContentManager.TextureType.Misc, "lighticon.png"
-                        );
-
-                        if (lightTex != null)
+                        if (Globals.MapGrid.ShowLines)
                         {
                             DrawTexture(
-                                lightTex, new RectangleF(0, 0, lightTex.Width, lightTex.Height),
+                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
                                 new RectangleF(
-                                    x * Options.TileWidth + Options.MapWidth * Options.TileWidth * 0 + CurrentView.Left,
-                                    y * Options.TileHeight +
-                                    Options.MapHeight * Options.TileHeight * 0 +
-                                    CurrentView.Top, Options.TileWidth, Options.TileHeight
-                                ), System.Drawing.Color.White, target
+                                    grid.ContentRect.X + x * grid.TileWidth,
+                                    grid.ContentRect.Y + y * grid.TileHeight, grid.TileWidth, 1
+                                ), System.Drawing.Color.DarkGray, sMapGridChain
+                            );
+
+                            DrawTexture(
+                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+                                new RectangleF(
+                                    grid.ContentRect.X + x * grid.TileWidth,
+                                    grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
+                                ), System.Drawing.Color.DarkGray, sMapGridChain
+                            );
+
+                            DrawTexture(
+                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+                                new RectangleF(
+                                    grid.ContentRect.X + x * grid.TileWidth + grid.TileWidth,
+                                    grid.ContentRect.Y + y * grid.TileHeight, 1, grid.TileHeight
+                                ), System.Drawing.Color.DarkGray, sMapGridChain
+                            );
+
+                            DrawTexture(
+                                GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+                                new RectangleF(
+                                    grid.ContentRect.X + x * grid.TileWidth,
+                                    grid.ContentRect.Y + y * grid.TileHeight + grid.TileHeight, grid.TileWidth, 1
+                                ), System.Drawing.Color.DarkGray, sMapGridChain
                             );
                         }
                     }
+                }
+            }
+        }
+
+        EndSpriteBatch();
+        sMapGridChain.Present();
+    }
+
+    private static void SetRenderTarget(RenderTarget2D target)
+    {
+        EndSpriteBatch();
+        sGraphicsDevice.SetRenderTarget(target);
+    }
+
+    public static void DrawTileset()
+    {
+        if (sTilesetChain == null ||
+            sTilesetChain.IsContentLost ||
+            sTilesetChain.IsDisposed ||
+            Globals.MapLayersWindow.CurrentTab != LayerTabs.Tiles)
+        {
+            return;
+        }
+
+        SetRenderTarget(sTilesetChain);
+        sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
+        if (Globals.CurrentTileset != null)
+        {
+            var tilesetTex = GameContentManager.GetTexture(
+                GameContentManager.TextureType.Tileset, Globals.CurrentTileset.Name
+            );
+
+            if (tilesetTex != null)
+            {
+                DrawTexture(tilesetTex, 0, 0, sTilesetChain);
+                var selX = Globals.CurSelX;
+                var selY = Globals.CurSelY;
+                var selW = Globals.CurSelW;
+                var selH = Globals.CurSelH;
+                if (selW < 0)
+                {
+                    selX -= Math.Abs(selW);
+                    selW = Math.Abs(selW);
+                }
+
+                if (selH < 0)
+                {
+                    selY -= Math.Abs(selH);
+                    selH = Math.Abs(selH);
                 }
 
                 DrawBoxOutline(
-                    CurrentView.Left + Globals.CurTileX * Options.TileWidth,
-                    CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
-                    System.Drawing.Color.White, target
+                    selX * Options.TileWidth, selY * Options.TileHeight,
+                    Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight,
+                    System.Drawing.Color.White, sTilesetChain
                 );
             }
         }
 
-        private static void DrawLights(RenderTarget2D target = null)
-        {
-            foreach (var light in sLightQueue)
-            {
-                var x = light.Key.X;
-                var y = light.Key.Y;
-                DrawLight(x, y, light.Value, DarknessTexture);
-            }
+        EndSpriteBatch();
+        sTilesetChain.Present();
+    }
 
-            sLightQueue.Clear();
-        }
-
-        public static void DrawLight(int x, int y, LightBase light, RenderTarget2D target)
-        {
-            var shader = GameContentManager.GetShader("radialgradient_editor.xnb");
-            var vec = new Vector4(
-                light.Color.R / 255f, light.Color.G / 255f, light.Color.B / 255f, light.Intensity / 255f
-            );
-
-            shader.Parameters["LightColor"].SetValue(vec);
-            shader.Parameters["Expand"].SetValue((float) (light.Expand / 100f));
-            y -= light.Size;
-            x -= light.Size;
-            DrawTexture(
-                sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, light.Size * 2, light.Size * 2),
-                System.Drawing.Color.White, target, BlendState.Additive, shader
-            );
-        }
-
-        public static void AddLight(int x, int y, LightBase light, RenderTarget2D target = null)
-        {
-            if (target == null)
-            {
-                target = DarknessTexture;
-            }
-
-            sLightQueue.Add(
-                new KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>(
-                    new Microsoft.Xna.Framework.Point(x, y), light
-                )
-            );
-        }
-
-        //Rendering
-        //Rendering Functions
-        public static void DrawTexture(Texture2D tex, float x, float y, RenderTarget2D renderTarget2D)
-        {
-            var destRectangle = new RectangleF(x, y, (int) tex.Width, (int) tex.Height);
-            var srcRectangle = new RectangleF(0, 0, (int) tex.Width, (int) tex.Height);
-            DrawTexture(tex, srcRectangle, destRectangle, renderTarget2D);
-        }
-
-        public static void DrawTexture(
-            Texture2D tex,
-            float x,
-            float y,
-            RenderTarget2D renderTarget2D,
-            BlendState blendMode
-        )
-        {
-            var destRectangle = new RectangleF(x, y, (int)tex.Width, (int)tex.Height);
-            var srcRectangle = new RectangleF(0, 0, (int)tex.Width, (int)tex.Height);
-            DrawTexture(tex, srcRectangle, destRectangle, System.Drawing.Color.White, renderTarget2D, blendMode);
-        }
-
-        public static void DrawTexture(
-            Texture2D tex,
-            float dx,
-            float dy,
-            float sx,
-            float sy,
-            float w,
-            float h,
-            RenderTarget2D renderTarget2D
-        )
-        {
-            var destRectangle = new RectangleF(dx, dy, w, h);
-            var srcRectangle = new RectangleF(sx, sy, w, h);
-            DrawTexture(tex, srcRectangle, destRectangle, renderTarget2D);
-        }
-
-        public static void DrawTexture(
-            Texture2D tex,
-            RectangleF srcRectangle,
-            RectangleF targetRect,
-            RenderTarget2D renderTarget2D
-        )
-        {
-            DrawTexture(
-                tex, srcRectangle, targetRect, System.Drawing.Color.White, renderTarget2D, BlendState.NonPremultiplied
-            );
-        }
-
-        public static void DrawTexture(
-            Texture2D texture,
-            Microsoft.Xna.Framework.Rectangle source,
-            Microsoft.Xna.Framework.Rectangle destination,
-            Color renderColor,
-            RenderTarget2D renderTarget = null,
-            BlendState blendMode = null,
-            Effect shader = null,
-            float rotationDegrees = 0
-        ) => DrawTexture(
-            texture,
-            new RectangleF(source.X, source.Y, source.Width, source.Height),
-            new RectangleF(destination.X, destination.Y, destination.Width, destination.Height),
-            System.Drawing.Color.FromArgb(renderColor.ToArgb()),
-            renderTarget,
-            blendMode,
-            shader,
-            rotationDegrees
+    private static void DrawMapBorders()
+    {
+        //Horizontal Top
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, CurrentView.Y - 1, CurrentView.Width, 3),
+            System.Drawing.Color.DimGray
         );
 
-        public static void DrawTexture(
-            Texture2D texture,
-            RectangleF source,
-            RectangleF destination,
-            Color renderColor,
-            RenderTarget2D renderTarget = null,
-            BlendState blendMode = null,
-            Effect shader = null,
-            float rotationDegrees = 0
-        ) => DrawTexture(
-            texture,
-            source,
-            destination,
-            System.Drawing.Color.FromArgb(renderColor.ToArgb()),
-            renderTarget,
-            blendMode,
-            shader,
-            rotationDegrees
+        //Horizontal Buttom
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(0, CurrentView.Y + Options.TileHeight * Options.MapHeight - 1, CurrentView.Width, 3),
+            System.Drawing.Color.DimGray
         );
 
-        public static void DrawTexture(
-            Texture2D tex,
-            RectangleF srcRectangle,
-            RectangleF targetRect,
-            System.Drawing.Color renderColor,
-            RenderTarget2D renderTarget = null,
-            BlendState blendMode = null,
-            Effect shader = null,
-            float rotationDegrees = 0
-        )
+        //Vertical Left
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(CurrentView.Left - 1, 0, 3, CurrentView.Height),
+            System.Drawing.Color.DimGray
+        );
+
+        //Vertical Right
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(CurrentView.Left + Options.TileWidth * Options.MapWidth - 1, 0, 3, CurrentView.Height),
+            System.Drawing.Color.DimGray
+        );
+
+        //Horizontal Top
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(CurrentView.Left, CurrentView.Y - 1, Options.TileWidth * Options.MapWidth, 3),
+            System.Drawing.Color.DimGray
+        );
+
+        //Horizontal Buttom
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(
+                CurrentView.Left, CurrentView.Y + Options.TileHeight * Options.MapHeight - 1,
+                Options.TileWidth * Options.MapWidth, 3
+            ), System.Drawing.Color.DimGray
+        );
+
+        //Vertical Left
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(CurrentView.Left - 1, CurrentView.Y, 3, Options.MapHeight * Options.TileHeight),
+            System.Drawing.Color.DimGray
+        );
+
+        //Vertical Right
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1),
+            new RectangleF(
+                CurrentView.Left + Options.TileWidth * Options.MapWidth - 1, CurrentView.Y, 3,
+                Options.MapHeight * Options.TileHeight
+            ), System.Drawing.Color.DimGray
+        );
+    }
+
+    private static void DrawMapAttributes(
+        MapInstance map,
+        int gridX,
+        int gridY,
+        bool screenShotting,
+        RenderTarget2D renderTarget,
+        bool upper,
+        bool alternate
+    )
+    {
+        if (!screenShotting && HideResources)
         {
-            if (tex == null)
+            return;
+        }
+
+        if (screenShotting && Database.GridHideResources)
+        {
+            return;
+        }
+
+        var tmpMap = Globals.CurrentMap;
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        var x1 = 0;
+        var x2 = Options.MapWidth;
+        var y1 = 0;
+        var y2 = Options.MapHeight;
+        var xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
+        var yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
+
+        if (screenShotting)
+        {
+            xoffset -= CurrentView.Left;
+            yoffset -= CurrentView.Top;
+        }
+
+        if (gridX != 0 || gridY != 0)
+        {
+            tmpMap = map;
+        }
+        else if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
+        {
+            tmpMap = TilePreviewStruct;
+        }
+
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        for (var y = y1; y < y2; y++)
+        {
+            for (var x = x1; x < x2; x++)
             {
-                return;
+                if (tmpMap.Attributes[x, y] == null)
+                {
+                    continue;
+                }
+
+                if (tmpMap.Attributes[x, y].Type == MapAttribute.Resource && !upper && !alternate)
+                {
+                    var resource = ResourceBase.Get(((MapResourceAttribute) tmpMap.Attributes[x, y]).ResourceId);
+                    if (resource == null)
+                    {
+                        continue;
+                    }
+
+                    if (TextUtils.IsNone(resource.Initial.Graphic))
+                    {
+                        continue;
+                    }
+
+                    if (resource.Initial.GraphicFromTileset)
+                    {
+                        var res = GameContentManager.GetTexture(
+                            GameContentManager.TextureType.Tileset, resource.Initial.Graphic
+                        );
+
+                        if (res == null)
+                        {
+                            continue;
+                        }
+
+                        float xpos = x * Options.TileWidth + xoffset;
+                        float ypos = y * Options.TileHeight + yoffset;
+                        if ((resource.Initial.Height + 1) * Options.TileHeight > Options.TileHeight)
+                        {
+                            ypos -= (resource.Initial.Height + 1) * Options.TileHeight - Options.TileHeight;
+                        }
+
+                        if ((resource.Initial.Width + 1) * Options.TileWidth > Options.TileWidth)
+                        {
+                            xpos -= ((resource.Initial.Width + 1) * Options.TileWidth - Options.TileWidth) / 2;
+                        }
+
+                        DrawTexture(
+                            res, xpos, ypos, resource.Initial.X * Options.TileWidth,
+                            resource.Initial.Y * Options.TileHeight,
+                            (resource.Initial.Width + 1) * Options.TileWidth,
+                            (resource.Initial.Height + 1) * Options.TileHeight, renderTarget
+                        );
+                    }
+                    else
+                    {
+                        var res = GameContentManager.GetTexture(
+                            GameContentManager.TextureType.Resource, resource.Initial.Graphic
+                        );
+
+                        if (res == null)
+                        {
+                            continue;
+                        }
+
+                        float xpos = x * Options.TileWidth + xoffset;
+                        float ypos = y * Options.TileHeight + yoffset;
+                        if (res.Height > Options.TileHeight)
+                        {
+                            ypos -= res.Height - Options.TileHeight;
+                        }
+
+                        if (res.Width > Options.TileWidth)
+                        {
+                            xpos -= (res.Width - Options.TileWidth) / 2;
+                        }
+
+                        DrawTexture(res, xpos, ypos, 0, 0, res.Width, res.Height, renderTarget);
+                    }
+                }
+                else if (tmpMap.Attributes[x, y].Type == MapAttribute.Animation)
+                {
+                    var animation =
+                        AnimationBase.Get(((MapAnimationAttribute) tmpMap.Attributes[x, y]).AnimationId);
+
+                    if (animation != null)
+                    {
+                        float xpos = x * Options.TileWidth + xoffset + Options.TileWidth / 2;
+                        float ypos = y * Options.TileHeight + yoffset + Options.TileHeight / 2;
+                        if (tmpMap.Attributes[x, y] != null)
+                        {
+                            var animInstance = tmpMap.GetAttributeAnimation(tmpMap.Attributes[x, y], animation.Id);
+
+                            //Update if the animation isn't right!
+                            if (animInstance == null || animInstance.MyBase != animation)
+                            {
+                                tmpMap.SetAttributeAnimation(
+                                    tmpMap.Attributes[x, y], new Animation(animation, true)
+                                );
+                            }
+
+                            animInstance.Update();
+                            animInstance.SetPosition((int) xpos, (int) ypos, 0);
+                            animInstance.Draw(renderTarget, upper, alternate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void DrawMapEvents(
+        MapInstance map,
+        int gridX,
+        int gridY,
+        bool screenShotting,
+        RenderTarget2D renderTarget
+    )
+    {
+        if (!screenShotting && HideEvents)
+        {
+            return;
+        }
+
+        if (screenShotting && Database.GridHideEvents)
+        {
+            return;
+        }
+
+        var tmpMap = Globals.CurrentMap;
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        int x1 = 0, y1 = 0, x2 = 0, y2 = 0, xoffset = 0, yoffset = 0;
+
+        x1 = 0;
+        x2 = Options.MapWidth;
+        y1 = 0;
+        y2 = Options.MapHeight;
+        xoffset = CurrentView.Left + gridX * Options.TileWidth * Options.MapWidth;
+        yoffset = CurrentView.Top + gridY * Options.TileHeight * Options.MapHeight;
+        if (gridX != 0 || gridY != 0)
+        {
+            tmpMap = map;
+        }
+
+        if (screenShotting)
+        {
+            xoffset -= CurrentView.Left;
+            yoffset -= CurrentView.Top;
+        }
+
+        if (gridX == 0 && gridY == 0)
+        {
+            if ((!HideTilePreview || Globals.Dragging) && !screenShotting)
+            {
+                tmpMap = TilePreviewStruct;
+            }
+        }
+
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        for (var y = y1; y < y2; y++)
+        {
+            for (var x = x1; x < x2; x++)
+            {
+                var tmpEvent = tmpMap.FindEventAt(x, y);
+                if (tmpEvent == null)
+                {
+                    continue;
+                }
+
+                if (tmpEvent.Pages[0].Graphic == null)
+                {
+                    continue;
+                }
+
+                var tmpGraphic = tmpEvent.Pages[0].Graphic;
+                if (TextUtils.IsNone(tmpGraphic.Filename))
+                {
+                    continue;
+                }
+
+                Texture2D eventTex = null;
+                var destinationX = x * Options.TileWidth + xoffset;
+                var destinationY = y * Options.TileHeight + yoffset;
+                var sourceX = 0;
+                var sourceY = 0;
+                var width = 0;
+                var height = 0;
+
+                switch (tmpGraphic.Type)
+                {
+                    case EventGraphicType.Sprite: //Sprite
+                        eventTex = GameContentManager.GetTexture(
+                            GameContentManager.TextureType.Entity, tmpGraphic.Filename
+                        );
+                        if (eventTex == null)
+                        {
+                            continue;
+                        }
+
+                        sourceX = (int)tmpGraphic.X * (eventTex.Width / Options.Instance.Sprites.NormalFrames);
+                        sourceY = (int)tmpGraphic.Y * (eventTex.Height / Options.Instance.Sprites.Directions);
+                        width = (eventTex.Width / Options.Instance.Sprites.NormalFrames);
+                        height = (eventTex.Height / Options.Instance.Sprites.Directions);
+
+                        break;
+                    case EventGraphicType.Tileset: //Tile
+                        eventTex = GameContentManager.GetTexture(
+                            GameContentManager.TextureType.Tileset, tmpGraphic.Filename
+                        );
+                        if (eventTex == null)
+                        {
+                            continue;
+                        }
+
+                        sourceX = (int)tmpGraphic.X * Options.TileWidth;
+                        sourceY = (int)tmpGraphic.Y * Options.TileHeight;
+                        width = (tmpGraphic.Width + 1) * Options.TileWidth;
+                        height = (tmpGraphic.Height + 1) * Options.TileHeight;
+
+                        break;
+                }
+
+                if (height > Options.TileHeight)
+                {
+                    destinationY -= (height - Options.TileHeight);
+                }
+
+                if (width > Options.TileWidth)
+                {
+                    destinationX -= (width  - Options.TileWidth) / 2;
+                }
+
+                DrawTexture(eventTex, destinationX, destinationY, sourceX, sourceY, width, height, renderTarget);
+            }
+        }
+    }
+    private static void DrawMapOverlay(RenderTarget2D target)
+    {
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, 0, CurrentView.Width, CurrentView.Height),
+            System.Drawing.Color.FromArgb(
+                Globals.CurrentMap.AHue, Globals.CurrentMap.RHue, Globals.CurrentMap.GHue, Globals.CurrentMap.BHue
+            ), target
+        );
+    }
+
+    public static Bitmap ScreenShotMap()
+    {
+        if (sScreenShotRenderTexture == null)
+        {
+            sScreenShotRenderTexture = CreateRenderTexture(
+                Options.MapWidth * Options.TileWidth, Options.MapHeight * Options.TileHeight
+            );
+        }
+
+        SetRenderTarget(sScreenShotRenderTexture);
+        sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
+
+        if (Globals.MapGrid.Contains(Globals.CurrentMap.Id))
+        {
+            //Draw The lower maps
+            for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; ++y)
+            {
+                for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; ++x)
+                {
+                    if (x < 0 || x >= Globals.MapGrid.GridWidth)
+                    {
+                        continue;
+                    }
+
+                    if (y < 0 || y >= Globals.MapGrid.GridHeight)
+                    {
+                        continue;
+                    }
+
+                    var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                    if (map == null)
+                    {
+                        continue;
+                    }
+
+                    lock (map.MapLock)
+                    {
+                        //Draw this map
+                        DrawMap(
+                            map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true, 0,
+                            sScreenShotRenderTexture
+                        );
+                    }
+                }
             }
 
-            if (blendMode == null)
+            //Draw the lower resources/animations
+            for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
             {
-                blendMode = BlendState.NonPremultiplied;
+                for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                {
+                    if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                    {
+                        var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                        if (map != null)
+                        {
+                            lock (map.MapLock)
+                            {
+                                DrawMapAttributes(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
+                                    sScreenShotRenderTexture, false, false
+                                );
+
+                                DrawMapAttributes(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
+                                    sScreenShotRenderTexture, false, true
+                                );
+
+                                DrawMapAttributes(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
+                                    sScreenShotRenderTexture, true, true
+                                );
+                            }
+                        }
+                    }
+                }
             }
+
+            // Draw events
+            for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+            {
+                for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                {
+                    if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                    {
+                        var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                        if (map != null)
+                        {
+                            lock (map.MapLock)
+                            {
+                                DrawMapEvents(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY,
+                                    true, sScreenShotRenderTexture
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            //Draw The upper maps
+            for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+            {
+                for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                {
+                    if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                    {
+                        var map = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                        if (map != null)
+                        {
+                            lock (map.MapLock)
+                            {
+                                //Draw this map
+                                DrawMap(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true, 1,
+                                    sScreenShotRenderTexture
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            //Draw the upper resources/animations
+            for (var y = Globals.CurrentMap.MapGridY - 1; y <= Globals.CurrentMap.MapGridY + 1; y++)
+            {
+                for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                {
+                    if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                    {
+                        var map = MapInstance.Get(Globals.MapGrid.Grid?[x, y]?.MapId ?? Guid.Empty);
+                        if (map != null)
+                        {
+                            lock (map.MapLock)
+                            {
+                                DrawMapAttributes(
+                                    map, x - Globals.CurrentMap.MapGridX, y - Globals.CurrentMap.MapGridY, true,
+                                    sScreenShotRenderTexture, true, false
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            lock (Globals.CurrentMap.MapLock)
+            {
+                //Draw this map
+                DrawMap(Globals.CurrentMap, 0, 0, true, 0, sScreenShotRenderTexture);
+                DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, false, false);
+                DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, false, true);
+                DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, true, true);
+
+                //Draw this map
+                DrawMap(Globals.CurrentMap, 0, 0, true, 1, sScreenShotRenderTexture);
+                DrawMapAttributes(Globals.CurrentMap, 0, 0, true, sScreenShotRenderTexture, true, false);
+            }
+        }
+
+        if (!Database.GridHideFog)
+        {
+            DrawFog(sScreenShotRenderTexture);
+        }
+
+        if (!Database.GridHideOverlay)
+        {
+            DrawMapOverlay(sScreenShotRenderTexture);
+        }
+
+        if (!Database.GridHideDarkness || Globals.CurrentLayer == LayerOptions.Lights)
+        {
+            ClearDarknessTexture(sScreenShotRenderTexture, true);
+            OverlayDarkness(sScreenShotRenderTexture, true);
+        }
+
+        EndSpriteBatch();
+        var data = new int[sScreenShotRenderTexture.Width * sScreenShotRenderTexture.Height];
+        sScreenShotRenderTexture.GetData(
+            0,
+            new Microsoft.Xna.Framework.Rectangle(
+                0, 0, sScreenShotRenderTexture.Width, sScreenShotRenderTexture.Height
+            ), data, 0, sScreenShotRenderTexture.Width * sScreenShotRenderTexture.Height
+        );
+
+        var bitmap = new Bitmap(sScreenShotRenderTexture.Width, sScreenShotRenderTexture.Height);
+        var bits = bitmap.LockBits(
+            new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadWrite,
+            PixelFormat.Format32bppArgb
+        );
+
+        unsafe
+        {
+            var dstPointer = (byte*) bits.Scan0;
+            for (var y = 0; y < sScreenShotRenderTexture.Height; ++y)
+            {
+                for (var x = 0; x < sScreenShotRenderTexture.Width; ++x)
+                {
+                    var bitmapColor = System.Drawing.Color.FromArgb(data[y * sScreenShotRenderTexture.Width + x]);
+                    dstPointer[0] = bitmapColor.R;
+                    dstPointer[1] = bitmapColor.G;
+                    dstPointer[2] = bitmapColor.B;
+                    dstPointer[3] = bitmapColor.A;
+
+                    dstPointer += 4;
+                }
+            }
+        }
+
+        bitmap.UnlockBits(bits);
+
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Draws the fog over the map editor view.
+    /// </summary>
+    private static void DrawFog(RenderTarget2D target)
+    {
+        // Exit early if the map has no fog or if the fog texture is not available.
+        var currentMap = Globals.CurrentMap;
+        var fog = currentMap.Fog;
+        if (string.IsNullOrWhiteSpace(fog))
+        {
+            return;
+        }
+
+        // Get fog texture and exit early if it is not available.
+        var fogTex = GameContentManager.GetTexture(GameContentManager.TextureType.Fog, fog);
+        if (fogTex == null)
+        {
+            return;
+        }
+
+        // Calculate elapsed time since the last update and set maximum value for elapsedTime to
+        // prevent large jumps in fog intensity (1 second maximum).
+        float elapsedTime = Math.Min(Timing.Global.MillisecondsUtc - sFogUpdateTime, 1000);
+        sFogUpdateTime = Timing.Global.MillisecondsUtc;
+
+        // Calculate the number of times the fog texture needs to be drawn to cover the map area.
+        var xCount = Globals.MapEditorWindow.picMap.Width * Options.TileWidth / fogTex.Width;
+        var yCount = Globals.MapEditorWindow.picMap.Height * Options.TileHeight / fogTex.Height;
+
+        // Update the fog texture's position based on its speed and elapsed time.
+        sFogCurrentX += elapsedTime / 1000f * currentMap.FogXSpeed * 2;
+        sFogCurrentY += elapsedTime / 1000f * currentMap.FogYSpeed * 2;
+
+        // Handle cases where the fog texture's position goes out of bounds.
+        sFogCurrentX %= fogTex.Width;
+        sFogCurrentY %= fogTex.Height;
+
+        // Round the fog texture's position to the nearest integer value.
+        var drawX = (float)Math.Round(sFogCurrentX);
+        var drawY = (float)Math.Round(sFogCurrentY);
+
+        for (var x = 0; x <= xCount; x++)
+        {
+            for (var y = 0; y <= yCount; y++)
+            {
+                DrawTexture(
+                    fogTex, new RectangleF(0, 0, fogTex.Width, fogTex.Height),
+                    new RectangleF(
+                        0 - Options.MapWidth * Options.TileWidth * 1f + x * fogTex.Width + drawX,
+                        0 - Options.MapHeight * Options.TileHeight * 1f + y * fogTex.Height + drawY, fogTex.Width,
+                        fogTex.Height
+                    ), System.Drawing.Color.FromArgb(currentMap.FogTransparency, 255, 255, 255), target
+                );
+            }
+        }
+    }
+
+    //Lighting
+    private static void ClearDarknessTexture(RenderTarget2D target, bool screenShotting = false)
+    {
+        if (DarknessTexture == null)
+        {
+            DarknessTexture = CreateRenderTexture(
+                Options.TileWidth * Options.MapWidth * 3, Options.TileHeight * Options.MapHeight * 3
+            );
+        }
+
+        SetRenderTarget(DarknessTexture);
+        sGraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
+        SetRenderTarget(null);
+
+        if (Globals.CurrentMap == null)
+        {
+            return;
+        }
+
+        var tmpMap = Globals.CurrentMap;
+        if (tmpMap == null)
+        {
+            return;
+        }
+
+        if (screenShotting)
+        {
+            var gridLightColor = System.Drawing.Color.FromArgb(Database.GridLightColor);
+            if (!tmpMap.IsIndoors)
+            {
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb(
+                        gridLightColor.A, gridLightColor.R, gridLightColor.G, gridLightColor.B
+                    ), DarknessTexture, BlendState.NonPremultiplied
+                );
+            }
+            else
+            {
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb((byte) ((float) tmpMap.Brightness / 100f * 255f), 255, 255, 255),
+                    DarknessTexture, BlendState.Additive
+                );
+            }
+        }
+        else
+        {
+            if (!tmpMap.IsIndoors && LightColor != null)
+            {
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb(LightColor.A, LightColor.R, LightColor.G, LightColor.B),
+                    DarknessTexture, BlendState.NonPremultiplied
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, 0, 32, 32),
+                    System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(0, DarknessTexture.Height - 32, 32, 32),
+                    System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(DarknessTexture.Width - 32, 0, 32, 32),
+                    System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
+                );
+
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(DarknessTexture.Width - 32, DarknessTexture.Height - 32, 32, 32),
+                    System.Drawing.Color.FromArgb(255, 255, 0, 0), DarknessTexture, BlendState.NonPremultiplied
+                );
+            }
+            else if (tmpMap.IsIndoors)
+            {
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb((byte) ((float) tmpMap.Brightness / 100f * 255f), 255, 255, 255),
+                    DarknessTexture, BlendState.Additive
+                );
+            }
+            else
+            {
+                DrawTexture(
+                    sWhiteTex, new RectangleF(0, 0, 1, 1),
+                    new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+                    System.Drawing.Color.FromArgb(255, 255, 255, 255), DarknessTexture, BlendState.Additive
+                );
+            }
+        }
+
+        DrawLights(target);
+    }
+
+    private static void OverlayDarkness(RenderTarget2D target, bool screenShotting = false)
+    {
+        if (DarknessTexture == null)
+        {
+            return;
+        }
+
+        var tmpMap = Globals.CurrentMap;
+        if (TilePreviewStruct != null)
+        {
+            tmpMap = TilePreviewStruct;
+        }
+
+        DrawTexture(
+            DarknessTexture, new RectangleF(0, 0, DarknessTexture.Width, DarknessTexture.Height),
+            new RectangleF(
+                CurrentView.Left - Options.MapWidth * Options.TileWidth,
+                CurrentView.Top - Options.MapHeight * Options.TileHeight, DarknessTexture.Width,
+                DarknessTexture.Height
+            ), System.Drawing.Color.FromArgb(255, 255, 255, 255), target, MultiplyState
+        );
+
+        ////Draw Light Attribute Icons
+        if (Globals.CurrentLayer != LayerOptions.Lights)
+        {
+            return;
+        }
+
+        if (!screenShotting)
+        {
+            for (var x = 0; x < Options.MapWidth; x++)
+            {
+                for (var y = 0; y < Options.MapHeight; y++)
+                {
+                    if (tmpMap.FindLightAt(x, y) == null)
+                    {
+                        continue;
+                    }
+
+                    var lightTex = GameContentManager.GetTexture(
+                        GameContentManager.TextureType.Misc, "lighticon.png"
+                    );
+
+                    if (lightTex != null)
+                    {
+                        DrawTexture(
+                            lightTex, new RectangleF(0, 0, lightTex.Width, lightTex.Height),
+                            new RectangleF(
+                                x * Options.TileWidth + Options.MapWidth * Options.TileWidth * 0 + CurrentView.Left,
+                                y * Options.TileHeight +
+                                Options.MapHeight * Options.TileHeight * 0 +
+                                CurrentView.Top, Options.TileWidth, Options.TileHeight
+                            ), System.Drawing.Color.White, target
+                        );
+                    }
+                }
+            }
+
+            DrawBoxOutline(
+                CurrentView.Left + Globals.CurTileX * Options.TileWidth,
+                CurrentView.Top + Globals.CurTileY * Options.TileHeight, Options.TileWidth, Options.TileHeight,
+                System.Drawing.Color.White, target
+            );
+        }
+    }
+
+    private static void DrawLights(RenderTarget2D target = null)
+    {
+        foreach (var light in sLightQueue)
+        {
+            var x = light.Key.X;
+            var y = light.Key.Y;
+            DrawLight(x, y, light.Value, DarknessTexture);
+        }
+
+        sLightQueue.Clear();
+    }
+
+    public static void DrawLight(int x, int y, LightBase light, RenderTarget2D target)
+    {
+        var shader = GameContentManager.GetShader("radialgradient_editor.xnb");
+        var vec = new Vector4(
+            light.Color.R / 255f, light.Color.G / 255f, light.Color.B / 255f, light.Intensity / 255f
+        );
+
+        shader.Parameters["LightColor"].SetValue(vec);
+        shader.Parameters["Expand"].SetValue((float) (light.Expand / 100f));
+        y -= light.Size;
+        x -= light.Size;
+        DrawTexture(
+            sWhiteTex, new RectangleF(0, 0, 1, 1), new RectangleF(x, y, light.Size * 2, light.Size * 2),
+            System.Drawing.Color.White, target, BlendState.Additive, shader
+        );
+    }
+
+    public static void AddLight(int x, int y, LightBase light, RenderTarget2D target = null)
+    {
+        if (target == null)
+        {
+            target = DarknessTexture;
+        }
+
+        sLightQueue.Add(
+            new KeyValuePair<Microsoft.Xna.Framework.Point, LightBase>(
+                new Microsoft.Xna.Framework.Point(x, y), light
+            )
+        );
+    }
+
+    //Rendering
+    //Rendering Functions
+    public static void DrawTexture(Texture2D tex, float x, float y, RenderTarget2D renderTarget2D)
+    {
+        var destRectangle = new RectangleF(x, y, (int) tex.Width, (int) tex.Height);
+        var srcRectangle = new RectangleF(0, 0, (int) tex.Width, (int) tex.Height);
+        DrawTexture(tex, srcRectangle, destRectangle, renderTarget2D);
+    }
+
+    public static void DrawTexture(
+        Texture2D tex,
+        float x,
+        float y,
+        RenderTarget2D renderTarget2D,
+        BlendState blendMode
+    )
+    {
+        var destRectangle = new RectangleF(x, y, (int)tex.Width, (int)tex.Height);
+        var srcRectangle = new RectangleF(0, 0, (int)tex.Width, (int)tex.Height);
+        DrawTexture(tex, srcRectangle, destRectangle, System.Drawing.Color.White, renderTarget2D, blendMode);
+    }
+
+    public static void DrawTexture(
+        Texture2D tex,
+        float dx,
+        float dy,
+        float sx,
+        float sy,
+        float w,
+        float h,
+        RenderTarget2D renderTarget2D
+    )
+    {
+        var destRectangle = new RectangleF(dx, dy, w, h);
+        var srcRectangle = new RectangleF(sx, sy, w, h);
+        DrawTexture(tex, srcRectangle, destRectangle, renderTarget2D);
+    }
+
+    public static void DrawTexture(
+        Texture2D tex,
+        RectangleF srcRectangle,
+        RectangleF targetRect,
+        RenderTarget2D renderTarget2D
+    )
+    {
+        DrawTexture(
+            tex, srcRectangle, targetRect, System.Drawing.Color.White, renderTarget2D, BlendState.NonPremultiplied
+        );
+    }
+
+    public static void DrawTexture(
+        Texture2D texture,
+        Microsoft.Xna.Framework.Rectangle source,
+        Microsoft.Xna.Framework.Rectangle destination,
+        Color renderColor,
+        RenderTarget2D renderTarget = null,
+        BlendState blendMode = null,
+        Effect shader = null,
+        float rotationDegrees = 0
+    ) => DrawTexture(
+        texture,
+        new RectangleF(source.X, source.Y, source.Width, source.Height),
+        new RectangleF(destination.X, destination.Y, destination.Width, destination.Height),
+        System.Drawing.Color.FromArgb(renderColor.ToArgb()),
+        renderTarget,
+        blendMode,
+        shader,
+        rotationDegrees
+    );
+
+    public static void DrawTexture(
+        Texture2D texture,
+        RectangleF source,
+        RectangleF destination,
+        Color renderColor,
+        RenderTarget2D renderTarget = null,
+        BlendState blendMode = null,
+        Effect shader = null,
+        float rotationDegrees = 0
+    ) => DrawTexture(
+        texture,
+        source,
+        destination,
+        System.Drawing.Color.FromArgb(renderColor.ToArgb()),
+        renderTarget,
+        blendMode,
+        shader,
+        rotationDegrees
+    );
+
+    public static void DrawTexture(
+        Texture2D tex,
+        RectangleF srcRectangle,
+        RectangleF targetRect,
+        System.Drawing.Color renderColor,
+        RenderTarget2D renderTarget = null,
+        BlendState blendMode = null,
+        Effect shader = null,
+        float rotationDegrees = 0
+    )
+    {
+        if (tex == null)
+        {
+            return;
+        }
+
+        if (blendMode == null)
+        {
+            blendMode = BlendState.NonPremultiplied;
+        }
 
 			StartSpritebatch(blendMode, shader, renderTarget, false, null);
 			sSpriteBatch.Draw(
@@ -2233,83 +2233,81 @@ namespace Intersect.Editor.Core
 					(int) srcRectangle.X, (int) srcRectangle.Y, (int) srcRectangle.Width, (int) srcRectangle.Height
 				), ConvertColor(renderColor), rotationDegrees, Vector2.Zero, SpriteEffects.None, 0
 			);
-        }
+    }
 
-        //Extra MonoGame Stuff
-        public static Microsoft.Xna.Framework.Color ConvertColor(System.Drawing.Color clr)
+    //Extra MonoGame Stuff
+    public static Microsoft.Xna.Framework.Color ConvertColor(System.Drawing.Color clr)
+    {
+        return new Microsoft.Xna.Framework.Color(
+            new Vector4(clr.R / 255f, clr.G / 255f, clr.B / 255f, clr.A / 255f)
+        );
+    }
+
+    private static void StartSpritebatch(
+        BlendState mode = null,
+        Effect shader = null,
+        RenderTarget2D target = null,
+        bool forced = false,
+        RasterizerState rs = null
+    )
+    {
+        if (sSpriteBatch.GraphicsDevice == null)
         {
-            return new Microsoft.Xna.Framework.Color(
-                new Vector4(clr.R / 255f, clr.G / 255f, clr.B / 255f, clr.A / 255f)
-            );
+            return;
         }
 
-        private static void StartSpritebatch(
-            BlendState mode = null,
-            Effect shader = null,
-            RenderTarget2D target = null,
-            bool forced = false,
-            RasterizerState rs = null
-        )
+        var viewsDiff = false;
+        if (mode == null)
         {
-            if (sSpriteBatch.GraphicsDevice == null)
-            {
-                return;
-            }
-
-            var viewsDiff = false;
-            if (mode == null)
-            {
-                mode = BlendState.NonPremultiplied;
-            }
-
-            if (mode != sCurrentBlendmode ||
-                shader != sCurrentShader ||
-                target != sCurrentTarget ||
-                viewsDiff ||
-                forced ||
-                !sSpriteBatchBegan)
-            {
-                if (sSpriteBatchBegan)
-                {
-                    EndSpriteBatch();
-                }
-
-                if (target == null)
-                {
-                    SetRenderTarget(sMapEditorChain);
-                }
-                else
-                {
-                    SetRenderTarget(target);
-                }
-
-                if (shader != null)
-                {
-                    sSpriteBatch.Begin(SpriteSortMode.Immediate, mode, null, null, rs, shader);
-                }
-                else
-                {
-                    sSpriteBatch.Begin(SpriteSortMode.Deferred, mode, null, null, rs, shader);
-                }
-
-                sCurrentBlendmode = mode;
-                sCurrentShader = shader;
-                sCurrentTarget = target;
-                sSpriteBatchBegan = true;
-            }
+            mode = BlendState.NonPremultiplied;
         }
 
-        public static void EndSpriteBatch()
+        if (mode != sCurrentBlendmode ||
+            shader != sCurrentShader ||
+            target != sCurrentTarget ||
+            viewsDiff ||
+            forced ||
+            !sSpriteBatchBegan)
         {
-            if (!sSpriteBatchBegan)
+            if (sSpriteBatchBegan)
             {
-                return;
+                EndSpriteBatch();
             }
 
-            sSpriteBatch.End();
-            sSpriteBatchBegan = false;
+            if (target == null)
+            {
+                SetRenderTarget(sMapEditorChain);
+            }
+            else
+            {
+                SetRenderTarget(target);
+            }
+
+            if (shader != null)
+            {
+                sSpriteBatch.Begin(SpriteSortMode.Immediate, mode, null, null, rs, shader);
+            }
+            else
+            {
+                sSpriteBatch.Begin(SpriteSortMode.Deferred, mode, null, null, rs, shader);
+            }
+
+            sCurrentBlendmode = mode;
+            sCurrentShader = shader;
+            sCurrentTarget = target;
+            sSpriteBatchBegan = true;
+        }
+    }
+
+    public static void EndSpriteBatch()
+    {
+        if (!sSpriteBatchBegan)
+        {
+            return;
         }
 
+        sSpriteBatch.End();
+        sSpriteBatchBegan = false;
     }
 
 }

--- a/Intersect.Editor/Core/Main.cs
+++ b/Intersect.Editor/Core/Main.cs
@@ -5,179 +5,177 @@ using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Core
+namespace Intersect.Editor.Core;
+
+
+public static partial class Main
 {
 
-    public static partial class Main
+    private static long sAnimationTimer = Timing.Global.MillisecondsUtc;
+
+    private static int sFps;
+
+    private static int sFpsCount;
+
+    private static long sFpsTime;
+
+    private static Thread sMapThread;
+
+    private static FrmMain sMyForm;
+
+    private static FrmProgress sProgressForm;
+
+    private static long sWaterfallTimer = Timing.Global.MillisecondsUtc;
+
+    public static void StartLoop()
     {
+        AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
+        Globals.MainForm.Visible = true;
+        Globals.MainForm.EnterMap(Globals.CurrentMap == null ? Guid.Empty : Globals.CurrentMap.Id);
+        sMyForm = Globals.MainForm;
 
-        private static long sAnimationTimer = Timing.Global.MillisecondsUtc;
+        if (sMapThread == null)
 
-        private static int sFps;
-
-        private static int sFpsCount;
-
-        private static long sFpsTime;
-
-        private static Thread sMapThread;
-
-        private static FrmMain sMyForm;
-
-        private static FrmProgress sProgressForm;
-
-        private static long sWaterfallTimer = Timing.Global.MillisecondsUtc;
-
-        public static void StartLoop()
         {
-            AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
-            Globals.MainForm.Visible = true;
-            Globals.MainForm.EnterMap(Globals.CurrentMap == null ? Guid.Empty : Globals.CurrentMap.Id);
-            sMyForm = Globals.MainForm;
+            sMapThread = new Thread(UpdateMaps);
+            sMapThread.Start();
 
-            if (sMapThread == null)
-
+            // drawing loop
+            while (sMyForm.Visible) // loop while the window is open
             {
-                sMapThread = new Thread(UpdateMaps);
-                sMapThread.Start();
-
-                // drawing loop
-                while (sMyForm.Visible) // loop while the window is open
-                {
-                    RunFrame();
-                }
+                RunFrame();
             }
         }
+    }
 
-        public static void DrawFrame()
+    public static void DrawFrame()
+    {
+        //Check Editors
+        if (Globals.ResourceEditor != null && Globals.ResourceEditor.IsDisposed == false)
         {
-            //Check Editors
-            if (Globals.ResourceEditor != null && Globals.ResourceEditor.IsDisposed == false)
-            {
-                Globals.ResourceEditor.Render();
-            }
-
-            if (Globals.MapGrid == null)
-            {
-                return;
-            }
-
-            lock (Globals.MapGrid.GetMapGridLock())
-            {
-                Graphics.Render();
-            }
+            Globals.ResourceEditor.Render();
         }
 
-        public static void RunFrame()
+        if (Globals.MapGrid == null)
         {
-            //Shooting for 30fps
-            var startTime = Timing.Global.MillisecondsUtc;
-            sMyForm.Update();
-
-            if (sWaterfallTimer < Timing.Global.MillisecondsUtc)
-            {
-                Globals.WaterfallFrame++;
-                if (Globals.WaterfallFrame == 3)
-                {
-                    Globals.WaterfallFrame = 0;
-                }
-
-                sWaterfallTimer = Timing.Global.MillisecondsUtc + 500;
-            }
-
-            if (sAnimationTimer < Timing.Global.MillisecondsUtc)
-            {
-                Globals.AutotileFrame++;
-                if (Globals.AutotileFrame == 3)
-                {
-                    Globals.AutotileFrame = 0;
-                }
-
-                sAnimationTimer = Timing.Global.MillisecondsUtc + 600;
-            }
-
-            DrawFrame();
-
-            GameContentManager.Update();
-            Networking.Network.Update();
-            Application.DoEvents(); // handle form events
-
-            sFpsCount++;
-            if (sFpsTime < Timing.Global.MillisecondsUtc)
-            {
-                sFps = sFpsCount;
-                sMyForm.toolStripLabelFPS.Text = Strings.MainForm.fps.ToString(sFps);
-                sFpsCount = 0;
-                sFpsTime = Timing.Global.MillisecondsUtc + 1000;
-            }
-
-            Thread.Sleep(Math.Max(1, (int) (1000 / 60f - (Timing.Global.MillisecondsUtc - startTime))));
+            return;
         }
 
-        private static void UpdateMaps()
+        lock (Globals.MapGrid.GetMapGridLock())
         {
-            while (!Globals.ClosingEditor)
+            Graphics.Render();
+        }
+    }
+
+    public static void RunFrame()
+    {
+        //Shooting for 30fps
+        var startTime = Timing.Global.MillisecondsUtc;
+        sMyForm.Update();
+
+        if (sWaterfallTimer < Timing.Global.MillisecondsUtc)
+        {
+            Globals.WaterfallFrame++;
+            if (Globals.WaterfallFrame == 3)
             {
-                if (Globals.MapsToScreenshot.Count > 0 &&
-                    Globals.FetchingMapPreviews == false &&
-                    sMyForm.InvokeRequired)
+                Globals.WaterfallFrame = 0;
+            }
+
+            sWaterfallTimer = Timing.Global.MillisecondsUtc + 500;
+        }
+
+        if (sAnimationTimer < Timing.Global.MillisecondsUtc)
+        {
+            Globals.AutotileFrame++;
+            if (Globals.AutotileFrame == 3)
+            {
+                Globals.AutotileFrame = 0;
+            }
+
+            sAnimationTimer = Timing.Global.MillisecondsUtc + 600;
+        }
+
+        DrawFrame();
+
+        GameContentManager.Update();
+        Networking.Network.Update();
+        Application.DoEvents(); // handle form events
+
+        sFpsCount++;
+        if (sFpsTime < Timing.Global.MillisecondsUtc)
+        {
+            sFps = sFpsCount;
+            sMyForm.toolStripLabelFPS.Text = Strings.MainForm.fps.ToString(sFps);
+            sFpsCount = 0;
+            sFpsTime = Timing.Global.MillisecondsUtc + 1000;
+        }
+
+        Thread.Sleep(Math.Max(1, (int) (1000 / 60f - (Timing.Global.MillisecondsUtc - startTime))));
+    }
+
+    private static void UpdateMaps()
+    {
+        while (!Globals.ClosingEditor)
+        {
+            if (Globals.MapsToScreenshot.Count > 0 &&
+                Globals.FetchingMapPreviews == false &&
+                sMyForm.InvokeRequired)
+            {
+                if (sProgressForm == null || sProgressForm.IsDisposed || sProgressForm.Visible == false)
                 {
-                    if (sProgressForm == null || sProgressForm.IsDisposed || sProgressForm.Visible == false)
+                    sProgressForm = new FrmProgress();
+
+                    sProgressForm.SetTitle(Strings.MapCacheProgress.title);
+                    new Task(() => Globals.MainForm.ShowDialogForm(sProgressForm)).Start();
+                    while (Globals.MapsToScreenshot.Count > 0)
                     {
-                        sProgressForm = new FrmProgress();
-
-                        sProgressForm.SetTitle(Strings.MapCacheProgress.title);
-                        new Task(() => Globals.MainForm.ShowDialogForm(sProgressForm)).Start();
-                        while (Globals.MapsToScreenshot.Count > 0)
+                        try
                         {
-                            try
+                            var maps = MapInstance.Lookup.ValueList.ToArray();
+                            foreach (MapInstance map in maps)
                             {
-                                var maps = MapInstance.Lookup.ValueList.ToArray();
-                                foreach (MapInstance map in maps)
+                                if (!sMyForm.Disposing && sProgressForm.IsHandleCreated)
                                 {
-                                    if (!sMyForm.Disposing && sProgressForm.IsHandleCreated)
-                                    {
-                                        sProgressForm.BeginInvoke(
-                                            (Action) (() => sProgressForm.SetProgress(
-                                                Strings.MapCacheProgress.remaining.ToString(
-                                                    Globals.MapsToScreenshot.Count
-                                                ), -1, false
-                                            ))
-                                        );
-                                    }
-
-                                    if (map != null)
-                                    {
-                                        map.Update();
-                                    }
-
-                                    Networking.Network.Update();
-                                    Application.DoEvents();
+                                    sProgressForm.BeginInvoke(
+                                        (Action) (() => sProgressForm.SetProgress(
+                                            Strings.MapCacheProgress.remaining.ToString(
+                                                Globals.MapsToScreenshot.Count
+                                            ), -1, false
+                                        ))
+                                    );
                                 }
-                            }
-                            catch (Exception ex)
-                            {
-                                Logging.Log.Error(
-                                    ex, "JC's Solution for UpdateMaps collection was modified bug did not work!"
-                                );
-                            }
 
-                            Thread.Sleep(50);
+                                if (map != null)
+                                {
+                                    map.Update();
+                                }
+
+                                Networking.Network.Update();
+                                Application.DoEvents();
+                            }
                         }
-
-                        Globals.MapGrid.ResetForm();
-                        while (!sProgressForm.IsHandleCreated)
+                        catch (Exception ex)
                         {
-                            Thread.Sleep(50);
+                            Logging.Log.Error(
+                                ex, "JC's Solution for UpdateMaps collection was modified bug did not work!"
+                            );
                         }
 
-                        sProgressForm.BeginInvoke(new Action(() => sProgressForm.Close()));
+                        Thread.Sleep(50);
                     }
+
+                    Globals.MapGrid.ResetForm();
+                    while (!sProgressForm.IsHandleCreated)
+                    {
+                        Thread.Sleep(50);
+                    }
+
+                    sProgressForm.BeginInvoke(new Action(() => sProgressForm.Close()));
                 }
-
-                Thread.Sleep(100);
             }
-        }
 
+            Thread.Sleep(100);
+        }
     }
 
 }

--- a/Intersect.Editor/Core/Preferences.cs
+++ b/Intersect.Editor/Core/Preferences.cs
@@ -2,46 +2,44 @@ using Intersect.Configuration;
 
 using Microsoft.Win32;
 
-namespace Intersect.Editor
+namespace Intersect.Editor.Core;
+
+
+public static partial class Preferences
 {
 
-    public static partial class Preferences
+    public static void SavePreference(string key, string value)
     {
+        var regkey = Registry.CurrentUser.OpenSubKey("Software", true);
 
-        public static void SavePreference(string key, string value)
+        regkey = regkey.CreateSubKey("IntersectEditor");
+        regkey = regkey.CreateSubKey($"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}");
+
+        regkey.SetValue(key, value);
+    }
+
+    public static string LoadPreference(string key)
+    {
+        var regkey = Registry.CurrentUser.OpenSubKey("Software", false);
+        regkey = regkey.OpenSubKey("IntersectEditor", false);
+        if (regkey == null)
         {
-            var regkey = Registry.CurrentUser.OpenSubKey("Software", true);
-
-            regkey = regkey.CreateSubKey("IntersectEditor");
-            regkey = regkey.CreateSubKey($"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}");
-
-            regkey.SetValue(key, value);
+            return string.Empty;
         }
 
-        public static string LoadPreference(string key)
+        regkey = regkey.OpenSubKey($"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}");
+        if (regkey == null)
         {
-            var regkey = Registry.CurrentUser.OpenSubKey("Software", false);
-            regkey = regkey.OpenSubKey("IntersectEditor", false);
-            if (regkey == null)
-            {
-                return string.Empty;
-            }
-
-            regkey = regkey.OpenSubKey($"{ClientConfiguration.Instance.Host}:{ClientConfiguration.Instance.Port}");
-            if (regkey == null)
-            {
-                return string.Empty;
-            }
-
-            var value = (string) regkey.GetValue(key);
-            if (string.IsNullOrEmpty(value))
-            {
-                return string.Empty;
-            }
-
-            return value;
+            return string.Empty;
         }
 
+        var value = (string) regkey.GetValue(key);
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value;
     }
 
 }

--- a/Intersect.Editor/Core/Program.cs
+++ b/Intersect.Editor/Core/Program.cs
@@ -5,88 +5,84 @@ using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Logging;
 
-// TODO: Move or change the namespace?
-// ReSharper disable once CheckNamespace
-namespace Intersect.Editor
+namespace Intersect.Editor.Core;
+
+public static partial class Program
 {
-    public static partial class Program
+    internal static readonly Icon? Icon;
+
+    private const string IconManifestResourceName = "Intersect.Editor.intersect-logo-qu.ico";
+
+    static Program()
     {
-        internal static readonly Icon? Icon;
-
-        private const string IconManifestResourceName = "Intersect.Editor.intersect-logo-qu.ico";
-
-        static Program()
+        var iconStream = typeof(Program).Assembly.GetManifestResourceStream(IconManifestResourceName);
+        if (iconStream == default)
         {
-            var iconStream = typeof(Program).Assembly.GetManifestResourceStream(IconManifestResourceName);
-            if (iconStream == default)
+            Console.Error.WriteLine($"Unable to find embedded resource with name '{IconManifestResourceName}'.");
+        }
+        else
+        {
+            Icon = new Icon(iconStream);
+            Console.WriteLine("Loaded embedded application icon successfully");
+        }
+    }
+
+    /// <summary>
+    ///     The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    public static void Main()
+    {
+        Log.Diagnostic("Starting editor...");
+
+        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        Application.ThreadException += Application_ThreadException;
+        Application.SetUnhandledExceptionMode(UnhandledExceptionMode.Automatic);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+
+        Log.Diagnostic("Unpacking libraries...");
+
+        //Place sqlite3.dll where it's needed.
+        var dllname = Environment.Is64BitProcess ? "sqlite3x64.dll" : "sqlite3x86.dll";
+        using (var resourceStream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Intersect.Editor.Resources." + dllname))
+        {
+            Debug.Assert(resourceStream != null, "resourceStream != null");
+            using (var fileStream = new FileStream("sqlite3.dll", FileMode.OpenOrCreate, FileAccess.ReadWrite))
             {
-                Console.Error.WriteLine($"Unable to find embedded resource with name '{IconManifestResourceName}'.");
-            }
-            else
-            {
-                Icon = new Icon(iconStream);
-                Console.WriteLine("Loaded embedded application icon successfully");
+                var data = new byte[resourceStream.Length];
+                resourceStream.Read(data, 0, (int) resourceStream.Length);
+                fileStream.Write(data, 0, data.Length);
             }
         }
 
-        /// <summary>
-        ///     The main entry point for the application.
-        /// </summary>
-        [STAThread]
-        public static void Main()
-        {
-            Log.Diagnostic("Starting editor...");
+        Log.Diagnostic("Libraries unpacked.");
 
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            Application.ThreadException += Application_ThreadException;
-            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.Automatic);
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
+        Log.Diagnostic("Creating forms...");
+        Globals.UpdateForm = new FrmUpdate();
+        Globals.LoginForm = new FrmLogin();
+        Globals.MainForm = new FrmMain();
+        Log.Diagnostic("Forms created.");
 
-            Log.Diagnostic("Unpacking libraries...");
+        Log.Diagnostic("Starting application.");
+        Application.Run(Globals.UpdateForm);
+    }
 
-            //Place sqlite3.dll where it's needed.
-            var dllname = Environment.Is64BitProcess ? "sqlite3x64.dll" : "sqlite3x86.dll";
-            using (var resourceStream = Assembly.GetExecutingAssembly()
-                .GetManifestResourceStream("Intersect.Editor.Resources." + dllname))
-            {
-                Debug.Assert(resourceStream != null, "resourceStream != null");
-                using (var fileStream = new FileStream("sqlite3.dll", FileMode.OpenOrCreate, FileAccess.ReadWrite))
-                {
-                    var data = new byte[resourceStream.Length];
-                    resourceStream.Read(data, 0, (int) resourceStream.Length);
-                    fileStream.Write(data, 0, data.Length);
-                }
-            }
+    private static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
+    {
+        CurrentDomain_UnhandledException(null, new UnhandledExceptionEventArgs(e.Exception, true));
+    }
 
-            Log.Diagnostic("Libraries unpacked.");
+    //Really basic error handler for debugging purposes
+    public static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs exception)
+    {
+        Log.Error((Exception) exception?.ExceptionObject);
+        MessageBox.Show(
+            @"The Intersect Editor has encountered an error and must close. Error information can be found in logs/errors.log"
+        );
 
-            Log.Diagnostic("Creating forms...");
-            Globals.UpdateForm = new FrmUpdate();
-            Globals.LoginForm = new FrmLogin();
-            Globals.MainForm = new FrmMain();
-            Log.Diagnostic("Forms created.");
-
-            Log.Diagnostic("Starting application.");
-            Application.Run(Globals.UpdateForm);
-        }
-
-        private static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
-        {
-            CurrentDomain_UnhandledException(null, new UnhandledExceptionEventArgs(e.Exception, true));
-        }
-
-        //Really basic error handler for debugging purposes
-        public static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs exception)
-        {
-            Log.Error((Exception) exception?.ExceptionObject);
-            MessageBox.Show(
-                @"The Intersect Editor has encountered an error and must close. Error information can be found in logs/errors.log"
-            );
-
-            Environment.Exit(1);
-        }
-
+        Environment.Exit(1);
     }
 
 }

--- a/Intersect.Editor/Entities/Animation.cs
+++ b/Intersect.Editor/Entities/Animation.cs
@@ -4,204 +4,202 @@ using Intersect.Utilities;
 
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Editor.Entities
+namespace Intersect.Editor.Entities;
+
+
+public partial class Animation
 {
 
-    public partial class Animation
+    private bool mInfiniteLoop;
+
+    private int mLowerFrame;
+
+    private int mLowerLoop;
+
+    private long mLowerTimer;
+
+    private int mRenderDir;
+
+    private float mRenderX;
+
+    private float mRenderY;
+
+    private bool mShowLower = true;
+
+    private bool mShowUpper = true;
+
+    private int mUpperFrame;
+
+    private int mUpperLoop;
+
+    private long mUpperTimer;
+
+    public AnimationBase MyBase;
+
+    public Animation(AnimationBase animBase, bool loopForever)
     {
+        MyBase = animBase;
+        mLowerLoop = animBase.Lower.LoopCount;
+        mUpperLoop = animBase.Upper.LoopCount;
+        mLowerTimer = Timing.Global.MillisecondsUtc + animBase.Lower.FrameSpeed;
+        mUpperTimer = Timing.Global.MillisecondsUtc + animBase.Upper.FrameSpeed;
+        mInfiniteLoop = loopForever;
+    }
 
-        private bool mInfiniteLoop;
-
-        private int mLowerFrame;
-
-        private int mLowerLoop;
-
-        private long mLowerTimer;
-
-        private int mRenderDir;
-
-        private float mRenderX;
-
-        private float mRenderY;
-
-        private bool mShowLower = true;
-
-        private bool mShowUpper = true;
-
-        private int mUpperFrame;
-
-        private int mUpperLoop;
-
-        private long mUpperTimer;
-
-        public AnimationBase MyBase;
-
-        public Animation(AnimationBase animBase, bool loopForever)
+    public void Draw(RenderTarget2D target, bool upper = false, bool alternate = false)
+    {
+        if (!upper && alternate != MyBase.Lower.AlternateRenderLayer)
         {
-            MyBase = animBase;
-            mLowerLoop = animBase.Lower.LoopCount;
-            mUpperLoop = animBase.Upper.LoopCount;
-            mLowerTimer = Timing.Global.MillisecondsUtc + animBase.Lower.FrameSpeed;
-            mUpperTimer = Timing.Global.MillisecondsUtc + animBase.Upper.FrameSpeed;
-            mInfiniteLoop = loopForever;
+            return;
         }
 
-        public void Draw(RenderTarget2D target, bool upper = false, bool alternate = false)
+        if (upper && alternate != MyBase.Upper.AlternateRenderLayer)
         {
-            if (!upper && alternate != MyBase.Lower.AlternateRenderLayer)
-            {
-                return;
-            }
-
-            if (upper && alternate != MyBase.Upper.AlternateRenderLayer)
-            {
-                return;
-            }
-
-            if (!upper)
-            {
-                //Draw Lower
-                var tex = GameContentManager.GetTexture(GameContentManager.TextureType.Animation, MyBase.Lower.Sprite);
-                if (mShowLower)
-                {
-                    if (mLowerFrame >= MyBase.Lower.FrameCount)
-                    {
-                        return;
-                    }
-
-                    if (tex != null)
-                    {
-                        if (MyBase.Lower.XFrames > 0 && MyBase.Lower.YFrames > 0)
-                        {
-                            var frameWidth = (int) tex.Width / MyBase.Lower.XFrames;
-                            var frameHeight = (int) tex.Height / MyBase.Lower.YFrames;
-                            Core.Graphics.DrawTexture(
-                                tex,
-                                new RectangleF(
-                                    mLowerFrame % MyBase.Lower.XFrames * frameWidth,
-                                    (float) Math.Floor((double) mLowerFrame / MyBase.Lower.XFrames) * frameHeight,
-                                    frameWidth, frameHeight
-                                ),
-                                new RectangleF(
-                                    mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
-                                ), System.Drawing.Color.White, target, BlendState.NonPremultiplied
-                            );
-                        }
-                    }
-
-                    Core.Graphics.AddLight(
-                        Options.MapWidth * Options.TileWidth -
-                        Core.Graphics.CurrentView.Left +
-                        (int) mRenderX +
-                        MyBase.Lower.Lights[mLowerFrame].OffsetX,
-                        Options.MapHeight * Options.TileHeight -
-                        Core.Graphics.CurrentView.Top +
-                        (int) mRenderY +
-                        MyBase.Lower.Lights[mLowerFrame].OffsetY, MyBase.Lower.Lights[mLowerFrame]
-                    );
-                }
-            }
-            else
-            {
-                //Draw Upper
-                var tex = GameContentManager.GetTexture(GameContentManager.TextureType.Animation, MyBase.Upper.Sprite);
-                if (mShowUpper)
-                {
-                    if (mUpperFrame >= MyBase.Upper.FrameCount)
-                    {
-                        return;
-                    }
-
-                    if (tex != null)
-                    {
-                        if (MyBase.Upper.XFrames > 0 && MyBase.Upper.YFrames > 0)
-                        {
-                            var frameWidth = (int) tex.Width / MyBase.Upper.XFrames;
-                            var frameHeight = (int) tex.Height / MyBase.Upper.YFrames;
-                            Core.Graphics.DrawTexture(
-                                tex,
-                                new RectangleF(
-                                    mUpperFrame % MyBase.Upper.XFrames * frameWidth,
-                                    (float) Math.Floor((double) mUpperFrame / MyBase.Upper.XFrames) * frameHeight,
-                                    frameWidth, frameHeight
-                                ),
-                                new RectangleF(
-                                    mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
-                                ), System.Drawing.Color.White, target, BlendState.NonPremultiplied
-                            );
-                        }
-                    }
-
-                    Core.Graphics.AddLight(
-                        Options.MapWidth * Options.TileWidth -
-                        Core.Graphics.CurrentView.Left +
-                        (int) mRenderX +
-                        MyBase.Upper.Lights[mUpperFrame].OffsetX,
-                        Options.MapHeight * Options.TileHeight -
-                        Core.Graphics.CurrentView.Top +
-                        (int) mRenderY +
-                        MyBase.Upper.Lights[mUpperFrame].OffsetY, MyBase.Upper.Lights[mUpperFrame]
-                    );
-                }
-            }
+            return;
         }
 
-        public void SetPosition(float x, float y, int dir)
+        if (!upper)
         {
-            mRenderX = x;
-            mRenderY = y;
-            mRenderDir = dir;
-        }
-
-        public void Update()
-        {
-            if (mLowerTimer < Timing.Global.MillisecondsUtc && mShowLower)
+            //Draw Lower
+            var tex = GameContentManager.GetTexture(GameContentManager.TextureType.Animation, MyBase.Lower.Sprite);
+            if (mShowLower)
             {
-                mLowerFrame++;
                 if (mLowerFrame >= MyBase.Lower.FrameCount)
                 {
-                    mLowerLoop--;
-                    mLowerFrame = 0;
-                    if (mLowerLoop < 0)
-                    {
-                        if (mInfiniteLoop)
-                        {
-                            mLowerLoop = MyBase.Lower.LoopCount;
-                        }
-                        else
-                        {
-                            mShowLower = false;
-                        }
-                    }
+                    return;
                 }
 
-                mLowerTimer = Timing.Global.MillisecondsUtc + MyBase.Lower.FrameSpeed;
-            }
-
-            if (mUpperTimer < Timing.Global.MillisecondsUtc && mShowUpper)
-            {
-                mUpperFrame++;
-                if (mUpperFrame >= MyBase.Upper.FrameCount)
+                if (tex != null)
                 {
-                    mUpperLoop--;
-                    mUpperFrame = 0;
-                    if (mUpperLoop < 0)
+                    if (MyBase.Lower.XFrames > 0 && MyBase.Lower.YFrames > 0)
                     {
-                        if (mInfiniteLoop)
-                        {
-                            mUpperLoop = MyBase.Upper.LoopCount;
-                        }
-                        else
-                        {
-                            mShowUpper = false;
-                        }
+                        var frameWidth = (int) tex.Width / MyBase.Lower.XFrames;
+                        var frameHeight = (int) tex.Height / MyBase.Lower.YFrames;
+                        Core.Graphics.DrawTexture(
+                            tex,
+                            new RectangleF(
+                                mLowerFrame % MyBase.Lower.XFrames * frameWidth,
+                                (float) Math.Floor((double) mLowerFrame / MyBase.Lower.XFrames) * frameHeight,
+                                frameWidth, frameHeight
+                            ),
+                            new RectangleF(
+                                mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
+                            ), System.Drawing.Color.White, target, BlendState.NonPremultiplied
+                        );
                     }
                 }
 
-                mUpperTimer = Timing.Global.MillisecondsUtc + MyBase.Upper.FrameSpeed;
+                Core.Graphics.AddLight(
+                    Options.MapWidth * Options.TileWidth -
+                    Core.Graphics.CurrentView.Left +
+                    (int) mRenderX +
+                    MyBase.Lower.Lights[mLowerFrame].OffsetX,
+                    Options.MapHeight * Options.TileHeight -
+                    Core.Graphics.CurrentView.Top +
+                    (int) mRenderY +
+                    MyBase.Lower.Lights[mLowerFrame].OffsetY, MyBase.Lower.Lights[mLowerFrame]
+                );
             }
         }
+        else
+        {
+            //Draw Upper
+            var tex = GameContentManager.GetTexture(GameContentManager.TextureType.Animation, MyBase.Upper.Sprite);
+            if (mShowUpper)
+            {
+                if (mUpperFrame >= MyBase.Upper.FrameCount)
+                {
+                    return;
+                }
 
+                if (tex != null)
+                {
+                    if (MyBase.Upper.XFrames > 0 && MyBase.Upper.YFrames > 0)
+                    {
+                        var frameWidth = (int) tex.Width / MyBase.Upper.XFrames;
+                        var frameHeight = (int) tex.Height / MyBase.Upper.YFrames;
+                        Core.Graphics.DrawTexture(
+                            tex,
+                            new RectangleF(
+                                mUpperFrame % MyBase.Upper.XFrames * frameWidth,
+                                (float) Math.Floor((double) mUpperFrame / MyBase.Upper.XFrames) * frameHeight,
+                                frameWidth, frameHeight
+                            ),
+                            new RectangleF(
+                                mRenderX - frameWidth / 2, mRenderY - frameHeight / 2, frameWidth, frameHeight
+                            ), System.Drawing.Color.White, target, BlendState.NonPremultiplied
+                        );
+                    }
+                }
+
+                Core.Graphics.AddLight(
+                    Options.MapWidth * Options.TileWidth -
+                    Core.Graphics.CurrentView.Left +
+                    (int) mRenderX +
+                    MyBase.Upper.Lights[mUpperFrame].OffsetX,
+                    Options.MapHeight * Options.TileHeight -
+                    Core.Graphics.CurrentView.Top +
+                    (int) mRenderY +
+                    MyBase.Upper.Lights[mUpperFrame].OffsetY, MyBase.Upper.Lights[mUpperFrame]
+                );
+            }
+        }
+    }
+
+    public void SetPosition(float x, float y, int dir)
+    {
+        mRenderX = x;
+        mRenderY = y;
+        mRenderDir = dir;
+    }
+
+    public void Update()
+    {
+        if (mLowerTimer < Timing.Global.MillisecondsUtc && mShowLower)
+        {
+            mLowerFrame++;
+            if (mLowerFrame >= MyBase.Lower.FrameCount)
+            {
+                mLowerLoop--;
+                mLowerFrame = 0;
+                if (mLowerLoop < 0)
+                {
+                    if (mInfiniteLoop)
+                    {
+                        mLowerLoop = MyBase.Lower.LoopCount;
+                    }
+                    else
+                    {
+                        mShowLower = false;
+                    }
+                }
+            }
+
+            mLowerTimer = Timing.Global.MillisecondsUtc + MyBase.Lower.FrameSpeed;
+        }
+
+        if (mUpperTimer < Timing.Global.MillisecondsUtc && mShowUpper)
+        {
+            mUpperFrame++;
+            if (mUpperFrame >= MyBase.Upper.FrameCount)
+            {
+                mUpperLoop--;
+                mUpperFrame = 0;
+                if (mUpperLoop < 0)
+                {
+                    if (mInfiniteLoop)
+                    {
+                        mUpperLoop = MyBase.Upper.LoopCount;
+                    }
+                    else
+                    {
+                        mShowUpper = false;
+                    }
+                }
+            }
+
+            mUpperTimer = Timing.Global.MillisecondsUtc + MyBase.Upper.FrameSpeed;
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Controls/AutoDragPanel.cs
+++ b/Intersect.Editor/Forms/Controls/AutoDragPanel.cs
@@ -1,131 +1,129 @@
 ﻿using Timer = System.Windows.Forms.Timer;
 
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+
+public partial class AutoDragPanel : Panel
 {
 
-    public partial class AutoDragPanel : Panel
+    private Timer mDragTimer;
+
+    private int mMaxDragChange = 2;
+
+    public AutoDragPanel()
     {
-
-        private Timer mDragTimer;
-
-        private int mMaxDragChange = 2;
-
-        public AutoDragPanel()
+        InitializeComponent();
+        mDragTimer = new Timer()
         {
-            InitializeComponent();
-            mDragTimer = new Timer()
-            {
-                Interval = 1
-            };
+            Interval = 1
+        };
 
-            mDragTimer.Tick += DragTimer_Tick;
-            MouseDown += AutoDragPanel_MouseDown;
-            MouseUp += AutoDragPanel_MouseUp;
+        mDragTimer.Tick += DragTimer_Tick;
+        MouseDown += AutoDragPanel_MouseDown;
+        MouseUp += AutoDragPanel_MouseUp;
+    }
+
+    public void AutoDragPanel_MouseUp(object sender, MouseEventArgs e)
+    {
+        mDragTimer.Enabled = false;
+    }
+
+    public void AutoDragPanel_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Left)
+        {
+            mDragTimer.Enabled = true;
+        }
+    }
+
+    private void DragTimer_Tick(object sender, EventArgs e)
+    {
+        var pos = PointToClient(MousePosition);
+
+        var right = ClientRectangle.Right;
+        var bottom = ClientRectangle.Bottom;
+
+        if (VerticalScroll.Visible)
+        {
+            right = Width - SystemInformation.VerticalScrollBarWidth;
         }
 
-        public void AutoDragPanel_MouseUp(object sender, MouseEventArgs e)
+        if (HorizontalScroll.Visible)
         {
-            mDragTimer.Enabled = false;
+            bottom = Height - SystemInformation.HorizontalScrollBarHeight;
         }
 
-        public void AutoDragPanel_MouseDown(object sender, MouseEventArgs e)
+        if (VerticalScroll.Visible)
         {
-            if (e.Button == MouseButtons.Left)
+            // Scroll up
+            if (pos.Y < ClientRectangle.Top)
             {
-                mDragTimer.Enabled = true;
-            }
-        }
+                var difference = (pos.Y - ClientRectangle.Top) * -1;
 
-        private void DragTimer_Tick(object sender, EventArgs e)
-        {
-            var pos = PointToClient(MousePosition);
-
-            var right = ClientRectangle.Right;
-            var bottom = ClientRectangle.Bottom;
-
-            if (VerticalScroll.Visible)
-            {
-                right = Width - SystemInformation.VerticalScrollBarWidth;
-            }
-
-            if (HorizontalScroll.Visible)
-            {
-                bottom = Height - SystemInformation.HorizontalScrollBarHeight;
-            }
-
-            if (VerticalScroll.Visible)
-            {
-                // Scroll up
-                if (pos.Y < ClientRectangle.Top)
+                if (mMaxDragChange > 0 && difference > mMaxDragChange)
                 {
-                    var difference = (pos.Y - ClientRectangle.Top) * -1;
-
-                    if (mMaxDragChange > 0 && difference > mMaxDragChange)
-                    {
-                        difference = mMaxDragChange;
-                    }
-
-                    if (VerticalScroll.Value < difference)
-                    {
-                        VerticalScroll.Value = 0;
-                    }
-                    else
-                    {
-                        VerticalScroll.Value = VerticalScroll.Value - difference;
-                    }
+                    difference = mMaxDragChange;
                 }
 
-                // Scroll down
-                if (pos.Y > bottom)
+                if (VerticalScroll.Value < difference)
                 {
-                    var difference = pos.Y - bottom;
-
-                    if (mMaxDragChange > 0 && difference > mMaxDragChange)
-                    {
-                        difference = mMaxDragChange;
-                    }
-
-                    VerticalScroll.Value = VerticalScroll.Value + difference;
+                    VerticalScroll.Value = 0;
+                }
+                else
+                {
+                    VerticalScroll.Value = VerticalScroll.Value - difference;
                 }
             }
 
-            if (HorizontalScroll.Visible)
+            // Scroll down
+            if (pos.Y > bottom)
             {
-                // Scroll left
-                if (pos.X < ClientRectangle.Left)
+                var difference = pos.Y - bottom;
+
+                if (mMaxDragChange > 0 && difference > mMaxDragChange)
                 {
-                    var difference = (pos.X - ClientRectangle.Left) * -1;
-
-                    if (mMaxDragChange > 0 && difference > mMaxDragChange)
-                    {
-                        difference = mMaxDragChange;
-                    }
-
-                    if (HorizontalScroll.Value < difference)
-                    {
-                        HorizontalScroll.Value = 0;
-                    }
-                    else
-                    {
-                        HorizontalScroll.Value = HorizontalScroll.Value - difference;
-                    }
+                    difference = mMaxDragChange;
                 }
 
-                // Scroll right
-                if (pos.X > right)
-                {
-                    var difference = pos.X - right;
-
-                    if (mMaxDragChange > 0 && difference > mMaxDragChange)
-                    {
-                        difference = mMaxDragChange;
-                    }
-
-                    HorizontalScroll.Value = HorizontalScroll.Value + difference;
-                }
+                VerticalScroll.Value = VerticalScroll.Value + difference;
             }
         }
 
+        if (HorizontalScroll.Visible)
+        {
+            // Scroll left
+            if (pos.X < ClientRectangle.Left)
+            {
+                var difference = (pos.X - ClientRectangle.Left) * -1;
+
+                if (mMaxDragChange > 0 && difference > mMaxDragChange)
+                {
+                    difference = mMaxDragChange;
+                }
+
+                if (HorizontalScroll.Value < difference)
+                {
+                    HorizontalScroll.Value = 0;
+                }
+                else
+                {
+                    HorizontalScroll.Value = HorizontalScroll.Value - difference;
+                }
+            }
+
+            // Scroll right
+            if (pos.X > right)
+            {
+                var difference = pos.X - right;
+
+                if (mMaxDragChange > 0 && difference > mMaxDragChange)
+                {
+                    difference = mMaxDragChange;
+                }
+
+                HorizontalScroll.Value = HorizontalScroll.Value + difference;
+            }
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Controls/GameObjectList.cs
+++ b/Intersect.Editor/Forms/Controls/GameObjectList.cs
@@ -1,277 +1,276 @@
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+public partial class GameObjectList : TreeView
 {
-    public partial class GameObjectList : TreeView
+    private bool mChangingName = false;
+
+    public delegate void UpdateItemDelegate(Guid id);
+
+    public delegate void UpdateToolstripDelegate();
+
+    public delegate void ToolstripButtonClickDelegate(object sender, EventArgs e);
+
+    public UpdateItemDelegate UpdateItemHandler;
+
+    public UpdateToolstripDelegate FocusChangedHandler;
+
+    public ToolstripButtonClickDelegate ToolStripItemNew_Click;
+
+    public ToolstripButtonClickDelegate ToolStripItemCopy_Click;
+
+    public ToolstripButtonClickDelegate ToolStripItemPaste_Click;
+
+    public ToolstripButtonClickDelegate ToolStripItemUndo_Click;
+
+    public ToolstripButtonClickDelegate ToolStripItemDelete_Click;
+
+    private List<string> mExpandedFolders = new List<string>();
+
+
+    public GameObjectList()
     {
-        private bool mChangingName = false;
+        InitializeComponent();
 
-        public delegate void UpdateItemDelegate(Guid id);
+        ImageList = imageList;
 
-        public delegate void UpdateToolstripDelegate();
+        AfterSelect += GameObjectList_AfterSelect;
 
-        public delegate void ToolstripButtonClickDelegate(object sender, EventArgs e);
+        NodeMouseClick += GameObjectList_NodeMouseClick;
 
-        public UpdateItemDelegate UpdateItemHandler;
+        GotFocus += GameObjectList_GotFocus;
 
-        public UpdateToolstripDelegate FocusChangedHandler;
+        LostFocus += GameObjectList_LostFocus;
 
-        public ToolstripButtonClickDelegate ToolStripItemNew_Click;
+        KeyDown += GameObjectList_KeyDown;
+    }
 
-        public ToolstripButtonClickDelegate ToolStripItemCopy_Click;
+    /// <summary>
+    /// Sets up this game object list for working with our editor
+    /// </summary>
+    public void Init(UpdateToolstripDelegate updateToolStripHandler, UpdateItemDelegate updateItemHandler, ToolstripButtonClickDelegate newDelegate, 
+        ToolstripButtonClickDelegate copyDelegate, ToolstripButtonClickDelegate undoDelegate, ToolstripButtonClickDelegate pasteDelegate, ToolstripButtonClickDelegate deleteDelegate)
+    {
+        FocusChangedHandler = updateToolStripHandler;
+        UpdateItemHandler = updateItemHandler;
+        ToolStripItemNew_Click = newDelegate;
+        ToolStripItemCopy_Click = copyDelegate;
+        ToolStripItemPaste_Click = pasteDelegate;
+        ToolStripItemUndo_Click = undoDelegate;
+        ToolStripItemDelete_Click = deleteDelegate;
+    }
 
-        public ToolstripButtonClickDelegate ToolStripItemPaste_Click;
-
-        public ToolstripButtonClickDelegate ToolStripItemUndo_Click;
-
-        public ToolstripButtonClickDelegate ToolStripItemDelete_Click;
-
-        private List<string> mExpandedFolders = new List<string>();
-
-
-        public GameObjectList()
+    /// <summary>
+    /// This function copies item ids to clipboards if right clicking. Otherwise it handles expanding/closing folders
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void GameObjectList_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        var node = e.Node;
+        if (node != null)
         {
-            InitializeComponent();
-
-            ImageList = imageList;
-
-            AfterSelect += GameObjectList_AfterSelect;
-
-            NodeMouseClick += GameObjectList_NodeMouseClick;
-
-            GotFocus += GameObjectList_GotFocus;
-
-            LostFocus += GameObjectList_LostFocus;
-
-            KeyDown += GameObjectList_KeyDown;
-        }
-
-        /// <summary>
-        /// Sets up this game object list for working with our editor
-        /// </summary>
-        public void Init(UpdateToolstripDelegate updateToolStripHandler, UpdateItemDelegate updateItemHandler, ToolstripButtonClickDelegate newDelegate, 
-            ToolstripButtonClickDelegate copyDelegate, ToolstripButtonClickDelegate undoDelegate, ToolstripButtonClickDelegate pasteDelegate, ToolstripButtonClickDelegate deleteDelegate)
-        {
-            FocusChangedHandler = updateToolStripHandler;
-            UpdateItemHandler = updateItemHandler;
-            ToolStripItemNew_Click = newDelegate;
-            ToolStripItemCopy_Click = copyDelegate;
-            ToolStripItemPaste_Click = pasteDelegate;
-            ToolStripItemUndo_Click = undoDelegate;
-            ToolStripItemDelete_Click = deleteDelegate;
-        }
-
-        /// <summary>
-        /// This function copies item ids to clipboards if right clicking. Otherwise it handles expanding/closing folders
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void GameObjectList_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
-        {
-            var node = e.Node;
-            if (node != null)
+            if (e.Button == MouseButtons.Right)
             {
-                if (e.Button == MouseButtons.Right)
+                if (e.Node.Tag != null && e.Node.Tag is Guid)
                 {
-                    if (e.Node.Tag != null && e.Node.Tag is Guid)
-                    {
-                        Clipboard.SetText(e.Node.Tag.ToString());
-                    }
+                    Clipboard.SetText(e.Node.Tag.ToString());
                 }
+            }
 
-                var hitTest = HitTest(e.Location);
-                if (hitTest.Location != TreeViewHitTestLocations.PlusMinus)
+            var hitTest = HitTest(e.Location);
+            if (hitTest.Location != TreeViewHitTestLocations.PlusMinus)
+            {
+                if (node.Nodes.Count > 0)
                 {
-                    if (node.Nodes.Count > 0)
+                    if (node.IsExpanded)
                     {
-                        if (node.IsExpanded)
-                        {
-                            node.Collapse();
-                        }
-                        else
-                        {
-                            node.Expand();
-                        }
+                        node.Collapse();
                     }
-                }
-
-                if (node.IsExpanded)
-                {
-                    if (!mExpandedFolders.Contains(node.Text))
+                    else
                     {
-                        mExpandedFolders.Add(node.Text);
-                    }
-                }
-                else
-                {
-                    if (mExpandedFolders.Contains(node.Text))
-                    {
-                        mExpandedFolders.Remove(node.Text);
+                        node.Expand();
                     }
                 }
             }
-        }
 
-        /// <summary>
-        /// This function tells our editor that we selected a new item to edit
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void GameObjectList_AfterSelect(object sender, TreeViewEventArgs e)
-        {
-            if (mChangingName)
+            if (node.IsExpanded)
             {
-                return;
-            }
-
-            if (SelectedNode == null || SelectedNode.Tag == null)
-            {
-                return;
-            }
-
-            UpdateItemHandler?.Invoke((Guid)SelectedNode.Tag);
-        }
-
-
-        private void GameObjectList_LostFocus(object sender, EventArgs e)
-        {
-            FocusChangedHandler?.Invoke();
-        }
-
-
-        private void GameObjectList_GotFocus(object sender, EventArgs e)
-        {
-            FocusChangedHandler?.Invoke();
-        }
-
-        private void GameObjectList_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.Z)
+                if (!mExpandedFolders.Contains(node.Text))
                 {
-                    ToolStripItemUndo_Click?.Invoke(null, null);
-                }
-                else if (e.KeyCode == Keys.V)
-                {
-                    ToolStripItemPaste_Click?.Invoke(null, null);
-                }
-                else if (e.KeyCode == Keys.C)
-                {
-                    ToolStripItemCopy_Click?.Invoke(null, null);
+                    mExpandedFolders.Add(node.Text);
                 }
             }
             else
             {
-                if (e.KeyCode == Keys.Delete)
+                if (mExpandedFolders.Contains(node.Text))
                 {
-                    ToolStripItemDelete_Click?.Invoke(null, null);
+                    mExpandedFolders.Remove(node.Text);
                 }
             }
         }
+    }
 
-
-        /// <summary>
-        /// Updates the name of the currently selected node
-        /// </summary>
-        /// <param name="text">New name</param>
-        public void UpdateText(string text)
+    /// <summary>
+    /// This function tells our editor that we selected a new item to edit
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void GameObjectList_AfterSelect(object sender, TreeViewEventArgs e)
+    {
+        if (mChangingName)
         {
-            mChangingName = true;
-            if (SelectedNode != null)
-            {
-                SelectedNode.Text = text;
-            }
-            mChangingName = false;
+            return;
         }
 
-
-        public void ExpandFolder(string name)
+        if (SelectedNode == null || SelectedNode.Tag == null)
         {
-            mExpandedFolders.Add(name);
+            return;
         }
 
-        public void ClearExpandedFolders()
+        UpdateItemHandler?.Invoke((Guid)SelectedNode.Tag);
+    }
+
+
+    private void GameObjectList_LostFocus(object sender, EventArgs e)
+    {
+        FocusChangedHandler?.Invoke();
+    }
+
+
+    private void GameObjectList_GotFocus(object sender, EventArgs e)
+    {
+        FocusChangedHandler?.Invoke();
+    }
+
+    private void GameObjectList_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
         {
-            mExpandedFolders.Clear();
+            if (e.KeyCode == Keys.Z)
+            {
+                ToolStripItemUndo_Click?.Invoke(null, null);
+            }
+            else if (e.KeyCode == Keys.V)
+            {
+                ToolStripItemPaste_Click?.Invoke(null, null);
+            }
+            else if (e.KeyCode == Keys.C)
+            {
+                ToolStripItemCopy_Click?.Invoke(null, null);
+            }
+        }
+        else
+        {
+            if (e.KeyCode == Keys.Delete)
+            {
+                ToolStripItemDelete_Click?.Invoke(null, null);
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Updates the name of the currently selected node
+    /// </summary>
+    /// <param name="text">New name</param>
+    public void UpdateText(string text)
+    {
+        mChangingName = true;
+        if (SelectedNode != null)
+        {
+            SelectedNode.Text = text;
+        }
+        mChangingName = false;
+    }
+
+
+    public void ExpandFolder(string name)
+    {
+        mExpandedFolders.Add(name);
+    }
+
+    public void ClearExpandedFolders()
+    {
+        mExpandedFolders.Clear();
+    }
+
+    public void Repopulate(KeyValuePair<Guid, KeyValuePair<string, string>>[] items, List<string> folders, bool chronological, bool customSearch, string search)
+    {
+        var selectedId = Guid.Empty;
+        var folderNodes = new Dictionary<string, TreeNode>();
+        if (SelectedNode != null && SelectedNode.Tag != null)
+        {
+            selectedId = (Guid)SelectedNode.Tag;
         }
 
-        public void Repopulate(KeyValuePair<Guid, KeyValuePair<string, string>>[] items, List<string> folders, bool chronological, bool customSearch, string search)
+        Nodes.Clear();
+
+        Sorted = chronological;
+
+        var nodes = new List<TreeNode>();
+        TreeNode selectNode = null;
+
+        if (!chronological && !customSearch)
         {
-            var selectedId = Guid.Empty;
-            var folderNodes = new Dictionary<string, TreeNode>();
-            if (SelectedNode != null && SelectedNode.Tag != null)
+            foreach (var folder in folders)
             {
-                selectedId = (Guid)SelectedNode.Tag;
+                var node = new TreeNode(folder);
+                node.ImageIndex = 0;
+                node.SelectedImageIndex = 0;
+                folderNodes.Add(folder, node);
+                nodes.Add(node);
             }
+        }
 
-            Nodes.Clear();
+        foreach (var itm in items)
+        {
+            var node = new TreeNode(itm.Value.Key);
+            node.Tag = itm.Key;
+            node.ImageIndex = 1;
+            node.SelectedImageIndex = 1;
 
-            Sorted = chronological;
-
-            var nodes = new List<TreeNode>();
-            TreeNode selectNode = null;
-
-            if (!chronological && !customSearch)
+            var folder = itm.Value.Value;
+            if (!string.IsNullOrEmpty(folder) && !chronological && !customSearch)
             {
-                foreach (var folder in folders)
-                {
-                    var node = new TreeNode(folder);
-                    node.ImageIndex = 0;
-                    node.SelectedImageIndex = 0;
-                    folderNodes.Add(folder, node);
-                    nodes.Add(node);
-                }
-            }
-
-            foreach (var itm in items)
-            {
-                var node = new TreeNode(itm.Value.Key);
-                node.Tag = itm.Key;
-                node.ImageIndex = 1;
-                node.SelectedImageIndex = 1;
-
-                var folder = itm.Value.Value;
-                if (!string.IsNullOrEmpty(folder) && !chronological && !customSearch)
-                {
-                    var folderNode = folderNodes[folder];
-                    folderNode.Nodes.Add(node);
-                    if (itm.Key == selectedId)
-                    {
-                        folderNode.Expand();
-                    }
-                }
-                else
-                {
-                    nodes.Add(node);
-                }
-
-                if (customSearch)
-                {
-                    if (!node.Text.ToLower().Contains(search.ToLower()))
-                    {
-                        nodes.Remove(node);
-                    }
-                }
-
+                var folderNode = folderNodes[folder];
+                folderNode.Nodes.Add(node);
                 if (itm.Key == selectedId)
                 {
-                    selectNode = node;
+                    folderNode.Expand();
                 }
             }
-
-            foreach (var node in mExpandedFolders)
+            else
             {
-                if (folderNodes.ContainsKey(node))
+                nodes.Add(node);
+            }
+
+            if (customSearch)
+            {
+                if (!node.Text.ToLower().Contains(search.ToLower()))
                 {
-                    folderNodes[node].Expand();
+                    nodes.Remove(node);
                 }
             }
 
-            Nodes.AddRange(nodes.ToArray());
-
-            if (selectNode != null)
+            if (itm.Key == selectedId)
             {
-                SelectedNode = selectNode;
+                selectNode = node;
             }
+        }
+
+        foreach (var node in mExpandedFolders)
+        {
+            if (folderNodes.ContainsKey(node))
+            {
+                folderNodes[node].Expand();
+            }
+        }
+
+        Nodes.AddRange(nodes.ToArray());
+
+        if (selectNode != null)
+        {
+            SelectedNode = selectNode;
         }
     }
 }

--- a/Intersect.Editor/Forms/Controls/LightEditorCtrl.cs
+++ b/Intersect.Editor/Forms/Controls/LightEditorCtrl.cs
@@ -4,172 +4,170 @@ using Intersect.GameObjects;
 
 using Graphics = Intersect.Editor.Core.Graphics;
 
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+
+public partial class LightEditorCtrl : UserControl
 {
 
-    public partial class LightEditorCtrl : UserControl
+    public bool CanClose = true;
+
+    private LightBase mBackupLight;
+
+    private LightBase mEditingLight;
+
+    private ToolTip _tooltip = new ToolTip();
+
+    public LightEditorCtrl()
     {
-
-        public bool CanClose = true;
-
-        private LightBase mBackupLight;
-
-        private LightBase mEditingLight;
-
-        private ToolTip _tooltip = new ToolTip();
-
-        public LightEditorCtrl()
+        InitializeComponent();
+        if (!CanClose)
         {
-            InitializeComponent();
-            if (!CanClose)
-            {
-                btnOkay.Visible = false;
-            }
+            btnOkay.Visible = false;
+        }
+    }
+
+    public void LoadEditor(LightBase tmpLight)
+    {
+        mEditingLight = tmpLight;
+        mBackupLight = new LightBase(tmpLight);
+        nudIntensity.Value = tmpLight.Intensity;
+        nudSize.Value = tmpLight.Size;
+        nudOffsetX.Value = tmpLight.OffsetX;
+        nudOffsetY.Value = tmpLight.OffsetY;
+        nudExpand.Value = (int)tmpLight.Expand;
+        pnlLightColor.BackColor = System.Drawing.Color.FromArgb(
+            tmpLight.Color.A, tmpLight.Color.R, tmpLight.Color.G, tmpLight.Color.B
+        );
+
+        if (!CanClose)
+        {
+            btnOkay.Hide();
         }
 
-        public void LoadEditor(LightBase tmpLight)
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        grpLightEditor.Text = Strings.LightEditor.title;
+        lblOffsetX.Text = Strings.LightEditor.xoffset;
+        lblOffsetY.Text = Strings.LightEditor.yoffset;
+        lblColor.Text = Strings.LightEditor.color;
+        lblIntensity.Text = Strings.LightEditor.intensity;
+        lblSize.Text = Strings.LightEditor.size;
+        lblExpandAmt.Text = Strings.LightEditor.expandamt;
+        _tooltip.SetToolTip(btnCancel, Strings.LightEditor.revert);
+        _tooltip.SetToolTip(btnOkay, Strings.LightEditor.save);
+        _tooltip.SetToolTip(btnSelectLightColor, Strings.LightEditor.SelectColor);
+    }
+
+    //Lights Tab
+    private void btnLightEditorClose_Click(object sender, EventArgs e)
+    {
+        if (CanClose)
         {
-            mEditingLight = tmpLight;
-            mBackupLight = new LightBase(tmpLight);
-            nudIntensity.Value = tmpLight.Intensity;
-            nudSize.Value = tmpLight.Size;
-            nudOffsetX.Value = tmpLight.OffsetX;
-            nudOffsetY.Value = tmpLight.OffsetY;
-            nudExpand.Value = (int)tmpLight.Expand;
-            pnlLightColor.BackColor = System.Drawing.Color.FromArgb(
-                tmpLight.Color.A, tmpLight.Color.R, tmpLight.Color.G, tmpLight.Color.B
-            );
-
-            if (!CanClose)
-            {
-                btnOkay.Hide();
-            }
-
-            InitLocalization();
+            Visible = false;
         }
 
-        private void InitLocalization()
+        if (mEditingLight == Globals.EditingLight)
         {
-            grpLightEditor.Text = Strings.LightEditor.title;
-            lblOffsetX.Text = Strings.LightEditor.xoffset;
-            lblOffsetY.Text = Strings.LightEditor.yoffset;
-            lblColor.Text = Strings.LightEditor.color;
-            lblIntensity.Text = Strings.LightEditor.intensity;
-            lblSize.Text = Strings.LightEditor.size;
-            lblExpandAmt.Text = Strings.LightEditor.expandamt;
-            _tooltip.SetToolTip(btnCancel, Strings.LightEditor.revert);
-            _tooltip.SetToolTip(btnOkay, Strings.LightEditor.save);
-            _tooltip.SetToolTip(btnSelectLightColor, Strings.LightEditor.SelectColor);
+            Globals.EditingLight = null;
         }
+    }
 
-        //Lights Tab
-        private void btnLightEditorClose_Click(object sender, EventArgs e)
+    private void btnLightEditorRevert_Click(object sender, EventArgs e)
+    {
+        if (mEditingLight != null)
         {
-            if (CanClose)
-            {
-                Visible = false;
-            }
-
+            mEditingLight.Intensity = mBackupLight.Intensity;
+            mEditingLight.Size = mBackupLight.Size;
+            mEditingLight.OffsetX = mBackupLight.OffsetX;
+            mEditingLight.OffsetY = mBackupLight.OffsetY;
+            LoadEditor(mEditingLight);
             if (mEditingLight == Globals.EditingLight)
             {
                 Globals.EditingLight = null;
             }
         }
 
-        private void btnLightEditorRevert_Click(object sender, EventArgs e)
+        Graphics.TilePreviewUpdated = true;
+        if (CanClose)
         {
-            if (mEditingLight != null)
-            {
-                mEditingLight.Intensity = mBackupLight.Intensity;
-                mEditingLight.Size = mBackupLight.Size;
-                mEditingLight.OffsetX = mBackupLight.OffsetX;
-                mEditingLight.OffsetY = mBackupLight.OffsetY;
-                LoadEditor(mEditingLight);
-                if (mEditingLight == Globals.EditingLight)
-                {
-                    Globals.EditingLight = null;
-                }
-            }
+            Visible = false;
+        }
+    }
 
-            Graphics.TilePreviewUpdated = true;
-            if (CanClose)
-            {
-                Visible = false;
-            }
+    private void btnSelectLightColor_Click(object sender, EventArgs e)
+    {
+        colorDialog.Color = System.Drawing.Color.White;
+        colorDialog.ShowDialog();
+        pnlLightColor.BackColor = colorDialog.Color;
+        mEditingLight.Color = Color.FromArgb(
+            colorDialog.Color.A, colorDialog.Color.R, colorDialog.Color.G, colorDialog.Color.B
+        );
+
+        Graphics.TilePreviewUpdated = true;
+    }
+
+    public void Cancel()
+    {
+        btnLightEditorClose_Click(null, null);
+    }
+
+    private void nudOffsetX_ValueChanged(object sender, EventArgs e)
+    {
+        if (mEditingLight == null)
+        {
+            return;
         }
 
-        private void btnSelectLightColor_Click(object sender, EventArgs e)
-        {
-            colorDialog.Color = System.Drawing.Color.White;
-            colorDialog.ShowDialog();
-            pnlLightColor.BackColor = colorDialog.Color;
-            mEditingLight.Color = Color.FromArgb(
-                colorDialog.Color.A, colorDialog.Color.R, colorDialog.Color.G, colorDialog.Color.B
-            );
+        mEditingLight.OffsetX = (int)nudOffsetX.Value;
+        Graphics.TilePreviewUpdated = true;
+    }
 
-            Graphics.TilePreviewUpdated = true;
+    private void nudOffsetY_ValueChanged(object sender, EventArgs e)
+    {
+        if (mEditingLight == null)
+        {
+            return;
         }
 
-        public void Cancel()
+        mEditingLight.OffsetY = (int)nudOffsetY.Value;
+        Graphics.TilePreviewUpdated = true;
+    }
+
+    private void nudSize_ValueChanged(object sender, EventArgs e)
+    {
+        if (mEditingLight == null)
         {
-            btnLightEditorClose_Click(null, null);
+            return;
         }
 
-        private void nudOffsetX_ValueChanged(object sender, EventArgs e)
-        {
-            if (mEditingLight == null)
-            {
-                return;
-            }
+        mEditingLight.Size = (int)nudSize.Value;
+        Graphics.TilePreviewUpdated = true;
+    }
 
-            mEditingLight.OffsetX = (int)nudOffsetX.Value;
-            Graphics.TilePreviewUpdated = true;
+    private void nudIntensity_ValueChanged(object sender, EventArgs e)
+    {
+        if (mEditingLight == null)
+        {
+            return;
         }
 
-        private void nudOffsetY_ValueChanged(object sender, EventArgs e)
-        {
-            if (mEditingLight == null)
-            {
-                return;
-            }
+        mEditingLight.Intensity = (byte)nudIntensity.Value;
+        Graphics.TilePreviewUpdated = true;
+    }
 
-            mEditingLight.OffsetY = (int)nudOffsetY.Value;
-            Graphics.TilePreviewUpdated = true;
+    private void nudExpand_ValueChanged(object sender, EventArgs e)
+    {
+        if (mEditingLight == null)
+        {
+            return;
         }
 
-        private void nudSize_ValueChanged(object sender, EventArgs e)
-        {
-            if (mEditingLight == null)
-            {
-                return;
-            }
-
-            mEditingLight.Size = (int)nudSize.Value;
-            Graphics.TilePreviewUpdated = true;
-        }
-
-        private void nudIntensity_ValueChanged(object sender, EventArgs e)
-        {
-            if (mEditingLight == null)
-            {
-                return;
-            }
-
-            mEditingLight.Intensity = (byte)nudIntensity.Value;
-            Graphics.TilePreviewUpdated = true;
-        }
-
-        private void nudExpand_ValueChanged(object sender, EventArgs e)
-        {
-            if (mEditingLight == null)
-            {
-                return;
-            }
-
-            mEditingLight.Expand = (int)nudExpand.Value;
-            Graphics.TilePreviewUpdated = true;
-        }
-
+        mEditingLight.Expand = (int)nudExpand.Value;
+        Graphics.TilePreviewUpdated = true;
     }
 
 }

--- a/Intersect.Editor/Forms/Controls/MapAttributeTooltip.cs
+++ b/Intersect.Editor/Forms/Controls/MapAttributeTooltip.cs
@@ -1,99 +1,98 @@
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Maps;
 
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+public partial class MapAttributeTooltip : FlowLayoutPanel
 {
-    public partial class MapAttributeTooltip : FlowLayoutPanel
+    private readonly object _mapAttributeLock = new object();
+    private MapAttribute _mapAttribute;
+
+    public MapAttributeTooltip()
     {
-        private readonly object _mapAttributeLock = new object();
-        private MapAttribute _mapAttribute;
+        InitializeComponent();
 
-        public MapAttributeTooltip()
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        BorderStyle = BorderStyle.FixedSingle;
+        FlowDirection = FlowDirection.TopDown;
+    }
+
+    public MapAttribute MapAttribute
+    {
+        get => _mapAttribute;
+        set
         {
-            InitializeComponent();
+            lock (_mapAttributeLock)
+            {
+                if (_mapAttribute == value)
+                {
+                    return;
+                }
 
-            AutoSize = true;
-            AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            BorderStyle = BorderStyle.FixedSingle;
-            FlowDirection = FlowDirection.TopDown;
+                var oldType = _mapAttribute?.GetType();
+                _mapAttribute = value;
+                OnAttributeChanged(oldType);
+            }
+        }
+    }
+
+    private static Label CreateLabel(AnchorStyles anchor = AnchorStyles.Left, FontStyle fontStyle = FontStyle.Regular)
+    {
+        return new Label
+        {
+            Anchor = anchor,
+            AutoSize = true,
+            Font = new Font(SystemFonts.DefaultFont, fontStyle),
+            ForeColor = System.Drawing.Color.White,
+        };
+    }
+
+    protected virtual void OnAttributeChanged(Type oldType)
+    {
+        Hide();
+
+        if (_mapAttribute == null)
+        {
+            return;
         }
 
-        public MapAttribute MapAttribute
+        var localizedProperties = Strings.Localizer.Localize(typeof(Strings), _mapAttribute);
+        if (localizedProperties.Count < 1)
         {
-            get => _mapAttribute;
-            set
-            {
-                lock (_mapAttributeLock)
-                {
-                    if (_mapAttribute == value)
-                    {
-                        return;
-                    }
+            return;
+        }
 
-                    var oldType = _mapAttribute?.GetType();
-                    _mapAttribute = value;
-                    OnAttributeChanged(oldType);
+        if (localizedProperties.Count < pnlContents.RowCount)
+        {
+            for (var rowIndex = pnlContents.RowCount - 1; rowIndex >= localizedProperties.Count; rowIndex--)
+            {
+                for (var columnIndex = 1; columnIndex >= 0; columnIndex--)
+                {
+                    var control = pnlContents.GetControlFromPosition(columnIndex, rowIndex);
+                    pnlContents.Controls.Remove(control);
                 }
             }
         }
 
-        private static Label CreateLabel(AnchorStyles anchor = AnchorStyles.Left, FontStyle fontStyle = FontStyle.Regular)
+        for (var rowIndex = 0; rowIndex < localizedProperties.Count; rowIndex++)
         {
-            return new Label
+            if (rowIndex >= pnlContents.RowCount)
             {
-                Anchor = anchor,
-                AutoSize = true,
-                Font = new Font(SystemFonts.DefaultFont, fontStyle),
-                ForeColor = System.Drawing.Color.White,
-            };
+                pnlContents.Controls.Add(CreateLabel(AnchorStyles.Right, FontStyle.Bold), 0, rowIndex);
+                pnlContents.Controls.Add(CreateLabel(AnchorStyles.Left, rowIndex == 0 ? FontStyle.Bold : FontStyle.Regular), 1, rowIndex);
+            }
+
+            var labelControl = pnlContents.GetControlFromPosition(0, rowIndex) as Label ?? throw new InvalidOperationException();
+            var displayValueControl = pnlContents.GetControlFromPosition(1, rowIndex) as Label ?? throw new InvalidOperationException();
+
+            var localizedProperty = localizedProperties[rowIndex];
+            labelControl.Text = localizedProperty.Key;
+            displayValueControl.Text = localizedProperty.Value;
         }
 
-        protected virtual void OnAttributeChanged(Type oldType)
-        {
-            Hide();
+        pnlContents.RowCount = localizedProperties.Count;
 
-            if (_mapAttribute == null)
-            {
-                return;
-            }
-
-            var localizedProperties = Strings.Localizer.Localize(typeof(Strings), _mapAttribute);
-            if (localizedProperties.Count < 1)
-            {
-                return;
-            }
-
-            if (localizedProperties.Count < pnlContents.RowCount)
-            {
-                for (var rowIndex = pnlContents.RowCount - 1; rowIndex >= localizedProperties.Count; rowIndex--)
-                {
-                    for (var columnIndex = 1; columnIndex >= 0; columnIndex--)
-                    {
-                        var control = pnlContents.GetControlFromPosition(columnIndex, rowIndex);
-                        pnlContents.Controls.Remove(control);
-                    }
-                }
-            }
-
-            for (var rowIndex = 0; rowIndex < localizedProperties.Count; rowIndex++)
-            {
-                if (rowIndex >= pnlContents.RowCount)
-                {
-                    pnlContents.Controls.Add(CreateLabel(AnchorStyles.Right, FontStyle.Bold), 0, rowIndex);
-                    pnlContents.Controls.Add(CreateLabel(AnchorStyles.Left, rowIndex == 0 ? FontStyle.Bold : FontStyle.Regular), 1, rowIndex);
-                }
-
-                var labelControl = pnlContents.GetControlFromPosition(0, rowIndex) as Label ?? throw new InvalidOperationException();
-                var displayValueControl = pnlContents.GetControlFromPosition(1, rowIndex) as Label ?? throw new InvalidOperationException();
-
-                var localizedProperty = localizedProperties[rowIndex];
-                labelControl.Text = localizedProperty.Key;
-                displayValueControl.Text = localizedProperty.Value;
-            }
-
-            pnlContents.RowCount = localizedProperties.Count;
-
-            Invalidate();
-        }
+        Invalidate();
     }
 }

--- a/Intersect.Editor/Forms/Controls/MapTreeList.cs
+++ b/Intersect.Editor/Forms/Controls/MapTreeList.cs
@@ -4,429 +4,427 @@ using Intersect.Editor.Networking;
 using Intersect.GameObjects.Maps.MapList;
 using Intersect.Logging;
 
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+
+public partial class MapTreeList : UserControl
 {
+    private readonly Dictionary<MapListItem, TreeNode> _nodeLookup = new();
 
-    public partial class MapTreeList : UserControl
+    //Cross Thread Delegates
+    public delegate void TryUpdateMapList(Guid selectMap, List<Guid> restrictMaps = null);
+
+    public bool Chronological = false;
+
+    public TryUpdateMapList MapListDelegate;
+
+    private bool mCanEdit;
+
+    private List<Guid> mOpenFolders = new List<Guid>();
+
+    private List<Guid>? mRestrictMapIds;
+
+    private System.Drawing.Point mScrollPoint;
+
+    private Guid mSelectedMap = Guid.Empty; //id or map or folder that is selected
+
+    private int mSelectionType = -1; //0 for none, 1 for map, 2 for folder
+
+    public MapTreeList()
     {
-        private readonly Dictionary<MapListItem, TreeNode> _nodeLookup = new();
+        InitializeComponent();
 
-        //Cross Thread Delegates
-        public delegate void TryUpdateMapList(Guid selectMap, List<Guid> restrictMaps = null);
+        //Init Delegates
+        MapListDelegate = UpdateMapList;
+    }
 
-        public bool Chronological = false;
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    internal static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
-        public TryUpdateMapList MapListDelegate;
-
-        private bool mCanEdit;
-
-        private List<Guid> mOpenFolders = new List<Guid>();
-
-        private List<Guid>? mRestrictMapIds;
-
-        private System.Drawing.Point mScrollPoint;
-
-        private Guid mSelectedMap = Guid.Empty; //id or map or folder that is selected
-
-        private int mSelectionType = -1; //0 for none, 1 for map, 2 for folder
-
-        public MapTreeList()
+    private void treeMapList_ItemDrag(object sender, ItemDragEventArgs e)
+    {
+        if (!mCanEdit)
         {
-            InitializeComponent();
-
-            //Init Delegates
-            MapListDelegate = UpdateMapList;
+            return;
         }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        internal static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+        DoDragDrop(e.Item, DragDropEffects.Move);
+    }
 
-        private void treeMapList_ItemDrag(object sender, ItemDragEventArgs e)
+    private void treeMapList_DragEnter(object sender, DragEventArgs e)
+    {
+        if (!mCanEdit)
         {
-            if (!mCanEdit)
+            return;
+        }
+
+        e.Effect = DragDropEffects.Move;
+    }
+
+    private void treeMapList_DragDrop(object sender, DragEventArgs e)
+    {
+        if (!mCanEdit)
+        {
+            return;
+        }
+
+        // Retrieve the client coordinates of the drop location.
+        var targetPoint = list.PointToClient(new System.Drawing.Point(e.X, e.Y));
+
+        // Retrieve the node at the drop location.
+        var targetNode = list.GetNodeAt(targetPoint);
+
+        // Retrieve the node that was dragged.
+        var draggedNode = (TreeNode)e.Data.GetData(typeof(TreeNode));
+        int srcType;
+        Guid srcId;
+        switch (draggedNode.Tag)
+        {
+            case MapListMap draggedMap:
+                srcType = 1;
+                srcId = draggedMap.MapId;
+                break;
+
+            case MapListFolder draggedFolder:
+                srcType = 0;
+                srcId = draggedFolder.FolderId;
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unknown type {draggedNode.Tag?.GetType()} is not supported.");
+        }
+
+        var parent = targetNode;
+        while (parent != null)
+        {
+            if (parent == draggedNode)
             {
                 return;
             }
 
-            DoDragDrop(e.Item, DragDropEffects.Move);
+            parent = parent.Parent;
         }
 
-        private void treeMapList_DragEnter(object sender, DragEventArgs e)
+        // Confirm that the node at the drop location is not
+        // the dragged node and that target node isn't null
+        // (for example if you drag outside the control)
+        if (!draggedNode.Equals(targetNode) && targetNode != null)
         {
-            if (!mCanEdit)
+            switch (targetNode.Tag)
             {
-                return;
-            }
+                case MapListMap targetMap:
+                    PacketSender.SendMapListMove(srcType, srcId, 1, targetMap.MapId);
 
-            e.Effect = DragDropEffects.Move;
-        }
+                    // Remove the node from its current
+                    // location and add it to the node at the drop location.
+                    draggedNode.Remove();
 
-        private void treeMapList_DragDrop(object sender, DragEventArgs e)
-        {
-            if (!mCanEdit)
-            {
-                return;
-            }
-
-            // Retrieve the client coordinates of the drop location.
-            var targetPoint = list.PointToClient(new System.Drawing.Point(e.X, e.Y));
-
-            // Retrieve the node at the drop location.
-            var targetNode = list.GetNodeAt(targetPoint);
-
-            // Retrieve the node that was dragged.
-            var draggedNode = (TreeNode)e.Data.GetData(typeof(TreeNode));
-            int srcType;
-            Guid srcId;
-            switch (draggedNode.Tag)
-            {
-                case MapListMap draggedMap:
-                    srcType = 1;
-                    srcId = draggedMap.MapId;
-                    break;
-
-                case MapListFolder draggedFolder:
-                    srcType = 0;
-                    srcId = draggedFolder.FolderId;
-                    break;
-
-                default:
-                    throw new InvalidOperationException($"Unknown type {draggedNode.Tag?.GetType()} is not supported.");
-            }
-
-            var parent = targetNode;
-            while (parent != null)
-            {
-                if (parent == draggedNode)
-                {
-                    return;
-                }
-
-                parent = parent.Parent;
-            }
-
-            // Confirm that the node at the drop location is not
-            // the dragged node and that target node isn't null
-            // (for example if you drag outside the control)
-            if (!draggedNode.Equals(targetNode) && targetNode != null)
-            {
-                switch (targetNode.Tag)
-                {
-                    case MapListMap targetMap:
-                        PacketSender.SendMapListMove(srcType, srcId, 1, targetMap.MapId);
-
-                        // Remove the node from its current
-                        // location and add it to the node at the drop location.
-                        draggedNode.Remove();
-
-                        if (targetNode.Parent == null)
-                        {
-                            list.Nodes.Insert(targetNode.Index, draggedNode);
-                        }
-                        else
-                        {
-                            targetNode.Parent.Nodes.Insert(targetNode.Index, draggedNode);
-                        }
-
-                        // Expand the node at the location
-                        // to show the dropped node.
-                        targetNode.Expand();
-                        break;
-
-                    case MapListFolder targetFolder:
-                        PacketSender.SendMapListMove(srcType, srcId, 0, targetFolder.FolderId);
-
-                        // Remove the node from its current
-                        // location and add it to the node at the drop location.
-                        draggedNode.Remove();
-                        targetNode.Nodes.Add(draggedNode);
-
-                        // Expand the node at the location
-                        // to show the dropped node.
-                        targetNode.Expand();
-                        break;
-                }
-            }
-            else if (list.ClientRectangle.Contains(targetPoint))
-            {
-                var destType = -1;
-                var destId = Guid.Empty;
-                PacketSender.SendMapListMove(srcType, srcId, destType, destId);
-
-                // Remove the node from its current
-                // location and add it to the node at the drop location.
-                draggedNode.Remove();
-                list.Nodes.Add(draggedNode);
-            }
-        }
-
-        private void treeMapList_AfterLabelEdit(object sender, NodeLabelEditEventArgs e)
-        {
-            if (!mCanEdit)
-            {
-                return;
-            }
-
-            if (e.Node != null)
-            {
-                if (string.IsNullOrEmpty(e.Label))
-                {
-                    e.Node.Text = e.Node.Tag is MapListMap mapListMap ? mapListMap.Name : e.Label;
-                }
-                else
-                {
-                    switch (e.Node.Tag)
+                    if (targetNode.Parent == null)
                     {
-                        case MapListMap mapListMap:
-                            mapListMap.Name = e.Label;
-
-                            //Send Rename Map
-                            PacketSender.SendRename(mapListMap, e.Label);
-                            e.Node.Text = mapListMap.Name;
-                            break;
-
-                        case MapListFolder mapListFolder:
-                            mapListFolder.Name = e.Label;
-
-                            //Send Rename Folder
-                            PacketSender.SendRename(mapListFolder, e.Label);
-                            e.Node.Text = e.Label;
-                            break;
+                        list.Nodes.Insert(targetNode.Index, draggedNode);
                     }
-                }
-            }
+                    else
+                    {
+                        targetNode.Parent.Nodes.Insert(targetNode.Index, draggedNode);
+                    }
 
-            e.CancelEdit = true;
+                    // Expand the node at the location
+                    // to show the dropped node.
+                    targetNode.Expand();
+                    break;
+
+                case MapListFolder targetFolder:
+                    PacketSender.SendMapListMove(srcType, srcId, 0, targetFolder.FolderId);
+
+                    // Remove the node from its current
+                    // location and add it to the node at the drop location.
+                    draggedNode.Remove();
+                    targetNode.Nodes.Add(draggedNode);
+
+                    // Expand the node at the location
+                    // to show the dropped node.
+                    targetNode.Expand();
+                    break;
+            }
+        }
+        else if (list.ClientRectangle.Contains(targetPoint))
+        {
+            var destType = -1;
+            var destId = Guid.Empty;
+            PacketSender.SendMapListMove(srcType, srcId, destType, destId);
+
+            // Remove the node from its current
+            // location and add it to the node at the drop location.
+            draggedNode.Remove();
+            list.Nodes.Add(draggedNode);
+        }
+    }
+
+    private void treeMapList_AfterLabelEdit(object sender, NodeLabelEditEventArgs e)
+    {
+        if (!mCanEdit)
+        {
+            return;
         }
 
-        private void treeMapList_BeforeLabelEdit(object sender, NodeLabelEditEventArgs e)
+        if (e.Node != null)
         {
-            if (!mCanEdit)
+            if (string.IsNullOrEmpty(e.Label))
             {
-                return;
+                e.Node.Text = e.Node.Tag is MapListMap mapListMap ? mapListMap.Name : e.Label;
             }
-
-            if (e.Node != null)
+            else
             {
-                if (e.Node.Tag is MapListMap mapListMap)
+                switch (e.Node.Tag)
                 {
-                    if (e.Node.Text == mapListMap.Name && Chronological)
-                    {
+                    case MapListMap mapListMap:
+                        mapListMap.Name = e.Label;
+
+                        //Send Rename Map
+                        PacketSender.SendRename(mapListMap, e.Label);
                         e.Node.Text = mapListMap.Name;
-                    }
+                        break;
+
+                    case MapListFolder mapListFolder:
+                        mapListFolder.Name = e.Label;
+
+                        //Send Rename Folder
+                        PacketSender.SendRename(mapListFolder, e.Label);
+                        e.Node.Text = e.Label;
+                        break;
                 }
             }
         }
 
-        private void treeMapList_AfterSelect(object sender, TreeViewEventArgs e)
+        e.CancelEdit = true;
+    }
+
+    private void treeMapList_BeforeLabelEdit(object sender, NodeLabelEditEventArgs e)
+    {
+        if (!mCanEdit)
         {
-            switch (e.Node.Tag)
-            {
-                case MapListMap mapListMap:
-                    mSelectionType = 0;
-                    mSelectedMap = mapListMap.MapId;
-                    break;
-
-                case MapListFolder mapListFolder:
-                    mSelectionType = 1;
-                    mSelectedMap = mapListFolder.FolderId;
-                    break;
-
-                default:
-                    mSelectionType = -1;
-                    mSelectedMap = Guid.Empty;
-                    break;
-            }
+            return;
         }
 
-        private void treeMapList_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        if (e.Node != null)
         {
-        }
-
-        private void treeMapList_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right)
+            if (e.Node.Tag is MapListMap mapListMap)
             {
-                list.SelectedNode = list.GetNodeAt(e.Location);
-            }
-        }
-
-        private void BeginEdit(TreeNode node)
-        {
-            node.BeginEdit();
-        }
-
-        public void UpdateMapList(Guid selectMapId = default, List<Guid>? restrictMaps = null)
-        {
-            Log.Info("Updating list");
-            var selectedMapListMap = selectMapId == default ? default : MapList.List.FindMap(selectMapId);
-            if (selectedMapListMap != default && _nodeLookup.TryGetValue(selectedMapListMap, out var treeNode))
-            {
-                list.SelectedNode = treeNode;
-            }
-            else
-            {
-                list.Nodes.Clear();
-                _nodeLookup.Clear();
-                mRestrictMapIds = restrictMaps;
-                AddMapListToTree(MapList.List, null, selectMapId, mRestrictMapIds);
-            }
-        }
-
-        private void AddMapListToTree(
-            MapList mapList,
-            TreeNode? parent,
-            Guid selectMapId = default,
-            List<Guid>? restrictMaps = null
-        )
-        {
-            TreeNode tmpNode;
-            if (Chronological)
-            {
-                foreach (var map in MapList.OrderedMaps)
+                if (e.Node.Text == mapListMap.Name && Chronological)
                 {
-                    if (restrictMaps != null && !restrictMaps.Contains(map.MapId))
-                    {
-                        continue;
-                    }
-
-                    tmpNode = list.Nodes.Add(map.Name);
-                    _nodeLookup[map] = tmpNode;
-                    tmpNode.Tag = map;
-                    tmpNode.ImageIndex = 1;
-                    tmpNode.SelectedImageIndex = 1;
-
-                    var selectedId = selectMapId;
-                    if (selectedId == default && mSelectionType == 0)
-                    {
-                        selectedId = mSelectedMap;
-                    }
-
-                    if (map.MapId == selectMapId)
-                    {
-                        list.SelectedNode = tmpNode;
-                        list.Focus();
-                    }
+                    e.Node.Text = mapListMap.Name;
                 }
             }
-            else
+        }
+    }
+
+    private void treeMapList_AfterSelect(object sender, TreeViewEventArgs e)
+    {
+        switch (e.Node.Tag)
+        {
+            case MapListMap mapListMap:
+                mSelectionType = 0;
+                mSelectedMap = mapListMap.MapId;
+                break;
+
+            case MapListFolder mapListFolder:
+                mSelectionType = 1;
+                mSelectedMap = mapListFolder.FolderId;
+                break;
+
+            default:
+                mSelectionType = -1;
+                mSelectedMap = Guid.Empty;
+                break;
+        }
+    }
+
+    private void treeMapList_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+    }
+
+    private void treeMapList_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Right)
+        {
+            list.SelectedNode = list.GetNodeAt(e.Location);
+        }
+    }
+
+    private void BeginEdit(TreeNode node)
+    {
+        node.BeginEdit();
+    }
+
+    public void UpdateMapList(Guid selectMapId = default, List<Guid>? restrictMaps = null)
+    {
+        Log.Info("Updating list");
+        var selectedMapListMap = selectMapId == default ? default : MapList.List.FindMap(selectMapId);
+        if (selectedMapListMap != default && _nodeLookup.TryGetValue(selectedMapListMap, out var treeNode))
+        {
+            list.SelectedNode = treeNode;
+        }
+        else
+        {
+            list.Nodes.Clear();
+            _nodeLookup.Clear();
+            mRestrictMapIds = restrictMaps;
+            AddMapListToTree(MapList.List, null, selectMapId, mRestrictMapIds);
+        }
+    }
+
+    private void AddMapListToTree(
+        MapList mapList,
+        TreeNode? parent,
+        Guid selectMapId = default,
+        List<Guid>? restrictMaps = null
+    )
+    {
+        TreeNode tmpNode;
+        if (Chronological)
+        {
+            foreach (var map in MapList.OrderedMaps)
             {
-                foreach (var item in mapList.Items)
+                if (restrictMaps != null && !restrictMaps.Contains(map.MapId))
                 {
-                    switch (item)
-                    {
-                        case MapListFolder folder:
+                    continue;
+                }
+
+                tmpNode = list.Nodes.Add(map.Name);
+                _nodeLookup[map] = tmpNode;
+                tmpNode.Tag = map;
+                tmpNode.ImageIndex = 1;
+                tmpNode.SelectedImageIndex = 1;
+
+                var selectedId = selectMapId;
+                if (selectedId == default && mSelectionType == 0)
+                {
+                    selectedId = mSelectedMap;
+                }
+
+                if (map.MapId == selectMapId)
+                {
+                    list.SelectedNode = tmpNode;
+                    list.Focus();
+                }
+            }
+        }
+        else
+        {
+            foreach (var item in mapList.Items)
+            {
+                switch (item)
+                {
+                    case MapListFolder folder:
+                        tmpNode = (parent?.Nodes ?? list.Nodes).Add(item.Name);
+                        _nodeLookup[item] = tmpNode;
+                        tmpNode.Tag = item;
+                        AddMapListToTree(folder.Children, tmpNode, selectMapId, restrictMaps);
+
+                        if (mOpenFolders.Contains(folder.FolderId))
+                        {
+                            tmpNode.Expand();
+                        }
+
+                        if (mSelectionType == 1 && mSelectedMap == folder.FolderId)
+                        {
+                            list.SelectedNode = tmpNode;
+                            list.Focus();
+                        }
+
+                        tmpNode.ImageIndex = 0;
+                        tmpNode.SelectedImageIndex = 0;
+                        break;
+
+                    case MapListMap map:
+                        if (restrictMaps?.Contains(map.MapId) ?? true)
+                        {
                             tmpNode = (parent?.Nodes ?? list.Nodes).Add(item.Name);
                             _nodeLookup[item] = tmpNode;
-                            tmpNode.Tag = item;
-                            AddMapListToTree(folder.Children, tmpNode, selectMapId, restrictMaps);
+                            tmpNode.Tag = map;
 
-                            if (mOpenFolders.Contains(folder.FolderId))
+                            var selectedId = selectMapId;
+                            if (selectedId == default && mSelectionType == 0)
                             {
-                                tmpNode.Expand();
+                                selectedId = mSelectedMap;
                             }
 
-                            if (mSelectionType == 1 && mSelectedMap == folder.FolderId)
+                            if (map.MapId == selectMapId)
                             {
                                 list.SelectedNode = tmpNode;
                                 list.Focus();
                             }
 
-                            tmpNode.ImageIndex = 0;
-                            tmpNode.SelectedImageIndex = 0;
+                            tmpNode.ImageIndex = 1;
+                            tmpNode.SelectedImageIndex = 1;
                             break;
+                        }
 
-                        case MapListMap map:
-                            if (restrictMaps?.Contains(map.MapId) ?? true)
-                            {
-                                tmpNode = (parent?.Nodes ?? list.Nodes).Add(item.Name);
-                                _nodeLookup[item] = tmpNode;
-                                tmpNode.Tag = map;
-
-                                var selectedId = selectMapId;
-                                if (selectedId == default && mSelectionType == 0)
-                                {
-                                    selectedId = mSelectedMap;
-                                }
-
-                                if (map.MapId == selectMapId)
-                                {
-                                    list.SelectedNode = tmpNode;
-                                    list.Focus();
-                                }
-
-                                tmpNode.ImageIndex = 1;
-                                tmpNode.SelectedImageIndex = 1;
-                                break;
-                            }
-
-                            break;
-                    }
+                        break;
                 }
             }
         }
+    }
 
-        public void EnableEditing(ContextMenuStrip menuStrip)
+    public void EnableEditing(ContextMenuStrip menuStrip)
+    {
+        if (menuStrip != null)
         {
-            if (menuStrip != null)
+            list.ContextMenuStrip = menuStrip;
+        }
+
+        list.LabelEdit = true;
+        mCanEdit = true;
+    }
+
+    public void SetDoubleClick(TreeNodeMouseClickEventHandler handler)
+    {
+        list.NodeMouseDoubleClick += handler;
+    }
+
+    public void SetSelect(TreeViewEventHandler handler)
+    {
+        list.AfterSelect += handler;
+    }
+
+    private void list_AfterExpand(object sender, TreeViewEventArgs e)
+    {
+        if (e.Node.Tag is MapListFolder folder)
+        {
+            if (!mOpenFolders.Contains(folder.FolderId))
             {
-                list.ContextMenuStrip = menuStrip;
-            }
-
-            list.LabelEdit = true;
-            mCanEdit = true;
-        }
-
-        public void SetDoubleClick(TreeNodeMouseClickEventHandler handler)
-        {
-            list.NodeMouseDoubleClick += handler;
-        }
-
-        public void SetSelect(TreeViewEventHandler handler)
-        {
-            list.AfterSelect += handler;
-        }
-
-        private void list_AfterExpand(object sender, TreeViewEventArgs e)
-        {
-            if (e.Node.Tag is MapListFolder folder)
-            {
-                if (!mOpenFolders.Contains(folder.FolderId))
-                {
-                    mOpenFolders.Add(folder.FolderId);
-                }
-            }
-        }
-
-        private void list_AfterCollapse(object sender, TreeViewEventArgs e)
-        {
-            if (e.Node.Tag is MapListFolder folder)
-            {
-                mOpenFolders.Remove(folder.FolderId);
+                mOpenFolders.Add(folder.FolderId);
             }
         }
+    }
 
-        public static void Scroll(Control control)
+    private void list_AfterCollapse(object sender, TreeViewEventArgs e)
+    {
+        if (e.Node.Tag is MapListFolder folder)
         {
-            var pt = control.PointToClient(Cursor.Position);
-
-            if (pt.Y + 20 > control.Height)
-            {
-                // scroll down
-                SendMessage(control.Handle, 277, (IntPtr)1, (IntPtr)0);
-            }
-            else if (pt.Y < 20)
-            {
-                // scroll up
-                SendMessage(control.Handle, 277, (IntPtr)0, (IntPtr)0);
-            }
+            mOpenFolders.Remove(folder.FolderId);
         }
+    }
 
-        private void list_DragOver(object sender, DragEventArgs e)
+    public static void Scroll(Control control)
+    {
+        var pt = control.PointToClient(Cursor.Position);
+
+        if (pt.Y + 20 > control.Height)
         {
-            Scroll(list);
+            // scroll down
+            SendMessage(control.Handle, 277, (IntPtr)1, (IntPtr)0);
         }
+        else if (pt.Y < 20)
+        {
+            // scroll up
+            SendMessage(control.Handle, 277, (IntPtr)0, (IntPtr)0);
+        }
+    }
 
+    private void list_DragOver(object sender, DragEventArgs e)
+    {
+        Scroll(list);
     }
 
 }

--- a/Intersect.Editor/Forms/Controls/SearchableDarkTreeView.cs
+++ b/Intersect.Editor/Forms/Controls/SearchableDarkTreeView.cs
@@ -3,150 +3,148 @@
 using Intersect.Collections;
 using Intersect.Models;
 
-namespace Intersect.Editor.Forms.Controls
+namespace Intersect.Editor.Forms.Controls;
+
+
+public partial class SearchableDarkTreeView : UserControl
 {
 
-    public partial class SearchableDarkTreeView : UserControl
+    private readonly Dictionary<Guid, DarkTreeNode> mIdNodeLookup;
+
+    private IGameObjectLookup<IDatabaseObject> mItemProvider;
+
+    private string mPreviousSearchText;
+
+    public SearchableDarkTreeView()
     {
+        InitializeComponent();
 
-        private readonly Dictionary<Guid, DarkTreeNode> mIdNodeLookup;
+        mIdNodeLookup = new Dictionary<Guid, DarkTreeNode>();
+    }
 
-        private IGameObjectLookup<IDatabaseObject> mItemProvider;
+    public DarkTreeNode SelectedNode => treeViewItems?.SelectedNodes?.FirstOrDefault();
 
-        private string mPreviousSearchText;
+    public IObject SelectedObject => SelectedNode?.Tag as IObject;
 
-        public SearchableDarkTreeView()
+    public Guid SelectedId
+    {
+        get => SelectedObject?.Id ?? Guid.Empty;
+        set => treeViewItems?.SelectNode(mIdNodeLookup.TryGetValue(value, out var node) ? node : null);
+    }
+
+    public IGameObjectLookup<IDatabaseObject> ItemProvider
+    {
+        get => mItemProvider;
+        set
         {
-            InitializeComponent();
-
-            mIdNodeLookup = new Dictionary<Guid, DarkTreeNode>();
-        }
-
-        public DarkTreeNode SelectedNode => treeViewItems?.SelectedNodes?.FirstOrDefault();
-
-        public IObject SelectedObject => SelectedNode?.Tag as IObject;
-
-        public Guid SelectedId
-        {
-            get => SelectedObject?.Id ?? Guid.Empty;
-            set => treeViewItems?.SelectNode(mIdNodeLookup.TryGetValue(value, out var node) ? node : null);
-        }
-
-        public IGameObjectLookup<IDatabaseObject> ItemProvider
-        {
-            get => mItemProvider;
-            set
-            {
-                mItemProvider = value;
-
-                UpdateNodes();
-            }
-        }
-
-        public string SearchText
-        {
-            get => txtSearch?.Text;
-            set
-            {
-                if (txtSearch == null)
-                {
-                    throw new ArgumentNullException(nameof(txtSearch));
-                }
-
-                txtSearch.Text = value;
-            }
-        }
-
-        public virtual void Refresh()
-        {
-            UpdateNodes();
-        }
-
-        public bool FilterBySearchText(IDatabaseObject databaseObject)
-        {
-            if (string.IsNullOrWhiteSpace(SearchText))
-            {
-                return true;
-            }
-
-            var name = databaseObject?.Name;
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return false;
-            }
-
-            var searchText = SearchText.Trim();
-            if (searchText.Length > name.Length)
-            {
-                return false;
-            }
-
-            return -1 < name.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase);
-        }
-
-        protected virtual bool FilterBySearchText(KeyValuePair<Guid, IDatabaseObject> pair)
-        {
-            return FilterBySearchText(pair.Value);
-        }
-
-        protected virtual DarkTreeNode ObjectAsNode(IDatabaseObject databaseObject)
-        {
-            if (!mIdNodeLookup.TryGetValue(databaseObject.Id, out var node))
-            {
-                node = new DarkTreeNode(databaseObject.Name ?? "NULL");
-            }
-
-            return node;
-        }
-
-        protected virtual DarkTreeNode PairAsNode(KeyValuePair<Guid, IDatabaseObject> pair)
-        {
-            return ObjectAsNode(
-                pair.Value ??
-                throw new ArgumentNullException(nameof(pair.Value), $@"{pair.Key} has a null object associated.")
-            );
-        }
-
-        protected void UpdateNodes()
-        {
-            treeViewItems?.Nodes?.Clear();
-
-            // TODO: Remove this when we fix DarkUI, which currently does not invalidate (and will show stale values when the list is emptied).
-            treeViewItems?.Invalidate();
-
-            if (ItemProvider == null)
-            {
-                return;
-            }
-
-            mPreviousSearchText = SearchText;
-
-            var filtered = string.IsNullOrWhiteSpace(SearchText)
-                ? ItemProvider
-                : ItemProvider.Where(FilterBySearchText);
-
-            var nodes = filtered.Select(PairAsNode).ToList();
-
-            treeViewItems?.Nodes?.AddRange(nodes);
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            var searchText = SearchText?.Trim() ?? "";
-            var previousSearchText = mPreviousSearchText?.Trim() ?? "";
-
-            if (string.Equals(searchText, previousSearchText, StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
+            mItemProvider = value;
 
             UpdateNodes();
         }
+    }
 
-        private void toolStripCreate_Click(object sender, EventArgs e)
+    public string SearchText
+    {
+        get => txtSearch?.Text;
+        set
         {
+            if (txtSearch == null)
+            {
+                throw new ArgumentNullException(nameof(txtSearch));
+            }
+
+            txtSearch.Text = value;
+        }
+    }
+
+    public virtual void Refresh()
+    {
+        UpdateNodes();
+    }
+
+    public bool FilterBySearchText(IDatabaseObject databaseObject)
+    {
+        if (string.IsNullOrWhiteSpace(SearchText))
+        {
+            return true;
         }
 
+        var name = databaseObject?.Name;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        var searchText = SearchText.Trim();
+        if (searchText.Length > name.Length)
+        {
+            return false;
+        }
+
+        return -1 < name.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    protected virtual bool FilterBySearchText(KeyValuePair<Guid, IDatabaseObject> pair)
+    {
+        return FilterBySearchText(pair.Value);
+    }
+
+    protected virtual DarkTreeNode ObjectAsNode(IDatabaseObject databaseObject)
+    {
+        if (!mIdNodeLookup.TryGetValue(databaseObject.Id, out var node))
+        {
+            node = new DarkTreeNode(databaseObject.Name ?? "NULL");
+        }
+
+        return node;
+    }
+
+    protected virtual DarkTreeNode PairAsNode(KeyValuePair<Guid, IDatabaseObject> pair)
+    {
+        return ObjectAsNode(
+            pair.Value ??
+            throw new ArgumentNullException(nameof(pair.Value), $@"{pair.Key} has a null object associated.")
+        );
+    }
+
+    protected void UpdateNodes()
+    {
+        treeViewItems?.Nodes?.Clear();
+
+        // TODO: Remove this when we fix DarkUI, which currently does not invalidate (and will show stale values when the list is emptied).
+        treeViewItems?.Invalidate();
+
+        if (ItemProvider == null)
+        {
+            return;
+        }
+
+        mPreviousSearchText = SearchText;
+
+        var filtered = string.IsNullOrWhiteSpace(SearchText)
+            ? ItemProvider
+            : ItemProvider.Where(FilterBySearchText);
+
+        var nodes = filtered.Select(PairAsNode).ToList();
+
+        treeViewItems?.Nodes?.AddRange(nodes);
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        var searchText = SearchText?.Trim() ?? "";
+        var previousSearchText = mPreviousSearchText?.Trim() ?? "";
+
+        if (string.Equals(searchText, previousSearchText, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        UpdateNodes();
+    }
+
+    private void toolStripCreate_Click(object sender, EventArgs e)
+    {
     }
 
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapGrid.cs
@@ -8,239 +8,237 @@ using WeifenLuo.WinFormsUI.Docking;
 
 using Graphics = Intersect.Editor.Core.Graphics;
 
-namespace Intersect.Editor.Forms.DockingElements
+namespace Intersect.Editor.Forms.DockingElements;
+
+
+public partial class FrmMapGrid : DockContent
 {
 
-    public partial class FrmMapGrid : DockContent
+    //MonoGame Swap Chain
+    private SwapChainRenderTarget mChain;
+
+    private bool mDragging;
+
+    private int mDragX;
+
+    private int mDragY;
+
+    private int mPosX;
+
+    private int mPosY;
+
+    private ToolTip mToolTip = new ToolTip();
+
+    private MapGridItem mToolTipItem;
+
+    public FrmMapGrid()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        //MonoGame Swap Chain
-        private SwapChainRenderTarget mChain;
+        pnlMapGrid.MouseWheel += PnlMapGrid_MouseWheel;
+    }
 
-        private bool mDragging;
+    private void frmMapGrid_Load(object sender, EventArgs e)
+    {
+        CreateSwapChain();
+        Globals.MapGrid ??= new MapGrid(
+            linkMapToolStripMenuItem,
+            unlinkMapToolStripMenuItem,
+            recacheMapToolStripMenuItem,
+            contextMenuStrip,
+            Icon
+        );
 
-        private int mDragX;
+        InitLocalization();
+    }
 
-        private int mDragY;
+    private void InitLocalization()
+    {
+        Text = Strings.MapGrid.title;
+        btnScreenshotWorld.Text = Strings.MapGrid.screenshotworld;
+        btnGridView.Text = Strings.MapGrid.gridlines;
+        btnFetchPreview.Text = Strings.MapGrid.preview;
+        downloadMissingPreviewsToolStripMenuItem.Text = Strings.MapGrid.downloadmissing;
+        reDownloadAllPreviewsToolStripMenuItem.Text = Strings.MapGrid.downloadall;
+        unlinkMapToolStripMenuItem.Text = Strings.MapGrid.unlink;
+        linkMapToolStripMenuItem.Text = Strings.MapGrid.link;
+        recacheMapToolStripMenuItem.Text = Strings.MapGrid.recache;
+    }
 
-        private int mPosX;
+    public void InitGridWindow()
+    {
+        CreateSwapChain();
+    }
 
-        private int mPosY;
-
-        private ToolTip mToolTip = new ToolTip();
-
-        private MapGridItem mToolTipItem;
-
-        public FrmMapGrid()
+    private void CreateSwapChain()
+    {
+        if (!Globals.ClosingEditor)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            pnlMapGrid.MouseWheel += PnlMapGrid_MouseWheel;
-        }
-
-        private void frmMapGrid_Load(object sender, EventArgs e)
-        {
-            CreateSwapChain();
-            Globals.MapGrid ??= new MapGrid(
-                linkMapToolStripMenuItem,
-                unlinkMapToolStripMenuItem,
-                recacheMapToolStripMenuItem,
-                contextMenuStrip,
-                Icon
-            );
-
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.MapGrid.title;
-            btnScreenshotWorld.Text = Strings.MapGrid.screenshotworld;
-            btnGridView.Text = Strings.MapGrid.gridlines;
-            btnFetchPreview.Text = Strings.MapGrid.preview;
-            downloadMissingPreviewsToolStripMenuItem.Text = Strings.MapGrid.downloadmissing;
-            reDownloadAllPreviewsToolStripMenuItem.Text = Strings.MapGrid.downloadall;
-            unlinkMapToolStripMenuItem.Text = Strings.MapGrid.unlink;
-            linkMapToolStripMenuItem.Text = Strings.MapGrid.link;
-            recacheMapToolStripMenuItem.Text = Strings.MapGrid.recache;
-        }
-
-        public void InitGridWindow()
-        {
-            CreateSwapChain();
-        }
-
-        private void CreateSwapChain()
-        {
-            if (!Globals.ClosingEditor)
+            if (mChain != null)
             {
-                if (mChain != null)
-                {
-                    mChain.Dispose();
-                }
+                mChain.Dispose();
+            }
 
-                if (Graphics.GetGraphicsDevice() != null)
+            if (Graphics.GetGraphicsDevice() != null)
+            {
+                if (pnlMapGrid.Width > 0 && pnlMapGrid.Height > 0)
                 {
                     if (pnlMapGrid.Width > 0 && pnlMapGrid.Height > 0)
                     {
-                        if (pnlMapGrid.Width > 0 && pnlMapGrid.Height > 0)
-                        {
-                            mChain = new SwapChainRenderTarget(
-                                Graphics.GetGraphicsDevice(), pnlMapGrid.Handle, pnlMapGrid.Width, pnlMapGrid.Height,
-                                false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents,
-                                PresentInterval.Immediate
-                            );
+                        mChain = new SwapChainRenderTarget(
+                            Graphics.GetGraphicsDevice(), pnlMapGrid.Handle, pnlMapGrid.Width, pnlMapGrid.Height,
+                            false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents,
+                            PresentInterval.Immediate
+                        );
 
-                            Graphics.SetMapGridChain(mChain);
-                        }
+                        Graphics.SetMapGridChain(mChain);
                     }
                 }
             }
         }
+    }
 
-        private void frmMapGrid_DockStateChanged(object sender, EventArgs e)
+    private void frmMapGrid_DockStateChanged(object sender, EventArgs e)
+    {
+        CreateSwapChain();
+    }
+
+    private void pnlMapGrid_Resize(object sender, EventArgs e)
+    {
+        CreateSwapChain();
+    }
+
+    private void PnlMapGrid_MouseWheel(object sender, MouseEventArgs e)
+    {
+        Globals.MapGrid.ZoomIn(e.Delta, e.X, e.Y);
+    }
+
+    private void pnlMapGrid_MouseMove(object sender, MouseEventArgs e)
+    {
+        mPosX = e.X;
+        mPosY = e.Y;
+        if (mDragging)
         {
-            CreateSwapChain();
+            Globals.MapGrid.Move(mDragX - e.X, mDragY - e.Y);
+            mDragX = e.X;
+            mDragY = e.Y;
         }
 
-        private void pnlMapGrid_Resize(object sender, EventArgs e)
+        if (mToolTip.Active && mToolTipItem != null)
         {
-            CreateSwapChain();
-        }
-
-        private void PnlMapGrid_MouseWheel(object sender, MouseEventArgs e)
-        {
-            Globals.MapGrid.ZoomIn(e.Delta, e.X, e.Y);
-        }
-
-        private void pnlMapGrid_MouseMove(object sender, MouseEventArgs e)
-        {
-            mPosX = e.X;
-            mPosY = e.Y;
-            if (mDragging)
-            {
-                Globals.MapGrid.Move(mDragX - e.X, mDragY - e.Y);
-                mDragX = e.X;
-                mDragY = e.Y;
-            }
-
-            if (mToolTip.Active && mToolTipItem != null)
-            {
-                if (Globals.MapGrid.GetItemAt(mPosX, mPosY) != mToolTipItem)
-                {
-                    mToolTip.Hide(pnlMapGrid);
-                    mToolTipItem = null;
-                }
-            }
-            else
-            {
-                mToolTipItem = Globals.MapGrid.GetItemAt(mPosX, mPosY);
-                if (mToolTipItem != null)
-                {
-                    mToolTip.Show(mToolTipItem.Name, pnlMapGrid);
-                }
-            }
-        }
-
-        private void pnlMapGrid_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Left || e.Button == MouseButtons.Middle)
-            {
-                mDragging = true;
-                mDragX = e.X;
-                mDragY = e.Y;
-            }
-            else if (e.Button == MouseButtons.Right)
-            {
-                Globals.MapGrid.RightClickGrid(e.X, e.Y, pnlMapGrid);
-            }
-        }
-
-        private void pnlMapGrid_MouseUp(object sender, MouseEventArgs e)
-        {
-            mDragging = false;
-        }
-
-        private void pnlMapGrid_MouseLeave(object sender, EventArgs e)
-        {
-            if (mToolTip.Active)
+            if (Globals.MapGrid.GetItemAt(mPosX, mPosY) != mToolTipItem)
             {
                 mToolTip.Hide(pnlMapGrid);
                 mToolTipItem = null;
             }
         }
-
-        private void pnlMapGrid_MouseHover(object sender, EventArgs e)
+        else
         {
-        }
-
-        private void btnGridView_Click(object sender, EventArgs e)
-        {
-            Globals.MapGrid.ShowLines = !Globals.MapGrid.ShowLines;
-        }
-
-        private void pnlMapGrid_MouseDoubleClick(object sender, MouseEventArgs e)
-        {
-            Globals.MapGrid.DoubleClick(e.X, e.Y);
-        }
-
-        private void downloadMissingPreviewsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Globals.MapGrid.FetchMissingPreviews(false);
-        }
-
-        private void reDownloadAllPreviewsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Globals.MapGrid.FetchMissingPreviews(true);
-        }
-
-        private void btnScreenshotWorld_Click(object sender, EventArgs e)
-        {
-            Globals.MapGrid.ScreenshotWorld();
-        }
-
-        private void frmMapGrid_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Oemplus || e.KeyCode == Keys.Add)
+            mToolTipItem = Globals.MapGrid.GetItemAt(mPosX, mPosY);
+            if (mToolTipItem != null)
             {
-                var args = new MouseEventArgs(MouseButtons.None, 0, mPosX, mPosY, 120);
-                PnlMapGrid_MouseWheel(null, args);
-            }
-            else if (e.KeyCode == Keys.OemMinus || e.KeyCode == Keys.Subtract)
-            {
-                var args = new MouseEventArgs(MouseButtons.None, 0, mPosX, mPosY, -120);
-                PnlMapGrid_MouseWheel(null, args);
-            }
-
-            var xDiff = 0;
-            var yDiff = 0;
-            if (e.KeyCode == Keys.W || e.KeyCode == Keys.Up)
-            {
-                yDiff -= 20;
-            }
-
-            if (e.KeyCode == Keys.S || e.KeyCode == Keys.Down)
-            {
-                yDiff += 20;
-            }
-
-            if (e.KeyCode == Keys.A || e.KeyCode == Keys.Left)
-            {
-                xDiff -= 20;
-            }
-
-            if (e.KeyCode == Keys.D || e.KeyCode == Keys.Right)
-            {
-                xDiff += 20;
-            }
-
-            if (xDiff != 0 || yDiff != 0)
-            {
-                Globals.MapGrid.Move(xDiff, yDiff);
+                mToolTip.Show(mToolTipItem.Name, pnlMapGrid);
             }
         }
+    }
 
+    private void pnlMapGrid_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Left || e.Button == MouseButtons.Middle)
+        {
+            mDragging = true;
+            mDragX = e.X;
+            mDragY = e.Y;
+        }
+        else if (e.Button == MouseButtons.Right)
+        {
+            Globals.MapGrid.RightClickGrid(e.X, e.Y, pnlMapGrid);
+        }
+    }
+
+    private void pnlMapGrid_MouseUp(object sender, MouseEventArgs e)
+    {
+        mDragging = false;
+    }
+
+    private void pnlMapGrid_MouseLeave(object sender, EventArgs e)
+    {
+        if (mToolTip.Active)
+        {
+            mToolTip.Hide(pnlMapGrid);
+            mToolTipItem = null;
+        }
+    }
+
+    private void pnlMapGrid_MouseHover(object sender, EventArgs e)
+    {
+    }
+
+    private void btnGridView_Click(object sender, EventArgs e)
+    {
+        Globals.MapGrid.ShowLines = !Globals.MapGrid.ShowLines;
+    }
+
+    private void pnlMapGrid_MouseDoubleClick(object sender, MouseEventArgs e)
+    {
+        Globals.MapGrid.DoubleClick(e.X, e.Y);
+    }
+
+    private void downloadMissingPreviewsToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Globals.MapGrid.FetchMissingPreviews(false);
+    }
+
+    private void reDownloadAllPreviewsToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Globals.MapGrid.FetchMissingPreviews(true);
+    }
+
+    private void btnScreenshotWorld_Click(object sender, EventArgs e)
+    {
+        Globals.MapGrid.ScreenshotWorld();
+    }
+
+    private void frmMapGrid_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Oemplus || e.KeyCode == Keys.Add)
+        {
+            var args = new MouseEventArgs(MouseButtons.None, 0, mPosX, mPosY, 120);
+            PnlMapGrid_MouseWheel(null, args);
+        }
+        else if (e.KeyCode == Keys.OemMinus || e.KeyCode == Keys.Subtract)
+        {
+            var args = new MouseEventArgs(MouseButtons.None, 0, mPosX, mPosY, -120);
+            PnlMapGrid_MouseWheel(null, args);
+        }
+
+        var xDiff = 0;
+        var yDiff = 0;
+        if (e.KeyCode == Keys.W || e.KeyCode == Keys.Up)
+        {
+            yDiff -= 20;
+        }
+
+        if (e.KeyCode == Keys.S || e.KeyCode == Keys.Down)
+        {
+            yDiff += 20;
+        }
+
+        if (e.KeyCode == Keys.A || e.KeyCode == Keys.Left)
+        {
+            xDiff -= 20;
+        }
+
+        if (e.KeyCode == Keys.D || e.KeyCode == Keys.Right)
+        {
+            xDiff += 20;
+        }
+
+        if (xDiff != 0 || yDiff != 0)
+        {
+            Globals.MapGrid.Move(xDiff, yDiff);
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -15,1412 +15,1410 @@ using WeifenLuo.WinFormsUI.Docking;
 using Graphics = System.Drawing.Graphics;
 using MapAttribute = Intersect.Enums.MapAttribute;
 
-namespace Intersect.Editor.Forms.DockingElements
+namespace Intersect.Editor.Forms.DockingElements;
+
+
+public enum LayerTabs
 {
 
-    public enum LayerTabs
+    Tiles = 0,
+
+    Attributes,
+
+    Lights,
+
+    Events,
+
+    Npcs
+
+}
+
+public partial class FrmMapLayers : DockContent
+{
+
+    public LayerTabs CurrentTab = LayerTabs.Tiles;
+
+    public Dictionary<string, bool> LayerVisibility = new Dictionary<string,bool>();
+
+    //MonoGame Swap Chain
+    private SwapChainRenderTarget mChain;
+
+    private string mLastTileLayer;
+
+    private List<PictureBox> mMapLayers = new List<PictureBox>();
+
+    private bool mTMouseDown;
+
+    public static System.Drawing.Color NpcPulseColor;
+
+    public FrmMapLayers()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        Tiles = 0,
-
-        Attributes,
-
-        Lights,
-
-        Events,
-
-        Npcs
-
+        mMapLayers.Add(picLayer1);
+        mMapLayers.Add(picLayer2);
+        mMapLayers.Add(picLayer3);
+        mMapLayers.Add(picLayer4);
+        mMapLayers.Add(picLayer5);
     }
 
-    public partial class FrmMapLayers : DockContent
+    public void Init()
     {
+        cmbAutotile.SelectedIndex = 0;
 
-        public LayerTabs CurrentTab = LayerTabs.Tiles;
-
-        public Dictionary<string, bool> LayerVisibility = new Dictionary<string,bool>();
-
-        //MonoGame Swap Chain
-        private SwapChainRenderTarget mChain;
-
-        private string mLastTileLayer;
-
-        private List<PictureBox> mMapLayers = new List<PictureBox>();
-
-        private bool mTMouseDown;
-
-        public static System.Drawing.Color NpcPulseColor;
-
-        public FrmMapLayers()
+        // Selected Npc highlight color from preferences
+        NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+        
+        //See if we can use the old style icons instead of a combobox
+        if (Options.Instance.MapOpts.Layers.All.Count <= mMapLayers.Count)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            mMapLayers.Add(picLayer1);
-            mMapLayers.Add(picLayer2);
-            mMapLayers.Add(picLayer3);
-            mMapLayers.Add(picLayer4);
-            mMapLayers.Add(picLayer5);
-        }
-
-        public void Init()
-        {
-            cmbAutotile.SelectedIndex = 0;
-
-            // Selected Npc highlight color from preferences
-            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
-            
-            //See if we can use the old style icons instead of a combobox
-            if (Options.Instance.MapOpts.Layers.All.Count <= mMapLayers.Count)
+            //Hide combobox...
+            cmbMapLayer.Hide();
+            for (int i = 0; i < mMapLayers.Count; i++)
             {
-                //Hide combobox...
-                cmbMapLayer.Hide();
-                for (int i = 0; i < mMapLayers.Count; i++)
+                if (i < Options.Instance.MapOpts.Layers.All.Count)
                 {
-                    if (i < Options.Instance.MapOpts.Layers.All.Count)
-                    {
-                        Strings.Tiles.maplayers.TryGetValue(Options.Instance.MapOpts.Layers.All[i].ToLower(), out LocalizedString layerName);
-                        if (layerName == null) layerName = Options.Instance.MapOpts.Layers.All[i];
-                        mMapLayers[i].Text = layerName;
-                        mMapLayers[i].Show();
-                    }
-                    else
-                    {
-                        mMapLayers[i].Hide();
-                    }
-                }
-            }
-            else
-            {
-                foreach(var layer in mMapLayers)
-                {
-                    layer.Hide();
-                }
-                //Show Combobox
-                cmbMapLayer.Show();
-                cmbMapLayer.Items.AddRange(Options.Instance.MapOpts.Layers.All.ToArray());
-                cmbMapLayer.SelectedIndex = 0;
-            }
-
-            foreach (var layer in Options.Instance.MapOpts.Layers.All)
-            {
-                LayerVisibility.Add(layer, true);
-            }
-
-            SetLayer(Options.Instance.MapOpts.Layers.All[0]);
-            if (cmbTilesets.Items.Count > 0)
-            {
-                SetTileset(cmbTilesets.Items[0].ToString());
-            }
-
-            rbZDimension.Visible = Options.ZDimensionVisible;
-            grpZResource.Visible = Options.ZDimensionVisible;
-            grpInstanceSettings.Visible = chkChangeInstance.Checked;
-
-            cmbInstanceType.Items.Clear();
-            // We do not want to iterate over the "NoChange" enum
-            foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
-            {
-                cmbInstanceType.Items.Add(instanceType.ToString());
-            }
-            cmbInstanceType.SelectedIndex = 0;
-
-            cmbWarpSound.Items.Clear();
-            RefreshMapWarpSounds();
-        }
-
-        //Tiles Tab
-        private void cmbTilesets_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            SetTileset(cmbTilesets.Text);
-        }
-
-        private void picTileset_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.X > picTileset.Width || e.Y > picTileset.Height)
-            {
-                return;
-            }
-
-            mTMouseDown = true;
-            Globals.CurSelX = (int) Math.Floor((double) e.X / Options.TileWidth);
-            Globals.CurSelY = (int) Math.Floor((double) e.Y / Options.TileHeight);
-            Globals.CurSelW = 0;
-            Globals.CurSelH = 0;
-            if (Globals.CurSelX < 0)
-            {
-                Globals.CurSelX = 0;
-            }
-
-            if (Globals.CurSelY < 0)
-            {
-                Globals.CurSelY = 0;
-            }
-
-            switch (Globals.Autotilemode)
-            {
-                case 1:
-                case 5:
-                    Globals.CurSelW = 1;
-                    Globals.CurSelH = 2;
-
-                    break;
-                case 2:
-                    Globals.CurSelW = 0;
-                    Globals.CurSelH = 0;
-
-                    break;
-                case 3:
-                    Globals.CurSelW = 5;
-                    Globals.CurSelH = 2;
-
-                    break;
-                case 4:
-                    Globals.CurSelW = 1;
-                    Globals.CurSelH = 1;
-
-                    break;
-                case 6:
-                    Globals.CurSelW = 2;
-                    Globals.CurSelH = 3;
-
-                    break;
-                case 7:
-                    Globals.CurSelW = 8;
-                    Globals.CurSelH = 3;
-
-                    break;
-            }
-        }
-
-        private void picTileset_MouseMove(object sender, MouseEventArgs e)
-        {
-            if (e.X > picTileset.Width || e.Y > picTileset.Height)
-            {
-                return;
-            }
-
-            if (mTMouseDown && Globals.Autotilemode == 0)
-            {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
-                Globals.CurSelW = tmpX - Globals.CurSelX;
-                Globals.CurSelH = tmpY - Globals.CurSelY;
-            }
-        }
-
-        private void picTileset_MouseUp(object sender, MouseEventArgs e)
-        {
-            var selX = Globals.CurSelX;
-            var selY = Globals.CurSelY;
-            var selW = Globals.CurSelW;
-            var selH = Globals.CurSelH;
-            if (selW < 0)
-            {
-                selX -= Math.Abs(selW);
-                selW = Math.Abs(selW);
-            }
-
-            if (selH < 0)
-            {
-                selY -= Math.Abs(selH);
-                selH = Math.Abs(selH);
-            }
-
-            Globals.CurSelX = selX;
-            Globals.CurSelY = selY;
-            Globals.CurSelW = selW;
-            Globals.CurSelH = selH;
-            mTMouseDown = false;
-            Globals.MapEditorWindow.DockPanel.Focus();
-        }
-
-        private void cmbAutotile_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            SetAutoTile(cmbAutotile.SelectedIndex);
-        }
-
-        public void SetAutoTile(int index)
-        {
-            Globals.Autotilemode = index;
-            cmbAutotile.SelectedIndex = index;
-            switch (Globals.Autotilemode)
-            {
-                case 1:
-                case 5:
-                    Globals.CurSelW = 1;
-                    Globals.CurSelH = 2;
-
-                    break;
-                case 2:
-                    Globals.CurSelW = 0;
-                    Globals.CurSelH = 0;
-
-                    break;
-                case 3:
-                    Globals.CurSelW = 5;
-                    Globals.CurSelH = 2;
-
-                    break;
-                case 4:
-                    Globals.CurSelW = 1;
-                    Globals.CurSelH = 1;
-
-                    break;
-                case 6:
-                    Globals.CurSelW = 2;
-                    Globals.CurSelH = 3;
-
-                    break;
-                case 7:
-                    Globals.CurSelW = 8;
-                    Globals.CurSelH = 3;
-
-                    break;
-            }
-        }
-
-        public void InitTilesets()
-        {
-            Globals.MapLayersWindow.cmbTilesets.Items.Clear();
-            var tilesetList = new List<string>();
-            tilesetList.AddRange(TilesetBase.Names);
-            tilesetList.Sort(new AlphanumComparatorFast());
-            foreach (var filename in tilesetList)
-            {
-                if (File.Exists("resources/tilesets/" + filename))
-                {
-                    Globals.MapLayersWindow.cmbTilesets.Items.Add(filename);
+                    Strings.Tiles.maplayers.TryGetValue(Options.Instance.MapOpts.Layers.All[i].ToLower(), out LocalizedString layerName);
+                    if (layerName == null) layerName = Options.Instance.MapOpts.Layers.All[i];
+                    mMapLayers[i].Text = layerName;
+                    mMapLayers[i].Show();
                 }
                 else
                 {
-                }
-            }
-
-            if (TilesetBase.Lookup.Count > 0)
-            {
-                if (Globals.MapLayersWindow.cmbTilesets.Items.Count > 0)
-                {
-                    Globals.MapLayersWindow.cmbTilesets.SelectedIndex = 0;
-                }
-
-                Globals.CurrentTileset = (TilesetBase) TilesetBase.Lookup.Values.ToArray()[0];
-            }
-        }
-
-        public void SetTileset(string name)
-        {
-            TilesetBase tSet = null;
-            var tilesets = TilesetBase.Lookup;
-            var id = Guid.Empty;
-            foreach (var tileset in tilesets.Pairs)
-            {
-                if (tileset.Value.Name.ToLower() == name.ToLower())
-                {
-                    id = tileset.Key;
-
-                    break;
-                }
-            }
-
-            if (id != Guid.Empty)
-            {
-                tSet = TilesetBase.Get(id);
-            }
-
-            if (tSet != null)
-            {
-                if (File.Exists("resources/tilesets/" + tSet.Name))
-                {
-                    picTileset.Show();
-                    Globals.CurrentTileset = tSet;
-                    Globals.CurSelX = 0;
-                    Globals.CurSelY = 0;
-                    var tilesetTex = GameContentManager.GetTexture(GameContentManager.TextureType.Tileset, tSet.Name);
-                    if (tilesetTex != null)
-                    {
-                        picTileset.Width = tilesetTex.Width;
-                        picTileset.Height = tilesetTex.Height;
-                    }
-
-                    cmbTilesets.SelectedItem = name;
-                    CreateSwapChain();
+                    mMapLayers[i].Hide();
                 }
             }
         }
-
-        public void SetLayer(string name)
+        else
         {
-            Globals.CurrentLayer = name;
-
-            var index = Options.Instance.MapOpts.Layers.All.IndexOf(name);
-
-            if (!cmbMapLayer.Visible)
+            foreach(var layer in mMapLayers)
             {
-                for (var i = 0; i < mMapLayers.Count; i++)
-                {
-                    if (mMapLayers[i].BackgroundImage != null)
-                    {
-                        mMapLayers[i].BackgroundImage.Dispose();
-                        mMapLayers[i].BackgroundImage = null;
-                    }
-                    mMapLayers[i].BackgroundImage = DrawLayerImage(i, i == index, !LayerVisibility[Options.Instance.MapOpts.Layers.All[i]]);
-                }
+                layer.Hide();
+            }
+            //Show Combobox
+            cmbMapLayer.Show();
+            cmbMapLayer.Items.AddRange(Options.Instance.MapOpts.Layers.All.ToArray());
+            cmbMapLayer.SelectedIndex = 0;
+        }
+
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            LayerVisibility.Add(layer, true);
+        }
+
+        SetLayer(Options.Instance.MapOpts.Layers.All[0]);
+        if (cmbTilesets.Items.Count > 0)
+        {
+            SetTileset(cmbTilesets.Items[0].ToString());
+        }
+
+        rbZDimension.Visible = Options.ZDimensionVisible;
+        grpZResource.Visible = Options.ZDimensionVisible;
+        grpInstanceSettings.Visible = chkChangeInstance.Checked;
+
+        cmbInstanceType.Items.Clear();
+        // We do not want to iterate over the "NoChange" enum
+        foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
+        {
+            cmbInstanceType.Items.Add(instanceType.ToString());
+        }
+        cmbInstanceType.SelectedIndex = 0;
+
+        cmbWarpSound.Items.Clear();
+        RefreshMapWarpSounds();
+    }
+
+    //Tiles Tab
+    private void cmbTilesets_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        SetTileset(cmbTilesets.Text);
+    }
+
+    private void picTileset_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.X > picTileset.Width || e.Y > picTileset.Height)
+        {
+            return;
+        }
+
+        mTMouseDown = true;
+        Globals.CurSelX = (int) Math.Floor((double) e.X / Options.TileWidth);
+        Globals.CurSelY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        Globals.CurSelW = 0;
+        Globals.CurSelH = 0;
+        if (Globals.CurSelX < 0)
+        {
+            Globals.CurSelX = 0;
+        }
+
+        if (Globals.CurSelY < 0)
+        {
+            Globals.CurSelY = 0;
+        }
+
+        switch (Globals.Autotilemode)
+        {
+            case 1:
+            case 5:
+                Globals.CurSelW = 1;
+                Globals.CurSelH = 2;
+
+                break;
+            case 2:
+                Globals.CurSelW = 0;
+                Globals.CurSelH = 0;
+
+                break;
+            case 3:
+                Globals.CurSelW = 5;
+                Globals.CurSelH = 2;
+
+                break;
+            case 4:
+                Globals.CurSelW = 1;
+                Globals.CurSelH = 1;
+
+                break;
+            case 6:
+                Globals.CurSelW = 2;
+                Globals.CurSelH = 3;
+
+                break;
+            case 7:
+                Globals.CurSelW = 8;
+                Globals.CurSelH = 3;
+
+                break;
+        }
+    }
+
+    private void picTileset_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.X > picTileset.Width || e.Y > picTileset.Height)
+        {
+            return;
+        }
+
+        if (mTMouseDown && Globals.Autotilemode == 0)
+        {
+            var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
+            var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            Globals.CurSelW = tmpX - Globals.CurSelX;
+            Globals.CurSelH = tmpY - Globals.CurSelY;
+        }
+    }
+
+    private void picTileset_MouseUp(object sender, MouseEventArgs e)
+    {
+        var selX = Globals.CurSelX;
+        var selY = Globals.CurSelY;
+        var selW = Globals.CurSelW;
+        var selH = Globals.CurSelH;
+        if (selW < 0)
+        {
+            selX -= Math.Abs(selW);
+            selW = Math.Abs(selW);
+        }
+
+        if (selH < 0)
+        {
+            selY -= Math.Abs(selH);
+            selH = Math.Abs(selH);
+        }
+
+        Globals.CurSelX = selX;
+        Globals.CurSelY = selY;
+        Globals.CurSelW = selW;
+        Globals.CurSelH = selH;
+        mTMouseDown = false;
+        Globals.MapEditorWindow.DockPanel.Focus();
+    }
+
+    private void cmbAutotile_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        SetAutoTile(cmbAutotile.SelectedIndex);
+    }
+
+    public void SetAutoTile(int index)
+    {
+        Globals.Autotilemode = index;
+        cmbAutotile.SelectedIndex = index;
+        switch (Globals.Autotilemode)
+        {
+            case 1:
+            case 5:
+                Globals.CurSelW = 1;
+                Globals.CurSelH = 2;
+
+                break;
+            case 2:
+                Globals.CurSelW = 0;
+                Globals.CurSelH = 0;
+
+                break;
+            case 3:
+                Globals.CurSelW = 5;
+                Globals.CurSelH = 2;
+
+                break;
+            case 4:
+                Globals.CurSelW = 1;
+                Globals.CurSelH = 1;
+
+                break;
+            case 6:
+                Globals.CurSelW = 2;
+                Globals.CurSelH = 3;
+
+                break;
+            case 7:
+                Globals.CurSelW = 8;
+                Globals.CurSelH = 3;
+
+                break;
+        }
+    }
+
+    public void InitTilesets()
+    {
+        Globals.MapLayersWindow.cmbTilesets.Items.Clear();
+        var tilesetList = new List<string>();
+        tilesetList.AddRange(TilesetBase.Names);
+        tilesetList.Sort(new AlphanumComparatorFast());
+        foreach (var filename in tilesetList)
+        {
+            if (File.Exists("resources/tilesets/" + filename))
+            {
+                Globals.MapLayersWindow.cmbTilesets.Items.Add(filename);
             }
             else
             {
-                if (cmbMapLayer.Items.IndexOf(name) > -1)
+            }
+        }
+
+        if (TilesetBase.Lookup.Count > 0)
+        {
+            if (Globals.MapLayersWindow.cmbTilesets.Items.Count > 0)
+            {
+                Globals.MapLayersWindow.cmbTilesets.SelectedIndex = 0;
+            }
+
+            Globals.CurrentTileset = (TilesetBase) TilesetBase.Lookup.Values.ToArray()[0];
+        }
+    }
+
+    public void SetTileset(string name)
+    {
+        TilesetBase tSet = null;
+        var tilesets = TilesetBase.Lookup;
+        var id = Guid.Empty;
+        foreach (var tileset in tilesets.Pairs)
+        {
+            if (tileset.Value.Name.ToLower() == name.ToLower())
+            {
+                id = tileset.Key;
+
+                break;
+            }
+        }
+
+        if (id != Guid.Empty)
+        {
+            tSet = TilesetBase.Get(id);
+        }
+
+        if (tSet != null)
+        {
+            if (File.Exists("resources/tilesets/" + tSet.Name))
+            {
+                picTileset.Show();
+                Globals.CurrentTileset = tSet;
+                Globals.CurSelX = 0;
+                Globals.CurSelY = 0;
+                var tilesetTex = GameContentManager.GetTexture(GameContentManager.TextureType.Tileset, tSet.Name);
+                if (tilesetTex != null)
                 {
-                    cmbMapLayer.SelectedIndex = cmbMapLayer.Items.IndexOf(name);
-                }
-            }
-
-            mLastTileLayer = name;
-
-            Core.Graphics.TilePreviewUpdated = true;
-        }
-
-        private Bitmap DrawLayerImage(int layerIndex, bool selected, bool hidden)
-        {
-            var img = new Bitmap(32, 32);
-            img.MakeTransparent(img.GetPixel(0, 0));
-
-            var g = Graphics.FromImage(img);
-
-            var layer = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer");
-            var layerSel = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_sel");
-            var face = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_face");
-            var faceSel = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_face_sel");
-            var hiddenIcon = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_hidden");
-            var drawFace = selected ? faceSel : face;
-
-            var drawIndex = 0;
-
-            //Draw Lower & Middle Layers
-            foreach (var l in Options.Instance.MapOpts.Layers.LowerLayers)
-            {
-                var drawImg = layer;
-                if (drawIndex == layerIndex)
-                {
-                    drawImg = layerSel;
-                }
-                g.DrawImage(drawImg, new PointF(3, 23 - ((drawIndex) * (layer.Height - 4))));
-                drawIndex++;
-            }
-
-
-            //If this image for is an upper layer, render the face below the next layers
-            if (!Options.Instance.MapOpts.Layers.LowerLayers.Contains(Options.Instance.MapOpts.Layers.All[layerIndex]))
-            {
-                g.DrawImage(drawFace, new PointF(13, 13));
-            }
-
-
-            //Draw Upper Layers
-            var middleUpperLayers = Options.Instance.MapOpts.Layers.LowerLayers.ToList();
-            middleUpperLayers.AddRange(Options.Instance.MapOpts.Layers.MiddleLayers);
-            foreach (var l in middleUpperLayers)
-            {
-                var drawImg = layer;
-                if (drawIndex == layerIndex)
-                {
-                    drawImg = layerSel;
-                }
-                g.DrawImage(drawImg, new PointF(3, 23 - ((drawIndex) * (layer.Height - 4))));
-                drawIndex++;
-            }
-
-            //If this image for is a lower layer, render the face above everything
-            if (Options.Instance.MapOpts.Layers.LowerLayers.Contains(Options.Instance.MapOpts.Layers.All[layerIndex]))
-            {
-                g.DrawImage(drawFace, new PointF(13, 13));
-            }
-
-
-            //Draw Hidden Icon
-            if (hidden)
-            {
-                g.DrawImage(hiddenIcon, new PointF(32 - hiddenIcon.Width, 0));
-            }
-
-            g.Dispose();
-            return img;
-        }
-
-        //Mapping Attribute Functions
-        /// <summary>
-        ///     A method that hides all of the extra group boxes for tile data related to the map attributes.
-        /// </summary>
-        private void HideAttributeMenus()
-        {
-            grpItem.Visible = false;
-            grpZDimension.Visible = false;
-            grpWarp.Visible = false;
-            grpSound.Visible = false;
-            grpResource.Visible = false;
-            grpAnimation.Visible = false;
-            grpSlide.Visible = false;
-            grpCritter.Visible = false;
-        }
-
-        private void rbItem_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-            grpItem.Visible = true;
-            cmbItemAttribute.Items.Clear();
-            cmbItemAttribute.Items.AddRange(ItemBase.Names);
-            if (cmbItemAttribute.Items.Count > 0)
-            {
-                cmbItemAttribute.SelectedIndex = 0;
-            }
-            nudItemRespawnTime.Value = 0;
-        }
-
-        private void rbBlocked_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-        }
-
-        private void rbNPCAvoid_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-        }
-
-        private void rbZDimension_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-            grpZDimension.Visible = true;
-        }
-
-        private void rbWarp_CheckedChanged(object sender, EventArgs e)
-        {
-            nudWarpX.Maximum = Options.MapWidth;
-            nudWarpY.Maximum = Options.MapHeight;
-            cmbWarpMap.Items.Clear();
-            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-            {
-                cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
-            }
-
-            cmbWarpMap.SelectedIndex = 0;
-            cmbDirection.SelectedIndex = 0;
-            if (!rbWarp.Checked)
-            {
-                return;
-            }
-
-            HideAttributeMenus();
-            RefreshMapWarpSounds();
-            grpWarp.Visible = true;
-        }
-
-        private void rbSound_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-            grpSound.Visible = true;
-            cmbMapAttributeSound.Items.Clear();
-            cmbMapAttributeSound.Items.Add(Strings.General.None);
-            cmbMapAttributeSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-            cmbMapAttributeSound.SelectedIndex = 0;
-        }
-
-        private void rbResource_CheckedChanged(object sender, EventArgs e)
-        {
-            cmbResourceAttribute.Items.Clear();
-            cmbResourceAttribute.Items.AddRange(ResourceBase.Names);
-            if (cmbResourceAttribute.Items.Count > 0)
-            {
-                cmbResourceAttribute.SelectedIndex = 0;
-            }
-
-            if (!rbResource.Checked)
-            {
-                return;
-            }
-
-            HideAttributeMenus();
-            grpResource.Visible = true;
-        }
-
-        // Used for returning an integer value depending on which radio button is selected on the forms. This is merely used to make PlaceAtrribute less messy.
-        private byte GetEditorDimensionGateway()
-        {
-            if (rbGateway1.Checked == true)
-            {
-                return 1;
-            }
-            else if (rbGateway2.Checked == true)
-            {
-                return 2;
-            }
-
-            return 0;
-        }
-
-        private byte GetEditorDimensionBlock()
-        {
-            if (rbBlock1.Checked == true)
-            {
-                return 1;
-            }
-            else if (rbBlock2.Checked == true)
-            {
-                return 2;
-            }
-
-            return 0;
-        }
-
-        public int GetAttributeFromEditor()
-        {
-            if (rbBlocked.Checked == true)
-            {
-                return (int) MapAttribute.Blocked;
-            }
-            else if (rbItem.Checked == true)
-            {
-                return (int) MapAttribute.Item;
-            }
-            else if (rbZDimension.Checked == true)
-            {
-                return (int) MapAttribute.ZDimension;
-            }
-            else if (rbNPCAvoid.Checked == true)
-            {
-                return (int) MapAttribute.NpcAvoid;
-            }
-            else if (rbWarp.Checked == true)
-            {
-                return (int) MapAttribute.Warp;
-            }
-            else if (rbSound.Checked == true)
-            {
-                return (int) MapAttribute.Sound;
-            }
-            else if (rbResource.Checked == true)
-            {
-                return (int) MapAttribute.Resource;
-            }
-            else if (rbAnimation.Checked == true)
-            {
-                return (int) MapAttribute.Animation;
-            }
-            else if (rbGrappleStone.Checked == true)
-            {
-                return (int) MapAttribute.GrappleStone;
-            }
-            else if (rbSlide.Checked == true)
-            {
-                return (int) MapAttribute.Slide;
-            }
-            else if (rbCritter.Checked == true)
-            {
-                return (int) MapAttribute.Critter;
-            }
-
-            return (int) MapAttribute.Walkable;
-        }
-
-        private MapAttribute SelectedMapAttributeType
-        {
-            get
-            {
-                if (rbBlocked.Checked)
-                {
-                    return MapAttribute.Blocked;
+                    picTileset.Width = tilesetTex.Width;
+                    picTileset.Height = tilesetTex.Height;
                 }
 
-                if (rbItem.Checked)
-                {
-                    return MapAttribute.Item;
-                }
-
-                if (rbZDimension.Checked)
-                {
-                    return MapAttribute.ZDimension;
-                }
-
-                if (rbNPCAvoid.Checked)
-                {
-                    return MapAttribute.NpcAvoid;
-                }
-
-                if (rbWarp.Checked)
-                {
-                    return MapAttribute.Warp;
-                }
-
-                if (rbSound.Checked)
-                {
-                    return MapAttribute.Sound;
-                }
-
-                if (rbResource.Checked)
-                {
-                    return MapAttribute.Resource;
-                }
-
-                if (rbAnimation.Checked)
-                {
-                    return MapAttribute.Animation;
-                }
-
-                if (rbGrappleStone.Checked)
-                {
-                    return MapAttribute.GrappleStone;
-                }
-
-                if (rbSlide.Checked)
-                {
-                    return MapAttribute.Slide;
-                }
-
-                if (rbCritter.Checked)
-                {
-                    return MapAttribute.Critter;
-                }
-
-                return (MapAttribute) byte.MaxValue;
+                cmbTilesets.SelectedItem = name;
+                CreateSwapChain();
             }
         }
+    }
 
-        [Obsolete("The entire switch statement should be implemented as a parameterized CreateAttribute().")]
-        public GameObjects.Maps.MapAttribute CreateAttribute()
+    public void SetLayer(string name)
+    {
+        Globals.CurrentLayer = name;
+
+        var index = Options.Instance.MapOpts.Layers.All.IndexOf(name);
+
+        if (!cmbMapLayer.Visible)
         {
-            var attributeType = SelectedMapAttributeType;
-            var attribute = GameObjects.Maps.MapAttribute.CreateAttribute(attributeType);
-            switch (SelectedMapAttributeType)
+            for (var i = 0; i < mMapLayers.Count; i++)
             {
-                case MapAttribute.Walkable:
-                case MapAttribute.Blocked:
-                case MapAttribute.GrappleStone:
-                case MapAttribute.NpcAvoid:
-                    break;
-
-                case MapAttribute.Item:
-                    var itemAttribute = attribute as MapItemAttribute;
-                    itemAttribute.ItemId = ItemBase.IdFromList(cmbItemAttribute.SelectedIndex);
-                    itemAttribute.Quantity = (int)nudItemQuantity.Value;
-                    itemAttribute.RespawnTime = (long)nudItemRespawnTime.Value;
-                    break;
-
-                case MapAttribute.ZDimension:
-                    var zDimensionAttribute = attribute as MapZDimensionAttribute;
-                    zDimensionAttribute.GatewayTo = GetEditorDimensionGateway();
-                    zDimensionAttribute.BlockedLevel = GetEditorDimensionBlock();
-                    break;
-
-                case MapAttribute.Warp:
-                    var warpAttribute = attribute as MapWarpAttribute;
-                    warpAttribute.MapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
-                    warpAttribute.X = (byte)nudWarpX.Value;
-                    warpAttribute.Y = (byte)nudWarpY.Value;
-                    warpAttribute.Direction = (WarpDirection)cmbDirection.SelectedIndex;
-                    warpAttribute.ChangeInstance = chkChangeInstance.Checked;
-                    warpAttribute.InstanceType = (MapInstanceType)cmbInstanceType.SelectedIndex;
-                    warpAttribute.WarpSound = TextUtils.SanitizeNone(cmbWarpSound.Text);
-                    break;
-
-                case MapAttribute.Sound:
-                    var soundAttribute = attribute as MapSoundAttribute;
-                    soundAttribute.Distance = (byte)nudSoundDistance.Value;
-                    soundAttribute.File = TextUtils.SanitizeNone(cmbMapAttributeSound.Text);
-                    soundAttribute.LoopInterval = (int)nudSoundLoopInterval.Value;
-                    break;
-
-                case MapAttribute.Resource:
-                    var resourceAttribute = attribute as MapResourceAttribute;
-                    resourceAttribute.ResourceId = ResourceBase.IdFromList(cmbResourceAttribute.SelectedIndex);
-                    resourceAttribute.SpawnLevel = (byte)(rbLevel1.Checked ? 0 : 1);
-                    break;
-
-                case MapAttribute.Animation:
-                    var animationAttribute = attribute as MapAnimationAttribute;
-                    animationAttribute.AnimationId = AnimationBase.IdFromList(cmbAnimationAttribute.SelectedIndex);
-                    animationAttribute.IsBlock = chkAnimationBlock.Checked;
-                    break;
-
-                case MapAttribute.Slide:
-                    var slideAttribute = attribute as MapSlideAttribute;
-                    slideAttribute.Direction = (Direction)cmbSlideDir.SelectedIndex;
-                    break;
-
-                case MapAttribute.Critter:
-                    var critterAttribute = attribute as MapCritterAttribute;
-                    critterAttribute.Sprite = cmbCritterSprite.Text;
-                    critterAttribute.AnimationId = AnimationBase.IdFromList(cmbCritterAnimation.SelectedIndex - 1);
-                    critterAttribute.Movement = (byte)cmbCritterMovement.SelectedIndex;
-                    critterAttribute.Layer = (byte)cmbCritterLayer.SelectedIndex;
-                    critterAttribute.Speed = (int)nudCritterMoveSpeed.Value;
-                    critterAttribute.Frequency = (int)nudCritterMoveFrequency.Value;
-                    critterAttribute.IgnoreNpcAvoids = chkCritterIgnoreNpcAvoids.Checked;
-                    critterAttribute.BlockPlayers = chkCritterBlockPlayers.Checked;
-                    critterAttribute.Direction = (byte)cmbCritterDirection.SelectedIndex;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(SelectedMapAttributeType), @"The currently selected attribute type has not been fully implemented.");
+                if (mMapLayers[i].BackgroundImage != null)
+                {
+                    mMapLayers[i].BackgroundImage.Dispose();
+                    mMapLayers[i].BackgroundImage = null;
+                }
+                mMapLayers[i].BackgroundImage = DrawLayerImage(i, i == index, !LayerVisibility[Options.Instance.MapOpts.Layers.All[i]]);
             }
-
-            return attribute;
         }
-
-        public GameObjects.Maps.MapAttribute PlaceAttribute(MapBase mapDescriptor, int x, int y, GameObjects.Maps.MapAttribute attribute = null)
+        else
         {
-            if (attribute == null)
+            if (cmbMapLayer.Items.IndexOf(name) > -1)
             {
-                attribute = CreateAttribute();
+                cmbMapLayer.SelectedIndex = cmbMapLayer.Items.IndexOf(name);
             }
-
-            mapDescriptor.Attributes[x, y] = attribute;
-
-            return attribute;
         }
 
-        public bool RemoveAttribute(MapBase tmpMap, int x, int y)
+        mLastTileLayer = name;
+
+        Core.Graphics.TilePreviewUpdated = true;
+    }
+
+    private Bitmap DrawLayerImage(int layerIndex, bool selected, bool hidden)
+    {
+        var img = new Bitmap(32, 32);
+        img.MakeTransparent(img.GetPixel(0, 0));
+
+        var g = Graphics.FromImage(img);
+
+        var layer = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer");
+        var layerSel = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_sel");
+        var face = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_face");
+        var faceSel = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_face_sel");
+        var hiddenIcon = (Bitmap)Properties.Resources.ResourceManager.GetObject("layer_hidden");
+        var drawFace = selected ? faceSel : face;
+
+        var drawIndex = 0;
+
+        //Draw Lower & Middle Layers
+        foreach (var l in Options.Instance.MapOpts.Layers.LowerLayers)
         {
-            if (tmpMap.Attributes[x, y] != null && tmpMap.Attributes[x, y].Type != MapAttribute.Walkable)
+            var drawImg = layer;
+            if (drawIndex == layerIndex)
             {
-                tmpMap.Attributes[x, y] = null;
-
-                return true;
+                drawImg = layerSel;
             }
-
-            return false;
+            g.DrawImage(drawImg, new PointF(3, 23 - ((drawIndex) * (layer.Height - 4))));
+            drawIndex++;
         }
 
-        public void RefreshNpcList()
-        {
-            // Update the list incase npcs have been modified since form load.
-            cmbNpc.Items.Clear();
-            cmbNpc.Items.AddRange(NpcBase.Names);
 
-            // Add the map NPCs
+        //If this image for is an upper layer, render the face below the next layers
+        if (!Options.Instance.MapOpts.Layers.LowerLayers.Contains(Options.Instance.MapOpts.Layers.All[layerIndex]))
+        {
+            g.DrawImage(drawFace, new PointF(13, 13));
+        }
+
+
+        //Draw Upper Layers
+        var middleUpperLayers = Options.Instance.MapOpts.Layers.LowerLayers.ToList();
+        middleUpperLayers.AddRange(Options.Instance.MapOpts.Layers.MiddleLayers);
+        foreach (var l in middleUpperLayers)
+        {
+            var drawImg = layer;
+            if (drawIndex == layerIndex)
+            {
+                drawImg = layerSel;
+            }
+            g.DrawImage(drawImg, new PointF(3, 23 - ((drawIndex) * (layer.Height - 4))));
+            drawIndex++;
+        }
+
+        //If this image for is a lower layer, render the face above everything
+        if (Options.Instance.MapOpts.Layers.LowerLayers.Contains(Options.Instance.MapOpts.Layers.All[layerIndex]))
+        {
+            g.DrawImage(drawFace, new PointF(13, 13));
+        }
+
+
+        //Draw Hidden Icon
+        if (hidden)
+        {
+            g.DrawImage(hiddenIcon, new PointF(32 - hiddenIcon.Width, 0));
+        }
+
+        g.Dispose();
+        return img;
+    }
+
+    //Mapping Attribute Functions
+    /// <summary>
+    ///     A method that hides all of the extra group boxes for tile data related to the map attributes.
+    /// </summary>
+    private void HideAttributeMenus()
+    {
+        grpItem.Visible = false;
+        grpZDimension.Visible = false;
+        grpWarp.Visible = false;
+        grpSound.Visible = false;
+        grpResource.Visible = false;
+        grpAnimation.Visible = false;
+        grpSlide.Visible = false;
+        grpCritter.Visible = false;
+    }
+
+    private void rbItem_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+        grpItem.Visible = true;
+        cmbItemAttribute.Items.Clear();
+        cmbItemAttribute.Items.AddRange(ItemBase.Names);
+        if (cmbItemAttribute.Items.Count > 0)
+        {
+            cmbItemAttribute.SelectedIndex = 0;
+        }
+        nudItemRespawnTime.Value = 0;
+    }
+
+    private void rbBlocked_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+    }
+
+    private void rbNPCAvoid_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+    }
+
+    private void rbZDimension_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+        grpZDimension.Visible = true;
+    }
+
+    private void rbWarp_CheckedChanged(object sender, EventArgs e)
+    {
+        nudWarpX.Maximum = Options.MapWidth;
+        nudWarpY.Maximum = Options.MapHeight;
+        cmbWarpMap.Items.Clear();
+        for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+        {
+            cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
+        }
+
+        cmbWarpMap.SelectedIndex = 0;
+        cmbDirection.SelectedIndex = 0;
+        if (!rbWarp.Checked)
+        {
+            return;
+        }
+
+        HideAttributeMenus();
+        RefreshMapWarpSounds();
+        grpWarp.Visible = true;
+    }
+
+    private void rbSound_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+        grpSound.Visible = true;
+        cmbMapAttributeSound.Items.Clear();
+        cmbMapAttributeSound.Items.Add(Strings.General.None);
+        cmbMapAttributeSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+        cmbMapAttributeSound.SelectedIndex = 0;
+    }
+
+    private void rbResource_CheckedChanged(object sender, EventArgs e)
+    {
+        cmbResourceAttribute.Items.Clear();
+        cmbResourceAttribute.Items.AddRange(ResourceBase.Names);
+        if (cmbResourceAttribute.Items.Count > 0)
+        {
+            cmbResourceAttribute.SelectedIndex = 0;
+        }
+
+        if (!rbResource.Checked)
+        {
+            return;
+        }
+
+        HideAttributeMenus();
+        grpResource.Visible = true;
+    }
+
+    // Used for returning an integer value depending on which radio button is selected on the forms. This is merely used to make PlaceAtrribute less messy.
+    private byte GetEditorDimensionGateway()
+    {
+        if (rbGateway1.Checked == true)
+        {
+            return 1;
+        }
+        else if (rbGateway2.Checked == true)
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+
+    private byte GetEditorDimensionBlock()
+    {
+        if (rbBlock1.Checked == true)
+        {
+            return 1;
+        }
+        else if (rbBlock2.Checked == true)
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+
+    public int GetAttributeFromEditor()
+    {
+        if (rbBlocked.Checked == true)
+        {
+            return (int) MapAttribute.Blocked;
+        }
+        else if (rbItem.Checked == true)
+        {
+            return (int) MapAttribute.Item;
+        }
+        else if (rbZDimension.Checked == true)
+        {
+            return (int) MapAttribute.ZDimension;
+        }
+        else if (rbNPCAvoid.Checked == true)
+        {
+            return (int) MapAttribute.NpcAvoid;
+        }
+        else if (rbWarp.Checked == true)
+        {
+            return (int) MapAttribute.Warp;
+        }
+        else if (rbSound.Checked == true)
+        {
+            return (int) MapAttribute.Sound;
+        }
+        else if (rbResource.Checked == true)
+        {
+            return (int) MapAttribute.Resource;
+        }
+        else if (rbAnimation.Checked == true)
+        {
+            return (int) MapAttribute.Animation;
+        }
+        else if (rbGrappleStone.Checked == true)
+        {
+            return (int) MapAttribute.GrappleStone;
+        }
+        else if (rbSlide.Checked == true)
+        {
+            return (int) MapAttribute.Slide;
+        }
+        else if (rbCritter.Checked == true)
+        {
+            return (int) MapAttribute.Critter;
+        }
+
+        return (int) MapAttribute.Walkable;
+    }
+
+    private MapAttribute SelectedMapAttributeType
+    {
+        get
+        {
+            if (rbBlocked.Checked)
+            {
+                return MapAttribute.Blocked;
+            }
+
+            if (rbItem.Checked)
+            {
+                return MapAttribute.Item;
+            }
+
+            if (rbZDimension.Checked)
+            {
+                return MapAttribute.ZDimension;
+            }
+
+            if (rbNPCAvoid.Checked)
+            {
+                return MapAttribute.NpcAvoid;
+            }
+
+            if (rbWarp.Checked)
+            {
+                return MapAttribute.Warp;
+            }
+
+            if (rbSound.Checked)
+            {
+                return MapAttribute.Sound;
+            }
+
+            if (rbResource.Checked)
+            {
+                return MapAttribute.Resource;
+            }
+
+            if (rbAnimation.Checked)
+            {
+                return MapAttribute.Animation;
+            }
+
+            if (rbGrappleStone.Checked)
+            {
+                return MapAttribute.GrappleStone;
+            }
+
+            if (rbSlide.Checked)
+            {
+                return MapAttribute.Slide;
+            }
+
+            if (rbCritter.Checked)
+            {
+                return MapAttribute.Critter;
+            }
+
+            return (MapAttribute) byte.MaxValue;
+        }
+    }
+
+    [Obsolete("The entire switch statement should be implemented as a parameterized CreateAttribute().")]
+    public GameObjects.Maps.MapAttribute CreateAttribute()
+    {
+        var attributeType = SelectedMapAttributeType;
+        var attribute = GameObjects.Maps.MapAttribute.CreateAttribute(attributeType);
+        switch (SelectedMapAttributeType)
+        {
+            case MapAttribute.Walkable:
+            case MapAttribute.Blocked:
+            case MapAttribute.GrappleStone:
+            case MapAttribute.NpcAvoid:
+                break;
+
+            case MapAttribute.Item:
+                var itemAttribute = attribute as MapItemAttribute;
+                itemAttribute.ItemId = ItemBase.IdFromList(cmbItemAttribute.SelectedIndex);
+                itemAttribute.Quantity = (int)nudItemQuantity.Value;
+                itemAttribute.RespawnTime = (long)nudItemRespawnTime.Value;
+                break;
+
+            case MapAttribute.ZDimension:
+                var zDimensionAttribute = attribute as MapZDimensionAttribute;
+                zDimensionAttribute.GatewayTo = GetEditorDimensionGateway();
+                zDimensionAttribute.BlockedLevel = GetEditorDimensionBlock();
+                break;
+
+            case MapAttribute.Warp:
+                var warpAttribute = attribute as MapWarpAttribute;
+                warpAttribute.MapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
+                warpAttribute.X = (byte)nudWarpX.Value;
+                warpAttribute.Y = (byte)nudWarpY.Value;
+                warpAttribute.Direction = (WarpDirection)cmbDirection.SelectedIndex;
+                warpAttribute.ChangeInstance = chkChangeInstance.Checked;
+                warpAttribute.InstanceType = (MapInstanceType)cmbInstanceType.SelectedIndex;
+                warpAttribute.WarpSound = TextUtils.SanitizeNone(cmbWarpSound.Text);
+                break;
+
+            case MapAttribute.Sound:
+                var soundAttribute = attribute as MapSoundAttribute;
+                soundAttribute.Distance = (byte)nudSoundDistance.Value;
+                soundAttribute.File = TextUtils.SanitizeNone(cmbMapAttributeSound.Text);
+                soundAttribute.LoopInterval = (int)nudSoundLoopInterval.Value;
+                break;
+
+            case MapAttribute.Resource:
+                var resourceAttribute = attribute as MapResourceAttribute;
+                resourceAttribute.ResourceId = ResourceBase.IdFromList(cmbResourceAttribute.SelectedIndex);
+                resourceAttribute.SpawnLevel = (byte)(rbLevel1.Checked ? 0 : 1);
+                break;
+
+            case MapAttribute.Animation:
+                var animationAttribute = attribute as MapAnimationAttribute;
+                animationAttribute.AnimationId = AnimationBase.IdFromList(cmbAnimationAttribute.SelectedIndex);
+                animationAttribute.IsBlock = chkAnimationBlock.Checked;
+                break;
+
+            case MapAttribute.Slide:
+                var slideAttribute = attribute as MapSlideAttribute;
+                slideAttribute.Direction = (Direction)cmbSlideDir.SelectedIndex;
+                break;
+
+            case MapAttribute.Critter:
+                var critterAttribute = attribute as MapCritterAttribute;
+                critterAttribute.Sprite = cmbCritterSprite.Text;
+                critterAttribute.AnimationId = AnimationBase.IdFromList(cmbCritterAnimation.SelectedIndex - 1);
+                critterAttribute.Movement = (byte)cmbCritterMovement.SelectedIndex;
+                critterAttribute.Layer = (byte)cmbCritterLayer.SelectedIndex;
+                critterAttribute.Speed = (int)nudCritterMoveSpeed.Value;
+                critterAttribute.Frequency = (int)nudCritterMoveFrequency.Value;
+                critterAttribute.IgnoreNpcAvoids = chkCritterIgnoreNpcAvoids.Checked;
+                critterAttribute.BlockPlayers = chkCritterBlockPlayers.Checked;
+                critterAttribute.Direction = (byte)cmbCritterDirection.SelectedIndex;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(SelectedMapAttributeType), @"The currently selected attribute type has not been fully implemented.");
+        }
+
+        return attribute;
+    }
+
+    public GameObjects.Maps.MapAttribute PlaceAttribute(MapBase mapDescriptor, int x, int y, GameObjects.Maps.MapAttribute attribute = null)
+    {
+        if (attribute == null)
+        {
+            attribute = CreateAttribute();
+        }
+
+        mapDescriptor.Attributes[x, y] = attribute;
+
+        return attribute;
+    }
+
+    public bool RemoveAttribute(MapBase tmpMap, int x, int y)
+    {
+        if (tmpMap.Attributes[x, y] != null && tmpMap.Attributes[x, y].Type != MapAttribute.Walkable)
+        {
+            tmpMap.Attributes[x, y] = null;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public void RefreshNpcList()
+    {
+        // Update the list incase npcs have been modified since form load.
+        cmbNpc.Items.Clear();
+        cmbNpc.Items.AddRange(NpcBase.Names);
+
+        // Add the map NPCs
+        lstMapNpcs.Items.Clear();
+        for (var i = 0; i < Globals.CurrentMap.Spawns.Count; i++)
+        {
+            lstMapNpcs.Items.Add(NpcBase.GetName(Globals.CurrentMap.Spawns[i].NpcId));
+        }
+
+        // Don't select if there are no NPCs, to avoid crashes.
+        if (cmbNpc.Items.Count > 0)
+        {
+            cmbNpc.SelectedIndex = 0;
+        }
+
+        cmbDir.SelectedIndex = 0;
+        rbRandom.Checked = true;
+        if (lstMapNpcs.Items.Count > 0)
+        {
+            lstMapNpcs.SelectedIndex = 0;
+            if (lstMapNpcs.SelectedIndex < Globals.CurrentMap.Spawns.Count)
+            {
+                cmbDir.SelectedIndex = (int) Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction;
+                cmbNpc.SelectedIndex = NpcBase.ListIndex(Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId);
+                if (Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X >= 0)
+                {
+                    rbDeclared.Checked = true;
+                }
+            }
+        }
+
+        UpdateNpcCountLabel();
+    }
+
+    private void frmMapLayers_DockStateChanged(object sender, EventArgs e)
+    {
+        CreateSwapChain();
+    }
+
+    //Map NPC List
+    private void btnAddMapNpc_Click(object sender, EventArgs e)
+    {
+        var n = new NpcSpawn();
+
+        //Don't add nothing
+        if (cmbNpc.SelectedIndex > -1)
+        {
+            n.NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
+            n.X = -1;
+            n.Y = -1;
+            n.Direction = NpcSpawnDirection.Random;
+
+            Globals.CurrentMap.Spawns.Add(n);
+            lstMapNpcs.Items.Add(NpcBase.GetName(n.NpcId));
+            lstMapNpcs.SelectedIndex = lstMapNpcs.Items.Count - 1;
+        }
+
+        UpdateNpcCountLabel();
+    }
+
+    private void btnRemoveMapNpc_Click(object sender, EventArgs e)
+    {
+        if (lstMapNpcs.SelectedIndex > -1)
+        {
+            Globals.CurrentMap.Spawns.RemoveAt(lstMapNpcs.SelectedIndex);
+            lstMapNpcs.Items.RemoveAt(lstMapNpcs.SelectedIndex);
+
+            // Refresh List
             lstMapNpcs.Items.Clear();
             for (var i = 0; i < Globals.CurrentMap.Spawns.Count; i++)
             {
                 lstMapNpcs.Items.Add(NpcBase.GetName(Globals.CurrentMap.Spawns[i].NpcId));
             }
 
-            // Don't select if there are no NPCs, to avoid crashes.
-            if (cmbNpc.Items.Count > 0)
-            {
-                cmbNpc.SelectedIndex = 0;
-            }
-
-            cmbDir.SelectedIndex = 0;
-            rbRandom.Checked = true;
             if (lstMapNpcs.Items.Count > 0)
             {
                 lstMapNpcs.SelectedIndex = 0;
-                if (lstMapNpcs.SelectedIndex < Globals.CurrentMap.Spawns.Count)
-                {
-                    cmbDir.SelectedIndex = (int) Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction;
-                    cmbNpc.SelectedIndex = NpcBase.ListIndex(Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId);
-                    if (Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X >= 0)
-                    {
-                        rbDeclared.Checked = true;
-                    }
-                }
             }
 
-            UpdateNpcCountLabel();
+            Core.Graphics.TilePreviewUpdated = true;
         }
 
-        private void frmMapLayers_DockStateChanged(object sender, EventArgs e)
+        UpdateNpcCountLabel();
+    }
+
+    private void UpdateNpcCountLabel()
+    {
+        lblNpcCount.Text = Strings.NpcSpawns.SpawnCount.ToString(lstMapNpcs.Items.Count);
+    }
+
+    private void lstMapNpcs_Click(object sender, EventArgs e)
+    {
+        lstMapNpcs_Update();
+    }
+    
+    private void lstMapNpcs_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        lstMapNpcs_Update();
+    }
+
+    private void lstMapNpcs_Update()
+    {
+        if (lstMapNpcs.Items.Count <= 0 || lstMapNpcs.SelectedIndex <= -1)
         {
-            CreateSwapChain();
+            return;
         }
 
-        //Map NPC List
-        private void btnAddMapNpc_Click(object sender, EventArgs e)
+        var selectedSpawn = Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex];
+
+        cmbNpc.SelectedIndex = NpcBase.ListIndex(selectedSpawn.NpcId);
+        cmbDir.SelectedIndex = (int)selectedSpawn.Direction;
+        rbDeclared.Checked = selectedSpawn.X >= 0;
+        rbRandom.Checked = !rbDeclared.Checked;
+
+        UpdateSpawnLocationLabel();
+    }
+
+    private void rbRandom_Click(object sender, EventArgs e)
+    {
+        if (lstMapNpcs.SelectedIndex > -1)
         {
-            var n = new NpcSpawn();
-
-            //Don't add nothing
-            if (cmbNpc.SelectedIndex > -1)
-            {
-                n.NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
-                n.X = -1;
-                n.Y = -1;
-                n.Direction = NpcSpawnDirection.Random;
-
-                Globals.CurrentMap.Spawns.Add(n);
-                lstMapNpcs.Items.Add(NpcBase.GetName(n.NpcId));
-                lstMapNpcs.SelectedIndex = lstMapNpcs.Items.Count - 1;
-            }
-
-            UpdateNpcCountLabel();
-        }
-
-        private void btnRemoveMapNpc_Click(object sender, EventArgs e)
-        {
-            if (lstMapNpcs.SelectedIndex > -1)
-            {
-                Globals.CurrentMap.Spawns.RemoveAt(lstMapNpcs.SelectedIndex);
-                lstMapNpcs.Items.RemoveAt(lstMapNpcs.SelectedIndex);
-
-                // Refresh List
-                lstMapNpcs.Items.Clear();
-                for (var i = 0; i < Globals.CurrentMap.Spawns.Count; i++)
-                {
-                    lstMapNpcs.Items.Add(NpcBase.GetName(Globals.CurrentMap.Spawns[i].NpcId));
-                }
-
-                if (lstMapNpcs.Items.Count > 0)
-                {
-                    lstMapNpcs.SelectedIndex = 0;
-                }
-
-                Core.Graphics.TilePreviewUpdated = true;
-            }
-
-            UpdateNpcCountLabel();
-        }
-
-        private void UpdateNpcCountLabel()
-        {
-            lblNpcCount.Text = Strings.NpcSpawns.SpawnCount.ToString(lstMapNpcs.Items.Count);
-        }
-
-        private void lstMapNpcs_Click(object sender, EventArgs e)
-        {
-            lstMapNpcs_Update();
-        }
-        
-        private void lstMapNpcs_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            lstMapNpcs_Update();
-        }
-
-        private void lstMapNpcs_Update()
-        {
-            if (lstMapNpcs.Items.Count <= 0 || lstMapNpcs.SelectedIndex <= -1)
-            {
-                return;
-            }
-
-            var selectedSpawn = Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex];
-
-            cmbNpc.SelectedIndex = NpcBase.ListIndex(selectedSpawn.NpcId);
-            cmbDir.SelectedIndex = (int)selectedSpawn.Direction;
-            rbDeclared.Checked = selectedSpawn.X >= 0;
-            rbRandom.Checked = !rbDeclared.Checked;
-
+            Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X = -1;
+            Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Y = -1;
+            Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction = NpcSpawnDirection.Random;
+            Core.Graphics.TilePreviewUpdated = true;
             UpdateSpawnLocationLabel();
         }
+    }
+    
+    public void UpdateSpawnLocationLabel()
+    {
+        grpSpawnLoc.Text = rbDeclared.Checked ? Strings.NpcSpawns.spawndeclared : Strings.NpcSpawns.spawnrandom;
+        grpSpawnLoc.ForeColor = rbDeclared.Checked ? System.Drawing.Color.LawnGreen : System.Drawing.Color.HotPink;
+    }
 
-        private void rbRandom_Click(object sender, EventArgs e)
+    private void cmbDir_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstMapNpcs.SelectedIndex >= 0)
         {
-            if (lstMapNpcs.SelectedIndex > -1)
-            {
-                Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].X = -1;
-                Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Y = -1;
-                Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction = NpcSpawnDirection.Random;
-                Core.Graphics.TilePreviewUpdated = true;
-                UpdateSpawnLocationLabel();
-            }
-        }
-        
-        public void UpdateSpawnLocationLabel()
-        {
-            grpSpawnLoc.Text = rbDeclared.Checked ? Strings.NpcSpawns.spawndeclared : Strings.NpcSpawns.spawnrandom;
-            grpSpawnLoc.ForeColor = rbDeclared.Checked ? System.Drawing.Color.LawnGreen : System.Drawing.Color.HotPink;
-        }
-
-        private void cmbDir_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstMapNpcs.SelectedIndex >= 0)
-            {
-                Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction =
-                    (NpcSpawnDirection) cmbDir.SelectedIndex;
-            }
-        }
-
-        private void cmbNpc_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            var n = 0;
-
-            if (lstMapNpcs.SelectedIndex >= 0)
-            {
-                Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
-
-                // Refresh List
-                n = lstMapNpcs.SelectedIndex;
-                lstMapNpcs.Items.Clear();
-                for (var i = 0; i < Globals.CurrentMap.Spawns.Count; i++)
-                {
-                    lstMapNpcs.Items.Add(NpcBase.GetName(Globals.CurrentMap.Spawns[i].NpcId));
-                }
-
-                lstMapNpcs.SelectedIndex = n;
-            }
-        }
-
-        private void lightEditor_Load(object sender, EventArgs e)
-        {
-        }
-
-        private void btnVisualMapSelector_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(
-                MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int) nudWarpX.Value, (int) nudWarpY.Value
-            );
-
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                cmbWarpMap.Items.Clear();
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
-                }
-
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
-                    {
-                        cmbWarpMap.SelectedIndex = i;
-
-                        break;
-                    }
-                }
-
-                nudWarpX.Value = frmWarpSelection.GetX();
-                nudWarpY.Value = frmWarpSelection.GetY();
-            }
-        }
-
-        private void rbAnimation_CheckedChanged(object sender, EventArgs e)
-        {
-            cmbAnimationAttribute.Items.Clear();
-            cmbAnimationAttribute.Items.AddRange(AnimationBase.Names);
-            if (cmbAnimationAttribute.Items.Count > 0)
-            {
-                cmbAnimationAttribute.SelectedIndex = 0;
-            }
-
-            if (!rbAnimation.Checked)
-            {
-                return;
-            }
-
-            HideAttributeMenus();
-            grpAnimation.Visible = true;
-        }
-
-        private void rbCritter_CheckedChanged(object sender, EventArgs e)
-        {
-            cmbCritterAnimation.Items.Clear();
-            cmbCritterAnimation.Items.Add(Strings.General.None);
-            cmbCritterAnimation.Items.AddRange(AnimationBase.Names);
-            cmbCritterAnimation.SelectedIndex = 0;
-
-            cmbCritterSprite.Items.Clear();
-            cmbCritterSprite.Items.Add(Strings.General.None);
-            cmbCritterSprite.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity));
-            cmbCritterSprite.SelectedIndex = 0;
-
-            if (nudCritterMoveFrequency.Value == 0)
-            {
-                nudCritterMoveFrequency.Value = 1000;
-            }
-
-            if (nudCritterMoveSpeed.Value == 0)
-            {
-                nudCritterMoveSpeed.Value = 400;
-            }
-
-            if (!rbCritter.Checked)
-            {
-                return;
-            }
-
-            HideAttributeMenus();
-            grpCritter.Visible = true;
-        }
-
-        private void frmMapLayers_Load(object sender, EventArgs e)
-        {
-            CreateSwapChain();
-            picTileset.MouseDown += pnlTilesetContainer.AutoDragPanel_MouseDown;
-            picTileset.MouseUp += pnlTilesetContainer.AutoDragPanel_MouseUp;
-            pnlTiles.BringToFront();
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.MapLayers.title;
-            btnTileHeader.Text = Strings.MapLayers.tiles;
-            btnAttributeHeader.Text = Strings.MapLayers.attributes;
-            btnEventsHeader.Text = Strings.MapLayers.events;
-            btnLightsHeader.Text = Strings.MapLayers.lights;
-            btnNpcsHeader.Text = Strings.MapLayers.npcs;
-
-            //Tiles Panel
-            lblLayer.Text = Strings.Tiles.layer;
-            lblTileset.Text = Strings.Tiles.tileset;
-            lblTileType.Text = Strings.Tiles.tiletype;
-            cmbAutotile.Items.Clear();
-            cmbAutotile.Items.Add(Strings.Tiles.normal);
-            cmbAutotile.Items.Add(Strings.Tiles.autotile);
-            cmbAutotile.Items.Add(Strings.Tiles.fake);
-            cmbAutotile.Items.Add(Strings.Tiles.animated);
-            cmbAutotile.Items.Add(Strings.Tiles.cliff);
-            cmbAutotile.Items.Add(Strings.Tiles.waterfall);
-            cmbAutotile.Items.Add(Strings.Tiles.autotilexp);
-            cmbAutotile.Items.Add(Strings.Tiles.animatedxp);
-
-            //Attributes Panel
-            rbBlocked.Text = Strings.Attributes.Blocked;
-            rbZDimension.Text = Strings.Attributes.ZDimension;
-            rbNPCAvoid.Text = Strings.Attributes.NpcAvoid;
-            rbWarp.Text = Strings.Attributes.Warp;
-            rbItem.Text = Strings.Attributes.ItemSpawn;
-            rbSound.Text = Strings.Attributes.MapSound;
-            rbResource.Text = Strings.Attributes.ResourceSpawn;
-            rbAnimation.Text = Strings.Attributes.MapAnimation;
-            rbGrappleStone.Text = Strings.Attributes.Grapple;
-            rbSlide.Text = Strings.Attributes.Slide;
-            rbCritter.Text = Strings.Attributes.Critter;
-
-            //Map Animation Groupbox
-            grpAnimation.Text = Strings.Attributes.MapAnimation;
-            lblAnimation.Text = Strings.Attributes.MapAnimation;
-            chkAnimationBlock.Text = Strings.Attributes.MapAnimationBlock;
-
-            //Slide Groupbox
-            grpSlide.Text = Strings.Attributes.Slide;
-            lblSlideDir.Text = Strings.Attributes.Direction;
-            cmbSlideDir.Items.Clear();
-            for (var i = -1; i < 4; i++)
-            {
-                cmbSlideDir.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-
-            //Map Sound
-            grpSound.Text = Strings.Attributes.MapSound;
-            lblMapSound.Text = Strings.Attributes.Sound;
-            lblSoundDistance.Text = Strings.Attributes.Distance;
-            lblSoundInterval.Text = Strings.Attributes.SoundInterval;
-
-            //Map Item
-            grpItem.Text = Strings.Attributes.ItemSpawn;
-            lblMapItem.Text = Strings.Attributes.Item;
-            lblMaxItemAmount.Text = Strings.Attributes.Quantity;
-            lblItemRespawnTime.Text = Strings.Attributes.RespawnTime;
-            tooltips.SetToolTip(lblItemRespawnTime, Strings.Attributes.RespawnTimeTooltip);
-            tooltips.SetToolTip(nudItemRespawnTime, Strings.Attributes.RespawnTimeTooltip);
-
-            //Z-Dimension
-            grpZDimension.Text = Strings.Attributes.ZDimension;
-            grpGateway.Text = Strings.Attributes.ZGateway;
-            grpDimBlock.Text = Strings.Attributes.ZBlock;
-            rbGatewayNone.Text = Strings.Attributes.ZNone;
-            rbGateway1.Text = Strings.Attributes.ZLevel1;
-            rbGateway2.Text = Strings.Attributes.ZLevel2;
-            rbBlockNone.Text = Strings.Attributes.ZNone;
-            rbBlock1.Text = Strings.Attributes.ZLevel1;
-            rbBlock2.Text = Strings.Attributes.ZLevel2;
-
-            //Warp
-            grpWarp.Text = Strings.Attributes.Warp;
-            lblMap.Text = Strings.Attributes.Map;
-            lblX.Text = Strings.Warping.x.ToString("");
-            lblY.Text = Strings.Warping.y.ToString("");
-            lblWarpDir.Text = Strings.Warping.direction.ToString("");
-            cmbDirection.Items.Clear();
-            for (var i = -1; i < 4; i++)
-            {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-            lblInstance.Text = Strings.Warping.InstanceType;
-            chkChangeInstance.Text = Strings.Warping.ChangeInstance;
-            grpInstanceSettings.Text = Strings.Warping.MapInstancingGroup;
-            lblWarpSound.Text = Strings.Warping.WarpSound;
-
-            btnVisualMapSelector.Text = Strings.Warping.visual;
-
-            //Resource
-            grpResource.Text = Strings.Attributes.ResourceSpawn;
-            lblResource.Text = Strings.Attributes.Resource;
-            grpZResource.Text = Strings.Attributes.ZDimension;
-            rbLevel1.Text = Strings.Attributes.ZLevel1;
-            rbLevel2.Text = Strings.Attributes.ZLevel2;
-
-            //Critter
-            grpCritter.Text = Strings.Attributes.Critter;
-            lblCritterSprite.Text = Strings.Attributes.CritterSprite;
-            lblCritterAnimation.Text = Strings.Attributes.CritterAnimation;
-            lblCritterMovement.Text = Strings.Attributes.CritterMovement;
-            lblCritterLayer.Text = Strings.Attributes.CritterLayer;
-            lblCritterMoveSpeed.Text = Strings.Attributes.CritterSpeed;
-            lblCritterMoveFrequency.Text = Strings.Attributes.CritterFrequency;
-            chkCritterIgnoreNpcAvoids.Text = Strings.Attributes.CritterIgnoreNpcAvoids;
-            chkCritterBlockPlayers.Text = Strings.Attributes.CritterBlockPlayers;
-            lblCritterDirection.Text = Strings.Attributes.CritterDirection;
-
-            cmbCritterDirection.Items.Clear();
-            cmbCritterDirection.Items.Add(Strings.NpcSpawns.randomdirection);
-            for (var i = 0; i < 4; i++)
-            {
-                cmbCritterDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-            cmbCritterDirection.SelectedIndex = 0;
-
-            cmbCritterMovement.Items.Clear();
-            for (var i = 0; i < Strings.Attributes.CritterMovements.Count; i++)
-            {
-                cmbCritterMovement.Items.Add(Strings.Attributes.CritterMovements[i]);
-            }
-            cmbCritterMovement.SelectedIndex = 0;
-
-            cmbCritterLayer.Items.Clear();
-            for (var i = 0; i < Strings.Attributes.CritterLayers.Count; i++)
-            {
-                cmbCritterLayer.Items.Add(Strings.Attributes.CritterLayers[i]);
-            }
-            cmbCritterLayer.SelectedIndex = 1;
-
-            //NPCS Tab
-            grpSpawnDirection.Text = Strings.NpcSpawns.Direction;
-            rbDeclared.Text = Strings.NpcSpawns.declaredlocation;
-            rbRandom.Text = Strings.NpcSpawns.randomlocation;
-            btnNpcPulseColor.Text = Strings.NpcSpawns.PulseColorButton;
-            UpdateSpawnLocationLabel();
-            UpdateNpcCountLabel();
-            cmbDir.Items.Clear();
-            cmbDir.Items.Add(Strings.NpcSpawns.randomdirection);
-            for (var i = 0; i < 4; i++)
-            {
-                cmbDir.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-
-            grpNpcList.Text = Strings.NpcSpawns.AddRemove;
-            btnAddMapNpc.Text = Strings.NpcSpawns.add;
-            btnRemoveMapNpc.Text = Strings.NpcSpawns.remove;
-
-            lblEventInstructions.Text = Strings.MapLayers.eventinstructions;
-            lblLightInstructions.Text = Strings.MapLayers.lightinstructions;
-        }
-
-        public void InitMapLayers()
-        {
-            CreateSwapChain();
-        }
-
-        private void CreateSwapChain()
-        {
-            if (!Globals.ClosingEditor)
-            {
-                if (mChain != null)
-                {
-                    mChain.Dispose();
-                }
-
-                if (Core.Graphics.GetGraphicsDevice() != null)
-                {
-                    mChain = new SwapChainRenderTarget(
-                        Core.Graphics.GetGraphicsDevice(), picTileset.Handle, picTileset.Width, picTileset.Height,
-                        false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents,
-                        PresentInterval.Immediate
-                    );
-
-                    Core.Graphics.SetTilesetChain(mChain);
-                }
-            }
-        }
-
-        private void rbGrappleStone_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-        }
-
-        private void rbSlide_CheckedChanged(object sender, EventArgs e)
-        {
-            HideAttributeMenus();
-            grpSlide.Visible = true;
-            cmbSlideDir.SelectedIndex = 0;
-        }
-
-        private void lstMapNpcs_MouseDown(object sender, MouseEventArgs e)
-        {
-            lstMapNpcs.SelectedIndex = lstMapNpcs.IndexFromPoint(e.Location);
-        }
-
-        private void ChangeTab()
-        {
-            btnTileHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            btnAttributeHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            btnLightsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            btnEventsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            btnNpcsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            pnlTiles.Hide();
-            pnlAttributes.Hide();
-            pnlLights.Hide();
-            pnlEvents.Hide();
-            pnlNpcs.Hide();
-
-            //Force Game Object Lists to Refresh
-            rbAnimation_CheckedChanged(null, null);
-            rbWarp_CheckedChanged(null, null);
-            rbResource_CheckedChanged(null, null);
-
-            if (Globals.EditingLight != null)
-            {
-                Globals.MapLayersWindow.lightEditor.Cancel();
-            }
-        }
-
-        private void RefreshMapWarpSounds()
-        {
-            cmbWarpSound.Items.Add(Strings.General.None);
-            cmbWarpSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-            cmbWarpSound.SelectedIndex = 0;
-        }
-
-        private void btnTileHeader_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = Globals.SavedTool;
-            ChangeTab();
-            SetLayer(mLastTileLayer);
-            Core.Graphics.TilePreviewUpdated = true;
-            btnTileHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            CurrentTab = LayerTabs.Tiles;
-            pnlTiles.Show();
-        }
-
-        private void btnAttributeHeader_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = Globals.SavedTool;
-            ChangeTab();
-            Globals.CurrentLayer = LayerOptions.Attributes;
-            Core.Graphics.TilePreviewUpdated = true;
-            btnAttributeHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            CurrentTab = LayerTabs.Attributes;
-            pnlAttributes.Show();
-        }
-
-        public void btnLightsHeader_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
-            {
-                Globals.SavedTool = Globals.CurrentTool;
-            }
-
-            ChangeTab();
-            Globals.CurrentLayer = LayerOptions.Lights;
-            Core.Graphics.TilePreviewUpdated = true;
-            btnLightsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            CurrentTab = LayerTabs.Lights;
-            pnlLights.Show();
-        }
-
-        private void btnEventsHeader_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
-            {
-                Globals.SavedTool = Globals.CurrentTool;
-            }
-
-            ChangeTab();
-            Globals.CurrentLayer = LayerOptions.Events;
-            Core.Graphics.TilePreviewUpdated = true;
-            btnEventsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            CurrentTab = LayerTabs.Events;
-            pnlEvents.Show();
-        }
-
-        private void btnNpcsHeader_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
-            {
-                Globals.SavedTool = Globals.CurrentTool;
-            }
-
-            ChangeTab();
-            Globals.CurrentLayer = LayerOptions.Npcs;
-            Core.Graphics.TilePreviewUpdated = true;
-            RefreshNpcList();
-            btnNpcsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            CurrentTab = LayerTabs.Npcs;
-            pnlNpcs.Show();
-        }
-
-        private void picMapLayer_MouseClick(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Left)
-            {
-                var index = mMapLayers.IndexOf((PictureBox)sender);
-                if (index > -1 && index < Options.Instance.MapOpts.Layers.All.Count)
-                {
-                    SetLayer(Options.Instance.MapOpts.Layers.All[index]);
-                }
-            }
-            else
-            {
-                ToggleLayerVisibility(mMapLayers.IndexOf((PictureBox) sender));
-            }
-        }
-
-        private void ToggleLayerVisibility(int index)
-        {
-            if (index > -1 && index < Options.Instance.MapOpts.Layers.All.Count)
-            {
-                LayerVisibility[Options.Instance.MapOpts.Layers.All[index]] = !LayerVisibility[Options.Instance.MapOpts.Layers.All[index]];
-                SetLayer(Globals.CurrentLayer);
-            }
-
-        }
-
-        private void picMapLayer_MouseHover(object sender, EventArgs e)
-        {
-            var tt = new ToolTip();
-            tt.SetToolTip((PictureBox) sender, Options.Instance.MapOpts.Layers.All[mMapLayers.IndexOf((PictureBox)sender)]);
-        }
-
-        private void cmbTilesets_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right && Globals.CurrentTileset != null)
-            {
-                Clipboard.SetText(Globals.CurrentTileset.Id.ToString());
-            }
-        }
-
-        private void NudItemQuantity_ValueChanged(object sender, System.EventArgs e)
-        {
-            nudItemQuantity.Value = Math.Max(1, nudItemQuantity.Value);
-        }
-
-        private void NudItemRespawnTime_ValueChanged(object sender, System.EventArgs e)
-        {
-            nudItemRespawnTime.Value = Math.Max(0, nudItemRespawnTime.Value);
-        }
-
-        private void cmbMapLayer_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbMapLayer.SelectedIndex > -1)
-            {
-                SetLayer(Options.Instance.MapOpts.Layers.All[cmbMapLayer.SelectedIndex]);
-            }
-        }
-
-        private void chkChangeInstance_CheckedChanged(object sender, EventArgs e)
-        {
-            grpInstanceSettings.Visible = chkChangeInstance.Checked;
-        }
-
-        private void btnNpcPulseColor_Click(object sender, EventArgs e)
-        {
-            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
-            npcColorPulseDialog.Color = NpcPulseColor == default ? System.Drawing.Color.Red : NpcPulseColor;
-            npcColorPulseDialog.FullOpen = true;
-            npcColorPulseDialog.ShowDialog();
-            Preferences.SavePreference("NpcPulseColor", npcColorPulseDialog.Color.ToArgb().ToString());
-            NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+            Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].Direction =
+                (NpcSpawnDirection) cmbDir.SelectedIndex;
         }
     }
 
+    private void cmbNpc_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var n = 0;
+
+        if (lstMapNpcs.SelectedIndex >= 0)
+        {
+            Globals.CurrentMap.Spawns[lstMapNpcs.SelectedIndex].NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
+
+            // Refresh List
+            n = lstMapNpcs.SelectedIndex;
+            lstMapNpcs.Items.Clear();
+            for (var i = 0; i < Globals.CurrentMap.Spawns.Count; i++)
+            {
+                lstMapNpcs.Items.Add(NpcBase.GetName(Globals.CurrentMap.Spawns[i].NpcId));
+            }
+
+            lstMapNpcs.SelectedIndex = n;
+        }
+    }
+
+    private void lightEditor_Load(object sender, EventArgs e)
+    {
+    }
+
+    private void btnVisualMapSelector_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int) nudWarpX.Value, (int) nudWarpY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            cmbWarpMap.Items.Clear();
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
+            }
+
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbWarpMap.SelectedIndex = i;
+
+                    break;
+                }
+            }
+
+            nudWarpX.Value = frmWarpSelection.GetX();
+            nudWarpY.Value = frmWarpSelection.GetY();
+        }
+    }
+
+    private void rbAnimation_CheckedChanged(object sender, EventArgs e)
+    {
+        cmbAnimationAttribute.Items.Clear();
+        cmbAnimationAttribute.Items.AddRange(AnimationBase.Names);
+        if (cmbAnimationAttribute.Items.Count > 0)
+        {
+            cmbAnimationAttribute.SelectedIndex = 0;
+        }
+
+        if (!rbAnimation.Checked)
+        {
+            return;
+        }
+
+        HideAttributeMenus();
+        grpAnimation.Visible = true;
+    }
+
+    private void rbCritter_CheckedChanged(object sender, EventArgs e)
+    {
+        cmbCritterAnimation.Items.Clear();
+        cmbCritterAnimation.Items.Add(Strings.General.None);
+        cmbCritterAnimation.Items.AddRange(AnimationBase.Names);
+        cmbCritterAnimation.SelectedIndex = 0;
+
+        cmbCritterSprite.Items.Clear();
+        cmbCritterSprite.Items.Add(Strings.General.None);
+        cmbCritterSprite.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity));
+        cmbCritterSprite.SelectedIndex = 0;
+
+        if (nudCritterMoveFrequency.Value == 0)
+        {
+            nudCritterMoveFrequency.Value = 1000;
+        }
+
+        if (nudCritterMoveSpeed.Value == 0)
+        {
+            nudCritterMoveSpeed.Value = 400;
+        }
+
+        if (!rbCritter.Checked)
+        {
+            return;
+        }
+
+        HideAttributeMenus();
+        grpCritter.Visible = true;
+    }
+
+    private void frmMapLayers_Load(object sender, EventArgs e)
+    {
+        CreateSwapChain();
+        picTileset.MouseDown += pnlTilesetContainer.AutoDragPanel_MouseDown;
+        picTileset.MouseUp += pnlTilesetContainer.AutoDragPanel_MouseUp;
+        pnlTiles.BringToFront();
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.MapLayers.title;
+        btnTileHeader.Text = Strings.MapLayers.tiles;
+        btnAttributeHeader.Text = Strings.MapLayers.attributes;
+        btnEventsHeader.Text = Strings.MapLayers.events;
+        btnLightsHeader.Text = Strings.MapLayers.lights;
+        btnNpcsHeader.Text = Strings.MapLayers.npcs;
+
+        //Tiles Panel
+        lblLayer.Text = Strings.Tiles.layer;
+        lblTileset.Text = Strings.Tiles.tileset;
+        lblTileType.Text = Strings.Tiles.tiletype;
+        cmbAutotile.Items.Clear();
+        cmbAutotile.Items.Add(Strings.Tiles.normal);
+        cmbAutotile.Items.Add(Strings.Tiles.autotile);
+        cmbAutotile.Items.Add(Strings.Tiles.fake);
+        cmbAutotile.Items.Add(Strings.Tiles.animated);
+        cmbAutotile.Items.Add(Strings.Tiles.cliff);
+        cmbAutotile.Items.Add(Strings.Tiles.waterfall);
+        cmbAutotile.Items.Add(Strings.Tiles.autotilexp);
+        cmbAutotile.Items.Add(Strings.Tiles.animatedxp);
+
+        //Attributes Panel
+        rbBlocked.Text = Strings.Attributes.Blocked;
+        rbZDimension.Text = Strings.Attributes.ZDimension;
+        rbNPCAvoid.Text = Strings.Attributes.NpcAvoid;
+        rbWarp.Text = Strings.Attributes.Warp;
+        rbItem.Text = Strings.Attributes.ItemSpawn;
+        rbSound.Text = Strings.Attributes.MapSound;
+        rbResource.Text = Strings.Attributes.ResourceSpawn;
+        rbAnimation.Text = Strings.Attributes.MapAnimation;
+        rbGrappleStone.Text = Strings.Attributes.Grapple;
+        rbSlide.Text = Strings.Attributes.Slide;
+        rbCritter.Text = Strings.Attributes.Critter;
+
+        //Map Animation Groupbox
+        grpAnimation.Text = Strings.Attributes.MapAnimation;
+        lblAnimation.Text = Strings.Attributes.MapAnimation;
+        chkAnimationBlock.Text = Strings.Attributes.MapAnimationBlock;
+
+        //Slide Groupbox
+        grpSlide.Text = Strings.Attributes.Slide;
+        lblSlideDir.Text = Strings.Attributes.Direction;
+        cmbSlideDir.Items.Clear();
+        for (var i = -1; i < 4; i++)
+        {
+            cmbSlideDir.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        //Map Sound
+        grpSound.Text = Strings.Attributes.MapSound;
+        lblMapSound.Text = Strings.Attributes.Sound;
+        lblSoundDistance.Text = Strings.Attributes.Distance;
+        lblSoundInterval.Text = Strings.Attributes.SoundInterval;
+
+        //Map Item
+        grpItem.Text = Strings.Attributes.ItemSpawn;
+        lblMapItem.Text = Strings.Attributes.Item;
+        lblMaxItemAmount.Text = Strings.Attributes.Quantity;
+        lblItemRespawnTime.Text = Strings.Attributes.RespawnTime;
+        tooltips.SetToolTip(lblItemRespawnTime, Strings.Attributes.RespawnTimeTooltip);
+        tooltips.SetToolTip(nudItemRespawnTime, Strings.Attributes.RespawnTimeTooltip);
+
+        //Z-Dimension
+        grpZDimension.Text = Strings.Attributes.ZDimension;
+        grpGateway.Text = Strings.Attributes.ZGateway;
+        grpDimBlock.Text = Strings.Attributes.ZBlock;
+        rbGatewayNone.Text = Strings.Attributes.ZNone;
+        rbGateway1.Text = Strings.Attributes.ZLevel1;
+        rbGateway2.Text = Strings.Attributes.ZLevel2;
+        rbBlockNone.Text = Strings.Attributes.ZNone;
+        rbBlock1.Text = Strings.Attributes.ZLevel1;
+        rbBlock2.Text = Strings.Attributes.ZLevel2;
+
+        //Warp
+        grpWarp.Text = Strings.Attributes.Warp;
+        lblMap.Text = Strings.Attributes.Map;
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y.ToString("");
+        lblWarpDir.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = -1; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+        lblInstance.Text = Strings.Warping.InstanceType;
+        chkChangeInstance.Text = Strings.Warping.ChangeInstance;
+        grpInstanceSettings.Text = Strings.Warping.MapInstancingGroup;
+        lblWarpSound.Text = Strings.Warping.WarpSound;
+
+        btnVisualMapSelector.Text = Strings.Warping.visual;
+
+        //Resource
+        grpResource.Text = Strings.Attributes.ResourceSpawn;
+        lblResource.Text = Strings.Attributes.Resource;
+        grpZResource.Text = Strings.Attributes.ZDimension;
+        rbLevel1.Text = Strings.Attributes.ZLevel1;
+        rbLevel2.Text = Strings.Attributes.ZLevel2;
+
+        //Critter
+        grpCritter.Text = Strings.Attributes.Critter;
+        lblCritterSprite.Text = Strings.Attributes.CritterSprite;
+        lblCritterAnimation.Text = Strings.Attributes.CritterAnimation;
+        lblCritterMovement.Text = Strings.Attributes.CritterMovement;
+        lblCritterLayer.Text = Strings.Attributes.CritterLayer;
+        lblCritterMoveSpeed.Text = Strings.Attributes.CritterSpeed;
+        lblCritterMoveFrequency.Text = Strings.Attributes.CritterFrequency;
+        chkCritterIgnoreNpcAvoids.Text = Strings.Attributes.CritterIgnoreNpcAvoids;
+        chkCritterBlockPlayers.Text = Strings.Attributes.CritterBlockPlayers;
+        lblCritterDirection.Text = Strings.Attributes.CritterDirection;
+
+        cmbCritterDirection.Items.Clear();
+        cmbCritterDirection.Items.Add(Strings.NpcSpawns.randomdirection);
+        for (var i = 0; i < 4; i++)
+        {
+            cmbCritterDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+        cmbCritterDirection.SelectedIndex = 0;
+
+        cmbCritterMovement.Items.Clear();
+        for (var i = 0; i < Strings.Attributes.CritterMovements.Count; i++)
+        {
+            cmbCritterMovement.Items.Add(Strings.Attributes.CritterMovements[i]);
+        }
+        cmbCritterMovement.SelectedIndex = 0;
+
+        cmbCritterLayer.Items.Clear();
+        for (var i = 0; i < Strings.Attributes.CritterLayers.Count; i++)
+        {
+            cmbCritterLayer.Items.Add(Strings.Attributes.CritterLayers[i]);
+        }
+        cmbCritterLayer.SelectedIndex = 1;
+
+        //NPCS Tab
+        grpSpawnDirection.Text = Strings.NpcSpawns.Direction;
+        rbDeclared.Text = Strings.NpcSpawns.declaredlocation;
+        rbRandom.Text = Strings.NpcSpawns.randomlocation;
+        btnNpcPulseColor.Text = Strings.NpcSpawns.PulseColorButton;
+        UpdateSpawnLocationLabel();
+        UpdateNpcCountLabel();
+        cmbDir.Items.Clear();
+        cmbDir.Items.Add(Strings.NpcSpawns.randomdirection);
+        for (var i = 0; i < 4; i++)
+        {
+            cmbDir.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        grpNpcList.Text = Strings.NpcSpawns.AddRemove;
+        btnAddMapNpc.Text = Strings.NpcSpawns.add;
+        btnRemoveMapNpc.Text = Strings.NpcSpawns.remove;
+
+        lblEventInstructions.Text = Strings.MapLayers.eventinstructions;
+        lblLightInstructions.Text = Strings.MapLayers.lightinstructions;
+    }
+
+    public void InitMapLayers()
+    {
+        CreateSwapChain();
+    }
+
+    private void CreateSwapChain()
+    {
+        if (!Globals.ClosingEditor)
+        {
+            if (mChain != null)
+            {
+                mChain.Dispose();
+            }
+
+            if (Core.Graphics.GetGraphicsDevice() != null)
+            {
+                mChain = new SwapChainRenderTarget(
+                    Core.Graphics.GetGraphicsDevice(), picTileset.Handle, picTileset.Width, picTileset.Height,
+                    false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents,
+                    PresentInterval.Immediate
+                );
+
+                Core.Graphics.SetTilesetChain(mChain);
+            }
+        }
+    }
+
+    private void rbGrappleStone_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+    }
+
+    private void rbSlide_CheckedChanged(object sender, EventArgs e)
+    {
+        HideAttributeMenus();
+        grpSlide.Visible = true;
+        cmbSlideDir.SelectedIndex = 0;
+    }
+
+    private void lstMapNpcs_MouseDown(object sender, MouseEventArgs e)
+    {
+        lstMapNpcs.SelectedIndex = lstMapNpcs.IndexFromPoint(e.Location);
+    }
+
+    private void ChangeTab()
+    {
+        btnTileHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+        btnAttributeHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+        btnLightsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+        btnEventsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+        btnNpcsHeader.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+        pnlTiles.Hide();
+        pnlAttributes.Hide();
+        pnlLights.Hide();
+        pnlEvents.Hide();
+        pnlNpcs.Hide();
+
+        //Force Game Object Lists to Refresh
+        rbAnimation_CheckedChanged(null, null);
+        rbWarp_CheckedChanged(null, null);
+        rbResource_CheckedChanged(null, null);
+
+        if (Globals.EditingLight != null)
+        {
+            Globals.MapLayersWindow.lightEditor.Cancel();
+        }
+    }
+
+    private void RefreshMapWarpSounds()
+    {
+        cmbWarpSound.Items.Add(Strings.General.None);
+        cmbWarpSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+        cmbWarpSound.SelectedIndex = 0;
+    }
+
+    private void btnTileHeader_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = Globals.SavedTool;
+        ChangeTab();
+        SetLayer(mLastTileLayer);
+        Core.Graphics.TilePreviewUpdated = true;
+        btnTileHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        CurrentTab = LayerTabs.Tiles;
+        pnlTiles.Show();
+    }
+
+    private void btnAttributeHeader_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = Globals.SavedTool;
+        ChangeTab();
+        Globals.CurrentLayer = LayerOptions.Attributes;
+        Core.Graphics.TilePreviewUpdated = true;
+        btnAttributeHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        CurrentTab = LayerTabs.Attributes;
+        pnlAttributes.Show();
+    }
+
+    public void btnLightsHeader_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
+        {
+            Globals.SavedTool = Globals.CurrentTool;
+        }
+
+        ChangeTab();
+        Globals.CurrentLayer = LayerOptions.Lights;
+        Core.Graphics.TilePreviewUpdated = true;
+        btnLightsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        CurrentTab = LayerTabs.Lights;
+        pnlLights.Show();
+    }
+
+    private void btnEventsHeader_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
+        {
+            Globals.SavedTool = Globals.CurrentTool;
+        }
+
+        ChangeTab();
+        Globals.CurrentLayer = LayerOptions.Events;
+        Core.Graphics.TilePreviewUpdated = true;
+        btnEventsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        CurrentTab = LayerTabs.Events;
+        pnlEvents.Show();
+    }
+
+    private void btnNpcsHeader_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentLayer != LayerOptions.Lights && Globals.CurrentLayer != LayerOptions.Events && Globals.CurrentLayer != LayerOptions.Npcs)
+        {
+            Globals.SavedTool = Globals.CurrentTool;
+        }
+
+        ChangeTab();
+        Globals.CurrentLayer = LayerOptions.Npcs;
+        Core.Graphics.TilePreviewUpdated = true;
+        RefreshNpcList();
+        btnNpcsHeader.BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+        CurrentTab = LayerTabs.Npcs;
+        pnlNpcs.Show();
+    }
+
+    private void picMapLayer_MouseClick(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Left)
+        {
+            var index = mMapLayers.IndexOf((PictureBox)sender);
+            if (index > -1 && index < Options.Instance.MapOpts.Layers.All.Count)
+            {
+                SetLayer(Options.Instance.MapOpts.Layers.All[index]);
+            }
+        }
+        else
+        {
+            ToggleLayerVisibility(mMapLayers.IndexOf((PictureBox) sender));
+        }
+    }
+
+    private void ToggleLayerVisibility(int index)
+    {
+        if (index > -1 && index < Options.Instance.MapOpts.Layers.All.Count)
+        {
+            LayerVisibility[Options.Instance.MapOpts.Layers.All[index]] = !LayerVisibility[Options.Instance.MapOpts.Layers.All[index]];
+            SetLayer(Globals.CurrentLayer);
+        }
+
+    }
+
+    private void picMapLayer_MouseHover(object sender, EventArgs e)
+    {
+        var tt = new ToolTip();
+        tt.SetToolTip((PictureBox) sender, Options.Instance.MapOpts.Layers.All[mMapLayers.IndexOf((PictureBox)sender)]);
+    }
+
+    private void cmbTilesets_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Right && Globals.CurrentTileset != null)
+        {
+            Clipboard.SetText(Globals.CurrentTileset.Id.ToString());
+        }
+    }
+
+    private void NudItemQuantity_ValueChanged(object sender, System.EventArgs e)
+    {
+        nudItemQuantity.Value = Math.Max(1, nudItemQuantity.Value);
+    }
+
+    private void NudItemRespawnTime_ValueChanged(object sender, System.EventArgs e)
+    {
+        nudItemRespawnTime.Value = Math.Max(0, nudItemRespawnTime.Value);
+    }
+
+    private void cmbMapLayer_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbMapLayer.SelectedIndex > -1)
+        {
+            SetLayer(Options.Instance.MapOpts.Layers.All[cmbMapLayer.SelectedIndex]);
+        }
+    }
+
+    private void chkChangeInstance_CheckedChanged(object sender, EventArgs e)
+    {
+        grpInstanceSettings.Visible = chkChangeInstance.Checked;
+    }
+
+    private void btnNpcPulseColor_Click(object sender, EventArgs e)
+    {
+        NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+        npcColorPulseDialog.Color = NpcPulseColor == default ? System.Drawing.Color.Red : NpcPulseColor;
+        npcColorPulseDialog.FullOpen = true;
+        npcColorPulseDialog.ShowDialog();
+        Preferences.SavePreference("NpcPulseColor", npcColorPulseDialog.Color.ToArgb().ToString());
+        NpcPulseColor = ColorTranslator.FromHtml(Preferences.LoadPreference("NpcPulseColor"));
+    }
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapList.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapList.cs
@@ -7,143 +7,28 @@ using Intersect.GameObjects.Maps.MapList;
 
 using WeifenLuo.WinFormsUI.Docking;
 
-namespace Intersect.Editor.Forms.DockingElements
+namespace Intersect.Editor.Forms.DockingElements;
+
+
+public partial class FrmMapList : DockContent
 {
 
-    public partial class FrmMapList : DockContent
+    public FrmMapList()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        public FrmMapList()
+        //Enable Editting of the list
+        mapTreeList.EnableEditing(contextMenuStrip1);
+        mapTreeList.SetDoubleClick(NodeDoubleClick);
+    }
+
+    private void NodeDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        if (e.Node.Tag is MapListMap map)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            //Enable Editting of the list
-            mapTreeList.EnableEditing(contextMenuStrip1);
-            mapTreeList.SetDoubleClick(NodeDoubleClick);
-        }
-
-        private void NodeDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
-        {
-            if (e.Node.Tag is MapListMap map)
-            {
-                if (Globals.CurrentMap != null &&
-                    Globals.CurrentMap.Changed() &&
-                    DarkMessageBox.ShowInformation(
-                        Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    SaveMap();
-                }
-
-                Globals.MainForm.EnterMap(map.MapId, true);
-            }
-        }
-
-        private void SaveMap()
-        {
-            if (Globals.CurrentTool == EditingTool.Selection)
-            {
-                if (Globals.Dragging == true)
-                {
-                    //Place the change, we done!
-                    Globals.MapEditorWindow.ProcessSelectionMovement(Globals.CurrentMap, true);
-                    Globals.MapEditorWindow.PlaceSelection();
-                }
-            }
-
-            PacketSender.SendMap(Globals.CurrentMap);
-        }
-
-        private void frmMapList_Load(object sender, EventArgs e)
-        {
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.MapList.title;
-            btnAlphabetical.Text = Strings.MapList.alphabetical;
-            toolSelectMap.Text = Strings.MapList.selectcurrent;
-            btnNewMap.Text = Strings.MapList.newmap;
-            btnNewFolder.Text = Strings.MapList.newfolder;
-            btnRename.Text = Strings.MapList.rename;
-            btnDelete.Text = Strings.MapList.delete;
-            newMapToolStripMenuItem.Text = Strings.MapList.newmap;
-            renameToolStripMenuItem.Text = Strings.MapList.rename;
-            newFolderToolStripMenuItem.Text = Strings.MapList.newfolder;
-            deleteToolStripMenuItem.Text = Strings.MapList.delete;
-            copyIdToolStripMenuItem.Text = Strings.MapList.copyid;
-        }
-
-        private void btnRefreshList_Click(object sender, EventArgs e)
-        {
-            mapTreeList.UpdateMapList();
-        }
-
-        private void btnNewFolder_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendAddFolder(mapTreeList.list.SelectedNode?.Tag as MapListItem);
-        }
-
-        private void btnRename_Click(object sender, EventArgs e)
-        {
-            if (mapTreeList.list.SelectedNode == null)
-            {
-                DarkMessageBox.ShowError(
-                    Strings.MapList.selecttorename, Strings.MapList.rename, DarkDialogButton.Ok,
-                    Icon
-                );
-            }
-            else
-            {
-                mapTreeList.list.SelectedNode.BeginEdit();
-            }
-        }
-
-        private void btnDelete_Click(object sender, EventArgs e)
-        {
-            if (mapTreeList.list.SelectedNode == null)
-            {
-                DarkMessageBox.ShowError(
-                    Strings.MapList.selecttodelete, Strings.MapList.delete, DarkDialogButton.Ok,
-                    Icon
-                );
-            }
-            else
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.MapList.deleteconfirm.ToString(((MapListItem) mapTreeList.list.SelectedNode.Tag).Name),
-                        Strings.MapList.delete, DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDelete((MapListItem) mapTreeList.list.SelectedNode.Tag);
-                }
-            }
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            mapTreeList.Chronological = btnAlphabetical.Checked;
-            mapTreeList.UpdateMapList();
-        }
-
-        private void btnNewMap_Click(object sender, EventArgs e)
-        {
-            if (DarkMessageBox.ShowWarning(
-                    Strings.Mapping.newmap, Strings.Mapping.newmapcaption, DarkDialogButton.YesNo,
-                    Icon
-                ) !=
-                DialogResult.Yes)
-            {
-                return;
-            }
-
-            if (Globals.CurrentMap.Changed() &&
+            if (Globals.CurrentMap != null &&
+                Globals.CurrentMap.Changed() &&
                 DarkMessageBox.ShowInformation(
                     Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
                     Icon
@@ -153,37 +38,150 @@ namespace Intersect.Editor.Forms.DockingElements
                 SaveMap();
             }
 
-            if (mapTreeList.list.SelectedNode == null)
-            {
-                PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, null);
-            }
-            else
-            {
-                PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, (MapListItem) mapTreeList.list.SelectedNode.Tag);
-            }
+            Globals.MainForm.EnterMap(map.MapId, true);
         }
+    }
 
-        private void toolSelectMap_Click(object sender, EventArgs e)
+    private void SaveMap()
+    {
+        if (Globals.CurrentTool == EditingTool.Selection)
         {
-            mapTreeList.UpdateMapList(Globals.CurrentMap.Id);
-        }
-
-        private void contextMenuStrip1_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            var node = mapTreeList.list.SelectedNode;
-            copyIdToolStripMenuItem.Visible = node != null && node.Tag is MapListMap;
-        }
-
-        private void copyIdToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var node = mapTreeList.list.SelectedNode;
-            if (node != null && node.Tag is MapListMap map)
+            if (Globals.Dragging == true)
             {
-                var id = map.MapId;
-                Clipboard.SetText(id.ToString());
+                //Place the change, we done!
+                Globals.MapEditorWindow.ProcessSelectionMovement(Globals.CurrentMap, true);
+                Globals.MapEditorWindow.PlaceSelection();
             }
         }
 
+        PacketSender.SendMap(Globals.CurrentMap);
+    }
+
+    private void frmMapList_Load(object sender, EventArgs e)
+    {
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.MapList.title;
+        btnAlphabetical.Text = Strings.MapList.alphabetical;
+        toolSelectMap.Text = Strings.MapList.selectcurrent;
+        btnNewMap.Text = Strings.MapList.newmap;
+        btnNewFolder.Text = Strings.MapList.newfolder;
+        btnRename.Text = Strings.MapList.rename;
+        btnDelete.Text = Strings.MapList.delete;
+        newMapToolStripMenuItem.Text = Strings.MapList.newmap;
+        renameToolStripMenuItem.Text = Strings.MapList.rename;
+        newFolderToolStripMenuItem.Text = Strings.MapList.newfolder;
+        deleteToolStripMenuItem.Text = Strings.MapList.delete;
+        copyIdToolStripMenuItem.Text = Strings.MapList.copyid;
+    }
+
+    private void btnRefreshList_Click(object sender, EventArgs e)
+    {
+        mapTreeList.UpdateMapList();
+    }
+
+    private void btnNewFolder_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendAddFolder(mapTreeList.list.SelectedNode?.Tag as MapListItem);
+    }
+
+    private void btnRename_Click(object sender, EventArgs e)
+    {
+        if (mapTreeList.list.SelectedNode == null)
+        {
+            DarkMessageBox.ShowError(
+                Strings.MapList.selecttorename, Strings.MapList.rename, DarkDialogButton.Ok,
+                Icon
+            );
+        }
+        else
+        {
+            mapTreeList.list.SelectedNode.BeginEdit();
+        }
+    }
+
+    private void btnDelete_Click(object sender, EventArgs e)
+    {
+        if (mapTreeList.list.SelectedNode == null)
+        {
+            DarkMessageBox.ShowError(
+                Strings.MapList.selecttodelete, Strings.MapList.delete, DarkDialogButton.Ok,
+                Icon
+            );
+        }
+        else
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.MapList.deleteconfirm.ToString(((MapListItem) mapTreeList.list.SelectedNode.Tag).Name),
+                    Strings.MapList.delete, DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDelete((MapListItem) mapTreeList.list.SelectedNode.Tag);
+            }
+        }
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        mapTreeList.Chronological = btnAlphabetical.Checked;
+        mapTreeList.UpdateMapList();
+    }
+
+    private void btnNewMap_Click(object sender, EventArgs e)
+    {
+        if (DarkMessageBox.ShowWarning(
+                Strings.Mapping.newmap, Strings.Mapping.newmapcaption, DarkDialogButton.YesNo,
+                Icon
+            ) !=
+            DialogResult.Yes)
+        {
+            return;
+        }
+
+        if (Globals.CurrentMap.Changed() &&
+            DarkMessageBox.ShowInformation(
+                Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
+                Icon
+            ) ==
+            DialogResult.Yes)
+        {
+            SaveMap();
+        }
+
+        if (mapTreeList.list.SelectedNode == null)
+        {
+            PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, null);
+        }
+        else
+        {
+            PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, (MapListItem) mapTreeList.list.SelectedNode.Tag);
+        }
+    }
+
+    private void toolSelectMap_Click(object sender, EventArgs e)
+    {
+        mapTreeList.UpdateMapList(Globals.CurrentMap.Id);
+    }
+
+    private void contextMenuStrip1_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+    {
+        var node = mapTreeList.list.SelectedNode;
+        copyIdToolStripMenuItem.Visible = node != null && node.Tag is MapListMap;
+    }
+
+    private void copyIdToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var node = mapTreeList.list.SelectedNode;
+        if (node != null && node.Tag is MapListMap map)
+        {
+            var id = map.MapId;
+            Clipboard.SetText(id.ToString());
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
@@ -3,53 +3,51 @@ using Intersect.Editor.Maps;
 
 using WeifenLuo.WinFormsUI.Docking;
 
-namespace Intersect.Editor.Forms.DockingElements
+namespace Intersect.Editor.Forms.DockingElements;
+
+
+public partial class FrmMapProperties : DockContent
 {
 
-    public partial class FrmMapProperties : DockContent
+    //Cross Thread Delegates
+    public delegate void UpdateProperties();
+
+    public UpdateProperties UpdatePropertiesDelegate;
+
+    public FrmMapProperties()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        //Cross Thread Delegates
-        public delegate void UpdateProperties();
+        UpdatePropertiesDelegate = Update;
+    }
 
-        public UpdateProperties UpdatePropertiesDelegate;
-
-        public FrmMapProperties()
+    public void Init(MapInstance map)
+    {
+        if (gridMapProperties.InvokeRequired)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
+            gridMapProperties.Invoke((MethodInvoker) delegate { Init(map); });
 
-            UpdatePropertiesDelegate = Update;
+            return;
         }
 
-        public void Init(MapInstance map)
-        {
-            if (gridMapProperties.InvokeRequired)
-            {
-                gridMapProperties.Invoke((MethodInvoker) delegate { Init(map); });
+        gridMapProperties.SelectedObject = new MapProperties(map);
+        InitLocalization();
+    }
 
-                return;
-            }
+    private void InitLocalization()
+    {
+        Text = Strings.MapProperties.title;
+    }
 
-            gridMapProperties.SelectedObject = new MapProperties(map);
-            InitLocalization();
-        }
+    public void Update()
+    {
+        gridMapProperties.Refresh();
+    }
 
-        private void InitLocalization()
-        {
-            Text = Strings.MapProperties.title;
-        }
-
-        public void Update()
-        {
-            gridMapProperties.Refresh();
-        }
-
-        public GridItem Selection()
-        {
-            return gridMapProperties.SelectedGridItem;
-        }
-
+    public GridItem Selection()
+    {
+        return gridMapProperties.SelectedGridItem;
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/EditorForm.cs
+++ b/Intersect.Editor/Forms/Editors/EditorForm.cs
@@ -2,84 +2,82 @@ using Intersect.Editor.Networking;
 using Intersect.Enums;
 using Intersect.Logging;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class EditorForm : Form
 {
 
-    public partial class EditorForm : Form
+    private bool mClosing = false;
+
+    protected EditorForm()
     {
+        Icon = Program.Icon;
 
-        private bool mClosing = false;
+        ApplyHooks();
+    }
 
-        protected EditorForm()
-        {
-            Icon = Program.Icon;
-
-            ApplyHooks();
-        }
-
-        protected void ApplyHooks()
-        {
-            PacketHandler.GameObjectUpdatedDelegate = type =>
-            {
-                if (IsDisposed || mClosing || Disposing)
-                {
-                    return;
-                }
-
-                var action = (Action<GameObjectType>) FireGameObjectUpdatedDelegate;
-                try
-                {
-                    if (!this.Disposing && !this.IsDisposed)
-                    {
-                        if (InvokeRequired)
-                        {
-                            Invoke(action, type);
-                        }
-                        else
-                        {
-                            action(type);
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    Log.Debug(e);
-                }
-            };
-
-            this.Closing += EditorForm_Closing;
-        }
-
-        private void EditorForm_Closing(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            mClosing = true;
-        }
-
-        private void FireGameObjectUpdatedDelegate(GameObjectType type)
+    protected void ApplyHooks()
+    {
+        PacketHandler.GameObjectUpdatedDelegate = type =>
         {
             if (IsDisposed || mClosing || Disposing)
             {
                 return;
             }
 
-            GameObjectUpdatedDelegate(type);
-        }
+            var action = (Action<GameObjectType>) FireGameObjectUpdatedDelegate;
+            try
+            {
+                if (!this.Disposing && !this.IsDisposed)
+                {
+                    if (InvokeRequired)
+                    {
+                        Invoke(action, type);
+                    }
+                    else
+                    {
+                        action(type);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e);
+            }
+        };
 
-        protected virtual void GameObjectUpdatedDelegate(GameObjectType type)
+        this.Closing += EditorForm_Closing;
+    }
+
+    private void EditorForm_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+    {
+        mClosing = true;
+    }
+
+    private void FireGameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (IsDisposed || mClosing || Disposing)
         {
+            return;
         }
 
-        private void InitializeComponent()
-        {
-            this.SuspendLayout();
-            //
-            // EditorForm
-            //
-            this.ClientSize = new System.Drawing.Size(284, 261);
-            this.Name = "EditorForm";
-            this.ResumeLayout(false);
+        GameObjectUpdatedDelegate(type);
+    }
 
-        }
+    protected virtual void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+    }
+
+    private void InitializeComponent()
+    {
+        this.SuspendLayout();
+        //
+        // EditorForm
+        //
+        this.ClientSize = new System.Drawing.Size(284, 261);
+        this.Name = "EditorForm";
+        this.ResumeLayout(false);
 
     }
 

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -10,93 +10,76 @@ using Intersect.GameObjects.Maps.MapList;
 using Intersect.Logging;
 using VariableMod = Intersect.GameObjects.Events.VariableMod;
 
-namespace Intersect.Editor.Forms.Editors.Events
+namespace Intersect.Editor.Forms.Editors.Events;
+
+
+public static partial class CommandPrinter
 {
 
-    public static partial class CommandPrinter
+    /// <summary>
+    ///     Takes a string and a length value. If the string is longer than the length it will cut the string and add a ...,
+    ///     otherwise it will return the original string.
+    /// </summary>
+    /// <param name="value">String to process.</param>
+    /// <param name="maxChars">Max length allowed for the string.</param>
+    /// <returns></returns>
+    private static string Truncate(string value, int maxChars)
     {
+        return value.Length <= maxChars ? value : value.Substring(0, maxChars) + " ..";
+    }
 
-        /// <summary>
-        ///     Takes a string and a length value. If the string is longer than the length it will cut the string and add a ...,
-        ///     otherwise it will return the original string.
-        /// </summary>
-        /// <param name="value">String to process.</param>
-        /// <param name="maxChars">Max length allowed for the string.</param>
-        /// <returns></returns>
-        private static string Truncate(string value, int maxChars)
+    /// <summary>
+    ///     Recursively prints the referenced command list and all of it's children.
+    /// </summary>
+    /// <param name="commandList">The command list to print.</param>
+    /// <param name="indent">The starting indent of commands in this list.</param>
+    public static void PrintCommandList(
+        EventPage page,
+        List<EventCommand> commandList,
+        string indent,
+        ListBox lstEventCommands,
+        List<CommandListProperties> mCommandProperties,
+        MapInstance map
+    ) //TODO: How we can simplify and clean this up?
+    {
+        CommandListProperties clp;
+        if (commandList.Count > 0)
         {
-            return value.Length <= maxChars ? value : value.Substring(0, maxChars) + " ..";
-        }
-
-        /// <summary>
-        ///     Recursively prints the referenced command list and all of it's children.
-        /// </summary>
-        /// <param name="commandList">The command list to print.</param>
-        /// <param name="indent">The starting indent of commands in this list.</param>
-        public static void PrintCommandList(
-            EventPage page,
-            List<EventCommand> commandList,
-            string indent,
-            ListBox lstEventCommands,
-            List<CommandListProperties> mCommandProperties,
-            MapInstance map
-        ) //TODO: How we can simplify and clean this up?
-        {
-            CommandListProperties clp;
-            if (commandList.Count > 0)
+            for (var i = 0; i < commandList.Count; i++)
             {
-                for (var i = 0; i < commandList.Count; i++)
+                switch (commandList[i].Type)
                 {
-                    switch (commandList[i].Type)
-                    {
-                        case EventCommandType.ShowOptions:
-                            var cmd = (ShowOptionsCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
+                    case EventCommandType.ShowOptions:
+                        var cmd = (ShowOptionsCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
 
-                            clp = new CommandListProperties
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+                        for (var x = 0; x < 4; x++)
+                        {
+                            if (cmd.Options[x].Trim().Length <= 0)
                             {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-                            for (var x = 0; x < 4; x++)
-                            {
-                                if (cmd.Options[x].Trim().Length <= 0)
-                                {
-                                    continue;
-                                }
-
-                                lstEventCommands.Items.Add(
-                                    indent +
-                                    "      : " +
-                                    Strings.EventCommandList.whenoption.ToString(Truncate(cmd.Options[x], 20))
-                                );
-
-                                clp = new CommandListProperties
-                                {
-                                    Editable = false,
-                                    MyIndex = i,
-                                    MyList = commandList,
-                                    Type = commandList[i].Type,
-                                    Cmd = commandList[i]
-                                };
-
-                                mCommandProperties.Add(clp);
-                                PrintCommandList(
-                                    page, page.CommandLists[cmd.BranchIds[x]], indent + "          ", lstEventCommands,
-                                    mCommandProperties, map
-                                );
+                                continue;
                             }
 
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endoptions);
+                            lstEventCommands.Items.Add(
+                                indent +
+                                "      : " +
+                                Strings.EventCommandList.whenoption.ToString(Truncate(cmd.Options[x], 20))
+                            );
+
                             clp = new CommandListProperties
                             {
                                 Editable = false,
@@ -107,35 +90,117 @@ namespace Intersect.Editor.Forms.Editors.Events
                             };
 
                             mCommandProperties.Add(clp);
-
-                            break;
-                        case EventCommandType.InputVariable:
-                            var cid = (InputVariableCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
                             PrintCommandList(
-                                page, page.CommandLists[cid.BranchIds[0]], indent + "          ", lstEventCommands,
+                                page, page.CommandLists[cmd.BranchIds[x]], indent + "          ", lstEventCommands,
                                 mCommandProperties, map
                             );
+                        }
 
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endoptions);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    case EventCommandType.InputVariable:
+                        var cid = (InputVariableCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        PrintCommandList(
+                            page, page.CommandLists[cid.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalelse);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        PrintCommandList(
+                            page, page.CommandLists[cid.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalend);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    case EventCommandType.ConditionalBranch:
+                        var cnd = (ConditionalBranchCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        if ((cnd.BranchIds?.Length ?? 0) < 2)
+                        {
+                            Log.Error("Missing branch ids in conditional branch.");
+                        }
+
+                        if (!page.CommandLists.TryGetValue(cnd.BranchIds[0], out var branchCommandList))
+                        {
+                            Log.Error($"Missing command list for branch {cnd.BranchIds[0]}");
+                        }
+
+                        PrintCommandList(
+                            page, branchCommandList, indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        if (cnd.Condition.ElseEnabled)
+                        {
                             lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalelse);
-                            clp = new CommandListProperties
-                            {
+                            clp = new CommandListProperties {
                                 Editable = false,
                                 MyIndex = i,
                                 MyList = commandList,
@@ -145,1581 +210,1514 @@ namespace Intersect.Editor.Forms.Editors.Events
 
                             mCommandProperties.Add(clp);
 
-                            PrintCommandList(
-                                page, page.CommandLists[cid.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalend);
-                            clp = new CommandListProperties
+                            if (!page.CommandLists.TryGetValue(cnd.BranchIds[1], out branchCommandList))
                             {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                        case EventCommandType.ConditionalBranch:
-                            var cnd = (ConditionalBranchCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            if ((cnd.BranchIds?.Length ?? 0) < 2)
-                            {
-                                Log.Error("Missing branch ids in conditional branch.");
-                            }
-
-                            if (!page.CommandLists.TryGetValue(cnd.BranchIds[0], out var branchCommandList))
-                            {
-                                Log.Error($"Missing command list for branch {cnd.BranchIds[0]}");
+                                Log.Error($"Missing command list for branch {cnd.BranchIds[1]}");
                             }
 
                             PrintCommandList(
                                 page, branchCommandList, indent + "          ", lstEventCommands,
                                 mCommandProperties, map
                             );
-
-                            if (cnd.Condition.ElseEnabled)
-                            {
-                                lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalelse);
-                                clp = new CommandListProperties {
-                                    Editable = false,
-                                    MyIndex = i,
-                                    MyList = commandList,
-                                    Type = commandList[i].Type,
-                                    Cmd = commandList[i]
-                                };
-
-                                mCommandProperties.Add(clp);
-
-                                if (!page.CommandLists.TryGetValue(cnd.BranchIds[1], out branchCommandList))
-                                {
-                                    Log.Error($"Missing command list for branch {cnd.BranchIds[1]}");
-                                }
-
-                                PrintCommandList(
-                                    page, branchCommandList, indent + "          ", lstEventCommands,
-                                    mCommandProperties, map
-                                );
-                            }
-                            
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalend);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                        case EventCommandType.ChangeSpells:
-                            var spl = (ChangeSpellsCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the spell was successfully taught:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.spellsucceeded);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[spl.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the spell failed to be taught:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.spellfailed);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[spl.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endspell);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                        case EventCommandType.ChangeItems:
-                            var itm = (ChangeItemsCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the item(s) were successfully given/taken:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.itemschanged);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[itm.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the items failed to be given/taken:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.itemnotchanged);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[itm.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.enditemchange);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-
-                        case EventCommandType.StartQuest:
-                            var qst = (StartQuestCommand) commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the quest is accepted/started successfully:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.queststarted);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[qst.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the quest was declined or requirements not met:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.questnotstarted);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[qst.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endstartquest);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                        case EventCommandType.ChangeName:
-                            var chna = (ChangeNameCommand)commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic)commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the name was successfully changed:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.namesucceeded);
-                            clp = new CommandListProperties {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[chna.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the name failed to change:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.namefailed);
-                            clp = new CommandListProperties {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[chna.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endname);
-                            clp = new CommandListProperties {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                        default:
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic) commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-
-                        case EventCommandType.CreateGuild:
-                            var gld = (CreateGuildCommand)commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic)commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the guild is created successfully:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildcreated);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[gld.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the guild was not created for any reason:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildfailed);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[gld.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endcreateguild);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-
-                        case EventCommandType.DisbandGuild:
-                            var gldd = (DisbandGuildCommand)commandList[i];
-                            lstEventCommands.Items.Add(
-                                indent +
-                                Strings.EventCommandList.linestart +
-                                GetCommandText((dynamic)commandList[i], map)
-                            );
-
-                            clp = new CommandListProperties
-                            {
-                                Editable = true,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Cmd = commandList[i],
-                                Type = commandList[i].Type
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            //When the guild is disbanded successfully:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildisbanded);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[gldd.BranchIds[0]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            //When the guild was not disbanded for any reason:
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guilddisbandfailed);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-                            PrintCommandList(
-                                page, page.CommandLists[gldd.BranchIds[1]], indent + "          ", lstEventCommands,
-                                mCommandProperties, map
-                            );
-
-                            lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.enddisbandguild);
-                            clp = new CommandListProperties
-                            {
-                                Editable = false,
-                                MyIndex = i,
-                                MyList = commandList,
-                                Type = commandList[i].Type,
-                                Cmd = commandList[i]
-                            };
-
-                            mCommandProperties.Add(clp);
-
-                            break;
-                    }
+                        }
+                        
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.conditionalend);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    case EventCommandType.ChangeSpells:
+                        var spl = (ChangeSpellsCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the spell was successfully taught:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.spellsucceeded);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[spl.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the spell failed to be taught:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.spellfailed);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[spl.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endspell);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    case EventCommandType.ChangeItems:
+                        var itm = (ChangeItemsCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the item(s) were successfully given/taken:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.itemschanged);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[itm.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the items failed to be given/taken:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.itemnotchanged);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[itm.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.enditemchange);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+
+                    case EventCommandType.StartQuest:
+                        var qst = (StartQuestCommand) commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the quest is accepted/started successfully:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.queststarted);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[qst.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the quest was declined or requirements not met:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.questnotstarted);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[qst.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endstartquest);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    case EventCommandType.ChangeName:
+                        var chna = (ChangeNameCommand)commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic)commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the name was successfully changed:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.namesucceeded);
+                        clp = new CommandListProperties {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[chna.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the name failed to change:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.namefailed);
+                        clp = new CommandListProperties {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[chna.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endname);
+                        clp = new CommandListProperties {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+                    default:
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic) commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+
+                    case EventCommandType.CreateGuild:
+                        var gld = (CreateGuildCommand)commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic)commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the guild is created successfully:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildcreated);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[gld.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the guild was not created for any reason:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildfailed);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[gld.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.endcreateguild);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
+
+                    case EventCommandType.DisbandGuild:
+                        var gldd = (DisbandGuildCommand)commandList[i];
+                        lstEventCommands.Items.Add(
+                            indent +
+                            Strings.EventCommandList.linestart +
+                            GetCommandText((dynamic)commandList[i], map)
+                        );
+
+                        clp = new CommandListProperties
+                        {
+                            Editable = true,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Cmd = commandList[i],
+                            Type = commandList[i].Type
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        //When the guild is disbanded successfully:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guildisbanded);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[gldd.BranchIds[0]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        //When the guild was not disbanded for any reason:
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.guilddisbandfailed);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+                        PrintCommandList(
+                            page, page.CommandLists[gldd.BranchIds[1]], indent + "          ", lstEventCommands,
+                            mCommandProperties, map
+                        );
+
+                        lstEventCommands.Items.Add(indent + "      : " + Strings.EventCommandList.enddisbandguild);
+                        clp = new CommandListProperties
+                        {
+                            Editable = false,
+                            MyIndex = i,
+                            MyList = commandList,
+                            Type = commandList[i].Type,
+                            Cmd = commandList[i]
+                        };
+
+                        mCommandProperties.Add(clp);
+
+                        break;
                 }
             }
-
-            lstEventCommands.Items.Add(indent + Strings.EventCommandList.linestart);
-            clp = new CommandListProperties {Editable = true, MyIndex = -1, MyList = commandList};
-            mCommandProperties.Add(clp);
         }
 
-        //TODO: Bring this in and clean up the above later (AFTER we get everything else working and we can actually test our changes.)
-        //public static void PrintCommand(List<EventCommand> commandList, EventCommand command, string indent, ListBox lstEventCommands, List<CommandListProperties> mCommandProperties)
-        //{
-        //    lstEventCommands.Items.Add(indent + Strings.EventCommandList.linestart + GetCommandText(command));
-        //    var clp = new CommandListProperties
-        //    {
-        //        Editable = true,
-        //        MyIndex = commandList.IndexOf(command),
-        //        MyList = commandList,
-        //        Type = command.Type,
-        //        Cmd = command
-        //    };
-        //    mCommandProperties.Add(clp);
-        //}
+        lstEventCommands.Items.Add(indent + Strings.EventCommandList.linestart);
+        clp = new CommandListProperties {Editable = true, MyIndex = -1, MyList = commandList};
+        mCommandProperties.Add(clp);
+    }
 
-        private static string GetCommandText(ShowTextCommand command, MapInstance map)
+    //TODO: Bring this in and clean up the above later (AFTER we get everything else working and we can actually test our changes.)
+    //public static void PrintCommand(List<EventCommand> commandList, EventCommand command, string indent, ListBox lstEventCommands, List<CommandListProperties> mCommandProperties)
+    //{
+    //    lstEventCommands.Items.Add(indent + Strings.EventCommandList.linestart + GetCommandText(command));
+    //    var clp = new CommandListProperties
+    //    {
+    //        Editable = true,
+    //        MyIndex = commandList.IndexOf(command),
+    //        MyList = commandList,
+    //        Type = command.Type,
+    //        Cmd = command
+    //    };
+    //    mCommandProperties.Add(clp);
+    //}
+
+    private static string GetCommandText(ShowTextCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.showtext.ToString(Truncate(command.Text, 30));
+    }
+
+    private static string GetCommandText(ShowOptionsCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.showoptions.ToString(Truncate(command.Text, 30));
+    }
+
+    private static string GetCommandText(InputVariableCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.variableinput.ToString(Truncate(command.Text, 30));
+    }
+
+    private static string GetCommandText(AddChatboxTextCommand command, MapInstance map)
+    {
+        var channel = "";
+        switch (command.Channel)
         {
-            return Strings.EventCommandList.showtext.ToString(Truncate(command.Text, 30));
+            case ChatboxChannel.Player:
+                channel += Strings.EventCommandList.chatplayer;
+
+                break;
+            case ChatboxChannel.Local:
+                channel += Strings.EventCommandList.chatlocal;
+
+                break;
+            case ChatboxChannel.Global:
+                channel += Strings.EventCommandList.chatglobal;
+
+                break;
         }
 
-        private static string GetCommandText(ShowOptionsCommand command, MapInstance map)
+        return Strings.EventCommandList.chatboxtext.ToString(channel, command.Color, Truncate(command.Text, 20));
+    }
+
+    private static string GetCommandText(SetVariableCommand command, MapInstance map)
+    {
+        return GetVariableModText(command, (dynamic) command.Modification);
+    }
+
+    private static string GetCommandText(SetSelfSwitchCommand command, MapInstance map)
+    {
+        var selfvalue = "";
+        selfvalue = Strings.EventCommandList.False;
+        if (command.Value)
         {
-            return Strings.EventCommandList.showoptions.ToString(Truncate(command.Text, 30));
+            selfvalue = Strings.EventCommandList.True;
         }
 
-        private static string GetCommandText(InputVariableCommand command, MapInstance map)
+        return Strings.EventCommandList.selfswitch.ToString(
+            Strings.EventCommandList.selfswitches[command.SwitchId], selfvalue
+        );
+    }
+
+    private static string GetCommandText(ConditionalBranchCommand command, MapInstance map)
+    {
+        if (command.Condition.Negated)
         {
-            return Strings.EventCommandList.variableinput.ToString(Truncate(command.Text, 30));
-        }
-
-        private static string GetCommandText(AddChatboxTextCommand command, MapInstance map)
-        {
-            var channel = "";
-            switch (command.Channel)
-            {
-                case ChatboxChannel.Player:
-                    channel += Strings.EventCommandList.chatplayer;
-
-                    break;
-                case ChatboxChannel.Local:
-                    channel += Strings.EventCommandList.chatlocal;
-
-                    break;
-                case ChatboxChannel.Global:
-                    channel += Strings.EventCommandList.chatglobal;
-
-                    break;
-            }
-
-            return Strings.EventCommandList.chatboxtext.ToString(channel, command.Color, Truncate(command.Text, 20));
-        }
-
-        private static string GetCommandText(SetVariableCommand command, MapInstance map)
-        {
-            return GetVariableModText(command, (dynamic) command.Modification);
-        }
-
-        private static string GetCommandText(SetSelfSwitchCommand command, MapInstance map)
-        {
-            var selfvalue = "";
-            selfvalue = Strings.EventCommandList.False;
-            if (command.Value)
-            {
-                selfvalue = Strings.EventCommandList.True;
-            }
-
-            return Strings.EventCommandList.selfswitch.ToString(
-                Strings.EventCommandList.selfswitches[command.SwitchId], selfvalue
-            );
-        }
-
-        private static string GetCommandText(ConditionalBranchCommand command, MapInstance map)
-        {
-            if (command.Condition.Negated)
-            {
-                return Strings.EventCommandList.conditionalbranch.ToString(
-                    Strings.EventConditionDesc.negated.ToString(
-                        Strings.GetEventConditionalDesc((dynamic) command.Condition)
-                    )
-                );
-            }
-            else
-            {
-                return Strings.EventCommandList.conditionalbranch.ToString(
+            return Strings.EventCommandList.conditionalbranch.ToString(
+                Strings.EventConditionDesc.negated.ToString(
                     Strings.GetEventConditionalDesc((dynamic) command.Condition)
-                );
-            }
+                )
+            );
+        }
+        else
+        {
+            return Strings.EventCommandList.conditionalbranch.ToString(
+                Strings.GetEventConditionalDesc((dynamic) command.Condition)
+            );
+        }
+    }
+
+    private static string GetCommandText(ExitEventProcessingCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.exitevent;
+    }
+
+    private static string GetCommandText(LabelCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.label.ToString(command.Label);
+    }
+
+    private static string GetCommandText(GoToLabelCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.gotolabel.ToString(command.Label);
+    }
+
+    private static string GetCommandText(StartCommmonEventCommand command, MapInstance map)
+    {
+        if (command.AllInInstance)
+        {
+            return Strings.EventCommandList.CommonEventInstanced.ToString(EventBase.GetName(command.EventId), command.AllowInOverworld);
         }
 
-        private static string GetCommandText(ExitEventProcessingCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.exitevent;
-        }
+        return Strings.EventCommandList.commonevent.ToString(EventBase.GetName(command.EventId));
+    }
 
-        private static string GetCommandText(LabelCommand command, MapInstance map)
+    private static string GetCommandText(RestoreHpCommand command, MapInstance map)
+    {
+        if (command.Amount == 0)
         {
-            return Strings.EventCommandList.label.ToString(command.Label);
+            return Strings.EventCommandList.restorehp.ToString();
         }
-
-        private static string GetCommandText(GoToLabelCommand command, MapInstance map)
+        else
         {
-            return Strings.EventCommandList.gotolabel.ToString(command.Label);
+            return Strings.EventCommandList.restorehpby.ToString(command.Amount);
         }
+    }
 
-        private static string GetCommandText(StartCommmonEventCommand command, MapInstance map)
+    private static string GetCommandText(RestoreMpCommand command, MapInstance map)
+    {
+        if (command.Amount == 0)
         {
-            if (command.AllInInstance)
+            return Strings.EventCommandList.restoremp.ToString();
+        }
+        else
+        {
+            return Strings.EventCommandList.restorempby.ToString(command.Amount);
+        }
+    }
+
+    private static string GetCommandText(LevelUpCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.levelup;
+    }
+
+    private static string GetCommandText(GiveExperienceCommand command, MapInstance map)
+    {
+        if (command.UseVariable)
+        {
+            var exp = string.Empty;
+            switch (command.VariableType)
             {
-                return Strings.EventCommandList.CommonEventInstanced.ToString(EventBase.GetName(command.EventId), command.AllowInOverworld);
+                case VariableType.PlayerVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.PlayerVariable, PlayerVariableBase.GetName(command.VariableId));
+                    break;
+                case VariableType.ServerVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.ServerVariable, ServerVariableBase.GetName(command.VariableId));
+                    break;
+                case VariableType.GuildVariable:
+                    exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.GuildVariable, GuildVariableBase.GetName(command.VariableId));
+                    break;
             }
 
-            return Strings.EventCommandList.commonevent.ToString(EventBase.GetName(command.EventId));
+            return Strings.EventCommandList.giveexp.ToString(exp);
         }
-
-        private static string GetCommandText(RestoreHpCommand command, MapInstance map)
+        else
         {
-            if (command.Amount == 0)
-            {
-                return Strings.EventCommandList.restorehp.ToString();
-            }
-            else
-            {
-                return Strings.EventCommandList.restorehpby.ToString(command.Amount);
-            }
+            return Strings.EventCommandList.giveexp.ToString(command.Exp);
         }
+    }
 
-        private static string GetCommandText(RestoreMpCommand command, MapInstance map)
+    private static string GetCommandText(ChangeLevelCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setlevel.ToString(command.Level);
+    }
+
+    private static string GetCommandText(ChangeSpellsCommand command, MapInstance map)
+    {
+        if (command.Add)
         {
-            if (command.Amount == 0)
-            {
-                return Strings.EventCommandList.restoremp.ToString();
-            }
-            else
-            {
-                return Strings.EventCommandList.restorempby.ToString(command.Amount);
-            }
-        }
-
-        private static string GetCommandText(LevelUpCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.levelup;
-        }
-
-        private static string GetCommandText(GiveExperienceCommand command, MapInstance map)
-        {
-            if (command.UseVariable)
-            {
-                var exp = string.Empty;
-                switch (command.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.PlayerVariable, PlayerVariableBase.GetName(command.VariableId));
-                        break;
-                    case VariableType.ServerVariable:
-                        exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.ServerVariable, ServerVariableBase.GetName(command.VariableId));
-                        break;
-                    case VariableType.GuildVariable:
-                        exp = string.Format(@"({0}: {1})", Strings.EventGiveExperience.GuildVariable, GuildVariableBase.GetName(command.VariableId));
-                        break;
-                }
-
-                return Strings.EventCommandList.giveexp.ToString(exp);
-            }
-            else
-            {
-                return Strings.EventCommandList.giveexp.ToString(command.Exp);
-            }
-        }
-
-        private static string GetCommandText(ChangeLevelCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setlevel.ToString(command.Level);
-        }
-
-        private static string GetCommandText(ChangeSpellsCommand command, MapInstance map)
-        {
-            if (command.Add)
-            {
-                return Strings.EventCommandList.changespells.ToString(
-                    Strings.EventCommandList.teach.ToString(SpellBase.GetName(command.SpellId))
-                );
-            }
-
             return Strings.EventCommandList.changespells.ToString(
-                Strings.EventCommandList.forget.ToString(SpellBase.GetName(command.SpellId))
+                Strings.EventCommandList.teach.ToString(SpellBase.GetName(command.SpellId))
             );
         }
 
-        private static string GetCommandText(ChangeItemsCommand command, MapInstance map)
-        {
-            if (command.Add)
-            {
-                return Strings.EventCommandList.changeitems.ToString(
-                    Strings.EventCommandList.give.ToString(ItemBase.GetName(command.ItemId))
-                );
-            }
+        return Strings.EventCommandList.changespells.ToString(
+            Strings.EventCommandList.forget.ToString(SpellBase.GetName(command.SpellId))
+        );
+    }
 
+    private static string GetCommandText(ChangeItemsCommand command, MapInstance map)
+    {
+        if (command.Add)
+        {
             return Strings.EventCommandList.changeitems.ToString(
-                Strings.EventCommandList.take.ToString(ItemBase.GetName(command.ItemId))
+                Strings.EventCommandList.give.ToString(ItemBase.GetName(command.ItemId))
             );
         }
 
-        private static string GetCommandText(EquipItemCommand command, MapInstance map)
-        {
-            var commandText = string.Empty;
+        return Strings.EventCommandList.changeitems.ToString(
+            Strings.EventCommandList.take.ToString(ItemBase.GetName(command.ItemId))
+        );
+    }
 
-            if(!command.Unequip)
+    private static string GetCommandText(EquipItemCommand command, MapInstance map)
+    {
+        var commandText = string.Empty;
+
+        if(!command.Unequip)
+        {
+            commandText = Strings.EventCommandList.equipitem.ToString(ItemBase.GetName(command.ItemId));
+        }
+        else
+        {
+            if (command.IsItem)
             {
-                commandText = Strings.EventCommandList.equipitem.ToString(ItemBase.GetName(command.ItemId));
+                 commandText = Strings.EventCommandList.unequipitem.ToString(ItemBase.GetName(command.ItemId));
             }
             else
             {
-                if (command.IsItem)
-                {
-                     commandText = Strings.EventCommandList.unequipitem.ToString(ItemBase.GetName(command.ItemId));
-                }
-                else
-                {
-                    commandText = Strings.EventCommandList.unequipslot.ToString(Options.EquipmentSlots[command.Slot]);
-                }
-            }
-
-            return commandText;
-        }
-
-        private static string GetCommandText(ChangeSpriteCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setsprite.ToString(command.Sprite);
-        }
-
-        private static string GetCommandText(ChangeFaceCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setface.ToString(command.Face);
-        }
-
-        private static string GetCommandText(ChangeNameColorCommand command, MapInstance map)
-        {
-            if (command.Remove)
-            {
-                return Strings.EventCommandList.removenamecolor.ToString();
-            }
-            else
-            {
-                return Strings.EventCommandList.setnamecolor.ToString();
+                commandText = Strings.EventCommandList.unequipslot.ToString(Options.EquipmentSlots[command.Slot]);
             }
         }
 
-        private static string GetCommandText(ChangePlayerLabelCommand command, MapInstance map)
+        return commandText;
+    }
+
+    private static string GetCommandText(ChangeSpriteCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setsprite.ToString(command.Sprite);
+    }
+
+    private static string GetCommandText(ChangeFaceCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setface.ToString(command.Face);
+    }
+
+    private static string GetCommandText(ChangeNameColorCommand command, MapInstance map)
+    {
+        if (command.Remove)
         {
-            return Strings.EventCommandList.changeplayerlabel.ToString(command.Value);
+            return Strings.EventCommandList.removenamecolor.ToString();
+        }
+        else
+        {
+            return Strings.EventCommandList.setnamecolor.ToString();
+        }
+    }
+
+    private static string GetCommandText(ChangePlayerLabelCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.changeplayerlabel.ToString(command.Value);
+    }
+
+    private static string GetCommandText(ChangeGenderCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setgender.ToString(command.Gender == 0
+            ? Strings.EventCommandList.male
+            : Strings.EventCommandList.female);
+    }
+
+    private static string GetCommandText(SetAccessCommand command, MapInstance map)
+    {
+        switch (command.Access)
+        {
+            case Access.None:
+                return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.regularuser);
+            case Access.Moderator:
+                return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.moderator);
+            case Access.Admin:
+                return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.admin);
         }
 
-        private static string GetCommandText(ChangeGenderCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setgender.ToString(command.Gender == 0
-                ? Strings.EventCommandList.male
-                : Strings.EventCommandList.female);
-        }
+        return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.unknownrole);
+    }
 
-        private static string GetCommandText(SetAccessCommand command, MapInstance map)
+    private static string GetCommandText(WarpCommand command, MapInstance map)
+    {
+        var mapName = Strings.EventCommandList.mapnotfound;
+        for (var i = 0; i < MapList.OrderedMaps.Count; i++)
         {
-            switch (command.Access)
+            if (MapList.OrderedMaps[i].MapId == command.MapId)
             {
-                case Access.None:
-                    return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.regularuser);
-                case Access.Moderator:
-                    return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.moderator);
-                case Access.Admin:
-                    return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.admin);
+                mapName = MapList.OrderedMaps[i].Name;
             }
-
-            return Strings.EventCommandList.setaccess.ToString(Strings.EventCommandList.unknownrole);
         }
 
-        private static string GetCommandText(WarpCommand command, MapInstance map)
+        if (command.ChangeInstance)
         {
-            var mapName = Strings.EventCommandList.mapnotfound;
-            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-            {
-                if (MapList.OrderedMaps[i].MapId == command.MapId)
-                {
-                    mapName = MapList.OrderedMaps[i].Name;
-                }
-            }
+            return Strings.EventCommandList.InstancedWarp.ToString(
+                mapName, command.X, command.Y, Strings.Direction.dir[(Direction)command.Direction - 1], command.InstanceType.ToString()
+            );
+        } else
+        {
+            return Strings.EventCommandList.warp.ToString(
+                mapName, command.X, command.Y, Strings.Direction.dir[(Direction)command.Direction - 1]
+            );
+        }
+    }
 
-            if (command.ChangeInstance)
+    private static string GetCommandText(SetMoveRouteCommand command, MapInstance map)
+    {
+        if (command.Route.Target == Guid.Empty)
+        {
+            return Strings.EventCommandList.moveroute.ToString(Strings.EventCommandList.moverouteplayer);
+        }
+        else
+        {
+            if (map.LocalEvents.ContainsKey(command.Route.Target))
             {
-                return Strings.EventCommandList.InstancedWarp.ToString(
-                    mapName, command.X, command.Y, Strings.Direction.dir[(Direction)command.Direction - 1], command.InstanceType.ToString()
+                return Strings.EventCommandList.moveroute.ToString(
+                    Strings.EventCommandList.moverouteevent.ToString(map.LocalEvents[command.Route.Target].Name)
                 );
-            } else
-            {
-                return Strings.EventCommandList.warp.ToString(
-                    mapName, command.X, command.Y, Strings.Direction.dir[(Direction)command.Direction - 1]
-                );
-            }
-        }
-
-        private static string GetCommandText(SetMoveRouteCommand command, MapInstance map)
-        {
-            if (command.Route.Target == Guid.Empty)
-            {
-                return Strings.EventCommandList.moveroute.ToString(Strings.EventCommandList.moverouteplayer);
             }
             else
             {
-                if (map.LocalEvents.ContainsKey(command.Route.Target))
+                return Strings.EventCommandList.moveroute.ToString(Strings.EventCommandList.deletedevent);
+            }
+        }
+    }
+
+    private static string GetCommandText(WaitForRouteCommand command, MapInstance map)
+    {
+        if (command.TargetId == Guid.Empty)
+        {
+            return Strings.EventCommandList.waitforroute.ToString(Strings.EventCommandList.moverouteplayer);
+        }
+        else if (map.LocalEvents.ContainsKey(command.TargetId))
+        {
+            return Strings.EventCommandList.waitforroute.ToString(
+                Strings.EventCommandList.moverouteevent.ToString(map.LocalEvents[command.TargetId].Name)
+            );
+        }
+        else
+        {
+            return Strings.EventCommandList.waitforroute.ToString(Strings.EventCommandList.deletedevent);
+        }
+    }
+
+    private static string GetCommandText(HoldPlayerCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.holdplayer;
+    }
+
+    private static string GetCommandText(ReleasePlayerCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.releaseplayer;
+    }
+
+    private static string GetCommandText(HidePlayerCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.hideplayer;
+    }
+
+    private static string GetCommandText(ShowPlayerCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.showplayer;
+    }
+
+    private static string GetCommandText(SpawnNpcCommand command, MapInstance map)
+    {
+        if (command == null)
+        {
+            return null;
+        }
+
+        if (command.MapId != Guid.Empty)
+        {
+            foreach (var orderedMap in MapList.OrderedMaps)
+            {
+                if (orderedMap == null)
                 {
-                    return Strings.EventCommandList.moveroute.ToString(
-                        Strings.EventCommandList.moverouteevent.ToString(map.LocalEvents[command.Route.Target].Name)
+                    continue;
+                }
+
+                if (orderedMap.MapId == command.MapId)
+                {
+                    return Strings.EventCommandList.spawnnpc.ToString(
+                        NpcBase.GetName(command.NpcId),
+                        Strings.EventCommandList.spawnonmap.ToString(
+                            orderedMap.Name, command.X, command.Y, Strings.Direction.dir?[command.Dir]
+                        )
                     );
                 }
-                else
-                {
-                    return Strings.EventCommandList.moveroute.ToString(Strings.EventCommandList.deletedevent);
-                }
-            }
-        }
-
-        private static string GetCommandText(WaitForRouteCommand command, MapInstance map)
-        {
-            if (command.TargetId == Guid.Empty)
-            {
-                return Strings.EventCommandList.waitforroute.ToString(Strings.EventCommandList.moverouteplayer);
-            }
-            else if (map.LocalEvents.ContainsKey(command.TargetId))
-            {
-                return Strings.EventCommandList.waitforroute.ToString(
-                    Strings.EventCommandList.moverouteevent.ToString(map.LocalEvents[command.TargetId].Name)
-                );
-            }
-            else
-            {
-                return Strings.EventCommandList.waitforroute.ToString(Strings.EventCommandList.deletedevent);
-            }
-        }
-
-        private static string GetCommandText(HoldPlayerCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.holdplayer;
-        }
-
-        private static string GetCommandText(ReleasePlayerCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.releaseplayer;
-        }
-
-        private static string GetCommandText(HidePlayerCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.hideplayer;
-        }
-
-        private static string GetCommandText(ShowPlayerCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.showplayer;
-        }
-
-        private static string GetCommandText(SpawnNpcCommand command, MapInstance map)
-        {
-            if (command == null)
-            {
-                return null;
-            }
-
-            if (command.MapId != Guid.Empty)
-            {
-                foreach (var orderedMap in MapList.OrderedMaps)
-                {
-                    if (orderedMap == null)
-                    {
-                        continue;
-                    }
-
-                    if (orderedMap.MapId == command.MapId)
-                    {
-                        return Strings.EventCommandList.spawnnpc.ToString(
-                            NpcBase.GetName(command.NpcId),
-                            Strings.EventCommandList.spawnonmap.ToString(
-                                orderedMap.Name, command.X, command.Y, Strings.Direction.dir?[command.Dir]
-                            )
-                        );
-                    }
-                }
-
-                return Strings.EventCommandList.spawnnpc.ToString(
-                    NpcBase.GetName(command.NpcId),
-                    Strings.EventCommandList.spawnonmap.ToString(
-                        Strings.EventCommandList.mapnotfound, command.X, command.Y, Strings.Direction.dir[command.Dir]
-                    )
-                );
-            }
-
-            var retain = Strings.EventCommandList.False;
-
-            //TODO: Possibly bugged -- test this.
-            if (Convert.ToBoolean(command.Dir))
-            {
-                retain = Strings.EventCommandList.True;
-            }
-
-            if (command.EntityId == Guid.Empty)
-            {
-                return Strings.EventCommandList.spawnnpc.ToString(
-                    NpcBase.GetName(command.NpcId),
-                    Strings.EventCommandList.spawnonplayer.ToString(command.X, command.Y, retain)
-                );
-            }
-
-            if (map.LocalEvents.TryGetValue(command.EntityId, out var localEvent))
-            {
-                return Strings.EventCommandList.spawnnpc.ToString(
-                    NpcBase.GetName(command.NpcId),
-                    Strings.EventCommandList.spawnonevent.ToString(localEvent.Name, command.X, command.Y, retain)
-                );
             }
 
             return Strings.EventCommandList.spawnnpc.ToString(
                 NpcBase.GetName(command.NpcId),
-                Strings.EventCommandList.spawnonevent.ToString(
-                    Strings.EventCommandList.deletedevent, command.X, command.Y, retain
+                Strings.EventCommandList.spawnonmap.ToString(
+                    Strings.EventCommandList.mapnotfound, command.X, command.Y, Strings.Direction.dir[command.Dir]
                 )
             );
         }
 
-        private static string GetCommandText(DespawnNpcCommand command, MapInstance map)
+        var retain = Strings.EventCommandList.False;
+
+        //TODO: Possibly bugged -- test this.
+        if (Convert.ToBoolean(command.Dir))
         {
-            return Strings.EventCommandList.despawnnpcs;
+            retain = Strings.EventCommandList.True;
         }
 
-        private static string GetCommandText(PlayAnimationCommand command, MapInstance map)
+        if (command.EntityId == Guid.Empty)
         {
-            StringBuilder commandTextBuilder = new StringBuilder();
-            if (command.MapId != Guid.Empty)
-            {
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == command.MapId)
-                    {
-                        commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
-                            AnimationBase.GetName(command.AnimationId),
-                            Strings.EventCommandList.animationonmap.ToString(
-                                MapList.OrderedMaps[i].Name, command.X, command.Y,
-                                Strings.Direction.dir[(Direction) command.Dir]
-                            )
-                        ));
-                    }
-                }
+            return Strings.EventCommandList.spawnnpc.ToString(
+                NpcBase.GetName(command.NpcId),
+                Strings.EventCommandList.spawnonplayer.ToString(command.X, command.Y, retain)
+            );
+        }
 
+        if (map.LocalEvents.TryGetValue(command.EntityId, out var localEvent))
+        {
+            return Strings.EventCommandList.spawnnpc.ToString(
+                NpcBase.GetName(command.NpcId),
+                Strings.EventCommandList.spawnonevent.ToString(localEvent.Name, command.X, command.Y, retain)
+            );
+        }
+
+        return Strings.EventCommandList.spawnnpc.ToString(
+            NpcBase.GetName(command.NpcId),
+            Strings.EventCommandList.spawnonevent.ToString(
+                Strings.EventCommandList.deletedevent, command.X, command.Y, retain
+            )
+        );
+    }
+
+    private static string GetCommandText(DespawnNpcCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.despawnnpcs;
+    }
+
+    private static string GetCommandText(PlayAnimationCommand command, MapInstance map)
+    {
+        StringBuilder commandTextBuilder = new StringBuilder();
+        if (command.MapId != Guid.Empty)
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == command.MapId)
+                {
+                    commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
+                        AnimationBase.GetName(command.AnimationId),
+                        Strings.EventCommandList.animationonmap.ToString(
+                            MapList.OrderedMaps[i].Name, command.X, command.Y,
+                            Strings.Direction.dir[(Direction) command.Dir]
+                        )
+                    ));
+                }
+            }
+
+            commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
+                AnimationBase.GetName(command.AnimationId),
+                Strings.EventCommandList.animationonmap.ToString(
+                    Strings.EventCommandList.mapnotfound, command.X, command.Y, Strings.Direction.dir[(Direction)command.Dir]
+                )
+            ));
+        }
+        else
+        {
+            var spawnOpt = "";
+            switch (command.Dir)
+            {
+                //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                case 1:
+                    spawnOpt = Strings.EventCommandList.animationrelativedir;
+
+                    break;
+                case 2:
+                    spawnOpt = Strings.EventCommandList.animationrotatedir;
+
+                    break;
+                case 3:
+                    spawnOpt = Strings.EventCommandList.animationrelativerotate;
+
+                    break;
+            }
+
+            if (command.EntityId == Guid.Empty)
+            {
                 commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
                     AnimationBase.GetName(command.AnimationId),
-                    Strings.EventCommandList.animationonmap.ToString(
-                        Strings.EventCommandList.mapnotfound, command.X, command.Y, Strings.Direction.dir[(Direction)command.Dir]
-                    )
+                    Strings.EventCommandList.animationonplayer.ToString(command.X, command.Y, spawnOpt)
                 ));
             }
             else
             {
-                var spawnOpt = "";
-                switch (command.Dir)
-                {
-                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                    case 1:
-                        spawnOpt = Strings.EventCommandList.animationrelativedir;
-
-                        break;
-                    case 2:
-                        spawnOpt = Strings.EventCommandList.animationrotatedir;
-
-                        break;
-                    case 3:
-                        spawnOpt = Strings.EventCommandList.animationrelativerotate;
-
-                        break;
-                }
-
-                if (command.EntityId == Guid.Empty)
+                if (map.LocalEvents.ContainsKey(command.EntityId))
                 {
                     commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
                         AnimationBase.GetName(command.AnimationId),
-                        Strings.EventCommandList.animationonplayer.ToString(command.X, command.Y, spawnOpt)
+                        Strings.EventCommandList.animationonevent.ToString(
+                            map.LocalEvents[command.EntityId].Name, command.X, command.Y, spawnOpt
+                        )
                     ));
                 }
                 else
                 {
-                    if (map.LocalEvents.ContainsKey(command.EntityId))
-                    {
-                        commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
-                            AnimationBase.GetName(command.AnimationId),
-                            Strings.EventCommandList.animationonevent.ToString(
-                                map.LocalEvents[command.EntityId].Name, command.X, command.Y, spawnOpt
-                            )
-                        ));
-                    }
-                    else
-                    {
-                        commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
-                            AnimationBase.GetName(command.AnimationId),
-                            Strings.EventCommandList.animationonevent.ToString(
-                                Strings.EventCommandList.deletedevent, command.X, command.Y, spawnOpt
-                            )
-                        ));
-                    }
+                    commandTextBuilder.Append(Strings.EventCommandList.playanimation.ToString(
+                        AnimationBase.GetName(command.AnimationId),
+                        Strings.EventCommandList.animationonevent.ToString(
+                            Strings.EventCommandList.deletedevent, command.X, command.Y, spawnOpt
+                        )
+                    ));
                 }
             }
-
-            commandTextBuilder.Append(Strings.EventCommandList.PlayAnimationInstanced.ToString(command.InstanceToPlayer));
-            return commandTextBuilder.ToString();
         }
 
-        private static string GetCommandText(PlayBgmCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.playbgm.ToString(command.File);
-        }
+        commandTextBuilder.Append(Strings.EventCommandList.PlayAnimationInstanced.ToString(command.InstanceToPlayer));
+        return commandTextBuilder.ToString();
+    }
 
-        private static string GetCommandText(FadeoutBgmCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.fadeoutbgm;
-        }
+    private static string GetCommandText(PlayBgmCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.playbgm.ToString(command.File);
+    }
 
-        private static string GetCommandText(PlaySoundCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.playsound.ToString(command.File);
-        }
+    private static string GetCommandText(FadeoutBgmCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.fadeoutbgm;
+    }
 
-        private static string GetCommandText(StopSoundsCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.stopsounds;
-        }
+    private static string GetCommandText(PlaySoundCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.playsound.ToString(command.File);
+    }
 
-        private static string GetCommandText(ShowPictureCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.showpicture;
-        }
+    private static string GetCommandText(StopSoundsCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.stopsounds;
+    }
 
-        private static string GetCommandText(ChangeNameCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.changename.ToString(PlayerVariableBase.GetName(command.VariableId));
-        }
+    private static string GetCommandText(ShowPictureCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.showpicture;
+    }
 
-        private static string GetCommandText(HidePictureCommmand command, MapInstance map)
-        {
-            return Strings.EventCommandList.hidepicture;
-        }
+    private static string GetCommandText(ChangeNameCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.changename.ToString(PlayerVariableBase.GetName(command.VariableId));
+    }
 
-        private static string GetCommandText(WaitCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.wait.ToString(command.Time);
-        }
+    private static string GetCommandText(HidePictureCommmand command, MapInstance map)
+    {
+        return Strings.EventCommandList.hidepicture;
+    }
 
-        private static string GetCommandText(OpenBankCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.openbank;
-        }
+    private static string GetCommandText(WaitCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.wait.ToString(command.Time);
+    }
 
-        private static string GetCommandText(OpenShopCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.openshop.ToString(ShopBase.GetName(command.ShopId));
-        }
+    private static string GetCommandText(OpenBankCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.openbank;
+    }
 
-        private static string GetCommandText(OpenCraftingTableCommand command, MapInstance map)
-        {
-            return command.JournalMode ?
-                Strings.EventCommandList.OpenCraftingJournal.ToString(CraftingTableBase.GetName(command.CraftingTableId)) :
-                Strings.EventCommandList.opencrafting.ToString(CraftingTableBase.GetName(command.CraftingTableId));
-        }
+    private static string GetCommandText(OpenShopCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.openshop.ToString(ShopBase.GetName(command.ShopId));
+    }
 
-        private static string GetCommandText(SetClassCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setclass.ToString(ClassBase.GetName(command.ClassId));
-        }
+    private static string GetCommandText(OpenCraftingTableCommand command, MapInstance map)
+    {
+        return command.JournalMode ?
+            Strings.EventCommandList.OpenCraftingJournal.ToString(CraftingTableBase.GetName(command.CraftingTableId)) :
+            Strings.EventCommandList.opencrafting.ToString(CraftingTableBase.GetName(command.CraftingTableId));
+    }
 
-        private static string GetCommandText(StartQuestCommand command, MapInstance map)
-        {
-            if (!command.Offer)
-            {
-                return Strings.EventCommandList.startquest.ToString(
-                    QuestBase.GetName(command.QuestId), Strings.EventCommandList.forcedstart
-                );
-            }
-            else
-            {
-                return Strings.EventCommandList.startquest.ToString(
-                    QuestBase.GetName(command.QuestId), Strings.EventCommandList.showoffer
-                );
-            }
-        }
+    private static string GetCommandText(SetClassCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setclass.ToString(ClassBase.GetName(command.ClassId));
+    }
 
-        private static string GetCommandText(CompleteQuestTaskCommand command, MapInstance map)
+    private static string GetCommandText(StartQuestCommand command, MapInstance map)
+    {
+        if (!command.Offer)
         {
-            var quest = QuestBase.Get(command.QuestId);
-            if (quest != null)
-            {
-                //Try to find task
-                foreach (var task in quest.Tasks)
-                {
-                    if (task.Id == command.TaskId)
-                    {
-                        return Strings.EventCommandList.completetask.ToString(
-                            QuestBase.GetName(command.QuestId), task.GetTaskString(Strings.TaskEditor.descriptions)
-                        );
-                    }
-                }
-            }
-
-            return Strings.EventCommandList.completetask.ToString(
-                QuestBase.GetName(command.QuestId), Strings.EventCommandList.taskundefined
+            return Strings.EventCommandList.startquest.ToString(
+                QuestBase.GetName(command.QuestId), Strings.EventCommandList.forcedstart
             );
         }
-
-        private static string GetCommandText(EndQuestCommand command, MapInstance map)
+        else
         {
-            if (!command.SkipCompletionEvent)
-            {
-                return Strings.EventCommandList.endquest.ToString(
-                    QuestBase.GetName(command.QuestId), Strings.EventCommandList.runcompletionevent
-                );
-            }
+            return Strings.EventCommandList.startquest.ToString(
+                QuestBase.GetName(command.QuestId), Strings.EventCommandList.showoffer
+            );
+        }
+    }
 
+    private static string GetCommandText(CompleteQuestTaskCommand command, MapInstance map)
+    {
+        var quest = QuestBase.Get(command.QuestId);
+        if (quest != null)
+        {
+            //Try to find task
+            foreach (var task in quest.Tasks)
+            {
+                if (task.Id == command.TaskId)
+                {
+                    return Strings.EventCommandList.completetask.ToString(
+                        QuestBase.GetName(command.QuestId), task.GetTaskString(Strings.TaskEditor.descriptions)
+                    );
+                }
+            }
+        }
+
+        return Strings.EventCommandList.completetask.ToString(
+            QuestBase.GetName(command.QuestId), Strings.EventCommandList.taskundefined
+        );
+    }
+
+    private static string GetCommandText(EndQuestCommand command, MapInstance map)
+    {
+        if (!command.SkipCompletionEvent)
+        {
             return Strings.EventCommandList.endquest.ToString(
-                QuestBase.GetName(command.QuestId), Strings.EventCommandList.skipcompletionevent
+                QuestBase.GetName(command.QuestId), Strings.EventCommandList.runcompletionevent
             );
         }
 
-        private static string GetCommandText(ChangePlayerColorCommand command, MapInstance map)
+        return Strings.EventCommandList.endquest.ToString(
+            QuestBase.GetName(command.QuestId), Strings.EventCommandList.skipcompletionevent
+        );
+    }
+
+    private static string GetCommandText(ChangePlayerColorCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.ChangePlayerColor.ToString(command.Color.R, command.Color.G, command.Color.B, command.Color.A);
+    }
+
+    private static string GetCommandText(CreateGuildCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.createguild.ToString(PlayerVariableBase.GetName(command.VariableId));
+    }
+
+    private static string GetCommandText(DisbandGuildCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.disbandguild;
+    }
+
+    private static string GetCommandText(OpenGuildBankCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.openguildbank;
+    }
+
+    private static string GetCommandText(SetGuildBankSlotsCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.setguildbankslots;
+    }
+
+    private static string GetCommandText(ResetStatPointAllocationsCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.resetstatpointallocations;
+    }
+
+    private static string GetCommandText(CastSpellOn command, MapInstance map)
+    {
+        return Strings.EventCommandList.CastSpellOn.ToString(SpellBase.GetName(command.SpellId), command.Self, command.PartyMembers, command.GuildMembers);
+    }
+
+    private static string GetCommandText(ScreenFadeCommand command, MapInstance map)
+    {
+        Strings.EventScreenFade.FadeTypes.TryGetValue((int)command.FadeType, out var commandType);
+
+        if (command.FadeType == FadeType.None)
         {
-            return Strings.EventCommandList.ChangePlayerColor.ToString(command.Color.R, command.Color.G, command.Color.B, command.Color.A);
+            return Strings.EventCommandList.FadeCancel.ToString(commandType, command.WaitForCompletion);
         }
+        
+        return Strings.EventCommandList.Fade.ToString(commandType, command.WaitForCompletion, command.DurationMs);
+    }
 
-        private static string GetCommandText(CreateGuildCommand command, MapInstance map)
+    //Set Variable Modification Texts
+    private static string GetVariableModText(SetVariableCommand command, VariableMod mod)
+    {
+        return Strings.EventCommandList.invalid;
+    }
+
+    private static string GetVariableModText(SetVariableCommand command, BooleanVariableMod mod)
+    {
+        var varvalue = "";
+        if (mod.DuplicateVariableId != Guid.Empty)
         {
-            return Strings.EventCommandList.createguild.ToString(PlayerVariableBase.GetName(command.VariableId));
-        }
-
-        private static string GetCommandText(DisbandGuildCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.disbandguild;
-        }
-
-        private static string GetCommandText(OpenGuildBankCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.openguildbank;
-        }
-
-        private static string GetCommandText(SetGuildBankSlotsCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.setguildbankslots;
-        }
-
-        private static string GetCommandText(ResetStatPointAllocationsCommand command, MapInstance map)
-        {
-            return Strings.EventCommandList.resetstatpointallocations;
-        }
-
-        private static string GetCommandText(CastSpellOn command, MapInstance map)
-        {
-            return Strings.EventCommandList.CastSpellOn.ToString(SpellBase.GetName(command.SpellId), command.Self, command.PartyMembers, command.GuildMembers);
-        }
-
-        private static string GetCommandText(ScreenFadeCommand command, MapInstance map)
-        {
-            Strings.EventScreenFade.FadeTypes.TryGetValue((int)command.FadeType, out var commandType);
-
-            if (command.FadeType == FadeType.None)
+            if (mod.DupVariableType == VariableType.PlayerVariable)
             {
-                return Strings.EventCommandList.FadeCancel.ToString(commandType, command.WaitForCompletion);
+                varvalue = Strings.EventCommandList.dupplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
             }
-            
-            return Strings.EventCommandList.Fade.ToString(commandType, command.WaitForCompletion, command.DurationMs);
-        }
-
-        //Set Variable Modification Texts
-        private static string GetVariableModText(SetVariableCommand command, VariableMod mod)
-        {
-            return Strings.EventCommandList.invalid;
-        }
-
-        private static string GetVariableModText(SetVariableCommand command, BooleanVariableMod mod)
-        {
-            var varvalue = "";
-            if (mod.DuplicateVariableId != Guid.Empty)
+            else if (mod.DupVariableType == VariableType.ServerVariable)
             {
-                if (mod.DupVariableType == VariableType.PlayerVariable)
-                {
-                    varvalue = Strings.EventCommandList.dupplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-                }
-                else if (mod.DupVariableType == VariableType.ServerVariable)
-                {
-                    varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-                }
-                else if (mod.DupVariableType == VariableType.GuildVariable)
-                {
-                    varvalue = Strings.EventCommandList.dupguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-                }
-                else if (mod.DupVariableType == VariableType.UserVariable)
-                {
-                    varvalue = Strings.EventCommandList.DupUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-                }
+                varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+            }
+            else if (mod.DupVariableType == VariableType.GuildVariable)
+            {
+                varvalue = Strings.EventCommandList.dupguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+            }
+            else if (mod.DupVariableType == VariableType.UserVariable)
+            {
+                varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+            }
+        }
+        else
+        {
+            if (mod.Value == true)
+            {
+                varvalue = Strings.EventCommandList.setvariable.ToString(Strings.EventCommandList.True);
             }
             else
             {
-                if (mod.Value == true)
-                {
-                    varvalue = Strings.EventCommandList.setvariable.ToString(Strings.EventCommandList.True);
-                }
-                else
-                {
-                    varvalue = Strings.EventCommandList.setvariable.ToString(Strings.EventCommandList.False);
-                }
+                varvalue = Strings.EventCommandList.setvariable.ToString(Strings.EventCommandList.False);
             }
-
-            if (command.VariableType == VariableType.PlayerVariable)
-            {
-                return Strings.EventCommandList.playervariable.ToString(
-                    PlayerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.ServerVariable)
-            {
-                return Strings.EventCommandList.globalvariable.ToString(
-                    ServerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.GuildVariable)
-            {
-                return Strings.EventCommandList.guildvariable.ToString(
-                    GuildVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.UserVariable)
-            {
-                return Strings.EventCommandList.UserVariable.ToString(
-                    Strings.GameObjectStrings.UserVariable,
-                    UserVariableBase.GetName(command.VariableId),
-                    varvalue
-                );
-            }
-
-            return Strings.EventCommandList.invalid;
         }
 
-        private static string GetVariableModText(SetVariableCommand command, IntegerVariableMod mod)
+        if (command.VariableType == VariableType.PlayerVariable)
         {
-            var varvalue = "";
-            switch (mod.ModType)
-            {
-                case Enums.VariableMod.Set:
-                    varvalue = Strings.EventCommandList.setvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Add:
-                    varvalue = Strings.EventCommandList.addvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Subtract:
-                    varvalue = Strings.EventCommandList.subtractvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Multiply:
-                    varvalue = Strings.EventCommandList.multiplyvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Divide:
-                    varvalue = Strings.EventCommandList.dividevariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.LeftShift:
-                    varvalue = Strings.EventCommandList.leftshiftvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.RightShift:
-                    varvalue = Strings.EventCommandList.rightshiftvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Random:
-                    varvalue = Strings.EventCommandList.randvariable.ToString(mod.Value, mod.HighValue);
-
-                    break;
-                case Enums.VariableMod.SystemTime:
-                    varvalue = Strings.EventCommandList.systemtimevariable;
-
-                    break;
-
-
-                //Player Variable
-                case Enums.VariableMod.DupPlayerVar:
-                    varvalue = Strings.EventCommandList.dupplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.AddPlayerVar:
-                    varvalue = Strings.EventCommandList.addplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.SubtractPlayerVar:
-                    varvalue = Strings.EventCommandList.subtractplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.MultiplyPlayerVar:
-                    varvalue = Strings.EventCommandList.multiplyplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.DividePlayerVar:
-                    varvalue = Strings.EventCommandList.divideplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.LeftShiftPlayerVar:
-                    varvalue = Strings.EventCommandList.leftshiftplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.RightShiftPlayerVar:
-                    varvalue = Strings.EventCommandList.rightshiftplayervariable.ToString(
-                        PlayerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-
-
-                //Global Variable
-                case Enums.VariableMod.DupGlobalVar:
-                    varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.AddGlobalVar:
-                    varvalue = Strings.EventCommandList.addglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.SubtractGlobalVar:
-                    varvalue = Strings.EventCommandList.subtractglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.MultiplyGlobalVar:
-                    varvalue = Strings.EventCommandList.multiplyglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.DivideGlobalVar:
-                    varvalue = Strings.EventCommandList.divideglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.LeftShiftGlobalVar:
-                    varvalue = Strings.EventCommandList.leftshiftglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.RightShiftGlobalVar:
-                    varvalue = Strings.EventCommandList.rightshiftglobalvariable.ToString(
-                        ServerVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-
-
-                //Guilds Variable
-                case Enums.VariableMod.DupGuildVar:
-                    varvalue = Strings.EventCommandList.dupguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.AddGuildVar:
-                    varvalue = Strings.EventCommandList.addguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.SubtractGuildVar:
-                    varvalue = Strings.EventCommandList.subtractguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.MultiplyGuildVar:
-                    varvalue = Strings.EventCommandList.multiplyguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.DivideGuildVar:
-                    varvalue = Strings.EventCommandList.divideguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.LeftShiftGuildVar:
-                    varvalue = Strings.EventCommandList.leftshiftguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.RightShiftGuildVar:
-                    varvalue = Strings.EventCommandList.rightshiftguildvariable.ToString(
-                        GuildVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-
-
-                //User Variable
-                case Enums.VariableMod.DuplicateUserVariable:
-                    varvalue = Strings.EventCommandList.DupUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.AddUserVariable:
-                    varvalue = Strings.EventCommandList.AddUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.SubtractUserVariable:
-                    varvalue = Strings.EventCommandList.SubtractUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.MultiplyUserVariable:
-                    varvalue = Strings.EventCommandList.MultiplyUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.DivideUserVariable:
-                    varvalue = Strings.EventCommandList.DivideUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.LeftShiftUserVariable:
-                    varvalue = Strings.EventCommandList.LeftShiftUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-                case Enums.VariableMod.RightShiftUserVariable:
-                    varvalue = Strings.EventCommandList.RightShiftUserVariable.ToString(
-                        Strings.GameObjectStrings.UserVariable,
-                        UserVariableBase.GetName(mod.DuplicateVariableId)
-                    );
-
-                    break;
-            }
-
-            if (command.VariableType == VariableType.PlayerVariable)
-            {
-                return Strings.EventCommandList.playervariable.ToString(
-                    PlayerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.ServerVariable)
-            {
-                return Strings.EventCommandList.globalvariable.ToString(
-                    ServerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.GuildVariable)
-            {
-                return Strings.EventCommandList.guildvariable.ToString(
-                    GuildVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.UserVariable)
-            {
-                return Strings.EventCommandList.UserVariable.ToString(
-                    Strings.GameObjectStrings.UserVariable,
-                    UserVariableBase.GetName(command.VariableId),
-                    varvalue
-                );
-            }
-
-            return Strings.EventCommandList.invalid;
+            return Strings.EventCommandList.playervariable.ToString(
+                PlayerVariableBase.GetName(command.VariableId), varvalue
+            );
         }
 
-        private static string GetVariableModText(SetVariableCommand command, StringVariableMod mod)
+        if (command.VariableType == VariableType.ServerVariable)
         {
-            var varvalue = "";
-            switch (mod.ModType)
-            {
-                case Enums.VariableMod.Set:
-                    varvalue = Strings.EventCommandList.setvariable.ToString(mod.Value);
-
-                    break;
-                case Enums.VariableMod.Replace:
-                    varvalue = Strings.EventCommandList.replace.ToString(mod.Value, mod.Replace);
-
-                    break;
-            }
-
-            if (command.VariableType == VariableType.PlayerVariable)
-            {
-                return Strings.EventCommandList.playervariable.ToString(
-                    PlayerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.ServerVariable)
-            {
-                return Strings.EventCommandList.globalvariable.ToString(
-                    ServerVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.GuildVariable)
-            {
-                return Strings.EventCommandList.guildvariable.ToString(
-                    GuildVariableBase.GetName(command.VariableId), varvalue
-                );
-            }
-
-            if (command.VariableType == VariableType.UserVariable)
-            {
-                return Strings.EventCommandList.UserVariable.ToString(
-                    Strings.GameObjectStrings.UserVariable,
-                    UserVariableBase.GetName(command.VariableId),
-                    varvalue
-                );
-            }
-
-            return Strings.EventCommandList.invalid;
+            return Strings.EventCommandList.globalvariable.ToString(
+                ServerVariableBase.GetName(command.VariableId), varvalue
+            );
         }
 
+        if (command.VariableType == VariableType.GuildVariable)
+        {
+            return Strings.EventCommandList.guildvariable.ToString(
+                GuildVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.UserVariable)
+        {
+            return Strings.EventCommandList.UserVariable.ToString(
+                Strings.GameObjectStrings.UserVariable,
+                UserVariableBase.GetName(command.VariableId),
+                varvalue
+            );
+        }
+
+        return Strings.EventCommandList.invalid;
+    }
+
+    private static string GetVariableModText(SetVariableCommand command, IntegerVariableMod mod)
+    {
+        var varvalue = "";
+        switch (mod.ModType)
+        {
+            case Enums.VariableMod.Set:
+                varvalue = Strings.EventCommandList.setvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Add:
+                varvalue = Strings.EventCommandList.addvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Subtract:
+                varvalue = Strings.EventCommandList.subtractvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Multiply:
+                varvalue = Strings.EventCommandList.multiplyvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Divide:
+                varvalue = Strings.EventCommandList.dividevariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.LeftShift:
+                varvalue = Strings.EventCommandList.leftshiftvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.RightShift:
+                varvalue = Strings.EventCommandList.rightshiftvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Random:
+                varvalue = Strings.EventCommandList.randvariable.ToString(mod.Value, mod.HighValue);
+
+                break;
+            case Enums.VariableMod.SystemTime:
+                varvalue = Strings.EventCommandList.systemtimevariable;
+
+                break;
+
+
+            //Player Variable
+            case Enums.VariableMod.DupPlayerVar:
+                varvalue = Strings.EventCommandList.dupplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.AddPlayerVar:
+                varvalue = Strings.EventCommandList.addplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.SubtractPlayerVar:
+                varvalue = Strings.EventCommandList.subtractplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.MultiplyPlayerVar:
+                varvalue = Strings.EventCommandList.multiplyplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.DividePlayerVar:
+                varvalue = Strings.EventCommandList.divideplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.LeftShiftPlayerVar:
+                varvalue = Strings.EventCommandList.leftshiftplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.RightShiftPlayerVar:
+                varvalue = Strings.EventCommandList.rightshiftplayervariable.ToString(
+                    PlayerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+
+
+            //Global Variable
+            case Enums.VariableMod.DupGlobalVar:
+                varvalue = Strings.EventCommandList.dupglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.AddGlobalVar:
+                varvalue = Strings.EventCommandList.addglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.SubtractGlobalVar:
+                varvalue = Strings.EventCommandList.subtractglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.MultiplyGlobalVar:
+                varvalue = Strings.EventCommandList.multiplyglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.DivideGlobalVar:
+                varvalue = Strings.EventCommandList.divideglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.LeftShiftGlobalVar:
+                varvalue = Strings.EventCommandList.leftshiftglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.RightShiftGlobalVar:
+                varvalue = Strings.EventCommandList.rightshiftglobalvariable.ToString(
+                    ServerVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+
+
+            //Guilds Variable
+            case Enums.VariableMod.DupGuildVar:
+                varvalue = Strings.EventCommandList.dupguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.AddGuildVar:
+                varvalue = Strings.EventCommandList.addguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.SubtractGuildVar:
+                varvalue = Strings.EventCommandList.subtractguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.MultiplyGuildVar:
+                varvalue = Strings.EventCommandList.multiplyguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.DivideGuildVar:
+                varvalue = Strings.EventCommandList.divideguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.LeftShiftGuildVar:
+                varvalue = Strings.EventCommandList.leftshiftguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.RightShiftGuildVar:
+                varvalue = Strings.EventCommandList.rightshiftguildvariable.ToString(
+                    GuildVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+
+
+            //User Variable
+            case Enums.VariableMod.DuplicateUserVariable:
+                varvalue = Strings.EventCommandList.DupUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.AddUserVariable:
+                varvalue = Strings.EventCommandList.AddUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.SubtractUserVariable:
+                varvalue = Strings.EventCommandList.SubtractUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.MultiplyUserVariable:
+                varvalue = Strings.EventCommandList.MultiplyUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.DivideUserVariable:
+                varvalue = Strings.EventCommandList.DivideUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.LeftShiftUserVariable:
+                varvalue = Strings.EventCommandList.LeftShiftUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+            case Enums.VariableMod.RightShiftUserVariable:
+                varvalue = Strings.EventCommandList.RightShiftUserVariable.ToString(
+                    Strings.GameObjectStrings.UserVariable,
+                    UserVariableBase.GetName(mod.DuplicateVariableId)
+                );
+
+                break;
+        }
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            return Strings.EventCommandList.playervariable.ToString(
+                PlayerVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.ServerVariable)
+        {
+            return Strings.EventCommandList.globalvariable.ToString(
+                ServerVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.GuildVariable)
+        {
+            return Strings.EventCommandList.guildvariable.ToString(
+                GuildVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.UserVariable)
+        {
+            return Strings.EventCommandList.UserVariable.ToString(
+                Strings.GameObjectStrings.UserVariable,
+                UserVariableBase.GetName(command.VariableId),
+                varvalue
+            );
+        }
+
+        return Strings.EventCommandList.invalid;
+    }
+
+    private static string GetVariableModText(SetVariableCommand command, StringVariableMod mod)
+    {
+        var varvalue = "";
+        switch (mod.ModType)
+        {
+            case Enums.VariableMod.Set:
+                varvalue = Strings.EventCommandList.setvariable.ToString(mod.Value);
+
+                break;
+            case Enums.VariableMod.Replace:
+                varvalue = Strings.EventCommandList.replace.ToString(mod.Value, mod.Replace);
+
+                break;
+        }
+
+        if (command.VariableType == VariableType.PlayerVariable)
+        {
+            return Strings.EventCommandList.playervariable.ToString(
+                PlayerVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.ServerVariable)
+        {
+            return Strings.EventCommandList.globalvariable.ToString(
+                ServerVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.GuildVariable)
+        {
+            return Strings.EventCommandList.guildvariable.ToString(
+                GuildVariableBase.GetName(command.VariableId), varvalue
+            );
+        }
+
+        if (command.VariableType == VariableType.UserVariable)
+        {
+            return Strings.EventCommandList.UserVariable.ToString(
+                Strings.GameObjectStrings.UserVariable,
+                UserVariableBase.GetName(command.VariableId),
+                varvalue
+            );
+        }
+
+        return Strings.EventCommandList.invalid;
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeFace.cs
@@ -4,74 +4,72 @@ using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeFace : UserControl
 {
 
-    public partial class EventCommandChangeFace : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeFaceCommand mMyCommand;
+
+    public EventCommandChangeFace(ChangeFaceCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbFace.Items.Clear();
+        cmbFace.Items.Add(Strings.General.None);
+        cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
+        cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
+        UpdatePreview();
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpChangeFace.Text = Strings.EventChangeFace.title;
+        lblFace.Text = Strings.EventChangeFace.label;
+        btnSave.Text = Strings.EventChangeFace.okay;
+        btnCancel.Text = Strings.EventChangeFace.cancel;
+    }
 
-        private ChangeFaceCommand mMyCommand;
-
-        public EventCommandChangeFace(ChangeFaceCommand refCommand, FrmEvent editor)
+    private void UpdatePreview()
+    {
+        var destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
+        var g = Graphics.FromImage(destBitmap);
+        g.Clear(System.Drawing.Color.Black);
+        if (File.Exists("resources/faces/" + cmbFace.Text))
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbFace.Items.Clear();
-            cmbFace.Items.Add(Strings.General.None);
-            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
-            UpdatePreview();
+            var sourceBitmap = new Bitmap("resources/faces/" + cmbFace.Text);
+            g.DrawImage(
+                sourceBitmap,
+                new Rectangle(
+                    pnlPreview.Width / 2 - sourceBitmap.Width / 2, pnlPreview.Height / 2 - sourceBitmap.Height / 2,
+                    sourceBitmap.Width, sourceBitmap.Height
+                ), new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height), GraphicsUnit.Pixel
+            );
         }
 
-        private void InitLocalization()
-        {
-            grpChangeFace.Text = Strings.EventChangeFace.title;
-            lblFace.Text = Strings.EventChangeFace.label;
-            btnSave.Text = Strings.EventChangeFace.okay;
-            btnCancel.Text = Strings.EventChangeFace.cancel;
-        }
+        g.Dispose();
+        pnlPreview.BackgroundImage = destBitmap;
+    }
 
-        private void UpdatePreview()
-        {
-            var destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
-            var g = Graphics.FromImage(destBitmap);
-            g.Clear(System.Drawing.Color.Black);
-            if (File.Exists("resources/faces/" + cmbFace.Text))
-            {
-                var sourceBitmap = new Bitmap("resources/faces/" + cmbFace.Text);
-                g.DrawImage(
-                    sourceBitmap,
-                    new Rectangle(
-                        pnlPreview.Width / 2 - sourceBitmap.Width / 2, pnlPreview.Height / 2 - sourceBitmap.Height / 2,
-                        sourceBitmap.Width, sourceBitmap.Height
-                    ), new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height), GraphicsUnit.Pixel
-                );
-            }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Face = cmbFace.Text;
+        mEventEditor.FinishCommandEdit();
+    }
 
-            g.Dispose();
-            pnlPreview.BackgroundImage = destBitmap;
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Face = cmbFace.Text;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdatePreview();
-        }
-
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdatePreview();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeGender.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeGender.cs
@@ -2,50 +2,48 @@
 using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeGender : UserControl
 {
 
-    public partial class EventCommandChangeGender : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeGenderCommand mMyCommand;
+
+    public EventCommandChangeGender(ChangeGenderCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbGender.SelectedIndex = (int) mMyCommand.Gender;
+    }
 
-        private readonly FrmEvent mEventEditor;
-
-        private ChangeGenderCommand mMyCommand;
-
-        public EventCommandChangeGender(ChangeGenderCommand refCommand, FrmEvent editor)
+    private void InitLocalization()
+    {
+        grpChangeGender.Text = Strings.EventChangeGender.title;
+        cmbGender.Items.Clear();
+        for (var i = 0; i < Strings.EventChangeGender.genders.Count; i++)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbGender.SelectedIndex = (int) mMyCommand.Gender;
+            cmbGender.Items.Add(Strings.EventChangeGender.genders[i]);
         }
 
-        private void InitLocalization()
-        {
-            grpChangeGender.Text = Strings.EventChangeGender.title;
-            cmbGender.Items.Clear();
-            for (var i = 0; i < Strings.EventChangeGender.genders.Count; i++)
-            {
-                cmbGender.Items.Add(Strings.EventChangeGender.genders[i]);
-            }
+        lblGender.Text = Strings.EventChangeGender.label;
+        btnSave.Text = Strings.EventChangeGender.okay;
+        btnCancel.Text = Strings.EventChangeGender.cancel;
+    }
 
-            lblGender.Text = Strings.EventChangeGender.label;
-            btnSave.Text = Strings.EventChangeGender.okay;
-            btnCancel.Text = Strings.EventChangeGender.cancel;
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Gender = (Gender) cmbGender.SelectedIndex;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Gender = (Gender) cmbGender.SelectedIndex;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeItems.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeItems.cs
@@ -4,220 +4,218 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeItems : UserControl
 {
 
-    public partial class EventCommandChangeItems : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private ChangeItemsCommand mMyCommand;
+
+    public EventCommandChangeItems(ChangeItemsCommand refCommand, EventPage refPage, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        mCurrentPage = refPage;
+        InitLocalization();
+        cmbItem.Items.Clear();
+        cmbItem.Items.AddRange(ItemBase.Names);
+        cmbAction.SelectedIndex = mMyCommand.Add ? 0 : 1;
+        cmbItem.SelectedIndex = ItemBase.ListIndex(mMyCommand.ItemId);
+        cmbMethod.SelectedIndex = (int)mMyCommand.ItemHandling;
 
-        private readonly FrmEvent mEventEditor;
+        rdoVariable.Checked = mMyCommand.UseVariable;
+        rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
+        rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
 
-        private EventPage mCurrentPage;
+        SetupAmountInput();
+    }
 
-        private ChangeItemsCommand mMyCommand;
-
-        public EventCommandChangeItems(ChangeItemsCommand refCommand, EventPage refPage, FrmEvent editor)
+    private void InitLocalization()
+    {
+        grpChangeItems.Text = Strings.EventChangeItems.title;
+        lblAction.Text = Strings.EventChangeItems.action;
+        cmbAction.Items.Clear();
+        for (var i = 0; i < Strings.EventChangeItems.actions.Count; i++)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            mCurrentPage = refPage;
-            InitLocalization();
-            cmbItem.Items.Clear();
-            cmbItem.Items.AddRange(ItemBase.Names);
-            cmbAction.SelectedIndex = mMyCommand.Add ? 0 : 1;
-            cmbItem.SelectedIndex = ItemBase.ListIndex(mMyCommand.ItemId);
-            cmbMethod.SelectedIndex = (int)mMyCommand.ItemHandling;
-
-            rdoVariable.Checked = mMyCommand.UseVariable;
-            rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
-            rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
-
-            SetupAmountInput();
+            cmbAction.Items.Add(Strings.EventChangeItems.actions[i]);
         }
 
-        private void InitLocalization()
+        lblMethod.Text = Strings.EventChangeItems.Method;
+        cmbMethod.Items.Clear();
+        for (var i = 0; i < Strings.EventChangeItems.Methods.Count; i++)
         {
-            grpChangeItems.Text = Strings.EventChangeItems.title;
-            lblAction.Text = Strings.EventChangeItems.action;
-            cmbAction.Items.Clear();
-            for (var i = 0; i < Strings.EventChangeItems.actions.Count; i++)
-            {
-                cmbAction.Items.Add(Strings.EventChangeItems.actions[i]);
-            }
-
-            lblMethod.Text = Strings.EventChangeItems.Method;
-            cmbMethod.Items.Clear();
-            for (var i = 0; i < Strings.EventChangeItems.Methods.Count; i++)
-            {
-                cmbMethod.Items.Add(Strings.EventChangeItems.Methods[i]);
-            }
-
-            lblAmount.Text = Strings.EventChangeItems.amount;
-            lblVariable.Text = Strings.EventChangeItems.Variable;
-
-            grpAmountType.Text = Strings.EventChangeItems.AmountType;
-            rdoManual.Text = Strings.EventChangeItems.Manual;
-            rdoVariable.Text = Strings.EventChangeItems.Variable;
-
-            grpManualAmount.Text = Strings.EventChangeItems.Manual;
-            grpVariableAmount.Text = Strings.EventChangeItems.Variable;
-
-            rdoPlayerVariable.Text = Strings.EventChangeItems.PlayerVariable;
-            rdoGlobalVariable.Text = Strings.EventChangeItems.ServerVariable;
-            rdoGuildVariable.Text = Strings.EventChangeItems.GuildVariable;
-
-            btnSave.Text = Strings.EventChangeItems.okay;
-            btnCancel.Text = Strings.EventChangeItems.cancel;
+            cmbMethod.Items.Add(Strings.EventChangeItems.Methods[i]);
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Add = !Convert.ToBoolean(cmbAction.SelectedIndex);
-            mMyCommand.ItemId = ItemBase.IdFromList(cmbItem.SelectedIndex);
-            if (rdoPlayerVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.PlayerVariable;
-                mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.ServerVariable;
-                mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.GuildVariable;
-                mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            mMyCommand.UseVariable = !rdoManual.Checked;
+        lblAmount.Text = Strings.EventChangeItems.amount;
+        lblVariable.Text = Strings.EventChangeItems.Variable;
 
-            mMyCommand.Quantity = (int)nudGiveTakeAmount.Value;
-            mMyCommand.ItemHandling = (ItemHandling)cmbMethod.SelectedIndex;
-            mEventEditor.FinishCommandEdit();
+        grpAmountType.Text = Strings.EventChangeItems.AmountType;
+        rdoManual.Text = Strings.EventChangeItems.Manual;
+        rdoVariable.Text = Strings.EventChangeItems.Variable;
+
+        grpManualAmount.Text = Strings.EventChangeItems.Manual;
+        grpVariableAmount.Text = Strings.EventChangeItems.Variable;
+
+        rdoPlayerVariable.Text = Strings.EventChangeItems.PlayerVariable;
+        rdoGlobalVariable.Text = Strings.EventChangeItems.ServerVariable;
+        rdoGuildVariable.Text = Strings.EventChangeItems.GuildVariable;
+
+        btnSave.Text = Strings.EventChangeItems.okay;
+        btnCancel.Text = Strings.EventChangeItems.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Add = !Convert.ToBoolean(cmbAction.SelectedIndex);
+        mMyCommand.ItemId = ItemBase.IdFromList(cmbItem.SelectedIndex);
+        if (rdoPlayerVariable.Checked)
+        {
+            mMyCommand.VariableType = VariableType.PlayerVariable;
+            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
-
-        private void btnCancel_Click(object sender, EventArgs e)
+        else if (rdoGlobalVariable.Checked)
         {
-            mEventEditor.CancelCommandEdit();
+            mMyCommand.VariableType = VariableType.ServerVariable;
+            mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
-
-        private void nudGiveTakeAmount_ValueChanged(object sender, EventArgs e)
+        else if (rdoGuildVariable.Checked)
         {
-            // This should never be below 1. We shouldn't accept giving or taking away 0 items!
-            nudGiveTakeAmount.Value = Math.Max(1, nudGiveTakeAmount.Value);
+            mMyCommand.VariableType = VariableType.GuildVariable;
+            mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
+        mMyCommand.UseVariable = !rdoManual.Checked;
 
-        private void rdoManual_CheckedChanged(object sender, EventArgs e)
+        mMyCommand.Quantity = (int)nudGiveTakeAmount.Value;
+        mMyCommand.ItemHandling = (ItemHandling)cmbMethod.SelectedIndex;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void nudGiveTakeAmount_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving or taking away 0 items!
+        nudGiveTakeAmount.Value = Math.Max(1, nudGiveTakeAmount.Value);
+    }
+
+    private void rdoManual_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void VariableBlank()
+    {
+        if (cmbVariable.Items.Count > 0)
         {
-            SetupAmountInput();
+            cmbVariable.SelectedIndex = 0;
         }
-
-        private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+        else
         {
-            SetupAmountInput();
-        }
-
-        private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void VariableBlank()
-        {
-            if (cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-            else
-            {
-                cmbVariable.SelectedIndex = -1;
-                cmbVariable.Text = "";
-            }
-        }
-
-        private void SetupAmountInput()
-        {
-            grpManualAmount.Visible = rdoManual.Checked;
-            grpVariableAmount.Visible = !rdoManual.Checked;
-
-            cmbVariable.Items.Clear();
-            if (rdoPlayerVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.PlayerVariable)
-                {
-                    var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.ServerVariable)
-                {
-                    var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.GuildVariable)
-                {
-                    var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-
-            nudGiveTakeAmount.Value = Math.Max(1, mMyCommand.Quantity);
+            cmbVariable.SelectedIndex = -1;
+            cmbVariable.Text = "";
         }
     }
 
+    private void SetupAmountInput()
+    {
+        grpManualAmount.Visible = rdoManual.Checked;
+        grpVariableAmount.Visible = !rdoManual.Checked;
+
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.PlayerVariable)
+            {
+                var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.ServerVariable)
+            {
+                var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.GuildVariable)
+            {
+                var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+
+        nudGiveTakeAmount.Value = Math.Max(1, mMyCommand.Quantity);
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeLevel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeLevel.cs
@@ -1,50 +1,48 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeLevel : UserControl
 {
 
-    public partial class EventCommandChangeLevel : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeLevelCommand mMyCommand;
+
+    public EventCommandChangeLevel(ChangeLevelCommand refCommand, FrmEvent editor)
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private ChangeLevelCommand mMyCommand;
-
-        public EventCommandChangeLevel(ChangeLevelCommand refCommand, FrmEvent editor)
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        if (mMyCommand.Level <= 0 || mMyCommand.Level > Options.MaxLevel)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            if (mMyCommand.Level <= 0 || mMyCommand.Level > Options.MaxLevel)
-            {
-                mMyCommand.Level = 1;
-            }
-
-            nudLevel.Maximum = Options.MaxLevel;
-            nudLevel.Value = mMyCommand.Level;
-            InitLocalization();
+            mMyCommand.Level = 1;
         }
 
-        private void InitLocalization()
-        {
-            grpChangeLevel.Text = Strings.EventChangeLevel.title;
-            lblLevel.Text = Strings.EventChangeLevel.label;
-            btnSave.Text = Strings.EventChangeLevel.okay;
-            btnCancel.Text = Strings.EventChangeLevel.cancel;
-        }
+        nudLevel.Maximum = Options.MaxLevel;
+        nudLevel.Value = mMyCommand.Level;
+        InitLocalization();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Level = (int) nudLevel.Value;
-            mEventEditor.FinishCommandEdit();
-        }
+    private void InitLocalization()
+    {
+        grpChangeLevel.Text = Strings.EventChangeLevel.title;
+        lblLevel.Text = Strings.EventChangeLevel.label;
+        btnSave.Text = Strings.EventChangeLevel.okay;
+        btnCancel.Text = Strings.EventChangeLevel.cancel;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Level = (int) nudLevel.Value;
+        mEventEditor.FinishCommandEdit();
+    }
 
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeName.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeName.cs
@@ -3,50 +3,48 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeName : UserControl
 {
 
-    public partial class EventCommandChangeName : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeNameCommand mMyCommand;
+
+    private EventPage mCurrentPage;
+
+    public EventCommandChangeName(ChangeNameCommand refCommand, EventPage refPage, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mCurrentPage = refPage;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
-
-        private ChangeNameCommand mMyCommand;
-
-        private EventPage mCurrentPage;
-
-        public EventCommandChangeName(ChangeNameCommand refCommand, EventPage refPage, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mCurrentPage = refPage;
-            mEventEditor = editor;
-
-            cmbVariable.Items.Clear();
-            cmbVariable.Items.AddRange(PlayerVariableBase.Names);
-            
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            grpChangeLevel.Text = Strings.EventChangeName.title;
-            btnSave.Text = Strings.EventChangeName.okay;
-            btnCancel.Text = Strings.EventChangeName.cancel;
-
-            lblVariable.Text = Strings.EventChangeName.variable;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+        cmbVariable.Items.Clear();
+        cmbVariable.Items.AddRange(PlayerVariableBase.Names);
+        
+        InitLocalization();
     }
 
+    private void InitLocalization()
+    {
+        grpChangeLevel.Text = Strings.EventChangeName.title;
+        btnSave.Text = Strings.EventChangeName.okay;
+        btnCancel.Text = Strings.EventChangeName.cancel;
+
+        lblVariable.Text = Strings.EventChangeName.variable;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeNameColor.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeNameColor.cs
@@ -1,69 +1,67 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeNameColor : UserControl
 {
 
-    public partial class EventCommandChangeNameColor : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeNameColorCommand mMyCommand;
+
+    public EventCommandChangeNameColor(ChangeNameColorCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
-
-        private ChangeNameColorCommand mMyCommand;
-
-        public EventCommandChangeNameColor(ChangeNameColorCommand refCommand, FrmEvent editor)
+        var color = refCommand.Color;
+        if (color == null)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-
-            var color = refCommand.Color;
-            if (color == null)
-            {
-                color = Color.White;
-            }
-
-            pnlColor.BackColor = System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
-            chkOverride.Checked = refCommand.Override;
-            chkRemove.Checked = refCommand.Remove;
-            InitLocalization();
+            color = Color.White;
         }
 
-        private void InitLocalization()
+        pnlColor.BackColor = System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+        chkOverride.Checked = refCommand.Override;
+        chkRemove.Checked = refCommand.Remove;
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        grpChangeLevel.Text = Strings.EventChangeNameColor.title;
+        btnSave.Text = Strings.EventChangeNameColor.okay;
+        btnCancel.Text = Strings.EventChangeNameColor.cancel;
+        btnSelectLightColor.Text = Strings.EventChangeNameColor.select;
+        chkOverride.Text = Strings.EventChangeNameColor.adminoverride;
+        chkRemove.Text = Strings.EventChangeNameColor.remove;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Color = Color.FromArgb(
+            pnlColor.BackColor.A, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
+        );
+
+        mMyCommand.Override = chkOverride.Checked;
+        mMyCommand.Remove = chkRemove.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void btnSelectLightColor_Click(object sender, EventArgs e)
+    {
+        colorDialog.Color = pnlColor.BackColor;
+        if (colorDialog.ShowDialog() == DialogResult.OK)
         {
-            grpChangeLevel.Text = Strings.EventChangeNameColor.title;
-            btnSave.Text = Strings.EventChangeNameColor.okay;
-            btnCancel.Text = Strings.EventChangeNameColor.cancel;
-            btnSelectLightColor.Text = Strings.EventChangeNameColor.select;
-            chkOverride.Text = Strings.EventChangeNameColor.adminoverride;
-            chkRemove.Text = Strings.EventChangeNameColor.remove;
+            pnlColor.BackColor = colorDialog.Color;
         }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Color = Color.FromArgb(
-                pnlColor.BackColor.A, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
-            );
-
-            mMyCommand.Override = chkOverride.Checked;
-            mMyCommand.Remove = chkRemove.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void btnSelectLightColor_Click(object sender, EventArgs e)
-        {
-            colorDialog.Color = pnlColor.BackColor;
-            if (colorDialog.ShowDialog() == DialogResult.OK)
-            {
-                pnlColor.BackColor = colorDialog.Color;
-            }
-        }
-
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerColor.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerColor.cs
@@ -1,52 +1,50 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangePlayerColor : UserControl
 {
 
-    public partial class EventCommandChangePlayerColor : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangePlayerColorCommand mMyCommand;
+
+    public EventCommandChangePlayerColor(ChangePlayerColorCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
 
-        private readonly FrmEvent mEventEditor;
+        nudRgbaR.Value = mMyCommand.Color.R;
+        nudRgbaG.Value = mMyCommand.Color.G;
+        nudRgbaB.Value = mMyCommand.Color.B;
+        nudRgbaA.Value = mMyCommand.Color.A;
+    }
 
-        private ChangePlayerColorCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpChangeColor.Text = Strings.EventChangePlayerColor.Title;
+        btnSave.Text = Strings.EventChangePlayerColor.Okay;
+        btnCancel.Text = Strings.EventChangePlayerColor.Cancel;
 
-        public EventCommandChangePlayerColor(ChangePlayerColorCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
+        lblRed.Text = Strings.EventChangePlayerColor.Red;
+        lblGreen.Text = Strings.EventChangePlayerColor.Green;
+        lblBlue.Text = Strings.EventChangePlayerColor.Blue;
+        lblAlpha.Text = Strings.EventChangePlayerColor.Alpha;
+    }
 
-            nudRgbaR.Value = mMyCommand.Color.R;
-            nudRgbaG.Value = mMyCommand.Color.G;
-            nudRgbaB.Value = mMyCommand.Color.B;
-            nudRgbaA.Value = mMyCommand.Color.A;
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Color = new Color((byte)nudRgbaA.Value, (byte)nudRgbaR.Value, (byte)nudRgbaG.Value, (byte)nudRgbaB.Value);
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void InitLocalization()
-        {
-            grpChangeColor.Text = Strings.EventChangePlayerColor.Title;
-            btnSave.Text = Strings.EventChangePlayerColor.Okay;
-            btnCancel.Text = Strings.EventChangePlayerColor.Cancel;
-
-            lblRed.Text = Strings.EventChangePlayerColor.Red;
-            lblGreen.Text = Strings.EventChangePlayerColor.Green;
-            lblBlue.Text = Strings.EventChangePlayerColor.Blue;
-            lblAlpha.Text = Strings.EventChangePlayerColor.Alpha;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Color = new Color((byte)nudRgbaA.Value, (byte)nudRgbaR.Value, (byte)nudRgbaG.Value, (byte)nudRgbaB.Value);
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerLabel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangePlayerLabel.cs
@@ -2,86 +2,84 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangePlayerLabel : UserControl
 {
 
-    public partial class EventCommandChangePlayerLabel : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangePlayerLabelCommand mMyCommand;
+
+    public EventCommandChangePlayerLabel(ChangePlayerLabelCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        InitLocalization();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
-
-        private ChangePlayerLabelCommand mMyCommand;
-
-        public EventCommandChangePlayerLabel(ChangePlayerLabelCommand refCommand, FrmEvent editor)
+        var color = refCommand.Color;
+        if (color == null)
         {
-            InitializeComponent();
-            InitLocalization();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-
-            var color = refCommand.Color;
-            if (color == null)
-            {
-                color = Color.White;
-            }
-
-            pnlColor.BackColor = System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
-            chkPlayerNameColor.Checked = refCommand.MatchNameColor;
-            cmbPosition.SelectedIndex = refCommand.Position;
-            txtLabel.Text = refCommand.Value;
+            color = Color.White;
         }
 
-        private void InitLocalization()
+        pnlColor.BackColor = System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+        chkPlayerNameColor.Checked = refCommand.MatchNameColor;
+        cmbPosition.SelectedIndex = refCommand.Position;
+        txtLabel.Text = refCommand.Value;
+    }
+
+    private void InitLocalization()
+    {
+        grpChangeLabel.Text = Strings.EventChangePlayerLabel.title;
+        btnSave.Text = Strings.EventChangePlayerLabel.okay;
+        btnCancel.Text = Strings.EventChangePlayerLabel.cancel;
+        btnSelectLightColor.Text = Strings.EventChangePlayerLabel.select;
+        chkPlayerNameColor.Text = Strings.EventChangePlayerLabel.copyplayernamecolor;
+
+        lblValue.Text = Strings.EventChangePlayerLabel.value;
+        lblStringTextVariables.Text = Strings.EventChangePlayerLabel.hint;
+
+        lblPosition.Text = Strings.EventChangePlayerLabel.position;
+        cmbPosition.Items.Clear();
+        foreach (var position in Strings.EventChangePlayerLabel.positions)
         {
-            grpChangeLabel.Text = Strings.EventChangePlayerLabel.title;
-            btnSave.Text = Strings.EventChangePlayerLabel.okay;
-            btnCancel.Text = Strings.EventChangePlayerLabel.cancel;
-            btnSelectLightColor.Text = Strings.EventChangePlayerLabel.select;
-            chkPlayerNameColor.Text = Strings.EventChangePlayerLabel.copyplayernamecolor;
-
-            lblValue.Text = Strings.EventChangePlayerLabel.value;
-            lblStringTextVariables.Text = Strings.EventChangePlayerLabel.hint;
-
-            lblPosition.Text = Strings.EventChangePlayerLabel.position;
-            cmbPosition.Items.Clear();
-            foreach (var position in Strings.EventChangePlayerLabel.positions)
-            {
-                cmbPosition.Items.Add(position.Value);
-            }
+            cmbPosition.Items.Add(position.Value);
         }
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Color = Color.FromArgb(
+            pnlColor.BackColor.A, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
+        );
+
+        mMyCommand.MatchNameColor = chkPlayerNameColor.Checked;
+        mMyCommand.Position = cmbPosition.SelectedIndex;
+        mMyCommand.Value = txtLabel.Text;
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void btnSelectLightColor_Click(object sender, EventArgs e)
+    {
+        colorDialog.Color = pnlColor.BackColor;
+        if (colorDialog.ShowDialog() == DialogResult.OK)
         {
-            mMyCommand.Color = Color.FromArgb(
-                pnlColor.BackColor.A, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
-            );
-
-            mMyCommand.MatchNameColor = chkPlayerNameColor.Checked;
-            mMyCommand.Position = cmbPosition.SelectedIndex;
-            mMyCommand.Value = txtLabel.Text;
-
-            mEventEditor.FinishCommandEdit();
+            pnlColor.BackColor = colorDialog.Color;
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void btnSelectLightColor_Click(object sender, EventArgs e)
-        {
-            colorDialog.Color = pnlColor.BackColor;
-            if (colorDialog.ShowDialog() == DialogResult.OK)
-            {
-                pnlColor.BackColor = colorDialog.Color;
-            }
-        }
-
-        private void lblStringTextVariables_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
+    private void lblStringTextVariables_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSpells.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSpells.cs
@@ -3,74 +3,72 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeSpells : UserControl
 {
 
-    public partial class EventCommandChangeSpells : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private ChangeSpellsCommand mMyCommand;
+
+    public EventCommandChangeSpells(ChangeSpellsCommand refCommand, EventPage refPage, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        mCurrentPage = refPage;
+        InitLocalization();
+        cmbSpell.Items.Clear();
+        cmbSpell.Items.AddRange(SpellBase.Names);
+        cmbAction.SelectedIndex = refCommand.Add ? 0 : 1;
+        cmbSpell.SelectedIndex = SpellBase.ListIndex(mMyCommand.SpellId);
+        chkRemoveBound.Checked = mMyCommand.RemoveBoundSpell;
+    }
 
-        private readonly FrmEvent mEventEditor;
-
-        private EventPage mCurrentPage;
-
-        private ChangeSpellsCommand mMyCommand;
-
-        public EventCommandChangeSpells(ChangeSpellsCommand refCommand, EventPage refPage, FrmEvent editor)
+    private void InitLocalization()
+    {
+        grpChangeSpells.Text = Strings.EventChangeSpells.title;
+        cmbAction.Items.Clear();
+        for (var i = 0; i < Strings.EventChangeSpells.actions.Count; i++)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            mCurrentPage = refPage;
-            InitLocalization();
-            cmbSpell.Items.Clear();
-            cmbSpell.Items.AddRange(SpellBase.Names);
-            cmbAction.SelectedIndex = refCommand.Add ? 0 : 1;
-            cmbSpell.SelectedIndex = SpellBase.ListIndex(mMyCommand.SpellId);
-            chkRemoveBound.Checked = mMyCommand.RemoveBoundSpell;
+            cmbAction.Items.Add(Strings.EventChangeSpells.actions[i]);
         }
 
-        private void InitLocalization()
+        lblAction.Text = Strings.EventChangeSpells.action;
+        lblSpell.Text = Strings.EventChangeSpells.spell;
+        chkRemoveBound.Text = Strings.EventChangeSpells.RemoveBound;
+        btnSave.Text = Strings.EventChangeSpells.okay;
+        btnCancel.Text = Strings.EventChangeSpells.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Add = !Convert.ToBoolean(cmbAction.SelectedIndex);
+        mMyCommand.SpellId = SpellBase.IdFromList(cmbSpell.SelectedIndex);
+        mMyCommand.RemoveBoundSpell = chkRemoveBound.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void cmbAction_IndexChanged(object sender, EventArgs e)
+    {
+        if (cmbAction.SelectedIndex == 0)
         {
-            grpChangeSpells.Text = Strings.EventChangeSpells.title;
-            cmbAction.Items.Clear();
-            for (var i = 0; i < Strings.EventChangeSpells.actions.Count; i++)
-            {
-                cmbAction.Items.Add(Strings.EventChangeSpells.actions[i]);
-            }
-
-            lblAction.Text = Strings.EventChangeSpells.action;
-            lblSpell.Text = Strings.EventChangeSpells.spell;
-            chkRemoveBound.Text = Strings.EventChangeSpells.RemoveBound;
-            btnSave.Text = Strings.EventChangeSpells.okay;
-            btnCancel.Text = Strings.EventChangeSpells.cancel;
+            chkRemoveBound.Checked = false;
+            chkRemoveBound.Enabled = false;
         }
-
-        private void btnSave_Click(object sender, EventArgs e)
+        else
         {
-            mMyCommand.Add = !Convert.ToBoolean(cmbAction.SelectedIndex);
-            mMyCommand.SpellId = SpellBase.IdFromList(cmbSpell.SelectedIndex);
-            mMyCommand.RemoveBoundSpell = chkRemoveBound.Checked;
-            mEventEditor.FinishCommandEdit();
+            chkRemoveBound.Enabled = true;
         }
+    }
 
-        private void cmbAction_IndexChanged(object sender, EventArgs e)
-        {
-            if (cmbAction.SelectedIndex == 0)
-            {
-                chkRemoveBound.Checked = false;
-                chkRemoveBound.Enabled = false;
-            }
-            else
-            {
-                chkRemoveBound.Enabled = true;
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeSprite.cs
@@ -4,75 +4,73 @@ using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeSprite : UserControl
 {
 
-    public partial class EventCommandChangeSprite : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ChangeSpriteCommand mMyCommand;
+
+    public EventCommandChangeSprite(ChangeSpriteCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbSprite.Items.Clear();
+        cmbSprite.Items.Add(Strings.General.None);
+        cmbSprite.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity));
+        cmbSprite.SelectedIndex = Math.Max(0, cmbSprite.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Sprite)));
+        UpdatePreview();
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpChangeSprite.Text = Strings.EventChangeSprite.title;
+        lblSprite.Text = Strings.EventChangeSprite.label;
+        btnSave.Text = Strings.EventChangeSprite.okay;
+        btnCancel.Text = Strings.EventChangeSprite.cancel;
+    }
 
-        private ChangeSpriteCommand mMyCommand;
-
-        public EventCommandChangeSprite(ChangeSpriteCommand refCommand, FrmEvent editor)
+    private void UpdatePreview()
+    {
+        var destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
+        var g = Graphics.FromImage(destBitmap);
+        g.Clear(System.Drawing.Color.Black);
+        if (File.Exists("resources/entities/" + cmbSprite.Text))
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbSprite.Items.Clear();
-            cmbSprite.Items.Add(Strings.General.None);
-            cmbSprite.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity));
-            cmbSprite.SelectedIndex = Math.Max(0, cmbSprite.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Sprite)));
-            UpdatePreview();
+            var sourceBitmap = new Bitmap("resources/entities/" + cmbSprite.Text);
+            g.DrawImage(
+                sourceBitmap,
+                new Rectangle(
+                    pnlPreview.Width / 2 - sourceBitmap.Width / (Options.Instance.Sprites.NormalFrames * 2), pnlPreview.Height / 2 - sourceBitmap.Height / (Options.Instance.Sprites.Directions * 2),
+                    sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
+                ), new Rectangle(0, 0, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
+            );
         }
 
-        private void InitLocalization()
-        {
-            grpChangeSprite.Text = Strings.EventChangeSprite.title;
-            lblSprite.Text = Strings.EventChangeSprite.label;
-            btnSave.Text = Strings.EventChangeSprite.okay;
-            btnCancel.Text = Strings.EventChangeSprite.cancel;
-        }
+        g.Dispose();
+        pnlPreview.BackgroundImage = destBitmap;
+    }
 
-        private void UpdatePreview()
-        {
-            var destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
-            var g = Graphics.FromImage(destBitmap);
-            g.Clear(System.Drawing.Color.Black);
-            if (File.Exists("resources/entities/" + cmbSprite.Text))
-            {
-                var sourceBitmap = new Bitmap("resources/entities/" + cmbSprite.Text);
-                g.DrawImage(
-                    sourceBitmap,
-                    new Rectangle(
-                        pnlPreview.Width / 2 - sourceBitmap.Width / (Options.Instance.Sprites.NormalFrames * 2), pnlPreview.Height / 2 - sourceBitmap.Height / (Options.Instance.Sprites.Directions * 2),
-                        sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
-                    ), new Rectangle(0, 0, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
-                );
-            }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Sprite = cmbSprite.Text;
+        mEventEditor.FinishCommandEdit();
+    }
 
-            g.Dispose();
-            pnlPreview.BackgroundImage = destBitmap;
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Sprite = cmbSprite.Text;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdatePreview();
-        }
-
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdatePreview();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeVital.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeVital.cs
@@ -1,71 +1,69 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChangeVital : UserControl
 {
 
-    public partial class EventCommandChangeVital : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventCommand mMyCommand;
+
+    public EventCommandChangeVital(RestoreHpCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        nudVital.Value = refCommand.Amount;
+        InitLocalization();
+    }
 
-        private readonly FrmEvent mEventEditor;
+    public EventCommandChangeVital(RestoreMpCommand refCommand, FrmEvent editor)
+    {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        nudVital.Value = refCommand.Amount;
+        InitLocalization();
+    }
 
-        private EventCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpChangeVital.Text = Strings.EventChangeVital.title;
+        btnSave.Text = Strings.EventChangeVital.okay;
+        btnCancel.Text = Strings.EventChangeVital.cancel;
 
-        public EventCommandChangeVital(RestoreHpCommand refCommand, FrmEvent editor)
+        if (mMyCommand is RestoreHpCommand)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            nudVital.Value = refCommand.Amount;
-            InitLocalization();
+            lblVital.Text = Strings.EventChangeVital.labelhealth;
         }
 
-        public EventCommandChangeVital(RestoreMpCommand refCommand, FrmEvent editor)
+        if (mMyCommand is RestoreMpCommand)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            nudVital.Value = refCommand.Amount;
-            InitLocalization();
+            lblVital.Text = Strings.EventChangeVital.labelmana;
+        }
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (mMyCommand is RestoreHpCommand)
+        {
+            ((RestoreHpCommand) mMyCommand).Amount = (int) nudVital.Value;
         }
 
-        private void InitLocalization()
+        if (mMyCommand is RestoreMpCommand)
         {
-            grpChangeVital.Text = Strings.EventChangeVital.title;
-            btnSave.Text = Strings.EventChangeVital.okay;
-            btnCancel.Text = Strings.EventChangeVital.cancel;
-
-            if (mMyCommand is RestoreHpCommand)
-            {
-                lblVital.Text = Strings.EventChangeVital.labelhealth;
-            }
-
-            if (mMyCommand is RestoreMpCommand)
-            {
-                lblVital.Text = Strings.EventChangeVital.labelmana;
-            }
+            ((RestoreMpCommand) mMyCommand).Amount = (int) nudVital.Value;
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (mMyCommand is RestoreHpCommand)
-            {
-                ((RestoreHpCommand) mMyCommand).Amount = (int) nudVital.Value;
-            }
+        mEventEditor.FinishCommandEdit();
+    }
 
-            if (mMyCommand is RestoreMpCommand)
-            {
-                ((RestoreMpCommand) mMyCommand).Amount = (int) nudVital.Value;
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChatboxText.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChatboxText.cs
@@ -4,76 +4,74 @@ using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandChatboxText : UserControl
 {
 
-    public partial class EventCommandChatboxText : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private AddChatboxTextCommand mMyCommand;
+
+    public EventCommandChatboxText(AddChatboxTextCommand refCommand, FrmEvent editor)
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private AddChatboxTextCommand mMyCommand;
-
-        public EventCommandChatboxText(AddChatboxTextCommand refCommand, FrmEvent editor)
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        txtAddText.Text = mMyCommand.Text;
+        cmbColor.Items.Clear();
+        foreach (Color.ChatColor color in Enum.GetValues(typeof(Color.ChatColor)))
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            txtAddText.Text = mMyCommand.Text;
-            cmbColor.Items.Clear();
-            foreach (Color.ChatColor color in Enum.GetValues(typeof(Color.ChatColor)))
-            {
-                cmbColor.Items.Add(Globals.GetColorName(color));
-            }
-
-            cmbColor.SelectedIndex = cmbColor.Items.IndexOf(mMyCommand.Color);
-            if (cmbColor.SelectedIndex == -1)
-            {
-                cmbColor.SelectedIndex = 0;
-            }
-
-            cmbChannel.SelectedIndex = (int) mMyCommand.Channel;
-            chkShowChatBubble.Checked = mMyCommand.ShowChatBubble;
+            cmbColor.Items.Add(Globals.GetColorName(color));
         }
 
-        private void InitLocalization()
+        cmbColor.SelectedIndex = cmbColor.Items.IndexOf(mMyCommand.Color);
+        if (cmbColor.SelectedIndex == -1)
         {
-            grpChatboxText.Text = Strings.EventChatboxText.title;
-            lblText.Text = Strings.EventChatboxText.text;
-            lblColor.Text = Strings.EventChatboxText.color;
-            lblChannel.Text = Strings.EventChatboxText.channel;
-            lblCommands.Text = Strings.EventChatboxText.commands;
-            cmbChannel.Items.Clear();
-            for (var i = 0; i < Strings.EventChatboxText.channels.Count; i++)
-            {
-                cmbChannel.Items.Add(Strings.EventChatboxText.channels[i]);
-            }
-            chkShowChatBubble.Text = Strings.EventChatboxText.ShowChatBubble;
-
-            btnSave.Text = Strings.EventChatboxText.okay;
-            btnCancel.Text = Strings.EventChatboxText.cancel;
+            cmbColor.SelectedIndex = 0;
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Text = txtAddText.Text;
-            mMyCommand.Color = cmbColor.Text;
-            mMyCommand.Channel = (ChatboxChannel) cmbChannel.SelectedIndex;
-            mMyCommand.ShowChatBubble = chkShowChatBubble.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
+        cmbChannel.SelectedIndex = (int) mMyCommand.Channel;
+        chkShowChatBubble.Checked = mMyCommand.ShowChatBubble;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void InitLocalization()
+    {
+        grpChatboxText.Text = Strings.EventChatboxText.title;
+        lblText.Text = Strings.EventChatboxText.text;
+        lblColor.Text = Strings.EventChatboxText.color;
+        lblChannel.Text = Strings.EventChatboxText.channel;
+        lblCommands.Text = Strings.EventChatboxText.commands;
+        cmbChannel.Items.Clear();
+        for (var i = 0; i < Strings.EventChatboxText.channels.Count; i++)
         {
-            mEventEditor.CancelCommandEdit();
+            cmbChannel.Items.Add(Strings.EventChatboxText.channels[i]);
         }
+        chkShowChatBubble.Text = Strings.EventChatboxText.ShowChatBubble;
 
-        private void lblCommands_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
+        btnSave.Text = Strings.EventChatboxText.okay;
+        btnCancel.Text = Strings.EventChatboxText.cancel;
+    }
 
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Text = txtAddText.Text;
+        mMyCommand.Color = cmbColor.Text;
+        mMyCommand.Channel = (ChatboxChannel) cmbChannel.SelectedIndex;
+        mMyCommand.ShowChatBubble = chkShowChatBubble.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void lblCommands_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CompleteQuestTask.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CompleteQuestTask.cs
@@ -2,88 +2,86 @@
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandCompleteQuestTask : UserControl
 {
 
-    public partial class EventCommandCompleteQuestTask : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private CompleteQuestTaskCommand mMyCommand;
+
+    public EventCommandCompleteQuestTask(CompleteQuestTaskCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbQuests.Items.Clear();
+        cmbQuests.Items.AddRange(QuestBase.Names);
+        cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpCompleteTask.Text = Strings.EventCompleteQuestTask.title;
+        lblQuest.Text = Strings.EventCompleteQuestTask.quest;
+        lblTask.Text = Strings.EventCompleteQuestTask.task;
+        btnSave.Text = Strings.EventCompleteQuestTask.okay;
+        btnCancel.Text = Strings.EventCompleteQuestTask.cancel;
+    }
 
-        private CompleteQuestTaskCommand mMyCommand;
-
-        public EventCommandCompleteQuestTask(CompleteQuestTaskCommand refCommand, FrmEvent editor)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
+        if (cmbQuests.SelectedIndex > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbQuests.Items.Clear();
-            cmbQuests.Items.AddRange(QuestBase.Names);
-            cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
-        }
-
-        private void InitLocalization()
-        {
-            grpCompleteTask.Text = Strings.EventCompleteQuestTask.title;
-            lblQuest.Text = Strings.EventCompleteQuestTask.quest;
-            lblTask.Text = Strings.EventCompleteQuestTask.task;
-            btnSave.Text = Strings.EventCompleteQuestTask.okay;
-            btnCancel.Text = Strings.EventCompleteQuestTask.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
-            if (cmbQuests.SelectedIndex > -1)
+            var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuests.SelectedIndex));
+            if (quest != null)
             {
-                var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuests.SelectedIndex));
-                if (quest != null)
+                var i = -1;
+                foreach (var task in quest.Tasks)
                 {
-                    var i = -1;
-                    foreach (var task in quest.Tasks)
+                    i++;
+                    if (i == cmbQuestTask.SelectedIndex)
                     {
-                        i++;
-                        if (i == cmbQuestTask.SelectedIndex)
-                        {
-                            mMyCommand.TaskId = task.Id;
-                        }
-                    }
-                }
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbQuests_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            cmbQuestTask.Hide();
-            lblTask.Hide();
-            if (cmbQuests.SelectedIndex > -1)
-            {
-                var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuests.SelectedIndex));
-                if (quest != null)
-                {
-                    lblTask.Show();
-                    cmbQuestTask.Show();
-                    cmbQuestTask.Items.Clear();
-                    foreach (var task in quest.Tasks)
-                    {
-                        cmbQuestTask.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
-                        if (task.Id == mMyCommand.TaskId)
-                        {
-                            cmbQuestTask.SelectedIndex = cmbQuestTask.Items.Count - 1;
-                        }
+                        mMyCommand.TaskId = task.Id;
                     }
                 }
             }
         }
 
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void cmbQuests_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        cmbQuestTask.Hide();
+        lblTask.Hide();
+        if (cmbQuests.SelectedIndex > -1)
+        {
+            var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuests.SelectedIndex));
+            if (quest != null)
+            {
+                lblTask.Show();
+                cmbQuestTask.Show();
+                cmbQuestTask.Items.Clear();
+                foreach (var task in quest.Tasks)
+                {
+                    cmbQuestTask.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
+                    if (task.Id == mMyCommand.TaskId)
+                    {
+                        cmbQuestTask.SelectedIndex = cmbQuestTask.Items.Count - 1;
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ConditionalBranch.cs
@@ -5,1612 +5,1610 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandConditionalBranch : UserControl
 {
 
-    public partial class EventCommandConditionalBranch : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    public bool Cancelled;
+
+    public Condition Condition;
+
+    private EventPage mCurrentPage;
+
+    private ConditionalBranchCommand mEventCommand;
+
+    private bool mLoading = false;
+
+    public EventCommandConditionalBranch(
+        Condition refCommand,
+        EventPage refPage,
+        FrmEvent editor,
+        ConditionalBranchCommand command
+    )
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        public bool Cancelled;
-
-        public Condition Condition;
-
-        private EventPage mCurrentPage;
-
-        private ConditionalBranchCommand mEventCommand;
-
-        private bool mLoading = false;
-
-        public EventCommandConditionalBranch(
-            Condition refCommand,
-            EventPage refPage,
-            FrmEvent editor,
-            ConditionalBranchCommand command
-        )
+        InitializeComponent();
+        mLoading = true;
+        if (refCommand == null)
         {
-            InitializeComponent();
-            mLoading = true;
-            if (refCommand == null)
+            refCommand = new VariableIsCondition();
+        }
+
+        Condition = refCommand;
+        mEventEditor = editor;
+        mEventCommand = command;
+        mCurrentPage = refPage;
+        UpdateFormElements(refCommand.Type);
+        InitLocalization();
+        var typeIndex = 0;
+        foreach (var itm in Strings.EventConditional.conditions)
+        {
+            if (itm.Key == (int)Condition.Type)
             {
-                refCommand = new VariableIsCondition();
+                cmbConditionType.SelectedIndex = typeIndex;
+
+                break;
             }
 
-            Condition = refCommand;
-            mEventEditor = editor;
-            mEventCommand = command;
-            mCurrentPage = refPage;
-            UpdateFormElements(refCommand.Type);
-            InitLocalization();
-            var typeIndex = 0;
-            foreach (var itm in Strings.EventConditional.conditions)
-            {
-                if (itm.Key == (int)Condition.Type)
-                {
-                    cmbConditionType.SelectedIndex = typeIndex;
+            typeIndex++;
+        }
 
-                    break;
+        nudVariableValue.Minimum = long.MinValue;
+        nudVariableValue.Maximum = long.MaxValue;
+        chkNegated.Checked = refCommand.Negated;
+        chkHasElse.Checked = refCommand.ElseEnabled;
+        SetupFormValues((dynamic)refCommand);
+        mLoading = false;
+    }
+
+    private void InitLocalization()
+    {
+        grpConditional.Text = Strings.EventConditional.title;
+        lblType.Text = Strings.EventConditional.type;
+
+        cmbConditionType.Items.Clear();
+        foreach (var itm in Strings.EventConditional.conditions)
+        {
+            cmbConditionType.Items.Add(itm.Value);
+        }
+
+        chkNegated.Text = Strings.EventConditional.negated;
+        chkHasElse.Text = Strings.EventConditional.HasElse;
+
+        //Variable Is
+        grpVariable.Text = Strings.EventConditional.variable;
+        grpSelectVariable.Text = Strings.EventConditional.selectvariable;
+        rdoPlayerVariable.Text = Strings.EventConditional.playervariable;
+        rdoGlobalVariable.Text = Strings.EventConditional.globalvariable;
+        rdoGuildVariable.Text = Strings.EventConditional.guildvariable;
+        rdoUserVariable.Text = Strings.GameObjectStrings.UserVariable;
+
+        //Numeric Variable
+        grpNumericVariable.Text = Strings.EventConditional.numericvariable;
+        lblNumericComparator.Text = Strings.EventConditional.comparator;
+        rdoVarCompareStaticValue.Text = Strings.EventConditional.value;
+        rdoVarComparePlayerVar.Text = Strings.EventConditional.playervariablevalue;
+        rdoVarCompareGlobalVar.Text = Strings.EventConditional.globalvariablevalue;
+        rdoVarCompareGuildVar.Text = Strings.EventConditional.guildvariablevalue;
+        rdoVarCompareUserVar.Text = Strings.EventConditional.UserVariableValue;
+        cmbNumericComparitor.Items.Clear();
+        for (var i = 0; i < Strings.EventConditional.comparators.Count; i++)
+        {
+            cmbNumericComparitor.Items.Add(Strings.EventConditional.comparators[i]);
+        }
+
+        cmbNumericComparitor.SelectedIndex = 0;
+
+        //Boolean Variable
+        grpBooleanVariable.Text = Strings.EventConditional.booleanvariable;
+        cmbBooleanComparator.Items.Clear();
+        cmbBooleanComparator.Items.Add(Strings.EventConditional.booleanequal);
+        cmbBooleanComparator.Items.Add(Strings.EventConditional.booleannotequal);
+        cmbBooleanComparator.SelectedIndex = 0;
+        optBooleanTrue.Text = Strings.EventConditional.True;
+        optBooleanFalse.Text = Strings.EventConditional.False;
+        optBooleanGlobalVariable.Text = Strings.EventConditional.globalvariablevalue;
+        optBooleanPlayerVariable.Text = Strings.EventConditional.playervariablevalue;
+        optBooleanGuildVariable.Text = Strings.EventConditional.guildvariablevalue;
+        optBooleanUserVariable.Text = Strings.EventConditional.UserVariableValue;
+
+        //String Variable
+        grpStringVariable.Text = Strings.EventConditional.stringvariable;
+        cmbStringComparitor.Items.Clear();
+        for (var i = 0; i < Strings.EventConditional.stringcomparators.Count; i++)
+        {
+            cmbStringComparitor.Items.Add(Strings.EventConditional.stringcomparators[i]);
+        }
+
+        cmbStringComparitor.SelectedIndex = 0;
+        lblStringComparator.Text = Strings.EventConditional.comparator;
+        lblStringComparatorValue.Text = Strings.EventConditional.value;
+        lblStringTextVariables.Text = Strings.EventConditional.stringtip;
+
+        //Has Item + Has Free Inventory Slots
+        grpInventoryConditions.Text = Strings.EventConditional.hasitem;
+        lblItemQuantity.Text = Strings.EventConditional.hasatleast;
+        lblItem.Text = Strings.EventConditional.item;
+        lblInvVariable.Text = Strings.EventConditional.VariableLabel;
+        grpAmountType.Text = Strings.EventConditional.AmountType;
+        rdoManual.Text = Strings.EventConditional.Manual;
+        rdoVariable.Text = Strings.EventConditional.VariableLabel;
+        grpManualAmount.Text = Strings.EventConditional.Manual;
+        grpVariableAmount.Text = Strings.EventConditional.VariableLabel;
+        rdoInvPlayerVariable.Text = Strings.EventConditional.playervariable;
+        rdoInvGlobalVariable.Text = Strings.EventConditional.globalvariable;
+        rdoInvGuildVariable.Text = Strings.EventConditional.guildvariable;
+
+        //Has Item Equipped
+        grpEquippedItem.Text = Strings.EventConditional.hasitemequipped;
+        lblEquippedItem.Text = Strings.EventConditional.item;
+
+        //Class is
+        grpClass.Text = Strings.EventConditional.classis;
+        lblClass.Text = Strings.EventConditional.Class;
+
+        //Knows Spell
+        grpSpell.Text = Strings.EventConditional.knowsspell;
+        lblSpell.Text = Strings.EventConditional.spell;
+
+        //Level or Stat is
+        grpLevelStat.Text = Strings.EventConditional.levelorstat;
+        lblLvlStatValue.Text = Strings.EventConditional.levelstatvalue;
+        lblLevelComparator.Text = Strings.EventConditional.comparator;
+        lblLevelOrStat.Text = Strings.EventConditional.levelstatitem;
+        cmbLevelStat.Items.Clear();
+        cmbLevelStat.Items.Add(Strings.EventConditional.level);
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            cmbLevelStat.Items.Add(Strings.Combat.stats[i]);
+        }
+
+        cmbLevelComparator.Items.Clear();
+        for (var i = 0; i < Strings.EventConditional.comparators.Count; i++)
+        {
+            cmbLevelComparator.Items.Add(Strings.EventConditional.comparators[i]);
+        }
+
+        chkStatIgnoreBuffs.Text = Strings.EventConditional.ignorestatbuffs;
+
+        //Self Switch Is
+        grpSelfSwitch.Text = Strings.EventConditional.selfswitchis;
+        lblSelfSwitch.Text = Strings.EventConditional.selfswitch;
+        lblSelfSwitchIs.Text = Strings.EventConditional.switchis;
+        cmbSelfSwitch.Items.Clear();
+        for (var i = 0; i < 4; i++)
+        {
+            cmbSelfSwitch.Items.Add(Strings.EventConditional.selfswitches[i]);
+        }
+
+        cmbSelfSwitchVal.Items.Clear();
+        cmbSelfSwitchVal.Items.Add(Strings.EventConditional.False);
+        cmbSelfSwitchVal.Items.Add(Strings.EventConditional.True);
+
+        //Power Is
+        grpPowerIs.Text = Strings.EventConditional.poweris;
+        lblPower.Text = Strings.EventConditional.power;
+        cmbPower.Items.Clear();
+        cmbPower.Items.Add(Strings.EventConditional.power0);
+        cmbPower.Items.Add(Strings.EventConditional.power1);
+
+        //Time Is
+        grpTime.Text = Strings.EventConditional.time;
+        lblStartRange.Text = Strings.EventConditional.startrange;
+        lblEndRange.Text = Strings.EventConditional.endrange;
+        lblAnd.Text = Strings.EventConditional.and;
+
+        //Can Start Quest
+        grpStartQuest.Text = Strings.EventConditional.canstartquest;
+        lblStartQuest.Text = Strings.EventConditional.startquest;
+
+        //Quest In Progress
+        grpQuestInProgress.Text = Strings.EventConditional.questinprogress;
+        lblQuestProgress.Text = Strings.EventConditional.questprogress;
+        lblQuestIs.Text = Strings.EventConditional.questis;
+        cmbTaskModifier.Items.Clear();
+        for (var i = 0; i < Strings.EventConditional.questcomparators.Count; i++)
+        {
+            cmbTaskModifier.Items.Add(Strings.EventConditional.questcomparators[i]);
+        }
+
+        lblQuestTask.Text = Strings.EventConditional.task;
+
+        //Quest Completed
+        grpQuestCompleted.Text = Strings.EventConditional.questcompleted;
+        lblQuestCompleted.Text = Strings.EventConditional.questcompletedlabel;
+
+        //Gender is
+        grpGender.Text = Strings.EventConditional.genderis;
+        lblGender.Text = Strings.EventConditional.gender;
+        cmbGender.Items.Clear();
+        cmbGender.Items.Add(Strings.EventConditional.male);
+        cmbGender.Items.Add(Strings.EventConditional.female);
+
+        //Map Is
+        grpMapIs.Text = Strings.EventConditional.mapis;
+        btnSelectMap.Text = Strings.EventConditional.selectmap;
+
+        //In Guild With At Least Rank
+        grpInGuild.Text = Strings.EventConditional.inguild;
+        lblRank.Text = Strings.EventConditional.rank;
+        cmbRank.Items.Clear();
+        foreach (var rank in Options.Instance.Guild.Ranks)
+        {
+            cmbRank.Items.Add(rank.Title);
+        }
+
+        // Map Zone Type
+        grpMapZoneType.Text = Strings.EventConditional.MapZoneTypeIs;
+        lblMapZoneType.Text = Strings.EventConditional.MapZoneTypeLabel;
+        cmbMapZoneType.Items.Clear();
+        for (var i = 0; i < Strings.MapProperties.zones.Count; i++)
+        {
+            cmbMapZoneType.Items.Add(Strings.MapProperties.zones[i]);
+        }
+
+        chkBank.Text = Strings.EventConditional.CheckBank;
+
+        //Check Equipped Slot
+        grpCheckEquippedSlot.Text = Strings.EventConditional.CheckEquipment;
+        lblCheckEquippedSlot.Text = Strings.EventConditional.EquipmentSlot;
+
+        // NPC Group
+        grpNpc.Text = Strings.EventConditional.NpcGroup;
+        lblNpc.Text = Strings.EventConditional.NpcLabel;
+        chkNpc.Text = Strings.EventConditional.SpecificNpcCheck;
+
+        btnSave.Text = Strings.EventConditional.okay;
+        btnCancel.Text = Strings.EventConditional.cancel;
+    }
+
+    private void ConditionTypeChanged(ConditionTypes type)
+    {
+        chkBank.Visible = false;
+        switch (type)
+        {
+            case ConditionTypes.VariableIs:
+                Condition = new VariableIsCondition();
+                SetupFormValues((dynamic)Condition);
+
+                break;
+            case ConditionTypes.HasItem:
+                Condition = new HasItemCondition();
+                if (cmbItem.Items.Count > 0)
+                {
+                    cmbItem.SelectedIndex = 0;
                 }
 
-                typeIndex++;
-            }
-
-            nudVariableValue.Minimum = long.MinValue;
-            nudVariableValue.Maximum = long.MaxValue;
-            chkNegated.Checked = refCommand.Negated;
-            chkHasElse.Checked = refCommand.ElseEnabled;
-            SetupFormValues((dynamic)refCommand);
-            mLoading = false;
-        }
-
-        private void InitLocalization()
-        {
-            grpConditional.Text = Strings.EventConditional.title;
-            lblType.Text = Strings.EventConditional.type;
-
-            cmbConditionType.Items.Clear();
-            foreach (var itm in Strings.EventConditional.conditions)
-            {
-                cmbConditionType.Items.Add(itm.Value);
-            }
-
-            chkNegated.Text = Strings.EventConditional.negated;
-            chkHasElse.Text = Strings.EventConditional.HasElse;
-
-            //Variable Is
-            grpVariable.Text = Strings.EventConditional.variable;
-            grpSelectVariable.Text = Strings.EventConditional.selectvariable;
-            rdoPlayerVariable.Text = Strings.EventConditional.playervariable;
-            rdoGlobalVariable.Text = Strings.EventConditional.globalvariable;
-            rdoGuildVariable.Text = Strings.EventConditional.guildvariable;
-            rdoUserVariable.Text = Strings.GameObjectStrings.UserVariable;
-
-            //Numeric Variable
-            grpNumericVariable.Text = Strings.EventConditional.numericvariable;
-            lblNumericComparator.Text = Strings.EventConditional.comparator;
-            rdoVarCompareStaticValue.Text = Strings.EventConditional.value;
-            rdoVarComparePlayerVar.Text = Strings.EventConditional.playervariablevalue;
-            rdoVarCompareGlobalVar.Text = Strings.EventConditional.globalvariablevalue;
-            rdoVarCompareGuildVar.Text = Strings.EventConditional.guildvariablevalue;
-            rdoVarCompareUserVar.Text = Strings.EventConditional.UserVariableValue;
-            cmbNumericComparitor.Items.Clear();
-            for (var i = 0; i < Strings.EventConditional.comparators.Count; i++)
-            {
-                cmbNumericComparitor.Items.Add(Strings.EventConditional.comparators[i]);
-            }
-
-            cmbNumericComparitor.SelectedIndex = 0;
-
-            //Boolean Variable
-            grpBooleanVariable.Text = Strings.EventConditional.booleanvariable;
-            cmbBooleanComparator.Items.Clear();
-            cmbBooleanComparator.Items.Add(Strings.EventConditional.booleanequal);
-            cmbBooleanComparator.Items.Add(Strings.EventConditional.booleannotequal);
-            cmbBooleanComparator.SelectedIndex = 0;
-            optBooleanTrue.Text = Strings.EventConditional.True;
-            optBooleanFalse.Text = Strings.EventConditional.False;
-            optBooleanGlobalVariable.Text = Strings.EventConditional.globalvariablevalue;
-            optBooleanPlayerVariable.Text = Strings.EventConditional.playervariablevalue;
-            optBooleanGuildVariable.Text = Strings.EventConditional.guildvariablevalue;
-            optBooleanUserVariable.Text = Strings.EventConditional.UserVariableValue;
-
-            //String Variable
-            grpStringVariable.Text = Strings.EventConditional.stringvariable;
-            cmbStringComparitor.Items.Clear();
-            for (var i = 0; i < Strings.EventConditional.stringcomparators.Count; i++)
-            {
-                cmbStringComparitor.Items.Add(Strings.EventConditional.stringcomparators[i]);
-            }
-
-            cmbStringComparitor.SelectedIndex = 0;
-            lblStringComparator.Text = Strings.EventConditional.comparator;
-            lblStringComparatorValue.Text = Strings.EventConditional.value;
-            lblStringTextVariables.Text = Strings.EventConditional.stringtip;
-
-            //Has Item + Has Free Inventory Slots
-            grpInventoryConditions.Text = Strings.EventConditional.hasitem;
-            lblItemQuantity.Text = Strings.EventConditional.hasatleast;
-            lblItem.Text = Strings.EventConditional.item;
-            lblInvVariable.Text = Strings.EventConditional.VariableLabel;
-            grpAmountType.Text = Strings.EventConditional.AmountType;
-            rdoManual.Text = Strings.EventConditional.Manual;
-            rdoVariable.Text = Strings.EventConditional.VariableLabel;
-            grpManualAmount.Text = Strings.EventConditional.Manual;
-            grpVariableAmount.Text = Strings.EventConditional.VariableLabel;
-            rdoInvPlayerVariable.Text = Strings.EventConditional.playervariable;
-            rdoInvGlobalVariable.Text = Strings.EventConditional.globalvariable;
-            rdoInvGuildVariable.Text = Strings.EventConditional.guildvariable;
-
-            //Has Item Equipped
-            grpEquippedItem.Text = Strings.EventConditional.hasitemequipped;
-            lblEquippedItem.Text = Strings.EventConditional.item;
-
-            //Class is
-            grpClass.Text = Strings.EventConditional.classis;
-            lblClass.Text = Strings.EventConditional.Class;
-
-            //Knows Spell
-            grpSpell.Text = Strings.EventConditional.knowsspell;
-            lblSpell.Text = Strings.EventConditional.spell;
-
-            //Level or Stat is
-            grpLevelStat.Text = Strings.EventConditional.levelorstat;
-            lblLvlStatValue.Text = Strings.EventConditional.levelstatvalue;
-            lblLevelComparator.Text = Strings.EventConditional.comparator;
-            lblLevelOrStat.Text = Strings.EventConditional.levelstatitem;
-            cmbLevelStat.Items.Clear();
-            cmbLevelStat.Items.Add(Strings.EventConditional.level);
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                cmbLevelStat.Items.Add(Strings.Combat.stats[i]);
-            }
-
-            cmbLevelComparator.Items.Clear();
-            for (var i = 0; i < Strings.EventConditional.comparators.Count; i++)
-            {
-                cmbLevelComparator.Items.Add(Strings.EventConditional.comparators[i]);
-            }
-
-            chkStatIgnoreBuffs.Text = Strings.EventConditional.ignorestatbuffs;
-
-            //Self Switch Is
-            grpSelfSwitch.Text = Strings.EventConditional.selfswitchis;
-            lblSelfSwitch.Text = Strings.EventConditional.selfswitch;
-            lblSelfSwitchIs.Text = Strings.EventConditional.switchis;
-            cmbSelfSwitch.Items.Clear();
-            for (var i = 0; i < 4; i++)
-            {
-                cmbSelfSwitch.Items.Add(Strings.EventConditional.selfswitches[i]);
-            }
-
-            cmbSelfSwitchVal.Items.Clear();
-            cmbSelfSwitchVal.Items.Add(Strings.EventConditional.False);
-            cmbSelfSwitchVal.Items.Add(Strings.EventConditional.True);
-
-            //Power Is
-            grpPowerIs.Text = Strings.EventConditional.poweris;
-            lblPower.Text = Strings.EventConditional.power;
-            cmbPower.Items.Clear();
-            cmbPower.Items.Add(Strings.EventConditional.power0);
-            cmbPower.Items.Add(Strings.EventConditional.power1);
-
-            //Time Is
-            grpTime.Text = Strings.EventConditional.time;
-            lblStartRange.Text = Strings.EventConditional.startrange;
-            lblEndRange.Text = Strings.EventConditional.endrange;
-            lblAnd.Text = Strings.EventConditional.and;
-
-            //Can Start Quest
-            grpStartQuest.Text = Strings.EventConditional.canstartquest;
-            lblStartQuest.Text = Strings.EventConditional.startquest;
-
-            //Quest In Progress
-            grpQuestInProgress.Text = Strings.EventConditional.questinprogress;
-            lblQuestProgress.Text = Strings.EventConditional.questprogress;
-            lblQuestIs.Text = Strings.EventConditional.questis;
-            cmbTaskModifier.Items.Clear();
-            for (var i = 0; i < Strings.EventConditional.questcomparators.Count; i++)
-            {
-                cmbTaskModifier.Items.Add(Strings.EventConditional.questcomparators[i]);
-            }
-
-            lblQuestTask.Text = Strings.EventConditional.task;
-
-            //Quest Completed
-            grpQuestCompleted.Text = Strings.EventConditional.questcompleted;
-            lblQuestCompleted.Text = Strings.EventConditional.questcompletedlabel;
-
-            //Gender is
-            grpGender.Text = Strings.EventConditional.genderis;
-            lblGender.Text = Strings.EventConditional.gender;
-            cmbGender.Items.Clear();
-            cmbGender.Items.Add(Strings.EventConditional.male);
-            cmbGender.Items.Add(Strings.EventConditional.female);
-
-            //Map Is
-            grpMapIs.Text = Strings.EventConditional.mapis;
-            btnSelectMap.Text = Strings.EventConditional.selectmap;
-
-            //In Guild With At Least Rank
-            grpInGuild.Text = Strings.EventConditional.inguild;
-            lblRank.Text = Strings.EventConditional.rank;
-            cmbRank.Items.Clear();
-            foreach (var rank in Options.Instance.Guild.Ranks)
-            {
-                cmbRank.Items.Add(rank.Title);
-            }
-
-            // Map Zone Type
-            grpMapZoneType.Text = Strings.EventConditional.MapZoneTypeIs;
-            lblMapZoneType.Text = Strings.EventConditional.MapZoneTypeLabel;
-            cmbMapZoneType.Items.Clear();
-            for (var i = 0; i < Strings.MapProperties.zones.Count; i++)
-            {
-                cmbMapZoneType.Items.Add(Strings.MapProperties.zones[i]);
-            }
-
-            chkBank.Text = Strings.EventConditional.CheckBank;
-
-            //Check Equipped Slot
-            grpCheckEquippedSlot.Text = Strings.EventConditional.CheckEquipment;
-            lblCheckEquippedSlot.Text = Strings.EventConditional.EquipmentSlot;
-
-            // NPC Group
-            grpNpc.Text = Strings.EventConditional.NpcGroup;
-            lblNpc.Text = Strings.EventConditional.NpcLabel;
-            chkNpc.Text = Strings.EventConditional.SpecificNpcCheck;
-
-            btnSave.Text = Strings.EventConditional.okay;
-            btnCancel.Text = Strings.EventConditional.cancel;
-        }
-
-        private void ConditionTypeChanged(ConditionTypes type)
-        {
-            chkBank.Visible = false;
-            switch (type)
-            {
-                case ConditionTypes.VariableIs:
-                    Condition = new VariableIsCondition();
-                    SetupFormValues((dynamic)Condition);
-
-                    break;
-                case ConditionTypes.HasItem:
-                    Condition = new HasItemCondition();
-                    if (cmbItem.Items.Count > 0)
-                    {
-                        cmbItem.SelectedIndex = 0;
-                    }
-
-                    nudItemAmount.Value = 1;
-                    chkBank.Visible = true;
-
-                    break;
-                case ConditionTypes.ClassIs:
-                    Condition = new ClassIsCondition();
-                    if (cmbClass.Items.Count > 0)
-                    {
-                        cmbClass.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.KnowsSpell:
-                    Condition = new KnowsSpellCondition();
-                    if (cmbSpell.Items.Count > 0)
-                    {
-                        cmbSpell.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.LevelOrStat:
-                    Condition = new LevelOrStatCondition();
-                    cmbLevelComparator.SelectedIndex = 0;
-                    cmbLevelStat.SelectedIndex = 0;
-                    nudLevelStatValue.Value = 0;
-                    chkStatIgnoreBuffs.Checked = false;
-
-                    break;
-                case ConditionTypes.SelfSwitch:
-                    Condition = new SelfSwitchCondition();
-                    cmbSelfSwitch.SelectedIndex = 0;
-                    cmbSelfSwitchVal.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.AccessIs:
-                    Condition = new AccessIsCondition();
-                    cmbPower.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.TimeBetween:
-                    Condition = new TimeBetweenCondition();
-                    cmbTime1.SelectedIndex = 0;
-                    cmbTime2.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.CanStartQuest:
-                    Condition = new CanStartQuestCondition();
-                    if (cmbStartQuest.Items.Count > 0)
-                    {
-                        cmbStartQuest.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.QuestInProgress:
-                    Condition = new QuestInProgressCondition();
-                    if (cmbQuestInProgress.Items.Count > 0)
-                    {
-                        cmbQuestInProgress.SelectedIndex = 0;
-                    }
-
-                    cmbTaskModifier.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.QuestCompleted:
-                    Condition = new QuestCompletedCondition();
-                    if (cmbCompletedQuest.Items.Count > 0)
-                    {
-                        cmbCompletedQuest.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.NoNpcsOnMap:
-                    Condition = new NoNpcsOnMapCondition();
-                    if (cmbNpcs.Items.Count > 0)
-                    {
-                        cmbNpcs.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.GenderIs:
-                    Condition = new GenderIsCondition();
-                    cmbGender.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.MapIs:
-                    Condition = new MapIsCondition();
-                    btnSelectMap.Tag = Guid.Empty;
-
-                    break;
-                case ConditionTypes.IsItemEquipped:
-                    Condition = new IsItemEquippedCondition();
-                    if (cmbEquippedItem.Items.Count > 0)
-                    {
-                        cmbEquippedItem.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.HasFreeInventorySlots:
-                    Condition = new HasFreeInventorySlots();
-
-
-                    break;
-                case ConditionTypes.InGuildWithRank:
-                    Condition = new InGuildWithRank();
-                    cmbRank.SelectedIndex = 0;
-
-                    break;
-                case ConditionTypes.MapZoneTypeIs:
-                    Condition = new MapZoneTypeIs();
-                    if (cmbMapZoneType.Items.Count > 0)
-                    {
-                        cmbMapZoneType.SelectedIndex = 0;
-                    }
-
-                    break;
-                case ConditionTypes.CheckEquipment:
-                    Condition = new CheckEquippedSlot();
-                    if (cmbCheckEquippedSlot.Items.Count > 0)
-                    {
-                        cmbCheckEquippedSlot.SelectedIndex = 0;
-                    }
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        private void UpdateFormElements(ConditionTypes type)
-        {
-            grpVariable.Hide();
-            grpInventoryConditions.Hide();
-            grpSpell.Hide();
-            grpClass.Hide();
-            grpLevelStat.Hide();
-            grpSelfSwitch.Hide();
-            grpPowerIs.Hide();
-            grpTime.Hide();
-            grpStartQuest.Hide();
-            grpQuestInProgress.Hide();
-            grpQuestCompleted.Hide();
-            grpGender.Hide();
-            grpMapIs.Hide();
-            grpEquippedItem.Hide();
-            grpInGuild.Hide();
-            grpMapZoneType.Hide();
-            grpNpc.Hide();
-            grpCheckEquippedSlot.Hide();
-            switch (type)
-            {
-                case ConditionTypes.VariableIs:
-                    grpVariable.Show();
-
-                    cmbCompareGlobalVar.Items.Clear();
-                    cmbCompareGlobalVar.Items.AddRange(ServerVariableBase.Names);
-                    cmbComparePlayerVar.Items.Clear();
-                    cmbComparePlayerVar.Items.AddRange(PlayerVariableBase.Names);
-                    cmbCompareGuildVar.Items.Clear();
-                    cmbCompareGuildVar.Items.AddRange(GuildVariableBase.Names);
-                    cmbCompareUserVar.Items.Clear();
-                    cmbCompareUserVar.Items.AddRange(UserVariableBase.Names);
-
-                    cmbBooleanGlobalVariable.Items.Clear();
-                    cmbBooleanGlobalVariable.Items.AddRange(ServerVariableBase.Names);
-                    cmbBooleanPlayerVariable.Items.Clear();
-                    cmbBooleanPlayerVariable.Items.AddRange(PlayerVariableBase.Names);
-                    cmbBooleanGuildVariable.Items.Clear();
-                    cmbBooleanGuildVariable.Items.AddRange(GuildVariableBase.Names);
-                    cmbBooleanUserVariable.Items.Clear();
-                    cmbBooleanUserVariable.Items.AddRange(UserVariableBase.Names);
-
-                    break;
-                case ConditionTypes.HasItem:
-                    grpInventoryConditions.Show();
-                    grpInventoryConditions.Text = Strings.EventConditional.hasitem;
-                    lblItem.Visible = true;
-                    cmbItem.Visible = true;
-                    cmbItem.Items.Clear();
-                    cmbItem.Items.AddRange(ItemBase.Names);
-                    SetupAmountInput();
-
-                    break;
-                case ConditionTypes.ClassIs:
-                    grpClass.Show();
-                    cmbClass.Items.Clear();
-                    cmbClass.Items.AddRange(ClassBase.Names);
-
-                    break;
-                case ConditionTypes.KnowsSpell:
-                    grpSpell.Show();
-                    cmbSpell.Items.Clear();
-                    cmbSpell.Items.AddRange(SpellBase.Names);
-
-                    break;
-                case ConditionTypes.LevelOrStat:
-                    grpLevelStat.Show();
-
-                    break;
-                case ConditionTypes.SelfSwitch:
-                    grpSelfSwitch.Show();
-
-                    break;
-                case ConditionTypes.AccessIs:
-                    grpPowerIs.Show();
-
-                    break;
-                case ConditionTypes.TimeBetween:
-                    grpTime.Show();
-                    cmbTime1.Items.Clear();
-                    cmbTime2.Items.Clear();
-                    var time = new DateTime(2000, 1, 1, 0, 0, 0);
-                    for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
-                    {
-                        var addRange = time.ToString("h:mm:ss tt") + " " + Strings.EventConditional.to + " ";
-                        time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
-                        addRange += time.ToString("h:mm:ss tt");
-                        cmbTime1.Items.Add(addRange);
-                        cmbTime2.Items.Add(addRange);
-                    }
-
-                    break;
-                case ConditionTypes.CanStartQuest:
-                    grpStartQuest.Show();
-                    cmbStartQuest.Items.Clear();
-                    cmbStartQuest.Items.AddRange(QuestBase.Names);
-
-                    break;
-                case ConditionTypes.QuestInProgress:
-                    grpQuestInProgress.Show();
-                    cmbQuestInProgress.Items.Clear();
-                    cmbQuestInProgress.Items.AddRange(QuestBase.Names);
-
-                    break;
-                case ConditionTypes.QuestCompleted:
-                    grpQuestCompleted.Show();
-                    cmbCompletedQuest.Items.Clear();
-                    cmbCompletedQuest.Items.AddRange(QuestBase.Names);
-
-                    break;
-                case ConditionTypes.NoNpcsOnMap:
-                    grpNpc.Show();
-                    cmbNpcs.Items.Clear();
-                    cmbNpcs.Items.AddRange(NpcBase.Names);
-
-                    chkNpc.Checked = false;
-                    cmbNpcs.Hide();
-                    lblNpc.Hide();
-                    break;
-                case ConditionTypes.GenderIs:
-                    grpGender.Show();
-
-                    break;
-                case ConditionTypes.MapIs:
-                    grpMapIs.Show();
-
-                    break;
-                case ConditionTypes.IsItemEquipped:
-                    grpEquippedItem.Show();
-                    cmbEquippedItem.Items.Clear();
-                    cmbEquippedItem.Items.AddRange(ItemBase.Names);
-
-                    break;
-
-                case ConditionTypes.HasFreeInventorySlots:
-                    grpInventoryConditions.Show();
-                    grpInventoryConditions.Text = Strings.EventConditional.FreeInventorySlots;
-                    lblItem.Visible = false;
-                    cmbItem.Visible = false;
-                    cmbItem.Items.Clear();
-                    SetupAmountInput();
-
-                    break;
-                case ConditionTypes.InGuildWithRank:
-                    grpInGuild.Show();
-
-                    break;
-                case ConditionTypes.MapZoneTypeIs:
-                    grpMapZoneType.Show();
-
-                    break;
-                case ConditionTypes.CheckEquipment:
-                    grpCheckEquippedSlot.Show();
-                    cmbCheckEquippedSlot.Items.Clear();
-                    foreach (var slot in Options.EquipmentSlots)
-                    {
-                        cmbCheckEquippedSlot.Items.Add(slot);
-                    }
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            SaveFormValues((dynamic)Condition);
-            Condition.Negated = chkNegated.Checked;
-            Condition.ElseEnabled = chkHasElse.Checked;
-
-            if (mEventCommand != null)
-            {
-                mEventCommand.Condition = Condition;
-            }
-
-            if (mEventEditor != null)
-            {
-                mEventEditor.FinishCommandEdit();
-            }
-            else
-            {
-                if (ParentForm != null)
+                nudItemAmount.Value = 1;
+                chkBank.Visible = true;
+
+                break;
+            case ConditionTypes.ClassIs:
+                Condition = new ClassIsCondition();
+                if (cmbClass.Items.Count > 0)
                 {
-                    ParentForm.Close();
+                    cmbClass.SelectedIndex = 0;
                 }
-            }
+
+                break;
+            case ConditionTypes.KnowsSpell:
+                Condition = new KnowsSpellCondition();
+                if (cmbSpell.Items.Count > 0)
+                {
+                    cmbSpell.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.LevelOrStat:
+                Condition = new LevelOrStatCondition();
+                cmbLevelComparator.SelectedIndex = 0;
+                cmbLevelStat.SelectedIndex = 0;
+                nudLevelStatValue.Value = 0;
+                chkStatIgnoreBuffs.Checked = false;
+
+                break;
+            case ConditionTypes.SelfSwitch:
+                Condition = new SelfSwitchCondition();
+                cmbSelfSwitch.SelectedIndex = 0;
+                cmbSelfSwitchVal.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.AccessIs:
+                Condition = new AccessIsCondition();
+                cmbPower.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.TimeBetween:
+                Condition = new TimeBetweenCondition();
+                cmbTime1.SelectedIndex = 0;
+                cmbTime2.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.CanStartQuest:
+                Condition = new CanStartQuestCondition();
+                if (cmbStartQuest.Items.Count > 0)
+                {
+                    cmbStartQuest.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.QuestInProgress:
+                Condition = new QuestInProgressCondition();
+                if (cmbQuestInProgress.Items.Count > 0)
+                {
+                    cmbQuestInProgress.SelectedIndex = 0;
+                }
+
+                cmbTaskModifier.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.QuestCompleted:
+                Condition = new QuestCompletedCondition();
+                if (cmbCompletedQuest.Items.Count > 0)
+                {
+                    cmbCompletedQuest.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.NoNpcsOnMap:
+                Condition = new NoNpcsOnMapCondition();
+                if (cmbNpcs.Items.Count > 0)
+                {
+                    cmbNpcs.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.GenderIs:
+                Condition = new GenderIsCondition();
+                cmbGender.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.MapIs:
+                Condition = new MapIsCondition();
+                btnSelectMap.Tag = Guid.Empty;
+
+                break;
+            case ConditionTypes.IsItemEquipped:
+                Condition = new IsItemEquippedCondition();
+                if (cmbEquippedItem.Items.Count > 0)
+                {
+                    cmbEquippedItem.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.HasFreeInventorySlots:
+                Condition = new HasFreeInventorySlots();
+
+
+                break;
+            case ConditionTypes.InGuildWithRank:
+                Condition = new InGuildWithRank();
+                cmbRank.SelectedIndex = 0;
+
+                break;
+            case ConditionTypes.MapZoneTypeIs:
+                Condition = new MapZoneTypeIs();
+                if (cmbMapZoneType.Items.Count > 0)
+                {
+                    cmbMapZoneType.SelectedIndex = 0;
+                }
+
+                break;
+            case ConditionTypes.CheckEquipment:
+                Condition = new CheckEquippedSlot();
+                if (cmbCheckEquippedSlot.Items.Count > 0)
+                {
+                    cmbCheckEquippedSlot.SelectedIndex = 0;
+                }
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private void UpdateFormElements(ConditionTypes type)
+    {
+        grpVariable.Hide();
+        grpInventoryConditions.Hide();
+        grpSpell.Hide();
+        grpClass.Hide();
+        grpLevelStat.Hide();
+        grpSelfSwitch.Hide();
+        grpPowerIs.Hide();
+        grpTime.Hide();
+        grpStartQuest.Hide();
+        grpQuestInProgress.Hide();
+        grpQuestCompleted.Hide();
+        grpGender.Hide();
+        grpMapIs.Hide();
+        grpEquippedItem.Hide();
+        grpInGuild.Hide();
+        grpMapZoneType.Hide();
+        grpNpc.Hide();
+        grpCheckEquippedSlot.Hide();
+        switch (type)
+        {
+            case ConditionTypes.VariableIs:
+                grpVariable.Show();
+
+                cmbCompareGlobalVar.Items.Clear();
+                cmbCompareGlobalVar.Items.AddRange(ServerVariableBase.Names);
+                cmbComparePlayerVar.Items.Clear();
+                cmbComparePlayerVar.Items.AddRange(PlayerVariableBase.Names);
+                cmbCompareGuildVar.Items.Clear();
+                cmbCompareGuildVar.Items.AddRange(GuildVariableBase.Names);
+                cmbCompareUserVar.Items.Clear();
+                cmbCompareUserVar.Items.AddRange(UserVariableBase.Names);
+
+                cmbBooleanGlobalVariable.Items.Clear();
+                cmbBooleanGlobalVariable.Items.AddRange(ServerVariableBase.Names);
+                cmbBooleanPlayerVariable.Items.Clear();
+                cmbBooleanPlayerVariable.Items.AddRange(PlayerVariableBase.Names);
+                cmbBooleanGuildVariable.Items.Clear();
+                cmbBooleanGuildVariable.Items.AddRange(GuildVariableBase.Names);
+                cmbBooleanUserVariable.Items.Clear();
+                cmbBooleanUserVariable.Items.AddRange(UserVariableBase.Names);
+
+                break;
+            case ConditionTypes.HasItem:
+                grpInventoryConditions.Show();
+                grpInventoryConditions.Text = Strings.EventConditional.hasitem;
+                lblItem.Visible = true;
+                cmbItem.Visible = true;
+                cmbItem.Items.Clear();
+                cmbItem.Items.AddRange(ItemBase.Names);
+                SetupAmountInput();
+
+                break;
+            case ConditionTypes.ClassIs:
+                grpClass.Show();
+                cmbClass.Items.Clear();
+                cmbClass.Items.AddRange(ClassBase.Names);
+
+                break;
+            case ConditionTypes.KnowsSpell:
+                grpSpell.Show();
+                cmbSpell.Items.Clear();
+                cmbSpell.Items.AddRange(SpellBase.Names);
+
+                break;
+            case ConditionTypes.LevelOrStat:
+                grpLevelStat.Show();
+
+                break;
+            case ConditionTypes.SelfSwitch:
+                grpSelfSwitch.Show();
+
+                break;
+            case ConditionTypes.AccessIs:
+                grpPowerIs.Show();
+
+                break;
+            case ConditionTypes.TimeBetween:
+                grpTime.Show();
+                cmbTime1.Items.Clear();
+                cmbTime2.Items.Clear();
+                var time = new DateTime(2000, 1, 1, 0, 0, 0);
+                for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
+                {
+                    var addRange = time.ToString("h:mm:ss tt") + " " + Strings.EventConditional.to + " ";
+                    time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
+                    addRange += time.ToString("h:mm:ss tt");
+                    cmbTime1.Items.Add(addRange);
+                    cmbTime2.Items.Add(addRange);
+                }
+
+                break;
+            case ConditionTypes.CanStartQuest:
+                grpStartQuest.Show();
+                cmbStartQuest.Items.Clear();
+                cmbStartQuest.Items.AddRange(QuestBase.Names);
+
+                break;
+            case ConditionTypes.QuestInProgress:
+                grpQuestInProgress.Show();
+                cmbQuestInProgress.Items.Clear();
+                cmbQuestInProgress.Items.AddRange(QuestBase.Names);
+
+                break;
+            case ConditionTypes.QuestCompleted:
+                grpQuestCompleted.Show();
+                cmbCompletedQuest.Items.Clear();
+                cmbCompletedQuest.Items.AddRange(QuestBase.Names);
+
+                break;
+            case ConditionTypes.NoNpcsOnMap:
+                grpNpc.Show();
+                cmbNpcs.Items.Clear();
+                cmbNpcs.Items.AddRange(NpcBase.Names);
+
+                chkNpc.Checked = false;
+                cmbNpcs.Hide();
+                lblNpc.Hide();
+                break;
+            case ConditionTypes.GenderIs:
+                grpGender.Show();
+
+                break;
+            case ConditionTypes.MapIs:
+                grpMapIs.Show();
+
+                break;
+            case ConditionTypes.IsItemEquipped:
+                grpEquippedItem.Show();
+                cmbEquippedItem.Items.Clear();
+                cmbEquippedItem.Items.AddRange(ItemBase.Names);
+
+                break;
+
+            case ConditionTypes.HasFreeInventorySlots:
+                grpInventoryConditions.Show();
+                grpInventoryConditions.Text = Strings.EventConditional.FreeInventorySlots;
+                lblItem.Visible = false;
+                cmbItem.Visible = false;
+                cmbItem.Items.Clear();
+                SetupAmountInput();
+
+                break;
+            case ConditionTypes.InGuildWithRank:
+                grpInGuild.Show();
+
+                break;
+            case ConditionTypes.MapZoneTypeIs:
+                grpMapZoneType.Show();
+
+                break;
+            case ConditionTypes.CheckEquipment:
+                grpCheckEquippedSlot.Show();
+                cmbCheckEquippedSlot.Items.Clear();
+                foreach (var slot in Options.EquipmentSlots)
+                {
+                    cmbCheckEquippedSlot.Items.Add(slot);
+                }
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        SaveFormValues((dynamic)Condition);
+        Condition.Negated = chkNegated.Checked;
+        Condition.ElseEnabled = chkHasElse.Checked;
+
+        if (mEventCommand != null)
+        {
+            mEventCommand.Condition = Condition;
         }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+        if (mEventEditor != null)
         {
-            if (mCurrentPage != null)
-            {
-                mEventEditor.CancelCommandEdit();
-            }
-
-            Cancelled = true;
+            mEventEditor.FinishCommandEdit();
+        }
+        else
+        {
             if (ParentForm != null)
             {
                 ParentForm.Close();
             }
         }
+    }
 
-        private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        if (mCurrentPage != null)
         {
-            var type = Strings.EventConditional.conditions.FirstOrDefault(x => x.Value == cmbConditionType.Text).Key;
-            if (type < 4)
-            {
-                type = 0;
-            }
-
-            UpdateFormElements((ConditionTypes)type);
-            if ((ConditionTypes)type != Condition.Type)
-            {
-                ConditionTypeChanged((ConditionTypes)type);
-            }
-        }
-
-        private void cmbTaskModifier_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbTaskModifier.SelectedIndex == 0)
-            {
-                cmbQuestTask.Enabled = false;
-            }
-            else
-            {
-                cmbQuestTask.Enabled = true;
-            }
-        }
-
-        private void cmbQuestInProgress_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            cmbQuestTask.Items.Clear();
-            var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
-            if (quest != null)
-            {
-                foreach (var task in quest.Tasks)
-                {
-                    cmbQuestTask.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
-                }
-
-                if (cmbQuestTask.Items.Count > 0)
-                {
-                    cmbQuestTask.SelectedIndex = 0;
-                }
-            }
-        }
-
-        private void btnSelectMap_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.InitForm(false, null);
-            frmWarpSelection.SelectTile((Guid)btnSelectMap.Tag, 0, 0);
-            frmWarpSelection.TopMost = true;
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                btnSelectMap.Tag = frmWarpSelection.GetMap();
-            }
-        }
-
-        private void rdoVarCompareStaticValue_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void rdoVarComparePlayerVar_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void rdoVarCompareGlobalVar_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void rdoVarCompareGuildVar_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void rdoVarCompareUserVar_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void rdoTimeSystem_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericVariableElements();
-        }
-
-        private void UpdateNumericVariableElements()
-        {
-            nudVariableValue.Enabled = rdoVarCompareStaticValue.Checked;
-            cmbComparePlayerVar.Enabled = rdoVarComparePlayerVar.Checked;
-            cmbCompareGlobalVar.Enabled = rdoVarCompareGlobalVar.Checked;
-            cmbCompareGuildVar.Enabled = rdoVarCompareGuildVar.Checked;
-            cmbCompareUserVar.Enabled = rdoVarCompareUserVar.Checked;
-        }
-
-        private void UpdateVariableElements()
-        {
-            //Hide editor windows until we have a variable selected to work with
-            grpNumericVariable.Hide();
-            grpBooleanVariable.Hide();
-            grpStringVariable.Hide();
-
-            var varType = 0;
-            if (cmbVariable.SelectedIndex > -1)
-            {
-                //Determine Variable Type
-                if (rdoPlayerVariable.Checked)
-                {
-                    var playerVar = PlayerVariableBase.FromList(cmbVariable.SelectedIndex);
-                    if (playerVar != null)
-                    {
-                        varType = (byte)playerVar.Type;
-                    }
-                }
-                else if (rdoGlobalVariable.Checked)
-                {
-                    var serverVar = ServerVariableBase.FromList(cmbVariable.SelectedIndex);
-                    if (serverVar != null)
-                    {
-                        varType = (byte)serverVar.Type;
-                    }
-                }
-                else if (rdoGuildVariable.Checked)
-                {
-                    var guildVar = GuildVariableBase.FromList(cmbVariable.SelectedIndex);
-                    if (guildVar != null)
-                    {
-                        varType = (byte)guildVar.Type;
-                    }
-                }
-                else if (rdoUserVariable.Checked)
-                {
-                    var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
-                    if (userVar != null)
-                    {
-                        varType = (byte)userVar.Type;
-                    }
-                }
-            }
-
-            //Load the correct editor
-            if (varType > 0)
-            {
-                switch ((VariableDataType)varType)
-                {
-                    case VariableDataType.Boolean:
-                        grpBooleanVariable.Show();
-                        TryLoadVariableBooleanComparison(((VariableIsCondition)Condition).Comparison);
-
-                        break;
-
-                    case VariableDataType.Integer:
-                        grpNumericVariable.Show();
-                        TryLoadVariableIntegerComparison(((VariableIsCondition)Condition).Comparison);
-                        UpdateNumericVariableElements();
-
-                        break;
-
-                    case VariableDataType.Number:
-                        break;
-
-                    case VariableDataType.String:
-                        grpStringVariable.Show();
-                        TryLoadVariableStringComparison(((VariableIsCondition)Condition).Comparison);
-
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-        }
-
-        private void TryLoadVariableBooleanComparison(VariableComparison comparison)
-        {
-            if (!(comparison is BooleanVariableComparison booleanComparison))
-            {
-                return;
-            }
-
-            cmbBooleanComparator.SelectedIndex = Convert.ToInt32(!booleanComparison.ComparingEqual);
-
-            if (cmbBooleanComparator.SelectedIndex < 0)
-            {
-                cmbBooleanComparator.SelectedIndex = 0;
-            }
-
-            optBooleanTrue.Checked = booleanComparison.Value;
-            optBooleanFalse.Checked = !booleanComparison.Value;
-
-            if (booleanComparison.CompareVariableId != Guid.Empty)
-            {
-                if (booleanComparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    optBooleanPlayerVariable.Checked = true;
-                    cmbBooleanPlayerVariable.SelectedIndex = PlayerVariableBase.ListIndex(booleanComparison.CompareVariableId);
-                }
-                else if (booleanComparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    optBooleanGlobalVariable.Checked = true;
-                    cmbBooleanGlobalVariable.SelectedIndex = ServerVariableBase.ListIndex(booleanComparison.CompareVariableId);
-                }
-                else if (booleanComparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    optBooleanGuildVariable.Checked = true;
-                    cmbBooleanGuildVariable.SelectedIndex = GuildVariableBase.ListIndex(booleanComparison.CompareVariableId);
-                }
-                else if (booleanComparison.CompareVariableType == VariableType.UserVariable)
-                {
-                    optBooleanUserVariable.Checked = true;
-                    cmbBooleanUserVariable.SelectedIndex = UserVariableBase.ListIndex(booleanComparison.CompareVariableId);
-                }
-            }
-        }
-
-        private void TryLoadVariableIntegerComparison(VariableComparison comparison)
-        {
-            if (!(comparison is IntegerVariableComparison integerComparison))
-            {
-                return;
-            }
-
-            cmbNumericComparitor.SelectedIndex = (int)integerComparison.Comparator;
-
-            if (cmbNumericComparitor.SelectedIndex < 0)
-            {
-                cmbNumericComparitor.SelectedIndex = 0;
-            }
-
-            if (integerComparison.CompareVariableId != Guid.Empty)
-            {
-                if (integerComparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    rdoVarComparePlayerVar.Checked = true;
-                    cmbComparePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerComparison.CompareVariableId);
-                }
-                else if (integerComparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    rdoVarCompareGlobalVar.Checked = true;
-                    cmbCompareGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerComparison.CompareVariableId);
-                }
-                else if (integerComparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    rdoVarCompareGuildVar.Checked = true;
-                    cmbCompareGuildVar.SelectedIndex = GuildVariableBase.ListIndex(integerComparison.CompareVariableId);
-                }
-                else if (integerComparison.CompareVariableType == VariableType.UserVariable)
-                {
-                    rdoVarCompareUserVar.Checked = true;
-                    cmbCompareUserVar.SelectedIndex = UserVariableBase.ListIndex(integerComparison.CompareVariableId);
-                }
-            }
-            else if (integerComparison.TimeSystem)
-            {
-                rdoTimeSystem.Checked = true;
-            }
-            else
-            {
-                rdoVarCompareStaticValue.Checked = true;
-                nudVariableValue.Value = integerComparison.Value;
-            }
-
-            UpdateNumericVariableElements();
-        }
-
-        private void TryLoadVariableStringComparison(VariableComparison comparison)
-        {
-            if (!(comparison is StringVariableComparison stringComparison))
-            {
-                return;
-            }
-
-            cmbStringComparitor.SelectedIndex = Convert.ToInt32(stringComparison.Comparator);
-
-            if (cmbStringComparitor.SelectedIndex < 0)
-            {
-                cmbStringComparitor.SelectedIndex = 0;
-            }
-
-            txtStringValue.Text = stringComparison.Value;
-        }
-
-        private void InitVariableElements(Guid variableId)
-        {
-            mLoading = true;
-            cmbVariable.Items.Clear();
-            if (rdoPlayerVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(PlayerVariableBase.Names);
-                cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(variableId);
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(ServerVariableBase.Names);
-                cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(variableId);
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(GuildVariableBase.Names);
-                cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(variableId);
-            }
-            else if (rdoUserVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(UserVariableBase.Names);
-                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(variableId);
-            }
-
-            mLoading = false;
-        }
-
-        private BooleanVariableComparison GetBooleanVariableComparison()
-        {
-            if (cmbBooleanComparator.SelectedIndex < 0)
-            {
-                cmbBooleanComparator.SelectedIndex = 0;
-            }
-
-            var comparison = new BooleanVariableComparison
-            {
-                ComparingEqual = !Convert.ToBoolean(cmbBooleanComparator.SelectedIndex),
-                Value = optBooleanTrue.Checked,
-            };
-
-            if (optBooleanGlobalVariable.Checked)
-            {
-                comparison.CompareVariableType = VariableType.ServerVariable;
-                comparison.CompareVariableId = ServerVariableBase.IdFromList(cmbBooleanGlobalVariable.SelectedIndex);
-            }
-            else if (optBooleanPlayerVariable.Checked)
-            {
-                comparison.CompareVariableType = VariableType.PlayerVariable;
-                comparison.CompareVariableId = PlayerVariableBase.IdFromList(cmbBooleanPlayerVariable.SelectedIndex);
-            }
-            else if (optBooleanGuildVariable.Checked)
-            {
-                comparison.CompareVariableType = VariableType.GuildVariable;
-                comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbBooleanGuildVariable.SelectedIndex);
-            }
-            else if (optBooleanUserVariable.Checked)
-            {
-                comparison.CompareVariableType = VariableType.UserVariable;
-                comparison.CompareVariableId = UserVariableBase.IdFromList(cmbBooleanUserVariable.SelectedIndex);
-            }
-
-            return comparison;
-        }
-
-        private IntegerVariableComparison GetNumericVariableComparison()
-        {
-            if (cmbNumericComparitor.SelectedIndex < 0)
-            {
-                cmbNumericComparitor.SelectedIndex = 0;
-            }
-
-            var comparison = new IntegerVariableComparison
-            {
-                Comparator = (VariableComparator)cmbNumericComparitor.SelectedIndex,
-                CompareVariableId = Guid.Empty,
-                TimeSystem = false,
-            };
-
-            if (rdoVarCompareStaticValue.Checked)
-            {
-                comparison.Value = (long)nudVariableValue.Value;
-            }
-            else if (rdoVarCompareGlobalVar.Checked)
-            {
-                comparison.CompareVariableType = VariableType.ServerVariable;
-                comparison.CompareVariableId = ServerVariableBase.IdFromList(cmbCompareGlobalVar.SelectedIndex);
-            }
-            else if (rdoVarComparePlayerVar.Checked)
-            {
-                comparison.CompareVariableType = VariableType.PlayerVariable;
-                comparison.CompareVariableId = PlayerVariableBase.IdFromList(cmbComparePlayerVar.SelectedIndex);
-            }
-            else if (rdoVarCompareGuildVar.Checked)
-            {
-                comparison.CompareVariableType = VariableType.GuildVariable;
-                comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbCompareGuildVar.SelectedIndex);
-            }
-            else if (rdoVarCompareUserVar.Checked)
-            {
-                comparison.CompareVariableType = VariableType.UserVariable;
-                comparison.CompareVariableId = UserVariableBase.IdFromList(cmbCompareUserVar.SelectedIndex);
-            }
-            else
-            {
-                comparison.TimeSystem = true;
-            }
-
-            return comparison;
-        }
-
-        private StringVariableComparison GetStringVariableComparison()
-        {
-            if (cmbStringComparitor.SelectedIndex < 0)
-            {
-                cmbStringComparitor.SelectedIndex = 0;
-            }
-
-            var comparison = new StringVariableComparison
-            {
-                Comparator = (StringVariableComparator)cmbStringComparitor.SelectedIndex,
-                Value = txtStringValue.Text,
-            };
-
-            return comparison;
-        }
-
-        private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            InitVariableElements(Guid.Empty);
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-        }
-
-        private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoUserVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void VariableRadioChanged()
-        {
-            InitVariableElements(Guid.Empty);
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-        }
-
-        private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (mLoading)
-            {
-                return;
-            }
-
-            if (rdoPlayerVariable.Checked)
-            {
-                InitVariableElements(PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex));
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                InitVariableElements(ServerVariableBase.IdFromList(cmbVariable.SelectedIndex));
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                InitVariableElements(GuildVariableBase.IdFromList(cmbVariable.SelectedIndex));
-            }
-            else if (rdoUserVariable.Checked)
-            {
-                InitVariableElements(UserVariableBase.IdFromList(cmbVariable.SelectedIndex));
-            }
-
-            UpdateVariableElements();
-        }
-
-        private void lblStringTextVariables_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
-        private void NudItemAmount_ValueChanged(object sender, System.EventArgs e)
-        {
-            nudItemAmount.Value = Math.Max(1, nudItemAmount.Value);
+            mEventEditor.CancelCommandEdit();
         }
 
-        private void rdoManual_CheckedChanged(object sender, EventArgs e)
+        Cancelled = true;
+        if (ParentForm != null)
         {
-            SetupAmountInput();
+            ParentForm.Close();
         }
+    }
 
-        private void rdoVariable_CheckedChanged(object sender, EventArgs e)
+    private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var type = Strings.EventConditional.conditions.FirstOrDefault(x => x.Value == cmbConditionType.Text).Key;
+        if (type < 4)
         {
-            SetupAmountInput();
+            type = 0;
         }
 
-        private void rdoInvPlayerVariable_CheckedChanged(object sender, EventArgs e)
+        UpdateFormElements((ConditionTypes)type);
+        if ((ConditionTypes)type != Condition.Type)
         {
-            SetupAmountInput();
+            ConditionTypeChanged((ConditionTypes)type);
         }
+    }
 
-        private void rdoInvGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    private void cmbTaskModifier_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbTaskModifier.SelectedIndex == 0)
         {
-            SetupAmountInput();
+            cmbQuestTask.Enabled = false;
         }
-
-        private void rdoInvGuildVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void SetupAmountInput()
-        {
-            grpManualAmount.Visible = rdoManual.Checked;
-            grpVariableAmount.Visible = !rdoManual.Checked;
-
-            VariableType conditionVariableType;
-            Guid conditionVariableId;
-            int ConditionQuantity;
-
-            switch (Condition.Type)
-            {
-                case ConditionTypes.HasFreeInventorySlots:
-                    conditionVariableType = ((HasFreeInventorySlots)Condition).VariableType;
-                    conditionVariableId = ((HasFreeInventorySlots)Condition).VariableId;
-                    ConditionQuantity = ((HasFreeInventorySlots)Condition).Quantity;
-                    break;
-                case ConditionTypes.HasItem:
-                    conditionVariableType = ((HasItemCondition)Condition).VariableType;
-                    conditionVariableId = ((HasItemCondition)Condition).VariableId;
-                    ConditionQuantity = ((HasItemCondition)Condition).Quantity;
-                    break;
-                default:
-                    conditionVariableType = VariableType.PlayerVariable;
-                    conditionVariableId = Guid.Empty;
-                    ConditionQuantity = 0;
-                    return;
-            }
-
-            cmbInvVariable.Items.Clear();
-            if (rdoInvPlayerVariable.Checked)
-            {
-                cmbInvVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (conditionVariableType == VariableType.PlayerVariable)
-                {
-                    var index = PlayerVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbInvVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            else if (rdoInvGlobalVariable.Checked)
-            {
-                cmbInvVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (conditionVariableType == VariableType.ServerVariable)
-                {
-                    var index = ServerVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbInvVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            else if (rdoInvGuildVariable.Checked)
-            {
-                cmbInvVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (conditionVariableType == VariableType.GuildVariable)
-                {
-                    var index = GuildVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbInvVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-
-            nudItemAmount.Value = Math.Max(1, ConditionQuantity);
-        }
-
-        private void VariableBlank()
-        {
-            if (cmbInvVariable.Items.Count > 0)
-            {
-                cmbInvVariable.SelectedIndex = 0;
-            }
-            else
-            {
-                cmbInvVariable.SelectedIndex = -1;
-                cmbInvVariable.Text = "";
-            }
-        }
-
-        #region "SetupFormValues"
-
-        private void SetupFormValues(VariableIsCondition condition)
-        {
-            if (condition.VariableType == VariableType.PlayerVariable)
-            {
-                rdoPlayerVariable.Checked = true;
-            }
-            else if (condition.VariableType == VariableType.ServerVariable)
-            {
-                rdoGlobalVariable.Checked = true;
-            }
-            else if (condition.VariableType == VariableType.GuildVariable)
-            {
-                rdoGuildVariable.Checked = true;
-            }
-            else if (condition.VariableType == VariableType.UserVariable)
-            {
-                rdoUserVariable.Checked = true;
-            }
-
-            InitVariableElements(condition.VariableId);
-
-            UpdateVariableElements();
-        }
-
-        private void SetupFormValues(HasItemCondition condition)
-        {
-            cmbItem.SelectedIndex = ItemBase.ListIndex(condition.ItemId);
-            nudItemAmount.Value = condition.Quantity;
-            rdoVariable.Checked = condition.UseVariable;
-            rdoInvGlobalVariable.Checked = condition.VariableType == VariableType.ServerVariable;
-            chkBank.Checked = condition.CheckBank;
-            rdoInvGuildVariable.Checked = condition.VariableType == VariableType.GuildVariable;
-            SetupAmountInput();
-        }
-
-        private void SetupFormValues(ClassIsCondition condition)
-        {
-            cmbClass.SelectedIndex = ClassBase.ListIndex(condition.ClassId);
-        }
-
-        private void SetupFormValues(KnowsSpellCondition condition)
-        {
-            cmbSpell.SelectedIndex = SpellBase.ListIndex(condition.SpellId);
-        }
-
-        private void SetupFormValues(LevelOrStatCondition condition)
-        {
-            cmbLevelComparator.SelectedIndex = (int)condition.Comparator;
-            nudLevelStatValue.Value = condition.Value;
-            cmbLevelStat.SelectedIndex = condition.ComparingLevel ? 0 : (int)condition.Stat + 1;
-            chkStatIgnoreBuffs.Checked = condition.IgnoreBuffs;
-        }
-
-        private void SetupFormValues(SelfSwitchCondition condition)
-        {
-            cmbSelfSwitch.SelectedIndex = condition.SwitchIndex;
-            cmbSelfSwitchVal.SelectedIndex = Convert.ToInt32(condition.Value);
-        }
-
-        private void SetupFormValues(AccessIsCondition condition)
-        {
-            cmbPower.SelectedIndex = (int)condition.Access;
-        }
-
-        private void SetupFormValues(TimeBetweenCondition condition)
-        {
-            cmbTime1.SelectedIndex = Math.Min(condition.Ranges[0], cmbTime1.Items.Count - 1);
-            cmbTime2.SelectedIndex = Math.Min(condition.Ranges[1], cmbTime2.Items.Count - 1);
-        }
-
-        private void SetupFormValues(CanStartQuestCondition condition)
-        {
-            cmbStartQuest.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
-        }
-
-        private void SetupFormValues(QuestInProgressCondition condition)
-        {
-            cmbQuestInProgress.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
-            cmbTaskModifier.SelectedIndex = (int)condition.Progress;
-            if (cmbTaskModifier.SelectedIndex == -1)
-            {
-                cmbTaskModifier.SelectedIndex = 0;
-            }
-
-            if (cmbTaskModifier.SelectedIndex != 0)
-            {
-                //Get Quest Task Here
-                var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
-                if (quest != null)
-                {
-                    for (var i = 0; i < quest.Tasks.Count; i++)
-                    {
-                        if (quest.Tasks[i].Id == condition.TaskId)
-                        {
-                            cmbQuestTask.SelectedIndex = i;
-                        }
-                    }
-                }
-            }
-        }
-
-        private void SetupFormValues(NoNpcsOnMapCondition condition)
-        {
-            chkNpc.Checked = condition.SpecificNpc;
-            if (condition.SpecificNpc)
-            {
-                lblNpc.Show();
-                cmbNpcs.Show();
-                cmbNpcs.SelectedIndex = NpcBase.ListIndex(condition.NpcId);
-            }
-            else
-            {
-                lblNpc.Hide();
-                cmbNpcs.Hide();
-            }
-        }
-
-        private void SetupFormValues(QuestCompletedCondition condition)
-        {
-            cmbCompletedQuest.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
-        }
-
-        private void SetupFormValues(GenderIsCondition condition)
-        {
-            cmbGender.SelectedIndex = (int)condition.Gender;
-        }
-
-        private void SetupFormValues(MapIsCondition condition)
-        {
-            btnSelectMap.Tag = condition.MapId;
-        }
-
-        private void SetupFormValues(IsItemEquippedCondition condition)
-        {
-            cmbEquippedItem.SelectedIndex = ItemBase.ListIndex(condition.ItemId);
-        }
-
-        private void SetupFormValues(HasFreeInventorySlots condition)
-        {
-            nudItemAmount.Value = condition.Quantity;
-            rdoVariable.Checked = condition.UseVariable;
-            rdoInvGlobalVariable.Checked = condition.VariableType == VariableType.ServerVariable;
-            rdoInvGuildVariable.Checked = condition.VariableType == VariableType.GuildVariable;
-            SetupAmountInput();
-        }
-
-        private void SetupFormValues(InGuildWithRank condition)
-        {
-            cmbRank.SelectedIndex = Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, condition.Rank));
-        }
-
-        private void SetupFormValues(MapZoneTypeIs condition)
-        {
-            if (cmbMapZoneType.Items.Count > 0)
-            {
-                cmbMapZoneType.SelectedIndex = (int)condition.ZoneType;
-            }
-        }
-
-        private void SetupFormValues(CheckEquippedSlot condition)
-        {
-            cmbCheckEquippedSlot.SelectedIndex = Options.EquipmentSlots.IndexOf(condition.Name);
-        }
-
-
-        #endregion
-
-        #region "SaveFormValues"
-
-        private void SaveFormValues(VariableIsCondition condition)
-        {
-            if (rdoGlobalVariable.Checked)
-            {
-                condition.VariableType = VariableType.ServerVariable;
-                condition.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoPlayerVariable.Checked)
-            {
-                condition.VariableType = VariableType.PlayerVariable;
-                condition.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                condition.VariableType = VariableType.GuildVariable;
-                condition.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoUserVariable.Checked)
-            {
-                condition.VariableType = VariableType.UserVariable;
-                condition.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-
-            if (grpBooleanVariable.Visible)
-            {
-                condition.Comparison = GetBooleanVariableComparison();
-            }
-            else if (grpNumericVariable.Visible)
-            {
-                condition.Comparison = GetNumericVariableComparison();
-            }
-            else if (grpStringVariable.Visible)
-            {
-                condition.Comparison = GetStringVariableComparison();
-            }
-            else
-            {
-                condition.Comparison = new VariableComparison();
-            }
-        }
-
-        private void SaveFormValues(HasItemCondition condition)
-        {
-            condition.ItemId = ItemBase.IdFromList(cmbItem.SelectedIndex);
-            condition.Quantity = (int)nudItemAmount.Value;
-            if (rdoInvPlayerVariable.Checked)
-            {
-                condition.VariableType = VariableType.PlayerVariable;
-                condition.VariableId = PlayerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoInvGlobalVariable.Checked)
-            {
-                condition.VariableType = VariableType.ServerVariable;
-                condition.VariableId = ServerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoInvGuildVariable.Checked)
-            {
-                condition.VariableType = VariableType.GuildVariable;
-                condition.VariableId = GuildVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            condition.UseVariable = !rdoManual.Checked;
-            condition.CheckBank = chkBank.Checked;
-        }
-
-        private void SaveFormValues(ClassIsCondition condition)
-        {
-            condition.ClassId = ClassBase.IdFromList(cmbClass.SelectedIndex);
-        }
-
-        private void SaveFormValues(KnowsSpellCondition condition)
-        {
-            condition.SpellId = SpellBase.IdFromList(cmbSpell.SelectedIndex);
-        }
-
-        private void SaveFormValues(LevelOrStatCondition condition)
-        {
-            condition.Comparator = (VariableComparator)cmbLevelComparator.SelectedIndex;
-            condition.Value = (int)nudLevelStatValue.Value;
-            condition.ComparingLevel = cmbLevelStat.SelectedIndex == 0;
-            if (!condition.ComparingLevel)
-            {
-                condition.Stat = (Stat)(cmbLevelStat.SelectedIndex - 1);
-            }
-
-            condition.IgnoreBuffs = chkStatIgnoreBuffs.Checked;
-        }
-
-        private void SaveFormValues(SelfSwitchCondition condition)
+        else
         {
-            condition.SwitchIndex = cmbSelfSwitch.SelectedIndex;
-            condition.Value = Convert.ToBoolean(cmbSelfSwitchVal.SelectedIndex);
+            cmbQuestTask.Enabled = true;
         }
+    }
 
-        private void SaveFormValues(AccessIsCondition condition)
+    private void cmbQuestInProgress_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        cmbQuestTask.Items.Clear();
+        var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
+        if (quest != null)
         {
-            condition.Access = (Access)cmbPower.SelectedIndex;
-        }
-
-        private void SaveFormValues(TimeBetweenCondition condition)
-        {
-            condition.Ranges[0] = cmbTime1.SelectedIndex;
-            condition.Ranges[1] = cmbTime2.SelectedIndex;
-        }
-
-        private void SaveFormValues(CanStartQuestCondition condition)
-        {
-            condition.QuestId = QuestBase.IdFromList(cmbStartQuest.SelectedIndex);
-        }
-
-        private void SaveFormValues(QuestInProgressCondition condition)
-        {
-            condition.QuestId = QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex);
-            condition.Progress = (QuestProgressState)cmbTaskModifier.SelectedIndex;
-            condition.TaskId = Guid.Empty;
-            if (cmbTaskModifier.SelectedIndex != 0)
-            {
-                //Get Quest Task Here
-                var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
-                if (quest != null)
-                {
-                    if (cmbQuestTask.SelectedIndex > -1)
-                    {
-                        condition.TaskId = quest.Tasks[cmbQuestTask.SelectedIndex].Id;
-                    }
-                }
-            }
-        }
-
-        private void SaveFormValues(QuestCompletedCondition condition)
-        {
-            condition.QuestId = QuestBase.IdFromList(cmbCompletedQuest.SelectedIndex);
-        }
-
-        private void SaveFormValues(NoNpcsOnMapCondition condition)
-        {
-            condition.SpecificNpc = chkNpc.Checked;
-            condition.NpcId = condition.SpecificNpc ? NpcBase.IdFromList(cmbNpcs.SelectedIndex) : default;
-        }
-
-        private void SaveFormValues(GenderIsCondition condition)
-        {
-            condition.Gender = (Gender)cmbGender.SelectedIndex;
-        }
-
-        private void SaveFormValues(MapIsCondition condition)
-        {
-            condition.MapId = (Guid)btnSelectMap.Tag;
-        }
-
-        private void SaveFormValues(IsItemEquippedCondition condition)
-        {
-            condition.ItemId = ItemBase.IdFromList(cmbEquippedItem.SelectedIndex);
-        }
-
-        private void SaveFormValues(HasFreeInventorySlots condition)
-        {
-            condition.Quantity = (int)nudItemAmount.Value;
-            if (rdoInvPlayerVariable.Checked)
-            {
-                condition.VariableType = VariableType.PlayerVariable;
-                condition.VariableId = PlayerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoInvGlobalVariable.Checked)
-            {
-                condition.VariableType = VariableType.ServerVariable;
-                condition.VariableId = ServerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoInvGuildVariable.Checked)
-            {
-                condition.VariableType = VariableType.GuildVariable;
-                condition.VariableId = GuildVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            condition.UseVariable = !rdoManual.Checked;
-        }
-
-        private void SaveFormValues(InGuildWithRank condition)
-        {
-            condition.Rank = Math.Max(cmbRank.SelectedIndex, 0);
-        }
-
-        private void SaveFormValues(MapZoneTypeIs condition)
-        {
-            if (cmbMapZoneType.Items.Count > 0)
-            {
-                condition.ZoneType = (MapZone)cmbMapZoneType.SelectedIndex;
-            }
-        }
-
-        private void SaveFormValues(CheckEquippedSlot condition)
-        {
-            condition.Name = Options.EquipmentSlots[cmbCheckEquippedSlot.SelectedIndex];
-        }
-        #endregion
-
-        private void chkNpc_CheckedChanged(object sender, EventArgs e)
-        {
-            if (!chkNpc.Checked)
+            foreach (var task in quest.Tasks)
             {
-                lblNpc.Hide();
-                cmbNpcs.Hide();
-
-                return;
+                cmbQuestTask.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
             }
 
-            lblNpc.Show();
-            cmbNpcs.Show();
-            if (cmbNpcs.Items.Count > 0)
+            if (cmbQuestTask.Items.Count > 0)
             {
-                cmbNpcs.SelectedIndex = 0;
+                cmbQuestTask.SelectedIndex = 0;
             }
         }
     }
 
+    private void btnSelectMap_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.InitForm(false, null);
+        frmWarpSelection.SelectTile((Guid)btnSelectMap.Tag, 0, 0);
+        frmWarpSelection.TopMost = true;
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            btnSelectMap.Tag = frmWarpSelection.GetMap();
+        }
+    }
+
+    private void rdoVarCompareStaticValue_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void rdoVarComparePlayerVar_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void rdoVarCompareGlobalVar_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void rdoVarCompareGuildVar_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void rdoVarCompareUserVar_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void rdoTimeSystem_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericVariableElements();
+    }
+
+    private void UpdateNumericVariableElements()
+    {
+        nudVariableValue.Enabled = rdoVarCompareStaticValue.Checked;
+        cmbComparePlayerVar.Enabled = rdoVarComparePlayerVar.Checked;
+        cmbCompareGlobalVar.Enabled = rdoVarCompareGlobalVar.Checked;
+        cmbCompareGuildVar.Enabled = rdoVarCompareGuildVar.Checked;
+        cmbCompareUserVar.Enabled = rdoVarCompareUserVar.Checked;
+    }
+
+    private void UpdateVariableElements()
+    {
+        //Hide editor windows until we have a variable selected to work with
+        grpNumericVariable.Hide();
+        grpBooleanVariable.Hide();
+        grpStringVariable.Hide();
+
+        var varType = 0;
+        if (cmbVariable.SelectedIndex > -1)
+        {
+            //Determine Variable Type
+            if (rdoPlayerVariable.Checked)
+            {
+                var playerVar = PlayerVariableBase.FromList(cmbVariable.SelectedIndex);
+                if (playerVar != null)
+                {
+                    varType = (byte)playerVar.Type;
+                }
+            }
+            else if (rdoGlobalVariable.Checked)
+            {
+                var serverVar = ServerVariableBase.FromList(cmbVariable.SelectedIndex);
+                if (serverVar != null)
+                {
+                    varType = (byte)serverVar.Type;
+                }
+            }
+            else if (rdoGuildVariable.Checked)
+            {
+                var guildVar = GuildVariableBase.FromList(cmbVariable.SelectedIndex);
+                if (guildVar != null)
+                {
+                    varType = (byte)guildVar.Type;
+                }
+            }
+            else if (rdoUserVariable.Checked)
+            {
+                var userVar = UserVariableBase.FromList(cmbVariable.SelectedIndex);
+                if (userVar != null)
+                {
+                    varType = (byte)userVar.Type;
+                }
+            }
+        }
+
+        //Load the correct editor
+        if (varType > 0)
+        {
+            switch ((VariableDataType)varType)
+            {
+                case VariableDataType.Boolean:
+                    grpBooleanVariable.Show();
+                    TryLoadVariableBooleanComparison(((VariableIsCondition)Condition).Comparison);
+
+                    break;
+
+                case VariableDataType.Integer:
+                    grpNumericVariable.Show();
+                    TryLoadVariableIntegerComparison(((VariableIsCondition)Condition).Comparison);
+                    UpdateNumericVariableElements();
+
+                    break;
+
+                case VariableDataType.Number:
+                    break;
+
+                case VariableDataType.String:
+                    grpStringVariable.Show();
+                    TryLoadVariableStringComparison(((VariableIsCondition)Condition).Comparison);
+
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+
+    private void TryLoadVariableBooleanComparison(VariableComparison comparison)
+    {
+        if (!(comparison is BooleanVariableComparison booleanComparison))
+        {
+            return;
+        }
+
+        cmbBooleanComparator.SelectedIndex = Convert.ToInt32(!booleanComparison.ComparingEqual);
+
+        if (cmbBooleanComparator.SelectedIndex < 0)
+        {
+            cmbBooleanComparator.SelectedIndex = 0;
+        }
+
+        optBooleanTrue.Checked = booleanComparison.Value;
+        optBooleanFalse.Checked = !booleanComparison.Value;
+
+        if (booleanComparison.CompareVariableId != Guid.Empty)
+        {
+            if (booleanComparison.CompareVariableType == VariableType.PlayerVariable)
+            {
+                optBooleanPlayerVariable.Checked = true;
+                cmbBooleanPlayerVariable.SelectedIndex = PlayerVariableBase.ListIndex(booleanComparison.CompareVariableId);
+            }
+            else if (booleanComparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                optBooleanGlobalVariable.Checked = true;
+                cmbBooleanGlobalVariable.SelectedIndex = ServerVariableBase.ListIndex(booleanComparison.CompareVariableId);
+            }
+            else if (booleanComparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                optBooleanGuildVariable.Checked = true;
+                cmbBooleanGuildVariable.SelectedIndex = GuildVariableBase.ListIndex(booleanComparison.CompareVariableId);
+            }
+            else if (booleanComparison.CompareVariableType == VariableType.UserVariable)
+            {
+                optBooleanUserVariable.Checked = true;
+                cmbBooleanUserVariable.SelectedIndex = UserVariableBase.ListIndex(booleanComparison.CompareVariableId);
+            }
+        }
+    }
+
+    private void TryLoadVariableIntegerComparison(VariableComparison comparison)
+    {
+        if (!(comparison is IntegerVariableComparison integerComparison))
+        {
+            return;
+        }
+
+        cmbNumericComparitor.SelectedIndex = (int)integerComparison.Comparator;
+
+        if (cmbNumericComparitor.SelectedIndex < 0)
+        {
+            cmbNumericComparitor.SelectedIndex = 0;
+        }
+
+        if (integerComparison.CompareVariableId != Guid.Empty)
+        {
+            if (integerComparison.CompareVariableType == VariableType.PlayerVariable)
+            {
+                rdoVarComparePlayerVar.Checked = true;
+                cmbComparePlayerVar.SelectedIndex = PlayerVariableBase.ListIndex(integerComparison.CompareVariableId);
+            }
+            else if (integerComparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                rdoVarCompareGlobalVar.Checked = true;
+                cmbCompareGlobalVar.SelectedIndex = ServerVariableBase.ListIndex(integerComparison.CompareVariableId);
+            }
+            else if (integerComparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                rdoVarCompareGuildVar.Checked = true;
+                cmbCompareGuildVar.SelectedIndex = GuildVariableBase.ListIndex(integerComparison.CompareVariableId);
+            }
+            else if (integerComparison.CompareVariableType == VariableType.UserVariable)
+            {
+                rdoVarCompareUserVar.Checked = true;
+                cmbCompareUserVar.SelectedIndex = UserVariableBase.ListIndex(integerComparison.CompareVariableId);
+            }
+        }
+        else if (integerComparison.TimeSystem)
+        {
+            rdoTimeSystem.Checked = true;
+        }
+        else
+        {
+            rdoVarCompareStaticValue.Checked = true;
+            nudVariableValue.Value = integerComparison.Value;
+        }
+
+        UpdateNumericVariableElements();
+    }
+
+    private void TryLoadVariableStringComparison(VariableComparison comparison)
+    {
+        if (!(comparison is StringVariableComparison stringComparison))
+        {
+            return;
+        }
+
+        cmbStringComparitor.SelectedIndex = Convert.ToInt32(stringComparison.Comparator);
+
+        if (cmbStringComparitor.SelectedIndex < 0)
+        {
+            cmbStringComparitor.SelectedIndex = 0;
+        }
+
+        txtStringValue.Text = stringComparison.Value;
+    }
+
+    private void InitVariableElements(Guid variableId)
+    {
+        mLoading = true;
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(PlayerVariableBase.Names);
+            cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(variableId);
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(ServerVariableBase.Names);
+            cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(variableId);
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(GuildVariableBase.Names);
+            cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(variableId);
+        }
+        else if (rdoUserVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(UserVariableBase.Names);
+            cmbVariable.SelectedIndex = UserVariableBase.ListIndex(variableId);
+        }
+
+        mLoading = false;
+    }
+
+    private BooleanVariableComparison GetBooleanVariableComparison()
+    {
+        if (cmbBooleanComparator.SelectedIndex < 0)
+        {
+            cmbBooleanComparator.SelectedIndex = 0;
+        }
+
+        var comparison = new BooleanVariableComparison
+        {
+            ComparingEqual = !Convert.ToBoolean(cmbBooleanComparator.SelectedIndex),
+            Value = optBooleanTrue.Checked,
+        };
+
+        if (optBooleanGlobalVariable.Checked)
+        {
+            comparison.CompareVariableType = VariableType.ServerVariable;
+            comparison.CompareVariableId = ServerVariableBase.IdFromList(cmbBooleanGlobalVariable.SelectedIndex);
+        }
+        else if (optBooleanPlayerVariable.Checked)
+        {
+            comparison.CompareVariableType = VariableType.PlayerVariable;
+            comparison.CompareVariableId = PlayerVariableBase.IdFromList(cmbBooleanPlayerVariable.SelectedIndex);
+        }
+        else if (optBooleanGuildVariable.Checked)
+        {
+            comparison.CompareVariableType = VariableType.GuildVariable;
+            comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbBooleanGuildVariable.SelectedIndex);
+        }
+        else if (optBooleanUserVariable.Checked)
+        {
+            comparison.CompareVariableType = VariableType.UserVariable;
+            comparison.CompareVariableId = UserVariableBase.IdFromList(cmbBooleanUserVariable.SelectedIndex);
+        }
+
+        return comparison;
+    }
+
+    private IntegerVariableComparison GetNumericVariableComparison()
+    {
+        if (cmbNumericComparitor.SelectedIndex < 0)
+        {
+            cmbNumericComparitor.SelectedIndex = 0;
+        }
+
+        var comparison = new IntegerVariableComparison
+        {
+            Comparator = (VariableComparator)cmbNumericComparitor.SelectedIndex,
+            CompareVariableId = Guid.Empty,
+            TimeSystem = false,
+        };
+
+        if (rdoVarCompareStaticValue.Checked)
+        {
+            comparison.Value = (long)nudVariableValue.Value;
+        }
+        else if (rdoVarCompareGlobalVar.Checked)
+        {
+            comparison.CompareVariableType = VariableType.ServerVariable;
+            comparison.CompareVariableId = ServerVariableBase.IdFromList(cmbCompareGlobalVar.SelectedIndex);
+        }
+        else if (rdoVarComparePlayerVar.Checked)
+        {
+            comparison.CompareVariableType = VariableType.PlayerVariable;
+            comparison.CompareVariableId = PlayerVariableBase.IdFromList(cmbComparePlayerVar.SelectedIndex);
+        }
+        else if (rdoVarCompareGuildVar.Checked)
+        {
+            comparison.CompareVariableType = VariableType.GuildVariable;
+            comparison.CompareVariableId = GuildVariableBase.IdFromList(cmbCompareGuildVar.SelectedIndex);
+        }
+        else if (rdoVarCompareUserVar.Checked)
+        {
+            comparison.CompareVariableType = VariableType.UserVariable;
+            comparison.CompareVariableId = UserVariableBase.IdFromList(cmbCompareUserVar.SelectedIndex);
+        }
+        else
+        {
+            comparison.TimeSystem = true;
+        }
+
+        return comparison;
+    }
+
+    private StringVariableComparison GetStringVariableComparison()
+    {
+        if (cmbStringComparitor.SelectedIndex < 0)
+        {
+            cmbStringComparitor.SelectedIndex = 0;
+        }
+
+        var comparison = new StringVariableComparison
+        {
+            Comparator = (StringVariableComparator)cmbStringComparitor.SelectedIndex,
+            Value = txtStringValue.Text,
+        };
+
+        return comparison;
+    }
+
+    private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        InitVariableElements(Guid.Empty);
+        if (!mLoading && cmbVariable.Items.Count > 0)
+        {
+            cmbVariable.SelectedIndex = 0;
+        }
+    }
+
+    private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoUserVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void VariableRadioChanged()
+    {
+        InitVariableElements(Guid.Empty);
+        if (!mLoading && cmbVariable.Items.Count > 0)
+        {
+            cmbVariable.SelectedIndex = 0;
+        }
+    }
+
+    private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (mLoading)
+        {
+            return;
+        }
+
+        if (rdoPlayerVariable.Checked)
+        {
+            InitVariableElements(PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex));
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            InitVariableElements(ServerVariableBase.IdFromList(cmbVariable.SelectedIndex));
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            InitVariableElements(GuildVariableBase.IdFromList(cmbVariable.SelectedIndex));
+        }
+        else if (rdoUserVariable.Checked)
+        {
+            InitVariableElements(UserVariableBase.IdFromList(cmbVariable.SelectedIndex));
+        }
+
+        UpdateVariableElements();
+    }
+
+    private void lblStringTextVariables_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
+    }
+
+    private void NudItemAmount_ValueChanged(object sender, System.EventArgs e)
+    {
+        nudItemAmount.Value = Math.Max(1, nudItemAmount.Value);
+    }
+
+    private void rdoManual_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoInvPlayerVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoInvGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoInvGuildVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void SetupAmountInput()
+    {
+        grpManualAmount.Visible = rdoManual.Checked;
+        grpVariableAmount.Visible = !rdoManual.Checked;
+
+        VariableType conditionVariableType;
+        Guid conditionVariableId;
+        int ConditionQuantity;
+
+        switch (Condition.Type)
+        {
+            case ConditionTypes.HasFreeInventorySlots:
+                conditionVariableType = ((HasFreeInventorySlots)Condition).VariableType;
+                conditionVariableId = ((HasFreeInventorySlots)Condition).VariableId;
+                ConditionQuantity = ((HasFreeInventorySlots)Condition).Quantity;
+                break;
+            case ConditionTypes.HasItem:
+                conditionVariableType = ((HasItemCondition)Condition).VariableType;
+                conditionVariableId = ((HasItemCondition)Condition).VariableId;
+                ConditionQuantity = ((HasItemCondition)Condition).Quantity;
+                break;
+            default:
+                conditionVariableType = VariableType.PlayerVariable;
+                conditionVariableId = Guid.Empty;
+                ConditionQuantity = 0;
+                return;
+        }
+
+        cmbInvVariable.Items.Clear();
+        if (rdoInvPlayerVariable.Checked)
+        {
+            cmbInvVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (conditionVariableType == VariableType.PlayerVariable)
+            {
+                var index = PlayerVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbInvVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoInvGlobalVariable.Checked)
+        {
+            cmbInvVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (conditionVariableType == VariableType.ServerVariable)
+            {
+                var index = ServerVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbInvVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoInvGuildVariable.Checked)
+        {
+            cmbInvVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (conditionVariableType == VariableType.GuildVariable)
+            {
+                var index = GuildVariableBase.ListIndex(conditionVariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbInvVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+
+        nudItemAmount.Value = Math.Max(1, ConditionQuantity);
+    }
+
+    private void VariableBlank()
+    {
+        if (cmbInvVariable.Items.Count > 0)
+        {
+            cmbInvVariable.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbInvVariable.SelectedIndex = -1;
+            cmbInvVariable.Text = "";
+        }
+    }
+
+    #region "SetupFormValues"
+
+    private void SetupFormValues(VariableIsCondition condition)
+    {
+        if (condition.VariableType == VariableType.PlayerVariable)
+        {
+            rdoPlayerVariable.Checked = true;
+        }
+        else if (condition.VariableType == VariableType.ServerVariable)
+        {
+            rdoGlobalVariable.Checked = true;
+        }
+        else if (condition.VariableType == VariableType.GuildVariable)
+        {
+            rdoGuildVariable.Checked = true;
+        }
+        else if (condition.VariableType == VariableType.UserVariable)
+        {
+            rdoUserVariable.Checked = true;
+        }
+
+        InitVariableElements(condition.VariableId);
+
+        UpdateVariableElements();
+    }
+
+    private void SetupFormValues(HasItemCondition condition)
+    {
+        cmbItem.SelectedIndex = ItemBase.ListIndex(condition.ItemId);
+        nudItemAmount.Value = condition.Quantity;
+        rdoVariable.Checked = condition.UseVariable;
+        rdoInvGlobalVariable.Checked = condition.VariableType == VariableType.ServerVariable;
+        chkBank.Checked = condition.CheckBank;
+        rdoInvGuildVariable.Checked = condition.VariableType == VariableType.GuildVariable;
+        SetupAmountInput();
+    }
+
+    private void SetupFormValues(ClassIsCondition condition)
+    {
+        cmbClass.SelectedIndex = ClassBase.ListIndex(condition.ClassId);
+    }
+
+    private void SetupFormValues(KnowsSpellCondition condition)
+    {
+        cmbSpell.SelectedIndex = SpellBase.ListIndex(condition.SpellId);
+    }
+
+    private void SetupFormValues(LevelOrStatCondition condition)
+    {
+        cmbLevelComparator.SelectedIndex = (int)condition.Comparator;
+        nudLevelStatValue.Value = condition.Value;
+        cmbLevelStat.SelectedIndex = condition.ComparingLevel ? 0 : (int)condition.Stat + 1;
+        chkStatIgnoreBuffs.Checked = condition.IgnoreBuffs;
+    }
+
+    private void SetupFormValues(SelfSwitchCondition condition)
+    {
+        cmbSelfSwitch.SelectedIndex = condition.SwitchIndex;
+        cmbSelfSwitchVal.SelectedIndex = Convert.ToInt32(condition.Value);
+    }
+
+    private void SetupFormValues(AccessIsCondition condition)
+    {
+        cmbPower.SelectedIndex = (int)condition.Access;
+    }
+
+    private void SetupFormValues(TimeBetweenCondition condition)
+    {
+        cmbTime1.SelectedIndex = Math.Min(condition.Ranges[0], cmbTime1.Items.Count - 1);
+        cmbTime2.SelectedIndex = Math.Min(condition.Ranges[1], cmbTime2.Items.Count - 1);
+    }
+
+    private void SetupFormValues(CanStartQuestCondition condition)
+    {
+        cmbStartQuest.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
+    }
+
+    private void SetupFormValues(QuestInProgressCondition condition)
+    {
+        cmbQuestInProgress.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
+        cmbTaskModifier.SelectedIndex = (int)condition.Progress;
+        if (cmbTaskModifier.SelectedIndex == -1)
+        {
+            cmbTaskModifier.SelectedIndex = 0;
+        }
+
+        if (cmbTaskModifier.SelectedIndex != 0)
+        {
+            //Get Quest Task Here
+            var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
+            if (quest != null)
+            {
+                for (var i = 0; i < quest.Tasks.Count; i++)
+                {
+                    if (quest.Tasks[i].Id == condition.TaskId)
+                    {
+                        cmbQuestTask.SelectedIndex = i;
+                    }
+                }
+            }
+        }
+    }
+
+    private void SetupFormValues(NoNpcsOnMapCondition condition)
+    {
+        chkNpc.Checked = condition.SpecificNpc;
+        if (condition.SpecificNpc)
+        {
+            lblNpc.Show();
+            cmbNpcs.Show();
+            cmbNpcs.SelectedIndex = NpcBase.ListIndex(condition.NpcId);
+        }
+        else
+        {
+            lblNpc.Hide();
+            cmbNpcs.Hide();
+        }
+    }
+
+    private void SetupFormValues(QuestCompletedCondition condition)
+    {
+        cmbCompletedQuest.SelectedIndex = QuestBase.ListIndex(condition.QuestId);
+    }
+
+    private void SetupFormValues(GenderIsCondition condition)
+    {
+        cmbGender.SelectedIndex = (int)condition.Gender;
+    }
+
+    private void SetupFormValues(MapIsCondition condition)
+    {
+        btnSelectMap.Tag = condition.MapId;
+    }
+
+    private void SetupFormValues(IsItemEquippedCondition condition)
+    {
+        cmbEquippedItem.SelectedIndex = ItemBase.ListIndex(condition.ItemId);
+    }
+
+    private void SetupFormValues(HasFreeInventorySlots condition)
+    {
+        nudItemAmount.Value = condition.Quantity;
+        rdoVariable.Checked = condition.UseVariable;
+        rdoInvGlobalVariable.Checked = condition.VariableType == VariableType.ServerVariable;
+        rdoInvGuildVariable.Checked = condition.VariableType == VariableType.GuildVariable;
+        SetupAmountInput();
+    }
+
+    private void SetupFormValues(InGuildWithRank condition)
+    {
+        cmbRank.SelectedIndex = Math.Max(0, Math.Min(Options.Instance.Guild.Ranks.Length - 1, condition.Rank));
+    }
+
+    private void SetupFormValues(MapZoneTypeIs condition)
+    {
+        if (cmbMapZoneType.Items.Count > 0)
+        {
+            cmbMapZoneType.SelectedIndex = (int)condition.ZoneType;
+        }
+    }
+
+    private void SetupFormValues(CheckEquippedSlot condition)
+    {
+        cmbCheckEquippedSlot.SelectedIndex = Options.EquipmentSlots.IndexOf(condition.Name);
+    }
+
+
+    #endregion
+
+    #region "SaveFormValues"
+
+    private void SaveFormValues(VariableIsCondition condition)
+    {
+        if (rdoGlobalVariable.Checked)
+        {
+            condition.VariableType = VariableType.ServerVariable;
+            condition.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoPlayerVariable.Checked)
+        {
+            condition.VariableType = VariableType.PlayerVariable;
+            condition.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            condition.VariableType = VariableType.GuildVariable;
+            condition.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoUserVariable.Checked)
+        {
+            condition.VariableType = VariableType.UserVariable;
+            condition.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+
+        if (grpBooleanVariable.Visible)
+        {
+            condition.Comparison = GetBooleanVariableComparison();
+        }
+        else if (grpNumericVariable.Visible)
+        {
+            condition.Comparison = GetNumericVariableComparison();
+        }
+        else if (grpStringVariable.Visible)
+        {
+            condition.Comparison = GetStringVariableComparison();
+        }
+        else
+        {
+            condition.Comparison = new VariableComparison();
+        }
+    }
+
+    private void SaveFormValues(HasItemCondition condition)
+    {
+        condition.ItemId = ItemBase.IdFromList(cmbItem.SelectedIndex);
+        condition.Quantity = (int)nudItemAmount.Value;
+        if (rdoInvPlayerVariable.Checked)
+        {
+            condition.VariableType = VariableType.PlayerVariable;
+            condition.VariableId = PlayerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoInvGlobalVariable.Checked)
+        {
+            condition.VariableType = VariableType.ServerVariable;
+            condition.VariableId = ServerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoInvGuildVariable.Checked)
+        {
+            condition.VariableType = VariableType.GuildVariable;
+            condition.VariableId = GuildVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        condition.UseVariable = !rdoManual.Checked;
+        condition.CheckBank = chkBank.Checked;
+    }
+
+    private void SaveFormValues(ClassIsCondition condition)
+    {
+        condition.ClassId = ClassBase.IdFromList(cmbClass.SelectedIndex);
+    }
+
+    private void SaveFormValues(KnowsSpellCondition condition)
+    {
+        condition.SpellId = SpellBase.IdFromList(cmbSpell.SelectedIndex);
+    }
+
+    private void SaveFormValues(LevelOrStatCondition condition)
+    {
+        condition.Comparator = (VariableComparator)cmbLevelComparator.SelectedIndex;
+        condition.Value = (int)nudLevelStatValue.Value;
+        condition.ComparingLevel = cmbLevelStat.SelectedIndex == 0;
+        if (!condition.ComparingLevel)
+        {
+            condition.Stat = (Stat)(cmbLevelStat.SelectedIndex - 1);
+        }
+
+        condition.IgnoreBuffs = chkStatIgnoreBuffs.Checked;
+    }
+
+    private void SaveFormValues(SelfSwitchCondition condition)
+    {
+        condition.SwitchIndex = cmbSelfSwitch.SelectedIndex;
+        condition.Value = Convert.ToBoolean(cmbSelfSwitchVal.SelectedIndex);
+    }
+
+    private void SaveFormValues(AccessIsCondition condition)
+    {
+        condition.Access = (Access)cmbPower.SelectedIndex;
+    }
+
+    private void SaveFormValues(TimeBetweenCondition condition)
+    {
+        condition.Ranges[0] = cmbTime1.SelectedIndex;
+        condition.Ranges[1] = cmbTime2.SelectedIndex;
+    }
+
+    private void SaveFormValues(CanStartQuestCondition condition)
+    {
+        condition.QuestId = QuestBase.IdFromList(cmbStartQuest.SelectedIndex);
+    }
+
+    private void SaveFormValues(QuestInProgressCondition condition)
+    {
+        condition.QuestId = QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex);
+        condition.Progress = (QuestProgressState)cmbTaskModifier.SelectedIndex;
+        condition.TaskId = Guid.Empty;
+        if (cmbTaskModifier.SelectedIndex != 0)
+        {
+            //Get Quest Task Here
+            var quest = QuestBase.Get(QuestBase.IdFromList(cmbQuestInProgress.SelectedIndex));
+            if (quest != null)
+            {
+                if (cmbQuestTask.SelectedIndex > -1)
+                {
+                    condition.TaskId = quest.Tasks[cmbQuestTask.SelectedIndex].Id;
+                }
+            }
+        }
+    }
+
+    private void SaveFormValues(QuestCompletedCondition condition)
+    {
+        condition.QuestId = QuestBase.IdFromList(cmbCompletedQuest.SelectedIndex);
+    }
+
+    private void SaveFormValues(NoNpcsOnMapCondition condition)
+    {
+        condition.SpecificNpc = chkNpc.Checked;
+        condition.NpcId = condition.SpecificNpc ? NpcBase.IdFromList(cmbNpcs.SelectedIndex) : default;
+    }
+
+    private void SaveFormValues(GenderIsCondition condition)
+    {
+        condition.Gender = (Gender)cmbGender.SelectedIndex;
+    }
+
+    private void SaveFormValues(MapIsCondition condition)
+    {
+        condition.MapId = (Guid)btnSelectMap.Tag;
+    }
+
+    private void SaveFormValues(IsItemEquippedCondition condition)
+    {
+        condition.ItemId = ItemBase.IdFromList(cmbEquippedItem.SelectedIndex);
+    }
+
+    private void SaveFormValues(HasFreeInventorySlots condition)
+    {
+        condition.Quantity = (int)nudItemAmount.Value;
+        if (rdoInvPlayerVariable.Checked)
+        {
+            condition.VariableType = VariableType.PlayerVariable;
+            condition.VariableId = PlayerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoInvGlobalVariable.Checked)
+        {
+            condition.VariableType = VariableType.ServerVariable;
+            condition.VariableId = ServerVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoInvGuildVariable.Checked)
+        {
+            condition.VariableType = VariableType.GuildVariable;
+            condition.VariableId = GuildVariableBase.IdFromList(cmbInvVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        condition.UseVariable = !rdoManual.Checked;
+    }
+
+    private void SaveFormValues(InGuildWithRank condition)
+    {
+        condition.Rank = Math.Max(cmbRank.SelectedIndex, 0);
+    }
+
+    private void SaveFormValues(MapZoneTypeIs condition)
+    {
+        if (cmbMapZoneType.Items.Count > 0)
+        {
+            condition.ZoneType = (MapZone)cmbMapZoneType.SelectedIndex;
+        }
+    }
+
+    private void SaveFormValues(CheckEquippedSlot condition)
+    {
+        condition.Name = Options.EquipmentSlots[cmbCheckEquippedSlot.SelectedIndex];
+    }
+    #endregion
+
+    private void chkNpc_CheckedChanged(object sender, EventArgs e)
+    {
+        if (!chkNpc.Checked)
+        {
+            lblNpc.Hide();
+            cmbNpcs.Hide();
+
+            return;
+        }
+
+        lblNpc.Show();
+        cmbNpcs.Show();
+        if (cmbNpcs.Items.Count > 0)
+        {
+            cmbNpcs.SelectedIndex = 0;
+        }
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CreateGuild.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_CreateGuild.cs
@@ -3,58 +3,56 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandCreateGuild : UserControl
 {
 
-    public partial class EventCommandCreateGuild : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private CreateGuildCommand mMyCommand;
+
+    public EventCommandCreateGuild(CreateGuildCommand refCommand, EventPage page, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mCurrentPage = page;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
+        InitLocalization();
+        cmbVariable.Items.Clear();
+        cmbVariable.Items.AddRange(PlayerVariableBase.Names);
 
-        private EventPage mCurrentPage;
-
-        private CreateGuildCommand mMyCommand;
-
-        public EventCommandCreateGuild(CreateGuildCommand refCommand, EventPage page, FrmEvent editor)
+        if (mMyCommand.VariableId != null && mMyCommand.VariableId != Guid.Empty )
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mCurrentPage = page;
-            mEventEditor = editor;
-
-            InitLocalization();
-            cmbVariable.Items.Clear();
-            cmbVariable.Items.AddRange(PlayerVariableBase.Names);
-
-            if (mMyCommand.VariableId != null && mMyCommand.VariableId != Guid.Empty )
-            {
-                cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(mMyCommand.VariableId);
-            }
-            else if (cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
+            cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(mMyCommand.VariableId);
         }
-
-        private void InitLocalization()
+        else if (cmbVariable.Items.Count > 0)
         {
-            grpCreateGuild.Text = Strings.EventCreateGuild.Title;
-            lblVariable.Text = Strings.EventCreateGuild.SelectVariable;
-            btnSave.Text = Strings.EventCreateGuild.Okay;
-            btnCancel.Text = Strings.EventCreateGuild.Cancel;
+            cmbVariable.SelectedIndex = 0;
         }
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            mEventEditor.FinishCommandEdit();
-        }
+    private void InitLocalization()
+    {
+        grpCreateGuild.Text = Strings.EventCreateGuild.Title;
+        lblVariable.Text = Strings.EventCreateGuild.SelectVariable;
+        btnSave.Text = Strings.EventCreateGuild.Okay;
+        btnCancel.Text = Strings.EventCreateGuild.Cancel;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        mEventEditor.FinishCommandEdit();
+    }
 
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EndQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EndQuest.cs
@@ -2,49 +2,47 @@
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandEndQuest : UserControl
 {
 
-    public partial class EventCommandEndQuest : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EndQuestCommand mMyCommand;
+
+    public EventCommandEndQuest(EndQuestCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbQuests.Items.Clear();
+        cmbQuests.Items.AddRange(QuestBase.Names);
+        cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
+        chkSkipCompletionEvent.Checked = refCommand.SkipCompletionEvent;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpEndQuest.Text = Strings.EventEndQuest.title;
+        lblQuest.Text = Strings.EventEndQuest.label;
+        chkSkipCompletionEvent.Text = Strings.EventEndQuest.skipcompletion;
+        btnSave.Text = Strings.EventEndQuest.okay;
+        btnCancel.Text = Strings.EventEndQuest.cancel;
+    }
 
-        private EndQuestCommand mMyCommand;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
+        mMyCommand.SkipCompletionEvent = chkSkipCompletionEvent.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        public EventCommandEndQuest(EndQuestCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbQuests.Items.Clear();
-            cmbQuests.Items.AddRange(QuestBase.Names);
-            cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
-            chkSkipCompletionEvent.Checked = refCommand.SkipCompletionEvent;
-        }
-
-        private void InitLocalization()
-        {
-            grpEndQuest.Text = Strings.EventEndQuest.title;
-            lblQuest.Text = Strings.EventEndQuest.label;
-            chkSkipCompletionEvent.Text = Strings.EventEndQuest.skipcompletion;
-            btnSave.Text = Strings.EventEndQuest.okay;
-            btnCancel.Text = Strings.EventEndQuest.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
-            mMyCommand.SkipCompletionEvent = chkSkipCompletionEvent.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EquipItem.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_EquipItem.cs
@@ -2,94 +2,92 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandEquipItems : UserControl
 {
 
-    public partial class EventCommandEquipItems : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EquipItemCommand mMyCommand;
+
+    public EventCommandEquipItems(EquipItemCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
+        InitLocalization();
+        cmbItem.Items.Clear();
+        cmbItem.Items.AddRange(ItemBase.Names);
+        cmbItem.SelectedIndex = ItemBase.ListIndex(mMyCommand.ItemId);
+        chkUnequip.Checked = mMyCommand.Unequip;
+        optUnequipItem.Enabled = mMyCommand.Unequip;
+        optUnequipItem.Checked = mMyCommand.Unequip && mMyCommand.IsItem;
+        optUnequipSlot.Enabled = mMyCommand.Unequip;
+        optUnequipSlot.Checked = mMyCommand.Unequip && !mMyCommand.IsItem;
+        chkTriggerCooldown.Checked = mMyCommand.TriggerCooldown;
+    }
 
-        private EquipItemCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpEquipItem.Text = Strings.EventEquipItems.title;
+        chkTriggerCooldown.Text = Strings.EventEquipItems.TriggerCooldown;
+        chkUnequip.Text = Strings.EventEquipItems.unequip;
+        optUnequipItem.Text = Strings.EventEquipItems.item;
+        optUnequipSlot.Text = Strings.EventEquipItems.slot;
+        btnSave.Text = Strings.EventEquipItems.okay;
+        btnCancel.Text = Strings.EventEquipItems.cancel;
+    }
 
-        public EventCommandEquipItems(EquipItemCommand refCommand, FrmEvent editor)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.ItemId = optUnequipItem.Checked || !chkUnequip.Checked ? ItemBase.IdFromList(cmbItem.SelectedIndex) : Guid.Empty;
+        mMyCommand.Slot = optUnequipSlot.Checked ? cmbItem.SelectedIndex : -1;
+        mMyCommand.Unequip = chkUnequip.Checked;
+        mMyCommand.IsItem = optUnequipItem.Checked;
+        mMyCommand.TriggerCooldown = chkTriggerCooldown.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void chkUnequip_CheckedChanged(object sender, EventArgs e)
+    {
+        if (chkUnequip.Checked)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-
-            InitLocalization();
-            cmbItem.Items.Clear();
-            cmbItem.Items.AddRange(ItemBase.Names);
-            cmbItem.SelectedIndex = ItemBase.ListIndex(mMyCommand.ItemId);
-            chkUnequip.Checked = mMyCommand.Unequip;
-            optUnequipItem.Enabled = mMyCommand.Unequip;
-            optUnequipItem.Checked = mMyCommand.Unequip && mMyCommand.IsItem;
-            optUnequipSlot.Enabled = mMyCommand.Unequip;
-            optUnequipSlot.Checked = mMyCommand.Unequip && !mMyCommand.IsItem;
-            chkTriggerCooldown.Checked = mMyCommand.TriggerCooldown;
+            chkTriggerCooldown.Checked = false;
+            chkTriggerCooldown.Enabled = false;
+            optUnequipItem.Checked = mMyCommand.IsItem;
+            optUnequipItem.Enabled = true;
+            optUnequipSlot.Checked = !mMyCommand.IsItem;
+            optUnequipSlot.Enabled = true;
         }
-
-        private void InitLocalization()
+        else
         {
-            grpEquipItem.Text = Strings.EventEquipItems.title;
-            chkTriggerCooldown.Text = Strings.EventEquipItems.TriggerCooldown;
-            chkUnequip.Text = Strings.EventEquipItems.unequip;
-            optUnequipItem.Text = Strings.EventEquipItems.item;
-            optUnequipSlot.Text = Strings.EventEquipItems.slot;
-            btnSave.Text = Strings.EventEquipItems.okay;
-            btnCancel.Text = Strings.EventEquipItems.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.ItemId = optUnequipItem.Checked || !chkUnequip.Checked ? ItemBase.IdFromList(cmbItem.SelectedIndex) : Guid.Empty;
-            mMyCommand.Slot = optUnequipSlot.Checked ? cmbItem.SelectedIndex : -1;
-            mMyCommand.Unequip = chkUnequip.Checked;
-            mMyCommand.IsItem = optUnequipItem.Checked;
-            mMyCommand.TriggerCooldown = chkTriggerCooldown.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void chkUnequip_CheckedChanged(object sender, EventArgs e)
-        {
-            if (chkUnequip.Checked)
-            {
-                chkTriggerCooldown.Checked = false;
-                chkTriggerCooldown.Enabled = false;
-                optUnequipItem.Checked = mMyCommand.IsItem;
-                optUnequipItem.Enabled = true;
-                optUnequipSlot.Checked = !mMyCommand.IsItem;
-                optUnequipSlot.Enabled = true;
-            }
-            else
-            {
-                chkTriggerCooldown.Enabled = true;
-                optUnequipItem.Checked = false;
-                optUnequipItem.Enabled = false;
-                optUnequipSlot.Checked = false;
-                optUnequipSlot.Enabled = false;
-                UpdateUnequipOptions();
-            }
-        }
-
-        private void optUnequipSlot_CheckedChanged(object sender, EventArgs e)
-        {
+            chkTriggerCooldown.Enabled = true;
+            optUnequipItem.Checked = false;
+            optUnequipItem.Enabled = false;
+            optUnequipSlot.Checked = false;
+            optUnequipSlot.Enabled = false;
             UpdateUnequipOptions();
-        }
-
-        private void UpdateUnequipOptions()
-        {
-            cmbItem.Items.Clear();
-            cmbItem.Items.AddRange(optUnequipItem.Checked || !chkUnequip.Checked ? ItemBase.Names : Options.EquipmentSlots.ToArray());
-            cmbItem.SelectedIndex = cmbItem.Items.Count > 0 ? 0 : -1;
-            lblItem.Text = optUnequipItem.Checked || !chkUnequip.Checked ? Strings.EventEquipItems.item : Strings.EventEquipItems.slot;
         }
     }
 
+    private void optUnequipSlot_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateUnequipOptions();
+    }
+
+    private void UpdateUnequipOptions()
+    {
+        cmbItem.Items.Clear();
+        cmbItem.Items.AddRange(optUnequipItem.Checked || !chkUnequip.Checked ? ItemBase.Names : Options.EquipmentSlots.ToArray());
+        cmbItem.SelectedIndex = cmbItem.Items.Count > 0 ? 0 : -1;
+        lblItem.Text = optUnequipItem.Checked || !chkUnequip.Checked ? Strings.EventEquipItems.item : Strings.EventEquipItems.slot;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveExperience.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveExperience.cs
@@ -3,188 +3,187 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandGiveExperience : UserControl
 {
 
-    public partial class EventCommandGiveExperience : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private GiveExperienceCommand mMyCommand;
+
+    public EventCommandGiveExperience(GiveExperienceCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
 
-        private readonly FrmEvent mEventEditor;
+        rdoVariable.Checked = mMyCommand.UseVariable;
+        rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
+        rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
 
-        private GiveExperienceCommand mMyCommand;
+        SetupAmountInput();
+    }
 
-        public EventCommandGiveExperience(GiveExperienceCommand refCommand, FrmEvent editor)
+    private void InitLocalization()
+    {
+        grpGiveExperience.Text = Strings.EventGiveExperience.title;
+        lblExperience.Text = Strings.EventGiveExperience.label;
+
+        lblVariable.Text = Strings.EventGiveExperience.Variable;
+
+        grpAmountType.Text = Strings.EventGiveExperience.AmountType;
+        rdoManual.Text = Strings.EventGiveExperience.Manual;
+        rdoVariable.Text = Strings.EventGiveExperience.Variable;
+
+        grpManualAmount.Text = Strings.EventGiveExperience.Manual;
+        grpVariableAmount.Text = Strings.EventGiveExperience.Variable;
+
+        rdoPlayerVariable.Text = Strings.EventGiveExperience.PlayerVariable;
+        rdoGlobalVariable.Text = Strings.EventGiveExperience.ServerVariable;
+        rdoGuildVariable.Text = Strings.EventGiveExperience.GuildVariable;
+
+        btnSave.Text = Strings.EventGiveExperience.okay;
+        btnCancel.Text = Strings.EventGiveExperience.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Exp = (long) nudExperience.Value;
+        if (rdoPlayerVariable.Checked)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-
-            rdoVariable.Checked = mMyCommand.UseVariable;
-            rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
-            rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
-
-            SetupAmountInput();
+            mMyCommand.VariableType = VariableType.PlayerVariable;
+            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
-
-        private void InitLocalization()
+        else if (rdoGlobalVariable.Checked)
         {
-            grpGiveExperience.Text = Strings.EventGiveExperience.title;
-            lblExperience.Text = Strings.EventGiveExperience.label;
-
-            lblVariable.Text = Strings.EventGiveExperience.Variable;
-
-            grpAmountType.Text = Strings.EventGiveExperience.AmountType;
-            rdoManual.Text = Strings.EventGiveExperience.Manual;
-            rdoVariable.Text = Strings.EventGiveExperience.Variable;
-
-            grpManualAmount.Text = Strings.EventGiveExperience.Manual;
-            grpVariableAmount.Text = Strings.EventGiveExperience.Variable;
-
-            rdoPlayerVariable.Text = Strings.EventGiveExperience.PlayerVariable;
-            rdoGlobalVariable.Text = Strings.EventGiveExperience.ServerVariable;
-            rdoGuildVariable.Text = Strings.EventGiveExperience.GuildVariable;
-
-            btnSave.Text = Strings.EventGiveExperience.okay;
-            btnCancel.Text = Strings.EventGiveExperience.cancel;
+            mMyCommand.VariableType = VariableType.ServerVariable;
+            mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
-
-        private void btnSave_Click(object sender, EventArgs e)
+        else if (rdoGuildVariable.Checked)
         {
-            mMyCommand.Exp = (long) nudExperience.Value;
-            if (rdoPlayerVariable.Checked)
+            mMyCommand.VariableType = VariableType.GuildVariable;
+            mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        mMyCommand.UseVariable = !rdoManual.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void rdoManual_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void VariableBlank()
+    {
+        if (cmbVariable.Items.Count > 0)
+        {
+            cmbVariable.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbVariable.SelectedIndex = -1;
+            cmbVariable.Text = "";
+        }
+    }
+
+    private void SetupAmountInput()
+    {
+        grpManualAmount.Visible = rdoManual.Checked;
+        grpVariableAmount.Visible = !rdoManual.Checked;
+
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.PlayerVariable)
             {
-                mMyCommand.VariableType = VariableType.PlayerVariable;
-                mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.ServerVariable;
-                mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.GuildVariable;
-                mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            mMyCommand.UseVariable = !rdoManual.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void rdoManual_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void VariableBlank()
-        {
-            if (cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
+                var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
             }
             else
             {
-                cmbVariable.SelectedIndex = -1;
-                cmbVariable.Text = "";
+                VariableBlank();
             }
         }
-
-        private void SetupAmountInput()
+        else if (rdoGlobalVariable.Checked)
         {
-            grpManualAmount.Visible = rdoManual.Checked;
-            grpVariableAmount.Visible = !rdoManual.Checked;
-
-            cmbVariable.Items.Clear();
-            if (rdoPlayerVariable.Checked)
+            cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.ServerVariable)
             {
-                cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.PlayerVariable)
+                var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
                 {
-                    var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
+                    cmbVariable.SelectedIndex = index;
                 }
                 else
                 {
                     VariableBlank();
                 }
             }
-            else if (rdoGlobalVariable.Checked)
+            else
             {
-                cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.ServerVariable)
-                {
-                    var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
+                VariableBlank();
             }
-            else if (rdoGuildVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.GuildVariable)
-                {
-                    var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-
-            nudExperience.Value = Math.Max(1, mMyCommand.Exp);
         }
+        else if (rdoGuildVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.GuildVariable)
+            {
+                var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+
+        nudExperience.Value = Math.Max(1, mMyCommand.Exp);
     }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GotoLabel.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GotoLabel.cs
@@ -1,44 +1,42 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandGotoLabel : UserControl
 {
 
-    public partial class EventCommandGotoLabel : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private GoToLabelCommand mMyCommand;
+
+    public EventCommandGotoLabel(GoToLabelCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        txtGotoLabel.Text = mMyCommand.Label;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpGotoLabel.Text = Strings.EventGotoLabel.title;
+        lblGotoLabel.Text = Strings.EventGotoLabel.label;
+        btnSave.Text = Strings.EventGotoLabel.okay;
+        btnCancel.Text = Strings.EventGotoLabel.cancel;
+    }
 
-        private GoToLabelCommand mMyCommand;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Label = txtGotoLabel.Text;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        public EventCommandGotoLabel(GoToLabelCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            txtGotoLabel.Text = mMyCommand.Label;
-        }
-
-        private void InitLocalization()
-        {
-            grpGotoLabel.Text = Strings.EventGotoLabel.title;
-            lblGotoLabel.Text = Strings.EventGotoLabel.label;
-            btnSave.Text = Strings.EventGotoLabel.okay;
-            btnCancel.Text = Strings.EventGotoLabel.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Label = txtGotoLabel.Text;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Input.cs
@@ -4,238 +4,236 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandInput : UserControl
 {
 
-    public partial class EventCommandInput : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    bool mLoading = false;
+
+    private InputVariableCommand mMyCommand;
+
+    public EventCommandInput(InputVariableCommand refCommand, FrmEvent editor)
     {
+        mLoading = true;
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
 
-        private readonly FrmEvent mEventEditor;
+        txtText.Text = mMyCommand.Text;
+        txtTitle.Text = mMyCommand.Title;
+        nudMaxVal.Value = mMyCommand.Maximum;
+        nudMinVal.Value = mMyCommand.Minimum;
 
-        bool mLoading = false;
-
-        private InputVariableCommand mMyCommand;
-
-        public EventCommandInput(InputVariableCommand refCommand, FrmEvent editor)
+        if (mMyCommand.VariableType == VariableType.PlayerVariable)
         {
-            mLoading = true;
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-
-            txtText.Text = mMyCommand.Text;
-            txtTitle.Text = mMyCommand.Title;
-            nudMaxVal.Value = mMyCommand.Maximum;
-            nudMinVal.Value = mMyCommand.Minimum;
-
-            if (mMyCommand.VariableType == VariableType.PlayerVariable)
-            {
-                rdoPlayerVariables.Checked = true;
-            }
-            else if (mMyCommand.VariableType == VariableType.ServerVariable)
-            {
-                rdoGlobalVariables.Checked = true;
-            }
-            else if (mMyCommand.VariableType == VariableType.GuildVariable)
-            {
-                rdoGuildVariables.Checked = true;
-            }
-            else if (mMyCommand.VariableType == VariableType.UserVariable)
-            {
-                rdoUserVariables.Checked = true;
-            }
-
-            LoadVariableList();
-            InitLocalization();
-            mLoading = false;
+            rdoPlayerVariables.Checked = true;
+        }
+        else if (mMyCommand.VariableType == VariableType.ServerVariable)
+        {
+            rdoGlobalVariables.Checked = true;
+        }
+        else if (mMyCommand.VariableType == VariableType.GuildVariable)
+        {
+            rdoGuildVariables.Checked = true;
+        }
+        else if (mMyCommand.VariableType == VariableType.UserVariable)
+        {
+            rdoUserVariables.Checked = true;
         }
 
-        private void InitLocalization()
+        LoadVariableList();
+        InitLocalization();
+        mLoading = false;
+    }
+
+    private void InitLocalization()
+    {
+        grpInput.Text = Strings.EventInput.title;
+        lblText.Text = Strings.EventInput.text;
+        lblTitle.Text = Strings.EventInput.titlestr;
+        lblCommands.Text = Strings.EventInput.commands;
+        btnSave.Text = Strings.EventInput.okay;
+        btnCancel.Text = Strings.EventInput.cancel;
+        rdoPlayerVariables.Text = Strings.EventInput.playervariable;
+        rdoGlobalVariables.Text = Strings.EventInput.globalvariable;
+        rdoGuildVariables.Text = Strings.EventInput.guildvariable;
+        rdoUserVariables.Text = Strings.GameObjectStrings.UserVariable;
+    }
+
+    private void LoadVariableList()
+    {
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariables.Checked)
         {
-            grpInput.Text = Strings.EventInput.title;
-            lblText.Text = Strings.EventInput.text;
-            lblTitle.Text = Strings.EventInput.titlestr;
-            lblCommands.Text = Strings.EventInput.commands;
-            btnSave.Text = Strings.EventInput.okay;
-            btnCancel.Text = Strings.EventInput.cancel;
-            rdoPlayerVariables.Text = Strings.EventInput.playervariable;
-            rdoGlobalVariables.Text = Strings.EventInput.globalvariable;
-            rdoGuildVariables.Text = Strings.EventInput.guildvariable;
-            rdoUserVariables.Text = Strings.GameObjectStrings.UserVariable;
-        }
+            cmbVariable.Items.AddRange(PlayerVariableBase.Names);
+            cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(mMyCommand.VariableId);
 
-        private void LoadVariableList()
-        {
-            cmbVariable.Items.Clear();
-            if (rdoPlayerVariables.Checked)
+            if (cmbVariable.SelectedIndex != -1)
             {
-                cmbVariable.Items.AddRange(PlayerVariableBase.Names);
-                cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(mMyCommand.VariableId);
-
-                if (cmbVariable.SelectedIndex != -1)
-                {
-                    UpdateMinMaxValues(
-                        PlayerVariableBase.Get(PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
-                    );
-                }
-            }
-            else if (rdoGlobalVariables.Checked)
-            {
-                cmbVariable.Items.AddRange(ServerVariableBase.Names);
-                cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(mMyCommand.VariableId);
-
-                if (cmbVariable.SelectedIndex != -1)
-                {
-                    UpdateMinMaxValues(
-                        ServerVariableBase.Get(ServerVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
-                    );
-                }
-            }
-            else if (rdoGuildVariables.Checked)
-            {
-                cmbVariable.Items.AddRange(GuildVariableBase.Names);
-                cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(mMyCommand.VariableId);
-                if (cmbVariable.SelectedIndex != -1)
-                {
-                    UpdateMinMaxValues(
-                        GuildVariableBase.Get(GuildVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
-                    );
-                }
-            }
-            else if (rdoUserVariables.Checked)
-            {
-                cmbVariable.Items.AddRange(UserVariableBase.Names);
-                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(mMyCommand.VariableId);
-                if (cmbVariable.SelectedIndex != -1 && UserVariableBase.TryGet(UserVariableBase.IdFromList(cmbVariable.SelectedIndex), out var userVar))
-                {
-                    UpdateMinMaxValues(
-                       userVar.Type
-                    );
-                }
+                UpdateMinMaxValues(
+                    PlayerVariableBase.Get(PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
+                );
             }
         }
-
-        private void UpdateMinMaxValues(VariableDataType type)
+        else if (rdoGlobalVariables.Checked)
         {
-            lblMaxVal.Show();
-            lblMinVal.Show();
-            nudMaxVal.Show();
-            nudMinVal.Show();
+            cmbVariable.Items.AddRange(ServerVariableBase.Names);
+            cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(mMyCommand.VariableId);
 
-            switch (type)
+            if (cmbVariable.SelectedIndex != -1)
             {
-                case VariableDataType.Integer:
-                case VariableDataType.Number:
-                    lblMinVal.Text = Strings.EventInput.minval;
-                    lblMaxVal.Text = Strings.EventInput.maxval;
-
-                    break;
-                case VariableDataType.String:
-                    lblMinVal.Text = Strings.EventInput.minlength;
-                    lblMaxVal.Text = Strings.EventInput.maxlength;
-
-                    break;
-                case VariableDataType.Boolean:
-                    lblMaxVal.Hide();
-                    lblMinVal.Hide();
-                    nudMaxVal.Hide();
-                    nudMinVal.Hide();
-
-                    break;
+                UpdateMinMaxValues(
+                    ServerVariableBase.Get(ServerVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
+                );
             }
         }
-
-        private void btnSave_Click(object sender, EventArgs e)
+        else if (rdoGuildVariables.Checked)
         {
-            mMyCommand.Text = txtText.Text;
-            mMyCommand.Title = txtTitle.Text;
-            mMyCommand.Maximum = (int) nudMaxVal.Value;
-            mMyCommand.Minimum = (int) nudMinVal.Value;
-
-            if (rdoPlayerVariables.Checked)
+            cmbVariable.Items.AddRange(GuildVariableBase.Names);
+            cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(mMyCommand.VariableId);
+            if (cmbVariable.SelectedIndex != -1)
             {
-                mMyCommand.VariableType = VariableType.PlayerVariable;
-                mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoGlobalVariables.Checked)
-            {
-                mMyCommand.VariableType = VariableType.ServerVariable;
-                mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoGuildVariables.Checked)
-            {
-                mMyCommand.VariableType = VariableType.GuildVariable;
-                mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-            else if (rdoUserVariables.Checked)
-            {
-                mMyCommand.VariableType = VariableType.UserVariable;
-                mMyCommand.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void lblCommands_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
-        private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void VariableRadioChanged()
-        {
-            LoadVariableList();
-            if (!mLoading && cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
+                UpdateMinMaxValues(
+                    GuildVariableBase.Get(GuildVariableBase.IdFromList(cmbVariable.SelectedIndex)).Type
+                );
             }
         }
-
-        private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
+        else if (rdoUserVariables.Checked)
         {
-            var idx = cmbVariable.SelectedIndex;
-            if (rdoPlayerVariables.Checked && PlayerVariableBase.TryGet(PlayerVariableBase.IdFromList(idx), out var playerVar))
+            cmbVariable.Items.AddRange(UserVariableBase.Names);
+            cmbVariable.SelectedIndex = UserVariableBase.ListIndex(mMyCommand.VariableId);
+            if (cmbVariable.SelectedIndex != -1 && UserVariableBase.TryGet(UserVariableBase.IdFromList(cmbVariable.SelectedIndex), out var userVar))
             {
-                UpdateMinMaxValues(playerVar.Type);
-            }
-            else if (rdoGlobalVariables.Checked && ServerVariableBase.TryGet(ServerVariableBase.IdFromList(idx), out var serverVar))
-            {
-                UpdateMinMaxValues(serverVar.Type);
-            }
-            else if (rdoGuildVariables.Checked && GuildVariableBase.TryGet(GuildVariableBase.IdFromList(idx), out var guildVar))
-            {
-                UpdateMinMaxValues(guildVar.Type);
-            }
-            else if (rdoUserVariables.Checked && UserVariableBase.TryGet(UserVariableBase.IdFromList(idx), out var userVar))
-            {
-                UpdateMinMaxValues(userVar.Type);
+                UpdateMinMaxValues(
+                   userVar.Type
+                );
             }
         }
+    }
 
+    private void UpdateMinMaxValues(VariableDataType type)
+    {
+        lblMaxVal.Show();
+        lblMinVal.Show();
+        nudMaxVal.Show();
+        nudMinVal.Show();
+
+        switch (type)
+        {
+            case VariableDataType.Integer:
+            case VariableDataType.Number:
+                lblMinVal.Text = Strings.EventInput.minval;
+                lblMaxVal.Text = Strings.EventInput.maxval;
+
+                break;
+            case VariableDataType.String:
+                lblMinVal.Text = Strings.EventInput.minlength;
+                lblMaxVal.Text = Strings.EventInput.maxlength;
+
+                break;
+            case VariableDataType.Boolean:
+                lblMaxVal.Hide();
+                lblMinVal.Hide();
+                nudMaxVal.Hide();
+                nudMinVal.Hide();
+
+                break;
+        }
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Text = txtText.Text;
+        mMyCommand.Title = txtTitle.Text;
+        mMyCommand.Maximum = (int) nudMaxVal.Value;
+        mMyCommand.Minimum = (int) nudMinVal.Value;
+
+        if (rdoPlayerVariables.Checked)
+        {
+            mMyCommand.VariableType = VariableType.PlayerVariable;
+            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoGlobalVariables.Checked)
+        {
+            mMyCommand.VariableType = VariableType.ServerVariable;
+            mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoGuildVariables.Checked)
+        {
+            mMyCommand.VariableType = VariableType.GuildVariable;
+            mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+        else if (rdoUserVariables.Checked)
+        {
+            mMyCommand.VariableType = VariableType.UserVariable;
+            mMyCommand.VariableId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex);
+        }
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void lblCommands_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
+    }
+
+    private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void VariableRadioChanged()
+    {
+        LoadVariableList();
+        if (!mLoading && cmbVariable.Items.Count > 0)
+        {
+            cmbVariable.SelectedIndex = 0;
+        }
+    }
+
+    private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var idx = cmbVariable.SelectedIndex;
+        if (rdoPlayerVariables.Checked && PlayerVariableBase.TryGet(PlayerVariableBase.IdFromList(idx), out var playerVar))
+        {
+            UpdateMinMaxValues(playerVar.Type);
+        }
+        else if (rdoGlobalVariables.Checked && ServerVariableBase.TryGet(ServerVariableBase.IdFromList(idx), out var serverVar))
+        {
+            UpdateMinMaxValues(serverVar.Type);
+        }
+        else if (rdoGuildVariables.Checked && GuildVariableBase.TryGet(GuildVariableBase.IdFromList(idx), out var guildVar))
+        {
+            UpdateMinMaxValues(guildVar.Type);
+        }
+        else if (rdoUserVariables.Checked && UserVariableBase.TryGet(UserVariableBase.IdFromList(idx), out var userVar))
+        {
+            UpdateMinMaxValues(userVar.Type);
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Label.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Label.cs
@@ -1,44 +1,42 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandLabel : UserControl
 {
 
-    public partial class EventCommandLabel : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private LabelCommand mMyCommand;
+
+    public EventCommandLabel(LabelCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        txtLabel.Text = mMyCommand.Label;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpLabel.Text = Strings.EventLabel.title;
+        lblLabel.Text = Strings.EventLabel.label;
+        btnSave.Text = Strings.EventLabel.okay;
+        btnCancel.Text = Strings.EventLabel.cancel;
+    }
 
-        private LabelCommand mMyCommand;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Label = txtLabel.Text;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        public EventCommandLabel(LabelCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            txtLabel.Text = mMyCommand.Label;
-        }
-
-        private void InitLocalization()
-        {
-            grpLabel.Text = Strings.EventLabel.title;
-            lblLabel.Text = Strings.EventLabel.label;
-            btnSave.Text = Strings.EventLabel.okay;
-            btnCancel.Text = Strings.EventLabel.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Label = txtLabel.Text;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenCrafting.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenCrafting.cs
@@ -2,63 +2,61 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandOpenCraftingTable : UserControl
 {
 
-    public partial class EventCommandOpenCraftingTable : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private OpenCraftingTableCommand mMyCommand;
+
+    public EventCommandOpenCraftingTable(OpenCraftingTableCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbTable.Items.Clear();
+        cmbTable.Items.AddRange(CraftingTableBase.Names);
+        cmbTable.SelectedIndex = CraftingTableBase.ListIndex(mMyCommand.CraftingTableId);
+        chkJournalMode.Checked = mMyCommand.JournalMode;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpTable.Text = Strings.EventOpenCrafting.title;
+        lblTable.Text = Strings.EventOpenCrafting.label;
+        btnSave.Text = Strings.EventOpenCrafting.okay;
+        btnCancel.Text = Strings.EventOpenCrafting.cancel;
+        chkJournalMode.Text = Strings.EventOpenCrafting.JournalMode;
 
-        private OpenCraftingTableCommand mMyCommand;
+        ToolTip toolTip1 = new ToolTip();
 
-        public EventCommandOpenCraftingTable(OpenCraftingTableCommand refCommand, FrmEvent editor)
+        toolTip1.AutoPopDelay = 5000;
+        toolTip1.InitialDelay = 1000;
+        toolTip1.ReshowDelay = 500;
+        toolTip1.ShowAlways = true;
+
+        toolTip1.SetToolTip(chkJournalMode, Strings.EventOpenCrafting.JournalModeTooltip);
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (cmbTable.SelectedIndex > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbTable.Items.Clear();
-            cmbTable.Items.AddRange(CraftingTableBase.Names);
-            cmbTable.SelectedIndex = CraftingTableBase.ListIndex(mMyCommand.CraftingTableId);
-            chkJournalMode.Checked = mMyCommand.JournalMode;
+            mMyCommand.CraftingTableId = CraftingTableBase.IdFromList(cmbTable.SelectedIndex);
         }
 
-        private void InitLocalization()
-        {
-            grpTable.Text = Strings.EventOpenCrafting.title;
-            lblTable.Text = Strings.EventOpenCrafting.label;
-            btnSave.Text = Strings.EventOpenCrafting.okay;
-            btnCancel.Text = Strings.EventOpenCrafting.cancel;
-            chkJournalMode.Text = Strings.EventOpenCrafting.JournalMode;
+        mMyCommand.JournalMode = chkJournalMode.Checked;
 
-            ToolTip toolTip1 = new ToolTip();
+        mEventEditor.FinishCommandEdit();
+    }
 
-            toolTip1.AutoPopDelay = 5000;
-            toolTip1.InitialDelay = 1000;
-            toolTip1.ReshowDelay = 500;
-            toolTip1.ShowAlways = true;
-
-            toolTip1.SetToolTip(chkJournalMode, Strings.EventOpenCrafting.JournalModeTooltip);
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (cmbTable.SelectedIndex > -1)
-            {
-                mMyCommand.CraftingTableId = CraftingTableBase.IdFromList(cmbTable.SelectedIndex);
-            }
-
-            mMyCommand.JournalMode = chkJournalMode.Checked;
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenShop.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_OpenShop.cs
@@ -2,50 +2,48 @@
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandOpenShop : UserControl
 {
 
-    public partial class EventCommandOpenShop : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private OpenShopCommand mMyCommand;
+
+    public EventCommandOpenShop(OpenShopCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbShop.Items.Clear();
+        cmbShop.Items.AddRange(ShopBase.Names);
+        cmbShop.SelectedIndex = ShopBase.ListIndex(mMyCommand.ShopId);
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpShop.Text = Strings.EventOpenShop.title;
+        lblShop.Text = Strings.EventOpenShop.label;
+        btnSave.Text = Strings.EventOpenShop.okay;
+        btnCancel.Text = Strings.EventOpenShop.cancel;
+    }
 
-        private OpenShopCommand mMyCommand;
-
-        public EventCommandOpenShop(OpenShopCommand refCommand, FrmEvent editor)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (cmbShop.SelectedIndex > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbShop.Items.Clear();
-            cmbShop.Items.AddRange(ShopBase.Names);
-            cmbShop.SelectedIndex = ShopBase.ListIndex(mMyCommand.ShopId);
+            mMyCommand.ShopId = ShopBase.IdFromList(cmbShop.SelectedIndex);
         }
 
-        private void InitLocalization()
-        {
-            grpShop.Text = Strings.EventOpenShop.title;
-            lblShop.Text = Strings.EventOpenShop.label;
-            btnSave.Text = Strings.EventOpenShop.okay;
-            btnCancel.Text = Strings.EventOpenShop.cancel;
-        }
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (cmbShop.SelectedIndex > -1)
-            {
-                mMyCommand.ShopId = ShopBase.IdFromList(cmbShop.SelectedIndex);
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Options.cs
@@ -4,89 +4,87 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandOptions : UserControl
 {
 
-    public partial class EventCommandOptions : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private ShowOptionsCommand mMyCommand;
+
+    public EventCommandOptions(ShowOptionsCommand refCommand, EventPage refPage, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        mCurrentPage = refPage;
+        InitLocalization();
+        txtShowOptions.Text = mMyCommand.Text;
+        txtShowOptionsOpt1.Text = mMyCommand.Options[0];
+        txtShowOptionsOpt2.Text = mMyCommand.Options[1];
+        txtShowOptionsOpt3.Text = mMyCommand.Options[2];
+        txtShowOptionsOpt4.Text = mMyCommand.Options[3];
+        cmbFace.Items.Clear();
+        cmbFace.Items.Add(Strings.General.None);
+        cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
+        cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
+        UpdateFacePreview();
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpOptions.Text = Strings.EventShowOptions.title;
+        lblText.Text = Strings.EventShowOptions.text;
+        lblFace.Text = Strings.EventShowOptions.face;
+        lblCommands.Text = Strings.EventShowOptions.commands;
+        lblOpt1.Text = Strings.EventShowOptions.option1;
+        lblOpt2.Text = Strings.EventShowOptions.option2;
+        lblOpt3.Text = Strings.EventShowOptions.option3;
+        lblOpt4.Text = Strings.EventShowOptions.option4;
+        btnSave.Text = Strings.EventShowOptions.okay;
+        btnCancel.Text = Strings.EventShowOptions.cancel;
+    }
 
-        private EventPage mCurrentPage;
-
-        private ShowOptionsCommand mMyCommand;
-
-        public EventCommandOptions(ShowOptionsCommand refCommand, EventPage refPage, FrmEvent editor)
+    private void UpdateFacePreview()
+    {
+        if (pnlFace == null)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            mCurrentPage = refPage;
-            InitLocalization();
-            txtShowOptions.Text = mMyCommand.Text;
-            txtShowOptionsOpt1.Text = mMyCommand.Options[0];
-            txtShowOptionsOpt2.Text = mMyCommand.Options[1];
-            txtShowOptionsOpt3.Text = mMyCommand.Options[2];
-            txtShowOptionsOpt4.Text = mMyCommand.Options[3];
-            cmbFace.Items.Clear();
-            cmbFace.Items.Add(Strings.General.None);
-            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
-            UpdateFacePreview();
+            return;
         }
 
-        private void InitLocalization()
-        {
-            grpOptions.Text = Strings.EventShowOptions.title;
-            lblText.Text = Strings.EventShowOptions.text;
-            lblFace.Text = Strings.EventShowOptions.face;
-            lblCommands.Text = Strings.EventShowOptions.commands;
-            lblOpt1.Text = Strings.EventShowOptions.option1;
-            lblOpt2.Text = Strings.EventShowOptions.option2;
-            lblOpt3.Text = Strings.EventShowOptions.option3;
-            lblOpt4.Text = Strings.EventShowOptions.option4;
-            btnSave.Text = Strings.EventShowOptions.okay;
-            btnCancel.Text = Strings.EventShowOptions.cancel;
-        }
+        pnlFace.BackgroundImage = File.Exists($"resources/faces/{cmbFace?.Text}")
+            ? new Bitmap($"resources/faces/{cmbFace?.Text}")
+            : null;
+    }
 
-        private void UpdateFacePreview()
-        {
-            if (pnlFace == null)
-            {
-                return;
-            }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Text = txtShowOptions.Text;
+        mMyCommand.Options[0] = txtShowOptionsOpt1.Text;
+        mMyCommand.Options[1] = txtShowOptionsOpt2.Text;
+        mMyCommand.Options[2] = txtShowOptionsOpt3.Text;
+        mMyCommand.Options[3] = txtShowOptionsOpt4.Text;
+        mMyCommand.Face = TextUtils.SanitizeNone(cmbFace.Text);
+        mEventEditor.FinishCommandEdit();
+    }
 
-            pnlFace.BackgroundImage = File.Exists($"resources/faces/{cmbFace?.Text}")
-                ? new Bitmap($"resources/faces/{cmbFace?.Text}")
-                : null;
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Text = txtShowOptions.Text;
-            mMyCommand.Options[0] = txtShowOptionsOpt1.Text;
-            mMyCommand.Options[1] = txtShowOptionsOpt2.Text;
-            mMyCommand.Options[2] = txtShowOptionsOpt3.Text;
-            mMyCommand.Options[3] = txtShowOptionsOpt4.Text;
-            mMyCommand.Face = TextUtils.SanitizeNone(cmbFace.Text);
-            mEventEditor.FinishCommandEdit();
-        }
+    private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFacePreview();
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdateFacePreview();
-        }
-
-        private void lblCommands_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
+    private void lblCommands_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayAnimation.cs
@@ -7,317 +7,315 @@ using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;
 using Intersect.GameObjects.Maps.MapList;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandPlayAnimation : UserControl
 {
 
-    public partial class EventCommandPlayAnimation : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private MapBase mCurrentMap;
+
+    private EventBase mEditingEvent;
+
+    private PlayAnimationCommand mMyCommand;
+
+    private int mSpawnX;
+
+    private int mSpawnY;
+
+    private Grid? mGrid;
+
+    public EventCommandPlayAnimation(
+        FrmEvent eventEditor,
+        MapBase currentMap,
+        EventBase currentEvent,
+        PlayAnimationCommand editingCommand
+    )
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private MapBase mCurrentMap;
-
-        private EventBase mEditingEvent;
-
-        private PlayAnimationCommand mMyCommand;
-
-        private int mSpawnX;
-
-        private int mSpawnY;
-
-        private Grid? mGrid;
-
-        public EventCommandPlayAnimation(
-            FrmEvent eventEditor,
-            MapBase currentMap,
-            EventBase currentEvent,
-            PlayAnimationCommand editingCommand
-        )
+        InitializeComponent();
+        mMyCommand = editingCommand;
+        mEventEditor = eventEditor;
+        mEditingEvent = currentEvent;
+        mCurrentMap = currentMap;
+        InitLocalization();
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+        cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mMyCommand.AnimationId);
+        if (mMyCommand.MapId != Guid.Empty)
         {
-            InitializeComponent();
-            mMyCommand = editingCommand;
-            mEventEditor = eventEditor;
-            mEditingEvent = currentEvent;
-            mCurrentMap = currentMap;
-            InitLocalization();
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
-            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mMyCommand.AnimationId);
-            if (mMyCommand.MapId != Guid.Empty)
-            {
-                cmbConditionType.SelectedIndex = 0;
-            }
-            else
-            {
-                cmbConditionType.SelectedIndex = 1;
-            }
-
-            chkInstanceToPlayer.Checked = mMyCommand.InstanceToPlayer;
-
-            nudWarpX.Maximum = Options.MapWidth;
-            nudWarpY.Maximum = Options.MapHeight;
-            UpdateFormElements();
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile spawn
-                    //Fill in the map cmb
-                    nudWarpX.Value = mMyCommand.X;
-                    nudWarpY.Value = mMyCommand.Y;
-                    cmbDirection.SelectedIndex = mMyCommand.Dir;
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    mSpawnX = mMyCommand.X;
-                    mSpawnY = mMyCommand.Y;
-                    switch (mMyCommand.Dir)
-                    {
-                        //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                        case 1:
-                            chkRelativeLocation.Checked = true;
-
-                            break;
-                        case 2:
-                            chkRotateDirection.Checked = true;
-
-                            break;
-                        case 3:
-                            chkRelativeLocation.Checked = true;
-                            chkRotateDirection.Checked = true;
-
-                            break;
-                    }
-
-                    UpdateSpawnPreview();
-
-                    break;
-            }
+            cmbConditionType.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbConditionType.SelectedIndex = 1;
         }
 
-        private void InitLocalization()
+        chkInstanceToPlayer.Checked = mMyCommand.InstanceToPlayer;
+
+        nudWarpX.Maximum = Options.MapWidth;
+        nudWarpY.Maximum = Options.MapHeight;
+        UpdateFormElements();
+        switch (cmbConditionType.SelectedIndex)
         {
-            grpPlayAnimation.Text = Strings.EventPlayAnimation.title;
-            lblAnimation.Text = Strings.EventPlayAnimation.animation;
-            lblSpawnType.Text = Strings.EventPlayAnimation.spawntype;
-            cmbConditionType.Items.Clear();
-            cmbConditionType.Items.Add(Strings.EventPlayAnimation.spawntype0);
-            cmbConditionType.Items.Add(Strings.EventPlayAnimation.spawntype1);
+            case 0: //Tile spawn
+                //Fill in the map cmb
+                nudWarpX.Value = mMyCommand.X;
+                nudWarpY.Value = mMyCommand.Y;
+                cmbDirection.SelectedIndex = mMyCommand.Dir;
 
-            grpTileSpawn.Text = Strings.EventPlayAnimation.spawntype0;
-            grpEntitySpawn.Text = Strings.EventPlayAnimation.spawntype1;
-
-            lblMap.Text = Strings.Warping.map.ToString("");
-            lblX.Text = Strings.Warping.x.ToString("");
-            lblY.Text = Strings.Warping.y.ToString("");
-            lblDir.Text = Strings.Warping.direction.ToString("");
-            cmbDirection.Items.Clear();
-            for (var i = 0; i < 4; i++)
-            {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-
-            cmbDirection.SelectedIndex = 0;
-
-            lblEntity.Text = Strings.EventPlayAnimation.entity;
-            lblRelativeLocation.Text = Strings.EventPlayAnimation.relativelocation;
-            chkRelativeLocation.Text = Strings.EventPlayAnimation.spawnrelative;
-            chkRotateDirection.Text = Strings.EventPlayAnimation.rotaterelative;
-
-            chkInstanceToPlayer.Text = Strings.EventPlayAnimation.InstanceToPlayer;
-            
-            ToolTip instanceTooltip = new ToolTip()
-            {
-                InitialDelay = 1000,
-                ReshowDelay = 500
-            };
-            instanceTooltip.SetToolTip(chkInstanceToPlayer, Strings.EventPlayAnimation.InstanceToPlayerTooltip);
-
-            btnSave.Text = Strings.EventPlayAnimation.okay;
-            btnCancel.Text = Strings.EventPlayAnimation.cancel;
-        }
-
-        private void UpdateFormElements()
-        {
-            grpTileSpawn.Hide();
-            grpEntitySpawn.Hide();
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile Spawn
-                    grpTileSpawn.Show();
-                    cmbMap.Items.Clear();
-                    for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                    {
-                        cmbMap.Items.Add($@"{MapList.OrderedMaps[i].Name} ({MapList.OrderedMaps[i].MapId})");
-                        if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
-                        {
-                            cmbMap.SelectedIndex = i;
-                        }
-                    }
-
-                    if (cmbMap.SelectedIndex == -1)
-                    {
-                        cmbMap.SelectedIndex = 0;
-                    }
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    grpEntitySpawn.Show();
-                    cmbEntities.Items.Clear();
-                    cmbEntities.Items.Add(Strings.EventPlayAnimation.player);
-                    cmbEntities.SelectedIndex = 0;
-
-                    if (!mEditingEvent.CommonEvent)
-                    {
-                        foreach (var evt in mCurrentMap.LocalEvents)
-                        {
-                            cmbEntities.Items.Add(
-                                evt.Key == mEditingEvent.Id
-                                    ? Strings.EventPlayAnimation.This + " "
-                                    : "" + evt.Value.Name
-                            );
-
-                            if (mMyCommand.EntityId == evt.Key)
-                            {
-                                cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
-                            }
-                        }
-                    }
-
-                    UpdateSpawnPreview();
-
-                    break;
-            }
-        }
-
-        private void UpdateSpawnPreview()
-        {
-            if (mGrid == null)
-            {
-                mGrid = new Grid
+                break;
+            case 1: //On/Around Entity Spawn
+                mSpawnX = mMyCommand.X;
+                mSpawnY = mMyCommand.Y;
+                switch (mMyCommand.Dir)
                 {
-                    DisplayWidth = pnlSpawnLoc.Width,
-                    DisplayHeight = pnlSpawnLoc.Height,
-                    Columns = 5,
-                    Rows = 5,
-                    Cells = new[] { new GridCell(2, 2, null, "E") }
-                };
-            }
-
-            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(
-                mGrid.Value.WithAdditionalCells(
-                    new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red)
-                )
-            );
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex);
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile Spawn
-                    mMyCommand.EntityId = Guid.Empty;
-                    mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
-                    mMyCommand.X = (sbyte) nudWarpX.Value;
-                    mMyCommand.Y = (sbyte) nudWarpY.Value;
-                    mMyCommand.Dir = (byte) cmbDirection.SelectedIndex;
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    mMyCommand.MapId = Guid.Empty;
-                    if (cmbEntities.SelectedIndex == 0 || cmbEntities.SelectedIndex == -1)
-                    {
-                        mMyCommand.EntityId = Guid.Empty;
-                    }
-                    else
-                    {
-                        mMyCommand.EntityId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
-                    }
-
-                    mMyCommand.X = (sbyte) mSpawnX;
-                    mMyCommand.Y = (sbyte) mSpawnY;
-                    if (chkRelativeLocation.Checked && chkRotateDirection.Checked)
-                    {
-                        mMyCommand.Dir = 3;
-
-                        //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                    }
-                    else if (chkRelativeLocation.Checked)
-                    {
-                        mMyCommand.Dir = 1;
-
-                        //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                    }
-                    else if (chkRotateDirection.Checked)
-                    {
-                        mMyCommand.Dir = 2;
-
-                        //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                    }
-                    else
-                    {
-                        mMyCommand.Dir = 0;
-
-                        //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
-                    }
-
-                    break;
-            }
-
-            mMyCommand.InstanceToPlayer = chkInstanceToPlayer.Checked;
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdateFormElements();
-        }
-
-        private void btnVisual_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(
-                MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, (int) nudWarpX.Value, (int) nudWarpY.Value
-            );
-
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
-                    {
-                        cmbMap.SelectedIndex = i;
+                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                    case 1:
+                        chkRelativeLocation.Checked = true;
 
                         break;
+                    case 2:
+                        chkRotateDirection.Checked = true;
+
+                        break;
+                    case 3:
+                        chkRelativeLocation.Checked = true;
+                        chkRotateDirection.Checked = true;
+
+                        break;
+                }
+
+                UpdateSpawnPreview();
+
+                break;
+        }
+    }
+
+    private void InitLocalization()
+    {
+        grpPlayAnimation.Text = Strings.EventPlayAnimation.title;
+        lblAnimation.Text = Strings.EventPlayAnimation.animation;
+        lblSpawnType.Text = Strings.EventPlayAnimation.spawntype;
+        cmbConditionType.Items.Clear();
+        cmbConditionType.Items.Add(Strings.EventPlayAnimation.spawntype0);
+        cmbConditionType.Items.Add(Strings.EventPlayAnimation.spawntype1);
+
+        grpTileSpawn.Text = Strings.EventPlayAnimation.spawntype0;
+        grpEntitySpawn.Text = Strings.EventPlayAnimation.spawntype1;
+
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y.ToString("");
+        lblDir.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = 0; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        cmbDirection.SelectedIndex = 0;
+
+        lblEntity.Text = Strings.EventPlayAnimation.entity;
+        lblRelativeLocation.Text = Strings.EventPlayAnimation.relativelocation;
+        chkRelativeLocation.Text = Strings.EventPlayAnimation.spawnrelative;
+        chkRotateDirection.Text = Strings.EventPlayAnimation.rotaterelative;
+
+        chkInstanceToPlayer.Text = Strings.EventPlayAnimation.InstanceToPlayer;
+        
+        ToolTip instanceTooltip = new ToolTip()
+        {
+            InitialDelay = 1000,
+            ReshowDelay = 500
+        };
+        instanceTooltip.SetToolTip(chkInstanceToPlayer, Strings.EventPlayAnimation.InstanceToPlayerTooltip);
+
+        btnSave.Text = Strings.EventPlayAnimation.okay;
+        btnCancel.Text = Strings.EventPlayAnimation.cancel;
+    }
+
+    private void UpdateFormElements()
+    {
+        grpTileSpawn.Hide();
+        grpEntitySpawn.Hide();
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile Spawn
+                grpTileSpawn.Show();
+                cmbMap.Items.Clear();
+                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+                {
+                    cmbMap.Items.Add($@"{MapList.OrderedMaps[i].Name} ({MapList.OrderedMaps[i].MapId})");
+                    if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
+                    {
+                        cmbMap.SelectedIndex = i;
                     }
                 }
 
-                nudWarpX.Value = frmWarpSelection.GetX();
-                nudWarpY.Value = frmWarpSelection.GetY();
-            }
-        }
+                if (cmbMap.SelectedIndex == -1)
+                {
+                    cmbMap.SelectedIndex = 0;
+                }
 
-        private void pnlSpawnLoc_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (mGrid == null)
-            {
-                return;
-            }
+                break;
+            case 1: //On/Around Entity Spawn
+                grpEntitySpawn.Show();
+                cmbEntities.Items.Clear();
+                cmbEntities.Items.Add(Strings.EventPlayAnimation.player);
+                cmbEntities.SelectedIndex = 0;
 
-            var cell = GridHelper.CellFromPoint(mGrid.Value, e.X, e.Y);
-            if (cell != null)
-            {
-                (mSpawnX, mSpawnY) = cell.Value;
+                if (!mEditingEvent.CommonEvent)
+                {
+                    foreach (var evt in mCurrentMap.LocalEvents)
+                    {
+                        cmbEntities.Items.Add(
+                            evt.Key == mEditingEvent.Id
+                                ? Strings.EventPlayAnimation.This + " "
+                                : "" + evt.Value.Name
+                        );
+
+                        if (mMyCommand.EntityId == evt.Key)
+                        {
+                            cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
+                        }
+                    }
+                }
+
                 UpdateSpawnPreview();
-            }
+
+                break;
+        }
+    }
+
+    private void UpdateSpawnPreview()
+    {
+        if (mGrid == null)
+        {
+            mGrid = new Grid
+            {
+                DisplayWidth = pnlSpawnLoc.Width,
+                DisplayHeight = pnlSpawnLoc.Height,
+                Columns = 5,
+                Rows = 5,
+                Cells = new[] { new GridCell(2, 2, null, "E") }
+            };
         }
 
+        pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(
+            mGrid.Value.WithAdditionalCells(
+                new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red)
+            )
+        );
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex);
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile Spawn
+                mMyCommand.EntityId = Guid.Empty;
+                mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
+                mMyCommand.X = (sbyte) nudWarpX.Value;
+                mMyCommand.Y = (sbyte) nudWarpY.Value;
+                mMyCommand.Dir = (byte) cmbDirection.SelectedIndex;
+
+                break;
+            case 1: //On/Around Entity Spawn
+                mMyCommand.MapId = Guid.Empty;
+                if (cmbEntities.SelectedIndex == 0 || cmbEntities.SelectedIndex == -1)
+                {
+                    mMyCommand.EntityId = Guid.Empty;
+                }
+                else
+                {
+                    mMyCommand.EntityId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
+                }
+
+                mMyCommand.X = (sbyte) mSpawnX;
+                mMyCommand.Y = (sbyte) mSpawnY;
+                if (chkRelativeLocation.Checked && chkRotateDirection.Checked)
+                {
+                    mMyCommand.Dir = 3;
+
+                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                }
+                else if (chkRelativeLocation.Checked)
+                {
+                    mMyCommand.Dir = 1;
+
+                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                }
+                else if (chkRotateDirection.Checked)
+                {
+                    mMyCommand.Dir = 2;
+
+                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                }
+                else
+                {
+                    mMyCommand.Dir = 0;
+
+                    //0 does not adhere to direction, 1 is Spawning Relative to Direction, 2 is Rotating Relative to Direction, and 3 is both.
+                }
+
+                break;
+        }
+
+        mMyCommand.InstanceToPlayer = chkInstanceToPlayer.Checked;
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFormElements();
+    }
+
+    private void btnVisual_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, (int) nudWarpX.Value, (int) nudWarpY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbMap.SelectedIndex = i;
+
+                    break;
+                }
+            }
+
+            nudWarpX.Value = frmWarpSelection.GetX();
+            nudWarpY.Value = frmWarpSelection.GetY();
+        }
+    }
+
+    private void pnlSpawnLoc_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (mGrid == null)
+        {
+            return;
+        }
+
+        var cell = GridHelper.CellFromPoint(mGrid.Value, e.X, e.Y);
+        if (cell != null)
+        {
+            (mSpawnX, mSpawnY) = cell.Value;
+            UpdateSpawnPreview();
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgm.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgm.cs
@@ -3,58 +3,56 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandPlayBgm : UserControl
 {
 
-    public partial class EventCommandPlayBgm : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private PlayBgmCommand mMyCommand;
+
+    public EventCommandPlayBgm(PlayBgmCommand refCommand, FrmEvent editor)
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private PlayBgmCommand mMyCommand;
-
-        public EventCommandPlayBgm(PlayBgmCommand refCommand, FrmEvent editor)
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbBgm.Items.Clear();
+        cmbBgm.Items.Add(Strings.General.None);
+        cmbBgm.Items.AddRange(GameContentManager.SmartSortedMusicNames);
+        if (cmbBgm.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File)) > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbBgm.Items.Clear();
-            cmbBgm.Items.Add(Strings.General.None);
-            cmbBgm.Items.AddRange(GameContentManager.SmartSortedMusicNames);
-            if (cmbBgm.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File)) > -1)
-            {
-                cmbBgm.SelectedIndex = cmbBgm.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File));
-            }
-            else
-            {
-                cmbBgm.SelectedIndex = 0;
-            }
+            cmbBgm.SelectedIndex = cmbBgm.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File));
         }
-
-        private void InitLocalization()
+        else
         {
-            grpBGM.Text = Strings.EventPlayBgm.title;
-            lblBGM.Text = Strings.EventPlayBgm.label;
-            btnSave.Text = Strings.EventPlayBgm.okay;
-            btnCancel.Text = Strings.EventPlayBgm.cancel;
+            cmbBgm.SelectedIndex = 0;
         }
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.File = TextUtils.SanitizeNone(cmbBgm?.Text);
-            mEventEditor.FinishCommandEdit();
-        }
+    private void InitLocalization()
+    {
+        grpBGM.Text = Strings.EventPlayBgm.title;
+        lblBGM.Text = Strings.EventPlayBgm.label;
+        btnSave.Text = Strings.EventPlayBgm.okay;
+        btnCancel.Text = Strings.EventPlayBgm.cancel;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.File = TextUtils.SanitizeNone(cmbBgm?.Text);
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgs.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_PlayBgs.cs
@@ -3,58 +3,56 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandPlayBgs : UserControl
 {
 
-    public partial class EventCommandPlayBgs : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private PlaySoundCommand mMyCommand;
+
+    public EventCommandPlayBgs(PlaySoundCommand refCommand, FrmEvent editor)
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private PlaySoundCommand mMyCommand;
-
-        public EventCommandPlayBgs(PlaySoundCommand refCommand, FrmEvent editor)
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbSound.Items.Clear();
+        cmbSound.Items.Add(Strings.General.None);
+        cmbSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+        if (cmbSound.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File)) > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbSound.Items.Clear();
-            cmbSound.Items.Add(Strings.General.None);
-            cmbSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-            if (cmbSound.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File)) > -1)
-            {
-                cmbSound.SelectedIndex = cmbSound.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File));
-            }
-            else
-            {
-                cmbSound.SelectedIndex = 0;
-            }
+            cmbSound.SelectedIndex = cmbSound.Items.IndexOf(TextUtils.NullToNone(mMyCommand.File));
         }
-
-        private void InitLocalization()
+        else
         {
-            grpPlayBGS.Text = Strings.EventPlayBgs.title;
-            lblSound.Text = Strings.EventPlayBgs.label;
-            btnSave.Text = Strings.EventPlayBgs.okay;
-            btnCancel.Text = Strings.EventPlayBgs.cancel;
+            cmbSound.SelectedIndex = 0;
         }
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.File = TextUtils.SanitizeNone(cmbSound?.Text);
-            mEventEditor.FinishCommandEdit();
-        }
+    private void InitLocalization()
+    {
+        grpPlayBGS.Text = Strings.EventPlayBgs.title;
+        lblSound.Text = Strings.EventPlayBgs.label;
+        btnSave.Text = Strings.EventPlayBgs.okay;
+        btnCancel.Text = Strings.EventPlayBgs.cancel;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.File = TextUtils.SanitizeNone(cmbSound?.Text);
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SelfSwitch.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SelfSwitch.cs
@@ -1,55 +1,53 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSelfSwitch : UserControl
 {
 
-    public partial class EventCommandSelfSwitch : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private SetSelfSwitchCommand mMyCommand;
+
+    public EventCommandSelfSwitch(SetSelfSwitchCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbSetSwitch.SelectedIndex = mMyCommand.SwitchId;
+        cmbSetSwitchVal.SelectedIndex = Convert.ToInt32(mMyCommand.Value);
+    }
 
-        private readonly FrmEvent mEventEditor;
-
-        private SetSelfSwitchCommand mMyCommand;
-
-        public EventCommandSelfSwitch(SetSelfSwitchCommand refCommand, FrmEvent editor)
+    private void InitLocalization()
+    {
+        grpSelfSwitch.Text = Strings.EventSelfSwitch.title;
+        lblSelfSwitch.Text = Strings.EventSelfSwitch.label;
+        cmbSetSwitch.Items.Clear();
+        for (var i = 0; i < Strings.EventSelfSwitch.selfswitches.Count; i++)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbSetSwitch.SelectedIndex = mMyCommand.SwitchId;
-            cmbSetSwitchVal.SelectedIndex = Convert.ToInt32(mMyCommand.Value);
+            cmbSetSwitch.Items.Add(Strings.EventSelfSwitch.selfswitches[i]);
         }
 
-        private void InitLocalization()
-        {
-            grpSelfSwitch.Text = Strings.EventSelfSwitch.title;
-            lblSelfSwitch.Text = Strings.EventSelfSwitch.label;
-            cmbSetSwitch.Items.Clear();
-            for (var i = 0; i < Strings.EventSelfSwitch.selfswitches.Count; i++)
-            {
-                cmbSetSwitch.Items.Add(Strings.EventSelfSwitch.selfswitches[i]);
-            }
+        cmbSetSwitchVal.Items.Clear();
+        cmbSetSwitchVal.Items.Add(Strings.EventSelfSwitch.False);
+        cmbSetSwitchVal.Items.Add(Strings.EventSelfSwitch.True);
+        btnSave.Text = Strings.EventSelfSwitch.okay;
+        btnCancel.Text = Strings.EventSelfSwitch.cancel;
+    }
 
-            cmbSetSwitchVal.Items.Clear();
-            cmbSetSwitchVal.Items.Add(Strings.EventSelfSwitch.False);
-            cmbSetSwitchVal.Items.Add(Strings.EventSelfSwitch.True);
-            btnSave.Text = Strings.EventSelfSwitch.okay;
-            btnCancel.Text = Strings.EventSelfSwitch.cancel;
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.SwitchId = cmbSetSwitch.SelectedIndex;
+        mMyCommand.Value = Convert.ToBoolean(cmbSetSwitchVal.SelectedIndex);
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.SwitchId = cmbSetSwitch.SelectedIndex;
-            mMyCommand.Value = Convert.ToBoolean(cmbSetSwitchVal.SelectedIndex);
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAccess.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAccess.cs
@@ -2,48 +2,46 @@
 using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSetAccess : UserControl
 {
 
-    public partial class EventCommandSetAccess : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private SetAccessCommand mMyCommand;
+
+    public EventCommandSetAccess(SetAccessCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbAccess.SelectedIndex = (int) mMyCommand.Access;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpSetAccess.Text = Strings.EventSetAccess.title;
+        lblAccess.Text = Strings.EventSetAccess.label;
+        cmbAccess.Items.Clear();
+        cmbAccess.Items.Add(Strings.EventSetAccess.access0);
+        cmbAccess.Items.Add(Strings.EventSetAccess.access1);
+        cmbAccess.Items.Add(Strings.EventSetAccess.access2);
+        btnSave.Text = Strings.EventSetAccess.okay;
+        btnCancel.Text = Strings.EventSetAccess.cancel;
+    }
 
-        private SetAccessCommand mMyCommand;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Access = (Access) cmbAccess.SelectedIndex;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        public EventCommandSetAccess(SetAccessCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbAccess.SelectedIndex = (int) mMyCommand.Access;
-        }
-
-        private void InitLocalization()
-        {
-            grpSetAccess.Text = Strings.EventSetAccess.title;
-            lblAccess.Text = Strings.EventSetAccess.label;
-            cmbAccess.Items.Clear();
-            cmbAccess.Items.Add(Strings.EventSetAccess.access0);
-            cmbAccess.Items.Add(Strings.EventSetAccess.access1);
-            cmbAccess.Items.Add(Strings.EventSetAccess.access2);
-            btnSave.Text = Strings.EventSetAccess.okay;
-            btnCancel.Text = Strings.EventSetAccess.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Access = (Access) cmbAccess.SelectedIndex;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetClass.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetClass.cs
@@ -2,50 +2,48 @@
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSetClass : UserControl
 {
 
-    public partial class EventCommandSetClass : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private SetClassCommand mMyCommand;
+
+    public EventCommandSetClass(SetClassCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbClass.Items.Clear();
+        cmbClass.Items.AddRange(ClassBase.Names);
+        cmbClass.SelectedIndex = ClassBase.ListIndex(mMyCommand.ClassId);
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpSetClass.Text = Strings.EventSetClass.title;
+        lblClass.Text = Strings.EventSetClass.label;
+        btnSave.Text = Strings.EventSetClass.okay;
+        btnCancel.Text = Strings.EventSetClass.cancel;
+    }
 
-        private SetClassCommand mMyCommand;
-
-        public EventCommandSetClass(SetClassCommand refCommand, FrmEvent editor)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (cmbClass.SelectedIndex > -1)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbClass.Items.Clear();
-            cmbClass.Items.AddRange(ClassBase.Names);
-            cmbClass.SelectedIndex = ClassBase.ListIndex(mMyCommand.ClassId);
+            mMyCommand.ClassId = ClassBase.IdFromList(cmbClass.SelectedIndex);
         }
 
-        private void InitLocalization()
-        {
-            grpSetClass.Text = Strings.EventSetClass.title;
-            lblClass.Text = Strings.EventSetClass.label;
-            btnSave.Text = Strings.EventSetClass.okay;
-            btnCancel.Text = Strings.EventSetClass.cancel;
-        }
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (cmbClass.SelectedIndex > -1)
-            {
-                mMyCommand.ClassId = ClassBase.IdFromList(cmbClass.SelectedIndex);
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetGuildBankSlots.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetGuildBankSlots.cs
@@ -4,167 +4,165 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSetGuildBankSlots : UserControl
 {
 
-    public partial class EventCommandSetGuildBankSlots : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private SetGuildBankSlotsCommand mMyCommand;
+
+    public EventCommandSetGuildBankSlots(SetGuildBankSlotsCommand refCommand, EventPage refPage, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        mCurrentPage = refPage;
+        InitLocalization();
 
-        private readonly FrmEvent mEventEditor;
+        rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
+        rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
 
-        private EventPage mCurrentPage;
+        SetupAmountInput();
+    }
 
-        private SetGuildBankSlotsCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpGuildSlots.Text = Strings.EventGuildSetBankSlotsCount.title;
+        lblVariable.Text = Strings.EventGuildSetBankSlotsCount.Variable;
 
-        public EventCommandSetGuildBankSlots(SetGuildBankSlotsCommand refCommand, EventPage refPage, FrmEvent editor)
+        rdoPlayerVariable.Text = Strings.EventGuildSetBankSlotsCount.PlayerVariable;
+        rdoGlobalVariable.Text = Strings.EventGuildSetBankSlotsCount.ServerVariable;
+        rdoGuildVariable.Text = Strings.EventGuildSetBankSlotsCount.GuildVariable;
+
+        btnSave.Text = Strings.EventGuildSetBankSlotsCount.okay;
+        btnCancel.Text = Strings.EventGuildSetBankSlotsCount.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (rdoPlayerVariable.Checked)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            mCurrentPage = refPage;
-            InitLocalization();
-
-            rdoGlobalVariable.Checked = mMyCommand.VariableType == VariableType.ServerVariable;
-            rdoGuildVariable.Checked = mMyCommand.VariableType == VariableType.GuildVariable;
-
-            SetupAmountInput();
+            mMyCommand.VariableType = VariableType.PlayerVariable;
+            mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            mMyCommand.VariableType = VariableType.ServerVariable;
+            mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
+        }
+        else if (rdoGuildVariable.Checked)
+        {
+            mMyCommand.VariableType = VariableType.GuildVariable;
+            mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
         }
 
-        private void InitLocalization()
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void VariableBlank()
+    {
+        if (cmbVariable.Items.Count > 0)
         {
-            grpGuildSlots.Text = Strings.EventGuildSetBankSlotsCount.title;
-            lblVariable.Text = Strings.EventGuildSetBankSlotsCount.Variable;
-
-            rdoPlayerVariable.Text = Strings.EventGuildSetBankSlotsCount.PlayerVariable;
-            rdoGlobalVariable.Text = Strings.EventGuildSetBankSlotsCount.ServerVariable;
-            rdoGuildVariable.Text = Strings.EventGuildSetBankSlotsCount.GuildVariable;
-
-            btnSave.Text = Strings.EventGuildSetBankSlotsCount.okay;
-            btnCancel.Text = Strings.EventGuildSetBankSlotsCount.cancel;
+            cmbVariable.SelectedIndex = 0;
         }
-
-        private void btnSave_Click(object sender, EventArgs e)
+        else
         {
-            if (rdoPlayerVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.PlayerVariable;
-                mMyCommand.VariableId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.ServerVariable;
-                mMyCommand.VariableId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-            else if (rdoGuildVariable.Checked)
-            {
-                mMyCommand.VariableType = VariableType.GuildVariable;
-                mMyCommand.VariableId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex, VariableDataType.Integer);
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void VariableBlank()
-        {
-            if (cmbVariable.Items.Count > 0)
-            {
-                cmbVariable.SelectedIndex = 0;
-            }
-            else
-            {
-                cmbVariable.SelectedIndex = -1;
-                cmbVariable.Text = "";
-            }
-        }
-
-        private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            SetupAmountInput();
-        }
-
-        private void SetupAmountInput()
-        {
-
-            cmbVariable.Items.Clear();
-            if (rdoPlayerVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.PlayerVariable)
-                {
-                    var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            else if (rdoGlobalVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.ServerVariable)
-                {
-                    var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
-            if (rdoGuildVariable.Checked)
-            {
-                cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
-                // Do not update if the wrong type of variable is saved
-                if (mMyCommand.VariableType == VariableType.GuildVariable)
-                {
-                    var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
-                    if (index > -1)
-                    {
-                        cmbVariable.SelectedIndex = index;
-                    }
-                    else
-                    {
-                        VariableBlank();
-                    }
-                }
-                else
-                {
-                    VariableBlank();
-                }
-            }
+            cmbVariable.SelectedIndex = -1;
+            cmbVariable.Text = "";
         }
     }
 
+    private void rdoPlayerVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGlobalVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void rdoGuildVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        SetupAmountInput();
+    }
+
+    private void SetupAmountInput()
+    {
+
+        cmbVariable.Items.Clear();
+        if (rdoPlayerVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(PlayerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.PlayerVariable)
+            {
+                var index = PlayerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        else if (rdoGlobalVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(ServerVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.ServerVariable)
+            {
+                var index = ServerVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+        if (rdoGuildVariable.Checked)
+        {
+            cmbVariable.Items.AddRange(GuildVariableBase.GetNamesByType(VariableDataType.Integer));
+            // Do not update if the wrong type of variable is saved
+            if (mMyCommand.VariableType == VariableType.GuildVariable)
+            {
+                var index = GuildVariableBase.ListIndex(mMyCommand.VariableId, VariableDataType.Integer);
+                if (index > -1)
+                {
+                    cmbVariable.SelectedIndex = index;
+                }
+                else
+                {
+                    VariableBlank();
+                }
+            }
+            else
+            {
+                VariableBlank();
+            }
+        }
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ShowPicture.cs
@@ -2,78 +2,76 @@
 using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommand_ShowPicture : UserControl
 {
 
-    public partial class EventCommand_ShowPicture : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ShowPictureCommand mMyCommand;
+
+    public EventCommand_ShowPicture(ShowPictureCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbPicture.Items.Clear();
 
-        private readonly FrmEvent mEventEditor;
+        var sortedTextures = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image);
 
-        private ShowPictureCommand mMyCommand;
-
-        public EventCommand_ShowPicture(ShowPictureCommand refCommand, FrmEvent editor)
+        if (sortedTextures.Length > 0)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbPicture.Items.Clear();
-
-            var sortedTextures = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image);
-
-            if (sortedTextures.Length > 0)
-            {
-                cmbPicture.Items.AddRange(sortedTextures);
-            }
-            else
-            {
-                cmbPicture.Items.Add(Strings.General.None);
-            }
-
-            cmbSize.Items.Clear();
-            cmbSize.Items.Add(Strings.EventShowPicture.original);
-            cmbSize.Items.Add(Strings.EventShowPicture.fullscreen);
-            cmbSize.Items.Add(Strings.EventShowPicture.halfscreen);
-            cmbSize.Items.Add(Strings.EventShowPicture.stretchtofit);
-
-            if (mMyCommand != null)
-            {
-                cmbPicture.SelectedIndex = Math.Max(0, cmbPicture.Items.IndexOf(mMyCommand.File));
-                cmbSize.SelectedIndex = Math.Max(0, mMyCommand.Size);
-                chkClick.Checked = mMyCommand.Clickable;
-                nudHideTime.Value = mMyCommand.HideTime;
-                chkWaitUntilClosed.Checked = mMyCommand.WaitUntilClosed;
-            }
+            cmbPicture.Items.AddRange(sortedTextures);
+        }
+        else
+        {
+            cmbPicture.Items.Add(Strings.General.None);
         }
 
-        private void InitLocalization()
-        {
-            grpShowPicture.Text = Strings.EventShowPicture.title;
-            lblPicture.Text = Strings.EventShowPicture.label;
-            btnSave.Text = Strings.EventShowPicture.okay;
-            btnCancel.Text = Strings.EventShowPicture.cancel;
-            chkClick.Text = Strings.EventShowPicture.checkbox;
-            lblSize.Text = Strings.EventShowPicture.size;
-            lblHide.Text = Strings.EventShowPicture.hide;
-            chkWaitUntilClosed.Text = Strings.EventShowPicture.wait;
-        }
+        cmbSize.Items.Clear();
+        cmbSize.Items.Add(Strings.EventShowPicture.original);
+        cmbSize.Items.Add(Strings.EventShowPicture.fullscreen);
+        cmbSize.Items.Add(Strings.EventShowPicture.halfscreen);
+        cmbSize.Items.Add(Strings.EventShowPicture.stretchtofit);
 
-        private void btnSave_Click(object sender, EventArgs e)
+        if (mMyCommand != null)
         {
-            mMyCommand.File = cmbPicture.Text;
-            mMyCommand.Size = cmbSize.SelectedIndex;
-            mMyCommand.Clickable = chkClick.Checked;
-            mMyCommand.HideTime = (int)nudHideTime.Value;
-            mMyCommand.WaitUntilClosed = chkWaitUntilClosed.Checked;
-            mEventEditor.FinishCommandEdit();
+            cmbPicture.SelectedIndex = Math.Max(0, cmbPicture.Items.IndexOf(mMyCommand.File));
+            cmbSize.SelectedIndex = Math.Max(0, mMyCommand.Size);
+            chkClick.Checked = mMyCommand.Clickable;
+            nudHideTime.Value = mMyCommand.HideTime;
+            chkWaitUntilClosed.Checked = mMyCommand.WaitUntilClosed;
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void InitLocalization()
+    {
+        grpShowPicture.Text = Strings.EventShowPicture.title;
+        lblPicture.Text = Strings.EventShowPicture.label;
+        btnSave.Text = Strings.EventShowPicture.okay;
+        btnCancel.Text = Strings.EventShowPicture.cancel;
+        chkClick.Text = Strings.EventShowPicture.checkbox;
+        lblSize.Text = Strings.EventShowPicture.size;
+        lblHide.Text = Strings.EventShowPicture.hide;
+        chkWaitUntilClosed.Text = Strings.EventShowPicture.wait;
+    }
 
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.File = cmbPicture.Text;
+        mMyCommand.Size = cmbSize.SelectedIndex;
+        mMyCommand.Clickable = chkClick.Checked;
+        mMyCommand.HideTime = (int)nudHideTime.Value;
+        mMyCommand.WaitUntilClosed = chkWaitUntilClosed.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnNpc.cs
@@ -7,262 +7,260 @@ using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;
 using Intersect.GameObjects.Maps.MapList;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSpawnNpc : UserControl
 {
 
-    public partial class EventCommandSpawnNpc : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private MapBase mCurrentMap;
+
+    private EventBase mEditingEvent;
+
+    private SpawnNpcCommand mMyCommand;
+
+    private int mSpawnX;
+
+    private int mSpawnY;
+
+    private Grid? mGrid;
+
+    public EventCommandSpawnNpc(
+        FrmEvent eventEditor,
+        MapBase currentMap,
+        EventBase currentEvent,
+        SpawnNpcCommand editingCommand
+    )
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private MapBase mCurrentMap;
-
-        private EventBase mEditingEvent;
-
-        private SpawnNpcCommand mMyCommand;
-
-        private int mSpawnX;
-
-        private int mSpawnY;
-
-        private Grid? mGrid;
-
-        public EventCommandSpawnNpc(
-            FrmEvent eventEditor,
-            MapBase currentMap,
-            EventBase currentEvent,
-            SpawnNpcCommand editingCommand
-        )
+        InitializeComponent();
+        mMyCommand = editingCommand;
+        mEventEditor = eventEditor;
+        mEditingEvent = currentEvent;
+        mCurrentMap = currentMap;
+        InitLocalization();
+        cmbNpc.Items.Clear();
+        cmbNpc.Items.AddRange(NpcBase.Names);
+        cmbNpc.SelectedIndex = NpcBase.ListIndex(mMyCommand.NpcId);
+        if (mMyCommand.MapId != Guid.Empty)
         {
-            InitializeComponent();
-            mMyCommand = editingCommand;
-            mEventEditor = eventEditor;
-            mEditingEvent = currentEvent;
-            mCurrentMap = currentMap;
-            InitLocalization();
-            cmbNpc.Items.Clear();
-            cmbNpc.Items.AddRange(NpcBase.Names);
-            cmbNpc.SelectedIndex = NpcBase.ListIndex(mMyCommand.NpcId);
-            if (mMyCommand.MapId != Guid.Empty)
-            {
-                cmbConditionType.SelectedIndex = 0;
-            }
-            else
-            {
-                cmbConditionType.SelectedIndex = 1;
-            }
-
-            nudWarpX.Maximum = Options.MapWidth;
-            nudWarpY.Maximum = Options.MapHeight;
-            UpdateFormElements();
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile spawn
-                    //Fill in the map cmb
-                    nudWarpX.Value = mMyCommand.X;
-                    nudWarpY.Value = mMyCommand.Y;
-                    cmbDirection.SelectedIndex = (int)mMyCommand.Dir;
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    mSpawnX = mMyCommand.X;
-                    mSpawnY = mMyCommand.Y;
-                    chkDirRelative.Checked = Convert.ToBoolean(mMyCommand.Dir);
-                    UpdateSpawnPreview();
-
-                    break;
-            }
+            cmbConditionType.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbConditionType.SelectedIndex = 1;
         }
 
-        private void InitLocalization()
+        nudWarpX.Maximum = Options.MapWidth;
+        nudWarpY.Maximum = Options.MapHeight;
+        UpdateFormElements();
+        switch (cmbConditionType.SelectedIndex)
         {
-            grpSpawnNpc.Text = Strings.EventSpawnNpc.title;
-            lblNpc.Text = Strings.EventSpawnNpc.npc;
-            lblSpawnType.Text = Strings.EventSpawnNpc.spawntype;
-            cmbConditionType.Items.Clear();
-            cmbConditionType.Items.Add(Strings.EventSpawnNpc.spawntype0);
-            cmbConditionType.Items.Add(Strings.EventSpawnNpc.spawntype1);
+            case 0: //Tile spawn
+                //Fill in the map cmb
+                nudWarpX.Value = mMyCommand.X;
+                nudWarpY.Value = mMyCommand.Y;
+                cmbDirection.SelectedIndex = (int)mMyCommand.Dir;
 
-            grpTileSpawn.Text = Strings.EventSpawnNpc.spawntype0;
-            grpEntitySpawn.Text = Strings.EventSpawnNpc.spawntype1;
+                break;
+            case 1: //On/Around Entity Spawn
+                mSpawnX = mMyCommand.X;
+                mSpawnY = mMyCommand.Y;
+                chkDirRelative.Checked = Convert.ToBoolean(mMyCommand.Dir);
+                UpdateSpawnPreview();
 
-            lblMap.Text = Strings.Warping.map.ToString("");
-            lblX.Text = Strings.Warping.x.ToString("");
-            lblY.Text = Strings.Warping.y.ToString("");
-            lblMap.Text = Strings.Warping.direction.ToString("");
-            cmbDirection.Items.Clear();
-            for (var i = 0; i < 4; i++)
-            {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
+                break;
+        }
+    }
 
-            cmbDirection.SelectedIndex = 0;
-            btnVisual.Text = Strings.Warping.visual;
+    private void InitLocalization()
+    {
+        grpSpawnNpc.Text = Strings.EventSpawnNpc.title;
+        lblNpc.Text = Strings.EventSpawnNpc.npc;
+        lblSpawnType.Text = Strings.EventSpawnNpc.spawntype;
+        cmbConditionType.Items.Clear();
+        cmbConditionType.Items.Add(Strings.EventSpawnNpc.spawntype0);
+        cmbConditionType.Items.Add(Strings.EventSpawnNpc.spawntype1);
 
-            lblEntity.Text = Strings.EventSpawnNpc.entity;
-            lblRelativeLocation.Text = Strings.EventSpawnNpc.relativelocation;
-            chkDirRelative.Text = Strings.EventSpawnNpc.spawnrelative;
+        grpTileSpawn.Text = Strings.EventSpawnNpc.spawntype0;
+        grpEntitySpawn.Text = Strings.EventSpawnNpc.spawntype1;
 
-            btnSave.Text = Strings.EventSpawnNpc.okay;
-            btnCancel.Text = Strings.EventSpawnNpc.cancel;
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y.ToString("");
+        lblMap.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = 0; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
         }
 
-        private void UpdateFormElements()
+        cmbDirection.SelectedIndex = 0;
+        btnVisual.Text = Strings.Warping.visual;
+
+        lblEntity.Text = Strings.EventSpawnNpc.entity;
+        lblRelativeLocation.Text = Strings.EventSpawnNpc.relativelocation;
+        chkDirRelative.Text = Strings.EventSpawnNpc.spawnrelative;
+
+        btnSave.Text = Strings.EventSpawnNpc.okay;
+        btnCancel.Text = Strings.EventSpawnNpc.cancel;
+    }
+
+    private void UpdateFormElements()
+    {
+        grpTileSpawn.Hide();
+        grpEntitySpawn.Hide();
+        switch (cmbConditionType.SelectedIndex)
         {
-            grpTileSpawn.Hide();
-            grpEntitySpawn.Hide();
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile Spawn
-                    grpTileSpawn.Show();
-                    cmbMap.Items.Clear();
-                    for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                    {
-                        cmbMap.Items.Add(MapList.OrderedMaps[i].Name);
-                        if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
-                        {
-                            cmbMap.SelectedIndex = i;
-                        }
-                    }
-
-                    if (cmbMap.SelectedIndex == -1)
-                    {
-                        cmbMap.SelectedIndex = 0;
-                    }
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    grpEntitySpawn.Show();
-                    cmbEntities.Items.Clear();
-                    cmbEntities.Items.Add(Strings.EventSpawnNpc.player);
-                    cmbEntities.SelectedIndex = 0;
-
-                    if (!mEditingEvent.CommonEvent)
-                    {
-                        foreach (var evt in mCurrentMap.LocalEvents)
-                        {
-                            cmbEntities.Items.Add(
-                                evt.Key == mEditingEvent.Id ? Strings.EventSpawnNpc.This + " " : "" + evt.Value.Name
-                            );
-
-                            if (mMyCommand.EntityId == evt.Key)
-                            {
-                                cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
-                            }
-                        }
-                    }
-
-                    UpdateSpawnPreview();
-
-                    break;
-            }
-        }
-
-        private void UpdateSpawnPreview()
-        {
-            if (mGrid == null)
-            {
-                mGrid = new Grid
-                {
-                    DisplayWidth = pnlSpawnLoc.Width,
-                    DisplayHeight = pnlSpawnLoc.Height,
-                    Columns = 5,
-                    Rows = 5,
-                    Cells = new[] { new GridCell(2, 2, null, "E") }
-                };
-            }
-
-            pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(
-                mGrid.Value.WithAdditionalCells(
-                    new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red)
-                )
-            );
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
-            switch (cmbConditionType.SelectedIndex)
-            {
-                case 0: //Tile Spawn
-                    mMyCommand.EntityId = Guid.Empty;
-                    mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
-                    mMyCommand.X = (sbyte)nudWarpX.Value;
-                    mMyCommand.Y = (sbyte)nudWarpY.Value;
-                    mMyCommand.Dir = (Direction)cmbDirection.SelectedIndex;
-
-                    break;
-                case 1: //On/Around Entity Spawn
-                    mMyCommand.MapId = Guid.Empty;
-                    if (cmbEntities.SelectedIndex == 0 || cmbEntities.SelectedIndex == -1)
-                    {
-                        mMyCommand.EntityId = Guid.Empty;
-                    }
-                    else
-                    {
-                        mMyCommand.EntityId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
-                    }
-
-                    mMyCommand.X = (sbyte)mSpawnX;
-                    mMyCommand.Y = (sbyte)mSpawnY;
-                    mMyCommand.Dir = (Direction)Convert.ToInt32(chkDirRelative.Checked);
-
-                    break;
-            }
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdateFormElements();
-        }
-
-        private void btnVisual_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(
-                MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, (int)nudWarpX.Value, (int)nudWarpY.Value
-            );
-
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
+            case 0: //Tile Spawn
+                grpTileSpawn.Show();
+                cmbMap.Items.Clear();
                 for (var i = 0; i < MapList.OrderedMaps.Count; i++)
                 {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                    cmbMap.Items.Add(MapList.OrderedMaps[i].Name);
+                    if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
                     {
                         cmbMap.SelectedIndex = i;
-
-                        break;
                     }
                 }
 
-                nudWarpX.Value = frmWarpSelection.GetX();
-                nudWarpY.Value = frmWarpSelection.GetY();
-            }
-        }
+                if (cmbMap.SelectedIndex == -1)
+                {
+                    cmbMap.SelectedIndex = 0;
+                }
 
-        private void pnlSpawnLoc_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (mGrid == null)
-            {
-                return;
-            }
+                break;
+            case 1: //On/Around Entity Spawn
+                grpEntitySpawn.Show();
+                cmbEntities.Items.Clear();
+                cmbEntities.Items.Add(Strings.EventSpawnNpc.player);
+                cmbEntities.SelectedIndex = 0;
 
-            var cell = GridHelper.CellFromPoint(mGrid.Value, e.X, e.Y);
-            if (cell != null)
-            {
-                (mSpawnX, mSpawnY) = cell.Value;
+                if (!mEditingEvent.CommonEvent)
+                {
+                    foreach (var evt in mCurrentMap.LocalEvents)
+                    {
+                        cmbEntities.Items.Add(
+                            evt.Key == mEditingEvent.Id ? Strings.EventSpawnNpc.This + " " : "" + evt.Value.Name
+                        );
+
+                        if (mMyCommand.EntityId == evt.Key)
+                        {
+                            cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
+                        }
+                    }
+                }
+
                 UpdateSpawnPreview();
-            }
+
+                break;
+        }
+    }
+
+    private void UpdateSpawnPreview()
+    {
+        if (mGrid == null)
+        {
+            mGrid = new Grid
+            {
+                DisplayWidth = pnlSpawnLoc.Width,
+                DisplayHeight = pnlSpawnLoc.Height,
+                Columns = 5,
+                Rows = 5,
+                Cells = new[] { new GridCell(2, 2, null, "E") }
+            };
         }
 
+        pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(
+            mGrid.Value.WithAdditionalCells(
+                new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red)
+            )
+        );
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.NpcId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile Spawn
+                mMyCommand.EntityId = Guid.Empty;
+                mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
+                mMyCommand.X = (sbyte)nudWarpX.Value;
+                mMyCommand.Y = (sbyte)nudWarpY.Value;
+                mMyCommand.Dir = (Direction)cmbDirection.SelectedIndex;
+
+                break;
+            case 1: //On/Around Entity Spawn
+                mMyCommand.MapId = Guid.Empty;
+                if (cmbEntities.SelectedIndex == 0 || cmbEntities.SelectedIndex == -1)
+                {
+                    mMyCommand.EntityId = Guid.Empty;
+                }
+                else
+                {
+                    mMyCommand.EntityId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
+                }
+
+                mMyCommand.X = (sbyte)mSpawnX;
+                mMyCommand.Y = (sbyte)mSpawnY;
+                mMyCommand.Dir = (Direction)Convert.ToInt32(chkDirRelative.Checked);
+
+                break;
+        }
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFormElements();
+    }
+
+    private void btnVisual_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, (int)nudWarpX.Value, (int)nudWarpY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbMap.SelectedIndex = i;
+
+                    break;
+                }
+            }
+
+            nudWarpX.Value = frmWarpSelection.GetX();
+            nudWarpY.Value = frmWarpSelection.GetY();
+        }
+    }
+
+    private void pnlSpawnLoc_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (mGrid == null)
+        {
+            return;
+        }
+
+        var cell = GridHelper.CellFromPoint(mGrid.Value, e.X, e.Y);
+        if (cell != null)
+        {
+            (mSpawnX, mSpawnY) = cell.Value;
+            UpdateSpawnPreview();
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartCommonEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartCommonEvent.cs
@@ -2,71 +2,69 @@
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandStartCommonEvent : UserControl
 {
 
-    public partial class EventCommandStartCommonEvent : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private StartCommmonEventCommand mMyCommand;
+
+    public EventCommandStartCommonEvent(StartCommmonEventCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
 
-        private readonly FrmEvent mEventEditor;
+        cmbEvent.Items.Clear();
+        cmbEvent.Items.AddRange(EventBase.Names);
 
-        private StartCommmonEventCommand mMyCommand;
-
-        public EventCommandStartCommonEvent(StartCommmonEventCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-
-            cmbEvent.Items.Clear();
-            cmbEvent.Items.AddRange(EventBase.Names);
-
-            cmbEvent.SelectedIndex = EventBase.ListIndex(refCommand.EventId);
-            chkAllInInstance.Checked = refCommand.AllInInstance;
-            chkOverworldOverride.Checked = refCommand.AllowInOverworld;
-            chkOverworldOverride.Enabled = chkAllInInstance.Checked;
-        }
-
-        private void InitLocalization()
-        {
-            grpCommonEvent.Text = Strings.EventStartCommonEvent.title;
-            lblCommonEvent.Text = Strings.EventStartCommonEvent.label;
-            chkAllInInstance.Text = Strings.EventStartCommonEvent.AllInInstance;
-            chkOverworldOverride.Text = Strings.EventStartCommonEvent.AllowInOverworld;
-
-            ToolTip overworldWarningTooltip = new ToolTip()
-            {
-                InitialDelay = 1000,
-                ReshowDelay = 500,
-            };
-
-            overworldWarningTooltip.SetToolTip(chkOverworldOverride, Strings.EventStartCommonEvent.OverworldOverrideTooltip.ToString());
-
-            btnSave.Text = Strings.EventStartCommonEvent.okay;
-            btnCancel.Text = Strings.EventStartCommonEvent.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.EventId = EventBase.IdFromList(cmbEvent.SelectedIndex);
-            mMyCommand.AllInInstance = chkAllInInstance.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void chkAllInInstance_CheckedChanged(object sender, EventArgs e)
-        {
-            if (!chkAllInInstance.Checked)
-            {
-                chkOverworldOverride.Checked = false;
-            }
-            chkOverworldOverride.Enabled = chkAllInInstance.Checked;
-        }
+        cmbEvent.SelectedIndex = EventBase.ListIndex(refCommand.EventId);
+        chkAllInInstance.Checked = refCommand.AllInInstance;
+        chkOverworldOverride.Checked = refCommand.AllowInOverworld;
+        chkOverworldOverride.Enabled = chkAllInInstance.Checked;
     }
 
+    private void InitLocalization()
+    {
+        grpCommonEvent.Text = Strings.EventStartCommonEvent.title;
+        lblCommonEvent.Text = Strings.EventStartCommonEvent.label;
+        chkAllInInstance.Text = Strings.EventStartCommonEvent.AllInInstance;
+        chkOverworldOverride.Text = Strings.EventStartCommonEvent.AllowInOverworld;
+
+        ToolTip overworldWarningTooltip = new ToolTip()
+        {
+            InitialDelay = 1000,
+            ReshowDelay = 500,
+        };
+
+        overworldWarningTooltip.SetToolTip(chkOverworldOverride, Strings.EventStartCommonEvent.OverworldOverrideTooltip.ToString());
+
+        btnSave.Text = Strings.EventStartCommonEvent.okay;
+        btnCancel.Text = Strings.EventStartCommonEvent.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.EventId = EventBase.IdFromList(cmbEvent.SelectedIndex);
+        mMyCommand.AllInInstance = chkAllInInstance.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void chkAllInInstance_CheckedChanged(object sender, EventArgs e)
+    {
+        if (!chkAllInInstance.Checked)
+        {
+            chkOverworldOverride.Checked = false;
+        }
+        chkOverworldOverride.Enabled = chkAllInInstance.Checked;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_StartQuest.cs
@@ -3,52 +3,50 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandStartQuest : UserControl
 {
 
-    public partial class EventCommandStartQuest : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private EventPage mCurrentPage;
+
+    private StartQuestCommand mMyCommand;
+
+    public EventCommandStartQuest(StartQuestCommand refCommand, EventPage page, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mCurrentPage = page;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbQuests.Items.Clear();
+        cmbQuests.Items.AddRange(QuestBase.Names);
+        cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
+        chkShowOfferWindow.Checked = refCommand.Offer;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpStartQuest.Text = Strings.EventStartQuest.title;
+        lblQuest.Text = Strings.EventStartQuest.label;
+        chkShowOfferWindow.Text = Strings.EventStartQuest.showwindow;
+        btnSave.Text = Strings.EventStartQuest.okay;
+        btnCancel.Text = Strings.EventStartQuest.cancel;
+    }
 
-        private EventPage mCurrentPage;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
+        mMyCommand.Offer = chkShowOfferWindow.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private StartQuestCommand mMyCommand;
-
-        public EventCommandStartQuest(StartQuestCommand refCommand, EventPage page, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mCurrentPage = page;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbQuests.Items.Clear();
-            cmbQuests.Items.AddRange(QuestBase.Names);
-            cmbQuests.SelectedIndex = QuestBase.ListIndex(refCommand.QuestId);
-            chkShowOfferWindow.Checked = refCommand.Offer;
-        }
-
-        private void InitLocalization()
-        {
-            grpStartQuest.Text = Strings.EventStartQuest.title;
-            lblQuest.Text = Strings.EventStartQuest.label;
-            chkShowOfferWindow.Text = Strings.EventStartQuest.showwindow;
-            btnSave.Text = Strings.EventStartQuest.okay;
-            btnCancel.Text = Strings.EventStartQuest.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.QuestId = QuestBase.IdFromList(cmbQuests.SelectedIndex);
-            mMyCommand.Offer = chkShowOfferWindow.Checked;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Text.cs
@@ -3,75 +3,73 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandText : UserControl
 {
 
-    public partial class EventCommandText : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private ShowTextCommand mMyCommand;
+
+    public EventCommandText(ShowTextCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        txtShowText.Text = mMyCommand.Text;
+        cmbFace.Items.Clear();
+        cmbFace.Items.Add(Strings.General.None);
+        cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
+        cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
 
-        private readonly FrmEvent mEventEditor;
+        UpdateFacePreview();
+    }
 
-        private ShowTextCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpShowText.Text = Strings.EventShowText.title;
+        lblText.Text = Strings.EventShowText.text;
+        lblFace.Text = Strings.EventShowText.face;
+        lblCommands.Text = Strings.EventShowText.commands;
+        btnSave.Text = Strings.EventShowText.okay;
+        btnCancel.Text = Strings.EventShowText.cancel;
+    }
 
-        public EventCommandText(ShowTextCommand refCommand, FrmEvent editor)
+    private void UpdateFacePreview()
+    {
+        if (File.Exists("resources/faces/" + cmbFace.Text))
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            txtShowText.Text = mMyCommand.Text;
-            cmbFace.Items.Clear();
-            cmbFace.Items.Add(Strings.General.None);
-            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            cmbFace.SelectedIndex = Math.Max(0, cmbFace.Items.IndexOf(TextUtils.NullToNone(mMyCommand.Face)));
-
-            UpdateFacePreview();
+            pnlFace.BackgroundImage = new Bitmap("resources/faces/" + cmbFace.Text);
         }
-
-        private void InitLocalization()
+        else
         {
-            grpShowText.Text = Strings.EventShowText.title;
-            lblText.Text = Strings.EventShowText.text;
-            lblFace.Text = Strings.EventShowText.face;
-            lblCommands.Text = Strings.EventShowText.commands;
-            btnSave.Text = Strings.EventShowText.okay;
-            btnCancel.Text = Strings.EventShowText.cancel;
+            pnlFace.BackgroundImage = null;
         }
+    }
 
-        private void UpdateFacePreview()
-        {
-            if (File.Exists("resources/faces/" + cmbFace.Text))
-            {
-                pnlFace.BackgroundImage = new Bitmap("resources/faces/" + cmbFace.Text);
-            }
-            else
-            {
-                pnlFace.BackgroundImage = null;
-            }
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Text = txtShowText.Text;
+        mMyCommand.Face = TextUtils.SanitizeNone(cmbFace?.Text);
+        mEventEditor.FinishCommandEdit();
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Text = txtShowText.Text;
-            mMyCommand.Face = TextUtils.SanitizeNone(cmbFace?.Text);
-            mEventEditor.FinishCommandEdit();
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
+    private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFacePreview();
+    }
 
-        private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdateFacePreview();
-        }
-
-        private void lblCommands_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
+    private void lblCommands_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Variable.cs
@@ -7,661 +7,659 @@ using Intersect.GameObjects.Events.Commands;
 using Intersect.Utilities;
 using VariableMod = Intersect.Enums.VariableMod;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandVariable : UserControl
 {
 
-    public partial class EventCommandVariable : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private bool mLoading;
+
+    private SetVariableCommand mMyCommand;
+
+    private VariableType mSelectedVariableType = VariableType.PlayerVariable;
+    private Guid mSelectedVariableId = Guid.Empty;
+
+    private VariableType mSettingVariableType = VariableType.PlayerVariable;
+    private Guid mSettingVariableId = Guid.Empty;
+
+    public EventCommandVariable(SetVariableCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        mLoading = true;
+        InitLocalization();
 
-        private readonly FrmEvent mEventEditor;
+        mSelectedVariableId = refCommand.VariableId;
+        mSelectedVariableType = refCommand.VariableType;
 
-        private bool mLoading;
+        mLoading = false;
+        InitEditor();
+    }
 
-        private SetVariableCommand mMyCommand;
+    private void InitLocalization()
+    {
+        grpSetVariable.Text = Strings.EventSetVariable.title;
 
-        private VariableType mSelectedVariableType = VariableType.PlayerVariable;
-        private Guid mSelectedVariableId = Guid.Empty;
+        grpSelectVariable.Text = Strings.EventSetVariable.label;
+        btnSave.Text = Strings.EventSetVariable.okay;
+        btnCancel.Text = Strings.EventSetVariable.cancel;
+        chkSyncParty.Text = Strings.EventSetVariable.syncparty;
 
-        private VariableType mSettingVariableType = VariableType.PlayerVariable;
-        private Guid mSettingVariableId = Guid.Empty;
+        //Numeric
+        grpNumericVariable.Text = Strings.EventSetVariable.numericlabel;
+        grpNumericRandom.Text = Strings.EventSetVariable.numericrandomdesc;
+        optNumericSet.Text = Strings.EventSetVariable.numericset;
+        optNumericAdd.Text = Strings.EventSetVariable.numericadd;
+        optNumericSubtract.Text = Strings.EventSetVariable.numericsubtract;
+        optNumericMultiply.Text = Strings.EventSetVariable.numericmultiply;
+        optNumericDivide.Text = Strings.EventSetVariable.numericdivide;
+        optNumericLeftShift.Text = Strings.EventSetVariable.numericleftshift;
+        optNumericRightShift.Text = Strings.EventSetVariable.numericrightshift;
+        optNumericRandom.Text = Strings.EventSetVariable.numericrandom;
+        optNumericSystemTime.Text = Strings.EventSetVariable.numericsystemtime;
+        lblNumericRandomLow.Text = Strings.EventSetVariable.numericrandomlow;
+        lblNumericRandomHigh.Text = Strings.EventSetVariable.numericrandomhigh;
 
-        public EventCommandVariable(SetVariableCommand refCommand, FrmEvent editor)
+        //Booleanic
+        grpBooleanVariable.Text = Strings.EventSetVariable.booleanlabel;
+        optBooleanTrue.Text = Strings.EventSetVariable.booleantrue;
+        optBooleanFalse.Text = Strings.EventSetVariable.booleanfalse;
+
+        //String
+        grpStringVariable.Text = Strings.EventSetVariable.stringlabel;
+        optStaticString.Text = Strings.EventSetVariable.stringset;
+        optReplaceString.Text = Strings.EventSetVariable.stringreplace;
+        grpStringSet.Text = Strings.EventSetVariable.stringset;
+        grpStringReplace.Text = Strings.EventSetVariable.stringreplace;
+        lblStringValue.Text = Strings.EventSetVariable.stringsetvalue;
+        lblStringFind.Text = Strings.EventSetVariable.stringreplacefind;
+        lblStringReplace.Text = Strings.EventSetVariable.stringreplacereplace;
+        lblStringTextVariables.Text = Strings.EventSetVariable.stringtip;
+
+        // New variable handling
+        rdoBoolVariable.Text = Strings.EventSetVariable.VariableValue;
+        rdoVariableValue.Text = Strings.EventSetVariable.VariableValue;
+
+        btnSettingVariableSelector.Text = Strings.VariableSelector.Button;
+        btnVarSelector.Text = Strings.VariableSelector.Button;
+
+        grpSettingVariable.Text = Strings.EventSetVariable.SetVariableGroup;
+        grpSelectVariable.Text = Strings.EventSetVariable.SelectVariableGroup;
+
+        lblCurrentVar.Text = Strings.VariableSelector.LabelCurrentSelection;
+        lblSettingVarCurrentValue.Text = Strings.VariableSelector.LabelCurrentSelection;
+    }
+
+    private void InitEditor()
+    {
+        chkSyncParty.Checked = mMyCommand.SyncParty;
+
+        UpdateFormElements();
+    }
+
+    private VariableDataType GetCurrentDataTypeFilter()
+    {
+        if (mSelectedVariableId != Guid.Empty)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            mLoading = true;
-            InitLocalization();
-
-            mSelectedVariableId = refCommand.VariableId;
-            mSelectedVariableType = refCommand.VariableType;
-
-            mLoading = false;
-            InitEditor();
+            return mSelectedVariableType.GetRelatedTable().GetVariableType(mSelectedVariableId);
         }
-
-        private void InitLocalization()
+        else
         {
-            grpSetVariable.Text = Strings.EventSetVariable.title;
-
-            grpSelectVariable.Text = Strings.EventSetVariable.label;
-            btnSave.Text = Strings.EventSetVariable.okay;
-            btnCancel.Text = Strings.EventSetVariable.cancel;
-            chkSyncParty.Text = Strings.EventSetVariable.syncparty;
-
-            //Numeric
-            grpNumericVariable.Text = Strings.EventSetVariable.numericlabel;
-            grpNumericRandom.Text = Strings.EventSetVariable.numericrandomdesc;
-            optNumericSet.Text = Strings.EventSetVariable.numericset;
-            optNumericAdd.Text = Strings.EventSetVariable.numericadd;
-            optNumericSubtract.Text = Strings.EventSetVariable.numericsubtract;
-            optNumericMultiply.Text = Strings.EventSetVariable.numericmultiply;
-            optNumericDivide.Text = Strings.EventSetVariable.numericdivide;
-            optNumericLeftShift.Text = Strings.EventSetVariable.numericleftshift;
-            optNumericRightShift.Text = Strings.EventSetVariable.numericrightshift;
-            optNumericRandom.Text = Strings.EventSetVariable.numericrandom;
-            optNumericSystemTime.Text = Strings.EventSetVariable.numericsystemtime;
-            lblNumericRandomLow.Text = Strings.EventSetVariable.numericrandomlow;
-            lblNumericRandomHigh.Text = Strings.EventSetVariable.numericrandomhigh;
-
-            //Booleanic
-            grpBooleanVariable.Text = Strings.EventSetVariable.booleanlabel;
-            optBooleanTrue.Text = Strings.EventSetVariable.booleantrue;
-            optBooleanFalse.Text = Strings.EventSetVariable.booleanfalse;
-
-            //String
-            grpStringVariable.Text = Strings.EventSetVariable.stringlabel;
-            optStaticString.Text = Strings.EventSetVariable.stringset;
-            optReplaceString.Text = Strings.EventSetVariable.stringreplace;
-            grpStringSet.Text = Strings.EventSetVariable.stringset;
-            grpStringReplace.Text = Strings.EventSetVariable.stringreplace;
-            lblStringValue.Text = Strings.EventSetVariable.stringsetvalue;
-            lblStringFind.Text = Strings.EventSetVariable.stringreplacefind;
-            lblStringReplace.Text = Strings.EventSetVariable.stringreplacereplace;
-            lblStringTextVariables.Text = Strings.EventSetVariable.stringtip;
-
-            // New variable handling
-            rdoBoolVariable.Text = Strings.EventSetVariable.VariableValue;
-            rdoVariableValue.Text = Strings.EventSetVariable.VariableValue;
-
-            btnSettingVariableSelector.Text = Strings.VariableSelector.Button;
-            btnVarSelector.Text = Strings.VariableSelector.Button;
-
-            grpSettingVariable.Text = Strings.EventSetVariable.SetVariableGroup;
-            grpSelectVariable.Text = Strings.EventSetVariable.SelectVariableGroup;
-
-            lblCurrentVar.Text = Strings.VariableSelector.LabelCurrentSelection;
-            lblSettingVarCurrentValue.Text = Strings.VariableSelector.LabelCurrentSelection;
-        }
-
-        private void InitEditor()
-        {
-            chkSyncParty.Checked = mMyCommand.SyncParty;
-
-            UpdateFormElements();
-        }
-
-        private VariableDataType GetCurrentDataTypeFilter()
-        {
-            if (mSelectedVariableId != Guid.Empty)
-            {
-                return mSelectedVariableType.GetRelatedTable().GetVariableType(mSelectedVariableId);
-            }
-            else
-            {
-                return 0;
-            }
-        }
-
-        private void UpdateFormElements()
-        {
-            //Hide editor windows until we have a variable selected to work with
-            grpNumericVariable.Hide();
-            grpBooleanVariable.Hide();
-            grpStringVariable.Hide();
-
-            var varType = GetCurrentDataTypeFilter();
-
-            //Load the correct editor
-            if (varType > 0)
-            {
-                switch (varType)
-                {
-                    case VariableDataType.Boolean:
-                        grpBooleanVariable.Show();
-                        TryLoadBooleanMod(mMyCommand.Modification);
-
-                        break;
-
-                    case VariableDataType.Integer:
-                        grpNumericVariable.Show();
-                        TryLoadNumericMod(mMyCommand.Modification);
-                        UpdateNumericFormElements();
-
-                        break;
-
-                    case VariableDataType.Number:
-                        break;
-
-                    case VariableDataType.String:
-                        grpStringVariable.Show();
-                        TryLoadStringMod(mMyCommand.Modification);
-
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-
-            lblVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSelectedVariableType, mSelectedVariableId);
-            lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.VariableType = mSelectedVariableType;
-            mMyCommand.VariableId = mSelectedVariableId;
-
-            if (grpNumericVariable.Visible)
-            {
-                mMyCommand.Modification = GetNumericVariableMod();
-            }
-            else if (grpBooleanVariable.Visible)
-            {
-                mMyCommand.Modification = GetBooleanVariableMod();
-            }
-            else if (grpStringVariable.Visible)
-            {
-                mMyCommand.Modification = GetStringVariableMod();
-            }
-            else
-            {
-                switch (mMyCommand.Modification)
-                {
-                    case BooleanVariableMod _:
-                        mMyCommand.Modification = GetBooleanVariableMod();
-                        break;
-
-                    case IntegerVariableMod _:
-                        mMyCommand.Modification = GetNumericVariableMod();
-                        break;
-
-                    case null:
-                        mMyCommand.Modification = new BooleanVariableMod();
-                        break;
-                }
-            }
-
-            mMyCommand.SyncParty = chkSyncParty.Checked;
-
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        #region "Boolean Variable"
-
-        private void TryLoadBooleanMod(GameObjects.Events.VariableMod variableMod)
-        {
-            if (variableMod == null)
-            {
-                variableMod = new BooleanVariableMod();
-            }
-
-            if (!(variableMod is BooleanVariableMod booleanMod))
-            {
-                return;
-            }
-
-            optBooleanTrue.Checked = booleanMod.Value;
-            optBooleanFalse.Checked = !booleanMod.Value;
-
-            if (booleanMod.DuplicateVariableId == Guid.Empty)
-            {
-                ResetSettingVariableSelection();
-                return;
-            }
-
-            rdoBoolVariable.Checked = true;
-            mSettingVariableId = booleanMod.DuplicateVariableId;
-            mSettingVariableType = booleanMod.DupVariableType;
-
-            lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
-        }
-
-        private BooleanVariableMod GetBooleanVariableMod()
-        {
-            var mod = new BooleanVariableMod
-            {
-                Value = optBooleanTrue.Checked,
-                DuplicateVariableId = mSettingVariableId,
-                DupVariableType = mSettingVariableType
-            };
-
-            return mod;
-        }
-
-        #endregion
-
-        #region "Numeric Variable"
-
-        private void TryLoadNumericMod(GameObjects.Events.VariableMod variableMod)
-        {
-            if (variableMod == null)
-            {
-                variableMod = new IntegerVariableMod();
-            }
-
-            if (!(variableMod is IntegerVariableMod integerMod))
-            {
-                return;
-            }
-
-            switch (integerMod.ModType)
-            {
-                case VariableMod.Set:
-                case VariableMod.Add:
-                case VariableMod.Subtract:
-                case VariableMod.Multiply:
-                case VariableMod.Divide:
-                case VariableMod.LeftShift:
-                case VariableMod.RightShift:
-                case VariableMod.Random:
-                case VariableMod.SystemTime:
-                    nudNumericValue.Value = integerMod.Value;
-                    ResetSettingVariableSelection();
-                    break;
-
-                default:
-                    rdoVariableValue.Checked = true;
-                    mSettingVariableId = integerMod.DuplicateVariableId;
-                    mSettingVariableType = integerMod.ModType.GetRelatedVariableType();
-                    break;
-            }
-
-            optNumericSet.Checked = VariableModUtils.SetMods.Contains(integerMod.ModType);
-            optNumericAdd.Checked = VariableModUtils.AddMods.Contains(integerMod.ModType);
-            optNumericSubtract.Checked = VariableModUtils.SubMods.Contains(integerMod.ModType);
-            optNumericMultiply.Checked = VariableModUtils.MultMods.Contains(integerMod.ModType);
-            optNumericDivide.Checked = VariableModUtils.DivideMods.Contains(integerMod.ModType);
-            optNumericLeftShift.Checked = VariableModUtils.LShiftMods.Contains(integerMod.ModType);
-            optNumericRightShift.Checked = VariableModUtils.RShiftMods.Contains(integerMod.ModType);
-
-            optNumericSystemTime.Checked = integerMod.ModType == VariableMod.SystemTime;
-
-            if (integerMod.ModType == VariableMod.Random)
-            {
-                optNumericRandom.Checked = true;
-                nudLow.Value = integerMod.Value;
-                nudHigh.Value = integerMod.HighValue;
-            }
-        }
-
-        private void UpdateNumericFormElements()
-        {
-            grpNumericRandom.Visible = optNumericRandom.Checked;
-            grpNumericValues.Visible = optNumericAdd.Checked | optNumericSubtract.Checked | optNumericSet.Checked | optNumericMultiply.Checked |
-                                       optNumericDivide.Checked | optNumericLeftShift.Checked | optNumericRightShift.Checked;
-        }
-
-        private void optNumericSet_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericAdd_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericSubtract_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericMultiply_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericDivide_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericLeftShift_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericRightShift_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericRandom_CheckedChanged(object sender, EventArgs e)
-        {
-            ResetSettingVariableSelection();
-            UpdateNumericFormElements();
-        }
-
-        private void optNumericSystemTime_CheckedChanged(object sender, EventArgs e)
-        {
-            ResetSettingVariableSelection();
-            UpdateNumericFormElements();
-        }
-
-        private IntegerVariableMod GetNumericVariableMod()
-        {
-            var mod = new IntegerVariableMod()
-            {
-                DuplicateVariableId = mSettingVariableId
-            };
-
-            mod.Value = optNumericRandom.Checked ? (int)nudLow.Value : (int)nudNumericValue.Value;
-
-            if (optNumericSet.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.Set;
-            }
-            else if (optNumericAdd.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.Add;
-            }
-            else if (optNumericSubtract.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.Subtract;
-            }
-            else if (optNumericMultiply.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.Multiply;
-            }
-            else if (optNumericDivide.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.Divide;
-            }
-            else if (optNumericLeftShift.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.LeftShift;
-            }
-            else if (optNumericRightShift.Checked && optNumericStaticVal.Checked)
-            {
-                mod.ModType = VariableMod.RightShift;
-            }
-            else if (optNumericRandom.Checked)
-            {
-                mod.ModType = VariableMod.Random;
-                mod.HighValue = (int)nudHigh.Value;
-                if (mod.HighValue < mod.Value)
-                {
-                    var n = mod.Value;
-                    mod.Value = mod.HighValue;
-                    mod.HighValue = n;
-                }
-            }
-            else if (optNumericSystemTime.Checked)
-            {
-                mod.ModType = VariableMod.SystemTime;
-            }
-            else if (mSettingVariableType == VariableType.PlayerVariable)
-            {
-                if (optNumericSet.Checked)
-                {
-                    mod.ModType = VariableMod.DupPlayerVar;
-                }
-                else if (optNumericAdd.Checked)
-                {
-                    mod.ModType = VariableMod.AddPlayerVar;
-                }
-                else if (optNumericSubtract.Checked)
-                {
-                    mod.ModType = VariableMod.SubtractPlayerVar;
-                }
-                else if (optNumericMultiply.Checked)
-                {
-                    mod.ModType = VariableMod.MultiplyPlayerVar;
-                }
-                else if (optNumericDivide.Checked)
-                {
-                    mod.ModType = VariableMod.DividePlayerVar;
-                }
-                else if (optNumericLeftShift.Checked)
-                {
-                    mod.ModType = VariableMod.LeftShiftPlayerVar;
-                }
-                else
-                {
-                    mod.ModType = VariableMod.RightShiftPlayerVar;
-                }
-            }
-            else if (mSettingVariableType == VariableType.ServerVariable)
-            {
-                if (optNumericSet.Checked)
-                {
-                    mod.ModType = VariableMod.DupGlobalVar;
-                }
-                else if (optNumericAdd.Checked)
-                {
-                    mod.ModType = VariableMod.AddGlobalVar;
-                }
-                else if (optNumericSubtract.Checked)
-                {
-                    mod.ModType = VariableMod.SubtractGlobalVar;
-                }
-                else if (optNumericMultiply.Checked)
-                {
-                    mod.ModType = VariableMod.MultiplyGlobalVar;
-                }
-                else if (optNumericDivide.Checked)
-                {
-                    mod.ModType = VariableMod.DivideGlobalVar;
-                }
-                else if (optNumericLeftShift.Checked)
-                {
-                    mod.ModType = VariableMod.LeftShiftGlobalVar;
-                }
-                else
-                {
-                    mod.ModType = VariableMod.RightShiftGlobalVar;
-                }
-            }
-            else if (mSettingVariableType == VariableType.GuildVariable)
-            {
-                if (optNumericSet.Checked)
-                {
-                    mod.ModType = VariableMod.DupGuildVar;
-                }
-                else if (optNumericAdd.Checked)
-                {
-                    mod.ModType = VariableMod.AddGuildVar;
-                }
-                else if (optNumericSubtract.Checked)
-                {
-                    mod.ModType = VariableMod.SubtractGuildVar;
-                }
-                else if (optNumericMultiply.Checked)
-                {
-                    mod.ModType = VariableMod.MultiplyGuildVar;
-                }
-                else if (optNumericDivide.Checked)
-                {
-                    mod.ModType = VariableMod.DivideGuildVar;
-                }
-                else if (optNumericLeftShift.Checked)
-                {
-                    mod.ModType = VariableMod.LeftShiftGuildVar;
-                }
-                else
-                {
-                    mod.ModType = VariableMod.RightShiftGuildVar;
-                }
-            }
-            else if (mSettingVariableType == VariableType.UserVariable)
-            {
-                if (optNumericSet.Checked)
-                {
-                    mod.ModType = VariableMod.DuplicateUserVariable;
-                }
-                else if (optNumericAdd.Checked)
-                {
-                    mod.ModType = VariableMod.AddUserVariable;
-                }
-                else if (optNumericSubtract.Checked)
-                {
-                    mod.ModType = VariableMod.SubtractUserVariable;
-                }
-                else if (optNumericMultiply.Checked)
-                {
-                    mod.ModType = VariableMod.MultiplyUserVariable;
-                }
-                else if (optNumericDivide.Checked)
-                {
-                    mod.ModType = VariableMod.DivideUserVariable;
-                }
-                else if (optNumericLeftShift.Checked)
-                {
-                    mod.ModType = VariableMod.LeftShiftUserVariable;
-                }
-                else
-                {
-                    mod.ModType = VariableMod.RightShiftUserVariable;
-                }
-            }
-
-            return mod;
-        }
-
-        #endregion
-
-        #region "String Variable"
-
-        private void TryLoadStringMod(GameObjects.Events.VariableMod variableMod)
-        {
-            if (variableMod == null)
-            {
-                variableMod = new StringVariableMod();
-            }
-
-            if (variableMod is StringVariableMod stringMod)
-            {
-                switch (stringMod.ModType)
-                {
-                    case VariableMod.Set:
-                        optStaticString.Checked = true;
-                        txtStringValue.Text = stringMod.Value;
-
-                        break;
-                    case VariableMod.Replace:
-                        optReplaceString.Checked = true;
-                        txtStringFind.Text = stringMod.Value;
-                        txtStringReplace.Text = stringMod.Replace;
-
-                        break;
-                }
-            }
-
-            ResetSettingVariableSelection();
-        }
-
-        private StringVariableMod GetStringVariableMod()
-        {
-            var mod = new StringVariableMod();
-            if (optStaticString.Checked)
-            {
-                mod.ModType = VariableMod.Set;
-                mod.Value = txtStringValue.Text;
-            }
-            else if (optReplaceString.Checked)
-            {
-                mod.ModType = VariableMod.Replace;
-                mod.Value = txtStringFind.Text;
-                mod.Replace = txtStringReplace.Text;
-            }
-
-            return mod;
-        }
-
-        private void lblStringTextVariables_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
-        }
-
-        private void UpdateStringFormElements()
-        {
-            grpStringSet.Visible = optStaticString.Checked;
-            grpStringReplace.Visible = optReplaceString.Checked;
-        }
-
-        private void optStaticString_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateStringFormElements();
-        }
-
-        private void optReplaceString_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateStringFormElements();
-        }
-
-        #endregion
-
-        private void btnVisual_Click(object sender, EventArgs e)
-        {
-            VariableSelectorUtils.OpenVariableSelector((selection) =>
-            {
-                mSelectedVariableType = selection.VariableType;
-                mSelectedVariableId = selection.VariableId;
-
-                InitEditor();
-                ResetSettingVariableSelection();
-            }, mSelectedVariableId, mSelectedVariableType);
-        }
-
-        private void rdoBoolVariable_CheckedChanged(object sender, EventArgs e)
-        {
-            grpSettingVariable.Visible = true;
-        }
-
-        private void optBooleanTrue_CheckedChanged(object sender, EventArgs e)
-        {
-            ResetSettingVariableSelection();
-        }
-
-        private void optBooleanFalse_CheckedChanged(object sender, EventArgs e)
-        {
-            ResetSettingVariableSelection();
-        }
-
-        private void ResetSettingVariableSelection(bool hide = true)
-        {
-            grpSettingVariable.Visible = !hide;
-            mSettingVariableType = VariableType.PlayerVariable;
-            mSettingVariableId = Guid.Empty;
-        }
-
-        private void btnSettingVariableSelector_Click(object sender, EventArgs e)
-        {
-            VariableSelectorUtils.OpenVariableSelector((selection) =>
-            {
-                mSettingVariableType = selection.VariableType;
-                mSettingVariableId = selection.VariableId;
-
-                lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
-            }, mSettingVariableId, mSettingVariableType, GetCurrentDataTypeFilter());
-        }
-
-        private void rdoVariableValue_CheckedChanged(object sender, EventArgs e)
-        {
-            grpSettingVariable.Visible = true;
-        }
-
-        private void optNumericStaticVal_CheckedChanged(object sender, EventArgs e)
-        {
-            ResetSettingVariableSelection();
+            return 0;
         }
     }
 
+    private void UpdateFormElements()
+    {
+        //Hide editor windows until we have a variable selected to work with
+        grpNumericVariable.Hide();
+        grpBooleanVariable.Hide();
+        grpStringVariable.Hide();
+
+        var varType = GetCurrentDataTypeFilter();
+
+        //Load the correct editor
+        if (varType > 0)
+        {
+            switch (varType)
+            {
+                case VariableDataType.Boolean:
+                    grpBooleanVariable.Show();
+                    TryLoadBooleanMod(mMyCommand.Modification);
+
+                    break;
+
+                case VariableDataType.Integer:
+                    grpNumericVariable.Show();
+                    TryLoadNumericMod(mMyCommand.Modification);
+                    UpdateNumericFormElements();
+
+                    break;
+
+                case VariableDataType.Number:
+                    break;
+
+                case VariableDataType.String:
+                    grpStringVariable.Show();
+                    TryLoadStringMod(mMyCommand.Modification);
+
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        lblVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSelectedVariableType, mSelectedVariableId);
+        lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.VariableType = mSelectedVariableType;
+        mMyCommand.VariableId = mSelectedVariableId;
+
+        if (grpNumericVariable.Visible)
+        {
+            mMyCommand.Modification = GetNumericVariableMod();
+        }
+        else if (grpBooleanVariable.Visible)
+        {
+            mMyCommand.Modification = GetBooleanVariableMod();
+        }
+        else if (grpStringVariable.Visible)
+        {
+            mMyCommand.Modification = GetStringVariableMod();
+        }
+        else
+        {
+            switch (mMyCommand.Modification)
+            {
+                case BooleanVariableMod _:
+                    mMyCommand.Modification = GetBooleanVariableMod();
+                    break;
+
+                case IntegerVariableMod _:
+                    mMyCommand.Modification = GetNumericVariableMod();
+                    break;
+
+                case null:
+                    mMyCommand.Modification = new BooleanVariableMod();
+                    break;
+            }
+        }
+
+        mMyCommand.SyncParty = chkSyncParty.Checked;
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    #region "Boolean Variable"
+
+    private void TryLoadBooleanMod(GameObjects.Events.VariableMod variableMod)
+    {
+        if (variableMod == null)
+        {
+            variableMod = new BooleanVariableMod();
+        }
+
+        if (!(variableMod is BooleanVariableMod booleanMod))
+        {
+            return;
+        }
+
+        optBooleanTrue.Checked = booleanMod.Value;
+        optBooleanFalse.Checked = !booleanMod.Value;
+
+        if (booleanMod.DuplicateVariableId == Guid.Empty)
+        {
+            ResetSettingVariableSelection();
+            return;
+        }
+
+        rdoBoolVariable.Checked = true;
+        mSettingVariableId = booleanMod.DuplicateVariableId;
+        mSettingVariableType = booleanMod.DupVariableType;
+
+        lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
+    }
+
+    private BooleanVariableMod GetBooleanVariableMod()
+    {
+        var mod = new BooleanVariableMod
+        {
+            Value = optBooleanTrue.Checked,
+            DuplicateVariableId = mSettingVariableId,
+            DupVariableType = mSettingVariableType
+        };
+
+        return mod;
+    }
+
+    #endregion
+
+    #region "Numeric Variable"
+
+    private void TryLoadNumericMod(GameObjects.Events.VariableMod variableMod)
+    {
+        if (variableMod == null)
+        {
+            variableMod = new IntegerVariableMod();
+        }
+
+        if (!(variableMod is IntegerVariableMod integerMod))
+        {
+            return;
+        }
+
+        switch (integerMod.ModType)
+        {
+            case VariableMod.Set:
+            case VariableMod.Add:
+            case VariableMod.Subtract:
+            case VariableMod.Multiply:
+            case VariableMod.Divide:
+            case VariableMod.LeftShift:
+            case VariableMod.RightShift:
+            case VariableMod.Random:
+            case VariableMod.SystemTime:
+                nudNumericValue.Value = integerMod.Value;
+                ResetSettingVariableSelection();
+                break;
+
+            default:
+                rdoVariableValue.Checked = true;
+                mSettingVariableId = integerMod.DuplicateVariableId;
+                mSettingVariableType = integerMod.ModType.GetRelatedVariableType();
+                break;
+        }
+
+        optNumericSet.Checked = VariableModUtils.SetMods.Contains(integerMod.ModType);
+        optNumericAdd.Checked = VariableModUtils.AddMods.Contains(integerMod.ModType);
+        optNumericSubtract.Checked = VariableModUtils.SubMods.Contains(integerMod.ModType);
+        optNumericMultiply.Checked = VariableModUtils.MultMods.Contains(integerMod.ModType);
+        optNumericDivide.Checked = VariableModUtils.DivideMods.Contains(integerMod.ModType);
+        optNumericLeftShift.Checked = VariableModUtils.LShiftMods.Contains(integerMod.ModType);
+        optNumericRightShift.Checked = VariableModUtils.RShiftMods.Contains(integerMod.ModType);
+
+        optNumericSystemTime.Checked = integerMod.ModType == VariableMod.SystemTime;
+
+        if (integerMod.ModType == VariableMod.Random)
+        {
+            optNumericRandom.Checked = true;
+            nudLow.Value = integerMod.Value;
+            nudHigh.Value = integerMod.HighValue;
+        }
+    }
+
+    private void UpdateNumericFormElements()
+    {
+        grpNumericRandom.Visible = optNumericRandom.Checked;
+        grpNumericValues.Visible = optNumericAdd.Checked | optNumericSubtract.Checked | optNumericSet.Checked | optNumericMultiply.Checked |
+                                   optNumericDivide.Checked | optNumericLeftShift.Checked | optNumericRightShift.Checked;
+    }
+
+    private void optNumericSet_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericAdd_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericSubtract_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericMultiply_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericDivide_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericLeftShift_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericRightShift_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericRandom_CheckedChanged(object sender, EventArgs e)
+    {
+        ResetSettingVariableSelection();
+        UpdateNumericFormElements();
+    }
+
+    private void optNumericSystemTime_CheckedChanged(object sender, EventArgs e)
+    {
+        ResetSettingVariableSelection();
+        UpdateNumericFormElements();
+    }
+
+    private IntegerVariableMod GetNumericVariableMod()
+    {
+        var mod = new IntegerVariableMod()
+        {
+            DuplicateVariableId = mSettingVariableId
+        };
+
+        mod.Value = optNumericRandom.Checked ? (int)nudLow.Value : (int)nudNumericValue.Value;
+
+        if (optNumericSet.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.Set;
+        }
+        else if (optNumericAdd.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.Add;
+        }
+        else if (optNumericSubtract.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.Subtract;
+        }
+        else if (optNumericMultiply.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.Multiply;
+        }
+        else if (optNumericDivide.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.Divide;
+        }
+        else if (optNumericLeftShift.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.LeftShift;
+        }
+        else if (optNumericRightShift.Checked && optNumericStaticVal.Checked)
+        {
+            mod.ModType = VariableMod.RightShift;
+        }
+        else if (optNumericRandom.Checked)
+        {
+            mod.ModType = VariableMod.Random;
+            mod.HighValue = (int)nudHigh.Value;
+            if (mod.HighValue < mod.Value)
+            {
+                var n = mod.Value;
+                mod.Value = mod.HighValue;
+                mod.HighValue = n;
+            }
+        }
+        else if (optNumericSystemTime.Checked)
+        {
+            mod.ModType = VariableMod.SystemTime;
+        }
+        else if (mSettingVariableType == VariableType.PlayerVariable)
+        {
+            if (optNumericSet.Checked)
+            {
+                mod.ModType = VariableMod.DupPlayerVar;
+            }
+            else if (optNumericAdd.Checked)
+            {
+                mod.ModType = VariableMod.AddPlayerVar;
+            }
+            else if (optNumericSubtract.Checked)
+            {
+                mod.ModType = VariableMod.SubtractPlayerVar;
+            }
+            else if (optNumericMultiply.Checked)
+            {
+                mod.ModType = VariableMod.MultiplyPlayerVar;
+            }
+            else if (optNumericDivide.Checked)
+            {
+                mod.ModType = VariableMod.DividePlayerVar;
+            }
+            else if (optNumericLeftShift.Checked)
+            {
+                mod.ModType = VariableMod.LeftShiftPlayerVar;
+            }
+            else
+            {
+                mod.ModType = VariableMod.RightShiftPlayerVar;
+            }
+        }
+        else if (mSettingVariableType == VariableType.ServerVariable)
+        {
+            if (optNumericSet.Checked)
+            {
+                mod.ModType = VariableMod.DupGlobalVar;
+            }
+            else if (optNumericAdd.Checked)
+            {
+                mod.ModType = VariableMod.AddGlobalVar;
+            }
+            else if (optNumericSubtract.Checked)
+            {
+                mod.ModType = VariableMod.SubtractGlobalVar;
+            }
+            else if (optNumericMultiply.Checked)
+            {
+                mod.ModType = VariableMod.MultiplyGlobalVar;
+            }
+            else if (optNumericDivide.Checked)
+            {
+                mod.ModType = VariableMod.DivideGlobalVar;
+            }
+            else if (optNumericLeftShift.Checked)
+            {
+                mod.ModType = VariableMod.LeftShiftGlobalVar;
+            }
+            else
+            {
+                mod.ModType = VariableMod.RightShiftGlobalVar;
+            }
+        }
+        else if (mSettingVariableType == VariableType.GuildVariable)
+        {
+            if (optNumericSet.Checked)
+            {
+                mod.ModType = VariableMod.DupGuildVar;
+            }
+            else if (optNumericAdd.Checked)
+            {
+                mod.ModType = VariableMod.AddGuildVar;
+            }
+            else if (optNumericSubtract.Checked)
+            {
+                mod.ModType = VariableMod.SubtractGuildVar;
+            }
+            else if (optNumericMultiply.Checked)
+            {
+                mod.ModType = VariableMod.MultiplyGuildVar;
+            }
+            else if (optNumericDivide.Checked)
+            {
+                mod.ModType = VariableMod.DivideGuildVar;
+            }
+            else if (optNumericLeftShift.Checked)
+            {
+                mod.ModType = VariableMod.LeftShiftGuildVar;
+            }
+            else
+            {
+                mod.ModType = VariableMod.RightShiftGuildVar;
+            }
+        }
+        else if (mSettingVariableType == VariableType.UserVariable)
+        {
+            if (optNumericSet.Checked)
+            {
+                mod.ModType = VariableMod.DuplicateUserVariable;
+            }
+            else if (optNumericAdd.Checked)
+            {
+                mod.ModType = VariableMod.AddUserVariable;
+            }
+            else if (optNumericSubtract.Checked)
+            {
+                mod.ModType = VariableMod.SubtractUserVariable;
+            }
+            else if (optNumericMultiply.Checked)
+            {
+                mod.ModType = VariableMod.MultiplyUserVariable;
+            }
+            else if (optNumericDivide.Checked)
+            {
+                mod.ModType = VariableMod.DivideUserVariable;
+            }
+            else if (optNumericLeftShift.Checked)
+            {
+                mod.ModType = VariableMod.LeftShiftUserVariable;
+            }
+            else
+            {
+                mod.ModType = VariableMod.RightShiftUserVariable;
+            }
+        }
+
+        return mod;
+    }
+
+    #endregion
+
+    #region "String Variable"
+
+    private void TryLoadStringMod(GameObjects.Events.VariableMod variableMod)
+    {
+        if (variableMod == null)
+        {
+            variableMod = new StringVariableMod();
+        }
+
+        if (variableMod is StringVariableMod stringMod)
+        {
+            switch (stringMod.ModType)
+            {
+                case VariableMod.Set:
+                    optStaticString.Checked = true;
+                    txtStringValue.Text = stringMod.Value;
+
+                    break;
+                case VariableMod.Replace:
+                    optReplaceString.Checked = true;
+                    txtStringFind.Text = stringMod.Value;
+                    txtStringReplace.Text = stringMod.Replace;
+
+                    break;
+            }
+        }
+
+        ResetSettingVariableSelection();
+    }
+
+    private StringVariableMod GetStringVariableMod()
+    {
+        var mod = new StringVariableMod();
+        if (optStaticString.Checked)
+        {
+            mod.ModType = VariableMod.Set;
+            mod.Value = txtStringValue.Text;
+        }
+        else if (optReplaceString.Checked)
+        {
+            mod.ModType = VariableMod.Replace;
+            mod.Value = txtStringFind.Text;
+            mod.Replace = txtStringReplace.Text;
+        }
+
+        return mod;
+    }
+
+    private void lblStringTextVariables_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://www.ascensiongamedev.com/community/topic/749-event-text-variables/");
+    }
+
+    private void UpdateStringFormElements()
+    {
+        grpStringSet.Visible = optStaticString.Checked;
+        grpStringReplace.Visible = optReplaceString.Checked;
+    }
+
+    private void optStaticString_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateStringFormElements();
+    }
+
+    private void optReplaceString_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateStringFormElements();
+    }
+
+    #endregion
+
+    private void btnVisual_Click(object sender, EventArgs e)
+    {
+        VariableSelectorUtils.OpenVariableSelector((selection) =>
+        {
+            mSelectedVariableType = selection.VariableType;
+            mSelectedVariableId = selection.VariableId;
+
+            InitEditor();
+            ResetSettingVariableSelection();
+        }, mSelectedVariableId, mSelectedVariableType);
+    }
+
+    private void rdoBoolVariable_CheckedChanged(object sender, EventArgs e)
+    {
+        grpSettingVariable.Visible = true;
+    }
+
+    private void optBooleanTrue_CheckedChanged(object sender, EventArgs e)
+    {
+        ResetSettingVariableSelection();
+    }
+
+    private void optBooleanFalse_CheckedChanged(object sender, EventArgs e)
+    {
+        ResetSettingVariableSelection();
+    }
+
+    private void ResetSettingVariableSelection(bool hide = true)
+    {
+        grpSettingVariable.Visible = !hide;
+        mSettingVariableType = VariableType.PlayerVariable;
+        mSettingVariableId = Guid.Empty;
+    }
+
+    private void btnSettingVariableSelector_Click(object sender, EventArgs e)
+    {
+        VariableSelectorUtils.OpenVariableSelector((selection) =>
+        {
+            mSettingVariableType = selection.VariableType;
+            mSettingVariableId = selection.VariableId;
+
+            lblSettingVarSelection.Text = VariableSelectorUtils.GetSelectedVarText(mSettingVariableType, mSettingVariableId);
+        }, mSettingVariableId, mSettingVariableType, GetCurrentDataTypeFilter());
+    }
+
+    private void rdoVariableValue_CheckedChanged(object sender, EventArgs e)
+    {
+        grpSettingVariable.Visible = true;
+    }
+
+    private void optNumericStaticVal_CheckedChanged(object sender, EventArgs e)
+    {
+        ResetSettingVariableSelection();
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Wait.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Wait.cs
@@ -1,49 +1,47 @@
 ﻿using Intersect.Editor.Localization;
 using Intersect.GameObjects.Events.Commands;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandWait : UserControl
 {
 
-    public partial class EventCommandWait : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private WaitCommand mMyCommand;
+
+    public EventCommandWait(WaitCommand refCommand, FrmEvent editor)
     {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        nudWait.Value = mMyCommand.Time;
+        lblWait.Text = Strings.EventWait.label;
+    }
 
-        private readonly FrmEvent mEventEditor;
+    private void InitLocalization()
+    {
+        grpWait.Text = Strings.EventWait.title;
+        lblWait.Text = Strings.EventWait.label;
+        btnSave.Text = Strings.EventWait.okay;
+        btnCancel.Text = Strings.EventWait.cancel;
+    }
 
-        private WaitCommand mMyCommand;
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Time = (int) nudWait.Value;
+        mEventEditor.FinishCommandEdit();
+    }
 
-        public EventCommandWait(WaitCommand refCommand, FrmEvent editor)
-        {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            nudWait.Value = mMyCommand.Time;
-            lblWait.Text = Strings.EventWait.label;
-        }
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
 
-        private void InitLocalization()
-        {
-            grpWait.Text = Strings.EventWait.title;
-            lblWait.Text = Strings.EventWait.label;
-            btnSave.Text = Strings.EventWait.okay;
-            btnCancel.Text = Strings.EventWait.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.Time = (int) nudWait.Value;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void nudWait_ValueChanged(object sender, EventArgs e)
-        {
-        }
-
+    private void nudWait_ValueChanged(object sender, EventArgs e)
+    {
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_WaitForRouteCompletion.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_WaitForRouteCompletion.cs
@@ -3,98 +3,96 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandWaitForRouteCompletion : UserControl
 {
 
-    public partial class EventCommandWaitForRouteCompletion : UserControl
+    private readonly EventBase mEditingEvent;
+
+    private MapBase mCurrentMap;
+
+    private WaitForRouteCommand mEditingCommand;
+
+    private FrmEvent mEventEditor;
+
+    public EventCommandWaitForRouteCompletion(
+        WaitForRouteCommand refCommand,
+        FrmEvent eventEditor,
+        MapBase currentMap,
+        EventBase currentEvent
+    )
     {
+        InitializeComponent();
 
-        private readonly EventBase mEditingEvent;
-
-        private MapBase mCurrentMap;
-
-        private WaitForRouteCommand mEditingCommand;
-
-        private FrmEvent mEventEditor;
-
-        public EventCommandWaitForRouteCompletion(
-            WaitForRouteCommand refCommand,
-            FrmEvent eventEditor,
-            MapBase currentMap,
-            EventBase currentEvent
-        )
+        //Grab event editor reference
+        mEventEditor = eventEditor;
+        mEditingEvent = currentEvent;
+        mEditingCommand = refCommand;
+        mCurrentMap = currentMap;
+        InitLocalization();
+        cmbEntities.Items.Clear();
+        if (!mEditingEvent.CommonEvent)
         {
-            InitializeComponent();
-
-            //Grab event editor reference
-            mEventEditor = eventEditor;
-            mEditingEvent = currentEvent;
-            mEditingCommand = refCommand;
-            mCurrentMap = currentMap;
-            InitLocalization();
-            cmbEntities.Items.Clear();
-            if (!mEditingEvent.CommonEvent)
+            cmbEntities.Items.Add(Strings.EventWaitForRouteCompletion.player);
+            if (mEditingCommand.TargetId == Guid.Empty)
             {
-                cmbEntities.Items.Add(Strings.EventWaitForRouteCompletion.player);
-                if (mEditingCommand.TargetId == Guid.Empty)
-                {
-                    cmbEntities.SelectedIndex = -1;
-                }
-
-                foreach (var evt in mCurrentMap.LocalEvents)
-                {
-                    cmbEntities.Items.Add(
-                        evt.Key == mEditingEvent.Id
-                            ? Strings.EventWaitForRouteCompletion.This + " "
-                            : "" + evt.Value.Name
-                    );
-
-                    if (mEditingCommand.TargetId == evt.Key)
-                    {
-                        cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
-                    }
-                }
+                cmbEntities.SelectedIndex = -1;
             }
 
-            if (cmbEntities.SelectedIndex == -1 && cmbEntities.Items.Count > 0)
+            foreach (var evt in mCurrentMap.LocalEvents)
             {
-                cmbEntities.SelectedIndex = 0;
-            }
+                cmbEntities.Items.Add(
+                    evt.Key == mEditingEvent.Id
+                        ? Strings.EventWaitForRouteCompletion.This + " "
+                        : "" + evt.Value.Name
+                );
 
-            mEditingCommand = refCommand;
-            mEventEditor = eventEditor;
-        }
-
-        private void InitLocalization()
-        {
-            grpWaitRoute.Text = Strings.EventWaitForRouteCompletion.title;
-            lblEntity.Text = Strings.EventWaitForRouteCompletion.label;
-            btnSave.Text = Strings.EventWaitForRouteCompletion.okay;
-            btnCancel.Text = Strings.EventWaitForRouteCompletion.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (!mEditingEvent.CommonEvent)
-            {
-                if (cmbEntities.SelectedIndex == 0)
+                if (mEditingCommand.TargetId == evt.Key)
                 {
-                    mEditingCommand.TargetId = Guid.Empty;
-                }
-                else
-                {
-                    mEditingCommand.TargetId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
+                    cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
                 }
             }
-
-            mEventEditor.FinishCommandEdit();
         }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+        if (cmbEntities.SelectedIndex == -1 && cmbEntities.Items.Count > 0)
         {
-            mEventEditor.CancelCommandEdit();
+            cmbEntities.SelectedIndex = 0;
         }
 
+        mEditingCommand = refCommand;
+        mEventEditor = eventEditor;
+    }
+
+    private void InitLocalization()
+    {
+        grpWaitRoute.Text = Strings.EventWaitForRouteCompletion.title;
+        lblEntity.Text = Strings.EventWaitForRouteCompletion.label;
+        btnSave.Text = Strings.EventWaitForRouteCompletion.okay;
+        btnCancel.Text = Strings.EventWaitForRouteCompletion.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (!mEditingEvent.CommonEvent)
+        {
+            if (cmbEntities.SelectedIndex == 0)
+            {
+                mEditingCommand.TargetId = Guid.Empty;
+            }
+            else
+            {
+                mEditingCommand.TargetId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
+            }
+        }
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_Warp.cs
@@ -5,156 +5,154 @@ using Intersect.Enums;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps.MapList;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandWarp : UserControl
 {
 
-    public partial class EventCommandWarp : UserControl
+    private readonly FrmEvent mEventEditor;
+
+    private WarpCommand mMyCommand;
+
+    public EventCommandWarp(WarpCommand refCommand, FrmEvent editor)
     {
-
-        private readonly FrmEvent mEventEditor;
-
-        private WarpCommand mMyCommand;
-
-        public EventCommandWarp(WarpCommand refCommand, FrmEvent editor)
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbMap.Items.Clear();
+        cmbInstanceType.Items.Clear();
+        for (var i = 0; i < MapList.OrderedMaps.Count; i++)
         {
-            InitializeComponent();
-            mMyCommand = refCommand;
-            mEventEditor = editor;
-            InitLocalization();
-            cmbMap.Items.Clear();
-            cmbInstanceType.Items.Clear();
+            cmbMap.Items.Add(MapList.OrderedMaps[i].Name);
+            if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
+            {
+                cmbMap.SelectedIndex = i;
+            }
+        }
+
+        if (cmbMap.SelectedIndex == -1)
+        {
+            cmbMap.SelectedIndex = 0;
+        }
+
+        scrlX.Maximum = Options.MapWidth - 1;
+        scrlY.Maximum = Options.MapHeight - 1;
+        scrlX.Value = mMyCommand.X;
+        scrlY.Value = mMyCommand.Y;
+        lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
+        lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
+        cmbDirection.SelectedIndex = (int) mMyCommand.Direction;
+        chkChangeInstance.Checked = mMyCommand.ChangeInstance;
+        grpInstanceSettings.Visible = chkChangeInstance.Checked;
+
+        // We do not want to iterate over the "NoChange" enum
+        foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
+        {
+            cmbInstanceType.Items.Add(instanceType.ToString());
+        }
+        cmbInstanceType.SelectedIndex = (int) mMyCommand.InstanceType;
+    }
+
+    private void InitLocalization()
+    {
+        grpWarp.Text = Strings.EventWarp.title;
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
+        lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
+        lblDir.Text = Strings.Warping.direction.ToString("");
+        btnVisual.Text = Strings.Warping.visual;
+        cmbDirection.Items.Clear();
+        for (var i = -1; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        chkChangeInstance.Text = Strings.Warping.ChangeInstance;
+        grpInstanceSettings.Text = Strings.Warping.MapInstancingGroup;
+        lblInstanceType.Text = Strings.Warping.InstanceType;
+
+        btnSave.Text = Strings.EventWarp.okay;
+        btnCancel.Text = Strings.EventWarp.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
+        mMyCommand.X = (byte) scrlX.Value;
+        mMyCommand.Y = (byte) scrlY.Value;
+        mMyCommand.Direction = (WarpDirection) cmbDirection.SelectedIndex;
+        mMyCommand.ChangeInstance = chkChangeInstance.Checked;
+        mMyCommand.InstanceType = (MapInstanceType)cmbInstanceType.SelectedIndex;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void scrlX_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
+    }
+
+    private void scrlY_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
+    }
+
+    private void btnVisual_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, scrlX.Value, scrlY.Value);
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
             for (var i = 0; i < MapList.OrderedMaps.Count; i++)
             {
-                cmbMap.Items.Add(MapList.OrderedMaps[i].Name);
-                if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
                 {
                     cmbMap.SelectedIndex = i;
+
+                    break;
                 }
             }
 
-            if (cmbMap.SelectedIndex == -1)
-            {
-                cmbMap.SelectedIndex = 0;
-            }
-
-            scrlX.Maximum = Options.MapWidth - 1;
-            scrlY.Maximum = Options.MapHeight - 1;
-            scrlX.Value = mMyCommand.X;
-            scrlY.Value = mMyCommand.Y;
+            scrlX.Value = frmWarpSelection.GetX();
+            scrlY.Value = frmWarpSelection.GetY();
             lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
             lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
-            cmbDirection.SelectedIndex = (int) mMyCommand.Direction;
-            chkChangeInstance.Checked = mMyCommand.ChangeInstance;
-            grpInstanceSettings.Visible = chkChangeInstance.Checked;
-
-            // We do not want to iterate over the "NoChange" enum
-            foreach (MapInstanceType instanceType in Enum.GetValues(typeof(MapInstanceType)))
-            {
-                cmbInstanceType.Items.Add(instanceType.ToString());
-            }
-            cmbInstanceType.SelectedIndex = (int) mMyCommand.InstanceType;
-        }
-
-        private void InitLocalization()
-        {
-            grpWarp.Text = Strings.EventWarp.title;
-            lblMap.Text = Strings.Warping.map.ToString("");
-            lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
-            lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
-            lblDir.Text = Strings.Warping.direction.ToString("");
-            btnVisual.Text = Strings.Warping.visual;
-            cmbDirection.Items.Clear();
-            for (var i = -1; i < 4; i++)
-            {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-
-            chkChangeInstance.Text = Strings.Warping.ChangeInstance;
-            grpInstanceSettings.Text = Strings.Warping.MapInstancingGroup;
-            lblInstanceType.Text = Strings.Warping.InstanceType;
-
-            btnSave.Text = Strings.EventWarp.okay;
-            btnCancel.Text = Strings.EventWarp.cancel;
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
-            mMyCommand.X = (byte) scrlX.Value;
-            mMyCommand.Y = (byte) scrlY.Value;
-            mMyCommand.Direction = (WarpDirection) cmbDirection.SelectedIndex;
-            mMyCommand.ChangeInstance = chkChangeInstance.Checked;
-            mMyCommand.InstanceType = (MapInstanceType)cmbInstanceType.SelectedIndex;
-            mEventEditor.FinishCommandEdit();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mEventEditor.CancelCommandEdit();
-        }
-
-        private void scrlX_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
-        }
-
-        private void scrlY_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
-        }
-
-        private void btnVisual_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, scrlX.Value, scrlY.Value);
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
-                    {
-                        cmbMap.SelectedIndex = i;
-
-                        break;
-                    }
-                }
-
-                scrlX.Value = frmWarpSelection.GetX();
-                scrlY.Value = frmWarpSelection.GetY();
-                lblX.Text = Strings.Warping.x.ToString(scrlX.Value);
-                lblY.Text = Strings.Warping.y.ToString(scrlY.Value);
-            }
-        }
-
-        private void lblY_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void lblX_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void label23_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void cmbMap_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void label21_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void chkChangeInstance_CheckedChanged(object sender, EventArgs e)
-        {
-            grpInstanceSettings.Visible = chkChangeInstance.Checked;
         }
     }
 
+    private void lblY_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void lblX_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void label23_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
+    {
+    }
+
+    private void cmbMap_SelectedIndexChanged(object sender, EventArgs e)
+    {
+    }
+
+    private void label21_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void chkChangeInstance_CheckedChanged(object sender, EventArgs e)
+    {
+        grpInstanceSettings.Visible = chkChangeInstance.Checked;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -4,381 +4,379 @@ using Intersect.Enums;
 using Intersect.GameObjects.Events;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventGraphicSelector : UserControl
 {
 
-    public partial class EventGraphicSelector : UserControl
+    private EventGraphic mEditingGraphic;
+
+    private FrmEvent mEventEditor;
+
+    private bool mLoading;
+
+    private bool mMouseDown;
+
+    private bool mNewRouteAction;
+
+    private EventMoveRouteDesigner mRouteDesigner;
+
+    private int mSpriteHeight;
+
+    private int mSpriteWidth;
+
+    private EventGraphic mTmpGraphic = new EventGraphic();
+
+    public EventGraphicSelector(
+        EventGraphic editingGraphic,
+        FrmEvent eventEditor,
+        EventMoveRouteDesigner moveRouteDesigner = null,
+        bool newMoveRouteAction = false
+    )
     {
-
-        private EventGraphic mEditingGraphic;
-
-        private FrmEvent mEventEditor;
-
-        private bool mLoading;
-
-        private bool mMouseDown;
-
-        private bool mNewRouteAction;
-
-        private EventMoveRouteDesigner mRouteDesigner;
-
-        private int mSpriteHeight;
-
-        private int mSpriteWidth;
-
-        private EventGraphic mTmpGraphic = new EventGraphic();
-
-        public EventGraphicSelector(
-            EventGraphic editingGraphic,
-            FrmEvent eventEditor,
-            EventMoveRouteDesigner moveRouteDesigner = null,
-            bool newMoveRouteAction = false
-        )
+        InitializeComponent();
+        InitLocalization();
+        mEditingGraphic = editingGraphic;
+        mEventEditor = eventEditor;
+        mLoading = true;
+        cmbGraphicType.SelectedIndex = (int)mEditingGraphic.Type;
+        UpdateGraphicList();
+        if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
         {
-            InitializeComponent();
-            InitLocalization();
-            mEditingGraphic = editingGraphic;
-            mEventEditor = eventEditor;
-            mLoading = true;
-            cmbGraphicType.SelectedIndex = (int)mEditingGraphic.Type;
-            UpdateGraphicList();
-            if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
-            {
-                cmbGraphic.SelectedIndex = cmbGraphic.Items.IndexOf(mEditingGraphic.Filename);
-            }
+            cmbGraphic.SelectedIndex = cmbGraphic.Items.IndexOf(mEditingGraphic.Filename);
+        }
 
-            mRouteDesigner = moveRouteDesigner;
-            mNewRouteAction = newMoveRouteAction;
-            mLoading = false;
-            mTmpGraphic.CopyFrom(mEditingGraphic);
+        mRouteDesigner = moveRouteDesigner;
+        mNewRouteAction = newMoveRouteAction;
+        mLoading = false;
+        mTmpGraphic.CopyFrom(mEditingGraphic);
+        UpdatePreview();
+    }
+
+    private void InitLocalization()
+    {
+        grpSelector.Text = Strings.EventGraphic.title;
+        lblType.Text = Strings.EventGraphic.type;
+        cmbGraphicType.Items.Clear();
+        cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype0);
+        cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype1);
+        cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype2);
+        lblGraphic.Text = Strings.EventGraphic.graphic;
+        grpPreview.Text = Strings.EventGraphic.preview;
+        btnOk.Text = Strings.EventGraphic.okay;
+        btnCancel.Text = Strings.EventGraphic.cancel;
+    }
+
+    private void GraphicTypeUpdated()
+    {
+        mTmpGraphic.Filename = "";
+        mTmpGraphic.Type = EventGraphicType.None;
+        mTmpGraphic.X = 0;
+        mTmpGraphic.Y = 0;
+        mTmpGraphic.Width = -1;
+        mTmpGraphic.Height = -1;
+        if (cmbGraphicType.SelectedIndex == 0) //No Graphic
+        {
+            cmbGraphic.Hide();
+            lblGraphic.Hide();
             UpdatePreview();
         }
-
-        private void InitLocalization()
+        else if (cmbGraphicType.SelectedIndex == 1) //Sprite
         {
-            grpSelector.Text = Strings.EventGraphic.title;
-            lblType.Text = Strings.EventGraphic.type;
-            cmbGraphicType.Items.Clear();
-            cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype0);
-            cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype1);
-            cmbGraphicType.Items.Add(Strings.EventGraphic.graphictype2);
-            lblGraphic.Text = Strings.EventGraphic.graphic;
-            grpPreview.Text = Strings.EventGraphic.preview;
-            btnOk.Text = Strings.EventGraphic.okay;
-            btnCancel.Text = Strings.EventGraphic.cancel;
-        }
-
-        private void GraphicTypeUpdated()
-        {
-            mTmpGraphic.Filename = "";
-            mTmpGraphic.Type = EventGraphicType.None;
-            mTmpGraphic.X = 0;
-            mTmpGraphic.Y = 0;
-            mTmpGraphic.Width = -1;
-            mTmpGraphic.Height = -1;
-            if (cmbGraphicType.SelectedIndex == 0) //No Graphic
-            {
-                cmbGraphic.Hide();
-                lblGraphic.Hide();
-                UpdatePreview();
-            }
-            else if (cmbGraphicType.SelectedIndex == 1) //Sprite
-            {
-                mTmpGraphic.Type = EventGraphicType.Sprite;
-                cmbGraphic.Show();
-                lblGraphic.Show();
-                cmbGraphic.Items.Clear();
-
-                var sortedTextures =
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
-
-                if (sortedTextures.Length > 0)
-                {
-                    cmbGraphic.Items.AddRange(sortedTextures);
-                }
-                else
-                {
-                    cmbGraphic.Items.Add(Strings.General.None);
-                }
-
-                cmbGraphic.SelectedIndex = 0;
-            }
-            else if (cmbGraphicType.SelectedIndex == 2) //Tileset
-            {
-                mTmpGraphic.Type = EventGraphicType.Tileset;
-                mTmpGraphic.Width = 0;
-                mTmpGraphic.Height = 0;
-                lblGraphic.Show();
-                cmbGraphic.Show();
-                cmbGraphic.Items.Clear();
-
-                var sortedTextures =
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
-
-                if (sortedTextures.Length > 0)
-                {
-                    cmbGraphic.Items.AddRange(sortedTextures);
-                }
-                else
-                {
-                    cmbGraphic.Items.Add(Strings.General.None);
-                }
-
-                cmbGraphic.SelectedIndex = 0;
-            }
-        }
-
-        private void UpdateGraphicList()
-        {
+            mTmpGraphic.Type = EventGraphicType.Sprite;
+            cmbGraphic.Show();
+            lblGraphic.Show();
             cmbGraphic.Items.Clear();
-            if (cmbGraphicType.SelectedIndex == 0) //No Graphic
+
+            var sortedTextures =
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
+
+            if (sortedTextures.Length > 0)
             {
-                cmbGraphic.Hide();
-                lblGraphic.Hide();
-            }
-            else if (cmbGraphicType.SelectedIndex == 1) //Sprite
-            {
-                cmbGraphic.Show();
-                lblGraphic.Show();
-
-                var sortedTextures =
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
-
-                if (sortedTextures.Length > 0)
-                {
-                    cmbGraphic.Items.AddRange(sortedTextures);
-                }
-                else
-                {
-                    cmbGraphic.Items.Add(Strings.General.None);
-                }
-
-                cmbGraphic.SelectedIndex = 0;
-            }
-            else if (cmbGraphicType.SelectedIndex == 2) //Tileset
-            {
-                lblGraphic.Show();
-                cmbGraphic.Show();
-
-                var sortedTextures =
-                    GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
-
-                if (sortedTextures.Length > 0)
-                {
-                    cmbGraphic.Items.AddRange(sortedTextures);
-                }
-                else
-                {
-                    cmbGraphic.Items.Add(Strings.General.None);
-                }
-
-                cmbGraphic.SelectedIndex = 0;
-            }
-        }
-
-        private void UpdatePreview()
-        {
-            Graphics graphics;
-            Bitmap sourceBitmap = null;
-            Bitmap destBitmap = null;
-            if (cmbGraphicType.SelectedIndex == 1) //Sprite
-            {
-                var spriteFile = "resources/entities/" + cmbGraphic.Text;
-                if (File.Exists(spriteFile))
-                {
-                    sourceBitmap = new Bitmap(spriteFile);
-                    mSpriteWidth = sourceBitmap.Width / Options.Instance.Sprites.NormalFrames;
-                    mSpriteHeight = sourceBitmap.Height / Options.Instance.Sprites.Directions;
-                }
-            }
-            else if (cmbGraphicType.SelectedIndex == 2) //Tileset
-            {
-                var tileSetFile = "resources/tilesets/" + cmbGraphic.Text;
-                if (File.Exists(tileSetFile))
-                {
-                    sourceBitmap = new Bitmap(tileSetFile);
-                }
-            }
-
-            if (sourceBitmap != null)
-            {
-                pnlGraphic.Show();
-                destBitmap = new Bitmap(sourceBitmap.Width, sourceBitmap.Height);
-                pnlGraphic.Width = sourceBitmap.Width;
-                pnlGraphic.Height = sourceBitmap.Height;
-                graphics = Graphics.FromImage(destBitmap);
-                graphics.Clear(System.Drawing.Color.FromArgb(60, 63, 65));
-                graphics.DrawImage(sourceBitmap, new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height));
-                if (cmbGraphicType.SelectedIndex == 1)
-                {
-                    graphics.DrawRectangle(
-                        new Pen(System.Drawing.Color.White, 2f),
-                        new Rectangle(
-                            mTmpGraphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, mTmpGraphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions,
-                            sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
-                        )
-                    );
-                }
-                else if (cmbGraphicType.SelectedIndex == 2)
-                {
-                    var selX = mTmpGraphic.X;
-                    var selY = mTmpGraphic.Y;
-                    var selW = mTmpGraphic.Width;
-                    var selH = mTmpGraphic.Height;
-                    if (selW < 0)
-                    {
-                        selX -= Math.Abs(selW);
-                        selW = Math.Abs(selW);
-                    }
-
-                    if (selH < 0)
-                    {
-                        selY -= Math.Abs(selH);
-                        selH = Math.Abs(selH);
-                    }
-
-                    graphics.DrawRectangle(
-                        new Pen(System.Drawing.Color.White, 2f),
-                        new Rectangle(
-                            selX * Options.TileWidth, selY * Options.TileHeight,
-                            Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
-                        )
-                    );
-                }
-
-                sourceBitmap.Dispose();
-                graphics.Dispose();
-                pnlGraphic.BackgroundImage = destBitmap;
+                cmbGraphic.Items.AddRange(sortedTextures);
             }
             else
             {
-                pnlGraphic.Hide();
+                cmbGraphic.Items.Add(Strings.General.None);
             }
+
+            cmbGraphic.SelectedIndex = 0;
         }
-
-        private void cmbGraphicType_SelectedIndexChanged(object sender, EventArgs e)
+        else if (cmbGraphicType.SelectedIndex == 2) //Tileset
         {
-            if (!mLoading)
-            {
-                GraphicTypeUpdated();
-            }
-        }
-
-        private void cmbGraphic_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mTmpGraphic.Filename = cmbGraphic.Text;
-            UpdatePreview();
-        }
-
-        private void pnlGraphic_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
-            {
-                return;
-            }
-
-            if (cmbGraphicType.SelectedIndex == 1)
-            {
-                mTmpGraphic.X = (int) Math.Floor((double) e.X / mSpriteWidth);
-                mTmpGraphic.Y = (int) Math.Floor((double) e.Y / mSpriteHeight);
-            }
-            else
-            {
-                mMouseDown = true;
-                mTmpGraphic.X = (int) Math.Floor((double) e.X / Options.TileWidth);
-                mTmpGraphic.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
-            }
-
+            mTmpGraphic.Type = EventGraphicType.Tileset;
             mTmpGraphic.Width = 0;
             mTmpGraphic.Height = 0;
-            if (mTmpGraphic.X < 0)
+            lblGraphic.Show();
+            cmbGraphic.Show();
+            cmbGraphic.Items.Clear();
+
+            var sortedTextures =
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+
+            if (sortedTextures.Length > 0)
             {
-                mTmpGraphic.X = 0;
+                cmbGraphic.Items.AddRange(sortedTextures);
+            }
+            else
+            {
+                cmbGraphic.Items.Add(Strings.General.None);
             }
 
-            if (mTmpGraphic.Y < 0)
-            {
-                mTmpGraphic.Y = 0;
-            }
-
-            UpdatePreview();
+            cmbGraphic.SelectedIndex = 0;
         }
+    }
 
-        private void pnlGraphic_MouseUp(object sender, MouseEventArgs e)
+    private void UpdateGraphicList()
+    {
+        cmbGraphic.Items.Clear();
+        if (cmbGraphicType.SelectedIndex == 0) //No Graphic
         {
-            if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
-            {
-                return;
-            }
-
-            if (cmbGraphicType.SelectedIndex != 2)
-            {
-                return;
-            }
-
-            var selX = mTmpGraphic.X;
-            var selY = mTmpGraphic.Y;
-            var selW = mTmpGraphic.Width;
-            var selH = mTmpGraphic.Height;
-            if (selW < 0)
-            {
-                selX -= Math.Abs(selW);
-                selW = Math.Abs(selW);
-            }
-
-            if (selH < 0)
-            {
-                selY -= Math.Abs(selH);
-                selH = Math.Abs(selH);
-            }
-
-            mTmpGraphic.X = selX;
-            mTmpGraphic.Y = selY;
-            mTmpGraphic.Width = selW;
-            mTmpGraphic.Height = selH;
-            mMouseDown = false;
-            UpdatePreview();
+            cmbGraphic.Hide();
+            lblGraphic.Hide();
         }
-
-        private void pnlGraphic_MouseMove(object sender, MouseEventArgs e)
+        else if (cmbGraphicType.SelectedIndex == 1) //Sprite
         {
-            if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
+            cmbGraphic.Show();
+            lblGraphic.Show();
+
+            var sortedTextures =
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
+
+            if (sortedTextures.Length > 0)
             {
-                return;
+                cmbGraphic.Items.AddRange(sortedTextures);
+            }
+            else
+            {
+                cmbGraphic.Items.Add(Strings.General.None);
             }
 
-            if (cmbGraphicType.SelectedIndex != 2)
-            {
-                return;
-            }
-
-            if (mMouseDown)
-            {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
-                mTmpGraphic.Width = tmpX - mTmpGraphic.X;
-                mTmpGraphic.Height = tmpY - mTmpGraphic.Y;
-            }
-
-            UpdatePreview();
+            cmbGraphic.SelectedIndex = 0;
         }
-
-        private void btnOk_Click(object sender, EventArgs e)
+        else if (cmbGraphicType.SelectedIndex == 2) //Tileset
         {
-            mEditingGraphic.CopyFrom(mTmpGraphic);
-            mEventEditor.CloseGraphicSelector(this);
-        }
+            lblGraphic.Show();
+            cmbGraphic.Show();
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            if (mRouteDesigner != null && mNewRouteAction)
+            var sortedTextures =
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+
+            if (sortedTextures.Length > 0)
             {
-                mRouteDesigner.RemoveLastAction();
+                cmbGraphic.Items.AddRange(sortedTextures);
+            }
+            else
+            {
+                cmbGraphic.Items.Add(Strings.General.None);
             }
 
-            mEventEditor.CloseGraphicSelector(this);
+            cmbGraphic.SelectedIndex = 0;
+        }
+    }
+
+    private void UpdatePreview()
+    {
+        Graphics graphics;
+        Bitmap sourceBitmap = null;
+        Bitmap destBitmap = null;
+        if (cmbGraphicType.SelectedIndex == 1) //Sprite
+        {
+            var spriteFile = "resources/entities/" + cmbGraphic.Text;
+            if (File.Exists(spriteFile))
+            {
+                sourceBitmap = new Bitmap(spriteFile);
+                mSpriteWidth = sourceBitmap.Width / Options.Instance.Sprites.NormalFrames;
+                mSpriteHeight = sourceBitmap.Height / Options.Instance.Sprites.Directions;
+            }
+        }
+        else if (cmbGraphicType.SelectedIndex == 2) //Tileset
+        {
+            var tileSetFile = "resources/tilesets/" + cmbGraphic.Text;
+            if (File.Exists(tileSetFile))
+            {
+                sourceBitmap = new Bitmap(tileSetFile);
+            }
         }
 
+        if (sourceBitmap != null)
+        {
+            pnlGraphic.Show();
+            destBitmap = new Bitmap(sourceBitmap.Width, sourceBitmap.Height);
+            pnlGraphic.Width = sourceBitmap.Width;
+            pnlGraphic.Height = sourceBitmap.Height;
+            graphics = Graphics.FromImage(destBitmap);
+            graphics.Clear(System.Drawing.Color.FromArgb(60, 63, 65));
+            graphics.DrawImage(sourceBitmap, new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height));
+            if (cmbGraphicType.SelectedIndex == 1)
+            {
+                graphics.DrawRectangle(
+                    new Pen(System.Drawing.Color.White, 2f),
+                    new Rectangle(
+                        mTmpGraphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, mTmpGraphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions,
+                        sourceBitmap.Width / Options.Instance.Sprites.NormalFrames, sourceBitmap.Height / Options.Instance.Sprites.Directions
+                    )
+                );
+            }
+            else if (cmbGraphicType.SelectedIndex == 2)
+            {
+                var selX = mTmpGraphic.X;
+                var selY = mTmpGraphic.Y;
+                var selW = mTmpGraphic.Width;
+                var selH = mTmpGraphic.Height;
+                if (selW < 0)
+                {
+                    selX -= Math.Abs(selW);
+                    selW = Math.Abs(selW);
+                }
+
+                if (selH < 0)
+                {
+                    selY -= Math.Abs(selH);
+                    selH = Math.Abs(selH);
+                }
+
+                graphics.DrawRectangle(
+                    new Pen(System.Drawing.Color.White, 2f),
+                    new Rectangle(
+                        selX * Options.TileWidth, selY * Options.TileHeight,
+                        Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
+                    )
+                );
+            }
+
+            sourceBitmap.Dispose();
+            graphics.Dispose();
+            pnlGraphic.BackgroundImage = destBitmap;
+        }
+        else
+        {
+            pnlGraphic.Hide();
+        }
+    }
+
+    private void cmbGraphicType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (!mLoading)
+        {
+            GraphicTypeUpdated();
+        }
+    }
+
+    private void cmbGraphic_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mTmpGraphic.Filename = cmbGraphic.Text;
+        UpdatePreview();
+    }
+
+    private void pnlGraphic_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
+        {
+            return;
+        }
+
+        if (cmbGraphicType.SelectedIndex == 1)
+        {
+            mTmpGraphic.X = (int) Math.Floor((double) e.X / mSpriteWidth);
+            mTmpGraphic.Y = (int) Math.Floor((double) e.Y / mSpriteHeight);
+        }
+        else
+        {
+            mMouseDown = true;
+            mTmpGraphic.X = (int) Math.Floor((double) e.X / Options.TileWidth);
+            mTmpGraphic.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        }
+
+        mTmpGraphic.Width = 0;
+        mTmpGraphic.Height = 0;
+        if (mTmpGraphic.X < 0)
+        {
+            mTmpGraphic.X = 0;
+        }
+
+        if (mTmpGraphic.Y < 0)
+        {
+            mTmpGraphic.Y = 0;
+        }
+
+        UpdatePreview();
+    }
+
+    private void pnlGraphic_MouseUp(object sender, MouseEventArgs e)
+    {
+        if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
+        {
+            return;
+        }
+
+        if (cmbGraphicType.SelectedIndex != 2)
+        {
+            return;
+        }
+
+        var selX = mTmpGraphic.X;
+        var selY = mTmpGraphic.Y;
+        var selW = mTmpGraphic.Width;
+        var selH = mTmpGraphic.Height;
+        if (selW < 0)
+        {
+            selX -= Math.Abs(selW);
+            selW = Math.Abs(selW);
+        }
+
+        if (selH < 0)
+        {
+            selY -= Math.Abs(selH);
+            selH = Math.Abs(selH);
+        }
+
+        mTmpGraphic.X = selX;
+        mTmpGraphic.Y = selY;
+        mTmpGraphic.Width = selW;
+        mTmpGraphic.Height = selH;
+        mMouseDown = false;
+        UpdatePreview();
+    }
+
+    private void pnlGraphic_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.X > pnlGraphic.Width || e.Y > pnlGraphic.Height)
+        {
+            return;
+        }
+
+        if (cmbGraphicType.SelectedIndex != 2)
+        {
+            return;
+        }
+
+        if (mMouseDown)
+        {
+            var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
+            var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            mTmpGraphic.Width = tmpX - mTmpGraphic.X;
+            mTmpGraphic.Height = tmpY - mTmpGraphic.Y;
+        }
+
+        UpdatePreview();
+    }
+
+    private void btnOk_Click(object sender, EventArgs e)
+    {
+        mEditingGraphic.CopyFrom(mTmpGraphic);
+        mEventEditor.CloseGraphicSelector(this);
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        if (mRouteDesigner != null && mNewRouteAction)
+        {
+            mRouteDesigner.RemoveLastAction();
+        }
+
+        mEventEditor.CloseGraphicSelector(this);
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteAnimationSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteAnimationSelector.cs
@@ -2,59 +2,57 @@
 using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventMoveRouteAnimationSelector : UserControl
 {
 
-    public partial class EventMoveRouteAnimationSelector : UserControl
+    private MoveRouteAction mMyAction;
+
+    private bool mNewAction;
+
+    private EventMoveRouteDesigner mRouteDesigner;
+
+    public EventMoveRouteAnimationSelector(
+        EventMoveRouteDesigner moveRouteDesigner,
+        MoveRouteAction action,
+        bool newAction = false
+    )
     {
-
-        private MoveRouteAction mMyAction;
-
-        private bool mNewAction;
-
-        private EventMoveRouteDesigner mRouteDesigner;
-
-        public EventMoveRouteAnimationSelector(
-            EventMoveRouteDesigner moveRouteDesigner,
-            MoveRouteAction action,
-            bool newAction = false
-        )
+        InitializeComponent();
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+        if (!newAction)
         {
-            InitializeComponent();
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.Add(Strings.General.None);
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
-            if (!newAction)
-            {
-                cmbAnimation.SelectedIndex = AnimationBase.ListIndex(action.AnimationId) + 1;
-            }
-
-            mNewAction = newAction;
-            mRouteDesigner = moveRouteDesigner;
-            mMyAction = action;
-            InitLocalization();
+            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(action.AnimationId) + 1;
         }
 
-        private void InitLocalization()
-        {
-            grpSetAnimation.Text = Strings.EventSetAnimation.title;
-            lblAnimation.Text = Strings.EventSetAnimation.label;
-            btnOkay.Text = Strings.EventSetAnimation.okay;
-            btnCancel.Text = Strings.EventSetAnimation.cancel;
-        }
+        mNewAction = newAction;
+        mRouteDesigner = moveRouteDesigner;
+        mMyAction = action;
+        InitLocalization();
+    }
 
-        private void btnOkay_Click(object sender, EventArgs e)
-        {
-            mMyAction.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
-            mRouteDesigner.Controls.Remove(this);
-        }
+    private void InitLocalization()
+    {
+        grpSetAnimation.Text = Strings.EventSetAnimation.title;
+        lblAnimation.Text = Strings.EventSetAnimation.label;
+        btnOkay.Text = Strings.EventSetAnimation.okay;
+        btnCancel.Text = Strings.EventSetAnimation.cancel;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mRouteDesigner.RemoveLastAction();
-            mRouteDesigner.Controls.Remove(this);
-        }
+    private void btnOkay_Click(object sender, EventArgs e)
+    {
+        mMyAction.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
+        mRouteDesigner.Controls.Remove(this);
+    }
 
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mRouteDesigner.RemoveLastAction();
+        mRouteDesigner.Controls.Remove(this);
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteDesigner.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_MoveRouteDesigner.cs
@@ -3,377 +3,375 @@ using Intersect.GameObjects.Events;
 using Intersect.GameObjects.Events.Commands;
 using Intersect.GameObjects.Maps;
 
-namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventMoveRouteDesigner : UserControl
 {
 
-    public partial class EventMoveRouteDesigner : UserControl
+    private readonly EventBase mEditingEvent;
+
+    private MapBase mCurrentMap;
+
+    private SetMoveRouteCommand mEditingCommand;
+
+    private EventMoveRoute mEditingRoute;
+
+    private FrmEvent mEventEditor;
+
+    private MoveRouteAction mLastAddedAction;
+
+    private List<TreeNode> mOrigItems = new List<TreeNode>();
+
+    private EventMoveRoute mTmpMoveRoute;
+
+    public EventMoveRouteDesigner(
+        FrmEvent eventEditor,
+        MapBase currentMap,
+        EventBase currentEvent,
+        EventMoveRoute editingRoute,
+        SetMoveRouteCommand editingCommand = null,
+        bool disableRouteTarget = false
+    )
     {
+        InitializeComponent();
+        InitLocalization();
 
-        private readonly EventBase mEditingEvent;
-
-        private MapBase mCurrentMap;
-
-        private SetMoveRouteCommand mEditingCommand;
-
-        private EventMoveRoute mEditingRoute;
-
-        private FrmEvent mEventEditor;
-
-        private MoveRouteAction mLastAddedAction;
-
-        private List<TreeNode> mOrigItems = new List<TreeNode>();
-
-        private EventMoveRoute mTmpMoveRoute;
-
-        public EventMoveRouteDesigner(
-            FrmEvent eventEditor,
-            MapBase currentMap,
-            EventBase currentEvent,
-            EventMoveRoute editingRoute,
-            SetMoveRouteCommand editingCommand = null,
-            bool disableRouteTarget = false
-        )
+        foreach (var item in lstCommands.Nodes)
         {
-            InitializeComponent();
-            InitLocalization();
-
-            foreach (var item in lstCommands.Nodes)
+            var parentNode = new TreeNode(((TreeNode) item).Text)
             {
-                var parentNode = new TreeNode(((TreeNode) item).Text)
+                Name = ((TreeNode) item).Name,
+                Tag = ((TreeNode) item).Tag
+            };
+
+            foreach (var childItem in ((TreeNode) item).Nodes)
+            {
+                var childNode = new TreeNode(((TreeNode) childItem).Text)
                 {
-                    Name = ((TreeNode) item).Name,
-                    Tag = ((TreeNode) item).Tag
+                    Name = ((TreeNode) childItem).Name,
+                    Tag = ((TreeNode) childItem).Tag
                 };
 
-                foreach (var childItem in ((TreeNode) item).Nodes)
-                {
-                    var childNode = new TreeNode(((TreeNode) childItem).Text)
-                    {
-                        Name = ((TreeNode) childItem).Name,
-                        Tag = ((TreeNode) childItem).Tag
-                    };
-
-                    parentNode.Nodes.Add(childNode);
-                }
-
-                mOrigItems.Add(parentNode);
+                parentNode.Nodes.Add(childNode);
             }
 
-            //Grab event editor reference
-            mEventEditor = eventEditor;
-            mEditingEvent = currentEvent;
-            mEditingCommand = editingCommand;
-            mCurrentMap = currentMap;
+            mOrigItems.Add(parentNode);
+        }
 
-            //Generate temp route to edit
-            mTmpMoveRoute = new EventMoveRoute();
-            mTmpMoveRoute.CopyFrom(editingRoute);
-            mEditingRoute = editingRoute;
+        //Grab event editor reference
+        mEventEditor = eventEditor;
+        mEditingEvent = currentEvent;
+        mEditingCommand = editingCommand;
+        mCurrentMap = currentMap;
 
-            //Setup form
-            chkIgnoreIfBlocked.Checked = mTmpMoveRoute.IgnoreIfBlocked;
-            chkRepeatRoute.Checked = mTmpMoveRoute.RepeatRoute;
+        //Generate temp route to edit
+        mTmpMoveRoute = new EventMoveRoute();
+        mTmpMoveRoute.CopyFrom(editingRoute);
+        mEditingRoute = editingRoute;
 
-            cmbTarget.Items.Clear();
-            if (!mEditingEvent.CommonEvent)
+        //Setup form
+        chkIgnoreIfBlocked.Checked = mTmpMoveRoute.IgnoreIfBlocked;
+        chkRepeatRoute.Checked = mTmpMoveRoute.RepeatRoute;
+
+        cmbTarget.Items.Clear();
+        if (!mEditingEvent.CommonEvent)
+        {
+            if (mEditingCommand != null)
             {
+                cmbTarget.Items.Add(Strings.EventMoveRoute.player);
+                if (mEditingCommand.Route.Target == Guid.Empty)
+                {
+                    cmbTarget.SelectedIndex = 0;
+                }
+            }
+
+            foreach (var evt in mCurrentMap.LocalEvents)
+            {
+                cmbTarget.Items.Add(
+                    evt.Key == mEditingEvent.Id ? Strings.EventMoveRoute.thisevent.ToString() : "" + evt.Value.Name
+                );
+
                 if (mEditingCommand != null)
                 {
-                    cmbTarget.Items.Add(Strings.EventMoveRoute.player);
-                    if (mEditingCommand.Route.Target == Guid.Empty)
+                    if (mEditingCommand.Route.Target == evt.Key)
                     {
-                        cmbTarget.SelectedIndex = 0;
+                        cmbTarget.SelectedIndex = cmbTarget.Items.Count - 1;
                     }
                 }
-
-                foreach (var evt in mCurrentMap.LocalEvents)
+                else
                 {
-                    cmbTarget.Items.Add(
-                        evt.Key == mEditingEvent.Id ? Strings.EventMoveRoute.thisevent.ToString() : "" + evt.Value.Name
-                    );
-
-                    if (mEditingCommand != null)
+                    if (mEditingRoute.Target == evt.Key || mEditingRoute.Target == Guid.Empty)
                     {
-                        if (mEditingCommand.Route.Target == evt.Key)
-                        {
-                            cmbTarget.SelectedIndex = cmbTarget.Items.Count - 1;
-                        }
-                    }
-                    else
-                    {
-                        if (mEditingRoute.Target == evt.Key || mEditingRoute.Target == Guid.Empty)
-                        {
-                            cmbTarget.SelectedIndex = cmbTarget.Items.Count - 1;
-                        }
+                        cmbTarget.SelectedIndex = cmbTarget.Items.Count - 1;
                     }
                 }
             }
-
-            if (cmbTarget.SelectedIndex == -1 && cmbTarget.Items.Count > 0)
-            {
-                cmbTarget.SelectedIndex = 0;
-            }
-
-            if (disableRouteTarget)
-            {
-                cmbTarget.Enabled = false;
-            }
-
-            ListMoveRoute();
-            lstCommands.ExpandAll();
         }
 
-        private void InitLocalization()
+        if (cmbTarget.SelectedIndex == -1 && cmbTarget.Items.Count > 0)
         {
-            grpMoveRoute.Text = Strings.EventMoveRoute.title;
-            grpCommands.Text = Strings.EventMoveRoute.command;
-            chkIgnoreIfBlocked.Text = Strings.EventMoveRoute.ignoreblocked;
-            chkRepeatRoute.Text = Strings.EventMoveRoute.repeatroute;
-            btnOkay.Text = Strings.EventMoveRoute.okay;
-            btnCancel.Text = Strings.EventMoveRoute.cancel;
+            cmbTarget.SelectedIndex = 0;
+        }
+
+        if (disableRouteTarget)
+        {
+            cmbTarget.Enabled = false;
+        }
+
+        ListMoveRoute();
+        lstCommands.ExpandAll();
+    }
+
+    private void InitLocalization()
+    {
+        grpMoveRoute.Text = Strings.EventMoveRoute.title;
+        grpCommands.Text = Strings.EventMoveRoute.command;
+        chkIgnoreIfBlocked.Text = Strings.EventMoveRoute.ignoreblocked;
+        chkRepeatRoute.Text = Strings.EventMoveRoute.repeatroute;
+        btnOkay.Text = Strings.EventMoveRoute.okay;
+        btnCancel.Text = Strings.EventMoveRoute.cancel;
+        for (var i = 0; i < lstCommands.Nodes.Count; i++)
+        {
+            lstCommands.Nodes[i].Text = Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Name];
+            for (var x = 0; x < lstCommands.Nodes[i].Nodes.Count; x++)
+            {
+                lstCommands.Nodes[i].Nodes[x].Text =
+                    Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Nodes[x].Name];
+            }
+        }
+    }
+
+    private void ListMoveRoute()
+    {
+        lstActions.Items.Clear();
+        foreach (var action in mTmpMoveRoute.Actions)
+        {
             for (var i = 0; i < lstCommands.Nodes.Count; i++)
             {
-                lstCommands.Nodes[i].Text = Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Name];
                 for (var x = 0; x < lstCommands.Nodes[i].Nodes.Count; x++)
                 {
-                    lstCommands.Nodes[i].Nodes[x].Text =
-                        Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Nodes[x].Name];
-                }
-            }
-        }
-
-        private void ListMoveRoute()
-        {
-            lstActions.Items.Clear();
-            foreach (var action in mTmpMoveRoute.Actions)
-            {
-                for (var i = 0; i < lstCommands.Nodes.Count; i++)
-                {
-                    for (var x = 0; x < lstCommands.Nodes[i].Nodes.Count; x++)
+                    if (Convert.ToInt32(lstCommands.Nodes[i].Nodes[x].Tag) == (int) action.Type)
                     {
-                        if (Convert.ToInt32(lstCommands.Nodes[i].Nodes[x].Tag) == (int) action.Type)
-                        {
-                            lstActions.Items.Add(Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Nodes[x].Name]);
-                        }
+                        lstActions.Items.Add(Strings.EventMoveRoute.commands[lstCommands.Nodes[i].Nodes[x].Name]);
                     }
                 }
             }
         }
+    }
 
-        private void lstActions_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Delete)
-            {
-                if (lstActions.SelectedIndex > -1)
-                {
-                    mTmpMoveRoute.Actions.RemoveAt(lstActions.SelectedIndex);
-                    ListMoveRoute();
-                }
-            }
-        }
-
-        private void lstActions_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (lstActions.IndexFromPoint(new System.Drawing.Point(e.X, e.Y)) == -1)
-            {
-                lstActions.SelectedIndex = -1;
-            }
-        }
-
-        private void lstActions_DoubleClick(object sender, EventArgs e)
+    private void lstActions_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Delete)
         {
             if (lstActions.SelectedIndex > -1)
             {
-                if (mTmpMoveRoute.Actions[lstActions.SelectedIndex].Type == MoveRouteEnum.SetGraphic)
-                {
-                    //Open the graphic editor....
-                    var graphicSelector = new EventGraphicSelector(
-                        mTmpMoveRoute.Actions[lstActions.SelectedIndex].Graphic, mEventEditor, this, false
-                    );
-
-                    mEventEditor.Controls.Add(graphicSelector);
-                    graphicSelector.BringToFront();
-                    graphicSelector.Size = ClientSize;
-                }
-                else if (mTmpMoveRoute.Actions[lstActions.SelectedIndex].Type == MoveRouteEnum.SetAnimation)
-                {
-                    //Open the animation selector
-                    var animationSelector = new EventMoveRouteAnimationSelector(
-                        this, mTmpMoveRoute.Actions[lstActions.SelectedIndex], false
-                    );
-
-                    Controls.Add(animationSelector);
-                    animationSelector.BringToFront();
-                    animationSelector.Size = ClientSize;
-                }
-            }
-        }
-
-        public void RemoveLastAction()
-        {
-            if (mTmpMoveRoute.Actions.Count > 0)
-            {
-                mTmpMoveRoute.Actions.Remove(mLastAddedAction);
+                mTmpMoveRoute.Actions.RemoveAt(lstActions.SelectedIndex);
                 ListMoveRoute();
             }
         }
+    }
 
-        private void chkIgnoreIfBlocked_CheckedChanged(object sender, EventArgs e)
+    private void lstActions_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (lstActions.IndexFromPoint(new System.Drawing.Point(e.X, e.Y)) == -1)
         {
-            mTmpMoveRoute.IgnoreIfBlocked = chkIgnoreIfBlocked.Checked;
+            lstActions.SelectedIndex = -1;
         }
+    }
 
-        private void chkRepeatRoute_CheckedChanged(object sender, EventArgs e)
+    private void lstActions_DoubleClick(object sender, EventArgs e)
+    {
+        if (lstActions.SelectedIndex > -1)
         {
-            mTmpMoveRoute.RepeatRoute = chkRepeatRoute.Checked;
-        }
-
-        private void btnOkay_Click(object sender, EventArgs e)
-        {
-            mEditingRoute.CopyFrom(mTmpMoveRoute);
-            mEditingRoute.Target = Guid.Empty;
-            if (mEditingCommand != null)
+            if (mTmpMoveRoute.Actions[lstActions.SelectedIndex].Type == MoveRouteEnum.SetGraphic)
             {
-                if (!mEditingEvent.CommonEvent)
-                {
-                    if (cmbTarget.SelectedIndex == 0)
-                    {
-                        mEditingRoute.Target = Guid.Empty;
-                    }
-                    else
-                    {
-                        mEditingRoute.Target = mCurrentMap.LocalEvents.Keys.ToList()[cmbTarget.SelectedIndex - 1];
-                    }
-                }
-
-                mEventEditor.FinishCommandEdit(true);
-            }
-
-            mEventEditor.CloseMoveRouteDesigner(this);
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            if (mEditingCommand != null)
-            {
-                mEventEditor.CancelCommandEdit(true);
-            }
-
-            mEventEditor.CloseMoveRouteDesigner(this);
-        }
-
-        private void lstCommands_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void lstCommands_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
-        {
-            if (e.Node.Tag == null)
-            {
-                return;
-            }
-
-            var action = new MoveRouteAction()
-            {
-                Type = (MoveRouteEnum) Convert.ToInt32(e.Node.Tag)
-            };
-
-            if (action.Type == MoveRouteEnum.SetGraphic)
-            {
-                action.Graphic = new EventGraphic();
-
                 //Open the graphic editor....
-                var graphicSelector = new EventGraphicSelector(action.Graphic, mEventEditor, this, true);
+                var graphicSelector = new EventGraphicSelector(
+                    mTmpMoveRoute.Actions[lstActions.SelectedIndex].Graphic, mEventEditor, this, false
+                );
+
                 mEventEditor.Controls.Add(graphicSelector);
                 graphicSelector.BringToFront();
                 graphicSelector.Size = ClientSize;
             }
-            else if (action.Type == MoveRouteEnum.SetAnimation)
+            else if (mTmpMoveRoute.Actions[lstActions.SelectedIndex].Type == MoveRouteEnum.SetAnimation)
             {
                 //Open the animation selector
-                var animationSelector = new EventMoveRouteAnimationSelector(this, action, true);
+                var animationSelector = new EventMoveRouteAnimationSelector(
+                    this, mTmpMoveRoute.Actions[lstActions.SelectedIndex], false
+                );
+
                 Controls.Add(animationSelector);
                 animationSelector.BringToFront();
                 animationSelector.Size = ClientSize;
             }
+        }
+    }
 
-            if (lstActions.SelectedIndex == -1)
-            {
-                mTmpMoveRoute.Actions.Add(action);
-            }
-            else
-            {
-                mTmpMoveRoute.Actions.Insert(lstActions.SelectedIndex, action);
-            }
-
-            mLastAddedAction = action;
+    public void RemoveLastAction()
+    {
+        if (mTmpMoveRoute.Actions.Count > 0)
+        {
+            mTmpMoveRoute.Actions.Remove(mLastAddedAction);
             ListMoveRoute();
         }
+    }
 
-        private void cmbTarget_SelectedIndexChanged(object sender, EventArgs e)
+    private void chkIgnoreIfBlocked_CheckedChanged(object sender, EventArgs e)
+    {
+        mTmpMoveRoute.IgnoreIfBlocked = chkIgnoreIfBlocked.Checked;
+    }
+
+    private void chkRepeatRoute_CheckedChanged(object sender, EventArgs e)
+    {
+        mTmpMoveRoute.RepeatRoute = chkRepeatRoute.Checked;
+    }
+
+    private void btnOkay_Click(object sender, EventArgs e)
+    {
+        mEditingRoute.CopyFrom(mTmpMoveRoute);
+        mEditingRoute.Target = Guid.Empty;
+        if (mEditingCommand != null)
         {
-            lstCommands.Nodes.Clear();
-            foreach (var item in mOrigItems)
+            if (!mEditingEvent.CommonEvent)
             {
-                var parentNode = new TreeNode(((TreeNode) item).Text)
+                if (cmbTarget.SelectedIndex == 0)
                 {
-                    Name = ((TreeNode) item).Name,
-                    Tag = ((TreeNode) item).Tag
-                };
-
-                foreach (var childItem in item.Nodes)
-                {
-                    var childNode = new TreeNode(((TreeNode) childItem).Text)
-                    {
-                        Name = ((TreeNode) childItem).Name,
-                        Tag = ((TreeNode) childItem).Tag
-                    };
-
-                    parentNode.Nodes.Add(childNode);
+                    mEditingRoute.Target = Guid.Empty;
                 }
-
-                lstCommands.Nodes.Add(parentNode);
+                else
+                {
+                    mEditingRoute.Target = mCurrentMap.LocalEvents.Keys.ToList()[cmbTarget.SelectedIndex - 1];
+                }
             }
 
-            lstCommands.ExpandAll();
-            if (!mEditingEvent.CommonEvent && mEditingCommand != null && cmbTarget.SelectedIndex == 0)
+            mEventEditor.FinishCommandEdit(true);
+        }
+
+        mEventEditor.CloseMoveRouteDesigner(this);
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        if (mEditingCommand != null)
+        {
+            mEventEditor.CancelCommandEdit(true);
+        }
+
+        mEventEditor.CloseMoveRouteDesigner(this);
+    }
+
+    private void lstCommands_SelectedIndexChanged(object sender, EventArgs e)
+    {
+    }
+
+    private void lstCommands_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        if (e.Node.Tag == null)
+        {
+            return;
+        }
+
+        var action = new MoveRouteAction()
+        {
+            Type = (MoveRouteEnum) Convert.ToInt32(e.Node.Tag)
+        };
+
+        if (action.Type == MoveRouteEnum.SetGraphic)
+        {
+            action.Graphic = new EventGraphic();
+
+            //Open the graphic editor....
+            var graphicSelector = new EventGraphicSelector(action.Graphic, mEventEditor, this, true);
+            mEventEditor.Controls.Add(graphicSelector);
+            graphicSelector.BringToFront();
+            graphicSelector.Size = ClientSize;
+        }
+        else if (action.Type == MoveRouteEnum.SetAnimation)
+        {
+            //Open the animation selector
+            var animationSelector = new EventMoveRouteAnimationSelector(this, action, true);
+            Controls.Add(animationSelector);
+            animationSelector.BringToFront();
+            animationSelector.Size = ClientSize;
+        }
+
+        if (lstActions.SelectedIndex == -1)
+        {
+            mTmpMoveRoute.Actions.Add(action);
+        }
+        else
+        {
+            mTmpMoveRoute.Actions.Insert(lstActions.SelectedIndex, action);
+        }
+
+        mLastAddedAction = action;
+        ListMoveRoute();
+    }
+
+    private void cmbTarget_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        lstCommands.Nodes.Clear();
+        foreach (var item in mOrigItems)
+        {
+            var parentNode = new TreeNode(((TreeNode) item).Text)
             {
-                var hideNodes = new string[]
+                Name = ((TreeNode) item).Name,
+                Tag = ((TreeNode) item).Tag
+            };
+
+            foreach (var childItem in item.Nodes)
+            {
+                var childNode = new TreeNode(((TreeNode) childItem).Text)
                 {
-                    "movetowardplayer", "moveawayfromplayer", "turntowardplayer", "turnawayfromplayer", "setspeed",
-                    "setmovementfrequency", "setattribute", "setgraphic", "setanimation"
+                    Name = ((TreeNode) childItem).Name,
+                    Tag = ((TreeNode) childItem).Tag
                 };
 
-                var nodesToRemove = new List<TreeNode>();
-                foreach (var parentNode in lstCommands.Nodes)
-                {
-                    if (parentNode != null)
-                    {
-                        if (hideNodes.Contains(((TreeNode) parentNode).Name))
-                        {
-                            nodesToRemove.Add((TreeNode) parentNode);
-                        }
+                parentNode.Nodes.Add(childNode);
+            }
 
-                        foreach (var childNode in ((TreeNode) parentNode).Nodes)
+            lstCommands.Nodes.Add(parentNode);
+        }
+
+        lstCommands.ExpandAll();
+        if (!mEditingEvent.CommonEvent && mEditingCommand != null && cmbTarget.SelectedIndex == 0)
+        {
+            var hideNodes = new string[]
+            {
+                "movetowardplayer", "moveawayfromplayer", "turntowardplayer", "turnawayfromplayer", "setspeed",
+                "setmovementfrequency", "setattribute", "setgraphic", "setanimation"
+            };
+
+            var nodesToRemove = new List<TreeNode>();
+            foreach (var parentNode in lstCommands.Nodes)
+            {
+                if (parentNode != null)
+                {
+                    if (hideNodes.Contains(((TreeNode) parentNode).Name))
+                    {
+                        nodesToRemove.Add((TreeNode) parentNode);
+                    }
+
+                    foreach (var childNode in ((TreeNode) parentNode).Nodes)
+                    {
+                        if (childNode != null)
                         {
-                            if (childNode != null)
+                            if (hideNodes.Contains(((TreeNode) childNode).Name))
                             {
-                                if (hideNodes.Contains(((TreeNode) childNode).Name))
-                                {
-                                    nodesToRemove.Add((TreeNode) childNode);
-                                }
+                                nodesToRemove.Add((TreeNode) childNode);
                             }
                         }
                     }
                 }
+            }
 
-                foreach (var node in nodesToRemove)
-                {
-                    node.Remove();
-                }
+            foreach (var node in nodesToRemove)
+            {
+                node.Remove();
             }
         }
-
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -16,439 +16,343 @@ using Intersect.Utilities;
 using Newtonsoft.Json;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors.Events
+namespace Intersect.Editor.Forms.Editors.Events;
+
+
+public partial class FrmEvent : Form
 {
 
-    public partial class FrmEvent : Form
+    private static string mCopyData = null;
+
+    private static string mCopyLists = null;
+
+    private readonly List<CommandListProperties> mCommandProperties = new List<CommandListProperties>();
+
+    private readonly MapBase mCurrentMap;
+
+    public EventPage CurrentPage;
+
+    public int CurrentPageIndex;
+
+    private int mCurrentCommand = -1;
+
+    private EventCommand mEditingCommand;
+
+    private string mEventBackup = null;
+
+    private bool mIsEdit;
+
+    private bool mIsInsert;
+
+    private string mPageCopy;
+
+    private List<DarkButton> mPageTabs = new List<DarkButton>();
+
+    public EventBase MyEvent;
+
+    public MapInstance MyMap;
+
+    public bool NewEvent;
+
+    public int mOldSelectedCommand;
+
+    private void txtEventname_TextChanged(object sender, EventArgs e)
     {
+        MyEvent.Name = txtEventname.Text;
+        Text = Strings.EventEditor.title.ToString(txtEventname.Text);
+    }
 
-        private static string mCopyData = null;
+    private void lstEventCommands_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mCurrentCommand = lstEventCommands.SelectedIndex;
+        mOldSelectedCommand = lstEventCommands.SelectedIndex;
+    }
 
-        private static string mCopyLists = null;
-
-        private readonly List<CommandListProperties> mCommandProperties = new List<CommandListProperties>();
-
-        private readonly MapBase mCurrentMap;
-
-        public EventPage CurrentPage;
-
-        public int CurrentPageIndex;
-
-        private int mCurrentCommand = -1;
-
-        private EventCommand mEditingCommand;
-
-        private string mEventBackup = null;
-
-        private bool mIsEdit;
-
-        private bool mIsInsert;
-
-        private string mPageCopy;
-
-        private List<DarkButton> mPageTabs = new List<DarkButton>();
-
-        public EventBase MyEvent;
-
-        public MapInstance MyMap;
-
-        public bool NewEvent;
-
-        public int mOldSelectedCommand;
-
-        private void txtEventname_TextChanged(object sender, EventArgs e)
+    private void lstEventCommands_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode != Keys.Delete)
         {
-            MyEvent.Name = txtEventname.Text;
-            Text = Strings.EventEditor.title.ToString(txtEventname.Text);
+            return;
         }
 
-        private void lstEventCommands_SelectedIndexChanged(object sender, EventArgs e)
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
         {
-            mCurrentCommand = lstEventCommands.SelectedIndex;
-            mOldSelectedCommand = lstEventCommands.SelectedIndex;
+            return;
         }
 
-        private void lstEventCommands_KeyDown(object sender, KeyEventArgs e)
+        if (!mCommandProperties[mCurrentCommand].Editable)
         {
-            if (e.KeyCode != Keys.Delete)
-            {
-                return;
-            }
-
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                return;
-            }
-
-            HandleRemoveCommand(mCommandProperties[mCurrentCommand].Cmd);
-            mCommandProperties[mCurrentCommand].MyList.Remove(mCommandProperties[mCurrentCommand].Cmd);
-            mCurrentCommand = -1;
-
-            mOldSelectedCommand = lstEventCommands.SelectedIndex;
-            ListPageCommands();
+            return;
         }
 
-        private void lstEventCommands_Click(object sender, MouseEventArgs e)
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
         {
-            if (e.Button != MouseButtons.Right)
-            {
-                return;
-            }
-
-            var i = lstEventCommands.IndexFromPoint(e.Location);
-            if (i <= -1 || i >= lstEventCommands.Items.Count)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[i].Editable)
-            {
-                return;
-            }
-
-            lstEventCommands.SelectedIndex = i;
-
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
-
-            commandMenu.Show((ListBox)sender, e.Location);
-            btnEdit.Enabled = mCommandProperties[mCurrentCommand].Editable;
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                btnEdit.Enabled = false;
-            }
-
-            btnCopy.Enabled = btnEdit.Enabled;
-            btnCut.Enabled = btnEdit.Enabled;
-            btnDelete.Enabled = true;
-
-            mOldSelectedCommand = lstEventCommands.SelectedIndex;
+            return;
         }
 
-        private void lstEventCommands_DoubleClick(object sender, EventArgs e)
+        HandleRemoveCommand(mCommandProperties[mCurrentCommand].Cmd);
+        mCommandProperties[mCurrentCommand].MyList.Remove(mCommandProperties[mCurrentCommand].Cmd);
+        mCurrentCommand = -1;
+
+        mOldSelectedCommand = lstEventCommands.SelectedIndex;
+        ListPageCommands();
+    }
+
+    private void lstEventCommands_Click(object sender, MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Right)
         {
-            if (mCurrentCommand <= -1)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
-            {
-                grpNewCommands.Show();
-                DisableButtons();
-                mIsInsert = false;
-            }
-            else
-            {
-                grpNewCommands.Show();
-                DisableButtons();
-                mIsInsert = true;
-            }
-
-            mOldSelectedCommand = lstEventCommands.SelectedIndex;
+            return;
         }
 
-        /// <summary>
-        ///     Opens the graphic selector window to pick the default graphic for this event page.
-        /// </summary>
-        private void pnlPreview_DoubleClick(object sender, EventArgs e)
+        var i = lstEventCommands.IndexFromPoint(e.Location);
+        if (i <= -1 || i >= lstEventCommands.Items.Count)
         {
-            var graphicSelector = new EventGraphicSelector(CurrentPage.Graphic, this);
-            Controls.Add(graphicSelector);
-            graphicSelector.BringToFront();
-            graphicSelector.Size = ClientSize;
+            return;
         }
 
-        private void UpdateEventPreview()
+        if (!mCommandProperties[i].Editable)
         {
-            Graphics graphics;
-            Bitmap sourceBitmap = null;
-            Bitmap destBitmap = null;
-            destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
-            graphics = Graphics.FromImage(destBitmap);
-            graphics.Clear(System.Drawing.Color.FromArgb(60, 63, 65));
+            return;
+        }
 
+        lstEventCommands.SelectedIndex = i;
+
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
+        }
+
+        commandMenu.Show((ListBox)sender, e.Location);
+        btnEdit.Enabled = mCommandProperties[mCurrentCommand].Editable;
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
+        {
+            btnEdit.Enabled = false;
+        }
+
+        btnCopy.Enabled = btnEdit.Enabled;
+        btnCut.Enabled = btnEdit.Enabled;
+        btnDelete.Enabled = true;
+
+        mOldSelectedCommand = lstEventCommands.SelectedIndex;
+    }
+
+    private void lstEventCommands_DoubleClick(object sender, EventArgs e)
+    {
+        if (mCurrentCommand <= -1)
+        {
+            return;
+        }
+
+        if (!mCommandProperties[mCurrentCommand].Editable)
+        {
+            return;
+        }
+
+        if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
+        {
+            grpNewCommands.Show();
+            DisableButtons();
+            mIsInsert = false;
+        }
+        else
+        {
+            grpNewCommands.Show();
+            DisableButtons();
+            mIsInsert = true;
+        }
+
+        mOldSelectedCommand = lstEventCommands.SelectedIndex;
+    }
+
+    /// <summary>
+    ///     Opens the graphic selector window to pick the default graphic for this event page.
+    /// </summary>
+    private void pnlPreview_DoubleClick(object sender, EventArgs e)
+    {
+        var graphicSelector = new EventGraphicSelector(CurrentPage.Graphic, this);
+        Controls.Add(graphicSelector);
+        graphicSelector.BringToFront();
+        graphicSelector.Size = ClientSize;
+    }
+
+    private void UpdateEventPreview()
+    {
+        Graphics graphics;
+        Bitmap sourceBitmap = null;
+        Bitmap destBitmap = null;
+        destBitmap = new Bitmap(pnlPreview.Width, pnlPreview.Height);
+        graphics = Graphics.FromImage(destBitmap);
+        graphics.Clear(System.Drawing.Color.FromArgb(60, 63, 65));
+
+        if (CurrentPage.Graphic.Type == EventGraphicType.Sprite)
+        {
+            if (File.Exists("resources/entities/" + CurrentPage.Graphic.Filename))
+            {
+                sourceBitmap = new Bitmap("resources/entities/" + CurrentPage.Graphic.Filename);
+            }
+        }
+        else if (CurrentPage.Graphic.Type == EventGraphicType.Tileset)
+        {
+            if (File.Exists("resources/tilesets/" + CurrentPage.Graphic.Filename))
+            {
+                sourceBitmap = new Bitmap("resources/tilesets/" + CurrentPage.Graphic.Filename);
+            }
+        }
+
+        if (sourceBitmap != null)
+        {
             if (CurrentPage.Graphic.Type == EventGraphicType.Sprite)
             {
-                if (File.Exists("resources/entities/" + CurrentPage.Graphic.Filename))
-                {
-                    sourceBitmap = new Bitmap("resources/entities/" + CurrentPage.Graphic.Filename);
-                }
+                graphics.DrawImage(
+                    sourceBitmap,
+                    new Rectangle(
+                        pnlPreview.Width / 2 - sourceBitmap.Width / Options.Instance.Sprites.NormalFrames / 2,
+                        pnlPreview.Height / 2 - sourceBitmap.Height / Options.Instance.Sprites.Directions / 2, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                        sourceBitmap.Height / Options.Instance.Sprites.Directions
+                    ),
+                    new Rectangle(
+                        CurrentPage.Graphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                        CurrentPage.Graphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
+                        sourceBitmap.Height / Options.Instance.Sprites.Directions
+                    ), GraphicsUnit.Pixel
+                );
             }
             else if (CurrentPage.Graphic.Type == EventGraphicType.Tileset)
             {
-                if (File.Exists("resources/tilesets/" + CurrentPage.Graphic.Filename))
-                {
-                    sourceBitmap = new Bitmap("resources/tilesets/" + CurrentPage.Graphic.Filename);
-                }
-            }
-
-            if (sourceBitmap != null)
-            {
-                if (CurrentPage.Graphic.Type == EventGraphicType.Sprite)
-                {
-                    graphics.DrawImage(
-                        sourceBitmap,
-                        new Rectangle(
-                            pnlPreview.Width / 2 - sourceBitmap.Width / Options.Instance.Sprites.NormalFrames / 2,
-                            pnlPreview.Height / 2 - sourceBitmap.Height / Options.Instance.Sprites.Directions / 2, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
-                            sourceBitmap.Height / Options.Instance.Sprites.Directions
-                        ),
-                        new Rectangle(
-                            CurrentPage.Graphic.X * sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
-                            CurrentPage.Graphic.Y * sourceBitmap.Height / Options.Instance.Sprites.Directions, sourceBitmap.Width / Options.Instance.Sprites.NormalFrames,
-                            sourceBitmap.Height / Options.Instance.Sprites.Directions
-                        ), GraphicsUnit.Pixel
-                    );
-                }
-                else if (CurrentPage.Graphic.Type == EventGraphicType.Tileset)
-                {
-                    graphics.DrawImage(
-                        sourceBitmap,
-                        new Rectangle(
-                            pnlPreview.Width / 2 -
-                            (Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth) / 2,
-                            pnlPreview.Height / 2 -
-                            (Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight) / 2,
-                            Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth,
-                            Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight
-                        ),
-                        new Rectangle(
-                            CurrentPage.Graphic.X * Options.TileWidth, CurrentPage.Graphic.Y * Options.TileHeight,
-                            Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth,
-                            Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight
-                        ), GraphicsUnit.Pixel
-                    );
-                }
-
-                sourceBitmap.Dispose();
-            }
-
-            graphics.Dispose();
-            pnlPreview.BackgroundImage = destBitmap;
-        }
-
-        public void CloseMoveRouteDesigner(EventMoveRouteDesigner moveRouteDesigner)
-        {
-            Controls.Remove(moveRouteDesigner);
-        }
-
-        public void CloseGraphicSelector(EventGraphicSelector graphicSelector)
-        {
-            Controls.Remove(graphicSelector);
-            UpdateEventPreview();
-        }
-
-        private void btnNewPage_Click(object sender, EventArgs e)
-        {
-            MyEvent.Pages.Add(new EventPage());
-            UpdateTabControl();
-            LoadPage(MyEvent.Pages.Count - 1);
-        }
-
-        private void UpdateTabControl()
-        {
-            foreach (var page in mPageTabs)
-            {
-                pnlTabs.Controls.Remove(page);
-            }
-
-            mPageTabs.Clear();
-            for (var i = 0; i < MyEvent.Pages.Count; i++)
-            {
-                var btn = new DarkButton()
-                {
-                    Text = (i + 1).ToString()
-                };
-
-                btn.Click += TabBtn_Click;
-                mPageTabs.Add(btn);
-            }
-
-            pnlTabs.Controls.AddRange(mPageTabs.ToArray());
-            for (var i = 0; i < MyEvent.Pages.Count; i++)
-            {
-                var btn = mPageTabs[i];
-                btn.Size = new Size(0, 0);
-                btn.MaximumSize = new Size(100, 22);
-                btn.AutoSize = true;
-                if (i > 0)
-                {
-                    btn.Left = mPageTabs[i - 1].Right - 1;
-                }
-
-                btn.Top = 0;
-                btn.SendToBack();
-            }
-
-            pnlTabs.SetBounds(0, 0, pnlTabs.Width, pnlTabs.Height);
-            btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
-            btnTabsLeft.Enabled = pnlTabs.Left < 0;
-        }
-
-        private void TabBtn_Click(object sender, EventArgs e)
-        {
-            LoadPage(mPageTabs.IndexOf((DarkButton)sender));
-        }
-
-        private void EnableButtons()
-        {
-            //Enable Actions
-            btnNewPage.Enabled = true;
-            btnCopyPage.Enabled = true;
-            if (mPageCopy != null)
-            {
-                btnPastePage.Enabled = true;
-            }
-            else
-            {
-                btnPastePage.Enabled = false;
-            }
-
-            if (MyEvent.Pages.Count > 1)
-            {
-                btnDeletePage.Enabled = true;
-            }
-            else
-            {
-                btnDeletePage.Enabled = false;
-            }
-
-            btnClearPage.Enabled = true;
-            btnSave.Enabled = true;
-            btnCancel.Enabled = true;
-        }
-
-        private void DisableButtons()
-        {
-            //Disable Actions
-            btnNewPage.Enabled = false;
-            btnCopyPage.Enabled = false;
-            btnPastePage.Enabled = false;
-            btnDeletePage.Enabled = false;
-            btnClearPage.Enabled = false;
-            btnSave.Enabled = false;
-            btnCancel.Enabled = false;
-        }
-
-        private void FrmEvent_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Escape)
-            {
-                if (grpNewCommands.Visible)
-                {
-                    grpNewCommands.Hide();
-                    EnableButtons();
-                }
-            }
-            else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.X))
-            {
-                if (lstEventCommands.SelectedIndex > -1)
-                {
-                    btnCut_Click(null, null);
-                }
-
-                return;
-            }
-            else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.C))
-            {
-                if (lstEventCommands.SelectedIndex > -1)
-                {
-                    btnCopy_Click(null, null);
-                }
-
-                return;
-            }
-            else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.V))
-            {
-                if (lstEventCommands.SelectedIndex > -1)
-                {
-                    btnPaste_Click(null, null);
-                }
-
-                return;
-            }
-        }
-
-        private void btnDeletePage_Click(object sender, EventArgs e)
-        {
-            if (MyEvent.Pages.Count > 1)
-            {
-                MyEvent.Pages.RemoveAt(CurrentPageIndex);
-                UpdateTabControl();
-                LoadPage(0);
-            }
-        }
-
-        private void btnClearPage_Click(object sender, EventArgs e)
-        {
-            MyEvent.Pages[CurrentPageIndex] = new EventPage();
-            LoadPage(CurrentPageIndex);
-        }
-
-        private void btnCopyPage_Click(object sender, EventArgs e)
-        {
-            mPageCopy = JsonConvert.SerializeObject(
-                CurrentPage,
-                new JsonSerializerSettings()
-                {
-                    TypeNameHandling = TypeNameHandling.Auto,
-                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate
-                }
-            );
-
-            EnableButtons();
-        }
-
-        private void btnPastePage_Click(object sender, EventArgs e)
-        {
-            if (mPageCopy != null)
-            {
-                MyEvent.Pages[CurrentPageIndex] = new EventPage();
-                JsonConvert.PopulateObject(
-                    mPageCopy, MyEvent.Pages[CurrentPageIndex],
-                    new JsonSerializerSettings()
-                    {
-                        TypeNameHandling = TypeNameHandling.Auto,
-                        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                        ObjectCreationHandling = ObjectCreationHandling.Replace
-                    }
+                graphics.DrawImage(
+                    sourceBitmap,
+                    new Rectangle(
+                        pnlPreview.Width / 2 -
+                        (Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth) / 2,
+                        pnlPreview.Height / 2 -
+                        (Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight) / 2,
+                        Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth,
+                        Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight
+                    ),
+                    new Rectangle(
+                        CurrentPage.Graphic.X * Options.TileWidth, CurrentPage.Graphic.Y * Options.TileHeight,
+                        Options.TileWidth + CurrentPage.Graphic.Width * Options.TileWidth,
+                        Options.TileHeight + CurrentPage.Graphic.Height * Options.TileHeight
+                    ), GraphicsUnit.Pixel
                 );
-
-                LoadPage(CurrentPageIndex);
             }
+
+            sourceBitmap.Dispose();
         }
 
-        private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+        graphics.Dispose();
+        pnlPreview.BackgroundImage = destBitmap;
+    }
+
+    public void CloseMoveRouteDesigner(EventMoveRouteDesigner moveRouteDesigner)
+    {
+        Controls.Remove(moveRouteDesigner);
+    }
+
+    public void CloseGraphicSelector(EventGraphicSelector graphicSelector)
+    {
+        Controls.Remove(graphicSelector);
+        UpdateEventPreview();
+    }
+
+    private void btnNewPage_Click(object sender, EventArgs e)
+    {
+        MyEvent.Pages.Add(new EventPage());
+        UpdateTabControl();
+        LoadPage(MyEvent.Pages.Count - 1);
+    }
+
+    private void UpdateTabControl()
+    {
+        foreach (var page in mPageTabs)
         {
-            CurrentPage.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
+            pnlTabs.Controls.Remove(page);
         }
 
-        private void chkIsGlobal_CheckedChanged(object sender, EventArgs e)
+        mPageTabs.Clear();
+        for (var i = 0; i < MyEvent.Pages.Count; i++)
         {
-            MyEvent.Global = chkIsGlobal.Checked;
+            var btn = new DarkButton()
+            {
+                Text = (i + 1).ToString()
+            };
+
+            btn.Click += TabBtn_Click;
+            mPageTabs.Add(btn);
         }
 
-        private void lblCloseCommands_Click(object sender, EventArgs e)
+        pnlTabs.Controls.AddRange(mPageTabs.ToArray());
+        for (var i = 0; i < MyEvent.Pages.Count; i++)
+        {
+            var btn = mPageTabs[i];
+            btn.Size = new Size(0, 0);
+            btn.MaximumSize = new Size(100, 22);
+            btn.AutoSize = true;
+            if (i > 0)
+            {
+                btn.Left = mPageTabs[i - 1].Right - 1;
+            }
+
+            btn.Top = 0;
+            btn.SendToBack();
+        }
+
+        pnlTabs.SetBounds(0, 0, pnlTabs.Width, pnlTabs.Height);
+        btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
+        btnTabsLeft.Enabled = pnlTabs.Left < 0;
+    }
+
+    private void TabBtn_Click(object sender, EventArgs e)
+    {
+        LoadPage(mPageTabs.IndexOf((DarkButton)sender));
+    }
+
+    private void EnableButtons()
+    {
+        //Enable Actions
+        btnNewPage.Enabled = true;
+        btnCopyPage.Enabled = true;
+        if (mPageCopy != null)
+        {
+            btnPastePage.Enabled = true;
+        }
+        else
+        {
+            btnPastePage.Enabled = false;
+        }
+
+        if (MyEvent.Pages.Count > 1)
+        {
+            btnDeletePage.Enabled = true;
+        }
+        else
+        {
+            btnDeletePage.Enabled = false;
+        }
+
+        btnClearPage.Enabled = true;
+        btnSave.Enabled = true;
+        btnCancel.Enabled = true;
+    }
+
+    private void DisableButtons()
+    {
+        //Disable Actions
+        btnNewPage.Enabled = false;
+        btnCopyPage.Enabled = false;
+        btnPastePage.Enabled = false;
+        btnDeletePage.Enabled = false;
+        btnClearPage.Enabled = false;
+        btnSave.Enabled = false;
+        btnCancel.Enabled = false;
+    }
+
+    private void FrmEvent_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Escape)
         {
             if (grpNewCommands.Visible)
             {
@@ -456,1212 +360,1334 @@ namespace Intersect.Editor.Forms.Editors.Events
                 EnableButtons();
             }
         }
-
-        private void btnTabsRight_Click(object sender, EventArgs e)
+        else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.X))
         {
-            if (pnlTabs.Right > pnlTabsContainer.Width)
+            if (lstEventCommands.SelectedIndex > -1)
             {
-                pnlTabs.SetBounds(pnlTabs.Bounds.Left - 200, 0, pnlTabs.Width, pnlTabs.Height);
-                if (pnlTabs.Right < pnlTabsContainer.Width)
-                {
-                    pnlTabs.SetBounds(
-                        pnlTabs.Bounds.Left + pnlTabsContainer.Width - pnlTabs.Right, 0, pnlTabs.Width, pnlTabs.Height
-                    );
-                }
+                btnCut_Click(null, null);
             }
 
-            btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
-            btnTabsLeft.Enabled = pnlTabs.Left < 0;
+            return;
         }
-
-        private void btnTabsLeft_Click(object sender, EventArgs e)
+        else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.C))
         {
-            if (pnlTabs.Left < 0)
+            if (lstEventCommands.SelectedIndex > -1)
             {
-                pnlTabs.SetBounds(pnlTabs.Bounds.Left + 200, 0, pnlTabs.Width, pnlTabs.Height);
-                if (pnlTabs.Left > 0)
-                {
-                    pnlTabs.SetBounds(0, 0, pnlTabs.Width, pnlTabs.Height);
-                }
+                btnCopy_Click(null, null);
             }
 
-            btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
-            btnTabsLeft.Enabled = pnlTabs.Left < 0;
+            return;
         }
-
-        private void lstCommands_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        else if (lstEventCommands.Focused && e.KeyData == (Keys.Control | Keys.V))
         {
-            if (e.Node.Tag == null)
+            if (lstEventCommands.SelectedIndex > -1)
             {
-                return;
+                btnPaste_Click(null, null);
             }
 
-            var type = (EventCommandType)int.Parse(e.Node.Tag.ToString());
-
-            if ((type == EventCommandType.SetMoveRoute || type == EventCommandType.WaitForRouteCompletion) &&
-                MyEvent.CommonEvent)
-            {
-                DarkMessageBox.ShowWarning(
-                    Strings.EventCommandList.notcommon, Strings.EventCommandList.notcommoncaption, DarkDialogButton.Ok,
-                    Icon
-                );
-
-                EnableButtons();
-
-                return;
-            }
-
-            EventCommand tmpCommand = null;
-            grpNewCommands.Hide();
-
-            switch (type)
-            {
-                case EventCommandType.Null:
-                    break;
-                case EventCommandType.ShowText:
-                    tmpCommand = new ShowTextCommand();
-
-                    break;
-                case EventCommandType.ShowOptions:
-                    tmpCommand = new ShowOptionsCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.InputVariable:
-                    tmpCommand = new InputVariableCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.AddChatboxText:
-                    tmpCommand = new AddChatboxTextCommand();
-
-                    break;
-                case EventCommandType.SetVariable:
-                    tmpCommand = new SetVariableCommand();
-
-                    break;
-                case EventCommandType.SetSelfSwitch:
-                    tmpCommand = new SetSelfSwitchCommand() { Value = true };
-
-                    break;
-                case EventCommandType.ConditionalBranch:
-                    tmpCommand = new ConditionalBranchCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.ExitEventProcess:
-                    tmpCommand = new ExitEventProcessingCommand();
-
-                    break;
-                case EventCommandType.Label:
-                    tmpCommand = new LabelCommand();
-
-                    break;
-                case EventCommandType.GoToLabel:
-                    tmpCommand = new GoToLabelCommand();
-
-                    break;
-                case EventCommandType.StartCommonEvent:
-                    tmpCommand = new StartCommmonEventCommand();
-
-                    break;
-                case EventCommandType.RestoreHp:
-                    tmpCommand = new RestoreHpCommand();
-
-                    break;
-                case EventCommandType.RestoreMp:
-                    tmpCommand = new RestoreMpCommand();
-
-                    break;
-                case EventCommandType.LevelUp:
-                    tmpCommand = new LevelUpCommand();
-
-                    break;
-                case EventCommandType.GiveExperience:
-                    tmpCommand = new GiveExperienceCommand();
-
-                    break;
-                case EventCommandType.ChangeLevel:
-                    tmpCommand = new ChangeLevelCommand();
-
-                    break;
-                case EventCommandType.ChangeSpells:
-                    tmpCommand = new ChangeSpellsCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.ChangeItems:
-                    tmpCommand = new ChangeItemsCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.EquipItem:
-                    tmpCommand = new EquipItemCommand();
-
-                    break;
-                case EventCommandType.ChangeSprite:
-                    tmpCommand = new ChangeSpriteCommand();
-
-                    break;
-                case EventCommandType.ChangeFace:
-                    tmpCommand = new ChangeFaceCommand();
-
-                    break;
-                case EventCommandType.ChangeGender:
-                    tmpCommand = new ChangeGenderCommand();
-
-                    break;
-                case EventCommandType.ChangeNameColor:
-                    tmpCommand = new ChangeNameColorCommand();
-
-                    break;
-                case EventCommandType.PlayerLabel:
-                    tmpCommand = new ChangePlayerLabelCommand();
-
-                    break;
-                case EventCommandType.SetAccess:
-                    tmpCommand = new SetAccessCommand();
-
-                    break;
-                case EventCommandType.WarpPlayer:
-                    tmpCommand = new WarpCommand();
-
-                    break;
-                case EventCommandType.SetMoveRoute:
-                    tmpCommand = new SetMoveRouteCommand();
-
-                    break;
-                case EventCommandType.WaitForRouteCompletion:
-                    tmpCommand = new WaitForRouteCommand();
-
-                    break;
-                case EventCommandType.HoldPlayer:
-                    tmpCommand = new HoldPlayerCommand();
-
-                    break;
-                case EventCommandType.ReleasePlayer:
-                    tmpCommand = new ReleasePlayerCommand();
-
-                    break;
-                case EventCommandType.SpawnNpc:
-                    tmpCommand = new SpawnNpcCommand();
-
-                    break;
-                case EventCommandType.PlayAnimation:
-                    tmpCommand = new PlayAnimationCommand();
-
-                    break;
-                case EventCommandType.PlayBgm:
-                    tmpCommand = new PlayBgmCommand();
-
-                    break;
-                case EventCommandType.FadeoutBgm:
-                    tmpCommand = new FadeoutBgmCommand();
-
-                    break;
-                case EventCommandType.PlaySound:
-                    tmpCommand = new PlaySoundCommand();
-
-                    break;
-                case EventCommandType.StopSounds:
-                    tmpCommand = new StopSoundsCommand();
-
-                    break;
-                case EventCommandType.Wait:
-                    tmpCommand = new WaitCommand();
-
-                    break;
-                case EventCommandType.OpenBank:
-                    tmpCommand = new OpenBankCommand();
-
-                    break;
-                case EventCommandType.OpenShop:
-                    tmpCommand = new OpenShopCommand();
-
-                    break;
-                case EventCommandType.OpenCraftingTable:
-                    tmpCommand = new OpenCraftingTableCommand();
-
-                    break;
-                case EventCommandType.SetClass:
-                    tmpCommand = new SetClassCommand();
-
-                    break;
-                case EventCommandType.DespawnNpc:
-                    tmpCommand = new DespawnNpcCommand();
-
-                    break;
-                case EventCommandType.StartQuest:
-                    tmpCommand = new StartQuestCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.CompleteQuestTask:
-                    tmpCommand = new CompleteQuestTaskCommand();
-
-                    break;
-                case EventCommandType.EndQuest:
-                    tmpCommand = new EndQuestCommand();
-
-                    break;
-                case EventCommandType.ShowPicture:
-                    tmpCommand = new ShowPictureCommand();
-
-                    break;
-                case EventCommandType.HidePicture:
-                    tmpCommand = new HidePictureCommmand();
-
-                    break;
-                case EventCommandType.HidePlayer:
-                    tmpCommand = new HidePlayerCommand();
-
-                    break;
-                case EventCommandType.ShowPlayer:
-                    tmpCommand = new ShowPlayerCommand();
-
-                    break;
-
-                case EventCommandType.ChangePlayerColor:
-                    tmpCommand = new ChangePlayerColorCommand();
-
-                    break;
-
-                case EventCommandType.ChangeName:
-                    tmpCommand = new ChangeNameCommand(CurrentPage.CommandLists);
-
-                    break;
-
-                case EventCommandType.CreateGuild:
-                    tmpCommand = new CreateGuildCommand(CurrentPage.CommandLists);
-
-                    break;
-
-                case EventCommandType.DisbandGuild:
-                    tmpCommand = new DisbandGuildCommand(CurrentPage.CommandLists);
-
-                    break;
-                case EventCommandType.OpenGuildBank:
-                    tmpCommand = new OpenGuildBankCommand();
-
-                    break;
-                case EventCommandType.SetGuildBankSlots:
-                    tmpCommand = new SetGuildBankSlotsCommand();
-
-                    break;
-                case EventCommandType.ResetStatPointAllocations:
-                    tmpCommand = new ResetStatPointAllocationsCommand();
-
-                    break;
-                case EventCommandType.CastSpellOn:
-                    tmpCommand = new CastSpellOn();
-
-                    break;
-                case EventCommandType.Fade:
-                    tmpCommand = new ScreenFadeCommand();
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            if (mIsInsert)
-            {
-                mCommandProperties[mCurrentCommand]
-                    .MyList.Insert(
-                        mCommandProperties[mCurrentCommand].MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd),
-                        tmpCommand
-                    );
-            }
-            else
-            {
-                mCommandProperties[mCurrentCommand].MyList.Add(tmpCommand);
-            }
-
-            OpenEditCommand(tmpCommand);
-            mIsEdit = false;
+            return;
         }
+    }
 
-        private void btnEditConditions_Click(object sender, EventArgs e)
+    private void btnDeletePage_Click(object sender, EventArgs e)
+    {
+        if (MyEvent.Pages.Count > 1)
         {
-            var editForm = new FrmDynamicRequirements(CurrentPage.ConditionLists, RequirementType.Event);
-            editForm.ShowDialog();
-        }
-
-        private void txtCommand_TextChanged(object sender, EventArgs e)
-        {
-            CurrentPage.TriggerCommand = txtCommand.Text;
-        }
-
-        #region "Form Events"
-
-        public FrmEvent(MapBase currentMap)
-        {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            mCurrentMap = currentMap;
-        }
-
-        private Size _defaultFormSize;
-        private Size _defaultEditorComponentsSize;
-        private System.Drawing.Point _defaultSaveButtonPosition;
-        private System.Drawing.Point _defaultCancelButtonPosition;
-
-        private void frmEvent_Load(object sender, EventArgs e)
-        {
-            grpNewCommands.BringToFront();
-            grpCreateCommands.BringToFront();
-            InitLocalization();
-            lstCommands.ExpandAll();
-
-            _defaultFormSize = new Size(967, 757);
-            _defaultEditorComponentsSize = pnlEditorComponents.Size;
-            _defaultSaveButtonPosition = btnSave.Location;
-            _defaultCancelButtonPosition = btnCancel.Location;
-            MinimumSize = default;
-
-            FrmEvent_Move(sender, e);
-        }
-
-        private void FrmEvent_Move(object? sender, EventArgs e)
-        {
-            if (_defaultFormSize == default)
-            {
-                return;
-            }
-
-            var currentScreen = Screen.FromControl(this);
-            var workingAreaBounds = currentScreen.WorkingArea;
-            var maximumHeight = Math.Min(workingAreaBounds.Height - 40, Math.Max(Height, _defaultFormSize.Height));
-
-            if (maximumHeight >= Size.Height)
-            {
-                return;
-            }
-
-            Size = new Size(Width, maximumHeight);
-            MaximumSize = new Size(Width, maximumHeight);
-            pnlEditorComponents.MaximumSize = new Size(
-                _defaultEditorComponentsSize.Width,
-                _defaultEditorComponentsSize.Height + (maximumHeight - _defaultFormSize.Height)
-            );
-            var buttonY = _defaultSaveButtonPosition.Y + (pnlEditorComponents.MaximumSize.Height - _defaultEditorComponentsSize.Height);
-            btnSave.Location = new System.Drawing.Point(_defaultSaveButtonPosition.X, buttonY);
-            btnCancel.Location = new System.Drawing.Point(_defaultCancelButtonPosition.X, buttonY);
-        }
-
-        /// <summary>
-        ///     Intercepts the form closing event to ask the user if they want to save their changes or not.
-        /// </summary>
-        private void frmEvent_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            if (e.CloseReason != CloseReason.UserClosing)
-            {
-                return;
-            }
-
-            if (btnSave.Enabled == false)
-            {
-                e.Cancel = true;
-
-                return;
-            }
-
-            if (DarkMessageBox.ShowWarning(
-                    Strings.EventEditor.savedialogue, Strings.EventEditor.savecaption, DarkDialogButton.YesNo,
-                    Icon
-                ) ==
-                DialogResult.Yes)
-            {
-                btnSave_Click(null, null);
-            }
-            else
-            {
-                btnCancel_Click(null, null);
-            }
-        }
-
-        private void FrmEvent_FormClosed(object sender, FormClosedEventArgs e)
-        {
-        }
-
-        private void FrmEvent_VisibleChanged(object sender, EventArgs e)
-        {
-            //btnCancel_Click(null, null);
-        }
-
-        private void InitLocalization()
-        {
-            grpGeneral.Text = Strings.EventEditor.general;
-            lblName.Text = Strings.EventEditor.name;
-            chkIsGlobal.Text = Strings.EventEditor.global;
-
-            grpPageOptions.Text = Strings.EventEditor.pageoptions;
-            btnNewPage.Text = Strings.EventEditor.newpage;
-            btnCopyPage.Text = Strings.EventEditor.copypage;
-            btnPastePage.Text = Strings.EventEditor.pastepage;
-            btnDeletePage.Text = Strings.EventEditor.deletepage;
-            btnClearPage.Text = Strings.EventEditor.clearpage;
-
-            grpEventConditions.Text = Strings.EventEditor.conditions;
-            btnEditConditions.Text = Strings.EventEditor.editconditions;
-
-            grpEntityOptions.Text = Strings.EventEditor.entityoptions;
-            grpPreview.Text = Strings.EventEditor.eventpreview;
-            lblAnimation.Text = Strings.EventEditor.animation;
-
-            grpMovement.Text = Strings.EventEditor.movement;
-            lblType.Text = Strings.EventEditor.movementtype;
-            cmbMoveType.Items.Clear();
-            for (var i = 0; i < Strings.EventEditor.movementtypes.Count; i++)
-            {
-                cmbMoveType.Items.Add(Strings.EventEditor.movementtypes[i]);
-            }
-
-            btnSetRoute.Text = Strings.EventEditor.setroute;
-            lblSpeed.Text = Strings.EventEditor.speed;
-            cmbEventSpeed.Items.Clear();
-            for (var i = 0; i < Strings.EventEditor.speeds.Count; i++)
-            {
-                cmbEventSpeed.Items.Add(Strings.EventEditor.speeds[i]);
-            }
-
-            lblFreq.Text = Strings.EventEditor.frequency;
-            cmbEventFreq.Items.Clear();
-            for (var i = 0; i < Strings.EventEditor.frequencies.Count; i++)
-            {
-                cmbEventFreq.Items.Add(Strings.EventEditor.frequencies[i]);
-            }
-
-            lblLayer.Text = Strings.EventEditor.layer;
-            cmbLayering.Items.Clear();
-            for (var i = 0; i < Strings.EventEditor.layers.Count; i++)
-            {
-                cmbLayering.Items.Add(Strings.EventEditor.layers[i]);
-            }
-
-            grpInspector.Text = Strings.EventEditor.inspector;
-            chkDisableInspector.Text = Strings.EventEditor.disableinspector;
-            lblInspectorDesc.Text = Strings.EventEditor.inspectordesc;
-            lblFace.Text = Strings.EventEditor.face;
-            grpExtra.Text = Strings.EventEditor.extras;
-            chkWalkThrough.Text = Strings.EventEditor.passable;
-            chkHideName.Text = Strings.EventEditor.hidename;
-            chkDirectionFix.Text = Strings.EventEditor.directionfix;
-            chkWalkingAnimation.Text = Strings.EventEditor.walkinganim;
-            chkInteractionFreeze.Text = Strings.EventEditor.interactionfreeze;
-            chkIgnoreNpcAvoids.Text = Strings.EventEditor.ignorenpcavoids;
-            grpTriggers.Text = Strings.EventEditor.trigger;
-            chkParallelRun.Text = Strings.EventEditor.ParallelRun;
-            grpNewCommands.Text = Strings.EventEditor.addcommand;
-            grpEventCommands.Text = Strings.EventEditor.commandlist;
-            btnInsert.Text = Strings.EventEditor.insertcommand;
-            btnEdit.Text = Strings.EventEditor.editcommand;
-            btnDelete.Text = Strings.EventEditor.deletecommand;
-            btnCopy.Text = Strings.EventEditor.copycommand;
-            btnCut.Text = Strings.EventEditor.cutcommand;
-            btnPaste.Text = Strings.EventEditor.pastecommand;
-            btnSave.Text = Strings.EventEditor.save;
-            btnCancel.Text = Strings.EventEditor.cancel;
-
-            for (var i = 0; i < lstCommands.Nodes.Count; i++)
-            {
-                lstCommands.Nodes[i].Text = Strings.EventCommands.commands[lstCommands.Nodes[i].Name];
-                for (var x = 0; x < lstCommands.Nodes[i].Nodes.Count; x++)
-                {
-                    lstCommands.Nodes[i].Nodes[x].Text =
-                        Strings.EventCommands.commands[lstCommands.Nodes[i].Nodes[x].Name];
-                }
-            }
-        }
-
-        #endregion
-
-        #region "Loading/Initialization/Saving"
-
-        /// <summary>
-        ///     This function creates a backup of the event we are editting just in case we canel our revisions.
-        ///     It also populates General lists in our editor (ie. switches/variables) for event spawning conditions.
-        ///     If the event is a common event (not a map entity) we hide the entity Options on the form.
-        /// </summary>
-        public void InitEditor(bool disableNaming, bool disableTriggers, bool questEvent)
-        {
-            mEventBackup = MyEvent.JsonData;
-            txtEventname.Text = MyEvent.Name;
-            if (disableNaming)
-            {
-                txtEventname.Enabled = false;
-            }
-
-            if (disableTriggers)
-            {
-                grpTriggers.Hide();
-            }
-
-            cmbPreviewFace.Items.Clear();
-            cmbPreviewFace.Items.Add(Strings.General.None);
-            cmbPreviewFace.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face)
-            );
-
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.Add(Strings.General.None);
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
-            chkParallelRun.Checked = MyEvent.CanRunInParallel;
-            if (MyEvent.CommonEvent || questEvent)
-            {
-                grpEntityOptions.Hide();
-                cmbTrigger.Items.Clear();
-                for (var i = 0; i < Strings.EventEditor.commontriggers.Count; i++)
-                {
-                    cmbTrigger.Items.Add(Strings.EventEditor.commontriggers[i]);
-                }
-            }
-            else
-            {
-                cmbTrigger.Items.Clear();
-                for (var i = 0; i < Strings.EventEditor.triggers.Count; i++)
-                {
-                    cmbTrigger.Items.Add(Strings.EventEditor.triggers[i]);
-                }
-
-                cmbTriggerVal.Items.Clear();
-                cmbTriggerVal.Items.Add(Strings.General.None);
-                cmbTriggerVal.Items.AddRange(ProjectileBase.Names);
-            }
-
-            chkIsGlobal.Checked = Convert.ToBoolean(MyEvent.Global);
-            if (MyEvent.CommonEvent)
-            {
-                chkIsGlobal.Hide();
-            }
-
+            MyEvent.Pages.RemoveAt(CurrentPageIndex);
             UpdateTabControl();
             LoadPage(0);
         }
+    }
 
-        /// <summary>
-        ///     Initializes all of the form controls with values from the passed event page.
-        /// </summary>
-        /// <param name="pageNum">The index of the page to load.</param>
-        public void LoadPage(int pageNum)
-        {
-            Text = Strings.EventEditor.title.ToString(txtEventname.Text);
-            CurrentPageIndex = pageNum;
-            if (MyEvent.Pages.Count == 0)
+    private void btnClearPage_Click(object sender, EventArgs e)
+    {
+        MyEvent.Pages[CurrentPageIndex] = new EventPage();
+        LoadPage(CurrentPageIndex);
+    }
+
+    private void btnCopyPage_Click(object sender, EventArgs e)
+    {
+        mPageCopy = JsonConvert.SerializeObject(
+            CurrentPage,
+            new JsonSerializerSettings()
             {
-                MyEvent.Pages.Add(new EventPage());
+                TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate
             }
+        );
 
-            CurrentPage = MyEvent.Pages[pageNum];
-            for (var i = 0; i < mPageTabs.Count; i++)
-            {
-                if (i == CurrentPageIndex)
+        EnableButtons();
+    }
+
+    private void btnPastePage_Click(object sender, EventArgs e)
+    {
+        if (mPageCopy != null)
+        {
+            MyEvent.Pages[CurrentPageIndex] = new EventPage();
+            JsonConvert.PopulateObject(
+                mPageCopy, MyEvent.Pages[CurrentPageIndex],
+                new JsonSerializerSettings()
                 {
-                    mPageTabs[i].BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+                    TypeNameHandling = TypeNameHandling.Auto,
+                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                    ObjectCreationHandling = ObjectCreationHandling.Replace
                 }
-                else
-                {
-                    mPageTabs[i].BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-                }
-            }
-
-            cmbMoveType.SelectedIndex = (int)CurrentPage.Movement.Type;
-            if (CurrentPage.Movement.Type == EventMovementType.MoveRoute)
-            {
-                btnSetRoute.Enabled = true;
-            }
-            else
-            {
-                btnSetRoute.Enabled = false;
-            }
-
-            cmbEventSpeed.SelectedIndex = (int)CurrentPage.Movement.Speed;
-            cmbEventFreq.SelectedIndex = (int)CurrentPage.Movement.Frequency;
-            chkWalkThrough.Checked = Convert.ToBoolean(CurrentPage.Passable);
-            cmbLayering.SelectedIndex = (int)CurrentPage.Layer;
-            if (MyEvent.CommonEvent)
-            {
-                cmbTrigger.SelectedIndex = (int)CurrentPage.CommonTrigger;
-            }
-            else
-            {
-                cmbTrigger.SelectedIndex = (int)CurrentPage.Trigger;
-            }
-
-            SetupTrigger();
-
-            cmbPreviewFace.SelectedIndex = cmbPreviewFace.Items.IndexOf(TextUtils.NullToNone(CurrentPage.FaceGraphic));
-            if (cmbPreviewFace.SelectedIndex == -1)
-            {
-                cmbPreviewFace.SelectedIndex = 0;
-                UpdateFacePreview();
-            }
-
-            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(CurrentPage.AnimationId) + 1;
-            chkHideName.Checked = Convert.ToBoolean(CurrentPage.HideName);
-            chkDisableInspector.Checked = Convert.ToBoolean(CurrentPage.DisablePreview);
-            chkDirectionFix.Checked = Convert.ToBoolean(CurrentPage.DirectionFix);
-            chkWalkingAnimation.Checked = Convert.ToBoolean(CurrentPage.WalkingAnimation);
-            chkInteractionFreeze.Checked = Convert.ToBoolean(CurrentPage.InteractionFreeze);
-            chkIgnoreNpcAvoids.Checked = Convert.ToBoolean(CurrentPage.IgnoreNpcAvoids);
-            txtDesc.Text = CurrentPage.Description;
-            ListPageCommands();
-            UpdateEventPreview();
-            EnableButtons();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            if (grpCreateCommands.Visible)
-            {
-                CancelCommandEdit();
-            }
-
-            if (NewEvent)
-            {
-                MyMap.LocalEvents.Remove(MyEvent.Id);
-            }
-            else
-            {
-                MyEvent.Load(mEventBackup);
-            }
-
-            Hide();
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            if (grpCreateCommands.Visible)
-            {
-                CancelCommandEdit();
-            }
-
-            if (MyEvent.CommonEvent && MyEvent.Id != Guid.Empty)
-            {
-                PacketSender.SendSaveObject(MyEvent);
-            }
-
-            Hide();
-            Dispose();
-        }
-
-        #endregion
-
-        #region "CommandList Events/Functions"
-
-        /// <summary>
-        ///     Clears the listbox that displays event commands and re-populates it.
-        /// </summary>
-        private void ListPageCommands()
-        {
-            lstEventCommands.Items.Clear();
-            mCommandProperties.Clear();
-            CommandPrinter.PrintCommandList(
-                CurrentPage, CurrentPage.CommandLists.Values.First(), " ", lstEventCommands, mCommandProperties, MyMap
             );
 
-            // Reset our view to roughly where the user left off.
-            if (mOldSelectedCommand > (lstEventCommands.Items.Count - 1))
+            LoadPage(CurrentPageIndex);
+        }
+    }
+
+    private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.AnimationId = AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
+    }
+
+    private void chkIsGlobal_CheckedChanged(object sender, EventArgs e)
+    {
+        MyEvent.Global = chkIsGlobal.Checked;
+    }
+
+    private void lblCloseCommands_Click(object sender, EventArgs e)
+    {
+        if (grpNewCommands.Visible)
+        {
+            grpNewCommands.Hide();
+            EnableButtons();
+        }
+    }
+
+    private void btnTabsRight_Click(object sender, EventArgs e)
+    {
+        if (pnlTabs.Right > pnlTabsContainer.Width)
+        {
+            pnlTabs.SetBounds(pnlTabs.Bounds.Left - 200, 0, pnlTabs.Width, pnlTabs.Height);
+            if (pnlTabs.Right < pnlTabsContainer.Width)
             {
-                lstEventCommands.SelectedIndex = lstEventCommands.Items.Count - 1;
-            }
-            else
-            {
-                lstEventCommands.SelectedIndex = mOldSelectedCommand;
+                pnlTabs.SetBounds(
+                    pnlTabs.Bounds.Left + pnlTabsContainer.Width - pnlTabs.Right, 0, pnlTabs.Width, pnlTabs.Height
+                );
             }
         }
 
-        /// <summary>
-        ///     Given a new or existing command this creates the window to select to edit it's values.
-        /// </summary>
-        /// <param name="command">The command that will be modified.</param>
-        private void OpenEditCommand(EventCommand command)
+        btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
+        btnTabsLeft.Enabled = pnlTabs.Left < 0;
+    }
+
+    private void btnTabsLeft_Click(object sender, EventArgs e)
+    {
+        if (pnlTabs.Left < 0)
         {
-            UserControl cmdWindow = null;
-            switch (command.Type)
+            pnlTabs.SetBounds(pnlTabs.Bounds.Left + 200, 0, pnlTabs.Width, pnlTabs.Height);
+            if (pnlTabs.Left > 0)
             {
-                case EventCommandType.Null:
-                    break;
-                case EventCommandType.ShowText:
-                    cmdWindow = new EventCommandText((ShowTextCommand)command, this);
+                pnlTabs.SetBounds(0, 0, pnlTabs.Width, pnlTabs.Height);
+            }
+        }
 
-                    break;
-                case EventCommandType.ShowOptions:
-                    cmdWindow = new EventCommandOptions((ShowOptionsCommand)command, CurrentPage, this);
+        btnTabsRight.Enabled = pnlTabs.Right > pnlTabsContainer.Width;
+        btnTabsLeft.Enabled = pnlTabs.Left < 0;
+    }
 
-                    break;
-                case EventCommandType.InputVariable:
-                    cmdWindow = new EventCommandInput((InputVariableCommand)command, this);
+    private void lstCommands_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        if (e.Node.Tag == null)
+        {
+            return;
+        }
 
-                    break;
-                case EventCommandType.AddChatboxText:
-                    cmdWindow = new EventCommandChatboxText((AddChatboxTextCommand)command, this);
+        var type = (EventCommandType)int.Parse(e.Node.Tag.ToString());
 
-                    break;
-                case EventCommandType.SetVariable:
-                    cmdWindow = new EventCommandVariable((SetVariableCommand)command, this);
+        if ((type == EventCommandType.SetMoveRoute || type == EventCommandType.WaitForRouteCompletion) &&
+            MyEvent.CommonEvent)
+        {
+            DarkMessageBox.ShowWarning(
+                Strings.EventCommandList.notcommon, Strings.EventCommandList.notcommoncaption, DarkDialogButton.Ok,
+                Icon
+            );
 
-                    break;
-                case EventCommandType.SetSelfSwitch:
-                    cmdWindow = new EventCommandSelfSwitch((SetSelfSwitchCommand)command, this);
+            EnableButtons();
 
-                    break;
-                case EventCommandType.ConditionalBranch:
-                    cmdWindow = new EventCommandConditionalBranch(
-                        ((ConditionalBranchCommand)command).Condition, CurrentPage, this,
-                        (ConditionalBranchCommand)command
-                    );
+            return;
+        }
 
-                    break;
-                case EventCommandType.ExitEventProcess:
-                    //No editor
-                    break;
-                case EventCommandType.Label:
-                    cmdWindow = new EventCommandLabel((LabelCommand)command, this);
+        EventCommand tmpCommand = null;
+        grpNewCommands.Hide();
 
-                    break;
-                case EventCommandType.GoToLabel:
-                    cmdWindow = new EventCommandGotoLabel((GoToLabelCommand)command, this);
+        switch (type)
+        {
+            case EventCommandType.Null:
+                break;
+            case EventCommandType.ShowText:
+                tmpCommand = new ShowTextCommand();
 
-                    break;
-                case EventCommandType.StartCommonEvent:
-                    cmdWindow = new EventCommandStartCommonEvent((StartCommmonEventCommand)command, this);
+                break;
+            case EventCommandType.ShowOptions:
+                tmpCommand = new ShowOptionsCommand(CurrentPage.CommandLists);
 
-                    break;
-                case EventCommandType.RestoreHp:
-                    cmdWindow = new EventCommandChangeVital((RestoreHpCommand)command, this);
+                break;
+            case EventCommandType.InputVariable:
+                tmpCommand = new InputVariableCommand(CurrentPage.CommandLists);
 
-                    break;
-                case EventCommandType.RestoreMp:
-                    cmdWindow = new EventCommandChangeVital((RestoreMpCommand)command, this);
+                break;
+            case EventCommandType.AddChatboxText:
+                tmpCommand = new AddChatboxTextCommand();
 
-                    break;
-                case EventCommandType.LevelUp:
-                    //No editor
-                    break;
-                case EventCommandType.GiveExperience:
-                    cmdWindow = new EventCommandGiveExperience((GiveExperienceCommand)command, this);
+                break;
+            case EventCommandType.SetVariable:
+                tmpCommand = new SetVariableCommand();
 
-                    break;
-                case EventCommandType.ChangeLevel:
-                    cmdWindow = new EventCommandChangeLevel((ChangeLevelCommand)command, this);
+                break;
+            case EventCommandType.SetSelfSwitch:
+                tmpCommand = new SetSelfSwitchCommand() { Value = true };
 
-                    break;
-                case EventCommandType.ChangeSpells:
-                    cmdWindow = new EventCommandChangeSpells((ChangeSpellsCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.ConditionalBranch:
+                tmpCommand = new ConditionalBranchCommand(CurrentPage.CommandLists);
 
-                    break;
-                case EventCommandType.ChangeItems:
-                    cmdWindow = new EventCommandChangeItems((ChangeItemsCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.ExitEventProcess:
+                tmpCommand = new ExitEventProcessingCommand();
 
-                    break;
-                case EventCommandType.EquipItem:
-                    cmdWindow = new EventCommandEquipItems((EquipItemCommand)command, this);
+                break;
+            case EventCommandType.Label:
+                tmpCommand = new LabelCommand();
 
-                    break;
-                case EventCommandType.ChangeSprite:
-                    cmdWindow = new EventCommandChangeSprite((ChangeSpriteCommand)command, this);
+                break;
+            case EventCommandType.GoToLabel:
+                tmpCommand = new GoToLabelCommand();
 
-                    break;
-                case EventCommandType.ChangeFace:
-                    cmdWindow = new EventCommandChangeFace((ChangeFaceCommand)command, this);
+                break;
+            case EventCommandType.StartCommonEvent:
+                tmpCommand = new StartCommmonEventCommand();
 
-                    break;
-                case EventCommandType.ChangeGender:
-                    cmdWindow = new EventCommandChangeGender((ChangeGenderCommand)command, this);
+                break;
+            case EventCommandType.RestoreHp:
+                tmpCommand = new RestoreHpCommand();
 
-                    break;
-                case EventCommandType.ChangeNameColor:
-                    cmdWindow = new EventCommandChangeNameColor((ChangeNameColorCommand)command, this);
+                break;
+            case EventCommandType.RestoreMp:
+                tmpCommand = new RestoreMpCommand();
 
-                    break;
-                case EventCommandType.PlayerLabel:
-                    cmdWindow = new EventCommandChangePlayerLabel((ChangePlayerLabelCommand)command, this);
+                break;
+            case EventCommandType.LevelUp:
+                tmpCommand = new LevelUpCommand();
 
-                    break;
-                case EventCommandType.SetAccess:
-                    cmdWindow = new EventCommandSetAccess((SetAccessCommand)command, this);
+                break;
+            case EventCommandType.GiveExperience:
+                tmpCommand = new GiveExperienceCommand();
 
-                    break;
-                case EventCommandType.WarpPlayer:
-                    cmdWindow = new EventCommandWarp((WarpCommand)command, this);
+                break;
+            case EventCommandType.ChangeLevel:
+                tmpCommand = new ChangeLevelCommand();
 
-                    break;
-                case EventCommandType.SetMoveRoute:
-                    var cmd = (SetMoveRouteCommand)command;
-                    if (cmd.Route == null)
-                    {
-                        cmd.Route = new EventMoveRoute();
-                    }
+                break;
+            case EventCommandType.ChangeSpells:
+                tmpCommand = new ChangeSpellsCommand(CurrentPage.CommandLists);
 
-                    cmdWindow = new EventMoveRouteDesigner(this, mCurrentMap, MyEvent, cmd.Route, cmd);
+                break;
+            case EventCommandType.ChangeItems:
+                tmpCommand = new ChangeItemsCommand(CurrentPage.CommandLists);
 
-                    break;
-                case EventCommandType.WaitForRouteCompletion:
-                    cmdWindow = new EventCommandWaitForRouteCompletion(
-                        (WaitForRouteCommand)command, this, mCurrentMap, MyEvent
-                    );
+                break;
+            case EventCommandType.EquipItem:
+                tmpCommand = new EquipItemCommand();
 
-                    break;
-                case EventCommandType.HoldPlayer:
-                    break;
-                case EventCommandType.ReleasePlayer:
-                    break;
-                case EventCommandType.HidePlayer:
-                    break;
-                case EventCommandType.ShowPlayer:
-                    break;
-                case EventCommandType.SpawnNpc:
-                    cmdWindow = new EventCommandSpawnNpc(this, mCurrentMap, MyEvent, (SpawnNpcCommand)command);
+                break;
+            case EventCommandType.ChangeSprite:
+                tmpCommand = new ChangeSpriteCommand();
 
-                    break;
-                case EventCommandType.DespawnNpc:
-                    break;
-                case EventCommandType.PlayAnimation:
-                    cmdWindow = new EventCommandPlayAnimation(
-                        this, mCurrentMap, MyEvent, (PlayAnimationCommand)command
-                    );
+                break;
+            case EventCommandType.ChangeFace:
+                tmpCommand = new ChangeFaceCommand();
 
-                    break;
-                case EventCommandType.PlayBgm:
-                    cmdWindow = new EventCommandPlayBgm((PlayBgmCommand)command, this);
+                break;
+            case EventCommandType.ChangeGender:
+                tmpCommand = new ChangeGenderCommand();
 
-                    break;
-                case EventCommandType.FadeoutBgm:
-                    break;
-                case EventCommandType.PlaySound:
-                    cmdWindow = new EventCommandPlayBgs((PlaySoundCommand)command, this);
+                break;
+            case EventCommandType.ChangeNameColor:
+                tmpCommand = new ChangeNameColorCommand();
 
-                    break;
-                case EventCommandType.StopSounds:
-                    break;
-                case EventCommandType.ShowPicture:
-                    cmdWindow = new EventCommand_ShowPicture((ShowPictureCommand)command, this);
+                break;
+            case EventCommandType.PlayerLabel:
+                tmpCommand = new ChangePlayerLabelCommand();
 
-                    break;
-                case EventCommandType.HidePicture:
-                    break;
-                case EventCommandType.Wait:
-                    cmdWindow = new EventCommandWait((WaitCommand)command, this);
+                break;
+            case EventCommandType.SetAccess:
+                tmpCommand = new SetAccessCommand();
 
-                    break;
-                case EventCommandType.OpenBank:
-                    break;
-                case EventCommandType.OpenShop:
-                    cmdWindow = new EventCommandOpenShop((OpenShopCommand)command, this);
+                break;
+            case EventCommandType.WarpPlayer:
+                tmpCommand = new WarpCommand();
 
-                    break;
-                case EventCommandType.OpenCraftingTable:
-                    cmdWindow = new EventCommandOpenCraftingTable((OpenCraftingTableCommand)command, this);
+                break;
+            case EventCommandType.SetMoveRoute:
+                tmpCommand = new SetMoveRouteCommand();
 
-                    break;
-                case EventCommandType.SetClass:
-                    cmdWindow = new EventCommandSetClass((SetClassCommand)command, this);
+                break;
+            case EventCommandType.WaitForRouteCompletion:
+                tmpCommand = new WaitForRouteCommand();
 
-                    break;
-                case EventCommandType.StartQuest:
-                    cmdWindow = new EventCommandStartQuest((StartQuestCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.HoldPlayer:
+                tmpCommand = new HoldPlayerCommand();
 
-                    break;
-                case EventCommandType.CompleteQuestTask:
-                    cmdWindow = new EventCommandCompleteQuestTask((CompleteQuestTaskCommand)command, this);
+                break;
+            case EventCommandType.ReleasePlayer:
+                tmpCommand = new ReleasePlayerCommand();
 
-                    break;
-                case EventCommandType.EndQuest:
-                    cmdWindow = new EventCommandEndQuest((EndQuestCommand)command, this);
+                break;
+            case EventCommandType.SpawnNpc:
+                tmpCommand = new SpawnNpcCommand();
 
-                    break;
-                case EventCommandType.ChangePlayerColor:
-                    cmdWindow = new EventCommandChangePlayerColor((ChangePlayerColorCommand)command, this);
+                break;
+            case EventCommandType.PlayAnimation:
+                tmpCommand = new PlayAnimationCommand();
 
-                    break;
-                case EventCommandType.ChangeName:
-                    cmdWindow = new EventCommandChangeName((ChangeNameCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.PlayBgm:
+                tmpCommand = new PlayBgmCommand();
 
-                    break;
+                break;
+            case EventCommandType.FadeoutBgm:
+                tmpCommand = new FadeoutBgmCommand();
 
-                case EventCommandType.CreateGuild:
-                    cmdWindow = new EventCommandCreateGuild((CreateGuildCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.PlaySound:
+                tmpCommand = new PlaySoundCommand();
 
-                    break;
+                break;
+            case EventCommandType.StopSounds:
+                tmpCommand = new StopSoundsCommand();
 
-                case EventCommandType.DisbandGuild:
+                break;
+            case EventCommandType.Wait:
+                tmpCommand = new WaitCommand();
 
-                    break;
-                case EventCommandType.OpenGuildBank:
+                break;
+            case EventCommandType.OpenBank:
+                tmpCommand = new OpenBankCommand();
 
-                    break;
-                case EventCommandType.SetGuildBankSlots:
-                    cmdWindow = new EventCommandSetGuildBankSlots((SetGuildBankSlotsCommand)command, CurrentPage, this);
+                break;
+            case EventCommandType.OpenShop:
+                tmpCommand = new OpenShopCommand();
 
-                    break;
-                case EventCommandType.ResetStatPointAllocations:
+                break;
+            case EventCommandType.OpenCraftingTable:
+                tmpCommand = new OpenCraftingTableCommand();
 
-                    break;
-                case EventCommandType.CastSpellOn:
-                    cmdWindow = new EventCommand_CastSpellOn((CastSpellOn)command, this);
+                break;
+            case EventCommandType.SetClass:
+                tmpCommand = new SetClassCommand();
 
-                    break;
-                case EventCommandType.Fade:
-                    cmdWindow = new EventCommand_ScreenFade((ScreenFadeCommand)command, this);
+                break;
+            case EventCommandType.DespawnNpc:
+                tmpCommand = new DespawnNpcCommand();
 
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
+                break;
+            case EventCommandType.StartQuest:
+                tmpCommand = new StartQuestCommand(CurrentPage.CommandLists);
+
+                break;
+            case EventCommandType.CompleteQuestTask:
+                tmpCommand = new CompleteQuestTaskCommand();
+
+                break;
+            case EventCommandType.EndQuest:
+                tmpCommand = new EndQuestCommand();
+
+                break;
+            case EventCommandType.ShowPicture:
+                tmpCommand = new ShowPictureCommand();
+
+                break;
+            case EventCommandType.HidePicture:
+                tmpCommand = new HidePictureCommmand();
+
+                break;
+            case EventCommandType.HidePlayer:
+                tmpCommand = new HidePlayerCommand();
+
+                break;
+            case EventCommandType.ShowPlayer:
+                tmpCommand = new ShowPlayerCommand();
+
+                break;
+
+            case EventCommandType.ChangePlayerColor:
+                tmpCommand = new ChangePlayerColorCommand();
+
+                break;
+
+            case EventCommandType.ChangeName:
+                tmpCommand = new ChangeNameCommand(CurrentPage.CommandLists);
+
+                break;
+
+            case EventCommandType.CreateGuild:
+                tmpCommand = new CreateGuildCommand(CurrentPage.CommandLists);
+
+                break;
+
+            case EventCommandType.DisbandGuild:
+                tmpCommand = new DisbandGuildCommand(CurrentPage.CommandLists);
+
+                break;
+            case EventCommandType.OpenGuildBank:
+                tmpCommand = new OpenGuildBankCommand();
+
+                break;
+            case EventCommandType.SetGuildBankSlots:
+                tmpCommand = new SetGuildBankSlotsCommand();
+
+                break;
+            case EventCommandType.ResetStatPointAllocations:
+                tmpCommand = new ResetStatPointAllocationsCommand();
+
+                break;
+            case EventCommandType.CastSpellOn:
+                tmpCommand = new CastSpellOn();
+
+                break;
+            case EventCommandType.Fade:
+                tmpCommand = new ScreenFadeCommand();
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        if (mIsInsert)
+        {
+            mCommandProperties[mCurrentCommand]
+                .MyList.Insert(
+                    mCommandProperties[mCurrentCommand].MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd),
+                    tmpCommand
+                );
+        }
+        else
+        {
+            mCommandProperties[mCurrentCommand].MyList.Add(tmpCommand);
+        }
+
+        OpenEditCommand(tmpCommand);
+        mIsEdit = false;
+    }
+
+    private void btnEditConditions_Click(object sender, EventArgs e)
+    {
+        var editForm = new FrmDynamicRequirements(CurrentPage.ConditionLists, RequirementType.Event);
+        editForm.ShowDialog();
+    }
+
+    private void txtCommand_TextChanged(object sender, EventArgs e)
+    {
+        CurrentPage.TriggerCommand = txtCommand.Text;
+    }
+
+    #region "Form Events"
+
+    public FrmEvent(MapBase currentMap)
+    {
+        InitializeComponent();
+        Icon = Program.Icon;
+
+        mCurrentMap = currentMap;
+    }
+
+    private Size _defaultFormSize;
+    private Size _defaultEditorComponentsSize;
+    private System.Drawing.Point _defaultSaveButtonPosition;
+    private System.Drawing.Point _defaultCancelButtonPosition;
+
+    private void frmEvent_Load(object sender, EventArgs e)
+    {
+        grpNewCommands.BringToFront();
+        grpCreateCommands.BringToFront();
+        InitLocalization();
+        lstCommands.ExpandAll();
+
+        _defaultFormSize = new Size(967, 757);
+        _defaultEditorComponentsSize = pnlEditorComponents.Size;
+        _defaultSaveButtonPosition = btnSave.Location;
+        _defaultCancelButtonPosition = btnCancel.Location;
+        MinimumSize = default;
+
+        FrmEvent_Move(sender, e);
+    }
+
+    private void FrmEvent_Move(object? sender, EventArgs e)
+    {
+        if (_defaultFormSize == default)
+        {
+            return;
+        }
+
+        var currentScreen = Screen.FromControl(this);
+        var workingAreaBounds = currentScreen.WorkingArea;
+        var maximumHeight = Math.Min(workingAreaBounds.Height - 40, Math.Max(Height, _defaultFormSize.Height));
+
+        if (maximumHeight >= Size.Height)
+        {
+            return;
+        }
+
+        Size = new Size(Width, maximumHeight);
+        MaximumSize = new Size(Width, maximumHeight);
+        pnlEditorComponents.MaximumSize = new Size(
+            _defaultEditorComponentsSize.Width,
+            _defaultEditorComponentsSize.Height + (maximumHeight - _defaultFormSize.Height)
+        );
+        var buttonY = _defaultSaveButtonPosition.Y + (pnlEditorComponents.MaximumSize.Height - _defaultEditorComponentsSize.Height);
+        btnSave.Location = new System.Drawing.Point(_defaultSaveButtonPosition.X, buttonY);
+        btnCancel.Location = new System.Drawing.Point(_defaultCancelButtonPosition.X, buttonY);
+    }
+
+    /// <summary>
+    ///     Intercepts the form closing event to ask the user if they want to save their changes or not.
+    /// </summary>
+    private void frmEvent_FormClosing(object sender, FormClosingEventArgs e)
+    {
+        if (e.CloseReason != CloseReason.UserClosing)
+        {
+            return;
+        }
+
+        if (btnSave.Enabled == false)
+        {
+            e.Cancel = true;
+
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                Strings.EventEditor.savedialogue, Strings.EventEditor.savecaption, DarkDialogButton.YesNo,
+                Icon
+            ) ==
+            DialogResult.Yes)
+        {
+            btnSave_Click(null, null);
+        }
+        else
+        {
+            btnCancel_Click(null, null);
+        }
+    }
+
+    private void FrmEvent_FormClosed(object sender, FormClosedEventArgs e)
+    {
+    }
+
+    private void FrmEvent_VisibleChanged(object sender, EventArgs e)
+    {
+        //btnCancel_Click(null, null);
+    }
+
+    private void InitLocalization()
+    {
+        grpGeneral.Text = Strings.EventEditor.general;
+        lblName.Text = Strings.EventEditor.name;
+        chkIsGlobal.Text = Strings.EventEditor.global;
+
+        grpPageOptions.Text = Strings.EventEditor.pageoptions;
+        btnNewPage.Text = Strings.EventEditor.newpage;
+        btnCopyPage.Text = Strings.EventEditor.copypage;
+        btnPastePage.Text = Strings.EventEditor.pastepage;
+        btnDeletePage.Text = Strings.EventEditor.deletepage;
+        btnClearPage.Text = Strings.EventEditor.clearpage;
+
+        grpEventConditions.Text = Strings.EventEditor.conditions;
+        btnEditConditions.Text = Strings.EventEditor.editconditions;
+
+        grpEntityOptions.Text = Strings.EventEditor.entityoptions;
+        grpPreview.Text = Strings.EventEditor.eventpreview;
+        lblAnimation.Text = Strings.EventEditor.animation;
+
+        grpMovement.Text = Strings.EventEditor.movement;
+        lblType.Text = Strings.EventEditor.movementtype;
+        cmbMoveType.Items.Clear();
+        for (var i = 0; i < Strings.EventEditor.movementtypes.Count; i++)
+        {
+            cmbMoveType.Items.Add(Strings.EventEditor.movementtypes[i]);
+        }
+
+        btnSetRoute.Text = Strings.EventEditor.setroute;
+        lblSpeed.Text = Strings.EventEditor.speed;
+        cmbEventSpeed.Items.Clear();
+        for (var i = 0; i < Strings.EventEditor.speeds.Count; i++)
+        {
+            cmbEventSpeed.Items.Add(Strings.EventEditor.speeds[i]);
+        }
+
+        lblFreq.Text = Strings.EventEditor.frequency;
+        cmbEventFreq.Items.Clear();
+        for (var i = 0; i < Strings.EventEditor.frequencies.Count; i++)
+        {
+            cmbEventFreq.Items.Add(Strings.EventEditor.frequencies[i]);
+        }
+
+        lblLayer.Text = Strings.EventEditor.layer;
+        cmbLayering.Items.Clear();
+        for (var i = 0; i < Strings.EventEditor.layers.Count; i++)
+        {
+            cmbLayering.Items.Add(Strings.EventEditor.layers[i]);
+        }
+
+        grpInspector.Text = Strings.EventEditor.inspector;
+        chkDisableInspector.Text = Strings.EventEditor.disableinspector;
+        lblInspectorDesc.Text = Strings.EventEditor.inspectordesc;
+        lblFace.Text = Strings.EventEditor.face;
+        grpExtra.Text = Strings.EventEditor.extras;
+        chkWalkThrough.Text = Strings.EventEditor.passable;
+        chkHideName.Text = Strings.EventEditor.hidename;
+        chkDirectionFix.Text = Strings.EventEditor.directionfix;
+        chkWalkingAnimation.Text = Strings.EventEditor.walkinganim;
+        chkInteractionFreeze.Text = Strings.EventEditor.interactionfreeze;
+        chkIgnoreNpcAvoids.Text = Strings.EventEditor.ignorenpcavoids;
+        grpTriggers.Text = Strings.EventEditor.trigger;
+        chkParallelRun.Text = Strings.EventEditor.ParallelRun;
+        grpNewCommands.Text = Strings.EventEditor.addcommand;
+        grpEventCommands.Text = Strings.EventEditor.commandlist;
+        btnInsert.Text = Strings.EventEditor.insertcommand;
+        btnEdit.Text = Strings.EventEditor.editcommand;
+        btnDelete.Text = Strings.EventEditor.deletecommand;
+        btnCopy.Text = Strings.EventEditor.copycommand;
+        btnCut.Text = Strings.EventEditor.cutcommand;
+        btnPaste.Text = Strings.EventEditor.pastecommand;
+        btnSave.Text = Strings.EventEditor.save;
+        btnCancel.Text = Strings.EventEditor.cancel;
+
+        for (var i = 0; i < lstCommands.Nodes.Count; i++)
+        {
+            lstCommands.Nodes[i].Text = Strings.EventCommands.commands[lstCommands.Nodes[i].Name];
+            for (var x = 0; x < lstCommands.Nodes[i].Nodes.Count; x++)
+            {
+                lstCommands.Nodes[i].Nodes[x].Text =
+                    Strings.EventCommands.commands[lstCommands.Nodes[i].Nodes[x].Name];
+            }
+        }
+    }
+
+    #endregion
+
+    #region "Loading/Initialization/Saving"
+
+    /// <summary>
+    ///     This function creates a backup of the event we are editting just in case we canel our revisions.
+    ///     It also populates General lists in our editor (ie. switches/variables) for event spawning conditions.
+    ///     If the event is a common event (not a map entity) we hide the entity Options on the form.
+    /// </summary>
+    public void InitEditor(bool disableNaming, bool disableTriggers, bool questEvent)
+    {
+        mEventBackup = MyEvent.JsonData;
+        txtEventname.Text = MyEvent.Name;
+        if (disableNaming)
+        {
+            txtEventname.Enabled = false;
+        }
+
+        if (disableTriggers)
+        {
+            grpTriggers.Hide();
+        }
+
+        cmbPreviewFace.Items.Clear();
+        cmbPreviewFace.Items.Add(Strings.General.None);
+        cmbPreviewFace.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face)
+        );
+
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+        chkParallelRun.Checked = MyEvent.CanRunInParallel;
+        if (MyEvent.CommonEvent || questEvent)
+        {
+            grpEntityOptions.Hide();
+            cmbTrigger.Items.Clear();
+            for (var i = 0; i < Strings.EventEditor.commontriggers.Count; i++)
+            {
+                cmbTrigger.Items.Add(Strings.EventEditor.commontriggers[i]);
+            }
+        }
+        else
+        {
+            cmbTrigger.Items.Clear();
+            for (var i = 0; i < Strings.EventEditor.triggers.Count; i++)
+            {
+                cmbTrigger.Items.Add(Strings.EventEditor.triggers[i]);
             }
 
-            if (cmdWindow != null)
+            cmbTriggerVal.Items.Clear();
+            cmbTriggerVal.Items.Add(Strings.General.None);
+            cmbTriggerVal.Items.AddRange(ProjectileBase.Names);
+        }
+
+        chkIsGlobal.Checked = Convert.ToBoolean(MyEvent.Global);
+        if (MyEvent.CommonEvent)
+        {
+            chkIsGlobal.Hide();
+        }
+
+        UpdateTabControl();
+        LoadPage(0);
+    }
+
+    /// <summary>
+    ///     Initializes all of the form controls with values from the passed event page.
+    /// </summary>
+    /// <param name="pageNum">The index of the page to load.</param>
+    public void LoadPage(int pageNum)
+    {
+        Text = Strings.EventEditor.title.ToString(txtEventname.Text);
+        CurrentPageIndex = pageNum;
+        if (MyEvent.Pages.Count == 0)
+        {
+            MyEvent.Pages.Add(new EventPage());
+        }
+
+        CurrentPage = MyEvent.Pages[pageNum];
+        for (var i = 0; i < mPageTabs.Count; i++)
+        {
+            if (i == CurrentPageIndex)
             {
-                if (cmdWindow is EventMoveRouteDesigner)
+                mPageTabs[i].BackColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            }
+            else
+            {
+                mPageTabs[i].BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            }
+        }
+
+        cmbMoveType.SelectedIndex = (int)CurrentPage.Movement.Type;
+        if (CurrentPage.Movement.Type == EventMovementType.MoveRoute)
+        {
+            btnSetRoute.Enabled = true;
+        }
+        else
+        {
+            btnSetRoute.Enabled = false;
+        }
+
+        cmbEventSpeed.SelectedIndex = (int)CurrentPage.Movement.Speed;
+        cmbEventFreq.SelectedIndex = (int)CurrentPage.Movement.Frequency;
+        chkWalkThrough.Checked = Convert.ToBoolean(CurrentPage.Passable);
+        cmbLayering.SelectedIndex = (int)CurrentPage.Layer;
+        if (MyEvent.CommonEvent)
+        {
+            cmbTrigger.SelectedIndex = (int)CurrentPage.CommonTrigger;
+        }
+        else
+        {
+            cmbTrigger.SelectedIndex = (int)CurrentPage.Trigger;
+        }
+
+        SetupTrigger();
+
+        cmbPreviewFace.SelectedIndex = cmbPreviewFace.Items.IndexOf(TextUtils.NullToNone(CurrentPage.FaceGraphic));
+        if (cmbPreviewFace.SelectedIndex == -1)
+        {
+            cmbPreviewFace.SelectedIndex = 0;
+            UpdateFacePreview();
+        }
+
+        cmbAnimation.SelectedIndex = AnimationBase.ListIndex(CurrentPage.AnimationId) + 1;
+        chkHideName.Checked = Convert.ToBoolean(CurrentPage.HideName);
+        chkDisableInspector.Checked = Convert.ToBoolean(CurrentPage.DisablePreview);
+        chkDirectionFix.Checked = Convert.ToBoolean(CurrentPage.DirectionFix);
+        chkWalkingAnimation.Checked = Convert.ToBoolean(CurrentPage.WalkingAnimation);
+        chkInteractionFreeze.Checked = Convert.ToBoolean(CurrentPage.InteractionFreeze);
+        chkIgnoreNpcAvoids.Checked = Convert.ToBoolean(CurrentPage.IgnoreNpcAvoids);
+        txtDesc.Text = CurrentPage.Description;
+        ListPageCommands();
+        UpdateEventPreview();
+        EnableButtons();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        if (grpCreateCommands.Visible)
+        {
+            CancelCommandEdit();
+        }
+
+        if (NewEvent)
+        {
+            MyMap.LocalEvents.Remove(MyEvent.Id);
+        }
+        else
+        {
+            MyEvent.Load(mEventBackup);
+        }
+
+        Hide();
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (grpCreateCommands.Visible)
+        {
+            CancelCommandEdit();
+        }
+
+        if (MyEvent.CommonEvent && MyEvent.Id != Guid.Empty)
+        {
+            PacketSender.SendSaveObject(MyEvent);
+        }
+
+        Hide();
+        Dispose();
+    }
+
+    #endregion
+
+    #region "CommandList Events/Functions"
+
+    /// <summary>
+    ///     Clears the listbox that displays event commands and re-populates it.
+    /// </summary>
+    private void ListPageCommands()
+    {
+        lstEventCommands.Items.Clear();
+        mCommandProperties.Clear();
+        CommandPrinter.PrintCommandList(
+            CurrentPage, CurrentPage.CommandLists.Values.First(), " ", lstEventCommands, mCommandProperties, MyMap
+        );
+
+        // Reset our view to roughly where the user left off.
+        if (mOldSelectedCommand > (lstEventCommands.Items.Count - 1))
+        {
+            lstEventCommands.SelectedIndex = lstEventCommands.Items.Count - 1;
+        }
+        else
+        {
+            lstEventCommands.SelectedIndex = mOldSelectedCommand;
+        }
+    }
+
+    /// <summary>
+    ///     Given a new or existing command this creates the window to select to edit it's values.
+    /// </summary>
+    /// <param name="command">The command that will be modified.</param>
+    private void OpenEditCommand(EventCommand command)
+    {
+        UserControl cmdWindow = null;
+        switch (command.Type)
+        {
+            case EventCommandType.Null:
+                break;
+            case EventCommandType.ShowText:
+                cmdWindow = new EventCommandText((ShowTextCommand)command, this);
+
+                break;
+            case EventCommandType.ShowOptions:
+                cmdWindow = new EventCommandOptions((ShowOptionsCommand)command, CurrentPage, this);
+
+                break;
+            case EventCommandType.InputVariable:
+                cmdWindow = new EventCommandInput((InputVariableCommand)command, this);
+
+                break;
+            case EventCommandType.AddChatboxText:
+                cmdWindow = new EventCommandChatboxText((AddChatboxTextCommand)command, this);
+
+                break;
+            case EventCommandType.SetVariable:
+                cmdWindow = new EventCommandVariable((SetVariableCommand)command, this);
+
+                break;
+            case EventCommandType.SetSelfSwitch:
+                cmdWindow = new EventCommandSelfSwitch((SetSelfSwitchCommand)command, this);
+
+                break;
+            case EventCommandType.ConditionalBranch:
+                cmdWindow = new EventCommandConditionalBranch(
+                    ((ConditionalBranchCommand)command).Condition, CurrentPage, this,
+                    (ConditionalBranchCommand)command
+                );
+
+                break;
+            case EventCommandType.ExitEventProcess:
+                //No editor
+                break;
+            case EventCommandType.Label:
+                cmdWindow = new EventCommandLabel((LabelCommand)command, this);
+
+                break;
+            case EventCommandType.GoToLabel:
+                cmdWindow = new EventCommandGotoLabel((GoToLabelCommand)command, this);
+
+                break;
+            case EventCommandType.StartCommonEvent:
+                cmdWindow = new EventCommandStartCommonEvent((StartCommmonEventCommand)command, this);
+
+                break;
+            case EventCommandType.RestoreHp:
+                cmdWindow = new EventCommandChangeVital((RestoreHpCommand)command, this);
+
+                break;
+            case EventCommandType.RestoreMp:
+                cmdWindow = new EventCommandChangeVital((RestoreMpCommand)command, this);
+
+                break;
+            case EventCommandType.LevelUp:
+                //No editor
+                break;
+            case EventCommandType.GiveExperience:
+                cmdWindow = new EventCommandGiveExperience((GiveExperienceCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeLevel:
+                cmdWindow = new EventCommandChangeLevel((ChangeLevelCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeSpells:
+                cmdWindow = new EventCommandChangeSpells((ChangeSpellsCommand)command, CurrentPage, this);
+
+                break;
+            case EventCommandType.ChangeItems:
+                cmdWindow = new EventCommandChangeItems((ChangeItemsCommand)command, CurrentPage, this);
+
+                break;
+            case EventCommandType.EquipItem:
+                cmdWindow = new EventCommandEquipItems((EquipItemCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeSprite:
+                cmdWindow = new EventCommandChangeSprite((ChangeSpriteCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeFace:
+                cmdWindow = new EventCommandChangeFace((ChangeFaceCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeGender:
+                cmdWindow = new EventCommandChangeGender((ChangeGenderCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeNameColor:
+                cmdWindow = new EventCommandChangeNameColor((ChangeNameColorCommand)command, this);
+
+                break;
+            case EventCommandType.PlayerLabel:
+                cmdWindow = new EventCommandChangePlayerLabel((ChangePlayerLabelCommand)command, this);
+
+                break;
+            case EventCommandType.SetAccess:
+                cmdWindow = new EventCommandSetAccess((SetAccessCommand)command, this);
+
+                break;
+            case EventCommandType.WarpPlayer:
+                cmdWindow = new EventCommandWarp((WarpCommand)command, this);
+
+                break;
+            case EventCommandType.SetMoveRoute:
+                var cmd = (SetMoveRouteCommand)command;
+                if (cmd.Route == null)
                 {
-                    Controls.Add(cmdWindow);
-                    cmdWindow.Width = ClientSize.Width;
-                    cmdWindow.Height = ClientSize.Height;
-                    cmdWindow.BringToFront();
-                    mEditingCommand = command;
+                    cmd.Route = new EventMoveRoute();
+                }
+
+                cmdWindow = new EventMoveRouteDesigner(this, mCurrentMap, MyEvent, cmd.Route, cmd);
+
+                break;
+            case EventCommandType.WaitForRouteCompletion:
+                cmdWindow = new EventCommandWaitForRouteCompletion(
+                    (WaitForRouteCommand)command, this, mCurrentMap, MyEvent
+                );
+
+                break;
+            case EventCommandType.HoldPlayer:
+                break;
+            case EventCommandType.ReleasePlayer:
+                break;
+            case EventCommandType.HidePlayer:
+                break;
+            case EventCommandType.ShowPlayer:
+                break;
+            case EventCommandType.SpawnNpc:
+                cmdWindow = new EventCommandSpawnNpc(this, mCurrentMap, MyEvent, (SpawnNpcCommand)command);
+
+                break;
+            case EventCommandType.DespawnNpc:
+                break;
+            case EventCommandType.PlayAnimation:
+                cmdWindow = new EventCommandPlayAnimation(
+                    this, mCurrentMap, MyEvent, (PlayAnimationCommand)command
+                );
+
+                break;
+            case EventCommandType.PlayBgm:
+                cmdWindow = new EventCommandPlayBgm((PlayBgmCommand)command, this);
+
+                break;
+            case EventCommandType.FadeoutBgm:
+                break;
+            case EventCommandType.PlaySound:
+                cmdWindow = new EventCommandPlayBgs((PlaySoundCommand)command, this);
+
+                break;
+            case EventCommandType.StopSounds:
+                break;
+            case EventCommandType.ShowPicture:
+                cmdWindow = new EventCommand_ShowPicture((ShowPictureCommand)command, this);
+
+                break;
+            case EventCommandType.HidePicture:
+                break;
+            case EventCommandType.Wait:
+                cmdWindow = new EventCommandWait((WaitCommand)command, this);
+
+                break;
+            case EventCommandType.OpenBank:
+                break;
+            case EventCommandType.OpenShop:
+                cmdWindow = new EventCommandOpenShop((OpenShopCommand)command, this);
+
+                break;
+            case EventCommandType.OpenCraftingTable:
+                cmdWindow = new EventCommandOpenCraftingTable((OpenCraftingTableCommand)command, this);
+
+                break;
+            case EventCommandType.SetClass:
+                cmdWindow = new EventCommandSetClass((SetClassCommand)command, this);
+
+                break;
+            case EventCommandType.StartQuest:
+                cmdWindow = new EventCommandStartQuest((StartQuestCommand)command, CurrentPage, this);
+
+                break;
+            case EventCommandType.CompleteQuestTask:
+                cmdWindow = new EventCommandCompleteQuestTask((CompleteQuestTaskCommand)command, this);
+
+                break;
+            case EventCommandType.EndQuest:
+                cmdWindow = new EventCommandEndQuest((EndQuestCommand)command, this);
+
+                break;
+            case EventCommandType.ChangePlayerColor:
+                cmdWindow = new EventCommandChangePlayerColor((ChangePlayerColorCommand)command, this);
+
+                break;
+            case EventCommandType.ChangeName:
+                cmdWindow = new EventCommandChangeName((ChangeNameCommand)command, CurrentPage, this);
+
+                break;
+
+            case EventCommandType.CreateGuild:
+                cmdWindow = new EventCommandCreateGuild((CreateGuildCommand)command, CurrentPage, this);
+
+                break;
+
+            case EventCommandType.DisbandGuild:
+
+                break;
+            case EventCommandType.OpenGuildBank:
+
+                break;
+            case EventCommandType.SetGuildBankSlots:
+                cmdWindow = new EventCommandSetGuildBankSlots((SetGuildBankSlotsCommand)command, CurrentPage, this);
+
+                break;
+            case EventCommandType.ResetStatPointAllocations:
+
+                break;
+            case EventCommandType.CastSpellOn:
+                cmdWindow = new EventCommand_CastSpellOn((CastSpellOn)command, this);
+
+                break;
+            case EventCommandType.Fade:
+                cmdWindow = new EventCommand_ScreenFade((ScreenFadeCommand)command, this);
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        if (cmdWindow != null)
+        {
+            if (cmdWindow is EventMoveRouteDesigner)
+            {
+                Controls.Add(cmdWindow);
+                cmdWindow.Width = ClientSize.Width;
+                cmdWindow.Height = ClientSize.Height;
+                cmdWindow.BringToFront();
+                mEditingCommand = command;
+            }
+            else
+            {
+                grpCreateCommands.Show();
+                grpCreateCommands.Controls.Add(cmdWindow);
+                cmdWindow.Left = grpCreateCommands.Width / 2 - cmdWindow.Width / 2;
+                cmdWindow.Top = grpCreateCommands.Height / 2 - cmdWindow.Height / 2;
+                mEditingCommand = command;
+                DisableButtons();
+            }
+        }
+        else //Added a command with no editor
+        {
+            ListPageCommands();
+            EnableButtons();
+        }
+    }
+
+    /// <summary>
+    ///     Resets the form when a user saves a command they are creating or editting.
+    /// </summary>
+    public void FinishCommandEdit(bool moveRoute = false)
+    {
+        if (!moveRoute)
+        {
+            grpCreateCommands.Hide();
+            grpCreateCommands.Controls.RemoveAt(0);
+
+            //Remove the only control which should be the last editing window
+        }
+
+        ListPageCommands();
+        EnableButtons();
+    }
+
+    /// <summary>
+    ///     Resets the form when a user cancels editting or creating a new command for the event.
+    /// </summary>
+    public void CancelCommandEdit(bool moveRoute = false, bool condition = false)
+    {
+        if (mCurrentCommand > -1 && mCommandProperties.Count > mCurrentCommand && !condition)
+        {
+            if (!mIsEdit)
+            {
+                if (mIsInsert)
+                {
+                    HandleRemoveCommand(
+                        mCommandProperties[mCurrentCommand]
+                            .MyList[
+                                mCommandProperties[mCurrentCommand]
+                                    .MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd) -
+                                1]
+                    );
+
+                    mCommandProperties[mCurrentCommand]
+                        .MyList.RemoveAt(
+                            mCommandProperties[mCurrentCommand]
+                                .MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd) -
+                            1
+                        );
                 }
                 else
                 {
-                    grpCreateCommands.Show();
-                    grpCreateCommands.Controls.Add(cmdWindow);
-                    cmdWindow.Left = grpCreateCommands.Width / 2 - cmdWindow.Width / 2;
-                    cmdWindow.Top = grpCreateCommands.Height / 2 - cmdWindow.Height / 2;
-                    mEditingCommand = command;
-                    DisableButtons();
+                    HandleRemoveCommand(
+                        mCommandProperties[mCurrentCommand]
+                            .MyList[mCommandProperties[mCurrentCommand].MyList.Count - 1]
+                    );
+
+                    mCommandProperties[mCurrentCommand]
+                        .MyList.RemoveAt(mCommandProperties[mCurrentCommand].MyList.Count - 1);
                 }
             }
-            else //Added a command with no editor
-            {
-                ListPageCommands();
-                EnableButtons();
-            }
         }
 
-        /// <summary>
-        ///     Resets the form when a user saves a command they are creating or editting.
-        /// </summary>
-        public void FinishCommandEdit(bool moveRoute = false)
+        if (!moveRoute)
         {
-            if (!moveRoute)
-            {
-                grpCreateCommands.Hide();
-                grpCreateCommands.Controls.RemoveAt(0);
-
-                //Remove the only control which should be the last editing window
-            }
-
-            ListPageCommands();
-            EnableButtons();
+            grpCreateCommands.Hide();
+            grpCreateCommands.Controls.RemoveAt(0);
         }
 
-        /// <summary>
-        ///     Resets the form when a user cancels editting or creating a new command for the event.
-        /// </summary>
-        public void CancelCommandEdit(bool moveRoute = false, bool condition = false)
+        ListPageCommands();
+        EnableButtons();
+    }
+
+    private void HandleRemoveCommand(EventCommand cmd)
+    {
+        //If we cancelled an insert for a command that created additional command lists we need to remove those orphaned list(s)
+        var branchesToRemove = new List<Guid>();
+        switch (cmd.Type)
         {
-            if (mCurrentCommand > -1 && mCommandProperties.Count > mCurrentCommand && !condition)
-            {
-                if (!mIsEdit)
-                {
-                    if (mIsInsert)
-                    {
-                        HandleRemoveCommand(
-                            mCommandProperties[mCurrentCommand]
-                                .MyList[
-                                    mCommandProperties[mCurrentCommand]
-                                        .MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd) -
-                                    1]
-                        );
+            case EventCommandType.ShowOptions:
+                branchesToRemove.AddRange(((ShowOptionsCommand)cmd).BranchIds);
 
-                        mCommandProperties[mCurrentCommand]
-                            .MyList.RemoveAt(
-                                mCommandProperties[mCurrentCommand]
-                                    .MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd) -
-                                1
-                            );
-                    }
-                    else
-                    {
-                        HandleRemoveCommand(
-                            mCommandProperties[mCurrentCommand]
-                                .MyList[mCommandProperties[mCurrentCommand].MyList.Count - 1]
-                        );
+                break;
+            case EventCommandType.InputVariable:
+                branchesToRemove.AddRange(((InputVariableCommand)cmd).BranchIds);
 
-                        mCommandProperties[mCurrentCommand]
-                            .MyList.RemoveAt(mCommandProperties[mCurrentCommand].MyList.Count - 1);
-                    }
-                }
-            }
+                break;
+            case EventCommandType.ConditionalBranch:
+                branchesToRemove.AddRange(((ConditionalBranchCommand)cmd).BranchIds);
 
-            if (!moveRoute)
-            {
-                grpCreateCommands.Hide();
-                grpCreateCommands.Controls.RemoveAt(0);
-            }
+                break;
+            case EventCommandType.ChangeItems:
+                branchesToRemove.AddRange(((ChangeItemsCommand)cmd).BranchIds);
 
-            ListPageCommands();
-            EnableButtons();
+                break;
+            case EventCommandType.ChangeSpells:
+                branchesToRemove.AddRange(((ChangeSpellsCommand)cmd).BranchIds);
+
+                break;
+            case EventCommandType.StartQuest:
+                branchesToRemove.AddRange(((StartQuestCommand)cmd).BranchIds);
+
+                break;
         }
 
-        private void HandleRemoveCommand(EventCommand cmd)
+        foreach (var branch in branchesToRemove)
         {
-            //If we cancelled an insert for a command that created additional command lists we need to remove those orphaned list(s)
-            var branchesToRemove = new List<Guid>();
-            switch (cmd.Type)
-            {
-                case EventCommandType.ShowOptions:
-                    branchesToRemove.AddRange(((ShowOptionsCommand)cmd).BranchIds);
+            CurrentPage.CommandLists.Remove(branch);
+        }
+    }
 
-                    break;
-                case EventCommandType.InputVariable:
-                    branchesToRemove.AddRange(((InputVariableCommand)cmd).BranchIds);
-
-                    break;
-                case EventCommandType.ConditionalBranch:
-                    branchesToRemove.AddRange(((ConditionalBranchCommand)cmd).BranchIds);
-
-                    break;
-                case EventCommandType.ChangeItems:
-                    branchesToRemove.AddRange(((ChangeItemsCommand)cmd).BranchIds);
-
-                    break;
-                case EventCommandType.ChangeSpells:
-                    branchesToRemove.AddRange(((ChangeSpellsCommand)cmd).BranchIds);
-
-                    break;
-                case EventCommandType.StartQuest:
-                    branchesToRemove.AddRange(((StartQuestCommand)cmd).BranchIds);
-
-                    break;
-            }
-
-            foreach (var branch in branchesToRemove)
-            {
-                CurrentPage.CommandLists.Remove(branch);
-            }
+    /// <summary>
+    ///     Opens the 'Add Command' window in order to insert a command at the select location in the command list.
+    /// </summary>
+    private void btnInsert_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
         }
 
-        /// <summary>
-        ///     Opens the 'Add Command' window in order to insert a command at the select location in the command list.
-        /// </summary>
-        private void btnInsert_Click(object sender, EventArgs e)
+        if (!mCommandProperties[mCurrentCommand].Editable)
         {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
-            {
-                grpNewCommands.Show();
-                mIsInsert = false;
-                mIsEdit = false;
-            }
-            else
-            {
-                grpNewCommands.Show();
-                mIsInsert = true;
-                mIsEdit = false;
-            }
+            return;
         }
 
-        private void btnEdit_Click(object sender, EventArgs e)
+        if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
         {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
+            grpNewCommands.Show();
+            mIsInsert = false;
+            mIsEdit = false;
+        }
+        else
+        {
+            grpNewCommands.Show();
+            mIsInsert = true;
+            mIsEdit = false;
+        }
+    }
 
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                return;
-            }
-
-            OpenEditCommand(mCommandProperties[mCurrentCommand].MyList[mCommandProperties[mCurrentCommand].MyIndex]);
-            mIsEdit = true;
+    private void btnEdit_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
         }
 
-        private void btnDelete_Click(object sender, EventArgs e)
+        if (!mCommandProperties[mCurrentCommand].Editable)
         {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                return;
-            }
-
-            HandleRemoveCommand(mCommandProperties[mCurrentCommand].Cmd);
-            mCommandProperties[mCurrentCommand].MyList.Remove(mCommandProperties[mCurrentCommand].Cmd);
-            mCurrentCommand = -1;
-            ListPageCommands();
+            return;
         }
 
-        private void btnCut_Click(object sender, EventArgs e)
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
         {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
-            {
-                return;
-            }
-
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
-
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                return;
-            }
-
-            //Get a json representation of what we're cutting
-            btnCopy_Click(sender, e);
-
-            //Delete the command
-            btnDelete_Click(sender, e);
+            return;
         }
 
-        private void btnCopy_Click(object sender, EventArgs e)
+        OpenEditCommand(mCommandProperties[mCurrentCommand].MyList[mCommandProperties[mCurrentCommand].MyIndex]);
+        mIsEdit = true;
+    }
+
+    private void btnDelete_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
         {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+            return;
+        }
+
+        if (!mCommandProperties[mCurrentCommand].Editable)
+        {
+            return;
+        }
+
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
+        {
+            return;
+        }
+
+        HandleRemoveCommand(mCommandProperties[mCurrentCommand].Cmd);
+        mCommandProperties[mCurrentCommand].MyList.Remove(mCommandProperties[mCurrentCommand].Cmd);
+        mCurrentCommand = -1;
+        ListPageCommands();
+    }
+
+    private void btnCut_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
+        }
+
+        if (!mCommandProperties[mCurrentCommand].Editable)
+        {
+            return;
+        }
+
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
+        {
+            return;
+        }
+
+        //Get a json representation of what we're cutting
+        btnCopy_Click(sender, e);
+
+        //Delete the command
+        btnDelete_Click(sender, e);
+    }
+
+    private void btnCopy_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
+        }
+
+        if (!mCommandProperties[mCurrentCommand].Editable)
+        {
+            return;
+        }
+
+        if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
+            mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
+        {
+            return;
+        }
+
+        var copyLists = new Dictionary<Guid, List<EventCommand>>();
+        mCopyData = mCommandProperties[mCurrentCommand]
+            .MyList[mCommandProperties[mCurrentCommand].MyIndex]
+            .GetCopyData(CurrentPage.CommandLists, copyLists);
+
+        mCopyLists = JsonConvert.SerializeObject(
+            copyLists,
+            new JsonSerializerSettings()
             {
-                return;
+                Formatting = Formatting.None,
+                TypeNameHandling = TypeNameHandling.Auto,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
             }
+        );
+    }
 
-            if (!mCommandProperties[mCurrentCommand].Editable)
-            {
-                return;
-            }
+    private void btnPaste_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
+        }
 
-            if (mCommandProperties[mCurrentCommand].MyIndex < 0 ||
-                mCommandProperties[mCurrentCommand].MyIndex >= mCommandProperties[mCurrentCommand].MyList.Count)
-            {
-                return;
-            }
+        if (!mCommandProperties[mCurrentCommand].Editable)
+        {
+            return;
+        }
 
-            var copyLists = new Dictionary<Guid, List<EventCommand>>();
-            mCopyData = mCommandProperties[mCurrentCommand]
-                .MyList[mCommandProperties[mCurrentCommand].MyIndex]
-                .GetCopyData(CurrentPage.CommandLists, copyLists);
-
-            mCopyLists = JsonConvert.SerializeObject(
-                copyLists,
+        if (mCopyData != null)
+        {
+            var newCmd = JsonConvert.DeserializeObject<EventCommand>(
+                mCopyData,
                 new JsonSerializerSettings()
                 {
                     Formatting = Formatting.None,
@@ -1670,344 +1696,316 @@ namespace Intersect.Editor.Forms.Editors.Events
                     ObjectCreationHandling = ObjectCreationHandling.Replace
                 }
             );
-        }
 
-        private void btnPaste_Click(object sender, EventArgs e)
-        {
-            if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+            var lists = JsonConvert.DeserializeObject<Dictionary<Guid, List<EventCommand>>>(
+                mCopyLists,
+                new JsonSerializerSettings()
+                {
+                    Formatting = Formatting.None,
+                    TypeNameHandling = TypeNameHandling.Auto,
+                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                    ObjectCreationHandling = ObjectCreationHandling.Replace
+                }
+            );
+
+            var newListIds = new Dictionary<Guid, Guid>();
+            foreach (var list in lists)
             {
-                return;
+                newListIds.Add(list.Key, Guid.NewGuid());
             }
 
-            if (!mCommandProperties[mCurrentCommand].Editable)
+            newCmd.FixBranchIds(newListIds);
+            foreach (var list in lists)
             {
-                return;
-            }
-
-            if (mCopyData != null)
-            {
-                var newCmd = JsonConvert.DeserializeObject<EventCommand>(
-                    mCopyData,
-                    new JsonSerializerSettings()
-                    {
-                        Formatting = Formatting.None,
-                        TypeNameHandling = TypeNameHandling.Auto,
-                        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                        ObjectCreationHandling = ObjectCreationHandling.Replace
-                    }
-                );
-
-                var lists = JsonConvert.DeserializeObject<Dictionary<Guid, List<EventCommand>>>(
-                    mCopyLists,
-                    new JsonSerializerSettings()
-                    {
-                        Formatting = Formatting.None,
-                        TypeNameHandling = TypeNameHandling.Auto,
-                        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-                        ObjectCreationHandling = ObjectCreationHandling.Replace
-                    }
-                );
-
-                var newListIds = new Dictionary<Guid, Guid>();
-                foreach (var list in lists)
+                foreach (var cmd in list.Value)
                 {
-                    newListIds.Add(list.Key, Guid.NewGuid());
-                }
-
-                newCmd.FixBranchIds(newListIds);
-                foreach (var list in lists)
-                {
-                    foreach (var cmd in list.Value)
-                    {
-                        cmd.FixBranchIds(newListIds);
-                    }
-                }
-
-                foreach (var list in lists)
-                {
-                    CurrentPage.CommandLists.Add(newListIds[list.Key], list.Value);
-                }
-
-                if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
-                {
-                    mCommandProperties[mCurrentCommand].MyList.Add(newCmd);
-                }
-                else
-                {
-                    mCommandProperties[mCurrentCommand]
-                        .MyList.Insert(
-                            mCommandProperties[mCurrentCommand].MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd),
-                            newCmd
-                        );
-                }
-
-                ListPageCommands();
-            }
-        }
-
-        /// <summary>
-        /// Custom renderer for event commands to draw labels in green for easier visibility.
-        /// </summary>
-        private void lstEventCommands_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            e.DrawBackground();
-            Graphics g = e.Graphics;
-
-            if (e.Index > -1 && e.Index < lstEventCommands.Items.Count && e.Index < mCommandProperties.Count)
-            {
-                if (mCommandProperties[e.Index].Type == EventCommandType.Label)
-                {
-                    g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, Brushes.SpringGreen, new PointF(e.Bounds.X, e.Bounds.Y));
-                }
-                else
-                {
-                    g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), new PointF(e.Bounds.X, e.Bounds.Y));
+                    cmd.FixBranchIds(newListIds);
                 }
             }
 
-
-            e.DrawFocusRectangle();
-        }
-
-        #endregion
-
-        #region "Movement Options"
-
-        private void cmbMoveType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Movement.Type = (EventMovementType)cmbMoveType.SelectedIndex;
-            if (CurrentPage.Movement.Type == EventMovementType.MoveRoute)
+            foreach (var list in lists)
             {
-                btnSetRoute.Enabled = true;
+                CurrentPage.CommandLists.Add(newListIds[list.Key], list.Value);
+            }
+
+            if (mCommandProperties[mCurrentCommand].Type == EventCommandType.Null)
+            {
+                mCommandProperties[mCurrentCommand].MyList.Add(newCmd);
             }
             else
             {
-                btnSetRoute.Enabled = false;
-            }
-        }
-
-        private void cmbEventSpeed_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Movement.Speed = (EventMovementSpeed)cmbEventSpeed.SelectedIndex;
-        }
-
-        private void cmbEventFreq_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Movement.Frequency = (EventMovementFrequency)cmbEventFreq.SelectedIndex;
-        }
-
-        private void btnSetRoute_Click(object sender, EventArgs e)
-        {
-            var moveRouteDesigner = new EventMoveRouteDesigner(this, mCurrentMap, MyEvent, CurrentPage.Movement.Route, null, true);
-            Controls.Add(moveRouteDesigner);
-            moveRouteDesigner.BringToFront();
-            moveRouteDesigner.Size = ClientSize;
-        }
-
-        #endregion
-
-        #region "Extra Options"
-
-        private void chkWalkThrough_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Passable = chkWalkThrough.Checked;
-        }
-
-        private void cmbLayering_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Layer = (EventRenderLayer)cmbLayering.SelectedIndex;
-        }
-
-        private void chkParallelRun_CheckedChanged(object sender, EventArgs e)
-        {
-            MyEvent.CanRunInParallel = chkParallelRun.Checked;
-        }
-
-        private void cmbTrigger_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (MyEvent.CommonEvent)
-            {
-                CurrentPage.CommonTrigger = (CommonEventTrigger)cmbTrigger.SelectedIndex;
-            }
-            else
-            {
-                CurrentPage.Trigger = (EventTrigger)cmbTrigger.SelectedIndex;
+                mCommandProperties[mCurrentCommand]
+                    .MyList.Insert(
+                        mCommandProperties[mCurrentCommand].MyList.IndexOf(mCommandProperties[mCurrentCommand].Cmd),
+                        newCmd
+                    );
             }
 
-            SetupTrigger();
+            ListPageCommands();
         }
-
-        private void SetupTrigger()
-        {
-            cmbTriggerVal.Hide();
-            lblTriggerVal.Hide();
-            txtCommand.Hide();
-            lblCommand.Hide();
-            lblVariableTrigger.Hide();
-            cmbVariable.Hide();
-
-            if (MyEvent.CommonEvent)
-            {
-                cmbVariable.Items.Clear();
-
-
-                if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.SlashCommand)
-                {
-                    txtCommand.Show();
-                    txtCommand.Text = CurrentPage.TriggerCommand;
-                    lblCommand.Show();
-                    lblCommand.Text = Strings.EventEditor.command;
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.PlayerVariableChange)
-                {
-                    cmbVariable.Show();
-                    cmbVariable.Items.Add(Strings.General.None);
-                    cmbVariable.Items.AddRange(PlayerVariableBase.Names);
-                    cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
-                    lblVariableTrigger.Show();
-                    lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.ServerVariableChange)
-                {
-                    cmbVariable.Show();
-                    cmbVariable.Items.Add(Strings.General.None);
-                    cmbVariable.Items.AddRange(ServerVariableBase.Names);
-                    cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
-                    lblVariableTrigger.Show();
-                    lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.GuildVariableChange)
-                {
-                    cmbVariable.Show();
-                    cmbVariable.Items.Add(Strings.General.None);
-                    cmbVariable.Items.AddRange(GuildVariableBase.Names);
-                    cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
-                    lblVariableTrigger.Show();
-                    lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
-                {
-                    cmbVariable.Show();
-                    cmbVariable.Items.Add(Strings.General.None);
-                    cmbVariable.Items.AddRange(UserVariableBase.Names);
-                    cmbVariable.SelectedIndex = UserVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
-                    lblVariableTrigger.Show();
-                    lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
-                }
-            }
-        }
-
-        private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (MyEvent.CommonEvent)
-            {
-                if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.PlayerVariableChange)
-                {
-                    CurrentPage.TriggerId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.ServerVariableChange)
-                {
-                    CurrentPage.TriggerId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.GuildVariableChange)
-                {
-                    CurrentPage.TriggerId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
-                }
-                else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
-                {
-                    CurrentPage.TriggerId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
-                }
-            }
-        }
-
-        private void chkHideName_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.HideName = chkHideName.Checked;
-        }
-
-        private void chkDirectionFix_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.DirectionFix = chkDirectionFix.Checked;
-        }
-
-        private void chkWalkingAnimation_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.WalkingAnimation = chkWalkingAnimation.Checked;
-        }
-
-        private void chkInteractionFreeze_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.InteractionFreeze = chkInteractionFreeze.Checked;
-        }
-
-        private void chkIgnoreNpcAvoids_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.IgnoreNpcAvoids = chkIgnoreNpcAvoids.Checked;
-        }
-
-        #endregion
-
-        #region "Inspector Options"
-
-        private void txtDesc_TextChanged(object sender, EventArgs e)
-        {
-            CurrentPage.Description = txtDesc.Text;
-        }
-
-        private void chkDisablePreview_CheckedChanged(object sender, EventArgs e)
-        {
-            CurrentPage.DisablePreview = chkDisableInspector.Checked;
-            if (chkDisableInspector.Checked)
-            {
-                cmbPreviewFace.Enabled = false;
-                txtDesc.Enabled = false;
-            }
-            else
-            {
-                cmbPreviewFace.Enabled = true;
-                txtDesc.Enabled = true;
-            }
-
-            UpdateFacePreview();
-        }
-
-        private void UpdateFacePreview()
-        {
-            if (CurrentPage.DisablePreview || cmbPreviewFace.SelectedIndex < 1)
-            {
-                pnlFacePreview.BackgroundImage = null;
-
-                return;
-            }
-
-            if (File.Exists("resources/faces/" + cmbPreviewFace.Text))
-            {
-                pnlFacePreview.BackgroundImage = new Bitmap("resources/faces/" + cmbPreviewFace.Text);
-            }
-        }
-
-        private void cmbPreviewFace_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            CurrentPage.FaceGraphic = TextUtils.SanitizeNone(cmbPreviewFace?.Text);
-            UpdateFacePreview();
-        }
-
-        #endregion
     }
 
-    public partial class CommandListProperties
+    /// <summary>
+    /// Custom renderer for event commands to draw labels in green for easier visibility.
+    /// </summary>
+    private void lstEventCommands_DrawItem(object sender, DrawItemEventArgs e)
     {
+        e.DrawBackground();
+        Graphics g = e.Graphics;
 
-        public EventCommand Cmd;
+        if (e.Index > -1 && e.Index < lstEventCommands.Items.Count && e.Index < mCommandProperties.Count)
+        {
+            if (mCommandProperties[e.Index].Type == EventCommandType.Label)
+            {
+                g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, Brushes.SpringGreen, new PointF(e.Bounds.X, e.Bounds.Y));
+            }
+            else
+            {
+                g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), new PointF(e.Bounds.X, e.Bounds.Y));
+            }
+        }
 
-        public bool Editable;
 
-        public int MyIndex;
-
-        public List<EventCommand> MyList;
-
-        public EventCommandType Type = EventCommandType.Null;
-
+        e.DrawFocusRectangle();
     }
+
+    #endregion
+
+    #region "Movement Options"
+
+    private void cmbMoveType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Movement.Type = (EventMovementType)cmbMoveType.SelectedIndex;
+        if (CurrentPage.Movement.Type == EventMovementType.MoveRoute)
+        {
+            btnSetRoute.Enabled = true;
+        }
+        else
+        {
+            btnSetRoute.Enabled = false;
+        }
+    }
+
+    private void cmbEventSpeed_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Movement.Speed = (EventMovementSpeed)cmbEventSpeed.SelectedIndex;
+    }
+
+    private void cmbEventFreq_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Movement.Frequency = (EventMovementFrequency)cmbEventFreq.SelectedIndex;
+    }
+
+    private void btnSetRoute_Click(object sender, EventArgs e)
+    {
+        var moveRouteDesigner = new EventMoveRouteDesigner(this, mCurrentMap, MyEvent, CurrentPage.Movement.Route, null, true);
+        Controls.Add(moveRouteDesigner);
+        moveRouteDesigner.BringToFront();
+        moveRouteDesigner.Size = ClientSize;
+    }
+
+    #endregion
+
+    #region "Extra Options"
+
+    private void chkWalkThrough_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Passable = chkWalkThrough.Checked;
+    }
+
+    private void cmbLayering_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Layer = (EventRenderLayer)cmbLayering.SelectedIndex;
+    }
+
+    private void chkParallelRun_CheckedChanged(object sender, EventArgs e)
+    {
+        MyEvent.CanRunInParallel = chkParallelRun.Checked;
+    }
+
+    private void cmbTrigger_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (MyEvent.CommonEvent)
+        {
+            CurrentPage.CommonTrigger = (CommonEventTrigger)cmbTrigger.SelectedIndex;
+        }
+        else
+        {
+            CurrentPage.Trigger = (EventTrigger)cmbTrigger.SelectedIndex;
+        }
+
+        SetupTrigger();
+    }
+
+    private void SetupTrigger()
+    {
+        cmbTriggerVal.Hide();
+        lblTriggerVal.Hide();
+        txtCommand.Hide();
+        lblCommand.Hide();
+        lblVariableTrigger.Hide();
+        cmbVariable.Hide();
+
+        if (MyEvent.CommonEvent)
+        {
+            cmbVariable.Items.Clear();
+
+
+            if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.SlashCommand)
+            {
+                txtCommand.Show();
+                txtCommand.Text = CurrentPage.TriggerCommand;
+                lblCommand.Show();
+                lblCommand.Text = Strings.EventEditor.command;
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.PlayerVariableChange)
+            {
+                cmbVariable.Show();
+                cmbVariable.Items.Add(Strings.General.None);
+                cmbVariable.Items.AddRange(PlayerVariableBase.Names);
+                cmbVariable.SelectedIndex = PlayerVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
+                lblVariableTrigger.Show();
+                lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.ServerVariableChange)
+            {
+                cmbVariable.Show();
+                cmbVariable.Items.Add(Strings.General.None);
+                cmbVariable.Items.AddRange(ServerVariableBase.Names);
+                cmbVariable.SelectedIndex = ServerVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
+                lblVariableTrigger.Show();
+                lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.GuildVariableChange)
+            {
+                cmbVariable.Show();
+                cmbVariable.Items.Add(Strings.General.None);
+                cmbVariable.Items.AddRange(GuildVariableBase.Names);
+                cmbVariable.SelectedIndex = GuildVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
+                lblVariableTrigger.Show();
+                lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
+            {
+                cmbVariable.Show();
+                cmbVariable.Items.Add(Strings.General.None);
+                cmbVariable.Items.AddRange(UserVariableBase.Names);
+                cmbVariable.SelectedIndex = UserVariableBase.ListIndex(CurrentPage.TriggerId) + 1;
+                lblVariableTrigger.Show();
+                lblVariableTrigger.Text = Strings.EventEditor.VariableTrigger;
+            }
+        }
+    }
+
+    private void cmbVariable_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (MyEvent.CommonEvent)
+        {
+            if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.PlayerVariableChange)
+            {
+                CurrentPage.TriggerId = PlayerVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.ServerVariableChange)
+            {
+                CurrentPage.TriggerId = ServerVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.GuildVariableChange)
+            {
+                CurrentPage.TriggerId = GuildVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
+            }
+            else if (cmbTrigger.SelectedIndex == (int)CommonEventTrigger.UserVariableChange)
+            {
+                CurrentPage.TriggerId = UserVariableBase.IdFromList(cmbVariable.SelectedIndex - 1);
+            }
+        }
+    }
+
+    private void chkHideName_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.HideName = chkHideName.Checked;
+    }
+
+    private void chkDirectionFix_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.DirectionFix = chkDirectionFix.Checked;
+    }
+
+    private void chkWalkingAnimation_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.WalkingAnimation = chkWalkingAnimation.Checked;
+    }
+
+    private void chkInteractionFreeze_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.InteractionFreeze = chkInteractionFreeze.Checked;
+    }
+
+    private void chkIgnoreNpcAvoids_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.IgnoreNpcAvoids = chkIgnoreNpcAvoids.Checked;
+    }
+
+    #endregion
+
+    #region "Inspector Options"
+
+    private void txtDesc_TextChanged(object sender, EventArgs e)
+    {
+        CurrentPage.Description = txtDesc.Text;
+    }
+
+    private void chkDisablePreview_CheckedChanged(object sender, EventArgs e)
+    {
+        CurrentPage.DisablePreview = chkDisableInspector.Checked;
+        if (chkDisableInspector.Checked)
+        {
+            cmbPreviewFace.Enabled = false;
+            txtDesc.Enabled = false;
+        }
+        else
+        {
+            cmbPreviewFace.Enabled = true;
+            txtDesc.Enabled = true;
+        }
+
+        UpdateFacePreview();
+    }
+
+    private void UpdateFacePreview()
+    {
+        if (CurrentPage.DisablePreview || cmbPreviewFace.SelectedIndex < 1)
+        {
+            pnlFacePreview.BackgroundImage = null;
+
+            return;
+        }
+
+        if (File.Exists("resources/faces/" + cmbPreviewFace.Text))
+        {
+            pnlFacePreview.BackgroundImage = new Bitmap("resources/faces/" + cmbPreviewFace.Text);
+        }
+    }
+
+    private void cmbPreviewFace_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        CurrentPage.FaceGraphic = TextUtils.SanitizeNone(cmbPreviewFace?.Text);
+        UpdateFacePreview();
+    }
+
+    #endregion
+}
+
+public partial class CommandListProperties
+{
+
+    public EventCommand Cmd;
+
+    public bool Editable;
+
+    public int MyIndex;
+
+    public List<EventCommand> MyList;
+
+    public EventCommandType Type = EventCommandType.Null;
 
 }

--- a/Intersect.Editor/Forms/Editors/Quest/Quest_TaskEditor.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/Quest_TaskEditor.cs
@@ -5,178 +5,176 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Logging;
 
-namespace Intersect.Editor.Forms.Editors.Quest
+namespace Intersect.Editor.Forms.Editors.Quest;
+
+
+public partial class QuestTaskEditor : UserControl
 {
 
-    public partial class QuestTaskEditor : UserControl
+    public bool Cancelled;
+
+    private string mEventBackup = null;
+
+    private QuestBase mMyQuest;
+
+    private QuestBase.QuestTask mMyTask;
+
+    public QuestTaskEditor(QuestBase refQuest, QuestBase.QuestTask refTask)
     {
-
-        public bool Cancelled;
-
-        private string mEventBackup = null;
-
-        private QuestBase mMyQuest;
-
-        private QuestBase.QuestTask mMyTask;
-
-        public QuestTaskEditor(QuestBase refQuest, QuestBase.QuestTask refTask)
+        if (refQuest == null)
         {
-            if (refQuest == null)
-            {
-                Log.Warn($@"{nameof(refQuest)} is null.");
-            }
-
-            if (refTask == null)
-            {
-                Log.Warn($@"{nameof(refTask)} is null.");
-            }
-
-            InitializeComponent();
-            mMyTask = refTask;
-            mMyQuest = refQuest;
-
-            if (mMyTask?.EditingEvent == null)
-            {
-                Log.Warn($@"{nameof(mMyTask.EditingEvent)} is null.");
-            }
-
-            mEventBackup = mMyTask?.EditingEvent?.JsonData;
-            InitLocalization();
-            cmbTaskType.SelectedIndex = mMyTask == null ? -1 : (int) mMyTask.Objective;
-            txtStartDesc.Text = mMyTask?.Description;
-            UpdateFormElements();
-            switch (cmbTaskType.SelectedIndex)
-            {
-                case 0: //Event Driven
-                    break;
-                case 1: //Gather Items
-                    cmbItem.SelectedIndex = ItemBase.ListIndex(mMyTask?.TargetId ?? Guid.Empty);
-                    nudItemAmount.Value = mMyTask?.Quantity ?? 0;
-
-                    break;
-                case 2: //Kill NPCS
-                    cmbNpc.SelectedIndex = NpcBase.ListIndex(mMyTask?.TargetId ?? Guid.Empty);
-                    nudNpcQuantity.Value = mMyTask?.Quantity ?? 0;
-
-                    break;
-            }
+            Log.Warn($@"{nameof(refQuest)} is null.");
         }
 
-        private void InitLocalization()
+        if (refTask == null)
         {
-            grpEditor.Text = Strings.TaskEditor.editor;
-
-            lblType.Text = Strings.TaskEditor.type;
-            cmbTaskType.Items.Clear();
-            for (var i = 0; i < Strings.TaskEditor.types.Count; i++)
-            {
-                cmbTaskType.Items.Add(Strings.TaskEditor.types[i]);
-            }
-
-            lblDesc.Text = Strings.TaskEditor.desc;
-
-            grpKillNpcs.Text = Strings.TaskEditor.killnpcs;
-            lblNpc.Text = Strings.TaskEditor.npc;
-            lblNpcQuantity.Text = Strings.TaskEditor.npcamount;
-
-            grpGatherItems.Text = Strings.TaskEditor.gatheritems;
-            lblItem.Text = Strings.TaskEditor.item;
-            lblItemQuantity.Text = Strings.TaskEditor.gatheramount;
-
-            lblEventDriven.Text = Strings.TaskEditor.eventdriven;
-
-            btnEditTaskEvent.Text = Strings.TaskEditor.editcompletionevent;
-            btnSave.Text = Strings.TaskEditor.ok;
-            btnCancel.Text = Strings.TaskEditor.cancel;
+            Log.Warn($@"{nameof(refTask)} is null.");
         }
 
-        private void UpdateFormElements()
+        InitializeComponent();
+        mMyTask = refTask;
+        mMyQuest = refQuest;
+
+        if (mMyTask?.EditingEvent == null)
         {
-            grpGatherItems.Hide();
-            grpKillNpcs.Hide();
-            switch (cmbTaskType.SelectedIndex)
-            {
-                case 0: //Event Driven
-                    break;
-                case 1: //Gather Items
-                    grpGatherItems.Show();
-                    cmbItem.Items.Clear();
-                    cmbItem.Items.AddRange(ItemBase.Names);
-                    if (cmbItem.Items.Count > 0)
-                    {
-                        cmbItem.SelectedIndex = 0;
-                    }
-
-                    nudItemAmount.Value = 1;
-
-                    break;
-                case 2: //Kill Npcs
-                    grpKillNpcs.Show();
-                    cmbNpc.Items.Clear();
-                    cmbNpc.Items.AddRange(NpcBase.Names);
-                    if (cmbNpc.Items.Count > 0)
-                    {
-                        cmbNpc.SelectedIndex = 0;
-                    }
-
-                    nudNpcQuantity.Value = 1;
-
-                    break;
-            }
+            Log.Warn($@"{nameof(mMyTask.EditingEvent)} is null.");
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
+        mEventBackup = mMyTask?.EditingEvent?.JsonData;
+        InitLocalization();
+        cmbTaskType.SelectedIndex = mMyTask == null ? -1 : (int) mMyTask.Objective;
+        txtStartDesc.Text = mMyTask?.Description;
+        UpdateFormElements();
+        switch (cmbTaskType.SelectedIndex)
         {
-            mMyTask.Objective = (QuestObjective) cmbTaskType.SelectedIndex;
-            mMyTask.Description = txtStartDesc.Text;
-            switch (mMyTask.Objective)
-            {
-                case QuestObjective.EventDriven: //Event Driven
-                    mMyTask.TargetId = Guid.Empty;
-                    mMyTask.Quantity = 1;
+            case 0: //Event Driven
+                break;
+            case 1: //Gather Items
+                cmbItem.SelectedIndex = ItemBase.ListIndex(mMyTask?.TargetId ?? Guid.Empty);
+                nudItemAmount.Value = mMyTask?.Quantity ?? 0;
 
-                    break;
-                case QuestObjective.GatherItems: //Gather Items
-                    mMyTask.TargetId = ItemBase.IdFromList(cmbItem.SelectedIndex);
-                    mMyTask.Quantity = (int) nudItemAmount.Value;
+                break;
+            case 2: //Kill NPCS
+                cmbNpc.SelectedIndex = NpcBase.ListIndex(mMyTask?.TargetId ?? Guid.Empty);
+                nudNpcQuantity.Value = mMyTask?.Quantity ?? 0;
 
-                    break;
-                case QuestObjective.KillNpcs: //Kill Npcs
-                    mMyTask.TargetId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
-                    mMyTask.Quantity = (int) nudNpcQuantity.Value;
+                break;
+        }
+    }
 
-                    break;
-            }
+    private void InitLocalization()
+    {
+        grpEditor.Text = Strings.TaskEditor.editor;
 
-            ParentForm.Close();
+        lblType.Text = Strings.TaskEditor.type;
+        cmbTaskType.Items.Clear();
+        for (var i = 0; i < Strings.TaskEditor.types.Count; i++)
+        {
+            cmbTaskType.Items.Add(Strings.TaskEditor.types[i]);
         }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+        lblDesc.Text = Strings.TaskEditor.desc;
+
+        grpKillNpcs.Text = Strings.TaskEditor.killnpcs;
+        lblNpc.Text = Strings.TaskEditor.npc;
+        lblNpcQuantity.Text = Strings.TaskEditor.npcamount;
+
+        grpGatherItems.Text = Strings.TaskEditor.gatheritems;
+        lblItem.Text = Strings.TaskEditor.item;
+        lblItemQuantity.Text = Strings.TaskEditor.gatheramount;
+
+        lblEventDriven.Text = Strings.TaskEditor.eventdriven;
+
+        btnEditTaskEvent.Text = Strings.TaskEditor.editcompletionevent;
+        btnSave.Text = Strings.TaskEditor.ok;
+        btnCancel.Text = Strings.TaskEditor.cancel;
+    }
+
+    private void UpdateFormElements()
+    {
+        grpGatherItems.Hide();
+        grpKillNpcs.Hide();
+        switch (cmbTaskType.SelectedIndex)
         {
-            Cancelled = true;
-            mMyTask.EditingEvent.Load(mEventBackup);
-            ParentForm.Close();
+            case 0: //Event Driven
+                break;
+            case 1: //Gather Items
+                grpGatherItems.Show();
+                cmbItem.Items.Clear();
+                cmbItem.Items.AddRange(ItemBase.Names);
+                if (cmbItem.Items.Count > 0)
+                {
+                    cmbItem.SelectedIndex = 0;
+                }
+
+                nudItemAmount.Value = 1;
+
+                break;
+            case 2: //Kill Npcs
+                grpKillNpcs.Show();
+                cmbNpc.Items.Clear();
+                cmbNpc.Items.AddRange(NpcBase.Names);
+                if (cmbNpc.Items.Count > 0)
+                {
+                    cmbNpc.SelectedIndex = 0;
+                }
+
+                nudNpcQuantity.Value = 1;
+
+                break;
+        }
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyTask.Objective = (QuestObjective) cmbTaskType.SelectedIndex;
+        mMyTask.Description = txtStartDesc.Text;
+        switch (mMyTask.Objective)
+        {
+            case QuestObjective.EventDriven: //Event Driven
+                mMyTask.TargetId = Guid.Empty;
+                mMyTask.Quantity = 1;
+
+                break;
+            case QuestObjective.GatherItems: //Gather Items
+                mMyTask.TargetId = ItemBase.IdFromList(cmbItem.SelectedIndex);
+                mMyTask.Quantity = (int) nudItemAmount.Value;
+
+                break;
+            case QuestObjective.KillNpcs: //Kill Npcs
+                mMyTask.TargetId = NpcBase.IdFromList(cmbNpc.SelectedIndex);
+                mMyTask.Quantity = (int) nudNpcQuantity.Value;
+
+                break;
         }
 
-        private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+        ParentForm.Close();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        Cancelled = true;
+        mMyTask.EditingEvent.Load(mEventBackup);
+        ParentForm.Close();
+    }
+
+    private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFormElements();
+    }
+
+    private void btnEditTaskEvent_Click(object sender, EventArgs e)
+    {
+        mMyTask.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mMyQuest.Name);
+        var editor = new FrmEvent(null)
         {
-            UpdateFormElements();
-        }
+            MyEvent = mMyTask.EditingEvent
+        };
 
-        private void btnEditTaskEvent_Click(object sender, EventArgs e)
-        {
-            mMyTask.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mMyQuest.Name);
-            var editor = new FrmEvent(null)
-            {
-                MyEvent = mMyTask.EditingEvent
-            };
-
-            editor.InitEditor(true, true, true);
-            editor.ShowDialog();
-            Globals.MainForm.BringToFront();
-            BringToFront();
-        }
-
+        editor.InitEditor(true, true, true);
+        editor.ShowDialog();
+        Globals.MainForm.BringToFront();
+        BringToFront();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -9,711 +9,709 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Events;
 using Intersect.Logging;
 
-namespace Intersect.Editor.Forms.Editors.Quest
+namespace Intersect.Editor.Forms.Editors.Quest;
+
+
+public partial class FrmQuest : EditorForm
 {
 
-    public partial class FrmQuest : EditorForm
+    private List<QuestBase> mChanged = new List<QuestBase>();
+
+    private string mCopiedItem;
+
+    private QuestBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmQuest()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<QuestBase> mChanged = new List<QuestBase>();
+        InitLocalization();
 
-        private string mCopiedItem;
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = QuestBase.Get(id);
+        UpdateEditor();
+    }
 
-        private QuestBase mEditorItem;
+    private void InitLocalization()
+    {
+        Text = Strings.QuestEditor.title;
+        toolStripItemNew.Text = Strings.QuestEditor.New;
+        toolStripItemDelete.Text = Strings.QuestEditor.delete;
+        toolStripItemCopy.Text = Strings.QuestEditor.copy;
+        toolStripItemPaste.Text = Strings.QuestEditor.paste;
+        toolStripItemUndo.Text = Strings.QuestEditor.undo;
 
-        private List<string> mKnownFolders = new List<string>();
+        grpQuests.Text = Strings.QuestEditor.quests;
+        grpGeneral.Text = Strings.QuestEditor.general;
+        lblName.Text = Strings.QuestEditor.name;
 
-        public FrmQuest()
+        grpLogOptions.Text = Strings.QuestEditor.logoptions;
+        chkLogAfterComplete.Text = Strings.QuestEditor.showafter;
+        chkLogBeforeOffer.Text = Strings.QuestEditor.showbefore;
+
+        grpProgessionOptions.Text = Strings.QuestEditor.options;
+        chkRepeatable.Text = Strings.QuestEditor.repeatable;
+        chkQuittable.Text = Strings.QuestEditor.quit;
+
+        lblBeforeOffer.Text = Strings.QuestEditor.beforeofferdesc;
+        lblOffer.Text = Strings.QuestEditor.offerdesc;
+        lblInProgress.Text = Strings.QuestEditor.inprogressdesc;
+        lblCompleted.Text = Strings.QuestEditor.completeddesc;
+
+        grpQuestReqs.Text = Strings.QuestEditor.requirements;
+        btnEditRequirements.Text = Strings.QuestEditor.editrequirements;
+
+        grpQuestTasks.Text = Strings.QuestEditor.tasks;
+        btnAddTask.Text = Strings.QuestEditor.addtask;
+        btnRemoveTask.Text = Strings.QuestEditor.removetask;
+
+        grpActions.Text = Strings.QuestEditor.actions;
+        lblOnStart.Text = Strings.QuestEditor.onstart;
+        btnEditStartEvent.Text = Strings.QuestEditor.editstartevent;
+        lblOnEnd.Text = Strings.QuestEditor.onend;
+        btnEditCompletionEvent.Text = Strings.QuestEditor.editendevent;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.QuestEditor.sortalphabetically;
+        txtSearch.Text = Strings.QuestEditor.searchplaceholder;
+        lblFolder.Text = Strings.QuestEditor.folderlabel;
+
+
+        chkDoNotShowUnlessReqsMet.Text = Strings.QuestEditor.donotshowunlessreqsmet;
+
+        //Categories
+        lblUnstartedCategory.Text = Strings.QuestEditor.unstartedcategory;
+        lblInProgressCategory.Text = Strings.QuestEditor.inprogressgategory;
+        lblCompletedCategory.Text = Strings.QuestEditor.completedcategory;
+        cmbUnstartedCategory.Items.Add(Strings.General.None);
+        cmbInProgressCategory.Items.Add(Strings.General.None);
+        cmbCompletedCategory.Items.Add(Strings.General.None);
+
+        foreach (var questCategory in Options.Instance.Quest.Categories)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            InitLocalization();
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+            cmbUnstartedCategory.Items.Add(questCategory);
+            cmbInProgressCategory.Items.Add(questCategory);
+            cmbCompletedCategory.Items.Add(questCategory);
         }
-        private void AssignEditorItem(Guid id)
+
+        lblSortOrder.Text = Strings.QuestEditor.order;
+
+        btnSave.Text = Strings.QuestEditor.save;
+        btnCancel.Text = Strings.QuestEditor.cancel;
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Quest)
         {
-            mEditorItem = QuestBase.Get(id);
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.QuestEditor.title;
-            toolStripItemNew.Text = Strings.QuestEditor.New;
-            toolStripItemDelete.Text = Strings.QuestEditor.delete;
-            toolStripItemCopy.Text = Strings.QuestEditor.copy;
-            toolStripItemPaste.Text = Strings.QuestEditor.paste;
-            toolStripItemUndo.Text = Strings.QuestEditor.undo;
-
-            grpQuests.Text = Strings.QuestEditor.quests;
-            grpGeneral.Text = Strings.QuestEditor.general;
-            lblName.Text = Strings.QuestEditor.name;
-
-            grpLogOptions.Text = Strings.QuestEditor.logoptions;
-            chkLogAfterComplete.Text = Strings.QuestEditor.showafter;
-            chkLogBeforeOffer.Text = Strings.QuestEditor.showbefore;
-
-            grpProgessionOptions.Text = Strings.QuestEditor.options;
-            chkRepeatable.Text = Strings.QuestEditor.repeatable;
-            chkQuittable.Text = Strings.QuestEditor.quit;
-
-            lblBeforeOffer.Text = Strings.QuestEditor.beforeofferdesc;
-            lblOffer.Text = Strings.QuestEditor.offerdesc;
-            lblInProgress.Text = Strings.QuestEditor.inprogressdesc;
-            lblCompleted.Text = Strings.QuestEditor.completeddesc;
-
-            grpQuestReqs.Text = Strings.QuestEditor.requirements;
-            btnEditRequirements.Text = Strings.QuestEditor.editrequirements;
-
-            grpQuestTasks.Text = Strings.QuestEditor.tasks;
-            btnAddTask.Text = Strings.QuestEditor.addtask;
-            btnRemoveTask.Text = Strings.QuestEditor.removetask;
-
-            grpActions.Text = Strings.QuestEditor.actions;
-            lblOnStart.Text = Strings.QuestEditor.onstart;
-            btnEditStartEvent.Text = Strings.QuestEditor.editstartevent;
-            lblOnEnd.Text = Strings.QuestEditor.onend;
-            btnEditCompletionEvent.Text = Strings.QuestEditor.editendevent;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.QuestEditor.sortalphabetically;
-            txtSearch.Text = Strings.QuestEditor.searchplaceholder;
-            lblFolder.Text = Strings.QuestEditor.folderlabel;
-
-
-            chkDoNotShowUnlessReqsMet.Text = Strings.QuestEditor.donotshowunlessreqsmet;
-
-            //Categories
-            lblUnstartedCategory.Text = Strings.QuestEditor.unstartedcategory;
-            lblInProgressCategory.Text = Strings.QuestEditor.inprogressgategory;
-            lblCompletedCategory.Text = Strings.QuestEditor.completedcategory;
-            cmbUnstartedCategory.Items.Add(Strings.General.None);
-            cmbInProgressCategory.Items.Add(Strings.General.None);
-            cmbCompletedCategory.Items.Add(Strings.General.None);
-
-            foreach (var questCategory in Options.Instance.Quest.Categories)
+            InitEditor();
+            if (mEditorItem != null && !QuestBase.Lookup.Values.Contains(mEditorItem))
             {
-                cmbUnstartedCategory.Items.Add(questCategory);
-                cmbInProgressCategory.Items.Add(questCategory);
-                cmbCompletedCategory.Items.Add(questCategory);
-            }
-
-            lblSortOrder.Text = Strings.QuestEditor.order;
-
-            btnSave.Text = Strings.QuestEditor.save;
-            btnCancel.Text = Strings.QuestEditor.cancel;
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Quest)
-            {
-                InitEditor();
-                if (mEditorItem != null && !QuestBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                if (item == null)
-                {
-                    Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}");
-                }
-                else
-                {
-                    if (item.StartEvent == null)
-                    {
-                        Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}.{nameof(item.StartEvent)}");
-                    }
-
-                    if (item.EndEvent == null)
-                    {
-                        Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}.{nameof(item.EndEvent)}");
-                    }
-                }
-
-                item?.StartEvent?.RestoreBackup();
-                item?.StartEvent?.DeleteBackup();
-                item?.EndEvent?.RestoreBackup();
-                item?.EndEvent?.DeleteBackup();
-                item?.RestoreBackup();
-                item?.DeleteBackup();
-            }
-
-            mEditorItem = null;
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            mChanged?.ForEach(
-                item =>
-                {
-                    if (item == null)
-                    {
-                        return;
-                    }
-
-                    foreach (var id in item.OriginalTaskEventIds.Keys)
-                    {
-                        var found = false;
-                        for (var i = 0; i < item.Tasks.Count; i++)
-                        {
-                            if (item.Tasks[i].Id == id)
-                            {
-                                found = true;
-                            }
-                        }
-
-                        if (!found)
-                        {
-                            item.RemoveEvents.Add(item.OriginalTaskEventIds[id]);
-                        }
-                    }
-
-                    PacketSender.SendSaveObject(item);
-                    PacketSender.SendSaveObject(item.StartEvent);
-                    PacketSender.SendSaveObject(item.EndEvent);
-                    item.Tasks?.ForEach(
-                        tsk =>
-                        {
-                            if (tsk?.EditingEvent == null)
-                            {
-                                return;
-                            }
-
-                            if (tsk.EditingEvent.Id != Guid.Empty)
-                            {
-                                PacketSender.SendSaveObject(tsk.EditingEvent);
-                            }
-
-                            tsk.EditingEvent.DeleteBackup();
-                        }
-                    );
-
-                    item.StartEvent?.DeleteBackup();
-                    item.EndEvent?.DeleteBackup();
-                    item.DeleteBackup();
-                }
-            );
-
-            mEditorItem = null;
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                txtBeforeDesc.Text = mEditorItem.BeforeDescription;
-                txtStartDesc.Text = mEditorItem.StartDescription;
-                txtInProgressDesc.Text = mEditorItem.InProgressDescription;
-                txtEndDesc.Text = mEditorItem.EndDescription;
-
-                chkRepeatable.Checked = Convert.ToBoolean(mEditorItem.Repeatable);
-                chkQuittable.Checked = Convert.ToBoolean(mEditorItem.Quitable);
-                chkLogBeforeOffer.Checked = Convert.ToBoolean(mEditorItem.LogBeforeOffer);
-                chkLogAfterComplete.Checked = Convert.ToBoolean(mEditorItem.LogAfterComplete);
-
-                chkDoNotShowUnlessReqsMet.Checked = Convert.ToBoolean(mEditorItem.DoNotShowUnlessRequirementsMet);
-
-                cmbUnstartedCategory.SelectedIndex = cmbUnstartedCategory.Items.IndexOf(mEditorItem.UnstartedCategory ?? "");
-                cmbInProgressCategory.SelectedIndex = cmbInProgressCategory.Items.IndexOf(mEditorItem.InProgressCategory ?? "");
-                cmbCompletedCategory.SelectedIndex = cmbCompletedCategory.Items.IndexOf(mEditorItem.CompletedCategory ?? "");
-
-                if (cmbUnstartedCategory.SelectedIndex == -1)
-                {
-                    cmbUnstartedCategory.SelectedIndex = 0;
-                }
-
-                if (cmbInProgressCategory.SelectedIndex == -1)
-                {
-                    cmbInProgressCategory.SelectedIndex = 0;
-                }
-
-                if (cmbCompletedCategory.SelectedIndex == -1)
-                {
-                    cmbCompletedCategory.SelectedIndex = 0;
-                }
-
-                nudOrderValue.Value = mEditorItem.OrderValue;
-
-                ListQuestTasks();
-
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.StartEvent?.MakeBackup();
-                    mEditorItem.EndEvent?.MakeBackup();
-                    foreach (var tsk in mEditorItem.Tasks)
-                    {
-                        tsk.CompletionEvent?.MakeBackup();
-                        tsk.EditingEvent = tsk.CompletionEvent;
-                    }
-
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            if (mEditorItem != null)
-            {
-                mEditorItem.Name = txtName?.Text ?? "";
-
-                //Rename all events
-                if (mEditorItem.StartEvent != null)
-                {
-                    mEditorItem.StartEvent.Name = Strings.QuestEditor.startevent.ToString(mEditorItem.Name);
-                }
-
-                if (mEditorItem.EndEvent != null)
-                {
-                    mEditorItem.EndEvent.Name = Strings.QuestEditor.endevent.ToString(mEditorItem.Name);
-                }
-
-                if (mEditorItem.Tasks != null)
-                {
-                    foreach (var tsk in mEditorItem.Tasks)
-                    {
-                        if (tsk.CompletionEvent != null)
-                        {
-                            tsk.CompletionEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
-                        }
-                    }
-                }
-
-                lstGameObjects.UpdateText(txtName?.Text ?? "");
-            }
-        }
-
-        private void txtStartDesc_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StartDescription = txtStartDesc.Text;
-        }
-
-        private void txtEndDesc_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.EndDescription = txtEndDesc.Text;
-        }
-
-        private void btnEditStartEvent_Click(object sender, EventArgs e)
-        {
-            mEditorItem.StartEvent.Name = Strings.QuestEditor.startevent.ToString(mEditorItem.Name);
-            OpenQuestEvent(mEditorItem.StartEvent);
-        }
-
-        private void btnEditCompletionEvent_Click(object sender, EventArgs e)
-        {
-            mEditorItem.EndEvent.Name = Strings.QuestEditor.endevent.ToString(mEditorItem.Name);
-            OpenQuestEvent(mEditorItem.EndEvent);
-        }
-
-        private void OpenQuestEvent(EventBase evt)
-        {
-            var editor = new FrmEvent(null) {MyEvent = evt};
-            editor.InitEditor(true, true, true);
-            editor.ShowDialog();
-            Globals.MainForm.BringToFront();
-            BringToFront();
-        }
-
-        private void btnAddTask_Click(object sender, EventArgs e)
-        {
-            var questTask = new QuestBase.QuestTask(Guid.NewGuid());
-            questTask.EditingEvent = new EventBase(questTask.Id, Guid.Empty, 0, 0, false);
-            questTask.EditingEvent.CommonEvent = false;
-            questTask.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
-            mEditorItem.AddEvents.Add(questTask.Id, questTask.EditingEvent);
-            if (OpenTaskEditor(questTask))
-            {
-                mEditorItem.Tasks.Add(questTask);
-                ListQuestTasks();
-            }
-        }
-
-        private void ListQuestTasks()
-        {
-            lstTasks.Items.Clear();
-            foreach (var task in mEditorItem.Tasks)
-            {
-                lstTasks.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
-            }
-        }
-
-        private bool OpenTaskEditor(QuestBase.QuestTask task)
-        {
-            var cmdWindow = new QuestTaskEditor(mEditorItem, task);
-            var frm = new Form
-            {
-                Text = Strings.TaskEditor.title
-            };
-
-            frm.Controls.Add(cmdWindow);
-            frm.Size = new Size(0, 0);
-            frm.AutoSize = true;
-            frm.ControlBox = false;
-            frm.FormBorderStyle = FormBorderStyle.FixedDialog;
-            frm.StartPosition = FormStartPosition.CenterParent;
-            frm.BackColor = cmdWindow.BackColor;
-            cmdWindow.BringToFront();
-            frm.ShowDialog();
-            if (!cmdWindow.Cancelled)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private void btnRemoveTask_Click(object sender, EventArgs e)
-        {
-            if (lstTasks.SelectedIndex > -1)
-            {
-                if (mEditorItem.AddEvents.ContainsKey(mEditorItem.Tasks[lstTasks.SelectedIndex].Id))
-                {
-                    mEditorItem.AddEvents.Remove(mEditorItem.Tasks[lstTasks.SelectedIndex].Id);
-                }
-
-                mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
-                ListQuestTasks();
-            }
-        }
-
-        private void btnShiftTaskUp_Click(object sender, EventArgs e)
-        {
-            if (lstTasks.SelectedIndex > 0)
-            {
-                var item = mEditorItem.Tasks[lstTasks.SelectedIndex];
-                mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
-                mEditorItem.Tasks.Insert(lstTasks.SelectedIndex - 1, item);
-                ListQuestTasks();
-            }
-        }
-
-        private void btnShiftTaskDown_Click(object sender, EventArgs e)
-        {
-            if (lstTasks.SelectedIndex > -1 && lstTasks.SelectedIndex != lstTasks.Items.Count - 1)
-            {
-                var item = mEditorItem.Tasks[lstTasks.SelectedIndex];
-                mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
-                mEditorItem.Tasks.Insert(lstTasks.SelectedIndex + 1, item);
-                ListQuestTasks();
-            }
-        }
-
-        private void txtInProgressDesc_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.InProgressDescription = txtInProgressDesc.Text;
-        }
-
-        private void chkRepeatable_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Repeatable = chkRepeatable.Checked;
-        }
-
-        private void chkQuittable_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Quitable = chkQuittable.Checked;
-        }
-
-        private void lstTasks_DoubleClick(object sender, EventArgs e)
-        {
-            if (lstTasks.SelectedIndex > -1 && mEditorItem.Tasks.Count > lstTasks.SelectedIndex)
-            {
-                if (OpenTaskEditor(mEditorItem.Tasks[lstTasks.SelectedIndex]))
-                {
-                    ListQuestTasks();
-                }
-            }
-        }
-
-        private void txtBeforeDesc_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BeforeDescription = txtBeforeDesc.Text;
-        }
-
-        private void chkLogBeforeOffer_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.LogBeforeOffer = chkLogBeforeOffer.Checked;
-        }
-
-        private void chkLogAfterComplete_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.LogAfterComplete = chkLogAfterComplete.Checked;
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Quest);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.QuestEditor.deleteprompt, Strings.QuestEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                var startEventId = mEditorItem.StartEventId;
-                var endEventId = mEditorItem.EndEventId;
-                mEditorItem.Load(mCopiedItem, true);
-
-                EventBase.Get(startEventId).Load(mEditorItem.StartEvent.JsonData);
-                EventBase.Get(endEventId).Load(mEditorItem.EndEvent.JsonData);
-
-                mEditorItem.StartEventId = startEventId;
-                mEditorItem.EndEventId = endEventId;
-
-                //Fix tasks
-                foreach (var tsk in mEditorItem.Tasks)
-                {
-                    var oldId = tsk.Id;
-                    tsk.Id = Guid.NewGuid();
-
-                    if (mEditorItem.AddEvents.ContainsKey(oldId))
-                    {
-                        mEditorItem.AddEvents.Add(tsk.Id, mEditorItem.AddEvents[oldId]);
-                        tsk.EditingEvent = mEditorItem.AddEvents[tsk.Id];
-                        mEditorItem.AddEvents.Remove(oldId);
-                    }
-                    else
-                    {
-                        var tskEventData = EventBase.Get(tsk.CompletionEventId).JsonData;
-                        tsk.CompletionEventId = Guid.Empty;
-                        tsk.EditingEvent = new EventBase(Guid.Empty, Guid.Empty, 0, 0, false);
-                        tsk.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
-                        tsk.EditingEvent.Load(tskEventData);
-                        mEditorItem.AddEvents.Add(tsk.Id, tsk.EditingEvent);
-                    }
-                }
-
+                mEditorItem = null;
                 UpdateEditor();
             }
         }
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            if (item == null)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.QuestEditor.undoprompt, Strings.QuestEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
+                Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}");
+            }
+            else
+            {
+                if (item.StartEvent == null)
                 {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
+                    Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}.{nameof(item.StartEvent)}");
+                }
+
+                if (item.EndEvent == null)
+                {
+                    Log.Warn($"Unexpected null: {nameof(FrmQuest)}.{nameof(btnCancel_Click)}() {nameof(item)}.{nameof(item.EndEvent)}");
                 }
             }
+
+            item?.StartEvent?.RestoreBackup();
+            item?.StartEvent?.DeleteBackup();
+            item?.EndEvent?.RestoreBackup();
+            item?.EndEvent?.DeleteBackup();
+            item?.RestoreBackup();
+            item?.DeleteBackup();
         }
 
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
+        mEditorItem = null;
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        mChanged?.ForEach(
+            item =>
             {
-                if (e.KeyCode == Keys.N)
+                if (item == null)
                 {
-                    toolStripItemNew_Click(null, null);
+                    return;
                 }
-            }
-        }
 
-        private void btnEditRequirements_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.Requirements, RequirementType.Quest);
-            frm.ShowDialog();
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in QuestBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((QuestBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((QuestBase) itm.Value).Folder))
+                foreach (var id in item.OriginalTaskEventIds.Keys)
                 {
-                    mFolders.Add(((QuestBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((QuestBase) itm.Value).Folder))
+                    var found = false;
+                    for (var i = 0; i < item.Tasks.Count; i++)
                     {
-                        mKnownFolders.Add(((QuestBase) itm.Value).Folder);
+                        if (item.Tasks[i].Id == id)
+                        {
+                            found = true;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        item.RemoveEvents.Add(item.OriginalTaskEventIds[id]);
+                    }
+                }
+
+                PacketSender.SendSaveObject(item);
+                PacketSender.SendSaveObject(item.StartEvent);
+                PacketSender.SendSaveObject(item.EndEvent);
+                item.Tasks?.ForEach(
+                    tsk =>
+                    {
+                        if (tsk?.EditingEvent == null)
+                        {
+                            return;
+                        }
+
+                        if (tsk.EditingEvent.Id != Guid.Empty)
+                        {
+                            PacketSender.SendSaveObject(tsk.EditingEvent);
+                        }
+
+                        tsk.EditingEvent.DeleteBackup();
+                    }
+                );
+
+                item.StartEvent?.DeleteBackup();
+                item.EndEvent?.DeleteBackup();
+                item.DeleteBackup();
+            }
+        );
+
+        mEditorItem = null;
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            txtBeforeDesc.Text = mEditorItem.BeforeDescription;
+            txtStartDesc.Text = mEditorItem.StartDescription;
+            txtInProgressDesc.Text = mEditorItem.InProgressDescription;
+            txtEndDesc.Text = mEditorItem.EndDescription;
+
+            chkRepeatable.Checked = Convert.ToBoolean(mEditorItem.Repeatable);
+            chkQuittable.Checked = Convert.ToBoolean(mEditorItem.Quitable);
+            chkLogBeforeOffer.Checked = Convert.ToBoolean(mEditorItem.LogBeforeOffer);
+            chkLogAfterComplete.Checked = Convert.ToBoolean(mEditorItem.LogAfterComplete);
+
+            chkDoNotShowUnlessReqsMet.Checked = Convert.ToBoolean(mEditorItem.DoNotShowUnlessRequirementsMet);
+
+            cmbUnstartedCategory.SelectedIndex = cmbUnstartedCategory.Items.IndexOf(mEditorItem.UnstartedCategory ?? "");
+            cmbInProgressCategory.SelectedIndex = cmbInProgressCategory.Items.IndexOf(mEditorItem.InProgressCategory ?? "");
+            cmbCompletedCategory.SelectedIndex = cmbCompletedCategory.Items.IndexOf(mEditorItem.CompletedCategory ?? "");
+
+            if (cmbUnstartedCategory.SelectedIndex == -1)
+            {
+                cmbUnstartedCategory.SelectedIndex = 0;
+            }
+
+            if (cmbInProgressCategory.SelectedIndex == -1)
+            {
+                cmbInProgressCategory.SelectedIndex = 0;
+            }
+
+            if (cmbCompletedCategory.SelectedIndex == -1)
+            {
+                cmbCompletedCategory.SelectedIndex = 0;
+            }
+
+            nudOrderValue.Value = mEditorItem.OrderValue;
+
+            ListQuestTasks();
+
+            if (mChanged.IndexOf(mEditorItem) == -1)
+            {
+                mChanged.Add(mEditorItem);
+                mEditorItem.StartEvent?.MakeBackup();
+                mEditorItem.EndEvent?.MakeBackup();
+                foreach (var tsk in mEditorItem.Tasks)
+                {
+                    tsk.CompletionEvent?.MakeBackup();
+                    tsk.EditingEvent = tsk.CompletionEvent;
+                }
+
+                mEditorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        if (mEditorItem != null)
+        {
+            mEditorItem.Name = txtName?.Text ?? "";
+
+            //Rename all events
+            if (mEditorItem.StartEvent != null)
+            {
+                mEditorItem.StartEvent.Name = Strings.QuestEditor.startevent.ToString(mEditorItem.Name);
+            }
+
+            if (mEditorItem.EndEvent != null)
+            {
+                mEditorItem.EndEvent.Name = Strings.QuestEditor.endevent.ToString(mEditorItem.Name);
+            }
+
+            if (mEditorItem.Tasks != null)
+            {
+                foreach (var tsk in mEditorItem.Tasks)
+                {
+                    if (tsk.CompletionEvent != null)
+                    {
+                        tsk.CompletionEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
                     }
                 }
             }
 
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+            lstGameObjects.UpdateText(txtName?.Text ?? "");
+        }
+    }
 
-            var items = QuestBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((QuestBase)pair.Value)?.Name ?? Models.DatabaseObject<QuestBase>.Deleted, ((QuestBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    private void txtStartDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StartDescription = txtStartDesc.Text;
+    }
+
+    private void txtEndDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.EndDescription = txtEndDesc.Text;
+    }
+
+    private void btnEditStartEvent_Click(object sender, EventArgs e)
+    {
+        mEditorItem.StartEvent.Name = Strings.QuestEditor.startevent.ToString(mEditorItem.Name);
+        OpenQuestEvent(mEditorItem.StartEvent);
+    }
+
+    private void btnEditCompletionEvent_Click(object sender, EventArgs e)
+    {
+        mEditorItem.EndEvent.Name = Strings.QuestEditor.endevent.ToString(mEditorItem.Name);
+        OpenQuestEvent(mEditorItem.EndEvent);
+    }
+
+    private void OpenQuestEvent(EventBase evt)
+    {
+        var editor = new FrmEvent(null) {MyEvent = evt};
+        editor.InitEditor(true, true, true);
+        editor.ShowDialog();
+        Globals.MainForm.BringToFront();
+        BringToFront();
+    }
+
+    private void btnAddTask_Click(object sender, EventArgs e)
+    {
+        var questTask = new QuestBase.QuestTask(Guid.NewGuid());
+        questTask.EditingEvent = new EventBase(questTask.Id, Guid.Empty, 0, 0, false);
+        questTask.EditingEvent.CommonEvent = false;
+        questTask.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
+        mEditorItem.AddEvents.Add(questTask.Id, questTask.EditingEvent);
+        if (OpenTaskEditor(questTask))
+        {
+            mEditorItem.Tasks.Add(questTask);
+            ListQuestTasks();
+        }
+    }
+
+    private void ListQuestTasks()
+    {
+        lstTasks.Items.Clear();
+        foreach (var task in mEditorItem.Tasks)
+        {
+            lstTasks.Items.Add(task.GetTaskString(Strings.TaskEditor.descriptions));
+        }
+    }
+
+    private bool OpenTaskEditor(QuestBase.QuestTask task)
+    {
+        var cmdWindow = new QuestTaskEditor(mEditorItem, task);
+        var frm = new Form
+        {
+            Text = Strings.TaskEditor.title
+        };
+
+        frm.Controls.Add(cmdWindow);
+        frm.Size = new Size(0, 0);
+        frm.AutoSize = true;
+        frm.ControlBox = false;
+        frm.FormBorderStyle = FormBorderStyle.FixedDialog;
+        frm.StartPosition = FormStartPosition.CenterParent;
+        frm.BackColor = cmdWindow.BackColor;
+        cmdWindow.BringToFront();
+        frm.ShowDialog();
+        if (!cmdWindow.Cancelled)
+        {
+            return true;
         }
 
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.QuestEditor.folderprompt, Strings.QuestEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
+        return false;
+    }
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+    private void btnRemoveTask_Click(object sender, EventArgs e)
+    {
+        if (lstTasks.SelectedIndex > -1)
+        {
+            if (mEditorItem.AddEvents.ContainsKey(mEditorItem.Tasks[lstTasks.SelectedIndex].Id))
             {
-                if (!cmbFolder.Items.Contains(folderName))
+                mEditorItem.AddEvents.Remove(mEditorItem.Tasks[lstTasks.SelectedIndex].Id);
+            }
+
+            mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
+            ListQuestTasks();
+        }
+    }
+
+    private void btnShiftTaskUp_Click(object sender, EventArgs e)
+    {
+        if (lstTasks.SelectedIndex > 0)
+        {
+            var item = mEditorItem.Tasks[lstTasks.SelectedIndex];
+            mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
+            mEditorItem.Tasks.Insert(lstTasks.SelectedIndex - 1, item);
+            ListQuestTasks();
+        }
+    }
+
+    private void btnShiftTaskDown_Click(object sender, EventArgs e)
+    {
+        if (lstTasks.SelectedIndex > -1 && lstTasks.SelectedIndex != lstTasks.Items.Count - 1)
+        {
+            var item = mEditorItem.Tasks[lstTasks.SelectedIndex];
+            mEditorItem.Tasks.RemoveAt(lstTasks.SelectedIndex);
+            mEditorItem.Tasks.Insert(lstTasks.SelectedIndex + 1, item);
+            ListQuestTasks();
+        }
+    }
+
+    private void txtInProgressDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.InProgressDescription = txtInProgressDesc.Text;
+    }
+
+    private void chkRepeatable_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Repeatable = chkRepeatable.Checked;
+    }
+
+    private void chkQuittable_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Quitable = chkQuittable.Checked;
+    }
+
+    private void lstTasks_DoubleClick(object sender, EventArgs e)
+    {
+        if (lstTasks.SelectedIndex > -1 && mEditorItem.Tasks.Count > lstTasks.SelectedIndex)
+        {
+            if (OpenTaskEditor(mEditorItem.Tasks[lstTasks.SelectedIndex]))
+            {
+                ListQuestTasks();
+            }
+        }
+    }
+
+    private void txtBeforeDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BeforeDescription = txtBeforeDesc.Text;
+    }
+
+    private void chkLogBeforeOffer_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.LogBeforeOffer = chkLogBeforeOffer.Checked;
+    }
+
+    private void chkLogAfterComplete_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.LogAfterComplete = chkLogAfterComplete.Checked;
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Quest);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.QuestEditor.deleteprompt, Strings.QuestEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            var startEventId = mEditorItem.StartEventId;
+            var endEventId = mEditorItem.EndEventId;
+            mEditorItem.Load(mCopiedItem, true);
+
+            EventBase.Get(startEventId).Load(mEditorItem.StartEvent.JsonData);
+            EventBase.Get(endEventId).Load(mEditorItem.EndEvent.JsonData);
+
+            mEditorItem.StartEventId = startEventId;
+            mEditorItem.EndEventId = endEventId;
+
+            //Fix tasks
+            foreach (var tsk in mEditorItem.Tasks)
+            {
+                var oldId = tsk.Id;
+                tsk.Id = Guid.NewGuid();
+
+                if (mEditorItem.AddEvents.ContainsKey(oldId))
                 {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
+                    mEditorItem.AddEvents.Add(tsk.Id, mEditorItem.AddEvents[oldId]);
+                    tsk.EditingEvent = mEditorItem.AddEvents[tsk.Id];
+                    mEditorItem.AddEvents.Remove(oldId);
+                }
+                else
+                {
+                    var tskEventData = EventBase.Get(tsk.CompletionEventId).JsonData;
+                    tsk.CompletionEventId = Guid.Empty;
+                    tsk.EditingEvent = new EventBase(Guid.Empty, Guid.Empty, 0, 0, false);
+                    tsk.EditingEvent.Name = Strings.TaskEditor.completionevent.ToString(mEditorItem.Name);
+                    tsk.EditingEvent.Load(tskEventData);
+                    mEditorItem.AddEvents.Add(tsk.Id, tsk.EditingEvent);
+                }
+            }
+
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.QuestEditor.undoprompt, Strings.QuestEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void btnEditRequirements_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.Requirements, RequirementType.Quest);
+        frm.ShowDialog();
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in QuestBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((QuestBase) itm.Value).Folder) &&
+                !mFolders.Contains(((QuestBase) itm.Value).Folder))
+            {
+                mFolders.Add(((QuestBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((QuestBase) itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((QuestBase) itm.Value).Folder);
                 }
             }
         }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
 
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
+        var items = QuestBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((QuestBase)pair.Value)?.Name ?? Models.DatabaseObject<QuestBase>.Deleted, ((QuestBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.QuestEditor.folderprompt, Strings.QuestEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
 
-        private void txtSearch_Leave(object sender, EventArgs e)
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                txtSearch.Text = Strings.QuestEditor.searchplaceholder;
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.QuestEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.QuestEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.QuestEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
-
-        private void chkDoNotShowUnlessReqsMet_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DoNotShowUnlessRequirementsMet = chkDoNotShowUnlessReqsMet.Checked;
-        }
-
-        private void cmbUnstartedCategory_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbUnstartedCategory.SelectedIndex > -1)
-            {
-                mEditorItem.UnstartedCategory = cmbUnstartedCategory.Text;
-            }
-        }
-
-        private void cmbInProgressCategory_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbInProgressCategory.SelectedIndex > -1)
-            {
-                mEditorItem.InProgressCategory = cmbInProgressCategory.Text;
-            }
-        }
-
-        private void cmbCompletedCategory_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbCompletedCategory.SelectedIndex > -1)
-            {
-                mEditorItem.CompletedCategory = cmbCompletedCategory.Text;
-            }
-        }
-
-        private void nudOrderValue_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.OrderValue = (int)nudOrderValue.Value;
         }
     }
 
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.QuestEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.QuestEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.QuestEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.QuestEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
+
+    private void chkDoNotShowUnlessReqsMet_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DoNotShowUnlessRequirementsMet = chkDoNotShowUnlessReqsMet.Checked;
+    }
+
+    private void cmbUnstartedCategory_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbUnstartedCategory.SelectedIndex > -1)
+        {
+            mEditorItem.UnstartedCategory = cmbUnstartedCategory.Text;
+        }
+    }
+
+    private void cmbInProgressCategory_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbInProgressCategory.SelectedIndex > -1)
+        {
+            mEditorItem.InProgressCategory = cmbInProgressCategory.Text;
+        }
+    }
+
+    private void cmbCompletedCategory_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbCompletedCategory.SelectedIndex > -1)
+        {
+            mEditorItem.CompletedCategory = cmbCompletedCategory.Text;
+        }
+    }
+
+    private void nudOrderValue_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.OrderValue = (int)nudOrderValue.Value;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmAnimation.cs
+++ b/Intersect.Editor/Forms/Editors/frmAnimation.cs
@@ -13,910 +13,908 @@ using Intersect.Utilities;
 
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmAnimation : EditorForm
 {
+    private readonly ToolTip _tooltip = new();
 
-    public partial class FrmAnimation : EditorForm
+    private List<AnimationBase> mChanged = new List<AnimationBase>();
+
+    private string mCopiedItem;
+
+    private AnimationBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private RenderTarget2D mLowerDarkness;
+
+    private int mLowerFrame;
+
+    //Mono Rendering Variables
+    private SwapChainRenderTarget mLowerWindow;
+
+    private bool mPlayLower;
+
+    private bool mPlayUpper;
+
+    private SoundPlayer soundPlayer = new();
+
+    private bool loopSoundOnPreview;
+
+    private RenderTarget2D mUpperDarkness;
+
+    private int mUpperFrame;
+
+    private SwapChainRenderTarget mUpperWindow;
+
+    public FrmAnimation()
     {
-        private readonly ToolTip _tooltip = new();
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<AnimationBase> mChanged = new List<AnimationBase>();
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
 
-        private string mCopiedItem;
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = AnimationBase.Get(id);
+        UpdateEditor();
+    }
 
-        private AnimationBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        private RenderTarget2D mLowerDarkness;
-
-        private int mLowerFrame;
-
-        //Mono Rendering Variables
-        private SwapChainRenderTarget mLowerWindow;
-
-        private bool mPlayLower;
-
-        private bool mPlayUpper;
-
-        private SoundPlayer soundPlayer = new();
-
-        private bool loopSoundOnPreview;
-
-        private RenderTarget2D mUpperDarkness;
-
-        private int mUpperFrame;
-
-        private SwapChainRenderTarget mUpperWindow;
-
-        public FrmAnimation()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type != GameObjectType.Animation)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+            return;
         }
 
-        private void AssignEditorItem(Guid id)
+        InitEditor();
+        if (mEditorItem == null || AnimationBase.Lookup.Values.Contains(mEditorItem))
         {
-            mEditorItem = AnimationBase.Get(id);
-            UpdateEditor();
+            return;
         }
 
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
+        mEditorItem = null;
+        UpdateEditor();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            if (type != GameObjectType.Animation)
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmAnimation_Load(object sender, EventArgs e)
+    {
+        //Animation Sound
+        cmbSound.Items.Clear();
+        cmbSound.Items.Add(Strings.General.None);
+        cmbSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+
+        //Lower Animation Graphic
+        cmbLowerGraphic.Items.Clear();
+        cmbLowerGraphic.Items.Add(Strings.General.None);
+        cmbLowerGraphic.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Animation)
+        );
+
+        //Upper Animation Graphic
+        cmbUpperGraphic.Items.Clear();
+        cmbUpperGraphic.Items.Add(Strings.General.None);
+        cmbUpperGraphic.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Animation)
+        );
+
+        mLowerWindow = new SwapChainRenderTarget(
+            Core.Graphics.GetGraphicsDevice(), picLowerAnimation.Handle, picLowerAnimation.Width,
+            picLowerAnimation.Height
+        );
+
+        mUpperWindow = new SwapChainRenderTarget(
+            Core.Graphics.GetGraphicsDevice(), picUpperAnimation.Handle, picUpperAnimation.Width,
+            picUpperAnimation.Height
+        );
+
+        mLowerDarkness = Core.Graphics.CreateRenderTexture(picLowerAnimation.Width, picLowerAnimation.Height);
+        mUpperDarkness = Core.Graphics.CreateRenderTexture(picUpperAnimation.Width, picUpperAnimation.Height);
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.AnimationEditor.title;
+        toolStripItemNew.Text = Strings.AnimationEditor.New;
+        toolStripItemDelete.Text = Strings.AnimationEditor.delete;
+        toolStripItemCopy.Text = Strings.AnimationEditor.copy;
+        toolStripItemPaste.Text = Strings.AnimationEditor.paste;
+        toolStripItemUndo.Text = Strings.AnimationEditor.undo;
+
+        grpAnimations.Text = Strings.AnimationEditor.animations;
+
+        grpGeneral.Text = Strings.AnimationEditor.general;
+        lblName.Text = Strings.AnimationEditor.name;
+        lblSound.Text = Strings.AnimationEditor.sound;
+        chkCompleteSoundPlayback.Text = Strings.AnimationEditor.soundcomplete;
+        chkLoopSoundDuringPreview.Text = Strings.AnimationEditor.LoopSoundDuringPreview;
+        labelDarkness.Text = Strings.AnimationEditor.simulatedarkness.ToString(scrlDarkness.Value);
+        btnSwap.Text = Strings.AnimationEditor.swap;
+
+        grpLower.Text = Strings.AnimationEditor.lowergroup;
+        lblLowerGraphic.Text = Strings.AnimationEditor.Graphic;
+        lblLowerHorizontalFrames.Text = Strings.AnimationEditor.HorizontalFrames;
+        lblLowerVerticalFrames.Text = Strings.AnimationEditor.VerticalFrames;
+        lblLowerFrameCount.Text = Strings.AnimationEditor.FrameCount;
+        lblLowerFrameDuration.Text = Strings.AnimationEditor.FrameDuration;
+        lblLowerLoopCount.Text = Strings.AnimationEditor.LoopCount;
+        grpLowerPlayback.Text = Strings.AnimationEditor.Playback;
+        lblLowerFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlLowerFrame.Value);
+        btnPlayLower.ImageKey = "sharp_play_arrow_white_48dp.png";
+        _tooltip.SetToolTip(btnPlayLower, Strings.AnimationEditor.Play);
+        grpLowerFrameOpts.Text = Strings.AnimationEditor.FrameOptions;
+        btnLowerClone.Text = Strings.AnimationEditor.CloneFromPrevious;
+        chkDisableLowerRotations.Text = Strings.AnimationEditor.DisableRotations;
+        chkRenderAbovePlayer.Text = Strings.AnimationEditor.renderaboveplayer;
+        grpLowerExtraOptions.Text = Strings.AnimationEditor.extraoptions;
+
+        grpUpper.Text = Strings.AnimationEditor.uppergroup;
+        lblUpperGraphic.Text = Strings.AnimationEditor.Graphic;
+        lblUpperHorizontalFrames.Text = Strings.AnimationEditor.HorizontalFrames;
+        lblUpperVerticalFrames.Text = Strings.AnimationEditor.VerticalFrames;
+        lblUpperFrameCount.Text = Strings.AnimationEditor.FrameCount;
+        lblUpperFrameDuration.Text = Strings.AnimationEditor.FrameDuration;
+        lblUpperLoopCount.Text = Strings.AnimationEditor.LoopCount;
+        grpUpperPlayback.Text = Strings.AnimationEditor.Playback;
+        lblUpperFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlUpperFrame.Value);
+        btnPlayUpper.ImageKey = "sharp_play_arrow_white_48dp.png";
+        _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Play);
+        grpUpperFrameOpts.Text = Strings.AnimationEditor.FrameOptions;
+        btnUpperClone.Text = Strings.AnimationEditor.CloneFromPrevious;
+        chkDisableUpperRotations.Text = Strings.AnimationEditor.DisableRotations;
+        chkRenderBelowFringe.Text = Strings.AnimationEditor.renderbelowfringe;
+        grpUpperExtraOptions.Text = Strings.AnimationEditor.extraoptions;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.AnimationEditor.sortalphabetically;
+        txtSearch.Text = Strings.AnimationEditor.searchplaceholder;
+        lblFolder.Text = Strings.AnimationEditor.folderlabel;
+
+        btnSave.Text = Strings.AnimationEditor.save;
+        btnCancel.Text = Strings.AnimationEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            cmbFolder.Text = mEditorItem.Folder;
+
+            txtName.Text = mEditorItem.Name;
+            cmbSound.SelectedIndex = cmbSound.FindString(TextUtils.NullToNone(mEditorItem.Sound));
+            chkCompleteSoundPlayback.Checked = mEditorItem.CompleteSound;
+
+            cmbLowerGraphic.SelectedIndex =
+                cmbLowerGraphic.FindString(TextUtils.NullToNone(mEditorItem.Lower.Sprite));
+
+            nudLowerHorizontalFrames.Value = mEditorItem.Lower.XFrames;
+            nudLowerVerticalFrames.Value = mEditorItem.Lower.YFrames;
+            nudLowerFrameCount.Value = mEditorItem.Lower.FrameCount;
+            UpdateLowerFrames();
+
+            nudLowerFrameDuration.Value = mEditorItem.Lower.FrameSpeed;
+            tmrLowerAnimation.Interval = (int)nudLowerFrameDuration.Value;
+            nudLowerLoopCount.Value = mEditorItem.Lower.LoopCount;
+
+            cmbUpperGraphic.SelectedIndex =
+                cmbUpperGraphic.FindString(TextUtils.NullToNone(mEditorItem.Upper.Sprite));
+
+            nudUpperHorizontalFrames.Value = mEditorItem.Upper.XFrames;
+            nudUpperVerticalFrames.Value = mEditorItem.Upper.YFrames;
+            nudUpperFrameCount.Value = mEditorItem.Upper.FrameCount;
+            UpdateUpperFrames();
+
+            nudUpperFrameDuration.Value = mEditorItem.Upper.FrameSpeed;
+            tmrUpperAnimation.Interval = (int)nudUpperFrameDuration.Value;
+            nudUpperLoopCount.Value = mEditorItem.Upper.LoopCount;
+
+            chkDisableLowerRotations.Checked = mEditorItem.Lower.DisableRotations;
+            chkDisableUpperRotations.Checked = mEditorItem.Upper.DisableRotations;
+
+            chkRenderAbovePlayer.Checked = mEditorItem.Lower.AlternateRenderLayer;
+            chkRenderBelowFringe.Checked = mEditorItem.Upper.AlternateRenderLayer;
+
+            LoadLowerLight();
+            DrawLowerFrame();
+            LoadUpperLight();
+            DrawUpperFrame();
+
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                return;
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void cmbSound_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Sound = TextUtils.SanitizeNone(cmbSound?.Text);
+    }
+
+    private void chkCompleteSoundPlayback_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CompleteSound = chkCompleteSoundPlayback.Checked;
+    }
+
+    private void chkLoopSoundDuringPreview_CheckedChanged(object sender, EventArgs e)
+    {
+        loopSoundOnPreview = chkLoopSoundDuringPreview.Checked;
+    }
+
+    private void cmbLowerGraphic_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.Sprite = TextUtils.SanitizeNone(cmbLowerGraphic?.Text);
+    }
+
+    private void cmbUpperGraphic_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.Sprite = TextUtils.SanitizeNone(cmbUpperGraphic?.Text);
+    }
+
+    private void btnPlaySound_Click(object sender, EventArgs e)
+    {
+        PlayAnimationSound();
+    }
+
+    private void PlayAnimationSound()
+    {
+        if (cmbSound.SelectedIndex <= 0)
+        {
+            return;
+        }
+
+        soundPlayer.SoundLocation = "resources/sounds/" + mEditorItem.Sound;
+
+        soundPlayer.Play();
+    }
+
+    private void tmrLowerAnimation_Tick(object sender, EventArgs e)
+    {
+        if (mPlayLower)
+        {
+            mLowerFrame++;
+            if (mLowerFrame >= (int)nudLowerFrameCount.Value)
+            {
+                mLowerFrame = 0;
             }
 
-            InitEditor();
-            if (mEditorItem == null || AnimationBase.Lookup.Values.Contains(mEditorItem))
+            if (mLowerFrame == 1 && loopSoundOnPreview && !mPlayUpper)
             {
-                return;
+                PlayAnimationSound();
+            }
+        }
+    }
+
+    void UpdateLowerFrames()
+    {
+        LightBase[] newArray;
+        scrlLowerFrame.Maximum = (int)nudLowerFrameCount.Value;
+        if (mEditorItem.Lower.Lights == null || mEditorItem.Lower.FrameCount != mEditorItem.Lower.Lights.Length)
+        {
+            newArray = new LightBase[mEditorItem.Lower.FrameCount];
+            for (var i = 0; i < newArray.Length; i++)
+            {
+                if (mEditorItem.Lower.Lights != null && i < mEditorItem.Lower.Lights.Length)
+                {
+                    newArray[i] = mEditorItem.Lower.Lights[i];
+                }
+                else
+                {
+                    newArray[i] = new LightBase(-1, -1);
+                }
             }
 
-            mEditorItem = null;
-            UpdateEditor();
+            mEditorItem.Lower.Lights = newArray;
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    void UpdateUpperFrames()
+    {
+        LightBase[] newArray;
+        scrlUpperFrame.Maximum = (int)nudUpperFrameCount.Value;
+        if (mEditorItem.Upper.Lights == null || mEditorItem.Upper.FrameCount != mEditorItem.Upper.Lights.Length)
         {
-            foreach (var item in mChanged)
+            newArray = new LightBase[mEditorItem.Upper.FrameCount];
+            for (var i = 0; i < newArray.Length; i++)
             {
-                item.RestoreBackup();
-                item.DeleteBackup();
+                if (mEditorItem.Upper.Lights != null && i < mEditorItem.Upper.Lights.Length)
+                {
+                    newArray[i] = mEditorItem.Upper.Lights[i];
+                }
+                else
+                {
+                    newArray[i] = new LightBase(-1, -1);
+                }
             }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            mEditorItem.Upper.Lights = newArray;
+        }
+    }
+
+    void DrawLowerFrame()
+    {
+        if (mLowerWindow == null || mEditorItem == null)
+        {
+            return;
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
+        if (!mPlayLower)
         {
-            //Send Changed items
-            foreach (var item in mChanged)
+            mLowerFrame = scrlLowerFrame.Value - 1;
+        }
+
+        var graphicsDevice = Core.Graphics.GetGraphicsDevice();
+        Core.Graphics.EndSpriteBatch();
+        graphicsDevice.SetRenderTarget(mLowerDarkness);
+        graphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
+        if (mLowerFrame < mEditorItem.Lower.Lights.Length)
+        {
+            Core.Graphics.DrawLight(
+                picLowerAnimation.Width / 2 + mEditorItem.Lower.Lights[mLowerFrame].OffsetX,
+                picLowerAnimation.Height / 2 + mEditorItem.Lower.Lights[mLowerFrame].OffsetY,
+                mEditorItem.Lower.Lights[mLowerFrame], mLowerDarkness
+            );
+        }
+
+        Core.Graphics.DrawTexture(
+            Core.Graphics.GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+            new RectangleF(0, 0, mLowerDarkness.Width, mLowerDarkness.Height),
+            System.Drawing.Color.FromArgb((byte)((float)(100 - scrlDarkness.Value) / 100f * 255), 255, 255, 255),
+            mLowerDarkness, BlendState.Additive
+        );
+
+        Core.Graphics.EndSpriteBatch();
+        graphicsDevice.SetRenderTarget(mLowerWindow);
+        graphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
+        var animTexture = GameContentManager.GetTexture(
+            GameContentManager.TextureType.Animation, cmbLowerGraphic.Text
+        );
+
+        if (animTexture != null)
+        {
+            long w = animTexture.Width / (int)nudLowerHorizontalFrames.Value;
+            long h = animTexture.Height / (int)nudLowerVerticalFrames.Value;
+            long x = 0;
+            if (mLowerFrame > 0)
             {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
+                x = mLowerFrame % (int)nudLowerHorizontalFrames.Value * w;
             }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            var y = (int)Math.Floor(mLowerFrame / nudLowerHorizontalFrames.Value) * h;
+            Core.Graphics.DrawTexture(
+                animTexture, new RectangleF(x, y, w, h),
+                new RectangleF(
+                    picLowerAnimation.Width / 2 - (int)w / 2, (int)picLowerAnimation.Height / 2 - (int)h / 2, w,
+                    h
+                ), mLowerWindow
+            );
         }
 
-        private void frmAnimation_Load(object sender, EventArgs e)
+        Core.Graphics.DrawTexture(mLowerDarkness, 0, 0, mLowerWindow, Core.Graphics.MultiplyState);
+        Core.Graphics.EndSpriteBatch();
+        mLowerWindow.Present();
+    }
+
+    void DrawUpperFrame()
+    {
+        if (mUpperWindow == null || mEditorItem == null)
         {
-            //Animation Sound
-            cmbSound.Items.Clear();
-            cmbSound.Items.Add(Strings.General.None);
-            cmbSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-
-            //Lower Animation Graphic
-            cmbLowerGraphic.Items.Clear();
-            cmbLowerGraphic.Items.Add(Strings.General.None);
-            cmbLowerGraphic.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Animation)
-            );
-
-            //Upper Animation Graphic
-            cmbUpperGraphic.Items.Clear();
-            cmbUpperGraphic.Items.Add(Strings.General.None);
-            cmbUpperGraphic.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Animation)
-            );
-
-            mLowerWindow = new SwapChainRenderTarget(
-                Core.Graphics.GetGraphicsDevice(), picLowerAnimation.Handle, picLowerAnimation.Width,
-                picLowerAnimation.Height
-            );
-
-            mUpperWindow = new SwapChainRenderTarget(
-                Core.Graphics.GetGraphicsDevice(), picUpperAnimation.Handle, picUpperAnimation.Width,
-                picUpperAnimation.Height
-            );
-
-            mLowerDarkness = Core.Graphics.CreateRenderTexture(picLowerAnimation.Width, picLowerAnimation.Height);
-            mUpperDarkness = Core.Graphics.CreateRenderTexture(picUpperAnimation.Width, picUpperAnimation.Height);
-
-            InitLocalization();
-            UpdateEditor();
+            return;
         }
 
-        private void InitLocalization()
+        if (!mPlayUpper)
         {
-            Text = Strings.AnimationEditor.title;
-            toolStripItemNew.Text = Strings.AnimationEditor.New;
-            toolStripItemDelete.Text = Strings.AnimationEditor.delete;
-            toolStripItemCopy.Text = Strings.AnimationEditor.copy;
-            toolStripItemPaste.Text = Strings.AnimationEditor.paste;
-            toolStripItemUndo.Text = Strings.AnimationEditor.undo;
+            mUpperFrame = scrlUpperFrame.Value - 1;
+        }
 
-            grpAnimations.Text = Strings.AnimationEditor.animations;
+        var graphicsDevice = Core.Graphics.GetGraphicsDevice();
+        Core.Graphics.EndSpriteBatch();
+        graphicsDevice.SetRenderTarget(mUpperDarkness);
+        graphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
+        if (mUpperFrame < mEditorItem.Upper.Lights.Length)
+        {
+            Core.Graphics.DrawLight(
+                picUpperAnimation.Width / 2 + mEditorItem.Upper.Lights[mUpperFrame].OffsetX,
+                picUpperAnimation.Height / 2 + mEditorItem.Upper.Lights[mUpperFrame].OffsetY,
+                mEditorItem.Upper.Lights[mUpperFrame], mUpperDarkness
+            );
+        }
 
-            grpGeneral.Text = Strings.AnimationEditor.general;
-            lblName.Text = Strings.AnimationEditor.name;
-            lblSound.Text = Strings.AnimationEditor.sound;
-            chkCompleteSoundPlayback.Text = Strings.AnimationEditor.soundcomplete;
-            chkLoopSoundDuringPreview.Text = Strings.AnimationEditor.LoopSoundDuringPreview;
-            labelDarkness.Text = Strings.AnimationEditor.simulatedarkness.ToString(scrlDarkness.Value);
-            btnSwap.Text = Strings.AnimationEditor.swap;
+        Core.Graphics.DrawTexture(
+            Core.Graphics.GetWhiteTex(), new RectangleF(0, 0, 1, 1),
+            new RectangleF(0, 0, mUpperDarkness.Width, mUpperDarkness.Height),
+            System.Drawing.Color.FromArgb((byte)((float)(100 - scrlDarkness.Value) / 100f * 255), 255, 255, 255),
+            mUpperDarkness, BlendState.Additive
+        );
 
-            grpLower.Text = Strings.AnimationEditor.lowergroup;
-            lblLowerGraphic.Text = Strings.AnimationEditor.Graphic;
-            lblLowerHorizontalFrames.Text = Strings.AnimationEditor.HorizontalFrames;
-            lblLowerVerticalFrames.Text = Strings.AnimationEditor.VerticalFrames;
-            lblLowerFrameCount.Text = Strings.AnimationEditor.FrameCount;
-            lblLowerFrameDuration.Text = Strings.AnimationEditor.FrameDuration;
-            lblLowerLoopCount.Text = Strings.AnimationEditor.LoopCount;
-            grpLowerPlayback.Text = Strings.AnimationEditor.Playback;
-            lblLowerFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlLowerFrame.Value);
-            btnPlayLower.ImageKey = "sharp_play_arrow_white_48dp.png";
+        Core.Graphics.EndSpriteBatch();
+        graphicsDevice.SetRenderTarget(mUpperWindow);
+        graphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
+        var animTexture = GameContentManager.GetTexture(
+            GameContentManager.TextureType.Animation, cmbUpperGraphic.Text
+        );
+
+        if (animTexture != null)
+        {
+            long w = animTexture.Width / (int)nudUpperHorizontalFrames.Value;
+            long h = animTexture.Height / (int)nudUpperVerticalFrames.Value;
+            long x = 0;
+            if (mUpperFrame > 0)
+            {
+                x = mUpperFrame % (int)nudUpperHorizontalFrames.Value * w;
+            }
+
+            var y = (int)Math.Floor(mUpperFrame / nudUpperHorizontalFrames.Value) * h;
+            Core.Graphics.DrawTexture(
+                animTexture, new RectangleF(x, y, w, h),
+                new RectangleF(
+                    picUpperAnimation.Width / 2 - (int)w / 2, (int)picUpperAnimation.Height / 2 - (int)h / 2, w,
+                    h
+                ), mUpperWindow
+            );
+        }
+
+        Core.Graphics.DrawTexture(mUpperDarkness, 0, 0, mUpperWindow, Core.Graphics.MultiplyState);
+        Core.Graphics.EndSpriteBatch();
+        mUpperWindow.Present();
+    }
+
+    private void tmrUpperAnimation_Tick(object sender, EventArgs e)
+    {
+        if (mPlayUpper)
+        {
+            mUpperFrame++;
+            if (mUpperFrame >= (int)nudUpperFrameCount.Value)
+            {
+                mUpperFrame = 0;
+            }
+
+            if (mUpperFrame == 1 && loopSoundOnPreview && (!mPlayLower || (mPlayLower && mPlayUpper)))
+            {
+                PlayAnimationSound();
+            }
+        }
+    }
+
+    private void frmAnimation_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
+
+    private void scrlLowerFrame_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        lblLowerFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlLowerFrame.Value);
+        LoadLowerLight();
+        DrawLowerFrame();
+    }
+
+    private void LoadLowerLight()
+    {
+        lightEditorLower.CanClose = false;
+        lightEditorLower.LoadEditor(mEditorItem.Lower.Lights[scrlLowerFrame.Value - 1]);
+    }
+
+    private void LoadUpperLight()
+    {
+        lightEditorUpper.CanClose = false;
+        lightEditorUpper.LoadEditor(mEditorItem.Upper.Lights[scrlUpperFrame.Value - 1]);
+    }
+
+    private void scrlUpperFrame_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        lblUpperFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlUpperFrame.Value);
+        LoadUpperLight();
+        DrawUpperFrame();
+    }
+
+    private void btnPlayLower_Click(object sender, EventArgs e)
+    {
+        mPlayLower = !mPlayLower;
+        if (mPlayLower)
+        {
+            _tooltip.SetToolTip(btnPlayLower, Strings.AnimationEditor.Pause);
+            btnPlayLower.ImageKey = "sharp_pause_white_48dp.png";
+        }
+        else
+        {
             _tooltip.SetToolTip(btnPlayLower, Strings.AnimationEditor.Play);
-            grpLowerFrameOpts.Text = Strings.AnimationEditor.FrameOptions;
-            btnLowerClone.Text = Strings.AnimationEditor.CloneFromPrevious;
-            chkDisableLowerRotations.Text = Strings.AnimationEditor.DisableRotations;
-            chkRenderAbovePlayer.Text = Strings.AnimationEditor.renderaboveplayer;
-            grpLowerExtraOptions.Text = Strings.AnimationEditor.extraoptions;
-
-            grpUpper.Text = Strings.AnimationEditor.uppergroup;
-            lblUpperGraphic.Text = Strings.AnimationEditor.Graphic;
-            lblUpperHorizontalFrames.Text = Strings.AnimationEditor.HorizontalFrames;
-            lblUpperVerticalFrames.Text = Strings.AnimationEditor.VerticalFrames;
-            lblUpperFrameCount.Text = Strings.AnimationEditor.FrameCount;
-            lblUpperFrameDuration.Text = Strings.AnimationEditor.FrameDuration;
-            lblUpperLoopCount.Text = Strings.AnimationEditor.LoopCount;
-            grpUpperPlayback.Text = Strings.AnimationEditor.Playback;
-            lblUpperFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlUpperFrame.Value);
-            btnPlayUpper.ImageKey = "sharp_play_arrow_white_48dp.png";
-            _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Play);
-            grpUpperFrameOpts.Text = Strings.AnimationEditor.FrameOptions;
-            btnUpperClone.Text = Strings.AnimationEditor.CloneFromPrevious;
-            chkDisableUpperRotations.Text = Strings.AnimationEditor.DisableRotations;
-            chkRenderBelowFringe.Text = Strings.AnimationEditor.renderbelowfringe;
-            grpUpperExtraOptions.Text = Strings.AnimationEditor.extraoptions;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.AnimationEditor.sortalphabetically;
-            txtSearch.Text = Strings.AnimationEditor.searchplaceholder;
-            lblFolder.Text = Strings.AnimationEditor.folderlabel;
-
-            btnSave.Text = Strings.AnimationEditor.save;
-            btnCancel.Text = Strings.AnimationEditor.cancel;
+            btnPlayLower.ImageKey = "sharp_play_arrow_white_48dp.png";
+            soundPlayer.Stop();
         }
+    }
 
-        private void UpdateEditor()
+    private void btnLowerClone_Click(object sender, EventArgs e)
+    {
+        if (scrlLowerFrame.Value > 1)
         {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
+            mEditorItem.Lower.Lights[scrlLowerFrame.Value - 1] =
+                new LightBase(mEditorItem.Lower.Lights[scrlLowerFrame.Value - 2]);
 
-                cmbFolder.Text = mEditorItem.Folder;
-
-                txtName.Text = mEditorItem.Name;
-                cmbSound.SelectedIndex = cmbSound.FindString(TextUtils.NullToNone(mEditorItem.Sound));
-                chkCompleteSoundPlayback.Checked = mEditorItem.CompleteSound;
-
-                cmbLowerGraphic.SelectedIndex =
-                    cmbLowerGraphic.FindString(TextUtils.NullToNone(mEditorItem.Lower.Sprite));
-
-                nudLowerHorizontalFrames.Value = mEditorItem.Lower.XFrames;
-                nudLowerVerticalFrames.Value = mEditorItem.Lower.YFrames;
-                nudLowerFrameCount.Value = mEditorItem.Lower.FrameCount;
-                UpdateLowerFrames();
-
-                nudLowerFrameDuration.Value = mEditorItem.Lower.FrameSpeed;
-                tmrLowerAnimation.Interval = (int)nudLowerFrameDuration.Value;
-                nudLowerLoopCount.Value = mEditorItem.Lower.LoopCount;
-
-                cmbUpperGraphic.SelectedIndex =
-                    cmbUpperGraphic.FindString(TextUtils.NullToNone(mEditorItem.Upper.Sprite));
-
-                nudUpperHorizontalFrames.Value = mEditorItem.Upper.XFrames;
-                nudUpperVerticalFrames.Value = mEditorItem.Upper.YFrames;
-                nudUpperFrameCount.Value = mEditorItem.Upper.FrameCount;
-                UpdateUpperFrames();
-
-                nudUpperFrameDuration.Value = mEditorItem.Upper.FrameSpeed;
-                tmrUpperAnimation.Interval = (int)nudUpperFrameDuration.Value;
-                nudUpperLoopCount.Value = mEditorItem.Upper.LoopCount;
-
-                chkDisableLowerRotations.Checked = mEditorItem.Lower.DisableRotations;
-                chkDisableUpperRotations.Checked = mEditorItem.Upper.DisableRotations;
-
-                chkRenderAbovePlayer.Checked = mEditorItem.Lower.AlternateRenderLayer;
-                chkRenderBelowFringe.Checked = mEditorItem.Upper.AlternateRenderLayer;
-
-                LoadLowerLight();
-                DrawLowerFrame();
-                LoadUpperLight();
-                DrawUpperFrame();
-
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void cmbSound_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Sound = TextUtils.SanitizeNone(cmbSound?.Text);
-        }
-
-        private void chkCompleteSoundPlayback_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CompleteSound = chkCompleteSoundPlayback.Checked;
-        }
-
-        private void chkLoopSoundDuringPreview_CheckedChanged(object sender, EventArgs e)
-        {
-            loopSoundOnPreview = chkLoopSoundDuringPreview.Checked;
-        }
-
-        private void cmbLowerGraphic_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.Sprite = TextUtils.SanitizeNone(cmbLowerGraphic?.Text);
-        }
-
-        private void cmbUpperGraphic_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.Sprite = TextUtils.SanitizeNone(cmbUpperGraphic?.Text);
-        }
-
-        private void btnPlaySound_Click(object sender, EventArgs e)
-        {
-            PlayAnimationSound();
-        }
-
-        private void PlayAnimationSound()
-        {
-            if (cmbSound.SelectedIndex <= 0)
-            {
-                return;
-            }
-
-            soundPlayer.SoundLocation = "resources/sounds/" + mEditorItem.Sound;
-
-            soundPlayer.Play();
-        }
-
-        private void tmrLowerAnimation_Tick(object sender, EventArgs e)
-        {
-            if (mPlayLower)
-            {
-                mLowerFrame++;
-                if (mLowerFrame >= (int)nudLowerFrameCount.Value)
-                {
-                    mLowerFrame = 0;
-                }
-
-                if (mLowerFrame == 1 && loopSoundOnPreview && !mPlayUpper)
-                {
-                    PlayAnimationSound();
-                }
-            }
-        }
-
-        void UpdateLowerFrames()
-        {
-            LightBase[] newArray;
-            scrlLowerFrame.Maximum = (int)nudLowerFrameCount.Value;
-            if (mEditorItem.Lower.Lights == null || mEditorItem.Lower.FrameCount != mEditorItem.Lower.Lights.Length)
-            {
-                newArray = new LightBase[mEditorItem.Lower.FrameCount];
-                for (var i = 0; i < newArray.Length; i++)
-                {
-                    if (mEditorItem.Lower.Lights != null && i < mEditorItem.Lower.Lights.Length)
-                    {
-                        newArray[i] = mEditorItem.Lower.Lights[i];
-                    }
-                    else
-                    {
-                        newArray[i] = new LightBase(-1, -1);
-                    }
-                }
-
-                mEditorItem.Lower.Lights = newArray;
-            }
-        }
-
-        void UpdateUpperFrames()
-        {
-            LightBase[] newArray;
-            scrlUpperFrame.Maximum = (int)nudUpperFrameCount.Value;
-            if (mEditorItem.Upper.Lights == null || mEditorItem.Upper.FrameCount != mEditorItem.Upper.Lights.Length)
-            {
-                newArray = new LightBase[mEditorItem.Upper.FrameCount];
-                for (var i = 0; i < newArray.Length; i++)
-                {
-                    if (mEditorItem.Upper.Lights != null && i < mEditorItem.Upper.Lights.Length)
-                    {
-                        newArray[i] = mEditorItem.Upper.Lights[i];
-                    }
-                    else
-                    {
-                        newArray[i] = new LightBase(-1, -1);
-                    }
-                }
-
-                mEditorItem.Upper.Lights = newArray;
-            }
-        }
-
-        void DrawLowerFrame()
-        {
-            if (mLowerWindow == null || mEditorItem == null)
-            {
-                return;
-            }
-
-            if (!mPlayLower)
-            {
-                mLowerFrame = scrlLowerFrame.Value - 1;
-            }
-
-            var graphicsDevice = Core.Graphics.GetGraphicsDevice();
-            Core.Graphics.EndSpriteBatch();
-            graphicsDevice.SetRenderTarget(mLowerDarkness);
-            graphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
-            if (mLowerFrame < mEditorItem.Lower.Lights.Length)
-            {
-                Core.Graphics.DrawLight(
-                    picLowerAnimation.Width / 2 + mEditorItem.Lower.Lights[mLowerFrame].OffsetX,
-                    picLowerAnimation.Height / 2 + mEditorItem.Lower.Lights[mLowerFrame].OffsetY,
-                    mEditorItem.Lower.Lights[mLowerFrame], mLowerDarkness
-                );
-            }
-
-            Core.Graphics.DrawTexture(
-                Core.Graphics.GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                new RectangleF(0, 0, mLowerDarkness.Width, mLowerDarkness.Height),
-                System.Drawing.Color.FromArgb((byte)((float)(100 - scrlDarkness.Value) / 100f * 255), 255, 255, 255),
-                mLowerDarkness, BlendState.Additive
-            );
-
-            Core.Graphics.EndSpriteBatch();
-            graphicsDevice.SetRenderTarget(mLowerWindow);
-            graphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
-            var animTexture = GameContentManager.GetTexture(
-                GameContentManager.TextureType.Animation, cmbLowerGraphic.Text
-            );
-
-            if (animTexture != null)
-            {
-                long w = animTexture.Width / (int)nudLowerHorizontalFrames.Value;
-                long h = animTexture.Height / (int)nudLowerVerticalFrames.Value;
-                long x = 0;
-                if (mLowerFrame > 0)
-                {
-                    x = mLowerFrame % (int)nudLowerHorizontalFrames.Value * w;
-                }
-
-                var y = (int)Math.Floor(mLowerFrame / nudLowerHorizontalFrames.Value) * h;
-                Core.Graphics.DrawTexture(
-                    animTexture, new RectangleF(x, y, w, h),
-                    new RectangleF(
-                        picLowerAnimation.Width / 2 - (int)w / 2, (int)picLowerAnimation.Height / 2 - (int)h / 2, w,
-                        h
-                    ), mLowerWindow
-                );
-            }
-
-            Core.Graphics.DrawTexture(mLowerDarkness, 0, 0, mLowerWindow, Core.Graphics.MultiplyState);
-            Core.Graphics.EndSpriteBatch();
-            mLowerWindow.Present();
-        }
-
-        void DrawUpperFrame()
-        {
-            if (mUpperWindow == null || mEditorItem == null)
-            {
-                return;
-            }
-
-            if (!mPlayUpper)
-            {
-                mUpperFrame = scrlUpperFrame.Value - 1;
-            }
-
-            var graphicsDevice = Core.Graphics.GetGraphicsDevice();
-            Core.Graphics.EndSpriteBatch();
-            graphicsDevice.SetRenderTarget(mUpperDarkness);
-            graphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
-            if (mUpperFrame < mEditorItem.Upper.Lights.Length)
-            {
-                Core.Graphics.DrawLight(
-                    picUpperAnimation.Width / 2 + mEditorItem.Upper.Lights[mUpperFrame].OffsetX,
-                    picUpperAnimation.Height / 2 + mEditorItem.Upper.Lights[mUpperFrame].OffsetY,
-                    mEditorItem.Upper.Lights[mUpperFrame], mUpperDarkness
-                );
-            }
-
-            Core.Graphics.DrawTexture(
-                Core.Graphics.GetWhiteTex(), new RectangleF(0, 0, 1, 1),
-                new RectangleF(0, 0, mUpperDarkness.Width, mUpperDarkness.Height),
-                System.Drawing.Color.FromArgb((byte)((float)(100 - scrlDarkness.Value) / 100f * 255), 255, 255, 255),
-                mUpperDarkness, BlendState.Additive
-            );
-
-            Core.Graphics.EndSpriteBatch();
-            graphicsDevice.SetRenderTarget(mUpperWindow);
-            graphicsDevice.Clear(Microsoft.Xna.Framework.Color.White);
-            var animTexture = GameContentManager.GetTexture(
-                GameContentManager.TextureType.Animation, cmbUpperGraphic.Text
-            );
-
-            if (animTexture != null)
-            {
-                long w = animTexture.Width / (int)nudUpperHorizontalFrames.Value;
-                long h = animTexture.Height / (int)nudUpperVerticalFrames.Value;
-                long x = 0;
-                if (mUpperFrame > 0)
-                {
-                    x = mUpperFrame % (int)nudUpperHorizontalFrames.Value * w;
-                }
-
-                var y = (int)Math.Floor(mUpperFrame / nudUpperHorizontalFrames.Value) * h;
-                Core.Graphics.DrawTexture(
-                    animTexture, new RectangleF(x, y, w, h),
-                    new RectangleF(
-                        picUpperAnimation.Width / 2 - (int)w / 2, (int)picUpperAnimation.Height / 2 - (int)h / 2, w,
-                        h
-                    ), mUpperWindow
-                );
-            }
-
-            Core.Graphics.DrawTexture(mUpperDarkness, 0, 0, mUpperWindow, Core.Graphics.MultiplyState);
-            Core.Graphics.EndSpriteBatch();
-            mUpperWindow.Present();
-        }
-
-        private void tmrUpperAnimation_Tick(object sender, EventArgs e)
-        {
-            if (mPlayUpper)
-            {
-                mUpperFrame++;
-                if (mUpperFrame >= (int)nudUpperFrameCount.Value)
-                {
-                    mUpperFrame = 0;
-                }
-
-                if (mUpperFrame == 1 && loopSoundOnPreview && (!mPlayLower || (mPlayLower && mPlayUpper)))
-                {
-                    PlayAnimationSound();
-                }
-            }
-        }
-
-        private void frmAnimation_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void scrlLowerFrame_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            lblLowerFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlLowerFrame.Value);
             LoadLowerLight();
             DrawLowerFrame();
         }
+    }
 
-        private void LoadLowerLight()
+    private void btnPlayUpper_Click(object sender, EventArgs e)
+    {
+        mPlayUpper = !mPlayUpper;
+        if (mPlayUpper)
         {
-            lightEditorLower.CanClose = false;
-            lightEditorLower.LoadEditor(mEditorItem.Lower.Lights[scrlLowerFrame.Value - 1]);
+            _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Pause);
+            btnPlayUpper.ImageKey = "sharp_pause_white_48dp.png";
         }
-
-        private void LoadUpperLight()
+        else
         {
-            lightEditorUpper.CanClose = false;
-            lightEditorUpper.LoadEditor(mEditorItem.Upper.Lights[scrlUpperFrame.Value - 1]);
+            _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Play);
+            btnPlayUpper.ImageKey = "sharp_play_arrow_white_48dp.png";
+            soundPlayer.Stop();
         }
+    }
 
-        private void scrlUpperFrame_Scroll(object sender, ScrollValueEventArgs e)
+    private void btnUpperClone_Click(object sender, EventArgs e)
+    {
+        if (scrlUpperFrame.Value > 1)
         {
-            lblUpperFrame.Text = Strings.AnimationEditor.FrameX.ToString(scrlUpperFrame.Value);
+            mEditorItem.Upper.Lights[scrlUpperFrame.Value - 1] =
+                new LightBase(mEditorItem.Upper.Lights[scrlUpperFrame.Value - 2]);
+
             LoadUpperLight();
             DrawUpperFrame();
         }
+    }
 
-        private void btnPlayLower_Click(object sender, EventArgs e)
+    private void scrlDarkness_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        labelDarkness.Text = Strings.AnimationEditor.simulatedarkness.ToString(scrlDarkness.Value);
+    }
+
+    private void btnSwap_Click(object sender, EventArgs e)
+    {
+        var lowerAnimSprite = mEditorItem.Lower.Sprite;
+        var lowerAnimXFrames = mEditorItem.Lower.XFrames;
+        var lowerAnimYFrames = mEditorItem.Lower.YFrames;
+        var lowerAnimFrameCount = mEditorItem.Lower.FrameCount;
+        var lowerAnimFrameSpeed = mEditorItem.Lower.FrameSpeed;
+        var lowerAnimLoopCount = mEditorItem.Lower.LoopCount;
+        var disableLowerRotations = mEditorItem.Lower.DisableRotations;
+        var lowerLights = mEditorItem.Lower.Lights;
+        mEditorItem.Lower.Sprite = mEditorItem.Upper.Sprite;
+        mEditorItem.Lower.XFrames = mEditorItem.Upper.XFrames;
+        mEditorItem.Lower.YFrames = mEditorItem.Upper.YFrames;
+        mEditorItem.Lower.FrameCount = mEditorItem.Upper.FrameCount;
+        mEditorItem.Lower.FrameSpeed = mEditorItem.Upper.FrameSpeed;
+        mEditorItem.Lower.LoopCount = mEditorItem.Upper.LoopCount;
+        mEditorItem.Lower.Lights = mEditorItem.Upper.Lights;
+        mEditorItem.Lower.DisableRotations = mEditorItem.Upper.DisableRotations;
+
+        mEditorItem.Upper.Sprite = lowerAnimSprite;
+        mEditorItem.Upper.XFrames = lowerAnimXFrames;
+        mEditorItem.Upper.YFrames = lowerAnimYFrames;
+        mEditorItem.Upper.FrameCount = lowerAnimFrameCount;
+        mEditorItem.Upper.FrameSpeed = lowerAnimFrameSpeed;
+        mEditorItem.Upper.LoopCount = lowerAnimLoopCount;
+        mEditorItem.Upper.Lights = lowerLights;
+        mEditorItem.Upper.DisableRotations = disableLowerRotations;
+
+        mUpperFrame = 0;
+        mLowerFrame = 0;
+
+        UpdateEditor();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Animation);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
         {
-            mPlayLower = !mPlayLower;
-            if (mPlayLower)
+            if (DarkMessageBox.ShowWarning(
+                    Strings.AnimationEditor.deleteprompt, Strings.AnimationEditor.deletetitle,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
             {
-                _tooltip.SetToolTip(btnPlayLower, Strings.AnimationEditor.Pause);
-                btnPlayLower.ImageKey = "sharp_pause_white_48dp.png";
-            }
-            else
-            {
-                _tooltip.SetToolTip(btnPlayLower, Strings.AnimationEditor.Play);
-                btnPlayLower.ImageKey = "sharp_play_arrow_white_48dp.png";
-                soundPlayer.Stop();
+                PacketSender.SendDeleteObject(mEditorItem);
             }
         }
+    }
 
-        private void btnLowerClone_Click(object sender, EventArgs e)
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
         {
-            if (scrlLowerFrame.Value > 1)
-            {
-                mEditorItem.Lower.Lights[scrlLowerFrame.Value - 1] =
-                    new LightBase(mEditorItem.Lower.Lights[scrlLowerFrame.Value - 2]);
-
-                LoadLowerLight();
-                DrawLowerFrame();
-            }
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
         }
+    }
 
-        private void btnPlayUpper_Click(object sender, EventArgs e)
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
         {
-            mPlayUpper = !mPlayUpper;
-            if (mPlayUpper)
-            {
-                _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Pause);
-                btnPlayUpper.ImageKey = "sharp_pause_white_48dp.png";
-            }
-            else
-            {
-                _tooltip.SetToolTip(btnPlayUpper, Strings.AnimationEditor.Play);
-                btnPlayUpper.ImageKey = "sharp_play_arrow_white_48dp.png";
-                soundPlayer.Stop();
-            }
-        }
-
-        private void btnUpperClone_Click(object sender, EventArgs e)
-        {
-            if (scrlUpperFrame.Value > 1)
-            {
-                mEditorItem.Upper.Lights[scrlUpperFrame.Value - 1] =
-                    new LightBase(mEditorItem.Upper.Lights[scrlUpperFrame.Value - 2]);
-
-                LoadUpperLight();
-                DrawUpperFrame();
-            }
-        }
-
-        private void scrlDarkness_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            labelDarkness.Text = Strings.AnimationEditor.simulatedarkness.ToString(scrlDarkness.Value);
-        }
-
-        private void btnSwap_Click(object sender, EventArgs e)
-        {
-            var lowerAnimSprite = mEditorItem.Lower.Sprite;
-            var lowerAnimXFrames = mEditorItem.Lower.XFrames;
-            var lowerAnimYFrames = mEditorItem.Lower.YFrames;
-            var lowerAnimFrameCount = mEditorItem.Lower.FrameCount;
-            var lowerAnimFrameSpeed = mEditorItem.Lower.FrameSpeed;
-            var lowerAnimLoopCount = mEditorItem.Lower.LoopCount;
-            var disableLowerRotations = mEditorItem.Lower.DisableRotations;
-            var lowerLights = mEditorItem.Lower.Lights;
-            mEditorItem.Lower.Sprite = mEditorItem.Upper.Sprite;
-            mEditorItem.Lower.XFrames = mEditorItem.Upper.XFrames;
-            mEditorItem.Lower.YFrames = mEditorItem.Upper.YFrames;
-            mEditorItem.Lower.FrameCount = mEditorItem.Upper.FrameCount;
-            mEditorItem.Lower.FrameSpeed = mEditorItem.Upper.FrameSpeed;
-            mEditorItem.Lower.LoopCount = mEditorItem.Upper.LoopCount;
-            mEditorItem.Lower.Lights = mEditorItem.Upper.Lights;
-            mEditorItem.Lower.DisableRotations = mEditorItem.Upper.DisableRotations;
-
-            mEditorItem.Upper.Sprite = lowerAnimSprite;
-            mEditorItem.Upper.XFrames = lowerAnimXFrames;
-            mEditorItem.Upper.YFrames = lowerAnimYFrames;
-            mEditorItem.Upper.FrameCount = lowerAnimFrameCount;
-            mEditorItem.Upper.FrameSpeed = lowerAnimFrameSpeed;
-            mEditorItem.Upper.LoopCount = lowerAnimLoopCount;
-            mEditorItem.Upper.Lights = lowerLights;
-            mEditorItem.Upper.DisableRotations = disableLowerRotations;
-
-            mUpperFrame = 0;
-            mLowerFrame = 0;
-
+            mEditorItem.Load(mCopiedItem, true);
             UpdateEditor();
         }
+    }
 
-        private void toolStripItemNew_Click(object sender, EventArgs e)
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
         {
-            PacketSender.SendCreateObject(GameObjectType.Animation);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
+            if (DarkMessageBox.ShowWarning(
+                    Strings.AnimationEditor.undoprompt, Strings.AnimationEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.AnimationEditor.deleteprompt, Strings.AnimationEditor.deletetitle,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
+                mEditorItem.RestoreBackup();
                 UpdateEditor();
             }
         }
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            if (e.KeyCode == Keys.N)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.AnimationEditor.undoprompt, Strings.AnimationEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void CheckFrameCounts()
+    {
+        nudLowerFrameCount.Value = Math.Min(mEditorItem.Lower.FrameCount, mEditorItem.Lower.XFrames * mEditorItem.Lower.YFrames);
+        nudUpperFrameCount.Value = Math.Min(mEditorItem.Upper.FrameCount, mEditorItem.Upper.XFrames * mEditorItem.Upper.YFrames);
+    }
+
+    private void nudLowerHorizontalFrames_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.XFrames = (int)nudLowerHorizontalFrames.Value;
+        CheckFrameCounts();
+    }
+
+    private void nudLowerVerticalFrames_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.YFrames = (int)nudLowerVerticalFrames.Value;
+        CheckFrameCounts();
+    }
+
+    private void nudLowerFrameCount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.FrameCount = (int)nudLowerFrameCount.Value;
+        CheckFrameCounts();
+        UpdateLowerFrames();
+    }
+
+    private void nudLowerFrameDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.FrameSpeed = (int)nudLowerFrameDuration.Value;
+        tmrLowerAnimation.Interval = (int)nudLowerFrameDuration.Value;
+    }
+
+    private void nudLowerLoopCount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.LoopCount = (int)nudLowerLoopCount.Value;
+    }
+
+    private void nudUpperHorizontalFrames_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.XFrames = (int)nudUpperHorizontalFrames.Value;
+        CheckFrameCounts();
+    }
+
+    private void nudUpperVerticalFrames_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.YFrames = (int)nudUpperVerticalFrames.Value;
+        CheckFrameCounts();
+    }
+
+    private void nudUpperFrameCount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.FrameCount = (int)nudUpperFrameCount.Value;
+        CheckFrameCounts();
+        UpdateUpperFrames();
+    }
+
+    private void nudUpperFrameDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.FrameSpeed = (int)nudUpperFrameDuration.Value;
+        tmrUpperAnimation.Interval = (int)nudUpperFrameDuration.Value;
+    }
+
+    private void nudUpperLoopCount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.LoopCount = (int)nudUpperLoopCount.Value;
+    }
+
+    private void tmrRender_Tick(object sender, EventArgs e)
+    {
+        DrawLowerFrame();
+        DrawUpperFrame();
+    }
+
+    private void chkDisableLowerRotations_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.DisableRotations = chkDisableLowerRotations.Checked;
+    }
+
+    private void chkDisableUpperRotations_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.DisableRotations = chkDisableUpperRotations.Checked;
+    }
+
+    private void chkRenderAbovePlayer_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Lower.AlternateRenderLayer = chkRenderAbovePlayer.Checked;
+    }
+
+    private void chkRenderBelowFringe_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Upper.AlternateRenderLayer = chkRenderBelowFringe.Checked;
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var anim in AnimationBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((AnimationBase)anim.Value).Folder) &&
+                !mFolders.Contains(((AnimationBase)anim.Value).Folder))
+            {
+                mFolders.Add(((AnimationBase)anim.Value).Folder);
+                if (!mKnownFolders.Contains(((AnimationBase)anim.Value).Folder))
                 {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
+                    mKnownFolders.Add(((AnimationBase)anim.Value).Folder);
                 }
             }
         }
 
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
 
-        private void form_KeyDown(object sender, KeyEventArgs e)
+        var items = AnimationBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((AnimationBase)pair.Value)?.Name ?? Models.DatabaseObject<AnimationBase>.Deleted, ((AnimationBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.AnimationEditor.folderprompt, Strings.AnimationEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            if (e.Control)
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
         }
+    }
 
-        private void CheckFrameCounts()
-        {
-            nudLowerFrameCount.Value = Math.Min(mEditorItem.Lower.FrameCount, mEditorItem.Lower.XFrames * mEditorItem.Lower.YFrames);
-            nudUpperFrameCount.Value = Math.Min(mEditorItem.Upper.FrameCount, mEditorItem.Upper.XFrames * mEditorItem.Upper.YFrames);
-        }
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
 
-        private void nudLowerHorizontalFrames_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.XFrames = (int)nudLowerHorizontalFrames.Value;
-            CheckFrameCounts();
-        }
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
 
-        private void nudLowerVerticalFrames_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.YFrames = (int)nudLowerVerticalFrames.Value;
-            CheckFrameCounts();
-        }
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
 
-        private void nudLowerFrameCount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.FrameCount = (int)nudLowerFrameCount.Value;
-            CheckFrameCounts();
-            UpdateLowerFrames();
-        }
-
-        private void nudLowerFrameDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.FrameSpeed = (int)nudLowerFrameDuration.Value;
-            tmrLowerAnimation.Interval = (int)nudLowerFrameDuration.Value;
-        }
-
-        private void nudLowerLoopCount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.LoopCount = (int)nudLowerLoopCount.Value;
-        }
-
-        private void nudUpperHorizontalFrames_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.XFrames = (int)nudUpperHorizontalFrames.Value;
-            CheckFrameCounts();
-        }
-
-        private void nudUpperVerticalFrames_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.YFrames = (int)nudUpperVerticalFrames.Value;
-            CheckFrameCounts();
-        }
-
-        private void nudUpperFrameCount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.FrameCount = (int)nudUpperFrameCount.Value;
-            CheckFrameCounts();
-            UpdateUpperFrames();
-        }
-
-        private void nudUpperFrameDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.FrameSpeed = (int)nudUpperFrameDuration.Value;
-            tmrUpperAnimation.Interval = (int)nudUpperFrameDuration.Value;
-        }
-
-        private void nudUpperLoopCount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.LoopCount = (int)nudUpperLoopCount.Value;
-        }
-
-        private void tmrRender_Tick(object sender, EventArgs e)
-        {
-            DrawLowerFrame();
-            DrawUpperFrame();
-        }
-
-        private void chkDisableLowerRotations_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.DisableRotations = chkDisableLowerRotations.Checked;
-        }
-
-        private void chkDisableUpperRotations_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.DisableRotations = chkDisableUpperRotations.Checked;
-        }
-
-        private void chkRenderAbovePlayer_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Lower.AlternateRenderLayer = chkRenderAbovePlayer.Checked;
-        }
-
-        private void chkRenderBelowFringe_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Upper.AlternateRenderLayer = chkRenderBelowFringe.Checked;
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var anim in AnimationBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((AnimationBase)anim.Value).Folder) &&
-                    !mFolders.Contains(((AnimationBase)anim.Value).Folder))
-                {
-                    mFolders.Add(((AnimationBase)anim.Value).Folder);
-                    if (!mKnownFolders.Contains(((AnimationBase)anim.Value).Folder))
-                    {
-                        mKnownFolders.Add(((AnimationBase)anim.Value).Folder);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = AnimationBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((AnimationBase)pair.Value)?.Name ?? Models.DatabaseObject<AnimationBase>.Deleted, ((AnimationBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.AnimationEditor.folderprompt, Strings.AnimationEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.AnimationEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.AnimationEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.AnimationEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.AnimationEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.AnimationEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.AnimationEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.AnimationEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmClass.cs
+++ b/Intersect.Editor/Forms/Editors/frmClass.cs
@@ -10,513 +10,216 @@ using Intersect.GameObjects.Maps.MapList;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmClass : EditorForm
 {
 
-    public partial class FrmClass : EditorForm
+    private List<ClassBase> mChanged = new List<ClassBase>();
+
+    private string mCopiedItem;
+
+    private ClassBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmClass()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<ClassBase> mChanged = new List<ClassBase>();
-
-        private string mCopiedItem;
-
-        private ClassBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        public FrmClass()
+        cmbWarpMap.Items.Clear();
+        for (var i = 0; i < MapList.OrderedMaps.Count; i++)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            cmbWarpMap.Items.Clear();
-            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-            {
-                cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
-            }
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = ClassBase.Get(id);
-            UpdateEditor();
+            cmbWarpMap.Items.Add(MapList.OrderedMaps[i].Name);
         }
 
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = ClassBase.Get(id);
+        UpdateEditor();
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Class)
         {
-            if (type == GameObjectType.Class)
+            InitEditor();
+            if (mEditorItem != null && !ClassBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !ClassBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            item.RestoreBackup();
+            item.DeleteBackup();
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
         }
 
-        private void txtName_TextChanged(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void UpdateSpellList(bool keepIndex = true)
+    {
+        // Refresh List
+        var n = lstSpells.SelectedIndex;
+        lstSpells.Items.Clear();
+        for (var i = 0; i < mEditorItem.Spells.Count; i++)
         {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
+            lstSpells.Items.Add(
+                Strings.ClassEditor.spellitem.ToString(
+                    i + 1, SpellBase.GetName(mEditorItem.Spells[i].Id), mEditorItem.Spells[i].Level
+                )
+            );
         }
 
-        private void UpdateSpellList(bool keepIndex = true)
+        if (keepIndex)
         {
-            // Refresh List
-            var n = lstSpells.SelectedIndex;
-            lstSpells.Items.Clear();
-            for (var i = 0; i < mEditorItem.Spells.Count; i++)
-            {
-                lstSpells.Items.Add(
-                    Strings.ClassEditor.spellitem.ToString(
-                        i + 1, SpellBase.GetName(mEditorItem.Spells[i].Id), mEditorItem.Spells[i].Level
-                    )
-                );
-            }
+            lstSpells.SelectedIndex = n;
+        }
+    }
 
-            if (keepIndex)
-            {
-                lstSpells.SelectedIndex = n;
-            }
+    private void btnAddSpell_Click(object sender, EventArgs e)
+    {
+        var n = new ClassSpell
+        {
+            Id = SpellBase.IdFromList(cmbSpell.SelectedIndex),
+            Level = (int) nudLevel.Value
+        };
+
+        mEditorItem.Spells.Add(n);
+        UpdateSpellList(false);
+    }
+
+    private void btnRemoveSpell_Click(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex == -1)
+        {
+            return;
         }
 
-        private void btnAddSpell_Click(object sender, EventArgs e)
-        {
-            var n = new ClassSpell
-            {
-                Id = SpellBase.IdFromList(cmbSpell.SelectedIndex),
-                Level = (int) nudLevel.Value
-            };
+        mEditorItem.Spells.RemoveAt(lstSpells.SelectedIndex);
+        lstSpells.Items.RemoveAt(lstSpells.SelectedIndex);
 
-            mEditorItem.Spells.Add(n);
-            UpdateSpellList(false);
+        UpdateSpellList(false);
+
+        if (lstSpells.Items.Count > 0)
+        {
+            lstSpells.SelectedIndex = 0;
         }
+    }
 
-        private void btnRemoveSpell_Click(object sender, EventArgs e)
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
         {
-            if (lstSpells.SelectedIndex == -1)
+            pnlContainer.Show();
+            txtName.Text = mEditorItem.Name;
+            nudAttack.Value = mEditorItem.BaseStat[(int) Stat.Attack];
+            nudMag.Value = mEditorItem.BaseStat[(int) Stat.AbilityPower];
+            nudDef.Value = mEditorItem.BaseStat[(int) Stat.Defense];
+            nudMR.Value = mEditorItem.BaseStat[(int) Stat.MagicResist];
+            nudSpd.Value = mEditorItem.BaseStat[(int) Stat.Speed];
+            nudBaseHP.Value = Math.Max(
+                Math.Min(mEditorItem.BaseVital[(int) Vital.Health], nudBaseHP.Maximum), nudBaseHP.Minimum
+            );
+
+            nudBaseMana.Value = mEditorItem.BaseVital[(int) Vital.Mana];
+            nudPoints.Value = mEditorItem.BasePoints;
+            chkLocked.Checked = Convert.ToBoolean(mEditorItem.Locked);
+
+            cmbFolder.Text = mEditorItem.Folder;
+
+            //Combat
+            nudDamage.Value = mEditorItem.Damage;
+            nudCritChance.Value = mEditorItem.CritChance;
+            nudCritMultiplier.Value = (decimal) mEditorItem.CritMultiplier;
+            nudScaling.Value = mEditorItem.Scaling;
+            cmbDamageType.SelectedIndex = mEditorItem.DamageType;
+            cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
+            cmbAttackSprite.SelectedIndex = cmbAttackSprite.FindString(
+                    TextUtils.NullToNone(mEditorItem.AttackSpriteOverride)
+            );
+            cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
+            cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
+            nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
+
+            //Regen
+            nudHPRegen.Value = mEditorItem.VitalRegen[(int) Vital.Health];
+            nudMpRegen.Value = mEditorItem.VitalRegen[(int) Vital.Mana];
+
+            //Exp
+            nudBaseExp.Value = mEditorItem.BaseExp;
+            nudExpIncrease.Value = mEditorItem.ExpIncrease;
+
+            //Stat Increases
+            if (!mEditorItem.IncreasePercentage)
             {
-                return;
-            }
-
-            mEditorItem.Spells.RemoveAt(lstSpells.SelectedIndex);
-            lstSpells.Items.RemoveAt(lstSpells.SelectedIndex);
-
-            UpdateSpellList(false);
-
-            if (lstSpells.Items.Count > 0)
-            {
-                lstSpells.SelectedIndex = 0;
-            }
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-                txtName.Text = mEditorItem.Name;
-                nudAttack.Value = mEditorItem.BaseStat[(int) Stat.Attack];
-                nudMag.Value = mEditorItem.BaseStat[(int) Stat.AbilityPower];
-                nudDef.Value = mEditorItem.BaseStat[(int) Stat.Defense];
-                nudMR.Value = mEditorItem.BaseStat[(int) Stat.MagicResist];
-                nudSpd.Value = mEditorItem.BaseStat[(int) Stat.Speed];
-                nudBaseHP.Value = Math.Max(
-                    Math.Min(mEditorItem.BaseVital[(int) Vital.Health], nudBaseHP.Maximum), nudBaseHP.Minimum
-                );
-
-                nudBaseMana.Value = mEditorItem.BaseVital[(int) Vital.Mana];
-                nudPoints.Value = mEditorItem.BasePoints;
-                chkLocked.Checked = Convert.ToBoolean(mEditorItem.Locked);
-
-                cmbFolder.Text = mEditorItem.Folder;
-
-                //Combat
-                nudDamage.Value = mEditorItem.Damage;
-                nudCritChance.Value = mEditorItem.CritChance;
-                nudCritMultiplier.Value = (decimal) mEditorItem.CritMultiplier;
-                nudScaling.Value = mEditorItem.Scaling;
-                cmbDamageType.SelectedIndex = mEditorItem.DamageType;
-                cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
-                cmbAttackSprite.SelectedIndex = cmbAttackSprite.FindString(
-                        TextUtils.NullToNone(mEditorItem.AttackSpriteOverride)
-                );
-                cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
-                cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
-                nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
-
-                //Regen
-                nudHPRegen.Value = mEditorItem.VitalRegen[(int) Vital.Health];
-                nudMpRegen.Value = mEditorItem.VitalRegen[(int) Vital.Mana];
-
-                //Exp
-                nudBaseExp.Value = mEditorItem.BaseExp;
-                nudExpIncrease.Value = mEditorItem.ExpIncrease;
-
-                //Stat Increases
-                if (!mEditorItem.IncreasePercentage)
-                {
-                    rdoStaticIncrease.Checked = true;
-                }
-                else
-                {
-                    rdoPercentageIncrease.Checked = true;
-                }
-
-                UpdateIncreases();
-
-                UpdateSpellList(false);
-
-                cmbSpell.SelectedIndex = -1;
-
-                // Don't select if there are no Spells, to avoid crashes.
-                if (lstSpells.Items.Count > 0)
-                {
-                    lstSpells.SelectedIndex = 0;
-                    cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex].Id);
-                    nudLevel.Value = mEditorItem.Spells[lstSpells.SelectedIndex].Level;
-                }
-                else
-                {
-                    cmbSpell.SelectedIndex = -1;
-                    nudLevel.Value = 0;
-                }
-
-                RefreshSpriteList(false);
-
-                // Don't select if there are no Spells, to avoid crashes.
-                if (lstSprites.Items.Count > 0)
-                {
-                    lstSprites.SelectedIndex = 0;
-                    cmbSprite.SelectedIndex = cmbSprite.FindString(
-                        TextUtils.NullToNone(mEditorItem.Sprites[lstSprites.SelectedIndex].Sprite)
-                    );
-
-                    if (mEditorItem.Sprites[lstSprites.SelectedIndex].Gender == 0)
-                    {
-                        rbMale.Checked = true;
-                    }
-                    else
-                    {
-                        rbFemale.Checked = true;
-                    }
-                }
-
-                var mapIndex = -1;
-
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == mEditorItem.SpawnMapId)
-                    {
-                        mapIndex = i;
-
-                        break;
-                    }
-                }
-
-                if (mapIndex == -1)
-                {
-                    cmbWarpMap.SelectedIndex = 0;
-                    mEditorItem.SpawnMapId = MapList.OrderedMaps[0].MapId;
-                }
-                else
-                {
-                    cmbWarpMap.SelectedIndex = mapIndex;
-                }
-
-                nudX.Value = mEditorItem.SpawnX;
-                nudY.Value = mEditorItem.SpawnY;
-                cmbDirection.SelectedIndex = mEditorItem.SpawnDir;
-
-                UpdateSpawnItemValues();
-                DrawSprite();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-
-                grpExpGrid.Hide();
+                rdoStaticIncrease.Checked = true;
             }
             else
             {
-                pnlContainer.Hide();
+                rdoPercentageIncrease.Checked = true;
             }
 
-            UpdateToolStripItems();
-        }
+            UpdateIncreases();
 
-        private void frmClass_Load(object sender, EventArgs e)
-        {
-            cmbSprite.Items.Clear();
-            cmbSprite.Items.Add(Strings.General.None);
-            cmbSprite.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
-            );
+            UpdateSpellList(false);
 
-            cmbFace.Items.Clear();
-            cmbFace.Items.Add(Strings.General.None);
-            cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
-            cmbSpawnItem.Items.Clear();
-            cmbSpawnItem.Items.Add(Strings.General.None);
-            cmbSpawnItem.Items.AddRange(ItemBase.Names);
-            cmbSpell.Items.Clear();
-            cmbSpell.Items.AddRange(SpellBase.Names);
-            nudLevel.Maximum = Options.MaxLevel;
-            cmbAttackAnimation.Items.Clear();
-            cmbAttackAnimation.Items.Add(Strings.General.None);
-            cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
-            cmbAttackSprite.Items.Clear();
-            cmbAttackSprite.Items.Add(Strings.General.None);
-            cmbAttackSprite.Items.AddRange(
-                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "attack").ToArray()
-            );
-            cmbScalingStat.Items.Clear();
-            for (var x = 0; x < ((int)Stat.Speed) + 1; x++)
+            cmbSpell.SelectedIndex = -1;
+
+            // Don't select if there are no Spells, to avoid crashes.
+            if (lstSpells.Items.Count > 0)
             {
-                cmbScalingStat.Items.Add(Globals.GetStatName(x));
+                lstSpells.SelectedIndex = 0;
+                cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex].Id);
+                nudLevel.Value = mEditorItem.Spells[lstSpells.SelectedIndex].Level;
             }
-
-            nudAttack.Maximum = Options.MaxStatValue;
-            nudMag.Maximum = Options.MaxStatValue;
-            nudDef.Maximum = Options.MaxStatValue;
-            nudMR.Maximum = Options.MaxStatValue;
-            nudSpd.Maximum = Options.MaxStatValue;
-
-            InitLocalization();
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.ClassEditor.title;
-            toolStripItemNew.Text = Strings.ClassEditor.New;
-            toolStripItemDelete.Text = Strings.ClassEditor.delete;
-            toolStripItemCopy.Text = Strings.ClassEditor.copy;
-            toolStripItemPaste.Text = Strings.ClassEditor.paste;
-            toolStripItemUndo.Text = Strings.ClassEditor.undo;
-
-            grpClasses.Text = Strings.ClassEditor.classes;
-
-            grpGeneral.Text = Strings.ClassEditor.general;
-            lblName.Text = Strings.ClassEditor.name;
-            chkLocked.Text = Strings.ClassEditor.locked;
-
-            grpSpawnPoint.Text = Strings.ClassEditor.spawnpoint;
-            lblMap.Text = Strings.Warping.map.ToString("");
-            lblX.Text = Strings.Warping.x.ToString("");
-            lblY.Text = Strings.Warping.y;
-            lblDir.Text = Strings.Warping.direction.ToString("");
-            cmbDirection.Items.Clear();
-            for (var i = 0; i < 4; i++)
+            else
             {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+                cmbSpell.SelectedIndex = -1;
+                nudLevel.Value = 0;
             }
 
-            btnVisualMapSelector.Text = Strings.Warping.visual;
+            RefreshSpriteList(false);
 
-            grpSprite.Text = Strings.ClassEditor.spriteface;
-            grpSpriteOptions.Text = Strings.ClassEditor.spriteoptions;
-            btnAdd.Text = Strings.ClassEditor.addsprite;
-            btnRemove.Text = Strings.ClassEditor.removeicon;
-            grpGender.Text = Strings.ClassEditor.gender;
-            rbMale.Text = Strings.ClassEditor.male;
-            rbFemale.Text = Strings.ClassEditor.female;
-            lblSprite.Text = Strings.ClassEditor.sprite;
-            lblFace.Text = Strings.ClassEditor.face;
-
-            grpSpawnItems.Text = Strings.ClassEditor.spawnitems;
-            lblSpawnItem.Text = Strings.ClassEditor.spawnitem;
-            lblSpawnItemAmount.Text = Strings.ClassEditor.spawnamount;
-            btnSpawnItemAdd.Text = Strings.ClassEditor.spawnitemadd;
-            btnSpawnItemRemove.Text = Strings.ClassEditor.spawnitemremove;
-
-            grpBaseStats.Text = Strings.ClassEditor.basestats;
-            lblHP.Text = Strings.ClassEditor.basehp;
-            lblMana.Text = Strings.ClassEditor.basemp;
-            lblAttack.Text = Strings.ClassEditor.baseattack;
-            lblDef.Text = Strings.ClassEditor.basearmor;
-            lblSpd.Text = Strings.ClassEditor.basespeed;
-            lblMag.Text = Strings.ClassEditor.baseabilitypower;
-            lblMR.Text = Strings.ClassEditor.basemagicresist;
-            lblPoints.Text = Strings.ClassEditor.basepoints;
-
-            grpSpells.Text = Strings.ClassEditor.learntspells;
-            lblSpellNum.Text = Strings.ClassEditor.spell;
-            lblLevel.Text = Strings.ClassEditor.spelllevel;
-            btnAddSpell.Text = Strings.ClassEditor.addspell;
-            btnRemoveSpell.Text = Strings.ClassEditor.removespell;
-
-            grpRegen.Text = Strings.ClassEditor.regen;
-            lblHpRegen.Text = Strings.ClassEditor.hpregen;
-            lblManaRegen.Text = Strings.ClassEditor.mpregen;
-            lblRegenHint.Text = Strings.ClassEditor.regenhint;
-
-            grpCombat.Text = Strings.ClassEditor.combat;
-            lblDamage.Text = Strings.ClassEditor.basedamage;
-            lblCritChance.Text = Strings.ClassEditor.critchance;
-            lblCritMultiplier.Text = Strings.ClassEditor.critmultiplier;
-            lblDamageType.Text = Strings.ClassEditor.damagetype;
-            cmbDamageType.Items.Clear();
-            for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
-            {
-                cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
-            }
-
-            lblScalingStat.Text = Strings.ClassEditor.scalingstat;
-            lblScalingAmount.Text = Strings.ClassEditor.scalingamount;
-            lblAttackAnimation.Text = Strings.ClassEditor.attackanimation;
-            lblSpriteAttack.Text = Strings.ClassEditor.AttackSpriteOverride;
-
-            grpAttackSpeed.Text = Strings.NpcEditor.attackspeed;
-            lblAttackSpeedModifier.Text = Strings.NpcEditor.attackspeedmodifier;
-            lblAttackSpeedValue.Text = Strings.NpcEditor.attackspeedvalue;
-            cmbAttackSpeedModifier.Items.Clear();
-            foreach (var val in Strings.NpcEditor.attackspeedmodifiers.Values)
-            {
-                cmbAttackSpeedModifier.Items.Add(val.ToString());
-            }
-
-            grpLeveling.Text = Strings.ClassEditor.leveling;
-            lblBaseExp.Text = Strings.ClassEditor.levelexp;
-            lblExpIncrease.Text = Strings.ClassEditor.levelexpscale;
-            grpLevelBoosts.Text = Strings.ClassEditor.levelboosts;
-            rdoStaticIncrease.Text = Strings.ClassEditor.staticboost;
-            rdoPercentageIncrease.Text = Strings.ClassEditor.percentageboost;
-            lblHpIncrease.Text = Strings.ClassEditor.hpboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMpIncrease.Text = Strings.ClassEditor.mpboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblStrengthIncrease.Text = Strings.ClassEditor.attackboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblArmorIncrease.Text = Strings.ClassEditor.armorboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblSpeedIncrease.Text = Strings.ClassEditor.speedboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMagicIncrease.Text = Strings.ClassEditor.abilitypowerboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMagicResistIncrease.Text = Strings.ClassEditor.magicresistboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblPointsIncrease.Text = Strings.ClassEditor.pointsboost;
-
-            //Exp Grid
-            btnExpGrid.Text = Strings.ClassEditor.expgrid;
-            grpExpGrid.Text = Strings.ClassEditor.experiencegrid;
-            btnResetExpGrid.Text = Strings.ClassEditor.gridreset;
-            btnCloseExpGrid.Text = Strings.ClassEditor.gridclose;
-            btnExpPaste.Text = Strings.ClassEditor.gridpaste;
-
-            //Create EXP Grid...
-            var levelCol = new DataGridViewTextBoxColumn();
-            levelCol.HeaderText = Strings.ClassEditor.gridlevel;
-            levelCol.ReadOnly = true;
-            levelCol.SortMode = DataGridViewColumnSortMode.NotSortable;
-
-            var tnlCol = new DataGridViewTextBoxColumn();
-            tnlCol.HeaderText = Strings.ClassEditor.gridtnl;
-            tnlCol.SortMode = DataGridViewColumnSortMode.NotSortable;
-
-            var totalCol = new DataGridViewTextBoxColumn();
-            totalCol.HeaderText = Strings.ClassEditor.gridtotalexp;
-            totalCol.ReadOnly = true;
-            totalCol.SortMode = DataGridViewColumnSortMode.NotSortable;
-
-            expGrid.Columns.Clear();
-            expGrid.Columns.Add(levelCol);
-            expGrid.Columns.Add(tnlCol);
-            expGrid.Columns.Add(totalCol);
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.ClassEditor.sortalphabetically;
-            txtSearch.Text = Strings.ClassEditor.searchplaceholder;
-            lblFolder.Text = Strings.ClassEditor.folderlabel;
-
-            btnSave.Text = Strings.ClassEditor.save;
-            btnCancel.Text = Strings.ClassEditor.cancel;
-        }
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in ClassBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((ClassBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((ClassBase) itm.Value).Folder))
-                {
-                    mFolders.Add(((ClassBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ClassBase) itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((ClassBase) itm.Value).Folder);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = ClassBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((ClassBase)pair.Value)?.Name ?? Models.DatabaseObject<ClassBase>.Deleted, ((ClassBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void lstSprites_Click(object sender, EventArgs e)
-        {
+            // Don't select if there are no Spells, to avoid crashes.
             if (lstSprites.Items.Count > 0)
             {
+                lstSprites.SelectedIndex = 0;
                 cmbSprite.SelectedIndex = cmbSprite.FindString(
                     TextUtils.NullToNone(mEditorItem.Sprites[lstSprites.SelectedIndex].Sprite)
-                );
-
-                cmbFace.SelectedIndex = cmbFace.FindString(
-                    TextUtils.NullToNone(mEditorItem.Sprites[lstSprites.SelectedIndex].Face)
                 );
 
                 if (mEditorItem.Sprites[lstSprites.SelectedIndex].Gender == 0)
@@ -528,87 +231,349 @@ namespace Intersect.Editor.Forms.Editors
                     rbFemale.Checked = true;
                 }
             }
-        }
 
-        private void rbMale_Click(object sender, EventArgs e)
-        {
-            if (lstSprites.Items.Count > 0)
+            var mapIndex = -1;
+
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
             {
-                mEditorItem.Sprites[lstSprites.SelectedIndex].Gender = Gender.Male;
+                if (MapList.OrderedMaps[i].MapId == mEditorItem.SpawnMapId)
+                {
+                    mapIndex = i;
 
-                RefreshSpriteList();
-            }
-        }
-
-        private void rbFemale_Click(object sender, EventArgs e)
-        {
-            if (lstSprites.Items.Count > 0)
-            {
-                mEditorItem.Sprites[lstSprites.SelectedIndex].Gender = Gender.Female;
-
-                RefreshSpriteList();
-            }
-        }
-
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSprites.SelectedIndex >= 0)
-            {
-                mEditorItem.Sprites[lstSprites.SelectedIndex].Sprite = TextUtils.SanitizeNone(cmbSprite?.Text);
-
-                RefreshSpriteList();
+                    break;
+                }
             }
 
+            if (mapIndex == -1)
+            {
+                cmbWarpMap.SelectedIndex = 0;
+                mEditorItem.SpawnMapId = MapList.OrderedMaps[0].MapId;
+            }
+            else
+            {
+                cmbWarpMap.SelectedIndex = mapIndex;
+            }
+
+            nudX.Value = mEditorItem.SpawnX;
+            nudY.Value = mEditorItem.SpawnY;
+            cmbDirection.SelectedIndex = mEditorItem.SpawnDir;
+
+            UpdateSpawnItemValues();
             DrawSprite();
-        }
-
-        private void RefreshSpriteList(bool saveSpot = true)
-        {
-            // Refresh List
-            var n = lstSprites.SelectedIndex;
-            lstSprites.Items.Clear();
-            for (var i = 0; i < mEditorItem.Sprites.Count; i++)
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                if (mEditorItem.Sprites[i].Gender == 0)
-                {
-                    lstSprites.Items.Add(
-                        Strings.ClassEditor.spriteitemmale.ToString(
-                            i + 1, TextUtils.NullToNone(mEditorItem.Sprites[i].Sprite)
-                        )
-                    );
-                }
-                else
-                {
-                    lstSprites.Items.Add(
-                        Strings.ClassEditor.spriteitemfemale.ToString(
-                            i + 1, TextUtils.NullToNone(mEditorItem.Sprites[i].Sprite)
-                        )
-                    );
-                }
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
             }
 
-            if (saveSpot)
+            grpExpGrid.Hide();
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void frmClass_Load(object sender, EventArgs e)
+    {
+        cmbSprite.Items.Clear();
+        cmbSprite.Items.Add(Strings.General.None);
+        cmbSprite.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
+        );
+
+        cmbFace.Items.Clear();
+        cmbFace.Items.Add(Strings.General.None);
+        cmbFace.Items.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Face));
+        cmbSpawnItem.Items.Clear();
+        cmbSpawnItem.Items.Add(Strings.General.None);
+        cmbSpawnItem.Items.AddRange(ItemBase.Names);
+        cmbSpell.Items.Clear();
+        cmbSpell.Items.AddRange(SpellBase.Names);
+        nudLevel.Maximum = Options.MaxLevel;
+        cmbAttackAnimation.Items.Clear();
+        cmbAttackAnimation.Items.Add(Strings.General.None);
+        cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
+        cmbAttackSprite.Items.Clear();
+        cmbAttackSprite.Items.Add(Strings.General.None);
+        cmbAttackSprite.Items.AddRange(
+            GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "attack").ToArray()
+        );
+        cmbScalingStat.Items.Clear();
+        for (var x = 0; x < ((int)Stat.Speed) + 1; x++)
+        {
+            cmbScalingStat.Items.Add(Globals.GetStatName(x));
+        }
+
+        nudAttack.Maximum = Options.MaxStatValue;
+        nudMag.Maximum = Options.MaxStatValue;
+        nudDef.Maximum = Options.MaxStatValue;
+        nudMR.Maximum = Options.MaxStatValue;
+        nudSpd.Maximum = Options.MaxStatValue;
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.ClassEditor.title;
+        toolStripItemNew.Text = Strings.ClassEditor.New;
+        toolStripItemDelete.Text = Strings.ClassEditor.delete;
+        toolStripItemCopy.Text = Strings.ClassEditor.copy;
+        toolStripItemPaste.Text = Strings.ClassEditor.paste;
+        toolStripItemUndo.Text = Strings.ClassEditor.undo;
+
+        grpClasses.Text = Strings.ClassEditor.classes;
+
+        grpGeneral.Text = Strings.ClassEditor.general;
+        lblName.Text = Strings.ClassEditor.name;
+        chkLocked.Text = Strings.ClassEditor.locked;
+
+        grpSpawnPoint.Text = Strings.ClassEditor.spawnpoint;
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y;
+        lblDir.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = 0; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        btnVisualMapSelector.Text = Strings.Warping.visual;
+
+        grpSprite.Text = Strings.ClassEditor.spriteface;
+        grpSpriteOptions.Text = Strings.ClassEditor.spriteoptions;
+        btnAdd.Text = Strings.ClassEditor.addsprite;
+        btnRemove.Text = Strings.ClassEditor.removeicon;
+        grpGender.Text = Strings.ClassEditor.gender;
+        rbMale.Text = Strings.ClassEditor.male;
+        rbFemale.Text = Strings.ClassEditor.female;
+        lblSprite.Text = Strings.ClassEditor.sprite;
+        lblFace.Text = Strings.ClassEditor.face;
+
+        grpSpawnItems.Text = Strings.ClassEditor.spawnitems;
+        lblSpawnItem.Text = Strings.ClassEditor.spawnitem;
+        lblSpawnItemAmount.Text = Strings.ClassEditor.spawnamount;
+        btnSpawnItemAdd.Text = Strings.ClassEditor.spawnitemadd;
+        btnSpawnItemRemove.Text = Strings.ClassEditor.spawnitemremove;
+
+        grpBaseStats.Text = Strings.ClassEditor.basestats;
+        lblHP.Text = Strings.ClassEditor.basehp;
+        lblMana.Text = Strings.ClassEditor.basemp;
+        lblAttack.Text = Strings.ClassEditor.baseattack;
+        lblDef.Text = Strings.ClassEditor.basearmor;
+        lblSpd.Text = Strings.ClassEditor.basespeed;
+        lblMag.Text = Strings.ClassEditor.baseabilitypower;
+        lblMR.Text = Strings.ClassEditor.basemagicresist;
+        lblPoints.Text = Strings.ClassEditor.basepoints;
+
+        grpSpells.Text = Strings.ClassEditor.learntspells;
+        lblSpellNum.Text = Strings.ClassEditor.spell;
+        lblLevel.Text = Strings.ClassEditor.spelllevel;
+        btnAddSpell.Text = Strings.ClassEditor.addspell;
+        btnRemoveSpell.Text = Strings.ClassEditor.removespell;
+
+        grpRegen.Text = Strings.ClassEditor.regen;
+        lblHpRegen.Text = Strings.ClassEditor.hpregen;
+        lblManaRegen.Text = Strings.ClassEditor.mpregen;
+        lblRegenHint.Text = Strings.ClassEditor.regenhint;
+
+        grpCombat.Text = Strings.ClassEditor.combat;
+        lblDamage.Text = Strings.ClassEditor.basedamage;
+        lblCritChance.Text = Strings.ClassEditor.critchance;
+        lblCritMultiplier.Text = Strings.ClassEditor.critmultiplier;
+        lblDamageType.Text = Strings.ClassEditor.damagetype;
+        cmbDamageType.Items.Clear();
+        for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
+        {
+            cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
+        }
+
+        lblScalingStat.Text = Strings.ClassEditor.scalingstat;
+        lblScalingAmount.Text = Strings.ClassEditor.scalingamount;
+        lblAttackAnimation.Text = Strings.ClassEditor.attackanimation;
+        lblSpriteAttack.Text = Strings.ClassEditor.AttackSpriteOverride;
+
+        grpAttackSpeed.Text = Strings.NpcEditor.attackspeed;
+        lblAttackSpeedModifier.Text = Strings.NpcEditor.attackspeedmodifier;
+        lblAttackSpeedValue.Text = Strings.NpcEditor.attackspeedvalue;
+        cmbAttackSpeedModifier.Items.Clear();
+        foreach (var val in Strings.NpcEditor.attackspeedmodifiers.Values)
+        {
+            cmbAttackSpeedModifier.Items.Add(val.ToString());
+        }
+
+        grpLeveling.Text = Strings.ClassEditor.leveling;
+        lblBaseExp.Text = Strings.ClassEditor.levelexp;
+        lblExpIncrease.Text = Strings.ClassEditor.levelexpscale;
+        grpLevelBoosts.Text = Strings.ClassEditor.levelboosts;
+        rdoStaticIncrease.Text = Strings.ClassEditor.staticboost;
+        rdoPercentageIncrease.Text = Strings.ClassEditor.percentageboost;
+        lblHpIncrease.Text = Strings.ClassEditor.hpboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMpIncrease.Text = Strings.ClassEditor.mpboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblStrengthIncrease.Text = Strings.ClassEditor.attackboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblArmorIncrease.Text = Strings.ClassEditor.armorboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblSpeedIncrease.Text = Strings.ClassEditor.speedboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMagicIncrease.Text = Strings.ClassEditor.abilitypowerboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMagicResistIncrease.Text = Strings.ClassEditor.magicresistboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblPointsIncrease.Text = Strings.ClassEditor.pointsboost;
+
+        //Exp Grid
+        btnExpGrid.Text = Strings.ClassEditor.expgrid;
+        grpExpGrid.Text = Strings.ClassEditor.experiencegrid;
+        btnResetExpGrid.Text = Strings.ClassEditor.gridreset;
+        btnCloseExpGrid.Text = Strings.ClassEditor.gridclose;
+        btnExpPaste.Text = Strings.ClassEditor.gridpaste;
+
+        //Create EXP Grid...
+        var levelCol = new DataGridViewTextBoxColumn();
+        levelCol.HeaderText = Strings.ClassEditor.gridlevel;
+        levelCol.ReadOnly = true;
+        levelCol.SortMode = DataGridViewColumnSortMode.NotSortable;
+
+        var tnlCol = new DataGridViewTextBoxColumn();
+        tnlCol.HeaderText = Strings.ClassEditor.gridtnl;
+        tnlCol.SortMode = DataGridViewColumnSortMode.NotSortable;
+
+        var totalCol = new DataGridViewTextBoxColumn();
+        totalCol.HeaderText = Strings.ClassEditor.gridtotalexp;
+        totalCol.ReadOnly = true;
+        totalCol.SortMode = DataGridViewColumnSortMode.NotSortable;
+
+        expGrid.Columns.Clear();
+        expGrid.Columns.Add(levelCol);
+        expGrid.Columns.Add(tnlCol);
+        expGrid.Columns.Add(totalCol);
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.ClassEditor.sortalphabetically;
+        txtSearch.Text = Strings.ClassEditor.searchplaceholder;
+        lblFolder.Text = Strings.ClassEditor.folderlabel;
+
+        btnSave.Text = Strings.ClassEditor.save;
+        btnCancel.Text = Strings.ClassEditor.cancel;
+    }
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in ClassBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((ClassBase) itm.Value).Folder) &&
+                !mFolders.Contains(((ClassBase) itm.Value).Folder))
             {
-                lstSprites.SelectedIndex = n;
+                mFolders.Add(((ClassBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((ClassBase) itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((ClassBase) itm.Value).Folder);
+                }
             }
         }
 
-        private void btnAdd_Click(object sender, EventArgs e)
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = ClassBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((ClassBase)pair.Value)?.Name ?? Models.DatabaseObject<ClassBase>.Deleted, ((ClassBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void lstSprites_Click(object sender, EventArgs e)
+    {
+        if (lstSprites.Items.Count > 0)
         {
-            var n = new ClassSprite
+            cmbSprite.SelectedIndex = cmbSprite.FindString(
+                TextUtils.NullToNone(mEditorItem.Sprites[lstSprites.SelectedIndex].Sprite)
+            );
+
+            cmbFace.SelectedIndex = cmbFace.FindString(
+                TextUtils.NullToNone(mEditorItem.Sprites[lstSprites.SelectedIndex].Face)
+            );
+
+            if (mEditorItem.Sprites[lstSprites.SelectedIndex].Gender == 0)
             {
-                Sprite = null,
-                Face = null,
-                Gender = 0
-            };
+                rbMale.Checked = true;
+            }
+            else
+            {
+                rbFemale.Checked = true;
+            }
+        }
+    }
 
-            mEditorItem.Sprites.Add(n);
+    private void rbMale_Click(object sender, EventArgs e)
+    {
+        if (lstSprites.Items.Count > 0)
+        {
+            mEditorItem.Sprites[lstSprites.SelectedIndex].Gender = Gender.Male;
 
-            if (n.Gender == 0)
+            RefreshSpriteList();
+        }
+    }
+
+    private void rbFemale_Click(object sender, EventArgs e)
+    {
+        if (lstSprites.Items.Count > 0)
+        {
+            mEditorItem.Sprites[lstSprites.SelectedIndex].Gender = Gender.Female;
+
+            RefreshSpriteList();
+        }
+    }
+
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSprites.SelectedIndex >= 0)
+        {
+            mEditorItem.Sprites[lstSprites.SelectedIndex].Sprite = TextUtils.SanitizeNone(cmbSprite?.Text);
+
+            RefreshSpriteList();
+        }
+
+        DrawSprite();
+    }
+
+    private void RefreshSpriteList(bool saveSpot = true)
+    {
+        // Refresh List
+        var n = lstSprites.SelectedIndex;
+        lstSprites.Items.Clear();
+        for (var i = 0; i < mEditorItem.Sprites.Count; i++)
+        {
+            if (mEditorItem.Sprites[i].Gender == 0)
             {
                 lstSprites.Items.Add(
                     Strings.ClassEditor.spriteitemmale.ToString(
-                        mEditorItem.Sprites.Count, TextUtils.NullToNone(n.Sprite)
+                        i + 1, TextUtils.NullToNone(mEditorItem.Sprites[i].Sprite)
                     )
                 );
             }
@@ -616,923 +581,956 @@ namespace Intersect.Editor.Forms.Editors
             {
                 lstSprites.Items.Add(
                     Strings.ClassEditor.spriteitemfemale.ToString(
-                        mEditorItem.Sprites.Count, TextUtils.NullToNone(n.Sprite)
+                        i + 1, TextUtils.NullToNone(mEditorItem.Sprites[i].Sprite)
                     )
                 );
             }
-
-            lstSprites.SelectedIndex = lstSprites.Items.Count - 1;
-            lstSprites_Click(null, null);
         }
 
-        private void btnRemove_Click(object sender, EventArgs e)
+        if (saveSpot)
         {
-            if (lstSprites.SelectedIndex == -1)
-            {
-                return;
-            }
-
-            mEditorItem.Sprites.RemoveAt(lstSprites.SelectedIndex);
-            lstSprites.Items.RemoveAt(lstSprites.SelectedIndex);
-
-            RefreshSpriteList(false);
-
-            if (lstSprites.Items.Count > 0)
-            {
-                lstSprites.SelectedIndex = 0;
-            }
+            lstSprites.SelectedIndex = n;
         }
+    }
 
-        private void DrawSprite()
+    private void btnAdd_Click(object sender, EventArgs e)
+    {
+        var n = new ClassSprite
         {
-            var picSpriteBmp = new Bitmap(picSprite.Width, picSprite.Height);
-            var gfx = Graphics.FromImage(picSpriteBmp);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picSprite.Width, picSprite.Height));
-            if (cmbSprite.SelectedIndex > 0)
-            {
-                if (File.Exists("resources/entities/" + cmbSprite.Text))
-                {
-                    var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
-                    gfx.DrawImage(
-                        img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
-                        new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
-                    );
+            Sprite = null,
+            Face = null,
+            Gender = 0
+        };
 
-                    img.Dispose();
-                }
-            }
+        mEditorItem.Sprites.Add(n);
 
-            gfx.Dispose();
-            picSprite.BackgroundImage = picSpriteBmp;
-
-            var picFaceBmp = new Bitmap(picFace.Width, picFace.Height);
-            gfx = Graphics.FromImage(picFaceBmp);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picSprite.Width, picSprite.Height));
-            if (cmbFace.SelectedIndex > 0)
-            {
-                if (File.Exists("resources/faces/" + cmbFace.Text))
-                {
-                    var img = Image.FromFile("resources/faces/" + cmbFace.Text);
-                    gfx.DrawImage(
-                        img, new Rectangle(0, 0, img.Width, img.Height), new Rectangle(0, 0, img.Width, img.Height),
-                        GraphicsUnit.Pixel
-                    );
-
-                    img.Dispose();
-                }
-            }
-
-            gfx.Dispose();
-            picFace.BackgroundImage = picFaceBmp;
-        }
-
-        private void btnVisualMapSelector_Click(object sender, EventArgs e)
+        if (n.Gender == 0)
         {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(
-                MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int) nudX.Value, (int) nudY.Value
+            lstSprites.Items.Add(
+                Strings.ClassEditor.spriteitemmale.ToString(
+                    mEditorItem.Sprites.Count, TextUtils.NullToNone(n.Sprite)
+                )
             );
+        }
+        else
+        {
+            lstSprites.Items.Add(
+                Strings.ClassEditor.spriteitemfemale.ToString(
+                    mEditorItem.Sprites.Count, TextUtils.NullToNone(n.Sprite)
+                )
+            );
+        }
 
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
+        lstSprites.SelectedIndex = lstSprites.Items.Count - 1;
+        lstSprites_Click(null, null);
+    }
+
+    private void btnRemove_Click(object sender, EventArgs e)
+    {
+        if (lstSprites.SelectedIndex == -1)
+        {
+            return;
+        }
+
+        mEditorItem.Sprites.RemoveAt(lstSprites.SelectedIndex);
+        lstSprites.Items.RemoveAt(lstSprites.SelectedIndex);
+
+        RefreshSpriteList(false);
+
+        if (lstSprites.Items.Count > 0)
+        {
+            lstSprites.SelectedIndex = 0;
+        }
+    }
+
+    private void DrawSprite()
+    {
+        var picSpriteBmp = new Bitmap(picSprite.Width, picSprite.Height);
+        var gfx = Graphics.FromImage(picSpriteBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picSprite.Width, picSprite.Height));
+        if (cmbSprite.SelectedIndex > 0)
+        {
+            if (File.Exists("resources/entities/" + cmbSprite.Text))
             {
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
-                    {
-                        cmbWarpMap.SelectedIndex = i;
+                var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
+                gfx.DrawImage(
+                    img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
+                    new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
+                );
 
-                        break;
-                    }
-                }
-
-                nudX.Value = frmWarpSelection.GetX();
-                nudY.Value = frmWarpSelection.GetY();
-                mEditorItem.SpawnMapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
-                mEditorItem.SpawnX = (byte) nudX.Value;
-                mEditorItem.SpawnY = (byte) nudY.Value;
+                img.Dispose();
             }
         }
 
-        private void cmbWarpMap_SelectedIndexChanged(object sender, EventArgs e)
+        gfx.Dispose();
+        picSprite.BackgroundImage = picSpriteBmp;
+
+        var picFaceBmp = new Bitmap(picFace.Width, picFace.Height);
+        gfx = Graphics.FromImage(picFaceBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picSprite.Width, picSprite.Height));
+        if (cmbFace.SelectedIndex > 0)
         {
-            if (mEditorItem == null)
+            if (File.Exists("resources/faces/" + cmbFace.Text))
             {
-                return;
+                var img = Image.FromFile("resources/faces/" + cmbFace.Text);
+                gfx.DrawImage(
+                    img, new Rectangle(0, 0, img.Width, img.Height), new Rectangle(0, 0, img.Width, img.Height),
+                    GraphicsUnit.Pixel
+                );
+
+                img.Dispose();
+            }
+        }
+
+        gfx.Dispose();
+        picFace.BackgroundImage = picFaceBmp;
+    }
+
+    private void btnVisualMapSelector_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int) nudX.Value, (int) nudY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbWarpMap.SelectedIndex = i;
+
+                    break;
+                }
             }
 
+            nudX.Value = frmWarpSelection.GetX();
+            nudY.Value = frmWarpSelection.GetY();
             mEditorItem.SpawnMapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
+            mEditorItem.SpawnX = (byte) nudX.Value;
+            mEditorItem.SpawnY = (byte) nudY.Value;
+        }
+    }
+
+    private void cmbWarpMap_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (mEditorItem == null)
+        {
+            return;
         }
 
-        private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
+        mEditorItem.SpawnMapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
+    }
+
+    private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (mEditorItem == null)
         {
-            if (mEditorItem == null)
+            return;
+        }
+
+        mEditorItem.SpawnDir = (byte) cmbDirection.SelectedIndex;
+    }
+
+    private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSprites.SelectedIndex >= 0)
+        {
+            mEditorItem.Sprites[lstSprites.SelectedIndex].Face = TextUtils.SanitizeNone(cmbFace?.Text);
+
+            RefreshSpriteList();
+        }
+
+        DrawSprite();
+    }
+
+    private void chkLocked_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Locked = chkLocked.Checked;
+    }
+
+    private void UpdateIncreases()
+    {
+        if (rdoStaticIncrease.Checked)
+        {
+            nudHpIncrease.Maximum = 10000;
+            nudMpIncrease.Maximum = 10000;
+            nudStrengthIncrease.Maximum = Options.MaxStatValue;
+            nudArmorIncrease.Maximum = Options.MaxStatValue;
+            nudMagicIncrease.Maximum = Options.MaxStatValue;
+            nudMagicResistIncrease.Maximum = Options.MaxStatValue;
+            nudSpeedIncrease.Maximum = Options.MaxStatValue;
+        }
+        else
+        {
+            nudHpIncrease.Maximum = 100;
+            nudMpIncrease.Maximum = 100;
+            nudStrengthIncrease.Maximum = 100;
+            nudArmorIncrease.Maximum = 100;
+            nudMagicIncrease.Maximum = 100;
+            nudMagicResistIncrease.Maximum = 100;
+            nudSpeedIncrease.Maximum = 100;
+        }
+
+        nudHpIncrease.Value = Math.Min(nudHpIncrease.Maximum, mEditorItem.VitalIncrease[(int) Vital.Health]);
+        nudMpIncrease.Value = Math.Min(nudMpIncrease.Maximum, mEditorItem.VitalIncrease[(int) Vital.Mana]);
+
+        nudStrengthIncrease.Value = Math.Min(
+            nudStrengthIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Attack]
+        );
+
+        nudArmorIncrease.Value = Math.Min(nudArmorIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Defense]);
+        nudMagicIncrease.Value = Math.Min(
+            nudMagicIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.AbilityPower]
+        );
+
+        nudMagicResistIncrease.Value = Math.Min(
+            nudMagicResistIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.MagicResist]
+        );
+
+        nudSpeedIncrease.Value = Math.Min(nudSpeedIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Speed]);
+
+        lblHpIncrease.Text = Strings.ClassEditor.hpboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMpIncrease.Text = Strings.ClassEditor.mpboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblStrengthIncrease.Text = Strings.ClassEditor.attackboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblArmorIncrease.Text = Strings.ClassEditor.armorboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblSpeedIncrease.Text = Strings.ClassEditor.speedboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMagicIncrease.Text = Strings.ClassEditor.abilitypowerboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        lblMagicResistIncrease.Text = Strings.ClassEditor.magicresistboost.ToString(
+            rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
+        );
+
+        nudPointsIncrease.Value = mEditorItem.PointIncrease;
+    }
+
+    private void rdoPercentageIncrease_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IncreasePercentage = rdoPercentageIncrease.Checked;
+        UpdateIncreases();
+    }
+
+    private void rdoStaticIncrease_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IncreasePercentage = rdoPercentageIncrease.Checked;
+        UpdateIncreases();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Class);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ClassEditor.deleteprompt, Strings.ClassEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
             {
-                return;
+                PacketSender.SendDeleteObject(mEditorItem);
             }
-
-            mEditorItem.SpawnDir = (byte) cmbDirection.SelectedIndex;
         }
+    }
 
-        private void cmbFace_SelectedIndexChanged(object sender, EventArgs e)
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
         {
-            if (lstSprites.SelectedIndex >= 0)
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ClassEditor.undoprompt, Strings.ClassEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
             {
-                mEditorItem.Sprites[lstSprites.SelectedIndex].Face = TextUtils.SanitizeNone(cmbFace?.Text);
-
-                RefreshSpriteList();
-            }
-
-            DrawSprite();
-        }
-
-        private void chkLocked_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Locked = chkLocked.Checked;
-        }
-
-        private void UpdateIncreases()
-        {
-            if (rdoStaticIncrease.Checked)
-            {
-                nudHpIncrease.Maximum = 10000;
-                nudMpIncrease.Maximum = 10000;
-                nudStrengthIncrease.Maximum = Options.MaxStatValue;
-                nudArmorIncrease.Maximum = Options.MaxStatValue;
-                nudMagicIncrease.Maximum = Options.MaxStatValue;
-                nudMagicResistIncrease.Maximum = Options.MaxStatValue;
-                nudSpeedIncrease.Maximum = Options.MaxStatValue;
-            }
-            else
-            {
-                nudHpIncrease.Maximum = 100;
-                nudMpIncrease.Maximum = 100;
-                nudStrengthIncrease.Maximum = 100;
-                nudArmorIncrease.Maximum = 100;
-                nudMagicIncrease.Maximum = 100;
-                nudMagicResistIncrease.Maximum = 100;
-                nudSpeedIncrease.Maximum = 100;
-            }
-
-            nudHpIncrease.Value = Math.Min(nudHpIncrease.Maximum, mEditorItem.VitalIncrease[(int) Vital.Health]);
-            nudMpIncrease.Value = Math.Min(nudMpIncrease.Maximum, mEditorItem.VitalIncrease[(int) Vital.Mana]);
-
-            nudStrengthIncrease.Value = Math.Min(
-                nudStrengthIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Attack]
-            );
-
-            nudArmorIncrease.Value = Math.Min(nudArmorIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Defense]);
-            nudMagicIncrease.Value = Math.Min(
-                nudMagicIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.AbilityPower]
-            );
-
-            nudMagicResistIncrease.Value = Math.Min(
-                nudMagicResistIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.MagicResist]
-            );
-
-            nudSpeedIncrease.Value = Math.Min(nudSpeedIncrease.Maximum, mEditorItem.StatIncrease[(int) Stat.Speed]);
-
-            lblHpIncrease.Text = Strings.ClassEditor.hpboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMpIncrease.Text = Strings.ClassEditor.mpboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblStrengthIncrease.Text = Strings.ClassEditor.attackboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblArmorIncrease.Text = Strings.ClassEditor.armorboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblSpeedIncrease.Text = Strings.ClassEditor.speedboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMagicIncrease.Text = Strings.ClassEditor.abilitypowerboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            lblMagicResistIncrease.Text = Strings.ClassEditor.magicresistboost.ToString(
-                rdoStaticIncrease.Checked ? "" : Strings.ClassEditor.boostpercent.ToString()
-            );
-
-            nudPointsIncrease.Value = mEditorItem.PointIncrease;
-        }
-
-        private void rdoPercentageIncrease_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IncreasePercentage = rdoPercentageIncrease.Checked;
-            UpdateIncreases();
-        }
-
-        private void rdoStaticIncrease_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IncreasePercentage = rdoPercentageIncrease.Checked;
-            UpdateIncreases();
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Class);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ClassEditor.deleteprompt, Strings.ClassEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
+                mEditorItem.RestoreBackup();
                 UpdateEditor();
             }
         }
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            if (e.KeyCode == Keys.N)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ClassEditor.undoprompt, Strings.ClassEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackAnimation =
+            AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbAttackSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpriteOverride = TextUtils.SanitizeNone(cmbAttackSprite?.Text);
+    }
+
+    private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
+    }
+
+    private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex > -1 && cmbSpell.SelectedIndex > -1)
+        {
+            mEditorItem.Spells[lstSpells.SelectedIndex].Id = SpellBase.IdFromList(cmbSpell.SelectedIndex);
+            UpdateSpellList();
+        }
+    }
+
+    private void lstSpells_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex > -1)
+        {
+            cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex].Id);
+            nudLevel.Value = mEditorItem.Spells[lstSpells.SelectedIndex].Level;
+        }
+    }
+
+    private void nudScaling_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Scaling = (int) nudScaling.Value;
+    }
+
+    private void nudX_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SpawnX = (byte) nudX.Value;
+    }
+
+    private void nudY_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SpawnY = (byte) nudY.Value;
+    }
+
+    private void nudStr_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseStat[(int) Stat.Attack] = (int) nudAttack.Value;
+    }
+
+    private void nudMag_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseStat[(int) Stat.AbilityPower] = (int) nudMag.Value;
+    }
+
+    private void nudDef_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseStat[(int) Stat.Defense] = (int) nudDef.Value;
+    }
+
+    private void nudMR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseStat[(int) Stat.MagicResist] = (int) nudMR.Value;
+    }
+
+    private void nudPoints_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BasePoints = (int) nudPoints.Value;
+    }
+
+    private void nudSpd_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseStat[(int) Stat.Speed] = (int) nudSpd.Value;
+    }
+
+    private void nudLevel_ValueChanged(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex >= 0)
+        {
+            mEditorItem.Spells[lstSpells.SelectedIndex].Level = (int) nudLevel.Value;
+
+            UpdateSpellList();
+        }
+    }
+
+    private void nudHPRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalRegen[(int) Vital.Health] = (int) nudHPRegen.Value;
+        UpdateIncreases();
+    }
+
+    private void nudMpRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalRegen[(int) Vital.Mana] = (int) nudMpRegen.Value;
+        UpdateIncreases();
+    }
+
+    private void nudDamage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Damage = (int) nudDamage.Value;
+    }
+
+    private void nudCritChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritChance = (int) nudCritChance.Value;
+    }
+
+    private void nudExpIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ExpIncrease = (int) nudExpIncrease.Value;
+    }
+
+    private void nudHpIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalIncrease[(int) Vital.Health] = (int) nudHpIncrease.Value;
+    }
+
+    private void nudMpIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalIncrease[(int) Vital.Mana] = (int) nudMpIncrease.Value;
+    }
+
+    private void nudArmorIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatIncrease[(int) Stat.Defense] = (int) nudArmorIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudMagicResistIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatIncrease[(int) Stat.MagicResist] = (int) nudMagicResistIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudStrengthIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatIncrease[(int) Stat.Attack] = (int) nudStrengthIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudMagicIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatIncrease[(int) Stat.AbilityPower] = (int) nudMagicIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudSpeedIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatIncrease[(int) Stat.Speed] = (int) nudSpeedIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudPointsIncrease_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PointIncrease = (int) nudPointsIncrease.Value;
+        UpdateIncreases();
+    }
+
+    private void nudBaseExp_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseExp = (int) nudBaseExp.Value;
+    }
+
+    private void nudBaseHP_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseVital[(int) Vital.Health] = (int) nudBaseHP.Value;
+    }
+
+    private void nudBaseMana_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BaseVital[(int) Vital.Mana] = (int) nudBaseMana.Value;
+    }
+
+    private void UpdateSpawnItemValues(bool keepIndex = false)
+    {
+        var index = lstSpawnItems.SelectedIndex;
+        lstSpawnItems.Items.Clear();
+
+        var spawnItems = mEditorItem.Items.ToArray();
+        foreach (var spawnItem in spawnItems)
+        {
+            if (ItemBase.Get(spawnItem.Id) == null)
+            {
+                mEditorItem.Items.Remove(spawnItem);
             }
         }
 
-        private void UpdateToolStripItems()
+        for (var i = 0; i < mEditorItem.Items.Count; i++)
         {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
+            if (mEditorItem.Items[i].Id != Guid.Empty)
             {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackAnimation =
-                AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbAttackSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpriteOverride = TextUtils.SanitizeNone(cmbAttackSprite?.Text);
-        }
-
-        private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DamageType = cmbDamageType.SelectedIndex;
-        }
-
-        private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
-        }
-
-        private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex > -1 && cmbSpell.SelectedIndex > -1)
-            {
-                mEditorItem.Spells[lstSpells.SelectedIndex].Id = SpellBase.IdFromList(cmbSpell.SelectedIndex);
-                UpdateSpellList();
-            }
-        }
-
-        private void lstSpells_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex > -1)
-            {
-                cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex].Id);
-                nudLevel.Value = mEditorItem.Spells[lstSpells.SelectedIndex].Level;
-            }
-        }
-
-        private void nudScaling_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Scaling = (int) nudScaling.Value;
-        }
-
-        private void nudX_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SpawnX = (byte) nudX.Value;
-        }
-
-        private void nudY_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SpawnY = (byte) nudY.Value;
-        }
-
-        private void nudStr_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseStat[(int) Stat.Attack] = (int) nudAttack.Value;
-        }
-
-        private void nudMag_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseStat[(int) Stat.AbilityPower] = (int) nudMag.Value;
-        }
-
-        private void nudDef_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseStat[(int) Stat.Defense] = (int) nudDef.Value;
-        }
-
-        private void nudMR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseStat[(int) Stat.MagicResist] = (int) nudMR.Value;
-        }
-
-        private void nudPoints_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BasePoints = (int) nudPoints.Value;
-        }
-
-        private void nudSpd_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseStat[(int) Stat.Speed] = (int) nudSpd.Value;
-        }
-
-        private void nudLevel_ValueChanged(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex >= 0)
-            {
-                mEditorItem.Spells[lstSpells.SelectedIndex].Level = (int) nudLevel.Value;
-
-                UpdateSpellList();
-            }
-        }
-
-        private void nudHPRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalRegen[(int) Vital.Health] = (int) nudHPRegen.Value;
-            UpdateIncreases();
-        }
-
-        private void nudMpRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalRegen[(int) Vital.Mana] = (int) nudMpRegen.Value;
-            UpdateIncreases();
-        }
-
-        private void nudDamage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Damage = (int) nudDamage.Value;
-        }
-
-        private void nudCritChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritChance = (int) nudCritChance.Value;
-        }
-
-        private void nudExpIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.ExpIncrease = (int) nudExpIncrease.Value;
-        }
-
-        private void nudHpIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalIncrease[(int) Vital.Health] = (int) nudHpIncrease.Value;
-        }
-
-        private void nudMpIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalIncrease[(int) Vital.Mana] = (int) nudMpIncrease.Value;
-        }
-
-        private void nudArmorIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatIncrease[(int) Stat.Defense] = (int) nudArmorIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudMagicResistIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatIncrease[(int) Stat.MagicResist] = (int) nudMagicResistIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudStrengthIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatIncrease[(int) Stat.Attack] = (int) nudStrengthIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudMagicIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatIncrease[(int) Stat.AbilityPower] = (int) nudMagicIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudSpeedIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatIncrease[(int) Stat.Speed] = (int) nudSpeedIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudPointsIncrease_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PointIncrease = (int) nudPointsIncrease.Value;
-            UpdateIncreases();
-        }
-
-        private void nudBaseExp_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseExp = (int) nudBaseExp.Value;
-        }
-
-        private void nudBaseHP_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseVital[(int) Vital.Health] = (int) nudBaseHP.Value;
-        }
-
-        private void nudBaseMana_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BaseVital[(int) Vital.Mana] = (int) nudBaseMana.Value;
-        }
-
-        private void UpdateSpawnItemValues(bool keepIndex = false)
-        {
-            var index = lstSpawnItems.SelectedIndex;
-            lstSpawnItems.Items.Clear();
-
-            var spawnItems = mEditorItem.Items.ToArray();
-            foreach (var spawnItem in spawnItems)
-            {
-                if (ItemBase.Get(spawnItem.Id) == null)
-                {
-                    mEditorItem.Items.Remove(spawnItem);
-                }
-            }
-
-            for (var i = 0; i < mEditorItem.Items.Count; i++)
-            {
-                if (mEditorItem.Items[i].Id != Guid.Empty)
-                {
-                    lstSpawnItems.Items.Add(
-                        Strings.ClassEditor.spawnitemdisplay.ToString(
-                            ItemBase.GetName(mEditorItem.Items[i].Id), mEditorItem.Items[i].Quantity
-                        )
-                    );
-                }
-                else
-                {
-                    lstSpawnItems.Items.Add(TextUtils.None);
-                }
-            }
-
-            if (keepIndex && index < lstSpawnItems.Items.Count)
-            {
-                lstSpawnItems.SelectedIndex = index;
-            }
-        }
-
-        private void cmbSpawnItem_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpawnItems.SelectedIndex > -1 && lstSpawnItems.SelectedIndex < mEditorItem.Items.Count)
-            {
-                mEditorItem.Items[lstSpawnItems.SelectedIndex].Id = ItemBase.IdFromList(cmbSpawnItem.SelectedIndex - 1);
-            }
-
-            UpdateSpawnItemValues(true);
-        }
-
-        private void nudSpawnItemAmount_ValueChanged(object sender, EventArgs e)
-        {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudSpawnItemAmount.Value = Math.Max(1, nudSpawnItemAmount.Value);
-
-            if (lstSpawnItems.SelectedIndex < lstSpawnItems.Items.Count)
-            {
-                return;
-            }
-
-            mEditorItem.Items[(int) lstSpawnItems.SelectedIndex].Quantity = (int) nudSpawnItemAmount.Value;
-            UpdateSpawnItemValues(true);
-        }
-
-        private void lstSpawnItems_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpawnItems.SelectedIndex > -1)
-            {
-                cmbSpawnItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Items[lstSpawnItems.SelectedIndex].Id) + 1;
-                nudSpawnItemAmount.Value = mEditorItem.Items[lstSpawnItems.SelectedIndex].Quantity;
-            }
-        }
-
-        private void btnSpawnItemAdd_Click(object sender, EventArgs e)
-        {
-            mEditorItem.Items.Add(new ClassItem());
-            mEditorItem.Items[mEditorItem.Items.Count - 1].Id = ItemBase.IdFromList(cmbSpawnItem.SelectedIndex - 1);
-            mEditorItem.Items[mEditorItem.Items.Count - 1].Quantity = (int) nudSpawnItemAmount.Value;
-
-            UpdateSpawnItemValues();
-        }
-
-        private void btnSpawnItemRemove_Click(object sender, EventArgs e)
-        {
-            if (lstSpawnItems.SelectedIndex > -1)
-            {
-                var i = lstSpawnItems.SelectedIndex;
-                lstSpawnItems.Items.RemoveAt(i);
-                mEditorItem.Items.RemoveAt(i);
-            }
-
-            UpdateSpawnItemValues(true);
-        }
-
-        private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritMultiplier = (double) nudCritMultiplier.Value;
-        }
-
-        private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
-            nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
-        }
-
-        private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedValue = (int) nudAttackSpeedValue.Value;
-        }
-
-        #region "Exp Grid"
-
-        private void btnExpGrid_Click(object sender, EventArgs e)
-        {
-            grpExpGrid.Show();
-            grpExpGrid.BringToFront();
-
-            expGrid.Rows.Clear();
-
-            for (var i = 1; i <= Options.MaxLevel; i++)
-            {
-                var index = expGrid.Rows.Add(i.ToString(), "", "");
-                var row = expGrid.Rows[index];
-                row.Cells[0].Style.SelectionBackColor = row.Cells[0].Style.BackColor;
-                row.Cells[2].Style.SelectionBackColor = row.Cells[2].Style.BackColor;
-            }
-
-            UpdateExpGridValues(1);
-        }
-
-        private void UpdateExpGridValues(int start, int end = -1)
-        {
-            if (end == -1)
-            {
-                end = Options.MaxLevel;
-            }
-
-            if (start > end)
-            {
-                return;
-            }
-
-            if (start < 1)
-            {
-                start = 1;
-            }
-
-            for (var i = start; i <= end; i++)
-            {
-                if (i < Options.MaxLevel)
-                {
-                    if (mEditorItem.ExperienceOverrides.ContainsKey(i))
-                    {
-                        expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(
-                            mEditorItem.ExperienceOverrides[i], expGrid.Rows[i - 1].Cells[1].ValueType
-                        );
-
-                        var style = expGrid.Rows[i - 1].Cells[1].InheritedStyle;
-                        style.Font = new Font(style.Font, FontStyle.Bold);
-                        expGrid.Rows[i - 1].Cells[1].Style.ApplyStyle(style);
-                    }
-                    else
-                    {
-                        expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(
-                            mEditorItem.ExperienceCurve.Calculate(i), expGrid.Rows[i - 1].Cells[1].ValueType
-                        );
-
-                        expGrid.Rows[i - 1].Cells[1].Style.ApplyStyle(expGrid.Rows[i - 1].Cells[0].InheritedStyle);
-                    }
-                }
-                else
-                {
-                    expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(0, expGrid.Rows[i - 1].Cells[1].ValueType);
-                    expGrid.Rows[i - 1].Cells[1].ReadOnly = true;
-                }
-
-                if (i == 1)
-                {
-                    expGrid.Rows[i - 1].Cells[2].Value = Convert.ChangeType(0, expGrid.Rows[i - 1].Cells[1].ValueType);
-                }
-                else
-                {
-                    expGrid.Rows[i - 1].Cells[2].Value = Convert.ChangeType(
-                        long.Parse(expGrid.Rows[i - 2].Cells[2].Value.ToString()) +
-                        long.Parse(expGrid.Rows[i - 2].Cells[1].Value.ToString()),
-                        expGrid.Rows[i - 1].Cells[2].ValueType
-                    );
-                }
-            }
-        }
-
-        private void btnCloseExpGrid_Click(object sender, EventArgs e)
-        {
-            grpExpGrid.Hide();
-        }
-
-        private void expGrid_CellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right &&
-                expGrid.CurrentCell != null &&
-                expGrid.CurrentCell.IsInEditMode == false)
-            {
-                var cell = expGrid.CurrentCell;
-                if (cell != null)
-                {
-                    var r = cell.DataGridView.GetCellDisplayRectangle(cell.ColumnIndex, cell.RowIndex, false);
-                    var p = new System.Drawing.Point(r.X + r.Width, r.Y + r.Height);
-                    mnuExpGrid.Show((DataGridView) sender, p);
-                }
-            }
-        }
-
-        private void expGrid_SelectionChanged(object sender, EventArgs e)
-        {
-            if (expGrid.Rows.Count <= 0)
-            {
-                return;
-            }
-
-            var sel = expGrid.SelectedCells;
-            if (sel.Count == 0)
-            {
-                expGrid.Rows[0].Cells[1].Selected = true;
+                lstSpawnItems.Items.Add(
+                    Strings.ClassEditor.spawnitemdisplay.ToString(
+                        ItemBase.GetName(mEditorItem.Items[i].Id), mEditorItem.Items[i].Quantity
+                    )
+                );
             }
             else
             {
-                var selection = sel[0];
-                if (selection.ColumnIndex != 1)
-                {
-                    expGrid.Rows[selection.RowIndex].Cells[1].Selected = true;
-                }
+                lstSpawnItems.Items.Add(TextUtils.None);
             }
         }
 
-        private void btnPaste_Click(object sender, EventArgs e)
+        if (keepIndex && index < lstSpawnItems.Items.Count)
         {
-            try
+            lstSpawnItems.SelectedIndex = index;
+        }
+    }
+
+    private void cmbSpawnItem_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpawnItems.SelectedIndex > -1 && lstSpawnItems.SelectedIndex < mEditorItem.Items.Count)
+        {
+            mEditorItem.Items[lstSpawnItems.SelectedIndex].Id = ItemBase.IdFromList(cmbSpawnItem.SelectedIndex - 1);
+        }
+
+        UpdateSpawnItemValues(true);
+    }
+
+    private void nudSpawnItemAmount_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving 0 items!
+        nudSpawnItemAmount.Value = Math.Max(1, nudSpawnItemAmount.Value);
+
+        if (lstSpawnItems.SelectedIndex < lstSpawnItems.Items.Count)
+        {
+            return;
+        }
+
+        mEditorItem.Items[(int) lstSpawnItems.SelectedIndex].Quantity = (int) nudSpawnItemAmount.Value;
+        UpdateSpawnItemValues(true);
+    }
+
+    private void lstSpawnItems_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpawnItems.SelectedIndex > -1)
+        {
+            cmbSpawnItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Items[lstSpawnItems.SelectedIndex].Id) + 1;
+            nudSpawnItemAmount.Value = mEditorItem.Items[lstSpawnItems.SelectedIndex].Quantity;
+        }
+    }
+
+    private void btnSpawnItemAdd_Click(object sender, EventArgs e)
+    {
+        mEditorItem.Items.Add(new ClassItem());
+        mEditorItem.Items[mEditorItem.Items.Count - 1].Id = ItemBase.IdFromList(cmbSpawnItem.SelectedIndex - 1);
+        mEditorItem.Items[mEditorItem.Items.Count - 1].Quantity = (int) nudSpawnItemAmount.Value;
+
+        UpdateSpawnItemValues();
+    }
+
+    private void btnSpawnItemRemove_Click(object sender, EventArgs e)
+    {
+        if (lstSpawnItems.SelectedIndex > -1)
+        {
+            var i = lstSpawnItems.SelectedIndex;
+            lstSpawnItems.Items.RemoveAt(i);
+            mEditorItem.Items.RemoveAt(i);
+        }
+
+        UpdateSpawnItemValues(true);
+    }
+
+    private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritMultiplier = (double) nudCritMultiplier.Value;
+    }
+
+    private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
+        nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
+    }
+
+    private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedValue = (int) nudAttackSpeedValue.Value;
+    }
+
+    #region "Exp Grid"
+
+    private void btnExpGrid_Click(object sender, EventArgs e)
+    {
+        grpExpGrid.Show();
+        grpExpGrid.BringToFront();
+
+        expGrid.Rows.Clear();
+
+        for (var i = 1; i <= Options.MaxLevel; i++)
+        {
+            var index = expGrid.Rows.Add(i.ToString(), "", "");
+            var row = expGrid.Rows[index];
+            row.Cells[0].Style.SelectionBackColor = row.Cells[0].Style.BackColor;
+            row.Cells[2].Style.SelectionBackColor = row.Cells[2].Style.BackColor;
+        }
+
+        UpdateExpGridValues(1);
+    }
+
+    private void UpdateExpGridValues(int start, int end = -1)
+    {
+        if (end == -1)
+        {
+            end = Options.MaxLevel;
+        }
+
+        if (start > end)
+        {
+            return;
+        }
+
+        if (start < 1)
+        {
+            start = 1;
+        }
+
+        for (var i = start; i <= end; i++)
+        {
+            if (i < Options.MaxLevel)
             {
-                var s = Clipboard.GetText();
-                var lines = s.Split('\n');
-                int iFail = 0, iRow = expGrid.CurrentCell.RowIndex;
-                var iCol = expGrid.CurrentCell.ColumnIndex;
-                DataGridViewCell oCell;
-                foreach (var line in lines)
+                if (mEditorItem.ExperienceOverrides.ContainsKey(i))
                 {
-                    if (iRow < expGrid.RowCount && line.Length > 0)
+                    expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(
+                        mEditorItem.ExperienceOverrides[i], expGrid.Rows[i - 1].Cells[1].ValueType
+                    );
+
+                    var style = expGrid.Rows[i - 1].Cells[1].InheritedStyle;
+                    style.Font = new Font(style.Font, FontStyle.Bold);
+                    expGrid.Rows[i - 1].Cells[1].Style.ApplyStyle(style);
+                }
+                else
+                {
+                    expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(
+                        mEditorItem.ExperienceCurve.Calculate(i), expGrid.Rows[i - 1].Cells[1].ValueType
+                    );
+
+                    expGrid.Rows[i - 1].Cells[1].Style.ApplyStyle(expGrid.Rows[i - 1].Cells[0].InheritedStyle);
+                }
+            }
+            else
+            {
+                expGrid.Rows[i - 1].Cells[1].Value = Convert.ChangeType(0, expGrid.Rows[i - 1].Cells[1].ValueType);
+                expGrid.Rows[i - 1].Cells[1].ReadOnly = true;
+            }
+
+            if (i == 1)
+            {
+                expGrid.Rows[i - 1].Cells[2].Value = Convert.ChangeType(0, expGrid.Rows[i - 1].Cells[1].ValueType);
+            }
+            else
+            {
+                expGrid.Rows[i - 1].Cells[2].Value = Convert.ChangeType(
+                    long.Parse(expGrid.Rows[i - 2].Cells[2].Value.ToString()) +
+                    long.Parse(expGrid.Rows[i - 2].Cells[1].Value.ToString()),
+                    expGrid.Rows[i - 1].Cells[2].ValueType
+                );
+            }
+        }
+    }
+
+    private void btnCloseExpGrid_Click(object sender, EventArgs e)
+    {
+        grpExpGrid.Hide();
+    }
+
+    private void expGrid_CellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Right &&
+            expGrid.CurrentCell != null &&
+            expGrid.CurrentCell.IsInEditMode == false)
+        {
+            var cell = expGrid.CurrentCell;
+            if (cell != null)
+            {
+                var r = cell.DataGridView.GetCellDisplayRectangle(cell.ColumnIndex, cell.RowIndex, false);
+                var p = new System.Drawing.Point(r.X + r.Width, r.Y + r.Height);
+                mnuExpGrid.Show((DataGridView) sender, p);
+            }
+        }
+    }
+
+    private void expGrid_SelectionChanged(object sender, EventArgs e)
+    {
+        if (expGrid.Rows.Count <= 0)
+        {
+            return;
+        }
+
+        var sel = expGrid.SelectedCells;
+        if (sel.Count == 0)
+        {
+            expGrid.Rows[0].Cells[1].Selected = true;
+        }
+        else
+        {
+            var selection = sel[0];
+            if (selection.ColumnIndex != 1)
+            {
+                expGrid.Rows[selection.RowIndex].Cells[1].Selected = true;
+            }
+        }
+    }
+
+    private void btnPaste_Click(object sender, EventArgs e)
+    {
+        try
+        {
+            var s = Clipboard.GetText();
+            var lines = s.Split('\n');
+            int iFail = 0, iRow = expGrid.CurrentCell.RowIndex;
+            var iCol = expGrid.CurrentCell.ColumnIndex;
+            DataGridViewCell oCell;
+            foreach (var line in lines)
+            {
+                if (iRow < expGrid.RowCount && line.Length > 0)
+                {
+                    var sCells = line.Split('\t');
+                    for (var i = 0; i < 1; ++i)
                     {
-                        var sCells = line.Split('\t');
-                        for (var i = 0; i < 1; ++i)
+                        if (iCol + i < this.expGrid.ColumnCount)
                         {
-                            if (iCol + i < this.expGrid.ColumnCount)
+                            oCell = expGrid[iCol + i, iRow];
+                            if (!oCell.ReadOnly)
                             {
-                                oCell = expGrid[iCol + i, iRow];
-                                if (!oCell.ReadOnly)
+                                if (oCell.Value.ToString() != sCells[i])
                                 {
-                                    if (oCell.Value.ToString() != sCells[i])
+                                    var val = 0;
+                                    if (int.TryParse(sCells[i], out val))
                                     {
-                                        var val = 0;
-                                        if (int.TryParse(sCells[i], out val))
+                                        if (val > 0)
                                         {
-                                            if (val > 0)
-                                            {
-                                                oCell.Value = Convert.ChangeType(val.ToString(), oCell.ValueType);
-                                            }
+                                            oCell.Value = Convert.ChangeType(val.ToString(), oCell.ValueType);
                                         }
                                     }
-                                    else
-                                    {
-                                        iFail++;
-                                    }
-
-                                    //only traps a fail if the data has changed
-                                    //and you are pasting into a read only cell
                                 }
-                            }
-                            else
-                            {
-                                break;
+                                else
+                                {
+                                    iFail++;
+                                }
+
+                                //only traps a fail if the data has changed
+                                //and you are pasting into a read only cell
                             }
                         }
-
-                        iRow++;
+                        else
+                        {
+                            break;
+                        }
                     }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                return;
-            }
-        }
 
-        private void expGrid_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
-        {
-            e.Control.KeyPress -= new KeyPressEventHandler(expGrid_KeyPress);
-            var tb = e.Control as TextBox;
-            if (tb != null)
-            {
-                tb.KeyPress += new KeyPressEventHandler(expGrid_KeyPress);
-            }
-        }
-
-        private void expGrid_KeyPress(object sender, KeyPressEventArgs e)
-        {
-            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
-            {
-                e.Handled = true;
-            }
-        }
-
-        private void expGrid_CellEndEdit(object sender, DataGridViewCellEventArgs e)
-        {
-            var cell = expGrid.Rows[e.RowIndex].Cells[e.ColumnIndex];
-            long val = 0;
-            if (long.TryParse(cell.Value.ToString(), out val))
-            {
-                if (val == 0 || val == mEditorItem.ExperienceCurve.Calculate(e.RowIndex + 1))
-                {
-                    if (mEditorItem.ExperienceOverrides.ContainsKey(e.RowIndex + 1))
-                    {
-                        mEditorItem.ExperienceOverrides.Remove(e.RowIndex + 1);
-                    }
+                    iRow++;
                 }
                 else
                 {
-                    if (!mEditorItem.ExperienceOverrides.ContainsKey(e.RowIndex + 1))
-                    {
-                        mEditorItem.ExperienceOverrides.Add(e.RowIndex + 1, val);
-                    }
-                    else
-                    {
-                        mEditorItem.ExperienceOverrides[e.RowIndex + 1] = val;
-                    }
+                    break;
                 }
+            }
+        }
+        catch (Exception)
+        {
+            return;
+        }
+    }
 
-                UpdateExpGridValues(e.RowIndex + 1);
+    private void expGrid_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
+    {
+        e.Control.KeyPress -= new KeyPressEventHandler(expGrid_KeyPress);
+        var tb = e.Control as TextBox;
+        if (tb != null)
+        {
+            tb.KeyPress += new KeyPressEventHandler(expGrid_KeyPress);
+        }
+    }
+
+    private void expGrid_KeyPress(object sender, KeyPressEventArgs e)
+    {
+        if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void expGrid_CellEndEdit(object sender, DataGridViewCellEventArgs e)
+    {
+        var cell = expGrid.Rows[e.RowIndex].Cells[e.ColumnIndex];
+        long val = 0;
+        if (long.TryParse(cell.Value.ToString(), out val))
+        {
+            if (val == 0 || val == mEditorItem.ExperienceCurve.Calculate(e.RowIndex + 1))
+            {
+                if (mEditorItem.ExperienceOverrides.ContainsKey(e.RowIndex + 1))
+                {
+                    mEditorItem.ExperienceOverrides.Remove(e.RowIndex + 1);
+                }
             }
             else
             {
-                UpdateExpGridValues(e.RowIndex + 1, e.RowIndex + 2);
-            }
-        }
-
-        private void btnResetExpGrid_Click(object sender, EventArgs e)
-        {
-            mEditorItem.ExperienceOverrides.Clear();
-            UpdateExpGridValues(1);
-        }
-
-        private void expGrid_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Delete)
-            {
-                if (expGrid.CurrentCell != null)
+                if (!mEditorItem.ExperienceOverrides.ContainsKey(e.RowIndex + 1))
                 {
-                    if (!expGrid.CurrentCell.IsInEditMode && expGrid.CurrentCell.ReadOnly == false)
+                    mEditorItem.ExperienceOverrides.Add(e.RowIndex + 1, val);
+                }
+                else
+                {
+                    mEditorItem.ExperienceOverrides[e.RowIndex + 1] = val;
+                }
+            }
+
+            UpdateExpGridValues(e.RowIndex + 1);
+        }
+        else
+        {
+            UpdateExpGridValues(e.RowIndex + 1, e.RowIndex + 2);
+        }
+    }
+
+    private void btnResetExpGrid_Click(object sender, EventArgs e)
+    {
+        mEditorItem.ExperienceOverrides.Clear();
+        UpdateExpGridValues(1);
+    }
+
+    private void expGrid_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Delete)
+        {
+            if (expGrid.CurrentCell != null)
+            {
+                if (!expGrid.CurrentCell.IsInEditMode && expGrid.CurrentCell.ReadOnly == false)
+                {
+                    var level = expGrid.CurrentCell.RowIndex + 1;
+                    if (mEditorItem.ExperienceOverrides.ContainsKey(level))
                     {
-                        var level = expGrid.CurrentCell.RowIndex + 1;
-                        if (mEditorItem.ExperienceOverrides.ContainsKey(level))
-                        {
-                            mEditorItem.ExperienceOverrides.Remove(level);
-                        }
-
-                        UpdateExpGridValues(level);
+                        mEditorItem.ExperienceOverrides.Remove(level);
                     }
+
+                    UpdateExpGridValues(level);
                 }
             }
         }
+    }
 
-        #endregion
+    #endregion
 
-        #region "Item List - Folders, Searching, Sorting, Etc"
+    #region "Item List - Folders, Searching, Sorting, Etc"
 
-        private void btnAddFolder_Click(object sender, EventArgs e)
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ClassEditor.folderprompt, Strings.ClassEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ClassEditor.folderprompt, Strings.ClassEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
         }
+    }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
 
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
 
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.ClassEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.ClassEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.ClassEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.ClassEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.ClassEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.ClassEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.ClassEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmCommonEvent.cs
+++ b/Intersect.Editor/Forms/Editors/frmCommonEvent.cs
@@ -7,272 +7,270 @@ using Intersect.Editor.Networking;
 using Intersect.Enums;
 using Intersect.GameObjects.Events;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmCommonEvent : EditorForm
 {
 
-    public partial class FrmCommonEvent : EditorForm
+    private string mCopiedItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmCommonEvent()
     {
+        ApplyHooks();
+        InitializeComponent();
+        InitLocalization();
+        InitEditor();
 
-        private string mCopiedItem;
+        lstGameObjects.NodeMouseDoubleClick += lstGameObjects_NodeMouseDoubleClick;
+        lstGameObjects.AfterSelect += lstGameObjects_AfterSelect;
+        lstGameObjects.Init(null, null, toolStripItemNew_Click, toolStripItemCopy_Click, null, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
 
-        private List<string> mKnownFolders = new List<string>();
+    private void InitLocalization()
+    {
+        Text = Strings.CommonEventEditor.title;
+        grpCommonEvents.Text = Strings.CommonEventEditor.events;
+        toolStripItemNew.Text = Strings.CommonEventEditor.New;
+        toolStripItemDelete.Text = Strings.CommonEventEditor.delete;
+        toolStripItemCopy.Text = Strings.CommonEventEditor.copy;
+        toolStripItemPaste.Text = Strings.CommonEventEditor.paste;
 
-        public FrmCommonEvent()
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.CommonEventEditor.sortalphabetically;
+        txtSearch.Text = Strings.CommonEventEditor.searchplaceholder;
+        lblFolder.Text = Strings.CommonEventEditor.folderlabel;
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Event)
         {
-            ApplyHooks();
-            InitializeComponent();
-            InitLocalization();
             InitEditor();
-
-            lstGameObjects.NodeMouseDoubleClick += lstGameObjects_NodeMouseDoubleClick;
-            lstGameObjects.AfterSelect += lstGameObjects_AfterSelect;
-            lstGameObjects.Init(null, null, toolStripItemNew_Click, toolStripItemCopy_Click, null, toolStripItemPaste_Click, toolStripItemDelete_Click);
         }
+    }
 
-        private void InitLocalization()
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Event);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode?.Tag != null &&
+            EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag) != null)
         {
-            Text = Strings.CommonEventEditor.title;
-            grpCommonEvents.Text = Strings.CommonEventEditor.events;
-            toolStripItemNew.Text = Strings.CommonEventEditor.New;
-            toolStripItemDelete.Text = Strings.CommonEventEditor.delete;
-            toolStripItemCopy.Text = Strings.CommonEventEditor.copy;
-            toolStripItemPaste.Text = Strings.CommonEventEditor.paste;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.CommonEventEditor.sortalphabetically;
-            txtSearch.Text = Strings.CommonEventEditor.searchplaceholder;
-            lblFolder.Text = Strings.CommonEventEditor.folderlabel;
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Event)
+            if (MessageBox.Show(
+                    Strings.CommonEventEditor.deleteprompt, Strings.CommonEventEditor.delete,
+                    MessageBoxButtons.YesNo
+                ) ==
+                DialogResult.Yes)
             {
+                PacketSender.SendDeleteObject(EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag));
+            }
+        }
+    }
+
+    private void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in EventBase.Lookup)
+        {
+            if (((EventBase)itm.Value).CommonEvent)
+            {
+                if (!string.IsNullOrEmpty(((EventBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((EventBase)itm.Value).Folder))
+                {
+                    mFolders.Add(((EventBase)itm.Value).Folder);
+                    if (!mKnownFolders.Contains(((EventBase)itm.Value).Folder))
+                    {
+                        mKnownFolders.Add(((EventBase)itm.Value).Folder);
+                    }
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = EventBase.Lookup.Where(pair => ((EventBase)pair.Value)?.CommonEvent ?? false).OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((EventBase)pair.Value)?.Name ?? Models.DatabaseObject<EventBase>.Deleted, ((EventBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void frmCommonEvent_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        var evt = GetSelectedEvent();
+        if (evt != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = evt.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        var evt = GetSelectedEvent();
+        if (evt != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            if (MessageBox.Show(
+                    Strings.CommonEventEditor.pasteprompt, Strings.CommonEventEditor.pastetitle,
+                    MessageBoxButtons.YesNo
+                ) ==
+                DialogResult.Yes)
+            {
+                evt.Load(mCopiedItem, true);
+                PacketSender.SendSaveObject(evt);
                 InitEditor();
             }
         }
+    }
 
-        private void toolStripItemNew_Click(object sender, EventArgs e)
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    private EventBase GetSelectedEvent()
+    {
+        if (lstGameObjects.SelectedNode == null || lstGameObjects.SelectedNode.Tag == null)
         {
-            PacketSender.SendCreateObject(GameObjectType.Event);
+            return null;
         }
 
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
+        return EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.CommonEventEditor.folderprompt, Strings.CommonEventEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            if (lstGameObjects.SelectedNode?.Tag != null &&
-                EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag) != null)
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                if (MessageBox.Show(
-                        Strings.CommonEventEditor.deleteprompt, Strings.CommonEventEditor.delete,
-                        MessageBoxButtons.YesNo
-                    ) ==
-                    DialogResult.Yes)
+                var evt = GetSelectedEvent();
+                if (evt != null)
                 {
-                    PacketSender.SendDeleteObject(EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag));
-                }
-            }
-        }
-
-        private void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in EventBase.Lookup)
-            {
-                if (((EventBase)itm.Value).CommonEvent)
-                {
-                    if (!string.IsNullOrEmpty(((EventBase)itm.Value).Folder) &&
-                        !mFolders.Contains(((EventBase)itm.Value).Folder))
-                    {
-                        mFolders.Add(((EventBase)itm.Value).Folder);
-                        if (!mKnownFolders.Contains(((EventBase)itm.Value).Folder))
-                        {
-                            mKnownFolders.Add(((EventBase)itm.Value).Folder);
-                        }
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = EventBase.Lookup.Where(pair => ((EventBase)pair.Value)?.CommonEvent ?? false).OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((EventBase)pair.Value)?.Name ?? Models.DatabaseObject<EventBase>.Deleted, ((EventBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void frmCommonEvent_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            var evt = GetSelectedEvent();
-            if (evt != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = evt.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            var evt = GetSelectedEvent();
-            if (evt != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                if (MessageBox.Show(
-                        Strings.CommonEventEditor.pasteprompt, Strings.CommonEventEditor.pastetitle,
-                        MessageBoxButtons.YesNo
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    evt.Load(mCopiedItem, true);
+                    evt.Folder = folderName;
                     PacketSender.SendSaveObject(evt);
-                    InitEditor();
                 }
+
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
         }
+    }
 
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        private EventBase GetSelectedEvent()
+    private void lstGameObjects_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        if (lstGameObjects.SelectedNode == null || lstGameObjects.SelectedNode.Tag == null)
         {
-            if (lstGameObjects.SelectedNode == null || lstGameObjects.SelectedNode.Tag == null)
-            {
-                return null;
-            }
-
-            return EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+            return;
         }
 
-        private void btnAddFolder_Click(object sender, EventArgs e)
+        var editor = new FrmEvent(null)
         {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.CommonEventEditor.folderprompt, Strings.CommonEventEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
+            MyEvent = EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag)
+        };
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    var evt = GetSelectedEvent();
-                    if (evt != null)
-                    {
-                        evt.Folder = folderName;
-                        PacketSender.SendSaveObject(evt);
-                    }
+        editor.InitEditor(false, false, false);
+        editor.ShowDialog();
+        InitEditor();
+        Globals.MainForm.BringToFront();
+        BringToFront();
+    }
 
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var evt = GetSelectedEvent();
+        if (evt != null)
+        {
+            evt.Folder = cmbFolder.Text;
+            PacketSender.SendSaveObject(evt);
         }
 
-        private void lstGameObjects_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
-        {
-            if (lstGameObjects.SelectedNode == null || lstGameObjects.SelectedNode.Tag == null)
-            {
-                return;
-            }
+        InitEditor();
+    }
 
-            var editor = new FrmEvent(null)
-            {
-                MyEvent = EventBase.Get((Guid) lstGameObjects.SelectedNode.Tag)
-            };
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
 
-            editor.InitEditor(false, false, false);
-            editor.ShowDialog();
-            InitEditor();
-            Globals.MainForm.BringToFront();
-            BringToFront();
-        }
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            var evt = GetSelectedEvent();
-            if (evt != null)
-            {
-                evt.Folder = cmbFolder.Text;
-                PacketSender.SendSaveObject(evt);
-            }
-
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.CommonEventEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.CommonEventEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.CommonEventEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.CommonEventEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        private void lstGameObjects_AfterSelect(object sender, EventArgs e)
-        {
-            var evt = GetSelectedEvent();
-            toolStripItemDelete.Enabled = false;
-            toolStripItemCopy.Enabled = false;
-            toolStripItemPaste.Enabled = false;
-            cmbFolder.Hide();
-            btnAddFolder.Hide();
-            lblFolder.Hide();
-            if (evt != null)
-            {
-                cmbFolder.Text = evt.Folder;
-                toolStripItemDelete.Enabled = true;
-                toolStripItemCopy.Enabled = true;
-                toolStripItemPaste.Enabled = mCopiedItem != null;
-                cmbFolder.Show();
-                btnAddFolder.Show();
-                lblFolder.Show();
-            }
-        }
-
-        #endregion
-
     }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.CommonEventEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.CommonEventEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.CommonEventEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    private void lstGameObjects_AfterSelect(object sender, EventArgs e)
+    {
+        var evt = GetSelectedEvent();
+        toolStripItemDelete.Enabled = false;
+        toolStripItemCopy.Enabled = false;
+        toolStripItemPaste.Enabled = false;
+        cmbFolder.Hide();
+        btnAddFolder.Hide();
+        lblFolder.Hide();
+        if (evt != null)
+        {
+            cmbFolder.Text = evt.Folder;
+            toolStripItemDelete.Enabled = true;
+            toolStripItemCopy.Enabled = true;
+            toolStripItemPaste.Enabled = mCopiedItem != null;
+            cmbFolder.Show();
+            btnAddFolder.Show();
+            lblFolder.Show();
+        }
+    }
+
+    #endregion
 
 }

--- a/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
+++ b/Intersect.Editor/Forms/Editors/frmCraftingTables.cs
@@ -8,376 +8,374 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Crafting;
 using Intersect.Models;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmCraftingTables : EditorForm
 {
 
-    public partial class FrmCraftingTables : EditorForm
+    private List<CraftingTableBase> mChanged = new List<CraftingTableBase>();
+
+    private string mCopiedItem;
+
+    private CraftingTableBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmCraftingTables()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<CraftingTableBase> mChanged = new List<CraftingTableBase>();
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = CraftingTableBase.Get(id);
+        UpdateEditor();
+    }
 
-        private string mCopiedItem;
-
-        private CraftingTableBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        public FrmCraftingTables()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.CraftTables)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = CraftingTableBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.CraftTables)
+            InitEditor();
+            if (mEditorItem != null && !DatabaseObject<CraftingTableBase>.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !DatabaseObject<CraftingTableBase>.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-
-                cmbFolder.Text = mEditorItem.Folder;
-
-                UpdateList();
-
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.CraftTables);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.CraftingTableEditor.deleteprompt, Strings.CraftingTableEditor.delete,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
+                mEditorItem = null;
                 UpdateEditor();
             }
         }
-
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.CraftingTableEditor.undoprompt, Strings.CraftingTableEditor.undotitle,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void lstGameObjects_FocusChanged(object sender, EventArgs e)
-        {
-            UpdateToolStripItems();
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void frmCrafting_Load(object sender, EventArgs e)
-        {
-            cmbCrafts.Items.Clear();
-            cmbCrafts.Items.AddRange(CraftBase.Names);
-
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.CraftingTableEditor.title;
-            toolStripItemNew.Text = Strings.CraftingTableEditor.New;
-            toolStripItemDelete.Text = Strings.CraftingTableEditor.delete;
-            toolStripItemCopy.Text = Strings.CraftingTableEditor.copy;
-            toolStripItemPaste.Text = Strings.CraftingTableEditor.paste;
-            toolStripItemUndo.Text = Strings.CraftingTableEditor.undo;
-
-            grpTables.Text = Strings.CraftingTableEditor.tables;
-            grpCrafts.Text = Strings.CraftingTableEditor.crafts;
-
-            lblAddCraftedItem.Text = Strings.CraftingTableEditor.addcraftlabel;
-            btnAddCraftedItem.Text = Strings.CraftingTableEditor.add;
-            btnRemoveCraftedItem.Text = Strings.CraftingTableEditor.remove;
-
-            grpGeneral.Text = Strings.CraftingTableEditor.general;
-            lblName.Text = Strings.CraftingTableEditor.name;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.CraftingTableEditor.sortalphabetically;
-            txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
-            lblFolder.Text = Strings.CraftingTableEditor.folderlabel;
-
-            btnSave.Text = Strings.CraftingTableEditor.save;
-            btnCancel.Text = Strings.CraftingTableEditor.cancel;
-        }
-
-        public void UpdateList()
-        {
-            lstCrafts.Items.Clear();
-            foreach (var id in mEditorItem.Crafts)
-            {
-                lstCrafts.Items.Add(CraftBase.GetName(id));
-            }
-        }
-
-        private void btnAddCraftedItem_Click(object sender, EventArgs e)
-        {
-            var id = CraftBase.IdFromList(cmbCrafts.SelectedIndex);
-            var craft = CraftBase.Get(id);
-            if (craft != null && !mEditorItem.Crafts.Contains(id))
-            {
-                mEditorItem.Crafts.Add(id);
-                UpdateList();
-            }
-        }
-
-        private void btnRemoveCraftedItem_Click(object sender, EventArgs e)
-        {
-            if (lstCrafts.SelectedIndex > -1)
-            {
-                mEditorItem.Crafts.RemoveAt(lstCrafts.SelectedIndex);
-                UpdateList();
-            }
-        }
-
-        private void btnCraftUp_Click(object sender, EventArgs e)
-        {
-            if (lstCrafts.SelectedIndex > 0 && lstCrafts.Items.Count > 1)
-            {
-                var index = lstCrafts.SelectedIndex;
-                var swapWith = mEditorItem.Crafts[index - 1];
-                mEditorItem.Crafts[index - 1] = mEditorItem.Crafts[index];
-                mEditorItem.Crafts[index] = swapWith;
-                UpdateList();
-                lstCrafts.SelectedIndex = index - 1;
-            }
-        }
-
-        private void btnCraftDown_Click(object sender, EventArgs e)
-        {
-            if (lstCrafts.SelectedIndex > -1 && lstCrafts.SelectedIndex + 1 != lstCrafts.Items.Count)
-            {
-                var index = lstCrafts.SelectedIndex;
-                var swapWith = mEditorItem.Crafts[index + 1];
-                mEditorItem.Crafts[index + 1] = mEditorItem.Crafts[index];
-                mEditorItem.Crafts[index] = swapWith;
-                UpdateList();
-                lstCrafts.SelectedIndex = index + 1;
-            }
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in CraftingTableBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((CraftingTableBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((CraftingTableBase) itm.Value).Folder))
-                {
-                    mFolders.Add(((CraftingTableBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((CraftingTableBase) itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((CraftingTableBase) itm.Value).Folder);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = CraftingTableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((CraftingTableBase)pair.Value)?.Name ?? Models.DatabaseObject<CraftingTableBase>.Deleted, ((CraftingTableBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.CraftingTableEditor.folderprompt, Strings.CraftingTableEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.CraftingTableEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.CraftingTableEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+
+            cmbFolder.Text = mEditorItem.Folder;
+
+            UpdateList();
+
+            if (mChanged.IndexOf(mEditorItem) == -1)
+            {
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.CraftTables);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.CraftingTableEditor.deleteprompt, Strings.CraftingTableEditor.delete,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.CraftingTableEditor.undoprompt, Strings.CraftingTableEditor.undotitle,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void lstGameObjects_FocusChanged(object sender, EventArgs e)
+    {
+        UpdateToolStripItems();
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void frmCrafting_Load(object sender, EventArgs e)
+    {
+        cmbCrafts.Items.Clear();
+        cmbCrafts.Items.AddRange(CraftBase.Names);
+
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.CraftingTableEditor.title;
+        toolStripItemNew.Text = Strings.CraftingTableEditor.New;
+        toolStripItemDelete.Text = Strings.CraftingTableEditor.delete;
+        toolStripItemCopy.Text = Strings.CraftingTableEditor.copy;
+        toolStripItemPaste.Text = Strings.CraftingTableEditor.paste;
+        toolStripItemUndo.Text = Strings.CraftingTableEditor.undo;
+
+        grpTables.Text = Strings.CraftingTableEditor.tables;
+        grpCrafts.Text = Strings.CraftingTableEditor.crafts;
+
+        lblAddCraftedItem.Text = Strings.CraftingTableEditor.addcraftlabel;
+        btnAddCraftedItem.Text = Strings.CraftingTableEditor.add;
+        btnRemoveCraftedItem.Text = Strings.CraftingTableEditor.remove;
+
+        grpGeneral.Text = Strings.CraftingTableEditor.general;
+        lblName.Text = Strings.CraftingTableEditor.name;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.CraftingTableEditor.sortalphabetically;
+        txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
+        lblFolder.Text = Strings.CraftingTableEditor.folderlabel;
+
+        btnSave.Text = Strings.CraftingTableEditor.save;
+        btnCancel.Text = Strings.CraftingTableEditor.cancel;
+    }
+
+    public void UpdateList()
+    {
+        lstCrafts.Items.Clear();
+        foreach (var id in mEditorItem.Crafts)
+        {
+            lstCrafts.Items.Add(CraftBase.GetName(id));
+        }
+    }
+
+    private void btnAddCraftedItem_Click(object sender, EventArgs e)
+    {
+        var id = CraftBase.IdFromList(cmbCrafts.SelectedIndex);
+        var craft = CraftBase.Get(id);
+        if (craft != null && !mEditorItem.Crafts.Contains(id))
+        {
+            mEditorItem.Crafts.Add(id);
+            UpdateList();
+        }
+    }
+
+    private void btnRemoveCraftedItem_Click(object sender, EventArgs e)
+    {
+        if (lstCrafts.SelectedIndex > -1)
+        {
+            mEditorItem.Crafts.RemoveAt(lstCrafts.SelectedIndex);
+            UpdateList();
+        }
+    }
+
+    private void btnCraftUp_Click(object sender, EventArgs e)
+    {
+        if (lstCrafts.SelectedIndex > 0 && lstCrafts.Items.Count > 1)
+        {
+            var index = lstCrafts.SelectedIndex;
+            var swapWith = mEditorItem.Crafts[index - 1];
+            mEditorItem.Crafts[index - 1] = mEditorItem.Crafts[index];
+            mEditorItem.Crafts[index] = swapWith;
+            UpdateList();
+            lstCrafts.SelectedIndex = index - 1;
+        }
+    }
+
+    private void btnCraftDown_Click(object sender, EventArgs e)
+    {
+        if (lstCrafts.SelectedIndex > -1 && lstCrafts.SelectedIndex + 1 != lstCrafts.Items.Count)
+        {
+            var index = lstCrafts.SelectedIndex;
+            var swapWith = mEditorItem.Crafts[index + 1];
+            mEditorItem.Crafts[index + 1] = mEditorItem.Crafts[index];
+            mEditorItem.Crafts[index] = swapWith;
+            UpdateList();
+            lstCrafts.SelectedIndex = index + 1;
+        }
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in CraftingTableBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((CraftingTableBase) itm.Value).Folder) &&
+                !mFolders.Contains(((CraftingTableBase) itm.Value).Folder))
+            {
+                mFolders.Add(((CraftingTableBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((CraftingTableBase) itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((CraftingTableBase) itm.Value).Folder);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = CraftingTableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((CraftingTableBase)pair.Value)?.Name ?? Models.DatabaseObject<CraftingTableBase>.Deleted, ((CraftingTableBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.CraftingTableEditor.folderprompt, Strings.CraftingTableEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.CraftingTableEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.CraftingTableEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.CraftingTableEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmCrafts.cs
+++ b/Intersect.Editor/Forms/Editors/frmCrafts.cs
@@ -9,575 +9,573 @@ using Intersect.GameObjects.Crafting;
 using Intersect.GameObjects.Events;
 using Intersect.Models;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmCrafts : EditorForm
 {
 
-    public partial class FrmCrafts : EditorForm
+    private List<CraftBase> mChanged = new List<CraftBase>();
+
+    private string mCopiedItem;
+
+    private CraftBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private bool updatingIngedients = false;
+
+    public FrmCrafts()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<CraftBase> mChanged = new List<CraftBase>();
+        lstGameObjects.LostFocus += itemList_FocusChanged;
+        lstGameObjects.GotFocus += itemList_FocusChanged;
+        cmbResult.Items.Clear();
+        cmbResult.Items.Add(Strings.General.None);
+        cmbResult.Items.AddRange(ItemBase.Names);
+        cmbIngredient.Items.Clear();
+        cmbIngredient.Items.Add(Strings.General.None);
+        cmbIngredient.Items.AddRange(ItemBase.Names);
+        cmbEvent.Items.Clear();
+        cmbEvent.Items.Add(Strings.General.None);
+        cmbEvent.Items.AddRange(EventBase.Names);
 
-        private string mCopiedItem;
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = CraftBase.Get(id);
+        UpdateEditor();
+    }
 
-        private CraftBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        private bool updatingIngedients = false;
-
-        public FrmCrafts()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Crafts)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.LostFocus += itemList_FocusChanged;
-            lstGameObjects.GotFocus += itemList_FocusChanged;
-            cmbResult.Items.Clear();
-            cmbResult.Items.Add(Strings.General.None);
-            cmbResult.Items.AddRange(ItemBase.Names);
-            cmbIngredient.Items.Clear();
-            cmbIngredient.Items.Add(Strings.General.None);
-            cmbIngredient.Items.AddRange(ItemBase.Names);
-            cmbEvent.Items.Clear();
-            cmbEvent.Items.Add(Strings.General.None);
-            cmbEvent.Items.AddRange(EventBase.Names);
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = CraftBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Crafts)
+            InitEditor();
+            if (mEditorItem != null && !DatabaseObject<CraftBase>.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !DatabaseObject<CraftBase>.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
+    }
 
-        private void UpdateEditor()
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
         {
-            if (mEditorItem != null)
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+
+            cmbFolder.Text = mEditorItem.Folder;
+
+            //Populate ingredients and such
+            nudSpeed.Value = mEditorItem.Time;
+            nudFailureChance.Value = mEditorItem.FailureChance;
+            nudItemLossChance.Value = mEditorItem.ItemLossChance;
+            cmbResult.SelectedIndex = ItemBase.ListIndex(mEditorItem.ItemId) + 1;
+
+            nudCraftQuantity.Value = mEditorItem.Quantity;
+
+            lstIngredients.Items.Clear();
+            cmbIngredient.Hide();
+            nudQuantity.Hide();
+            lblQuantity.Hide();
+            lblIngredient.Hide();
+            for (var i = 0; i < mEditorItem.Ingredients.Count; i++)
             {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-
-                cmbFolder.Text = mEditorItem.Folder;
-
-                //Populate ingredients and such
-                nudSpeed.Value = mEditorItem.Time;
-                nudFailureChance.Value = mEditorItem.FailureChance;
-                nudItemLossChance.Value = mEditorItem.ItemLossChance;
-                cmbResult.SelectedIndex = ItemBase.ListIndex(mEditorItem.ItemId) + 1;
-
-                nudCraftQuantity.Value = mEditorItem.Quantity;
-
-                lstIngredients.Items.Clear();
-                cmbIngredient.Hide();
-                nudQuantity.Hide();
-                lblQuantity.Hide();
-                lblIngredient.Hide();
-                for (var i = 0; i < mEditorItem.Ingredients.Count; i++)
+                if (mEditorItem.Ingredients[i].ItemId != Guid.Empty)
                 {
-                    if (mEditorItem.Ingredients[i].ItemId != Guid.Empty)
-                    {
-                        lstIngredients.Items.Add(
-                            Strings.CraftsEditor.ingredientlistitem.ToString(
-                                ItemBase.GetName(mEditorItem.Ingredients[i].ItemId), mEditorItem.Ingredients[i].Quantity
-                            )
-                        );
-                    }
-                    else
-                    {
-                        lstIngredients.Items.Add(
-                            Strings.CraftsEditor.ingredientlistitem.ToString(
-                                Strings.CraftsEditor.ingredientnone, mEditorItem.Ingredients[i].Quantity
-                            )
-                        );
-                    }
-                }
-
-                if (lstIngredients.Items.Count > 0)
-                {
-                    lstIngredients.SelectedIndex = 0;
-                    cmbIngredient.SelectedIndex =
-                        ItemBase.ListIndex(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId) + 1;
-
-                    nudQuantity.Value = mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity;
-                }
-
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-
-                cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void nudQuantity_ValueChanged(object sender, EventArgs e)
-        {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudQuantity.Value = Math.Max(1, nudQuantity.Value);
-
-            if (lstIngredients.SelectedIndex > -1)
-            {
-                mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity = (int) nudQuantity.Value;
-                updatingIngedients = true;
-                if (cmbIngredient.SelectedIndex > 0)
-                {
-                    lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    lstIngredients.Items.Add(
                         Strings.CraftsEditor.ingredientlistitem.ToString(
-                            ItemBase.GetName(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId),
-                            nudQuantity.Value
-                        );
+                            ItemBase.GetName(mEditorItem.Ingredients[i].ItemId), mEditorItem.Ingredients[i].Quantity
+                        )
+                    );
                 }
                 else
                 {
-                    lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    lstIngredients.Items.Add(
                         Strings.CraftsEditor.ingredientlistitem.ToString(
-                            Strings.CraftsEditor.ingredientnone, nudQuantity.Value
-                        );
+                            Strings.CraftsEditor.ingredientnone, mEditorItem.Ingredients[i].Quantity
+                        )
+                    );
                 }
-
-                updatingIngedients = false;
             }
-        }
 
-        private void nudSpeed_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Time = (int) nudSpeed.Value;
-        }
-
-        private void nudFailureChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.FailureChance = (int) nudFailureChance.Value;
-        }
-
-        private void nudItemLossChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.ItemLossChance = (int) nudItemLossChance.Value;
-        }
-
-        private void btnAdd_Click(object sender, EventArgs e)
-        {
-            mEditorItem.Ingredients.Add(new CraftIngredient(Guid.Empty, 1));
-            lstIngredients.Items.Add(Strings.General.None);
-            lstIngredients.SelectedIndex = lstIngredients.Items.Count - 1;
-            cmbIngredient_SelectedIndexChanged(null, null);
-        }
-
-        private void btnRemove_Click(object sender, EventArgs e)
-        {
             if (lstIngredients.Items.Count > 0)
             {
-                mEditorItem.Ingredients.RemoveAt(lstIngredients.SelectedIndex);
-                UpdateEditor();
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Crafts);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.CraftsEditor.deleteprompt, Strings.CraftsEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
-                UpdateEditor();
-            }
-        }
-
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.CraftsEditor.undoprompt, Strings.CraftsEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void itemList_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.Z)
-                {
-                    toolStripItemUndo_Click(null, null);
-                }
-                else if (e.KeyCode == Keys.V)
-                {
-                    toolStripItemPaste_Click(null, null);
-                }
-                else if (e.KeyCode == Keys.C)
-                {
-                    toolStripItemCopy_Click(null, null);
-                }
-            }
-            else
-            {
-                if (e.KeyCode == Keys.Delete)
-                {
-                    toolStripItemDelete_Click(null, null);
-                }
-            }
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void itemList_FocusChanged(object sender, EventArgs e)
-        {
-            UpdateToolStripItems();
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void lstIngredients_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (updatingIngedients)
-            {
-                return;
-            }
-
-            if (lstIngredients.SelectedIndex > -1)
-            {
-                cmbIngredient.Show();
-                nudQuantity.Show();
-                lblQuantity.Show();
-                lblIngredient.Show();
+                lstIngredients.SelectedIndex = 0;
                 cmbIngredient.SelectedIndex =
                     ItemBase.ListIndex(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId) + 1;
 
                 nudQuantity.Value = mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity;
             }
-            else
+
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                cmbIngredient.Hide();
-                nudQuantity.Hide();
-                lblQuantity.Hide();
-                lblIngredient.Hide();
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
             }
+
+            cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
+        }
+        else
+        {
+            pnlContainer.Hide();
         }
 
-        private void btnDupIngredient_Click(object sender, EventArgs e)
-        {
-            if (lstIngredients.SelectedIndex > -1)
-            {
-                mEditorItem.Ingredients.Insert(
-                    lstIngredients.SelectedIndex,
-                    new CraftIngredient(
-                        mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId,
-                        mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity
-                    )
-                );
+        UpdateToolStripItems();
+    }
 
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void nudQuantity_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving 0 items!
+        nudQuantity.Value = Math.Max(1, nudQuantity.Value);
+
+        if (lstIngredients.SelectedIndex > -1)
+        {
+            mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity = (int) nudQuantity.Value;
+            updatingIngedients = true;
+            if (cmbIngredient.SelectedIndex > 0)
+            {
+                lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    Strings.CraftsEditor.ingredientlistitem.ToString(
+                        ItemBase.GetName(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId),
+                        nudQuantity.Value
+                    );
+            }
+            else
+            {
+                lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    Strings.CraftsEditor.ingredientlistitem.ToString(
+                        Strings.CraftsEditor.ingredientnone, nudQuantity.Value
+                    );
+            }
+
+            updatingIngedients = false;
+        }
+    }
+
+    private void nudSpeed_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Time = (int) nudSpeed.Value;
+    }
+
+    private void nudFailureChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.FailureChance = (int) nudFailureChance.Value;
+    }
+
+    private void nudItemLossChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ItemLossChance = (int) nudItemLossChance.Value;
+    }
+
+    private void btnAdd_Click(object sender, EventArgs e)
+    {
+        mEditorItem.Ingredients.Add(new CraftIngredient(Guid.Empty, 1));
+        lstIngredients.Items.Add(Strings.General.None);
+        lstIngredients.SelectedIndex = lstIngredients.Items.Count - 1;
+        cmbIngredient_SelectedIndexChanged(null, null);
+    }
+
+    private void btnRemove_Click(object sender, EventArgs e)
+    {
+        if (lstIngredients.Items.Count > 0)
+        {
+            mEditorItem.Ingredients.RemoveAt(lstIngredients.SelectedIndex);
+            UpdateEditor();
+        }
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Crafts);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.CraftsEditor.deleteprompt, Strings.CraftsEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.CraftsEditor.undoprompt, Strings.CraftsEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
                 UpdateEditor();
             }
         }
+    }
 
-        private void cmbResult_SelectedIndexChanged(object sender, EventArgs e)
+    private void itemList_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
         {
-            mEditorItem.ItemId = ItemBase.IdFromList(cmbResult.SelectedIndex - 1);
-            var itm = ItemBase.Get(mEditorItem.ItemId);
-            if (itm == null || !itm.IsStackable)
+            if (e.KeyCode == Keys.Z)
             {
-                nudCraftQuantity.Value = 1;
-                mEditorItem.Quantity = 1;
-                nudCraftQuantity.Enabled = false;
+                toolStripItemUndo_Click(null, null);
+            }
+            else if (e.KeyCode == Keys.V)
+            {
+                toolStripItemPaste_Click(null, null);
+            }
+            else if (e.KeyCode == Keys.C)
+            {
+                toolStripItemCopy_Click(null, null);
+            }
+        }
+        else
+        {
+            if (e.KeyCode == Keys.Delete)
+            {
+                toolStripItemDelete_Click(null, null);
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void itemList_FocusChanged(object sender, EventArgs e)
+    {
+        UpdateToolStripItems();
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void lstIngredients_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (updatingIngedients)
+        {
+            return;
+        }
+
+        if (lstIngredients.SelectedIndex > -1)
+        {
+            cmbIngredient.Show();
+            nudQuantity.Show();
+            lblQuantity.Show();
+            lblIngredient.Show();
+            cmbIngredient.SelectedIndex =
+                ItemBase.ListIndex(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId) + 1;
+
+            nudQuantity.Value = mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity;
+        }
+        else
+        {
+            cmbIngredient.Hide();
+            nudQuantity.Hide();
+            lblQuantity.Hide();
+            lblIngredient.Hide();
+        }
+    }
+
+    private void btnDupIngredient_Click(object sender, EventArgs e)
+    {
+        if (lstIngredients.SelectedIndex > -1)
+        {
+            mEditorItem.Ingredients.Insert(
+                lstIngredients.SelectedIndex,
+                new CraftIngredient(
+                    mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId,
+                    mEditorItem.Ingredients[lstIngredients.SelectedIndex].Quantity
+                )
+            );
+
+            UpdateEditor();
+        }
+    }
+
+    private void cmbResult_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ItemId = ItemBase.IdFromList(cmbResult.SelectedIndex - 1);
+        var itm = ItemBase.Get(mEditorItem.ItemId);
+        if (itm == null || !itm.IsStackable)
+        {
+            nudCraftQuantity.Value = 1;
+            mEditorItem.Quantity = 1;
+            nudCraftQuantity.Enabled = false;
+        }
+        else
+        {
+            nudCraftQuantity.Enabled = true;
+        }
+    }
+
+    private void cmbIngredient_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstIngredients.SelectedIndex > -1)
+        {
+            mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId =
+                ItemBase.IdFromList(cmbIngredient.SelectedIndex - 1);
+
+            updatingIngedients = true;
+            if (cmbIngredient.SelectedIndex > 0)
+            {
+                lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    Strings.CraftsEditor.ingredientlistitem.ToString(
+                        ItemBase.GetName(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId),
+                        nudQuantity.Value
+                    );
             }
             else
             {
-                nudCraftQuantity.Enabled = true;
-            }
-        }
-
-        private void cmbIngredient_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstIngredients.SelectedIndex > -1)
-            {
-                mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId =
-                    ItemBase.IdFromList(cmbIngredient.SelectedIndex - 1);
-
-                updatingIngedients = true;
-                if (cmbIngredient.SelectedIndex > 0)
-                {
-                    lstIngredients.Items[lstIngredients.SelectedIndex] =
-                        Strings.CraftsEditor.ingredientlistitem.ToString(
-                            ItemBase.GetName(mEditorItem.Ingredients[lstIngredients.SelectedIndex].ItemId),
-                            nudQuantity.Value
-                        );
-                }
-                else
-                {
-                    lstIngredients.Items[lstIngredients.SelectedIndex] =
-                        Strings.CraftsEditor.ingredientlistitem.ToString(
-                            Strings.CraftsEditor.ingredientnone, nudQuantity.Value
-                        );
-                }
-
-                updatingIngedients = false;
-            }
-        }
-
-        private void frmCrafting_Load(object sender, EventArgs e)
-        {
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.CraftsEditor.title;
-            toolStripItemNew.Text = Strings.CraftsEditor.New;
-            toolStripItemDelete.Text = Strings.CraftsEditor.delete;
-            toolStripItemCopy.Text = Strings.CraftsEditor.copy;
-            toolStripItemPaste.Text = Strings.CraftsEditor.paste;
-            toolStripItemUndo.Text = Strings.CraftsEditor.undo;
-
-            grpCrafts.Text = Strings.CraftsEditor.crafts;
-
-            grpGeneral.Text = Strings.CraftsEditor.general;
-            lblName.Text = Strings.CraftsEditor.name;
-            lblItem.Text = Strings.CraftsEditor.item;
-            lblCraftQuantity.Text = Strings.CraftsEditor.craftquantity;
-            lblSpeed.Text = Strings.CraftsEditor.time;
-            lblFailureChance.Text = Strings.CraftsEditor.FailureChance;
-            lblItemLossChance.Text = Strings.CraftsEditor.ItemLossChance;
-            btnCraftRequirements.Text = Strings.CraftsEditor.Requirements;
-
-            grpIngredients.Text = Strings.CraftsEditor.ingredients;
-            lblIngredient.Text = Strings.CraftsEditor.ingredientitem;
-            lblQuantity.Text = Strings.CraftsEditor.ingredientquantity;
-            lblCommonEvent.Text = Strings.CraftsEditor.commonevent;
-            btnAdd.Text = Strings.CraftsEditor.newingredient;
-            btnRemove.Text = Strings.CraftsEditor.deleteingredient;
-            btnDupIngredient.Text = Strings.CraftsEditor.duplicateingredient;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.CraftsEditor.sortalphabetically;
-            txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
-            lblFolder.Text = Strings.CraftsEditor.folderlabel;
-
-            btnSave.Text = Strings.CraftsEditor.save;
-            btnCancel.Text = Strings.CraftsEditor.cancel;
-        }
-
-        private void nudCraftQuantity_ValueChanged(object sender, EventArgs e)
-        {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudCraftQuantity.Value = Math.Max(1, nudCraftQuantity.Value);
-            mEditorItem.Quantity = (int) nudCraftQuantity.Value;
-        }
-
-        private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
-        }
-
-        private void btnCraftRequirements_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.CraftingRequirements, RequirementType.Craft);
-            frm.ShowDialog();
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in CraftBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((CraftBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((CraftBase) itm.Value).Folder))
-                {
-                    mFolders.Add(((CraftBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((CraftBase) itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((CraftBase) itm.Value).Folder);
-                    }
-                }
+                lstIngredients.Items[lstIngredients.SelectedIndex] =
+                    Strings.CraftsEditor.ingredientlistitem.ToString(
+                        Strings.CraftsEditor.ingredientnone, nudQuantity.Value
+                    );
             }
 
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = CraftBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((CraftBase)pair.Value)?.Name ?? Models.DatabaseObject<CraftBase>.Deleted, ((CraftBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+            updatingIngedients = false;
         }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.CraftsEditor.folderprompt, Strings.CraftsEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.CraftsEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.CraftsEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void frmCrafting_Load(object sender, EventArgs e)
+    {
+        InitLocalization();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.CraftsEditor.title;
+        toolStripItemNew.Text = Strings.CraftsEditor.New;
+        toolStripItemDelete.Text = Strings.CraftsEditor.delete;
+        toolStripItemCopy.Text = Strings.CraftsEditor.copy;
+        toolStripItemPaste.Text = Strings.CraftsEditor.paste;
+        toolStripItemUndo.Text = Strings.CraftsEditor.undo;
+
+        grpCrafts.Text = Strings.CraftsEditor.crafts;
+
+        grpGeneral.Text = Strings.CraftsEditor.general;
+        lblName.Text = Strings.CraftsEditor.name;
+        lblItem.Text = Strings.CraftsEditor.item;
+        lblCraftQuantity.Text = Strings.CraftsEditor.craftquantity;
+        lblSpeed.Text = Strings.CraftsEditor.time;
+        lblFailureChance.Text = Strings.CraftsEditor.FailureChance;
+        lblItemLossChance.Text = Strings.CraftsEditor.ItemLossChance;
+        btnCraftRequirements.Text = Strings.CraftsEditor.Requirements;
+
+        grpIngredients.Text = Strings.CraftsEditor.ingredients;
+        lblIngredient.Text = Strings.CraftsEditor.ingredientitem;
+        lblQuantity.Text = Strings.CraftsEditor.ingredientquantity;
+        lblCommonEvent.Text = Strings.CraftsEditor.commonevent;
+        btnAdd.Text = Strings.CraftsEditor.newingredient;
+        btnRemove.Text = Strings.CraftsEditor.deleteingredient;
+        btnDupIngredient.Text = Strings.CraftsEditor.duplicateingredient;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.CraftsEditor.sortalphabetically;
+        txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
+        lblFolder.Text = Strings.CraftsEditor.folderlabel;
+
+        btnSave.Text = Strings.CraftsEditor.save;
+        btnCancel.Text = Strings.CraftsEditor.cancel;
+    }
+
+    private void nudCraftQuantity_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving 0 items!
+        nudCraftQuantity.Value = Math.Max(1, nudCraftQuantity.Value);
+        mEditorItem.Quantity = (int) nudCraftQuantity.Value;
+    }
+
+    private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
+    }
+
+    private void btnCraftRequirements_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.CraftingRequirements, RequirementType.Craft);
+        frm.ShowDialog();
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in CraftBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((CraftBase) itm.Value).Folder) &&
+                !mFolders.Contains(((CraftBase) itm.Value).Folder))
+            {
+                mFolders.Add(((CraftBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((CraftBase) itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((CraftBase) itm.Value).Folder);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = CraftBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((CraftBase)pair.Value)?.Name ?? Models.DatabaseObject<CraftBase>.Deleted, ((CraftBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.CraftsEditor.folderprompt, Strings.CraftsEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.CraftsEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.CraftsEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.CraftsEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
+++ b/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
@@ -3,278 +3,276 @@ using Intersect.Editor.Localization;
 using Intersect.GameObjects.Conditions;
 using Intersect.GameObjects.Events;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public enum RequirementType
 {
 
-    public enum RequirementType
+    Item,
+
+    Resource,
+
+    Spell,
+
+    Event,
+
+    Quest,
+
+    NpcFriend,
+
+    NpcAttackOnSight,
+
+    NpcDontAttackOnSight,
+
+    NpcCanBeAttacked,
+
+    Craft
+
+}
+
+public partial class FrmDynamicRequirements : Form
+{
+
+    private ConditionList mEdittingList;
+
+    private ConditionLists mEdittingLists;
+
+    private ConditionList mSourceList;
+
+    private ConditionLists mSourceLists;
+
+    public FrmDynamicRequirements(ConditionLists lists, RequirementType type)
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        Item,
-
-        Resource,
-
-        Spell,
-
-        Event,
-
-        Quest,
-
-        NpcFriend,
-
-        NpcAttackOnSight,
-
-        NpcDontAttackOnSight,
-
-        NpcCanBeAttacked,
-
-        Craft
-
+        mSourceLists = lists;
+        mEdittingLists = new ConditionLists(lists.Data());
+        UpdateLists();
+        InitLocalization(type);
     }
 
-    public partial class FrmDynamicRequirements : Form
+    private void InitLocalization(RequirementType type)
     {
-
-        private ConditionList mEdittingList;
-
-        private ConditionLists mEdittingLists;
-
-        private ConditionList mSourceList;
-
-        private ConditionLists mSourceLists;
-
-        public FrmDynamicRequirements(ConditionLists lists, RequirementType type)
+        Text = Strings.DynamicRequirements.title;
+        grpConditionLists.Text = Strings.DynamicRequirements.conditionlists;
+        switch (type)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
+            case RequirementType.Item:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsitem;
 
-            mSourceLists = lists;
-            mEdittingLists = new ConditionLists(lists.Data());
+                break;
+            case RequirementType.Resource:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsresource;
+
+                break;
+            case RequirementType.Spell:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsspell;
+
+                break;
+            case RequirementType.Event:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsevent;
+
+                break;
+            case RequirementType.Quest:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsquest;
+
+                break;
+            case RequirementType.NpcFriend:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcfriend;
+
+                break;
+            case RequirementType.NpcAttackOnSight:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcattackonsight;
+
+                break;
+            case RequirementType.NpcDontAttackOnSight:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcdontattackonsight;
+
+                break;
+            case RequirementType.NpcCanBeAttacked:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsnpccanbeattacked;
+
+                break;
+            case RequirementType.Craft:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionscraft;
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+
+        btnAddList.Text = Strings.DynamicRequirements.addlist;
+        btnRemoveList.Text = Strings.DynamicRequirements.removelist;
+        btnSave.Text = Strings.DynamicRequirements.save;
+        btnCancel.Text = Strings.DynamicRequirements.cancel;
+        grpConditionList.Text = Strings.DynamicRequirements.conditionlist;
+        lblListName.Text = Strings.DynamicRequirements.listname;
+        btnAddCondition.Text = Strings.DynamicRequirements.addcondition;
+        btnRemoveCondition.Text = Strings.DynamicRequirements.removecondition;
+    }
+
+    private void UpdateLists()
+    {
+        grpConditionLists.Show();
+        grpConditionList.Hide();
+        lstConditionLists.Items.Clear();
+        for (var i = 0; i < mEdittingLists.Lists.Count; i++)
+        {
+            lstConditionLists.Items.Add(mEdittingLists.Lists[i].Name);
+        }
+    }
+
+    private void UpdateConditions(ConditionList list)
+    {
+        grpConditionList.Show();
+        lstConditions.Items.Clear();
+        if (list != mEdittingList)
+        {
+            mSourceList = list;
+            mEdittingList = mSourceList;
+        }
+
+        txtListName.Text = list.Name;
+        for (var i = 0; i < list.Conditions.Count; i++)
+        {
+            if (list.Conditions[i].Negated)
+            {
+                lstConditions.Items.Add(
+                    Strings.EventConditionDesc.negated.ToString(
+                        Strings.GetEventConditionalDesc((dynamic) list.Conditions[i])
+                    )
+                );
+            }
+            else
+            {
+                lstConditions.Items.Add(Strings.GetEventConditionalDesc((dynamic) list.Conditions[i]));
+            }
+        }
+    }
+
+    private void btnAddList_Click(object sender, EventArgs e)
+    {
+        var newList = new ConditionList();
+        mEdittingLists.Lists.Add(newList);
+        UpdateLists();
+        lstConditionLists.SelectedIndex = lstConditionLists.Items.Count - 1;
+        UpdateConditions(newList);
+    }
+
+    private void btnRemoveList_Click(object sender, EventArgs e)
+    {
+        if (lstConditionLists.SelectedIndex > -1)
+        {
+            mEdittingLists.Lists.RemoveAt(lstConditionLists.SelectedIndex);
             UpdateLists();
-            InitLocalization(type);
         }
+    }
 
-        private void InitLocalization(RequirementType type)
+    private void txtListName_TextChanged(object sender, EventArgs e)
+    {
+        if (txtListName.Text.Trim().Length > 0)
         {
-            Text = Strings.DynamicRequirements.title;
-            grpConditionLists.Text = Strings.DynamicRequirements.conditionlists;
-            switch (type)
+            mEdittingList.Name = txtListName.Text;
+            if (mEdittingLists.Lists.IndexOf(mEdittingList) > -1)
             {
-                case RequirementType.Item:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsitem;
-
-                    break;
-                case RequirementType.Resource:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsresource;
-
-                    break;
-                case RequirementType.Spell:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsspell;
-
-                    break;
-                case RequirementType.Event:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsevent;
-
-                    break;
-                case RequirementType.Quest:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsquest;
-
-                    break;
-                case RequirementType.NpcFriend:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcfriend;
-
-                    break;
-                case RequirementType.NpcAttackOnSight:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcattackonsight;
-
-                    break;
-                case RequirementType.NpcDontAttackOnSight:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsnpcdontattackonsight;
-
-                    break;
-                case RequirementType.NpcCanBeAttacked:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionsnpccanbeattacked;
-
-                    break;
-                case RequirementType.Craft:
-                    lblInstructions.Text = Strings.DynamicRequirements.instructionscraft;
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
-            }
-
-            btnAddList.Text = Strings.DynamicRequirements.addlist;
-            btnRemoveList.Text = Strings.DynamicRequirements.removelist;
-            btnSave.Text = Strings.DynamicRequirements.save;
-            btnCancel.Text = Strings.DynamicRequirements.cancel;
-            grpConditionList.Text = Strings.DynamicRequirements.conditionlist;
-            lblListName.Text = Strings.DynamicRequirements.listname;
-            btnAddCondition.Text = Strings.DynamicRequirements.addcondition;
-            btnRemoveCondition.Text = Strings.DynamicRequirements.removecondition;
-        }
-
-        private void UpdateLists()
-        {
-            grpConditionLists.Show();
-            grpConditionList.Hide();
-            lstConditionLists.Items.Clear();
-            for (var i = 0; i < mEdittingLists.Lists.Count; i++)
-            {
-                lstConditionLists.Items.Add(mEdittingLists.Lists[i].Name);
+                lstConditionLists.Items[mEdittingLists.Lists.IndexOf(mEdittingList)] = txtListName.Text;
             }
         }
+    }
 
-        private void UpdateConditions(ConditionList list)
+    private void lstConditions_DoubleClick(object sender, EventArgs e)
+    {
+        if (lstConditions.SelectedIndex > -1)
         {
-            grpConditionList.Show();
-            lstConditions.Items.Clear();
-            if (list != mEdittingList)
-            {
-                mSourceList = list;
-                mEdittingList = mSourceList;
-            }
-
-            txtListName.Text = list.Name;
-            for (var i = 0; i < list.Conditions.Count; i++)
-            {
-                if (list.Conditions[i].Negated)
-                {
-                    lstConditions.Items.Add(
-                        Strings.EventConditionDesc.negated.ToString(
-                            Strings.GetEventConditionalDesc((dynamic) list.Conditions[i])
-                        )
-                    );
-                }
-                else
-                {
-                    lstConditions.Items.Add(Strings.GetEventConditionalDesc((dynamic) list.Conditions[i]));
-                }
-            }
-        }
-
-        private void btnAddList_Click(object sender, EventArgs e)
-        {
-            var newList = new ConditionList();
-            mEdittingLists.Lists.Add(newList);
-            UpdateLists();
-            lstConditionLists.SelectedIndex = lstConditionLists.Items.Count - 1;
-            UpdateConditions(newList);
-        }
-
-        private void btnRemoveList_Click(object sender, EventArgs e)
-        {
-            if (lstConditionLists.SelectedIndex > -1)
-            {
-                mEdittingLists.Lists.RemoveAt(lstConditionLists.SelectedIndex);
-                UpdateLists();
-            }
-        }
-
-        private void txtListName_TextChanged(object sender, EventArgs e)
-        {
-            if (txtListName.Text.Trim().Length > 0)
-            {
-                mEdittingList.Name = txtListName.Text;
-                if (mEdittingLists.Lists.IndexOf(mEdittingList) > -1)
-                {
-                    lstConditionLists.Items[mEdittingLists.Lists.IndexOf(mEdittingList)] = txtListName.Text;
-                }
-            }
-        }
-
-        private void lstConditions_DoubleClick(object sender, EventArgs e)
-        {
-            if (lstConditions.SelectedIndex > -1)
-            {
-                var condition = OpenConditionEditor(mEdittingList.Conditions[lstConditions.SelectedIndex]);
-                if (condition != null)
-                {
-                    mEdittingList.Conditions[lstConditions.SelectedIndex] = condition;
-                    UpdateConditions(mEdittingList);
-                }
-            }
-        }
-
-        private void btnAddCondition_Click(object sender, EventArgs e)
-        {
-            var condition = OpenConditionEditor(new VariableIsCondition());
+            var condition = OpenConditionEditor(mEdittingList.Conditions[lstConditions.SelectedIndex]);
             if (condition != null)
             {
-                mEdittingList.Conditions.Add(condition);
+                mEdittingList.Conditions[lstConditions.SelectedIndex] = condition;
                 UpdateConditions(mEdittingList);
             }
         }
+    }
 
-        private Condition OpenConditionEditor(Condition condition)
+    private void btnAddCondition_Click(object sender, EventArgs e)
+    {
+        var condition = OpenConditionEditor(new VariableIsCondition());
+        if (condition != null)
         {
-            var cmdWindow = new EventCommandConditionalBranch(condition, null, null, null);
-            var frm = new Form
-            {
-                Text = Strings.DynamicRequirements.conditioneditor,
-                FormBorderStyle = FormBorderStyle.FixedSingle,
-                Size = new Size(0, 0),
-                AutoSize = true,
-                ControlBox = false,
-                StartPosition = FormStartPosition.CenterParent,
-                BackColor = cmdWindow.BackColor
-            };
+            mEdittingList.Conditions.Add(condition);
+            UpdateConditions(mEdittingList);
+        }
+    }
 
-            frm.Controls.Add(cmdWindow);
-            cmdWindow.BringToFront();
-            frm.TopMost = true;
-            frm.ShowDialog();
-            if (cmdWindow.Cancelled)
-            {
-                return null;
-            }
+    private Condition OpenConditionEditor(Condition condition)
+    {
+        var cmdWindow = new EventCommandConditionalBranch(condition, null, null, null);
+        var frm = new Form
+        {
+            Text = Strings.DynamicRequirements.conditioneditor,
+            FormBorderStyle = FormBorderStyle.FixedSingle,
+            Size = new Size(0, 0),
+            AutoSize = true,
+            ControlBox = false,
+            StartPosition = FormStartPosition.CenterParent,
+            BackColor = cmdWindow.BackColor
+        };
 
-            return cmdWindow.Condition;
+        frm.Controls.Add(cmdWindow);
+        cmdWindow.BringToFront();
+        frm.TopMost = true;
+        frm.ShowDialog();
+        if (cmdWindow.Cancelled)
+        {
+            return null;
         }
 
-        private void btnRemoveCondition_Click(object sender, EventArgs e)
-        {
-            if (lstConditions.SelectedIndex > -1)
-            {
-                mEdittingList.Conditions.RemoveAt(lstConditions.SelectedIndex);
-                UpdateConditions(mEdittingList);
-            }
-        }
+        return cmdWindow.Condition;
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void btnRemoveCondition_Click(object sender, EventArgs e)
+    {
+        if (lstConditions.SelectedIndex > -1)
         {
-            Close();
+            mEdittingList.Conditions.RemoveAt(lstConditions.SelectedIndex);
+            UpdateConditions(mEdittingList);
         }
+    }
 
-        private void btnSave_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        Close();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mSourceLists.Load(mEdittingLists.Data());
+        Close();
+    }
+
+    private void lstConditionLists_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Delete)
         {
-            mSourceLists.Load(mEdittingLists.Data());
-            Close();
+            btnRemoveList_Click(null, null);
         }
+    }
 
-        private void lstConditionLists_KeyDown(object sender, KeyEventArgs e)
+    private void lstConditions_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Delete)
         {
-            if (e.KeyCode == Keys.Delete)
-            {
-                btnRemoveList_Click(null, null);
-            }
+            btnRemoveCondition_Click(null, null);
         }
+    }
 
-        private void lstConditions_KeyDown(object sender, KeyEventArgs e)
+    private void lstConditionLists_Click(object sender, EventArgs e)
+    {
+        if (lstConditionLists.SelectedIndex > -1)
         {
-            if (e.KeyCode == Keys.Delete)
-            {
-                btnRemoveCondition_Click(null, null);
-            }
+            UpdateConditions(mEdittingLists.Lists[lstConditionLists.SelectedIndex]);
         }
-
-        private void lstConditionLists_Click(object sender, EventArgs e)
-        {
-            if (lstConditionLists.SelectedIndex > -1)
-            {
-                UpdateConditions(mEdittingLists.Lists[lstConditionLists.SelectedIndex]);
-            }
-        }
-
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -12,1527 +12,1525 @@ using Intersect.Localization;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmItem : EditorForm
 {
 
-    public partial class FrmItem : EditorForm
+    private List<ItemBase> mChanged = new List<ItemBase>();
+
+    private string mCopiedItem;
+
+    private ItemBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private List<string> mKnownCooldownGroups = new List<string>();
+
+    private bool EffectValueUpdating = false;
+
+    public FrmItem()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<ItemBase> mChanged = new List<ItemBase>();
+        cmbEquipmentSlot.Items.Clear();
+        cmbEquipmentSlot.Items.AddRange(Options.EquipmentSlots.ToArray());
+        cmbToolType.Items.Clear();
+        cmbToolType.Items.Add(Strings.General.None);
+        cmbToolType.Items.AddRange(Options.ToolTypes.ToArray());
 
-        private string mCopiedItem;
+        cmbProjectile.Items.Clear();
+        cmbProjectile.Items.Add(Strings.General.None);
+        cmbProjectile.Items.AddRange(ProjectileBase.Names);
 
-        private ItemBase mEditorItem;
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = ItemBase.Get(id);
+        UpdateEditor();
+    }
 
-        private List<string> mKnownFolders = new List<string>();
-
-        private List<string> mKnownCooldownGroups = new List<string>();
-
-        private bool EffectValueUpdating = false;
-
-        public FrmItem()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Item)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            cmbEquipmentSlot.Items.Clear();
-            cmbEquipmentSlot.Items.AddRange(Options.EquipmentSlots.ToArray());
-            cmbToolType.Items.Clear();
-            cmbToolType.Items.Add(Strings.General.None);
-            cmbToolType.Items.AddRange(Options.ToolTypes.ToArray());
-
-            cmbProjectile.Items.Clear();
-            cmbProjectile.Items.Add(Strings.General.None);
-            cmbProjectile.Items.AddRange(ProjectileBase.Names);
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = ItemBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Item)
+            InitEditor();
+            if (mEditorItem != null && !ItemBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !ItemBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-            else if (type == GameObjectType.Class ||
-                     type == GameObjectType.Projectile ||
-                     type == GameObjectType.Animation ||
-                     type == GameObjectType.Spell)
-            {
-                frmItem_Load(null, null);
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
-
-        private void btnCancel_Click(object sender, EventArgs e)
+        else if (type == GameObjectType.Class ||
+                 type == GameObjectType.Projectile ||
+                 type == GameObjectType.Animation ||
+                 type == GameObjectType.Spell)
         {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
+            frmItem_Load(null, null);
+        }
+    }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
         }
 
-        private void frmItem_Load(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmItem_Load(object sender, EventArgs e)
+    {
+        cmbPic.Items.Clear();
+        cmbPic.Items.Add(Strings.General.None);
+
+        var itemnames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Item);
+        cmbPic.Items.AddRange(itemnames);
+
+        cmbWeaponSprite.Items.Clear();
+        cmbWeaponSprite.Items.Add(Strings.General.None);
+        cmbWeaponSprite.Items.AddRange(
+            GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "weapon").ToArray()
+        );
+        cmbAttackAnimation.Items.Clear();
+        cmbAttackAnimation.Items.Add(Strings.General.None);
+        cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
+        cmbScalingStat.Items.Clear();
+        for (var x = 0; x < Enum.GetValues<Stat>().Length; x++)
         {
-            cmbPic.Items.Clear();
-            cmbPic.Items.Add(Strings.General.None);
+            cmbScalingStat.Items.Add(Globals.GetStatName(x));
+        }
 
-            var itemnames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Item);
-            cmbPic.Items.AddRange(itemnames);
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+        cmbEquipmentAnimation.Items.Clear();
+        cmbEquipmentAnimation.Items.Add(Strings.General.None);
+        cmbEquipmentAnimation.Items.AddRange(AnimationBase.Names);
+        cmbTeachSpell.Items.Clear();
+        cmbTeachSpell.Items.Add(Strings.General.None);
+        cmbTeachSpell.Items.AddRange(SpellBase.Names);
 
-            cmbWeaponSprite.Items.Clear();
-            cmbWeaponSprite.Items.Add(Strings.General.None);
-            cmbWeaponSprite.Items.AddRange(
-                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "weapon").ToArray()
+        var events = EventBase.Names;
+        var eventElements = new List<ComboBox>() { cmbEvent, cmbEventTriggers };
+        foreach (var element in eventElements)
+        {
+            element.Items.Clear();
+            element.Items.Add(Strings.General.None);
+            element.Items.AddRange(events);
+        }
+
+        cmbMalePaperdoll.Items.Clear();
+        cmbMalePaperdoll.Items.Add(Strings.General.None);
+        cmbFemalePaperdoll.Items.Clear();
+        cmbFemalePaperdoll.Items.Add(Strings.General.None);
+        var paperdollnames =
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Paperdoll);
+
+        for (var i = 0; i < paperdollnames.Length; i++)
+        {
+            cmbMalePaperdoll.Items.Add(paperdollnames[i]);
+            cmbFemalePaperdoll.Items.Add(paperdollnames[i]);
+        }
+
+        nudStr.Maximum = Options.MaxStatValue;
+        nudMag.Maximum = Options.MaxStatValue;
+        nudDef.Maximum = Options.MaxStatValue;
+        nudMR.Maximum = Options.MaxStatValue;
+        nudSpd.Maximum = Options.MaxStatValue;
+
+        nudStr.Minimum = -Options.MaxStatValue;
+        nudMag.Minimum = -Options.MaxStatValue;
+        nudDef.Minimum = -Options.MaxStatValue;
+        nudMR.Minimum = -Options.MaxStatValue;
+        nudSpd.Minimum = -Options.MaxStatValue;
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.ItemEditor.title;
+        toolStripItemNew.Text = Strings.ItemEditor.New;
+        toolStripItemDelete.Text = Strings.ItemEditor.delete;
+        toolStripItemCopy.Text = Strings.ItemEditor.copy;
+        toolStripItemPaste.Text = Strings.ItemEditor.paste;
+        toolStripItemUndo.Text = Strings.ItemEditor.undo;
+
+        grpItems.Text = Strings.ItemEditor.items;
+        grpGeneral.Text = Strings.ItemEditor.general;
+        lblName.Text = Strings.ItemEditor.name;
+        lblType.Text = Strings.ItemEditor.type;
+        cmbType.Items.Clear();
+        for (var i = 0; i < Strings.ItemEditor.types.Count; i++)
+        {
+            cmbType.Items.Add(Strings.ItemEditor.types[i]);
+        }
+
+        lblDesc.Text = Strings.ItemEditor.description;
+        lblPic.Text = Strings.ItemEditor.picture;
+        lblRed.Text = Strings.ItemEditor.Red;
+        lblGreen.Text = Strings.ItemEditor.Green;
+        lblBlue.Text = Strings.ItemEditor.Blue;
+        lblAlpha.Text = Strings.ItemEditor.Alpha;
+        lblPrice.Text = Strings.ItemEditor.price;
+        lblAnim.Text = Strings.ItemEditor.animation;
+        chkCanDrop.Text = Strings.ItemEditor.CanDrop;
+        lblDeathDropChance.Text = Strings.ItemEditor.DeathDropChance;
+        lblDespawnTime.Text = Strings.ItemEditor.DespawnTime;
+        tooltips.SetToolTip(lblDespawnTime, Strings.ItemEditor.DespawnTimeTooltip);
+        tooltips.SetToolTip(nudItemDespawnTime, Strings.ItemEditor.DespawnTimeTooltip);
+        chkCanBank.Text = Strings.ItemEditor.CanBank;
+        chkCanGuildBank.Text = Strings.ItemEditor.CanGuildBank;
+        chkCanBag.Text = Strings.ItemEditor.CanBag;
+        chkCanTrade.Text = Strings.ItemEditor.CanTrade;
+        chkCanSell.Text = Strings.ItemEditor.CanSell;
+
+        grpStack.Text = Strings.ItemEditor.StackOptions;
+        chkStackable.Text = Strings.ItemEditor.stackable;
+        lblInvStackLimit.Text = Strings.ItemEditor.InventoryStackLimit;
+        lblBankStackLimit.Text = Strings.ItemEditor.BankStackLimit;
+
+        cmbRarity.Items.Clear();
+        for (var i = 0; i < Options.Instance.Items.RarityTiers.Count; i++)
+        {
+            var rarityName = Options.Instance.Items.RarityTiers[i];
+            cmbRarity.Items.Add(Strings.ItemEditor.rarity[rarityName]);
+        }
+
+        grpEvents.Text = Strings.ItemEditor.EventGroup;
+        lblEventForTrigger.Text = Strings.ItemEditor.EventGroupLabel;
+
+        grpEquipment.Text = Strings.ItemEditor.equipment;
+        lblEquipmentSlot.Text = Strings.ItemEditor.slot;
+        grpStatBonuses.Text = Strings.ItemEditor.bonuses;
+        lblStr.Text = Strings.ItemEditor.attackbonus;
+        lblDef.Text = Strings.ItemEditor.defensebonus;
+        lblSpd.Text = Strings.ItemEditor.speedbonus;
+        lblMag.Text = Strings.ItemEditor.abilitypowerbonus;
+        lblMR.Text = Strings.ItemEditor.magicresistbonus;
+        lblEffectPercent.Text = Strings.ItemEditor.bonusamount;
+        lblEquipmentAnimation.Text = Strings.ItemEditor.equipmentanimation;
+
+        grpStatRanges.Text = Strings.ItemEditor.StatRangeTitle;
+        lblStatRangeFrom.Text = Strings.ItemEditor.StatRangeFrom;
+        lblStatRangeTo.Text = Strings.ItemEditor.StatRangeTo;
+
+        grpWeaponProperties.Text = Strings.ItemEditor.weaponproperties;
+        chk2Hand.Text = Strings.ItemEditor.twohanded;
+        lblDamage.Text = Strings.ItemEditor.basedamage;
+        lblCritChance.Text = Strings.ItemEditor.critchance;
+        lblCritMultiplier.Text = Strings.ItemEditor.critmultiplier;
+        lblDamageType.Text = Strings.ItemEditor.damagetype;
+        cmbDamageType.Items.Clear();
+        for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
+        {
+            cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
+        }
+
+        lblScalingStat.Text = Strings.ItemEditor.scalingstat;
+        lblScalingAmount.Text = Strings.ItemEditor.scalingamount;
+        lblAttackAnimation.Text = Strings.ItemEditor.attackanimation;
+        lblSpriteAttack.Text = Strings.ItemEditor.AttackSpriteOverride;
+        lblProjectile.Text = Strings.ItemEditor.projectile;
+        lblToolType.Text = Strings.ItemEditor.tooltype;
+
+        grpCooldown.Text = Strings.ItemEditor.CooldownOptions;
+        lblCooldown.Text = Strings.ItemEditor.cooldown;
+        lblCooldownGroup.Text = Strings.ItemEditor.CooldownGroup;
+        chkIgnoreGlobalCooldown.Text = Strings.ItemEditor.IgnoreGlobalCooldown;
+        chkIgnoreCdr.Text = Strings.ItemEditor.IgnoreCooldownReduction;
+
+        grpVitalBonuses.Text = Strings.ItemEditor.vitalbonuses;
+        lblHealthBonus.Text = Strings.ItemEditor.health;
+        lblManaBonus.Text = Strings.ItemEditor.mana;
+
+        grpRegen.Text = Strings.ItemEditor.regen;
+        lblHpRegen.Text = Strings.ItemEditor.hpregen;
+        lblManaRegen.Text = Strings.ItemEditor.mpregen;
+        lblRegenHint.Text = Strings.ItemEditor.regenhint;
+
+        grpAttackSpeed.Text = Strings.ItemEditor.attackspeed;
+        lblAttackSpeedModifier.Text = Strings.ItemEditor.attackspeedmodifier;
+        lblAttackSpeedValue.Text = Strings.ItemEditor.attackspeedvalue;
+        cmbAttackSpeedModifier.Items.Clear();
+        foreach (var val in Strings.ItemEditor.attackspeedmodifiers.Values)
+        {
+            cmbAttackSpeedModifier.Items.Add(val.ToString());
+        }
+
+        grpShieldProperties.Text = Strings.ItemEditor.ShieldProperties;
+        lblBlockChance.Text = Strings.ItemEditor.BlockChance;
+        lblBlockAmount.Text = Strings.ItemEditor.BlockAmount;
+        lblBlockDmgAbs.Text = Strings.ItemEditor.BlockAbsorption;
+
+        lblMalePaperdoll.Text = Strings.ItemEditor.malepaperdoll;
+        lblFemalePaperdoll.Text = Strings.ItemEditor.femalepaperdoll;
+
+        grpBags.Text = Strings.ItemEditor.bagpanel;
+        lblBag.Text = Strings.ItemEditor.bagslots;
+
+        grpSpell.Text = Strings.ItemEditor.spellpanel;
+        lblSpell.Text = Strings.ItemEditor.spell;
+        chkQuickCast.Text = Strings.ItemEditor.quickcast;
+        chkSingleUseSpell.Text = Strings.ItemEditor.destroyspell;
+
+        grpEvent.Text = Strings.ItemEditor.eventpanel;
+        chkSingleUseEvent.Text = Strings.ItemEditor.SingleUseEvent;
+
+        grpConsumable.Text = Strings.ItemEditor.consumeablepanel;
+        lblVital.Text = Strings.ItemEditor.vital;
+        lblInterval.Text = Strings.ItemEditor.consumeamount;
+        cmbConsume.Items.Clear();
+        for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
+        {
+            cmbConsume.Items.Add(Strings.Combat.vitals[i]);
+        }
+
+        cmbConsume.Items.Add(Strings.Combat.exp);
+
+        grpRequirements.Text = Strings.ItemEditor.requirementsgroup;
+        lblCannotUse.Text = Strings.ItemEditor.cannotuse;
+        btnEditRequirements.Text = Strings.ItemEditor.requirements;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.ItemEditor.sortalphabetically;
+        txtSearch.Text = Strings.ItemEditor.searchplaceholder;
+        lblFolder.Text = Strings.ItemEditor.folderlabel;
+
+        btnSave.Text = Strings.ItemEditor.save;
+        btnCancel.Text = Strings.ItemEditor.cancel;
+
+        grpEffects.Text = Strings.ItemEditor.BonusEffectGroup;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            txtDesc.Text = mEditorItem.Description;
+            cmbType.SelectedIndex = (int)mEditorItem.ItemType;
+            cmbPic.SelectedIndex = cmbPic.FindString(TextUtils.NullToNone(mEditorItem.Icon));
+            nudRgbaR.Value = mEditorItem.Color.R;
+            nudRgbaG.Value = mEditorItem.Color.G;
+            nudRgbaB.Value = mEditorItem.Color.B;
+            nudRgbaA.Value = mEditorItem.Color.A;
+            cmbEquipmentAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.EquipmentAnimationId) + 1;
+            nudPrice.Value = mEditorItem.Price;
+            cmbRarity.SelectedIndex = mEditorItem.Rarity;
+
+            nudStr.Value = mEditorItem.StatsGiven[0];
+            nudMag.Value = mEditorItem.StatsGiven[1];
+            nudDef.Value = mEditorItem.StatsGiven[2];
+            nudMR.Value = mEditorItem.StatsGiven[3];
+            nudSpd.Value = mEditorItem.StatsGiven[4];
+
+            nudStrPercentage.Value = mEditorItem.PercentageStatsGiven[0];
+            nudMagPercentage.Value = mEditorItem.PercentageStatsGiven[1];
+            nudDefPercentage.Value = mEditorItem.PercentageStatsGiven[2];
+            nudMRPercentage.Value = mEditorItem.PercentageStatsGiven[3];
+            nudSpdPercentage.Value = mEditorItem.PercentageStatsGiven[4];
+
+            nudHealthBonus.Value = mEditorItem.VitalsGiven[0];
+            nudManaBonus.Value = mEditorItem.VitalsGiven[1];
+            nudHPPercentage.Value = mEditorItem.PercentageVitalsGiven[0];
+            nudMPPercentage.Value = mEditorItem.PercentageVitalsGiven[1];
+            nudHPRegen.Value = mEditorItem.VitalsRegen[0];
+            nudMpRegen.Value = mEditorItem.VitalsRegen[1];
+
+            nudDamage.Value = mEditorItem.Damage;
+            nudCritChance.Value = mEditorItem.CritChance;
+            nudCritMultiplier.Value = (decimal)mEditorItem.CritMultiplier;
+            cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
+            nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
+            nudScaling.Value = mEditorItem.Scaling;
+            // This will be removed after conversion to a per-stat editor. Reminder that pre-migration LowRange == HighRange - Day
+            nudStatRangeHigh.Value = mEditorItem.StatRanges?.FirstOrDefault()?.HighRange ?? 0;
+            chkCanDrop.Checked = Convert.ToBoolean(mEditorItem.CanDrop);
+            chkCanBank.Checked = Convert.ToBoolean(mEditorItem.CanBank);
+            chkCanGuildBank.Checked = Convert.ToBoolean(mEditorItem.CanGuildBank);
+            chkCanBag.Checked = Convert.ToBoolean(mEditorItem.CanBag);
+            chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
+            chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
+            chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
+            nudInvStackLimit.Value = mEditorItem.MaxInventoryStack;
+            nudBankStackLimit.Value = mEditorItem.MaxBankStack;
+            nudDeathDropChance.Value = mEditorItem.DropChanceOnDeath;
+            nudItemDespawnTime.Value = mEditorItem.DespawnTime;
+            cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
+            cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
+            cmbWeaponSprite.SelectedIndex = cmbWeaponSprite.FindString(
+                    TextUtils.NullToNone(mEditorItem.WeaponSpriteOverride)
             );
-            cmbAttackAnimation.Items.Clear();
-            cmbAttackAnimation.Items.Add(Strings.General.None);
-            cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
-            cmbScalingStat.Items.Clear();
-            for (var x = 0; x < Enum.GetValues<Stat>().Length; x++)
-            {
-                cmbScalingStat.Items.Add(Globals.GetStatName(x));
-            }
+            nudBlockChance.Value = mEditorItem.BlockChance;
+            nudBlockAmount.Value = mEditorItem.BlockAmount;
+            nudBlockDmgAbs.Value = mEditorItem.BlockAbsorption;
+            RefreshExtendedData();
 
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.Add(Strings.General.None);
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
-            cmbEquipmentAnimation.Items.Clear();
-            cmbEquipmentAnimation.Items.Add(Strings.General.None);
-            cmbEquipmentAnimation.Items.AddRange(AnimationBase.Names);
-            cmbTeachSpell.Items.Clear();
-            cmbTeachSpell.Items.Add(Strings.General.None);
-            cmbTeachSpell.Items.AddRange(SpellBase.Names);
+            chk2Hand.Checked = mEditorItem.TwoHanded;
+            cmbMalePaperdoll.SelectedIndex =
+                cmbMalePaperdoll.FindString(TextUtils.NullToNone(mEditorItem.MalePaperdoll));
 
-            var events = EventBase.Names;
-            var eventElements = new List<ComboBox>() { cmbEvent, cmbEventTriggers };
-            foreach (var element in eventElements)
-            {
-                element.Items.Clear();
-                element.Items.Add(Strings.General.None);
-                element.Items.AddRange(events);
-            }
+            cmbFemalePaperdoll.SelectedIndex =
+                cmbFemalePaperdoll.FindString(TextUtils.NullToNone(mEditorItem.FemalePaperdoll));
 
-            cmbMalePaperdoll.Items.Clear();
-            cmbMalePaperdoll.Items.Add(Strings.General.None);
-            cmbFemalePaperdoll.Items.Clear();
-            cmbFemalePaperdoll.Items.Add(Strings.General.None);
-            var paperdollnames =
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Paperdoll);
-
-            for (var i = 0; i < paperdollnames.Length; i++)
-            {
-                cmbMalePaperdoll.Items.Add(paperdollnames[i]);
-                cmbFemalePaperdoll.Items.Add(paperdollnames[i]);
-            }
-
-            nudStr.Maximum = Options.MaxStatValue;
-            nudMag.Maximum = Options.MaxStatValue;
-            nudDef.Maximum = Options.MaxStatValue;
-            nudMR.Maximum = Options.MaxStatValue;
-            nudSpd.Maximum = Options.MaxStatValue;
-
-            nudStr.Minimum = -Options.MaxStatValue;
-            nudMag.Minimum = -Options.MaxStatValue;
-            nudDef.Minimum = -Options.MaxStatValue;
-            nudMR.Minimum = -Options.MaxStatValue;
-            nudSpd.Minimum = -Options.MaxStatValue;
-
-            InitLocalization();
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.ItemEditor.title;
-            toolStripItemNew.Text = Strings.ItemEditor.New;
-            toolStripItemDelete.Text = Strings.ItemEditor.delete;
-            toolStripItemCopy.Text = Strings.ItemEditor.copy;
-            toolStripItemPaste.Text = Strings.ItemEditor.paste;
-            toolStripItemUndo.Text = Strings.ItemEditor.undo;
-
-            grpItems.Text = Strings.ItemEditor.items;
-            grpGeneral.Text = Strings.ItemEditor.general;
-            lblName.Text = Strings.ItemEditor.name;
-            lblType.Text = Strings.ItemEditor.type;
-            cmbType.Items.Clear();
-            for (var i = 0; i < Strings.ItemEditor.types.Count; i++)
-            {
-                cmbType.Items.Add(Strings.ItemEditor.types[i]);
-            }
-
-            lblDesc.Text = Strings.ItemEditor.description;
-            lblPic.Text = Strings.ItemEditor.picture;
-            lblRed.Text = Strings.ItemEditor.Red;
-            lblGreen.Text = Strings.ItemEditor.Green;
-            lblBlue.Text = Strings.ItemEditor.Blue;
-            lblAlpha.Text = Strings.ItemEditor.Alpha;
-            lblPrice.Text = Strings.ItemEditor.price;
-            lblAnim.Text = Strings.ItemEditor.animation;
-            chkCanDrop.Text = Strings.ItemEditor.CanDrop;
-            lblDeathDropChance.Text = Strings.ItemEditor.DeathDropChance;
-            lblDespawnTime.Text = Strings.ItemEditor.DespawnTime;
-            tooltips.SetToolTip(lblDespawnTime, Strings.ItemEditor.DespawnTimeTooltip);
-            tooltips.SetToolTip(nudItemDespawnTime, Strings.ItemEditor.DespawnTimeTooltip);
-            chkCanBank.Text = Strings.ItemEditor.CanBank;
-            chkCanGuildBank.Text = Strings.ItemEditor.CanGuildBank;
-            chkCanBag.Text = Strings.ItemEditor.CanBag;
-            chkCanTrade.Text = Strings.ItemEditor.CanTrade;
-            chkCanSell.Text = Strings.ItemEditor.CanSell;
-
-            grpStack.Text = Strings.ItemEditor.StackOptions;
-            chkStackable.Text = Strings.ItemEditor.stackable;
-            lblInvStackLimit.Text = Strings.ItemEditor.InventoryStackLimit;
-            lblBankStackLimit.Text = Strings.ItemEditor.BankStackLimit;
-
-            cmbRarity.Items.Clear();
-            for (var i = 0; i < Options.Instance.Items.RarityTiers.Count; i++)
-            {
-                var rarityName = Options.Instance.Items.RarityTiers[i];
-                cmbRarity.Items.Add(Strings.ItemEditor.rarity[rarityName]);
-            }
-
-            grpEvents.Text = Strings.ItemEditor.EventGroup;
-            lblEventForTrigger.Text = Strings.ItemEditor.EventGroupLabel;
-
-            grpEquipment.Text = Strings.ItemEditor.equipment;
-            lblEquipmentSlot.Text = Strings.ItemEditor.slot;
-            grpStatBonuses.Text = Strings.ItemEditor.bonuses;
-            lblStr.Text = Strings.ItemEditor.attackbonus;
-            lblDef.Text = Strings.ItemEditor.defensebonus;
-            lblSpd.Text = Strings.ItemEditor.speedbonus;
-            lblMag.Text = Strings.ItemEditor.abilitypowerbonus;
-            lblMR.Text = Strings.ItemEditor.magicresistbonus;
-            lblEffectPercent.Text = Strings.ItemEditor.bonusamount;
-            lblEquipmentAnimation.Text = Strings.ItemEditor.equipmentanimation;
-
-            grpStatRanges.Text = Strings.ItemEditor.StatRangeTitle;
-            lblStatRangeFrom.Text = Strings.ItemEditor.StatRangeFrom;
-            lblStatRangeTo.Text = Strings.ItemEditor.StatRangeTo;
-
-            grpWeaponProperties.Text = Strings.ItemEditor.weaponproperties;
-            chk2Hand.Text = Strings.ItemEditor.twohanded;
-            lblDamage.Text = Strings.ItemEditor.basedamage;
-            lblCritChance.Text = Strings.ItemEditor.critchance;
-            lblCritMultiplier.Text = Strings.ItemEditor.critmultiplier;
-            lblDamageType.Text = Strings.ItemEditor.damagetype;
-            cmbDamageType.Items.Clear();
-            for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
-            {
-                cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
-            }
-
-            lblScalingStat.Text = Strings.ItemEditor.scalingstat;
-            lblScalingAmount.Text = Strings.ItemEditor.scalingamount;
-            lblAttackAnimation.Text = Strings.ItemEditor.attackanimation;
-            lblSpriteAttack.Text = Strings.ItemEditor.AttackSpriteOverride;
-            lblProjectile.Text = Strings.ItemEditor.projectile;
-            lblToolType.Text = Strings.ItemEditor.tooltype;
-
-            grpCooldown.Text = Strings.ItemEditor.CooldownOptions;
-            lblCooldown.Text = Strings.ItemEditor.cooldown;
-            lblCooldownGroup.Text = Strings.ItemEditor.CooldownGroup;
-            chkIgnoreGlobalCooldown.Text = Strings.ItemEditor.IgnoreGlobalCooldown;
-            chkIgnoreCdr.Text = Strings.ItemEditor.IgnoreCooldownReduction;
-
-            grpVitalBonuses.Text = Strings.ItemEditor.vitalbonuses;
-            lblHealthBonus.Text = Strings.ItemEditor.health;
-            lblManaBonus.Text = Strings.ItemEditor.mana;
-
-            grpRegen.Text = Strings.ItemEditor.regen;
-            lblHpRegen.Text = Strings.ItemEditor.hpregen;
-            lblManaRegen.Text = Strings.ItemEditor.mpregen;
-            lblRegenHint.Text = Strings.ItemEditor.regenhint;
-
-            grpAttackSpeed.Text = Strings.ItemEditor.attackspeed;
-            lblAttackSpeedModifier.Text = Strings.ItemEditor.attackspeedmodifier;
-            lblAttackSpeedValue.Text = Strings.ItemEditor.attackspeedvalue;
-            cmbAttackSpeedModifier.Items.Clear();
-            foreach (var val in Strings.ItemEditor.attackspeedmodifiers.Values)
-            {
-                cmbAttackSpeedModifier.Items.Add(val.ToString());
-            }
-
-            grpShieldProperties.Text = Strings.ItemEditor.ShieldProperties;
-            lblBlockChance.Text = Strings.ItemEditor.BlockChance;
-            lblBlockAmount.Text = Strings.ItemEditor.BlockAmount;
-            lblBlockDmgAbs.Text = Strings.ItemEditor.BlockAbsorption;
-
-            lblMalePaperdoll.Text = Strings.ItemEditor.malepaperdoll;
-            lblFemalePaperdoll.Text = Strings.ItemEditor.femalepaperdoll;
-
-            grpBags.Text = Strings.ItemEditor.bagpanel;
-            lblBag.Text = Strings.ItemEditor.bagslots;
-
-            grpSpell.Text = Strings.ItemEditor.spellpanel;
-            lblSpell.Text = Strings.ItemEditor.spell;
-            chkQuickCast.Text = Strings.ItemEditor.quickcast;
-            chkSingleUseSpell.Text = Strings.ItemEditor.destroyspell;
-
-            grpEvent.Text = Strings.ItemEditor.eventpanel;
-            chkSingleUseEvent.Text = Strings.ItemEditor.SingleUseEvent;
-
-            grpConsumable.Text = Strings.ItemEditor.consumeablepanel;
-            lblVital.Text = Strings.ItemEditor.vital;
-            lblInterval.Text = Strings.ItemEditor.consumeamount;
-            cmbConsume.Items.Clear();
-            for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
-            {
-                cmbConsume.Items.Add(Strings.Combat.vitals[i]);
-            }
-
-            cmbConsume.Items.Add(Strings.Combat.exp);
-
-            grpRequirements.Text = Strings.ItemEditor.requirementsgroup;
-            lblCannotUse.Text = Strings.ItemEditor.cannotuse;
-            btnEditRequirements.Text = Strings.ItemEditor.requirements;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.ItemEditor.sortalphabetically;
-            txtSearch.Text = Strings.ItemEditor.searchplaceholder;
-            lblFolder.Text = Strings.ItemEditor.folderlabel;
-
-            btnSave.Text = Strings.ItemEditor.save;
-            btnCancel.Text = Strings.ItemEditor.cancel;
-
-            grpEffects.Text = Strings.ItemEditor.BonusEffectGroup;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                txtDesc.Text = mEditorItem.Description;
-                cmbType.SelectedIndex = (int)mEditorItem.ItemType;
-                cmbPic.SelectedIndex = cmbPic.FindString(TextUtils.NullToNone(mEditorItem.Icon));
-                nudRgbaR.Value = mEditorItem.Color.R;
-                nudRgbaG.Value = mEditorItem.Color.G;
-                nudRgbaB.Value = mEditorItem.Color.B;
-                nudRgbaA.Value = mEditorItem.Color.A;
-                cmbEquipmentAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.EquipmentAnimationId) + 1;
-                nudPrice.Value = mEditorItem.Price;
-                cmbRarity.SelectedIndex = mEditorItem.Rarity;
-
-                nudStr.Value = mEditorItem.StatsGiven[0];
-                nudMag.Value = mEditorItem.StatsGiven[1];
-                nudDef.Value = mEditorItem.StatsGiven[2];
-                nudMR.Value = mEditorItem.StatsGiven[3];
-                nudSpd.Value = mEditorItem.StatsGiven[4];
-
-                nudStrPercentage.Value = mEditorItem.PercentageStatsGiven[0];
-                nudMagPercentage.Value = mEditorItem.PercentageStatsGiven[1];
-                nudDefPercentage.Value = mEditorItem.PercentageStatsGiven[2];
-                nudMRPercentage.Value = mEditorItem.PercentageStatsGiven[3];
-                nudSpdPercentage.Value = mEditorItem.PercentageStatsGiven[4];
-
-                nudHealthBonus.Value = mEditorItem.VitalsGiven[0];
-                nudManaBonus.Value = mEditorItem.VitalsGiven[1];
-                nudHPPercentage.Value = mEditorItem.PercentageVitalsGiven[0];
-                nudMPPercentage.Value = mEditorItem.PercentageVitalsGiven[1];
-                nudHPRegen.Value = mEditorItem.VitalsRegen[0];
-                nudMpRegen.Value = mEditorItem.VitalsRegen[1];
-
-                nudDamage.Value = mEditorItem.Damage;
-                nudCritChance.Value = mEditorItem.CritChance;
-                nudCritMultiplier.Value = (decimal)mEditorItem.CritMultiplier;
-                cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
-                nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
-                nudScaling.Value = mEditorItem.Scaling;
-                // This will be removed after conversion to a per-stat editor. Reminder that pre-migration LowRange == HighRange - Day
-                nudStatRangeHigh.Value = mEditorItem.StatRanges?.FirstOrDefault()?.HighRange ?? 0;
-                chkCanDrop.Checked = Convert.ToBoolean(mEditorItem.CanDrop);
-                chkCanBank.Checked = Convert.ToBoolean(mEditorItem.CanBank);
-                chkCanGuildBank.Checked = Convert.ToBoolean(mEditorItem.CanGuildBank);
-                chkCanBag.Checked = Convert.ToBoolean(mEditorItem.CanBag);
-                chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
-                chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
-                chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
-                nudInvStackLimit.Value = mEditorItem.MaxInventoryStack;
-                nudBankStackLimit.Value = mEditorItem.MaxBankStack;
-                nudDeathDropChance.Value = mEditorItem.DropChanceOnDeath;
-                nudItemDespawnTime.Value = mEditorItem.DespawnTime;
-                cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
-                cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
-                cmbWeaponSprite.SelectedIndex = cmbWeaponSprite.FindString(
-                        TextUtils.NullToNone(mEditorItem.WeaponSpriteOverride)
-                );
-                nudBlockChance.Value = mEditorItem.BlockChance;
-                nudBlockAmount.Value = mEditorItem.BlockAmount;
-                nudBlockDmgAbs.Value = mEditorItem.BlockAbsorption;
-                RefreshExtendedData();
-
-                chk2Hand.Checked = mEditorItem.TwoHanded;
-                cmbMalePaperdoll.SelectedIndex =
-                    cmbMalePaperdoll.FindString(TextUtils.NullToNone(mEditorItem.MalePaperdoll));
-
-                cmbFemalePaperdoll.SelectedIndex =
-                    cmbFemalePaperdoll.FindString(TextUtils.NullToNone(mEditorItem.FemalePaperdoll));
-
-                if (mEditorItem.ItemType == ItemType.Consumable)
-                {
-                    cmbConsume.SelectedIndex = (int)mEditorItem.Consumable.Type;
-                    nudInterval.Value = mEditorItem.Consumable.Value;
-                    nudIntervalPercentage.Value = mEditorItem.Consumable.Percentage;
-                }
-
-                picItem.BackgroundImage?.Dispose();
-                picItem.BackgroundImage = null;
-                if (cmbPic.SelectedIndex > 0)
-                {
-                    DrawItemIcon();
-                }
-
-                picMalePaperdoll.BackgroundImage?.Dispose();
-                picMalePaperdoll.BackgroundImage = null;
-                if (cmbMalePaperdoll.SelectedIndex > 0)
-                {
-                    DrawItemPaperdoll(Gender.Male);
-                }
-
-                picFemalePaperdoll.BackgroundImage?.Dispose();
-                picFemalePaperdoll.BackgroundImage = null;
-                if (cmbFemalePaperdoll.SelectedIndex > 0)
-                {
-                    DrawItemPaperdoll(Gender.Female);
-                }
-
-                cmbDamageType.SelectedIndex = mEditorItem.DamageType;
-                cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
-
-                //External References
-                cmbProjectile.SelectedIndex = ProjectileBase.ListIndex(mEditorItem.ProjectileId) + 1;
-                cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AnimationId) + 1;
-
-                nudCooldown.Value = mEditorItem.Cooldown;
-                cmbCooldownGroup.Text = mEditorItem.CooldownGroup;
-                chkIgnoreGlobalCooldown.Checked = mEditorItem.IgnoreGlobalCooldown;
-                chkIgnoreCdr.Checked = mEditorItem.IgnoreCooldownReduction;
-
-                txtCannotUse.Text = mEditorItem.CannotUseMessage;
-
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void RefreshExtendedData()
-        {
-            grpConsumable.Visible = false;
-            grpSpell.Visible = false;
-            grpEquipment.Visible = false;
-            grpEvent.Visible = false;
-            grpBags.Visible = false;
-            chkStackable.Enabled = true;
-
-            if ((int)mEditorItem.ItemType != cmbType.SelectedIndex)
-            {
-                mEditorItem.Consumable.Type = ConsumableType.Health;
-                mEditorItem.Consumable.Value = 0;
-
-                mEditorItem.TwoHanded = false;
-                mEditorItem.EquipmentSlot = 0;
-
-                mEditorItem.SlotCount = 0;
-
-                mEditorItem.Damage = 0;
-                mEditorItem.Tool = -1;
-
-                mEditorItem.Spell = null;
-                mEditorItem.Event = null;
-            }
-
-            if (cmbType.SelectedIndex == (int)ItemType.Consumable)
+            if (mEditorItem.ItemType == ItemType.Consumable)
             {
                 cmbConsume.SelectedIndex = (int)mEditorItem.Consumable.Type;
                 nudInterval.Value = mEditorItem.Consumable.Value;
                 nudIntervalPercentage.Value = mEditorItem.Consumable.Percentage;
-                grpConsumable.Visible = true;
-            }
-            else if (cmbType.SelectedIndex == (int)ItemType.Spell)
-            {
-                cmbTeachSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.SpellId) + 1;
-                chkQuickCast.Checked = mEditorItem.QuickCast;
-                chkSingleUseSpell.Checked = mEditorItem.SingleUse;
-                grpSpell.Visible = true;
-            }
-            else if (cmbType.SelectedIndex == (int)ItemType.Event)
-            {
-                cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
-                chkSingleUseEvent.Checked = mEditorItem.SingleUse;
-                grpEvent.Visible = true;
-            }
-            else if (cmbType.SelectedIndex == (int)ItemType.Equipment)
-            {
-                grpEquipment.Visible = true;
-                if (mEditorItem.EquipmentSlot < -1 || mEditorItem.EquipmentSlot >= cmbEquipmentSlot.Items.Count)
-                {
-                    mEditorItem.EquipmentSlot = 0;
-                }
-
-                cmbEquipmentSlot.SelectedIndex = mEditorItem.EquipmentSlot;
-
-                // Whether this item type is stackable is not up for debate.
-                chkStackable.Checked = false;
-                chkStackable.Enabled = false;
-
-                RefreshBonusList();
-                RefreshStatRangeList();
-            }
-            else if (cmbType.SelectedIndex == (int)ItemType.Bag)
-            {
-                // Cant have no space or negative space.
-                mEditorItem.SlotCount = Math.Max(1, mEditorItem.SlotCount);
-                grpBags.Visible = true;
-                nudBag.Value = mEditorItem.SlotCount;
-
-                // Whether this item type is stackable is not up for debate.
-                chkStackable.Checked = false;
-                chkStackable.Enabled = false;
-            }
-            else if (cmbType.SelectedIndex == (int)ItemType.Currency)
-            {
-                // Whether this item type is stackable is not up for debate.
-                chkStackable.Checked = true;
-                chkStackable.Enabled = false;
             }
 
-            mEditorItem.ItemType = (ItemType)cmbType.SelectedIndex;
-
-            PopulateEventTriggerList();
-        }
-
-        private void PopulateEventTriggerList(int lastIndex = -1)
-        {
-            lstEventTriggers.Items.Clear();
-            lstEventTriggers.SelectedIndex = -1;
-
-            // Some event triggers aren't valid for some item types - setup filters here
-            var invalidNonEquipOperations = new List<ItemEventTriggers>() { ItemEventTriggers.OnEquip, ItemEventTriggers.OnUnequip, ItemEventTriggers.OnHit, ItemEventTriggers.OnDamageReceived };
-
-            var invalidEventOperations = new List<ItemEventTriggers>() { ItemEventTriggers.OnUse };
-            invalidEventOperations.AddRange(invalidNonEquipOperations);
-
-            foreach (var triggerMapping in Strings.ItemEditor.EventTriggerSelections)
-            {
-                var trigger = triggerMapping.Key;
-                var triggerText = triggerMapping.Value;
-
-                Strings.ItemEditor.EventTriggerNames.TryGetValue(trigger, out var triggerName);
-                if (string.IsNullOrEmpty(triggerName))
-                {
-                    triggerName = EventBase.Deleted;
-                }
-
-                var evt = mEditorItem.GetEventTrigger(trigger);
-
-                if (mEditorItem.ItemType == ItemType.Event && invalidEventOperations.Contains(triggerMapping.Key))
-                {
-                    lstEventTriggers.Items.Add(Strings.ItemEditor.EventTriggerDisabled.ToString(triggerName));
-                    continue;
-                }
-
-                if (mEditorItem.ItemType != ItemType.Equipment && invalidNonEquipOperations.Contains(triggerMapping.Key))
-                {
-                    lstEventTriggers.Items.Add(Strings.ItemEditor.EventTriggerDisabled.ToString(triggerName));
-                    continue;
-                }
-
-                lstEventTriggers.Items.Add(triggerText.ToString(evt?.Name ?? Strings.General.None));
-            }
-
-            if (lastIndex < lstEventTriggers.Items.Count && lastIndex != -1)
-            {
-                lstEventTriggers.SelectedIndex = lastIndex;
-            }
-        }
-
-        private void cmbType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            RefreshExtendedData();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void cmbPic_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Icon = cmbPic.SelectedIndex < 1 ? null : cmbPic.Text;
             picItem.BackgroundImage?.Dispose();
             picItem.BackgroundImage = null;
             if (cmbPic.SelectedIndex > 0)
             {
                 DrawItemIcon();
             }
-        }
 
-        private void cmbConsume_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Consumable.Type = (ConsumableType)cmbConsume.SelectedIndex;
-        }
-
-        private void cmbPaperdoll_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MalePaperdoll = TextUtils.SanitizeNone(cmbMalePaperdoll.Text);
             picMalePaperdoll.BackgroundImage?.Dispose();
             picMalePaperdoll.BackgroundImage = null;
             if (cmbMalePaperdoll.SelectedIndex > 0)
             {
                 DrawItemPaperdoll(Gender.Male);
             }
-        }
 
-        private void txtDesc_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Description = txtDesc.Text;
-        }
-
-        private void cmbEquipmentSlot_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.EquipmentSlot = cmbEquipmentSlot.SelectedIndex;
-            if (cmbEquipmentSlot.SelectedIndex == Options.WeaponIndex)
-            {
-                grpShieldProperties.Hide();
-                grpWeaponProperties.Show();
-            }
-            else if (cmbEquipmentSlot.SelectedIndex == Options.ShieldIndex)
-            {
-                grpWeaponProperties.Hide();
-                grpShieldProperties.Show();
-            }
-            else
-            {
-                grpWeaponProperties.Hide();
-                grpShieldProperties.Hide();
-
-                mEditorItem.Projectile = null;
-                mEditorItem.Tool = -1;
-                mEditorItem.Damage = 0;
-                mEditorItem.TwoHanded = false;
-            }
-        }
-
-        private void cmbToolType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Tool = cmbToolType.SelectedIndex - 1;
-        }
-
-        private void cmbEquipmentBonus_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void chk2Hand_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.TwoHanded = chk2Hand.Checked;
-        }
-
-        private void FrmItem_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void cmbFemalePaperdoll_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.FemalePaperdoll = TextUtils.SanitizeNone(cmbFemalePaperdoll.Text);
             picFemalePaperdoll.BackgroundImage?.Dispose();
             picFemalePaperdoll.BackgroundImage = null;
             if (cmbFemalePaperdoll.SelectedIndex > 0)
             {
                 DrawItemPaperdoll(Gender.Female);
             }
-        }
 
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Item);
-        }
+            cmbDamageType.SelectedIndex = mEditorItem.DamageType;
+            cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
 
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
+            //External References
+            cmbProjectile.SelectedIndex = ProjectileBase.ListIndex(mEditorItem.ProjectileId) + 1;
+            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AnimationId) + 1;
+
+            nudCooldown.Value = mEditorItem.Cooldown;
+            cmbCooldownGroup.Text = mEditorItem.CooldownGroup;
+            chkIgnoreGlobalCooldown.Checked = mEditorItem.IgnoreGlobalCooldown;
+            chkIgnoreCdr.Checked = mEditorItem.IgnoreCooldownReduction;
+
+            txtCannotUse.Text = mEditorItem.CannotUseMessage;
+
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ItemEditor.deleteprompt, Strings.ItemEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
             }
         }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
+        else
         {
-            if (mEditorItem != null && lstGameObjects.Focused)
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void RefreshExtendedData()
+    {
+        grpConsumable.Visible = false;
+        grpSpell.Visible = false;
+        grpEquipment.Visible = false;
+        grpEvent.Visible = false;
+        grpBags.Visible = false;
+        chkStackable.Enabled = true;
+
+        if ((int)mEditorItem.ItemType != cmbType.SelectedIndex)
+        {
+            mEditorItem.Consumable.Type = ConsumableType.Health;
+            mEditorItem.Consumable.Value = 0;
+
+            mEditorItem.TwoHanded = false;
+            mEditorItem.EquipmentSlot = 0;
+
+            mEditorItem.SlotCount = 0;
+
+            mEditorItem.Damage = 0;
+            mEditorItem.Tool = -1;
+
+            mEditorItem.Spell = null;
+            mEditorItem.Event = null;
+        }
+
+        if (cmbType.SelectedIndex == (int)ItemType.Consumable)
+        {
+            cmbConsume.SelectedIndex = (int)mEditorItem.Consumable.Type;
+            nudInterval.Value = mEditorItem.Consumable.Value;
+            nudIntervalPercentage.Value = mEditorItem.Consumable.Percentage;
+            grpConsumable.Visible = true;
+        }
+        else if (cmbType.SelectedIndex == (int)ItemType.Spell)
+        {
+            cmbTeachSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.SpellId) + 1;
+            chkQuickCast.Checked = mEditorItem.QuickCast;
+            chkSingleUseSpell.Checked = mEditorItem.SingleUse;
+            grpSpell.Visible = true;
+        }
+        else if (cmbType.SelectedIndex == (int)ItemType.Event)
+        {
+            cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
+            chkSingleUseEvent.Checked = mEditorItem.SingleUse;
+            grpEvent.Visible = true;
+        }
+        else if (cmbType.SelectedIndex == (int)ItemType.Equipment)
+        {
+            grpEquipment.Visible = true;
+            if (mEditorItem.EquipmentSlot < -1 || mEditorItem.EquipmentSlot >= cmbEquipmentSlot.Items.Count)
             {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
-                UpdateEditor();
-            }
-        }
-
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ItemEditor.undoprompt, Strings.ItemEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void cmbWeaponSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.WeaponSpriteOverride = TextUtils.SanitizeNone(cmbWeaponSprite?.Text);
-        }
-
-        private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackAnimation =
-                AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DamageType = cmbDamageType.SelectedIndex;
-        }
-
-        private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
-        }
-
-        private void cmbProjectile_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Projectile = ProjectileBase.Get(ProjectileBase.IdFromList(cmbProjectile.SelectedIndex - 1));
-        }
-
-        private void btnEditRequirements_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.UsageRequirements, RequirementType.Item);
-            frm.ShowDialog();
-        }
-
-        private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Animation = AnimationBase.Get(AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
-        }
-
-        private void cmbTeachSpell_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Spell = SpellBase.Get(SpellBase.IdFromList(cmbTeachSpell.SelectedIndex - 1));
-        }
-
-        private void nudPrice_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Price = (int)nudPrice.Value;
-        }
-
-        private void nudScaling_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Scaling = (int)nudScaling.Value;
-        }
-
-        private void nudDamage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Damage = (int)nudDamage.Value;
-        }
-
-        private void nudCritChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritChance = (int)nudCritChance.Value;
-        }
-
-        private void nudEffectPercent_ValueChanged(object sender, EventArgs e)
-        {
-            if (!IsValidBonusSelection || EffectValueUpdating)
-            {
-                return;
+                mEditorItem.EquipmentSlot = 0;
             }
 
-            mEditorItem.SetEffectOfType(SelectedEffect, (int)nudEffectPercent.Value);
-            lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
+            cmbEquipmentSlot.SelectedIndex = mEditorItem.EquipmentSlot;
+
+            // Whether this item type is stackable is not up for debate.
+            chkStackable.Checked = false;
+            chkStackable.Enabled = false;
+
+            RefreshBonusList();
+            RefreshStatRangeList();
+        }
+        else if (cmbType.SelectedIndex == (int)ItemType.Bag)
+        {
+            // Cant have no space or negative space.
+            mEditorItem.SlotCount = Math.Max(1, mEditorItem.SlotCount);
+            grpBags.Visible = true;
+            nudBag.Value = mEditorItem.SlotCount;
+
+            // Whether this item type is stackable is not up for debate.
+            chkStackable.Checked = false;
+            chkStackable.Enabled = false;
+        }
+        else if (cmbType.SelectedIndex == (int)ItemType.Currency)
+        {
+            // Whether this item type is stackable is not up for debate.
+            chkStackable.Checked = true;
+            chkStackable.Enabled = false;
         }
 
-        private void nudStr_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatsGiven[0] = (int)nudStr.Value;
-        }
+        mEditorItem.ItemType = (ItemType)cmbType.SelectedIndex;
 
-        private void nudMag_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatsGiven[1] = (int)nudMag.Value;
-        }
+        PopulateEventTriggerList();
+    }
 
-        private void nudDef_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatsGiven[2] = (int)nudDef.Value;
-        }
+    private void PopulateEventTriggerList(int lastIndex = -1)
+    {
+        lstEventTriggers.Items.Clear();
+        lstEventTriggers.SelectedIndex = -1;
 
-        private void nudMR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatsGiven[3] = (int)nudMR.Value;
-        }
+        // Some event triggers aren't valid for some item types - setup filters here
+        var invalidNonEquipOperations = new List<ItemEventTriggers>() { ItemEventTriggers.OnEquip, ItemEventTriggers.OnUnequip, ItemEventTriggers.OnHit, ItemEventTriggers.OnDamageReceived };
 
-        private void nudSpd_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.StatsGiven[4] = (int)nudSpd.Value;
-        }
+        var invalidEventOperations = new List<ItemEventTriggers>() { ItemEventTriggers.OnUse };
+        invalidEventOperations.AddRange(invalidNonEquipOperations);
 
-        private void nudStrPercentage_ValueChanged(object sender, EventArgs e)
+        foreach (var triggerMapping in Strings.ItemEditor.EventTriggerSelections)
         {
-            mEditorItem.PercentageStatsGiven[0] = (int)nudStrPercentage.Value;
-        }
+            var trigger = triggerMapping.Key;
+            var triggerText = triggerMapping.Value;
 
-        private void nudMagPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageStatsGiven[1] = (int)nudMagPercentage.Value;
-        }
-
-        private void nudDefPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageStatsGiven[2] = (int)nudDefPercentage.Value;
-        }
-
-        private void nudMRPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageStatsGiven[3] = (int)nudMRPercentage.Value;
-        }
-
-        private void nudSpdPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageStatsGiven[4] = (int)nudSpdPercentage.Value;
-        }
-
-        private void nudBag_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SlotCount = (int)nudBag.Value;
-        }
-
-        private void nudInterval_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Consumable.Value = (int)nudInterval.Value;
-        }
-
-        private void nudIntervalPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Consumable.Percentage = (int)nudIntervalPercentage.Value;
-        }
-
-        private void chkBound_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanDrop = chkCanDrop.Checked;
-        }
-
-        private void chkCanBank_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanBank = chkCanBank.Checked;
-        }
-
-        private void chkCanGuildBank_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanGuildBank = chkCanGuildBank.Checked;
-        }
-
-        private void chkCanBag_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanBag = chkCanBag.Checked;
-        }
-
-        private void chkCanTrade_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanTrade = chkCanTrade.Checked;
-        }
-
-        private void chkCanSell_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CanSell = chkCanSell.Checked;
-        }
-
-        private void nudDeathDropChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DropChanceOnDeath = (int)nudDeathDropChance.Value;
-        }
-
-        private void chkStackable_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stackable = chkStackable.Checked;
-
-            if (chkStackable.Checked)
+            Strings.ItemEditor.EventTriggerNames.TryGetValue(trigger, out var triggerName);
+            if (string.IsNullOrEmpty(triggerName))
             {
-                nudInvStackLimit.Enabled = true;
-                nudBankStackLimit.Enabled = true;
-            }
-            else
-            {
-                nudInvStackLimit.Enabled = false;
-                nudInvStackLimit.Value = 1;
-                nudBankStackLimit.Enabled = false;
-                nudBankStackLimit.Value = 1;
-            }
-        }
-
-        private void nudInvStackLimit_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MaxInventoryStack = (int)nudInvStackLimit.Value;
-        }
-
-        private void nudBankStackLimit_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MaxBankStack = (int)nudBankStackLimit.Value;
-        }
-
-        private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritMultiplier = (double)nudCritMultiplier.Value;
-        }
-
-        private void nudCooldown_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Cooldown = (int)nudCooldown.Value;
-        }
-
-        private void nudHealthBonus_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalsGiven[0] = (int)nudHealthBonus.Value;
-        }
-
-        private void nudManaBonus_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalsGiven[1] = (int)nudManaBonus.Value;
-        }
-
-        private void nudHPPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageVitalsGiven[0] = (int)nudHPPercentage.Value;
-        }
-
-        private void nudMPPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PercentageVitalsGiven[1] = (int)nudMPPercentage.Value;
-        }
-
-        private void nudHPRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalsRegen[0] = (int)nudHPRegen.Value;
-        }
-
-        private void nudMpRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalsRegen[1] = (int)nudMpRegen.Value;
-        }
-
-        private void cmbEquipmentAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.EquipmentAnimation =
-                AnimationBase.Get(AnimationBase.IdFromList(cmbEquipmentAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
-            nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
-        }
-
-        private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedValue = (int)nudAttackSpeedValue.Value;
-        }
-
-        private void chkQuickCast_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.QuickCast = chkQuickCast.Checked;
-        }
-
-        private void chkSingleUse_CheckedChanged(object sender, EventArgs e)
-        {
-            switch ((ItemType)cmbType.SelectedIndex)
-            {
-                case ItemType.Spell:
-                    mEditorItem.SingleUse = chkSingleUseSpell.Checked;
-                    break;
-                case ItemType.Event:
-                    mEditorItem.SingleUse = chkSingleUseEvent.Checked;
-                    break;
-            }
-        }
-
-        private void cmbRarity_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Rarity = cmbRarity.SelectedIndex;
-        }
-
-        private void cmbCooldownGroup_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CooldownGroup = cmbCooldownGroup.Text;
-        }
-
-        private void btnAddCooldownGroup_Click(object sender, EventArgs e)
-        {
-            var cdGroupName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ItemEditor.CooldownGroupPrompt, Strings.ItemEditor.CooldownGroupTitle, ref cdGroupName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(cdGroupName))
-            {
-                if (!cmbCooldownGroup.Items.Contains(cdGroupName))
-                {
-                    mEditorItem.CooldownGroup = cdGroupName;
-                    mKnownCooldownGroups.Add(cdGroupName);
-                    InitEditor();
-                    cmbCooldownGroup.Text = cdGroupName;
-                }
-            }
-        }
-
-        private void chkIgnoreGlobalCooldown_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreGlobalCooldown = chkIgnoreGlobalCooldown.Checked;
-        }
-
-        private void chkIgnoreCdr_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreCooldownReduction = chkIgnoreCdr.Checked;
-        }
-
-        private void nudRgbaR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.R = (byte)nudRgbaR.Value;
-            DrawItemIcon();
-            DrawItemPaperdoll(Gender.Male);
-            DrawItemPaperdoll(Gender.Female);
-        }
-
-        private void nudRgbaG_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.G = (byte)nudRgbaG.Value;
-            DrawItemIcon();
-            DrawItemPaperdoll(Gender.Male);
-            DrawItemPaperdoll(Gender.Female);
-        }
-
-        private void nudRgbaB_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.B = (byte)nudRgbaB.Value;
-            DrawItemIcon();
-            DrawItemPaperdoll(Gender.Male);
-            DrawItemPaperdoll(Gender.Female);
-        }
-
-        private void nudRgbaA_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.A = (byte)nudRgbaA.Value;
-            DrawItemIcon();
-            DrawItemPaperdoll(Gender.Male);
-            DrawItemPaperdoll(Gender.Female);
-        }
-
-        private void nudBlockChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BlockChance = (int)nudBlockChance.Value;
-        }
-
-        private void nudBlockAmount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BlockAmount = (int)nudBlockAmount.Value;
-        }
-
-        private void nudBlockDmgAbs_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BlockAbsorption = (int)nudBlockDmgAbs.Value;
-        }
-
-        private void nudItemDespawnTime_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DespawnTime = (long)nudItemDespawnTime.Value;
-        }
-
-        /// <summary>
-        /// Draw the item Icon to the form.
-        /// </summary>
-        private void DrawItemIcon()
-        {
-            var picItemBmp = new Bitmap(picItem.Width, picItem.Height);
-            var gfx = Graphics.FromImage(picItemBmp);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picItem.Width, picItem.Height));
-            if (cmbPic.SelectedIndex > 0)
-            {
-                var img = Image.FromFile("resources/items/" + cmbPic.Text);
-                var imgAttributes = new ImageAttributes();
-
-                // Microsoft, what the heck is this crap?
-                imgAttributes.SetColorMatrix(
-                    new ColorMatrix(
-                        new float[][]
-                        {
-                            new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
-                            new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
-                            new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
-                            new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
-                            new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
-                        }
-                    )
-                );
-
-                gfx.DrawImage(
-                    img, new Rectangle(0, 0, img.Width, img.Height),
-                    0, 0, img.Width, img.Height, GraphicsUnit.Pixel, imgAttributes
-                );
-
-                img.Dispose();
-                imgAttributes.Dispose();
+                triggerName = EventBase.Deleted;
             }
 
-            gfx.Dispose();
+            var evt = mEditorItem.GetEventTrigger(trigger);
 
-            picItem.BackgroundImage = picItemBmp;
-        }
-
-        /// <summary>
-        /// Draw the item Paperdoll to the form for the specified Gender.
-        /// </summary>
-        /// <param name="gender"></param>
-        private void DrawItemPaperdoll(Gender gender)
-        {
-            PictureBox picPaperdoll;
-            ComboBox cmbPaperdoll;
-            switch (gender)
+            if (mEditorItem.ItemType == ItemType.Event && invalidEventOperations.Contains(triggerMapping.Key))
             {
-                case Gender.Male:
-                    picPaperdoll = picMalePaperdoll;
-                    cmbPaperdoll = cmbMalePaperdoll;
-                    break;
-
-                case Gender.Female:
-                    picPaperdoll = picFemalePaperdoll;
-                    cmbPaperdoll = cmbFemalePaperdoll;
-                    break;
-
-                default:
-                    throw new NotImplementedException();
+                lstEventTriggers.Items.Add(Strings.ItemEditor.EventTriggerDisabled.ToString(triggerName));
+                continue;
             }
 
-            var picItemBmp = new Bitmap(picPaperdoll.Width, picPaperdoll.Height);
-            var gfx = Graphics.FromImage(picItemBmp);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picPaperdoll.Width, picPaperdoll.Height));
-            if (cmbPaperdoll.SelectedIndex > 0)
+            if (mEditorItem.ItemType != ItemType.Equipment && invalidNonEquipOperations.Contains(triggerMapping.Key))
             {
-                var img = Image.FromFile("resources/paperdolls/" + cmbPaperdoll.Text);
-                var imgAttributes = new ImageAttributes();
-
-                // Microsoft, what the heck is this crap?
-                imgAttributes.SetColorMatrix(
-                    new ColorMatrix(
-                        new float[][]
-                        {
-                            new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
-                            new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
-                            new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
-                            new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
-                            new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
-                        }
-                    )
-                );
-
-                gfx.DrawImage(
-                    img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
-                    0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions, GraphicsUnit.Pixel, imgAttributes
-                );
-
-                img.Dispose();
-                imgAttributes.Dispose();
+                lstEventTriggers.Items.Add(Strings.ItemEditor.EventTriggerDisabled.ToString(triggerName));
+                continue;
             }
 
-            gfx.Dispose();
-
-            picPaperdoll.BackgroundImage = picItemBmp;
+            lstEventTriggers.Items.Add(triggerText.ToString(evt?.Name ?? Strings.General.None));
         }
 
-        private void txtCannotUse_TextChanged(object sender, EventArgs e)
+        if (lastIndex < lstEventTriggers.Items.Count && lastIndex != -1)
         {
-            mEditorItem.CannotUseMessage = txtCannotUse.Text;
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders and cooldown groups
-            var mFolders = new List<string>();
-            foreach (var itm in ItemBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((ItemBase)itm.Value).Folder) &&
-                    !mFolders.Contains(((ItemBase)itm.Value).Folder))
-                {
-                    mFolders.Add(((ItemBase)itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ItemBase)itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((ItemBase)itm.Value).Folder);
-                    }
-                }
-
-                if (!string.IsNullOrWhiteSpace(((ItemBase)itm.Value).CooldownGroup) &&
-                    !mKnownCooldownGroups.Contains(((ItemBase)itm.Value).CooldownGroup))
-                {
-                    mKnownCooldownGroups.Add(((ItemBase)itm.Value).CooldownGroup);
-                }
-            }
-
-            // Do we add spell cooldown groups as well?
-            if (Options.Combat.LinkSpellAndItemCooldowns)
-            {
-                foreach (var itm in SpellBase.Lookup)
-                {
-                    if (!string.IsNullOrWhiteSpace(((SpellBase)itm.Value).CooldownGroup) &&
-                    !mKnownCooldownGroups.Contains(((SpellBase)itm.Value).CooldownGroup))
-                    {
-                        mKnownCooldownGroups.Add(((SpellBase)itm.Value).CooldownGroup);
-                    }
-                }
-            }
-
-            mKnownCooldownGroups.Sort();
-            cmbCooldownGroup.Items.Clear();
-            cmbCooldownGroup.Items.Add(string.Empty);
-            cmbCooldownGroup.Items.AddRange(mKnownCooldownGroups.ToArray());
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = ItemBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((ItemBase)pair.Value)?.Name ?? Models.DatabaseObject<ItemBase>.Deleted, ((ItemBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ItemEditor.folderprompt, Strings.ItemEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.UpdateText(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.ItemEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.ItemEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.ItemEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.ItemEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-
-        #endregion
-
-        private void RefreshBonusList()
-        {
-            lstBonusEffects.Items.Clear();
-            // Skip the "none" value - we don't care about that anymore, that's legacy
-            var idx = 1;
-            foreach (var effectName in Strings.ItemEditor.bonuseffects.Skip(1))
-            {
-                lstBonusEffects.Items.Add(GetBonusEffectRow((ItemEffect)idx));
-                idx++;
-            }
-        }
-
-        private void RefreshStatRangeList()
-        {
-            lstStatRanges.Items.Clear();
-            foreach (var (stat, statName) in Strings.Combat.stats)
-            {
-                lstStatRanges.Items.Add(GetStatRangeRowText((Stat)stat, statName));
-            }
-        }
-
-        private string GetStatRangeRowText(Stat stat, LocalizedString? statName = null)
-        {
-            if (statName == null && !Strings.Combat.stats.TryGetValue((int)stat, out statName))
-            {
-                statName = Strings.General.None;
-            }
-
-            mEditorItem.TryGetRangeFor(stat, out var range);
-            return Strings.ItemEditor.StatRangeItem.ToString(statName, range?.LowRange ?? 0, range?.HighRange ?? 0);
-        }
-
-        private bool IsValidBonusSelection
-        {
-            get => lstBonusEffects.SelectedIndex > -1 && lstBonusEffects.SelectedIndex < lstBonusEffects.Items.Count;
-        }
-
-        private ItemEffect SelectedEffect
-        {
-            get => IsValidBonusSelection ? (ItemEffect)(lstBonusEffects.SelectedIndex + 1) : ItemEffect.None;
-        }
-
-        private string GetBonusEffectRow(ItemEffect itemEffect)
-        {
-            var effectName = Strings.ItemEditor.bonuseffects[(int)itemEffect];
-            var effectAmt = mEditorItem.GetEffectPercentage(itemEffect);
-            return Strings.ItemEditor.BonusEffectItem.ToString(effectName, effectAmt);
-        }
-
-        private Stat? SelectedStatRange
-        {
-            get => Enum.IsDefined((Stat)lstStatRanges.SelectedIndex) ? (Stat)(lstStatRanges.SelectedIndex) : null;
-        }
-
-        private ItemEventTriggers? SelectedEventTrigger
-        {
-            get => Enum.IsDefined((ItemEventTriggers)lstEventTriggers.SelectedIndex) ? (ItemEventTriggers)(lstEventTriggers.SelectedIndex) : null;
-        }
-
-        private void lstBonusEffects_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (!IsValidBonusSelection)
-            {
-                return;
-            }
-
-            var selected = SelectedEffect;
-            if (!mEditorItem.EffectsEnabled.Contains(selected))
-            {
-                mEditorItem.Effects.Add(new EffectData(selected, 0));
-            }
-
-            EffectValueUpdating = true;
-            nudEffectPercent.Value = mEditorItem.GetEffectPercentage(selected);
-            EffectValueUpdating = false;
-        }
-
-        private void nudStatRangeLow_ValueChanged(object sender, EventArgs e)
-        {
-            if (!SelectedStatRange.HasValue)
-            {
-                return;
-            }
-
-            mEditorItem.ModifyStatRangeLow(SelectedStatRange.Value, (int)nudStatRangeLow.Value);
-            UpdateStatRangeRow(lstStatRanges.SelectedIndex);
-            nudStatRangeLow.Focus();
-        }
-
-        private void nudStatRangeHigh_ValueChanged(object sender, EventArgs e)
-        {
-            if (!SelectedStatRange.HasValue)
-            {
-                return;
-            }
-
-            mEditorItem.ModifyStatRangeHigh(SelectedStatRange.Value, (int)nudStatRangeHigh.Value);
-            UpdateStatRangeRow(lstStatRanges.SelectedIndex);
-            nudStatRangeHigh.Focus();
-        }
-
-        private void UpdateStatRangeRow(int selectedIndex)
-        {
-            if (!SelectedStatRange.HasValue)
-            {
-                return;
-            }
-
-            lstStatRanges.Items[selectedIndex] = GetStatRangeRowText(SelectedStatRange.Value);
-        }
-
-        private void lstStatRanges_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            var statSelected = lstStatRanges.SelectedIndex >= 0;
-            nudStatRangeLow.Enabled = statSelected;
-            nudStatRangeHigh.Enabled = statSelected;
-
-            if (!SelectedStatRange.HasValue)
-            {
-                return;
-            }
-
-            if (!mEditorItem.TryGetRangeFor(SelectedStatRange.Value, out var range))
-            {
-                return;
-            }
-
-            nudStatRangeLow.Value = range.LowRange;
-            nudStatRangeHigh.Value = range.HighRange;
-        }
-
-        private void lstEventTriggers_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            var triggerSelected = lstEventTriggers.SelectedIndex >= 0;
-            cmbEventTriggers.Enabled = triggerSelected;
-
-            if (!SelectedEventTrigger.HasValue)
-            {
-                if (cmbEventTriggers.Items.Count > 0)
-                {
-                    cmbEventTriggers.SelectedIndex = 0;
-                }
-                return;
-            }
-
-            var trigger = mEditorItem.GetEventTrigger(SelectedEventTrigger.Value);
-            if (trigger == null)
-            {
-                if (cmbEventTriggers.Items.Count > 0)
-                {
-                    cmbEventTriggers.SelectedIndex = 0;
-                }
-                return;
-            }
-
-            cmbEventTriggers.SelectedIndex = EventBase.ListIndex(trigger.Id) + 1;
-        }
-
-        private void cmbEventTriggers_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (!SelectedEventTrigger.HasValue)
-            {
-                return;
-            }
-            
-            mEditorItem.EventTriggers[SelectedEventTrigger.Value] = EventBase.IdFromList(cmbEventTriggers.SelectedIndex - 1);
-
-            PopulateEventTriggerList(lstEventTriggers.SelectedIndex);
+            lstEventTriggers.SelectedIndex = lastIndex;
         }
     }
 
+    private void cmbType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        RefreshExtendedData();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void cmbPic_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Icon = cmbPic.SelectedIndex < 1 ? null : cmbPic.Text;
+        picItem.BackgroundImage?.Dispose();
+        picItem.BackgroundImage = null;
+        if (cmbPic.SelectedIndex > 0)
+        {
+            DrawItemIcon();
+        }
+    }
+
+    private void cmbConsume_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Consumable.Type = (ConsumableType)cmbConsume.SelectedIndex;
+    }
+
+    private void cmbPaperdoll_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MalePaperdoll = TextUtils.SanitizeNone(cmbMalePaperdoll.Text);
+        picMalePaperdoll.BackgroundImage?.Dispose();
+        picMalePaperdoll.BackgroundImage = null;
+        if (cmbMalePaperdoll.SelectedIndex > 0)
+        {
+            DrawItemPaperdoll(Gender.Male);
+        }
+    }
+
+    private void txtDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Description = txtDesc.Text;
+    }
+
+    private void cmbEquipmentSlot_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.EquipmentSlot = cmbEquipmentSlot.SelectedIndex;
+        if (cmbEquipmentSlot.SelectedIndex == Options.WeaponIndex)
+        {
+            grpShieldProperties.Hide();
+            grpWeaponProperties.Show();
+        }
+        else if (cmbEquipmentSlot.SelectedIndex == Options.ShieldIndex)
+        {
+            grpWeaponProperties.Hide();
+            grpShieldProperties.Show();
+        }
+        else
+        {
+            grpWeaponProperties.Hide();
+            grpShieldProperties.Hide();
+
+            mEditorItem.Projectile = null;
+            mEditorItem.Tool = -1;
+            mEditorItem.Damage = 0;
+            mEditorItem.TwoHanded = false;
+        }
+    }
+
+    private void cmbToolType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Tool = cmbToolType.SelectedIndex - 1;
+    }
+
+    private void cmbEquipmentBonus_SelectedIndexChanged(object sender, EventArgs e)
+    {
+    }
+
+    private void chk2Hand_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.TwoHanded = chk2Hand.Checked;
+    }
+
+    private void FrmItem_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
+
+    private void cmbFemalePaperdoll_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.FemalePaperdoll = TextUtils.SanitizeNone(cmbFemalePaperdoll.Text);
+        picFemalePaperdoll.BackgroundImage?.Dispose();
+        picFemalePaperdoll.BackgroundImage = null;
+        if (cmbFemalePaperdoll.SelectedIndex > 0)
+        {
+            DrawItemPaperdoll(Gender.Female);
+        }
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Item);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ItemEditor.deleteprompt, Strings.ItemEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ItemEditor.undoprompt, Strings.ItemEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void cmbWeaponSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.WeaponSpriteOverride = TextUtils.SanitizeNone(cmbWeaponSprite?.Text);
+    }
+
+    private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackAnimation =
+            AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
+    }
+
+    private void cmbProjectile_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Projectile = ProjectileBase.Get(ProjectileBase.IdFromList(cmbProjectile.SelectedIndex - 1));
+    }
+
+    private void btnEditRequirements_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.UsageRequirements, RequirementType.Item);
+        frm.ShowDialog();
+    }
+
+    private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Animation = AnimationBase.Get(AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
+    }
+
+    private void cmbTeachSpell_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Spell = SpellBase.Get(SpellBase.IdFromList(cmbTeachSpell.SelectedIndex - 1));
+    }
+
+    private void nudPrice_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Price = (int)nudPrice.Value;
+    }
+
+    private void nudScaling_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Scaling = (int)nudScaling.Value;
+    }
+
+    private void nudDamage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Damage = (int)nudDamage.Value;
+    }
+
+    private void nudCritChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritChance = (int)nudCritChance.Value;
+    }
+
+    private void nudEffectPercent_ValueChanged(object sender, EventArgs e)
+    {
+        if (!IsValidBonusSelection || EffectValueUpdating)
+        {
+            return;
+        }
+
+        mEditorItem.SetEffectOfType(SelectedEffect, (int)nudEffectPercent.Value);
+        lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
+    }
+
+    private void nudStr_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatsGiven[0] = (int)nudStr.Value;
+    }
+
+    private void nudMag_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatsGiven[1] = (int)nudMag.Value;
+    }
+
+    private void nudDef_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatsGiven[2] = (int)nudDef.Value;
+    }
+
+    private void nudMR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatsGiven[3] = (int)nudMR.Value;
+    }
+
+    private void nudSpd_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.StatsGiven[4] = (int)nudSpd.Value;
+    }
+
+    private void nudStrPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageStatsGiven[0] = (int)nudStrPercentage.Value;
+    }
+
+    private void nudMagPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageStatsGiven[1] = (int)nudMagPercentage.Value;
+    }
+
+    private void nudDefPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageStatsGiven[2] = (int)nudDefPercentage.Value;
+    }
+
+    private void nudMRPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageStatsGiven[3] = (int)nudMRPercentage.Value;
+    }
+
+    private void nudSpdPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageStatsGiven[4] = (int)nudSpdPercentage.Value;
+    }
+
+    private void nudBag_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SlotCount = (int)nudBag.Value;
+    }
+
+    private void nudInterval_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Consumable.Value = (int)nudInterval.Value;
+    }
+
+    private void nudIntervalPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Consumable.Percentage = (int)nudIntervalPercentage.Value;
+    }
+
+    private void chkBound_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanDrop = chkCanDrop.Checked;
+    }
+
+    private void chkCanBank_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanBank = chkCanBank.Checked;
+    }
+
+    private void chkCanGuildBank_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanGuildBank = chkCanGuildBank.Checked;
+    }
+
+    private void chkCanBag_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanBag = chkCanBag.Checked;
+    }
+
+    private void chkCanTrade_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanTrade = chkCanTrade.Checked;
+    }
+
+    private void chkCanSell_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CanSell = chkCanSell.Checked;
+    }
+
+    private void nudDeathDropChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DropChanceOnDeath = (int)nudDeathDropChance.Value;
+    }
+
+    private void chkStackable_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stackable = chkStackable.Checked;
+
+        if (chkStackable.Checked)
+        {
+            nudInvStackLimit.Enabled = true;
+            nudBankStackLimit.Enabled = true;
+        }
+        else
+        {
+            nudInvStackLimit.Enabled = false;
+            nudInvStackLimit.Value = 1;
+            nudBankStackLimit.Enabled = false;
+            nudBankStackLimit.Value = 1;
+        }
+    }
+
+    private void nudInvStackLimit_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MaxInventoryStack = (int)nudInvStackLimit.Value;
+    }
+
+    private void nudBankStackLimit_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MaxBankStack = (int)nudBankStackLimit.Value;
+    }
+
+    private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritMultiplier = (double)nudCritMultiplier.Value;
+    }
+
+    private void nudCooldown_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Cooldown = (int)nudCooldown.Value;
+    }
+
+    private void nudHealthBonus_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalsGiven[0] = (int)nudHealthBonus.Value;
+    }
+
+    private void nudManaBonus_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalsGiven[1] = (int)nudManaBonus.Value;
+    }
+
+    private void nudHPPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageVitalsGiven[0] = (int)nudHPPercentage.Value;
+    }
+
+    private void nudMPPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PercentageVitalsGiven[1] = (int)nudMPPercentage.Value;
+    }
+
+    private void nudHPRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalsRegen[0] = (int)nudHPRegen.Value;
+    }
+
+    private void nudMpRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalsRegen[1] = (int)nudMpRegen.Value;
+    }
+
+    private void cmbEquipmentAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.EquipmentAnimation =
+            AnimationBase.Get(AnimationBase.IdFromList(cmbEquipmentAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
+        nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
+    }
+
+    private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedValue = (int)nudAttackSpeedValue.Value;
+    }
+
+    private void chkQuickCast_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.QuickCast = chkQuickCast.Checked;
+    }
+
+    private void chkSingleUse_CheckedChanged(object sender, EventArgs e)
+    {
+        switch ((ItemType)cmbType.SelectedIndex)
+        {
+            case ItemType.Spell:
+                mEditorItem.SingleUse = chkSingleUseSpell.Checked;
+                break;
+            case ItemType.Event:
+                mEditorItem.SingleUse = chkSingleUseEvent.Checked;
+                break;
+        }
+    }
+
+    private void cmbRarity_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Rarity = cmbRarity.SelectedIndex;
+    }
+
+    private void cmbCooldownGroup_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CooldownGroup = cmbCooldownGroup.Text;
+    }
+
+    private void btnAddCooldownGroup_Click(object sender, EventArgs e)
+    {
+        var cdGroupName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ItemEditor.CooldownGroupPrompt, Strings.ItemEditor.CooldownGroupTitle, ref cdGroupName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(cdGroupName))
+        {
+            if (!cmbCooldownGroup.Items.Contains(cdGroupName))
+            {
+                mEditorItem.CooldownGroup = cdGroupName;
+                mKnownCooldownGroups.Add(cdGroupName);
+                InitEditor();
+                cmbCooldownGroup.Text = cdGroupName;
+            }
+        }
+    }
+
+    private void chkIgnoreGlobalCooldown_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreGlobalCooldown = chkIgnoreGlobalCooldown.Checked;
+    }
+
+    private void chkIgnoreCdr_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreCooldownReduction = chkIgnoreCdr.Checked;
+    }
+
+    private void nudRgbaR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.R = (byte)nudRgbaR.Value;
+        DrawItemIcon();
+        DrawItemPaperdoll(Gender.Male);
+        DrawItemPaperdoll(Gender.Female);
+    }
+
+    private void nudRgbaG_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.G = (byte)nudRgbaG.Value;
+        DrawItemIcon();
+        DrawItemPaperdoll(Gender.Male);
+        DrawItemPaperdoll(Gender.Female);
+    }
+
+    private void nudRgbaB_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.B = (byte)nudRgbaB.Value;
+        DrawItemIcon();
+        DrawItemPaperdoll(Gender.Male);
+        DrawItemPaperdoll(Gender.Female);
+    }
+
+    private void nudRgbaA_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.A = (byte)nudRgbaA.Value;
+        DrawItemIcon();
+        DrawItemPaperdoll(Gender.Male);
+        DrawItemPaperdoll(Gender.Female);
+    }
+
+    private void nudBlockChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BlockChance = (int)nudBlockChance.Value;
+    }
+
+    private void nudBlockAmount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BlockAmount = (int)nudBlockAmount.Value;
+    }
+
+    private void nudBlockDmgAbs_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BlockAbsorption = (int)nudBlockDmgAbs.Value;
+    }
+
+    private void nudItemDespawnTime_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DespawnTime = (long)nudItemDespawnTime.Value;
+    }
+
+    /// <summary>
+    /// Draw the item Icon to the form.
+    /// </summary>
+    private void DrawItemIcon()
+    {
+        var picItemBmp = new Bitmap(picItem.Width, picItem.Height);
+        var gfx = Graphics.FromImage(picItemBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picItem.Width, picItem.Height));
+        if (cmbPic.SelectedIndex > 0)
+        {
+            var img = Image.FromFile("resources/items/" + cmbPic.Text);
+            var imgAttributes = new ImageAttributes();
+
+            // Microsoft, what the heck is this crap?
+            imgAttributes.SetColorMatrix(
+                new ColorMatrix(
+                    new float[][]
+                    {
+                        new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
+                        new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
+                        new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
+                        new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
+                        new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
+                    }
+                )
+            );
+
+            gfx.DrawImage(
+                img, new Rectangle(0, 0, img.Width, img.Height),
+                0, 0, img.Width, img.Height, GraphicsUnit.Pixel, imgAttributes
+            );
+
+            img.Dispose();
+            imgAttributes.Dispose();
+        }
+
+        gfx.Dispose();
+
+        picItem.BackgroundImage = picItemBmp;
+    }
+
+    /// <summary>
+    /// Draw the item Paperdoll to the form for the specified Gender.
+    /// </summary>
+    /// <param name="gender"></param>
+    private void DrawItemPaperdoll(Gender gender)
+    {
+        PictureBox picPaperdoll;
+        ComboBox cmbPaperdoll;
+        switch (gender)
+        {
+            case Gender.Male:
+                picPaperdoll = picMalePaperdoll;
+                cmbPaperdoll = cmbMalePaperdoll;
+                break;
+
+            case Gender.Female:
+                picPaperdoll = picFemalePaperdoll;
+                cmbPaperdoll = cmbFemalePaperdoll;
+                break;
+
+            default:
+                throw new NotImplementedException();
+        }
+
+        var picItemBmp = new Bitmap(picPaperdoll.Width, picPaperdoll.Height);
+        var gfx = Graphics.FromImage(picItemBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picPaperdoll.Width, picPaperdoll.Height));
+        if (cmbPaperdoll.SelectedIndex > 0)
+        {
+            var img = Image.FromFile("resources/paperdolls/" + cmbPaperdoll.Text);
+            var imgAttributes = new ImageAttributes();
+
+            // Microsoft, what the heck is this crap?
+            imgAttributes.SetColorMatrix(
+                new ColorMatrix(
+                    new float[][]
+                    {
+                        new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
+                        new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
+                        new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
+                        new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
+                        new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
+                    }
+                )
+            );
+
+            gfx.DrawImage(
+                img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
+                0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions, GraphicsUnit.Pixel, imgAttributes
+            );
+
+            img.Dispose();
+            imgAttributes.Dispose();
+        }
+
+        gfx.Dispose();
+
+        picPaperdoll.BackgroundImage = picItemBmp;
+    }
+
+    private void txtCannotUse_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CannotUseMessage = txtCannotUse.Text;
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders and cooldown groups
+        var mFolders = new List<string>();
+        foreach (var itm in ItemBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((ItemBase)itm.Value).Folder) &&
+                !mFolders.Contains(((ItemBase)itm.Value).Folder))
+            {
+                mFolders.Add(((ItemBase)itm.Value).Folder);
+                if (!mKnownFolders.Contains(((ItemBase)itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((ItemBase)itm.Value).Folder);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(((ItemBase)itm.Value).CooldownGroup) &&
+                !mKnownCooldownGroups.Contains(((ItemBase)itm.Value).CooldownGroup))
+            {
+                mKnownCooldownGroups.Add(((ItemBase)itm.Value).CooldownGroup);
+            }
+        }
+
+        // Do we add spell cooldown groups as well?
+        if (Options.Combat.LinkSpellAndItemCooldowns)
+        {
+            foreach (var itm in SpellBase.Lookup)
+            {
+                if (!string.IsNullOrWhiteSpace(((SpellBase)itm.Value).CooldownGroup) &&
+                !mKnownCooldownGroups.Contains(((SpellBase)itm.Value).CooldownGroup))
+                {
+                    mKnownCooldownGroups.Add(((SpellBase)itm.Value).CooldownGroup);
+                }
+            }
+        }
+
+        mKnownCooldownGroups.Sort();
+        cmbCooldownGroup.Items.Clear();
+        cmbCooldownGroup.Items.Add(string.Empty);
+        cmbCooldownGroup.Items.AddRange(mKnownCooldownGroups.ToArray());
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = ItemBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((ItemBase)pair.Value)?.Name ?? Models.DatabaseObject<ItemBase>.Deleted, ((ItemBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ItemEditor.folderprompt, Strings.ItemEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.UpdateText(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.ItemEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.ItemEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.ItemEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.ItemEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+
+    #endregion
+
+    private void RefreshBonusList()
+    {
+        lstBonusEffects.Items.Clear();
+        // Skip the "none" value - we don't care about that anymore, that's legacy
+        var idx = 1;
+        foreach (var effectName in Strings.ItemEditor.bonuseffects.Skip(1))
+        {
+            lstBonusEffects.Items.Add(GetBonusEffectRow((ItemEffect)idx));
+            idx++;
+        }
+    }
+
+    private void RefreshStatRangeList()
+    {
+        lstStatRanges.Items.Clear();
+        foreach (var (stat, statName) in Strings.Combat.stats)
+        {
+            lstStatRanges.Items.Add(GetStatRangeRowText((Stat)stat, statName));
+        }
+    }
+
+    private string GetStatRangeRowText(Stat stat, LocalizedString? statName = null)
+    {
+        if (statName == null && !Strings.Combat.stats.TryGetValue((int)stat, out statName))
+        {
+            statName = Strings.General.None;
+        }
+
+        mEditorItem.TryGetRangeFor(stat, out var range);
+        return Strings.ItemEditor.StatRangeItem.ToString(statName, range?.LowRange ?? 0, range?.HighRange ?? 0);
+    }
+
+    private bool IsValidBonusSelection
+    {
+        get => lstBonusEffects.SelectedIndex > -1 && lstBonusEffects.SelectedIndex < lstBonusEffects.Items.Count;
+    }
+
+    private ItemEffect SelectedEffect
+    {
+        get => IsValidBonusSelection ? (ItemEffect)(lstBonusEffects.SelectedIndex + 1) : ItemEffect.None;
+    }
+
+    private string GetBonusEffectRow(ItemEffect itemEffect)
+    {
+        var effectName = Strings.ItemEditor.bonuseffects[(int)itemEffect];
+        var effectAmt = mEditorItem.GetEffectPercentage(itemEffect);
+        return Strings.ItemEditor.BonusEffectItem.ToString(effectName, effectAmt);
+    }
+
+    private Stat? SelectedStatRange
+    {
+        get => Enum.IsDefined((Stat)lstStatRanges.SelectedIndex) ? (Stat)(lstStatRanges.SelectedIndex) : null;
+    }
+
+    private ItemEventTriggers? SelectedEventTrigger
+    {
+        get => Enum.IsDefined((ItemEventTriggers)lstEventTriggers.SelectedIndex) ? (ItemEventTriggers)(lstEventTriggers.SelectedIndex) : null;
+    }
+
+    private void lstBonusEffects_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (!IsValidBonusSelection)
+        {
+            return;
+        }
+
+        var selected = SelectedEffect;
+        if (!mEditorItem.EffectsEnabled.Contains(selected))
+        {
+            mEditorItem.Effects.Add(new EffectData(selected, 0));
+        }
+
+        EffectValueUpdating = true;
+        nudEffectPercent.Value = mEditorItem.GetEffectPercentage(selected);
+        EffectValueUpdating = false;
+    }
+
+    private void nudStatRangeLow_ValueChanged(object sender, EventArgs e)
+    {
+        if (!SelectedStatRange.HasValue)
+        {
+            return;
+        }
+
+        mEditorItem.ModifyStatRangeLow(SelectedStatRange.Value, (int)nudStatRangeLow.Value);
+        UpdateStatRangeRow(lstStatRanges.SelectedIndex);
+        nudStatRangeLow.Focus();
+    }
+
+    private void nudStatRangeHigh_ValueChanged(object sender, EventArgs e)
+    {
+        if (!SelectedStatRange.HasValue)
+        {
+            return;
+        }
+
+        mEditorItem.ModifyStatRangeHigh(SelectedStatRange.Value, (int)nudStatRangeHigh.Value);
+        UpdateStatRangeRow(lstStatRanges.SelectedIndex);
+        nudStatRangeHigh.Focus();
+    }
+
+    private void UpdateStatRangeRow(int selectedIndex)
+    {
+        if (!SelectedStatRange.HasValue)
+        {
+            return;
+        }
+
+        lstStatRanges.Items[selectedIndex] = GetStatRangeRowText(SelectedStatRange.Value);
+    }
+
+    private void lstStatRanges_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var statSelected = lstStatRanges.SelectedIndex >= 0;
+        nudStatRangeLow.Enabled = statSelected;
+        nudStatRangeHigh.Enabled = statSelected;
+
+        if (!SelectedStatRange.HasValue)
+        {
+            return;
+        }
+
+        if (!mEditorItem.TryGetRangeFor(SelectedStatRange.Value, out var range))
+        {
+            return;
+        }
+
+        nudStatRangeLow.Value = range.LowRange;
+        nudStatRangeHigh.Value = range.HighRange;
+    }
+
+    private void lstEventTriggers_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var triggerSelected = lstEventTriggers.SelectedIndex >= 0;
+        cmbEventTriggers.Enabled = triggerSelected;
+
+        if (!SelectedEventTrigger.HasValue)
+        {
+            if (cmbEventTriggers.Items.Count > 0)
+            {
+                cmbEventTriggers.SelectedIndex = 0;
+            }
+            return;
+        }
+
+        var trigger = mEditorItem.GetEventTrigger(SelectedEventTrigger.Value);
+        if (trigger == null)
+        {
+            if (cmbEventTriggers.Items.Count > 0)
+            {
+                cmbEventTriggers.SelectedIndex = 0;
+            }
+            return;
+        }
+
+        cmbEventTriggers.SelectedIndex = EventBase.ListIndex(trigger.Id) + 1;
+    }
+
+    private void cmbEventTriggers_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (!SelectedEventTrigger.HasValue)
+        {
+            return;
+        }
+        
+        mEditorItem.EventTriggers[SelectedEventTrigger.Value] = EventBase.IdFromList(cmbEventTriggers.SelectedIndex - 1);
+
+        PopulateEventTriggerList(lstEventTriggers.SelectedIndex);
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -12,504 +12,335 @@ using Intersect.GameObjects.Events;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmNpc : EditorForm
 {
 
-    public partial class FrmNpc : EditorForm
+    private List<NpcBase> mChanged = new List<NpcBase>();
+
+    private string mCopiedItem;
+
+    private NpcBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmNpc()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<NpcBase> mChanged = new List<NpcBase>();
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = NpcBase.Get(id);
+        UpdateEditor();
+    }
 
-        private string mCopiedItem;
-
-        private NpcBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        public FrmNpc()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Npc)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = NpcBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Npc)
+            InitEditor();
+            if (mEditorItem != null && !NpcBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !NpcBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            item.RestoreBackup();
+            item.DeleteBackup();
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
         {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                // Sort immunities to keep change checker consistent
-                item.Immunities.Sort();
+            // Sort immunities to keep change checker consistent
+            item.Immunities.Sort();
 
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
         }
 
-        private void frmNpc_Load(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmNpc_Load(object sender, EventArgs e)
+    {
+        cmbSprite.Items.Clear();
+        cmbSprite.Items.Add(Strings.General.None);
+        cmbSprite.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
+        );
+
+        cmbSpell.Items.Clear();
+        cmbSpell.Items.AddRange(SpellBase.Names);
+        cmbHostileNPC.Items.Clear();
+        cmbHostileNPC.Items.AddRange(NpcBase.Names);
+        cmbDropItem.Items.Clear();
+        cmbDropItem.Items.Add(Strings.General.None);
+        cmbDropItem.Items.AddRange(ItemBase.Names);
+        cmbAttackAnimation.Items.Clear();
+        cmbAttackAnimation.Items.Add(Strings.General.None);
+        cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
+        cmbOnDeathEventKiller.Items.Clear();
+        cmbOnDeathEventKiller.Items.Add(Strings.General.None);
+        cmbOnDeathEventKiller.Items.AddRange(EventBase.Names);
+        cmbOnDeathEventParty.Items.Clear();
+        cmbOnDeathEventParty.Items.Add(Strings.General.None);
+        cmbOnDeathEventParty.Items.AddRange(EventBase.Names);
+        cmbScalingStat.Items.Clear();
+        for (var x = 0; x < Enum.GetValues<Stat>().Length; x++)
         {
-            cmbSprite.Items.Clear();
-            cmbSprite.Items.Add(Strings.General.None);
-            cmbSprite.Items.AddRange(
-                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
-            );
-
-            cmbSpell.Items.Clear();
-            cmbSpell.Items.AddRange(SpellBase.Names);
-            cmbHostileNPC.Items.Clear();
-            cmbHostileNPC.Items.AddRange(NpcBase.Names);
-            cmbDropItem.Items.Clear();
-            cmbDropItem.Items.Add(Strings.General.None);
-            cmbDropItem.Items.AddRange(ItemBase.Names);
-            cmbAttackAnimation.Items.Clear();
-            cmbAttackAnimation.Items.Add(Strings.General.None);
-            cmbAttackAnimation.Items.AddRange(AnimationBase.Names);
-            cmbOnDeathEventKiller.Items.Clear();
-            cmbOnDeathEventKiller.Items.Add(Strings.General.None);
-            cmbOnDeathEventKiller.Items.AddRange(EventBase.Names);
-            cmbOnDeathEventParty.Items.Clear();
-            cmbOnDeathEventParty.Items.Add(Strings.General.None);
-            cmbOnDeathEventParty.Items.AddRange(EventBase.Names);
-            cmbScalingStat.Items.Clear();
-            for (var x = 0; x < Enum.GetValues<Stat>().Length; x++)
-            {
-                cmbScalingStat.Items.Add(Globals.GetStatName(x));
-            }
-
-            nudStr.Maximum = Options.MaxStatValue;
-            nudMag.Maximum = Options.MaxStatValue;
-            nudDef.Maximum = Options.MaxStatValue;
-            nudMR.Maximum = Options.MaxStatValue;
-            nudSpd.Maximum = Options.MaxStatValue;
-            InitLocalization();
-            UpdateEditor();
+            cmbScalingStat.Items.Add(Globals.GetStatName(x));
         }
 
-        private void InitLocalization()
+        nudStr.Maximum = Options.MaxStatValue;
+        nudMag.Maximum = Options.MaxStatValue;
+        nudDef.Maximum = Options.MaxStatValue;
+        nudMR.Maximum = Options.MaxStatValue;
+        nudSpd.Maximum = Options.MaxStatValue;
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.NpcEditor.title;
+        toolStripItemNew.Text = Strings.NpcEditor.New;
+        toolStripItemDelete.Text = Strings.NpcEditor.delete;
+        toolStripItemCopy.Text = Strings.NpcEditor.copy;
+        toolStripItemPaste.Text = Strings.NpcEditor.paste;
+        toolStripItemUndo.Text = Strings.NpcEditor.undo;
+
+        grpNpcs.Text = Strings.NpcEditor.npcs;
+
+        grpGeneral.Text = Strings.NpcEditor.general;
+        lblName.Text = Strings.NpcEditor.name;
+        grpBehavior.Text = Strings.NpcEditor.behavior;
+
+        lblPic.Text = Strings.NpcEditor.sprite;
+        lblRed.Text = Strings.NpcEditor.Red;
+        lblGreen.Text = Strings.NpcEditor.Green;
+        lblBlue.Text = Strings.NpcEditor.Blue;
+        lblAlpha.Text = Strings.NpcEditor.Alpha;
+
+        lblSpawnDuration.Text = Strings.NpcEditor.spawnduration;
+
+        //Behavior
+        chkAggressive.Text = Strings.NpcEditor.aggressive;
+        lblSightRange.Text = Strings.NpcEditor.sightrange;
+        lblMovement.Text = Strings.NpcEditor.movement;
+        lblResetRadius.Text = Strings.NpcEditor.resetradius;
+        cmbMovement.Items.Clear();
+        for (var i = 0; i < Strings.NpcEditor.movements.Count; i++)
         {
-            Text = Strings.NpcEditor.title;
-            toolStripItemNew.Text = Strings.NpcEditor.New;
-            toolStripItemDelete.Text = Strings.NpcEditor.delete;
-            toolStripItemCopy.Text = Strings.NpcEditor.copy;
-            toolStripItemPaste.Text = Strings.NpcEditor.paste;
-            toolStripItemUndo.Text = Strings.NpcEditor.undo;
+            cmbMovement.Items.Add(Strings.NpcEditor.movements[i]);
+        }
 
-            grpNpcs.Text = Strings.NpcEditor.npcs;
+        chkSwarm.Text = Strings.NpcEditor.swarm;
+        lblFlee.Text = Strings.NpcEditor.flee;
+        grpConditions.Text = Strings.NpcEditor.conditions;
+        btnPlayerFriendProtectorCond.Text = Strings.NpcEditor.playerfriendprotectorconditions;
+        btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
+        btnPlayerCanAttackCond.Text = Strings.NpcEditor.playercanattackconditions;
+        chkFocusDamageDealer.Text = Strings.NpcEditor.focusdamagedealer;
 
-            grpGeneral.Text = Strings.NpcEditor.general;
-            lblName.Text = Strings.NpcEditor.name;
-            grpBehavior.Text = Strings.NpcEditor.behavior;
+        grpCommonEvents.Text = Strings.NpcEditor.commonevents;
+        lblOnDeathEventKiller.Text = Strings.NpcEditor.ondeathevent;
+        lblOnDeathEventParty.Text = Strings.NpcEditor.ondeathpartyevent;
 
-            lblPic.Text = Strings.NpcEditor.sprite;
-            lblRed.Text = Strings.NpcEditor.Red;
-            lblGreen.Text = Strings.NpcEditor.Green;
-            lblBlue.Text = Strings.NpcEditor.Blue;
-            lblAlpha.Text = Strings.NpcEditor.Alpha;
+        grpStats.Text = Strings.NpcEditor.stats;
+        lblHP.Text = Strings.NpcEditor.hp;
+        lblMana.Text = Strings.NpcEditor.mana;
+        lblStr.Text = Strings.NpcEditor.attack;
+        lblDef.Text = Strings.NpcEditor.defense;
+        lblSpd.Text = Strings.NpcEditor.speed;
+        lblMag.Text = Strings.NpcEditor.abilitypower;
+        lblMR.Text = Strings.NpcEditor.magicresist;
+        lblExp.Text = Strings.NpcEditor.exp;
 
-            lblSpawnDuration.Text = Strings.NpcEditor.spawnduration;
+        grpRegen.Text = Strings.NpcEditor.regen;
+        lblHpRegen.Text = Strings.NpcEditor.hpregen;
+        lblManaRegen.Text = Strings.NpcEditor.mpregen;
+        lblRegenHint.Text = Strings.NpcEditor.regenhint;
+
+        grpSpells.Text = Strings.NpcEditor.spells;
+        lblSpell.Text = Strings.NpcEditor.spell;
+        btnAdd.Text = Strings.NpcEditor.addspell;
+        btnRemove.Text = Strings.NpcEditor.removespell;
+        lblFreq.Text = Strings.NpcEditor.frequency;
+        cmbFreq.Items.Clear();
+        for (var i = 0; i < Strings.NpcEditor.frequencies.Count; i++)
+        {
+            cmbFreq.Items.Add(Strings.NpcEditor.frequencies[i]);
+        }
+
+        grpAttackSpeed.Text = Strings.NpcEditor.attackspeed;
+        lblAttackSpeedModifier.Text = Strings.NpcEditor.attackspeedmodifier;
+        lblAttackSpeedValue.Text = Strings.NpcEditor.attackspeedvalue;
+        cmbAttackSpeedModifier.Items.Clear();
+        foreach (var val in Strings.NpcEditor.attackspeedmodifiers.Values)
+        {
+            cmbAttackSpeedModifier.Items.Add(val.ToString());
+        }
+
+        grpNpcVsNpc.Text = Strings.NpcEditor.npcvsnpc;
+        chkEnabled.Text = Strings.NpcEditor.enabled;
+        chkAttackAllies.Text = Strings.NpcEditor.attackallies;
+        lblNPC.Text = Strings.NpcEditor.npc;
+        btnAddAggro.Text = Strings.NpcEditor.addhostility;
+        btnRemoveAggro.Text = Strings.NpcEditor.removehostility;
+
+        grpDrops.Text = Strings.NpcEditor.drops;
+        lblDropItem.Text = Strings.NpcEditor.dropitem;
+        lblDropAmount.Text = Strings.NpcEditor.dropamount;
+        lblDropChance.Text = Strings.NpcEditor.dropchance;
+        btnDropAdd.Text = Strings.NpcEditor.dropadd;
+        btnDropRemove.Text = Strings.NpcEditor.dropremove;
+        chkIndividualLoot.Text = Strings.NpcEditor.individualizedloot;
+
+        grpCombat.Text = Strings.NpcEditor.combat;
+        lblDamage.Text = Strings.NpcEditor.basedamage;
+        lblCritChance.Text = Strings.NpcEditor.critchance;
+        lblCritMultiplier.Text = Strings.NpcEditor.critmultiplier;
+        lblDamageType.Text = Strings.NpcEditor.damagetype;
+        cmbDamageType.Items.Clear();
+        for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
+        {
+            cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
+        }
+
+        lblScalingStat.Text = Strings.NpcEditor.scalingstat;
+        lblScaling.Text = Strings.NpcEditor.scalingamount;
+        lblAttackAnimation.Text = Strings.NpcEditor.attackanimation;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.NpcEditor.sortalphabetically;
+        txtSearch.Text = Strings.NpcEditor.searchplaceholder;
+        lblFolder.Text = Strings.NpcEditor.folderlabel;
+
+        grpImmunities.Text = Strings.NpcEditor.ImmunitiesTitle;
+        chkKnockback.Text = Strings.NpcEditor.Immunities[SpellEffect.Knockback];
+        chkSilence.Text = Strings.NpcEditor.Immunities[SpellEffect.Silence];
+        chkStun.Text = Strings.NpcEditor.Immunities[SpellEffect.Stun];
+        chkSnare.Text = Strings.NpcEditor.Immunities[SpellEffect.Snare];
+        chkBlind.Text = Strings.NpcEditor.Immunities[SpellEffect.Blind];
+        chkTransform.Text = Strings.NpcEditor.Immunities[SpellEffect.Transform];
+        chkTaunt.Text = Strings.NpcEditor.Immunities[SpellEffect.Taunt];
+        chkSleep.Text = Strings.NpcEditor.Immunities[SpellEffect.Sleep];
+        lblTenacity.Text = Strings.NpcEditor.Tenacity;
+
+        btnSave.Text = Strings.NpcEditor.save;
+        btnCancel.Text = Strings.NpcEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            cmbSprite.SelectedIndex = cmbSprite.FindString(TextUtils.NullToNone(mEditorItem.Sprite));
+            nudRgbaR.Value = mEditorItem.Color.R;
+            nudRgbaG.Value = mEditorItem.Color.G;
+            nudRgbaB.Value = mEditorItem.Color.B;
+            nudRgbaA.Value = mEditorItem.Color.A;
+
+            nudLevel.Value = mEditorItem.Level;
+            nudSpawnDuration.Value = mEditorItem.SpawnDuration;
 
             //Behavior
-            chkAggressive.Text = Strings.NpcEditor.aggressive;
-            lblSightRange.Text = Strings.NpcEditor.sightrange;
-            lblMovement.Text = Strings.NpcEditor.movement;
-            lblResetRadius.Text = Strings.NpcEditor.resetradius;
-            cmbMovement.Items.Clear();
-            for (var i = 0; i < Strings.NpcEditor.movements.Count; i++)
+            chkAggressive.Checked = mEditorItem.Aggressive;
+            if (mEditorItem.Aggressive)
             {
-                cmbMovement.Items.Add(Strings.NpcEditor.movements[i]);
-            }
-
-            chkSwarm.Text = Strings.NpcEditor.swarm;
-            lblFlee.Text = Strings.NpcEditor.flee;
-            grpConditions.Text = Strings.NpcEditor.conditions;
-            btnPlayerFriendProtectorCond.Text = Strings.NpcEditor.playerfriendprotectorconditions;
-            btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
-            btnPlayerCanAttackCond.Text = Strings.NpcEditor.playercanattackconditions;
-            chkFocusDamageDealer.Text = Strings.NpcEditor.focusdamagedealer;
-
-            grpCommonEvents.Text = Strings.NpcEditor.commonevents;
-            lblOnDeathEventKiller.Text = Strings.NpcEditor.ondeathevent;
-            lblOnDeathEventParty.Text = Strings.NpcEditor.ondeathpartyevent;
-
-            grpStats.Text = Strings.NpcEditor.stats;
-            lblHP.Text = Strings.NpcEditor.hp;
-            lblMana.Text = Strings.NpcEditor.mana;
-            lblStr.Text = Strings.NpcEditor.attack;
-            lblDef.Text = Strings.NpcEditor.defense;
-            lblSpd.Text = Strings.NpcEditor.speed;
-            lblMag.Text = Strings.NpcEditor.abilitypower;
-            lblMR.Text = Strings.NpcEditor.magicresist;
-            lblExp.Text = Strings.NpcEditor.exp;
-
-            grpRegen.Text = Strings.NpcEditor.regen;
-            lblHpRegen.Text = Strings.NpcEditor.hpregen;
-            lblManaRegen.Text = Strings.NpcEditor.mpregen;
-            lblRegenHint.Text = Strings.NpcEditor.regenhint;
-
-            grpSpells.Text = Strings.NpcEditor.spells;
-            lblSpell.Text = Strings.NpcEditor.spell;
-            btnAdd.Text = Strings.NpcEditor.addspell;
-            btnRemove.Text = Strings.NpcEditor.removespell;
-            lblFreq.Text = Strings.NpcEditor.frequency;
-            cmbFreq.Items.Clear();
-            for (var i = 0; i < Strings.NpcEditor.frequencies.Count; i++)
-            {
-                cmbFreq.Items.Add(Strings.NpcEditor.frequencies[i]);
-            }
-
-            grpAttackSpeed.Text = Strings.NpcEditor.attackspeed;
-            lblAttackSpeedModifier.Text = Strings.NpcEditor.attackspeedmodifier;
-            lblAttackSpeedValue.Text = Strings.NpcEditor.attackspeedvalue;
-            cmbAttackSpeedModifier.Items.Clear();
-            foreach (var val in Strings.NpcEditor.attackspeedmodifiers.Values)
-            {
-                cmbAttackSpeedModifier.Items.Add(val.ToString());
-            }
-
-            grpNpcVsNpc.Text = Strings.NpcEditor.npcvsnpc;
-            chkEnabled.Text = Strings.NpcEditor.enabled;
-            chkAttackAllies.Text = Strings.NpcEditor.attackallies;
-            lblNPC.Text = Strings.NpcEditor.npc;
-            btnAddAggro.Text = Strings.NpcEditor.addhostility;
-            btnRemoveAggro.Text = Strings.NpcEditor.removehostility;
-
-            grpDrops.Text = Strings.NpcEditor.drops;
-            lblDropItem.Text = Strings.NpcEditor.dropitem;
-            lblDropAmount.Text = Strings.NpcEditor.dropamount;
-            lblDropChance.Text = Strings.NpcEditor.dropchance;
-            btnDropAdd.Text = Strings.NpcEditor.dropadd;
-            btnDropRemove.Text = Strings.NpcEditor.dropremove;
-            chkIndividualLoot.Text = Strings.NpcEditor.individualizedloot;
-
-            grpCombat.Text = Strings.NpcEditor.combat;
-            lblDamage.Text = Strings.NpcEditor.basedamage;
-            lblCritChance.Text = Strings.NpcEditor.critchance;
-            lblCritMultiplier.Text = Strings.NpcEditor.critmultiplier;
-            lblDamageType.Text = Strings.NpcEditor.damagetype;
-            cmbDamageType.Items.Clear();
-            for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
-            {
-                cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
-            }
-
-            lblScalingStat.Text = Strings.NpcEditor.scalingstat;
-            lblScaling.Text = Strings.NpcEditor.scalingamount;
-            lblAttackAnimation.Text = Strings.NpcEditor.attackanimation;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.NpcEditor.sortalphabetically;
-            txtSearch.Text = Strings.NpcEditor.searchplaceholder;
-            lblFolder.Text = Strings.NpcEditor.folderlabel;
-
-            grpImmunities.Text = Strings.NpcEditor.ImmunitiesTitle;
-            chkKnockback.Text = Strings.NpcEditor.Immunities[SpellEffect.Knockback];
-            chkSilence.Text = Strings.NpcEditor.Immunities[SpellEffect.Silence];
-            chkStun.Text = Strings.NpcEditor.Immunities[SpellEffect.Stun];
-            chkSnare.Text = Strings.NpcEditor.Immunities[SpellEffect.Snare];
-            chkBlind.Text = Strings.NpcEditor.Immunities[SpellEffect.Blind];
-            chkTransform.Text = Strings.NpcEditor.Immunities[SpellEffect.Transform];
-            chkTaunt.Text = Strings.NpcEditor.Immunities[SpellEffect.Taunt];
-            chkSleep.Text = Strings.NpcEditor.Immunities[SpellEffect.Sleep];
-            lblTenacity.Text = Strings.NpcEditor.Tenacity;
-
-            btnSave.Text = Strings.NpcEditor.save;
-            btnCancel.Text = Strings.NpcEditor.cancel;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                cmbSprite.SelectedIndex = cmbSprite.FindString(TextUtils.NullToNone(mEditorItem.Sprite));
-                nudRgbaR.Value = mEditorItem.Color.R;
-                nudRgbaG.Value = mEditorItem.Color.G;
-                nudRgbaB.Value = mEditorItem.Color.B;
-                nudRgbaA.Value = mEditorItem.Color.A;
-
-                nudLevel.Value = mEditorItem.Level;
-                nudSpawnDuration.Value = mEditorItem.SpawnDuration;
-
-                //Behavior
-                chkAggressive.Checked = mEditorItem.Aggressive;
-                if (mEditorItem.Aggressive)
-                {
-                    btnAttackOnSightCond.Text = Strings.NpcEditor.dontattackonsightconditions;
-                }
-                else
-                {
-                    btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
-                }
-
-                nudSightRange.Value = mEditorItem.SightRange;
-                cmbMovement.SelectedIndex = Math.Min(mEditorItem.Movement, cmbMovement.Items.Count - 1);
-                chkSwarm.Checked = mEditorItem.Swarm;
-                nudFlee.Value = mEditorItem.FleeHealthPercentage;
-                chkFocusDamageDealer.Checked = mEditorItem.FocusHighestDamageDealer;
-                nudResetRadius.Value = mEditorItem.ResetRadius;
-
-                //Common Events
-                cmbOnDeathEventKiller.SelectedIndex = EventBase.ListIndex(mEditorItem.OnDeathEventId) + 1;
-                cmbOnDeathEventParty.SelectedIndex = EventBase.ListIndex(mEditorItem.OnDeathPartyEventId) + 1;
-
-                nudStr.Value = mEditorItem.Stats[(int)Stat.Attack];
-                nudMag.Value = mEditorItem.Stats[(int)Stat.AbilityPower];
-                nudDef.Value = mEditorItem.Stats[(int)Stat.Defense];
-                nudMR.Value = mEditorItem.Stats[(int)Stat.MagicResist];
-                nudSpd.Value = mEditorItem.Stats[(int)Stat.Speed];
-                nudHp.Value = mEditorItem.MaxVital[(int)Vital.Health];
-                nudMana.Value = mEditorItem.MaxVital[(int)Vital.Mana];
-                nudExp.Value = mEditorItem.Experience;
-                chkAttackAllies.Checked = mEditorItem.AttackAllies;
-                chkEnabled.Checked = mEditorItem.NpcVsNpcEnabled;
-
-                //Combat
-                nudDamage.Value = mEditorItem.Damage;
-                nudCritChance.Value = mEditorItem.CritChance;
-                nudCritMultiplier.Value = (decimal)mEditorItem.CritMultiplier;
-                nudScaling.Value = mEditorItem.Scaling;
-                cmbDamageType.SelectedIndex = mEditorItem.DamageType;
-                cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
-                cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
-                cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
-                nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
-
-                //Regen
-                nudHpRegen.Value = mEditorItem.VitalRegen[(int)Vital.Health];
-                nudMpRegen.Value = mEditorItem.VitalRegen[(int)Vital.Mana];
-
-                // Add the spells to the list
-                lstSpells.Items.Clear();
-                for (var i = 0; i < mEditorItem.Spells.Count; i++)
-                {
-                    if (mEditorItem.Spells[i] != Guid.Empty)
-                    {
-                        lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
-                    }
-                    else
-                    {
-                        lstSpells.Items.Add(Strings.General.None);
-                    }
-                }
-
-                if (lstSpells.Items.Count > 0)
-                {
-                    lstSpells.SelectedIndex = 0;
-                    cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex]);
-                }
-
-                cmbFreq.SelectedIndex = mEditorItem.SpellFrequency;
-
-                // Add the aggro NPC's to the list
-                lstAggro.Items.Clear();
-                for (var i = 0; i < mEditorItem.AggroList.Count; i++)
-                {
-                    if (mEditorItem.AggroList[i] != Guid.Empty)
-                    {
-                        lstAggro.Items.Add(NpcBase.GetName(mEditorItem.AggroList[i]));
-                    }
-                    else
-                    {
-                        lstAggro.Items.Add(Strings.General.None);
-                    }
-                }
-
-                UpdateDropValues();
-                chkIndividualLoot.Checked = mEditorItem.IndividualizedLoot;
-
-                DrawNpcSprite();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-
-                // Tenacity and immunities
-                nudTenacity.Value = (decimal)mEditorItem.Tenacity;
-
-                UpdateImmunities();
+                btnAttackOnSightCond.Text = Strings.NpcEditor.dontattackonsightconditions;
             }
             else
             {
-                pnlContainer.Hide();
+                btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
             }
 
-            UpdateToolStripItems();
-        }
+            nudSightRange.Value = mEditorItem.SightRange;
+            cmbMovement.SelectedIndex = Math.Min(mEditorItem.Movement, cmbMovement.Items.Count - 1);
+            chkSwarm.Checked = mEditorItem.Swarm;
+            nudFlee.Value = mEditorItem.FleeHealthPercentage;
+            chkFocusDamageDealer.Checked = mEditorItem.FocusHighestDamageDealer;
+            nudResetRadius.Value = mEditorItem.ResetRadius;
 
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
+            //Common Events
+            cmbOnDeathEventKiller.SelectedIndex = EventBase.ListIndex(mEditorItem.OnDeathEventId) + 1;
+            cmbOnDeathEventParty.SelectedIndex = EventBase.ListIndex(mEditorItem.OnDeathPartyEventId) + 1;
 
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Sprite = TextUtils.SanitizeNone(cmbSprite.Text);
-            DrawNpcSprite();
-        }
+            nudStr.Value = mEditorItem.Stats[(int)Stat.Attack];
+            nudMag.Value = mEditorItem.Stats[(int)Stat.AbilityPower];
+            nudDef.Value = mEditorItem.Stats[(int)Stat.Defense];
+            nudMR.Value = mEditorItem.Stats[(int)Stat.MagicResist];
+            nudSpd.Value = mEditorItem.Stats[(int)Stat.Speed];
+            nudHp.Value = mEditorItem.MaxVital[(int)Vital.Health];
+            nudMana.Value = mEditorItem.MaxVital[(int)Vital.Mana];
+            nudExp.Value = mEditorItem.Experience;
+            chkAttackAllies.Checked = mEditorItem.AttackAllies;
+            chkEnabled.Checked = mEditorItem.NpcVsNpcEnabled;
 
-        private void DrawNpcSprite()
-        {
-            var picSpriteBmp = new Bitmap(picNpc.Width, picNpc.Height);
-            var gfx = Graphics.FromImage(picSpriteBmp);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picNpc.Width, picNpc.Height));
-            if (cmbSprite.SelectedIndex > 0)
-            {
-                var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
-                var imgAttributes = new ImageAttributes();
+            //Combat
+            nudDamage.Value = mEditorItem.Damage;
+            nudCritChance.Value = mEditorItem.CritChance;
+            nudCritMultiplier.Value = (decimal)mEditorItem.CritMultiplier;
+            nudScaling.Value = mEditorItem.Scaling;
+            cmbDamageType.SelectedIndex = mEditorItem.DamageType;
+            cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
+            cmbAttackAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AttackAnimationId) + 1;
+            cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
+            nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
 
-                // Microsoft, what the heck is this crap?
-                imgAttributes.SetColorMatrix(
-                    new ColorMatrix(
-                        new float[][]
-                        {
-                            new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
-                            new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
-                            new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
-                            new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
-                            new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
-                        }
-                    )
-                );
+            //Regen
+            nudHpRegen.Value = mEditorItem.VitalRegen[(int)Vital.Health];
+            nudMpRegen.Value = mEditorItem.VitalRegen[(int)Vital.Mana];
 
-                gfx.DrawImage(
-                    img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
-                    0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions, GraphicsUnit.Pixel, imgAttributes
-                );
-
-                img.Dispose();
-                imgAttributes.Dispose();
-            }
-
-            gfx.Dispose();
-
-            picNpc.BackgroundImage = picSpriteBmp;
-        }
-
-        private void UpdateDropValues(bool keepIndex = false)
-        {
-            var index = lstDrops.SelectedIndex;
-            lstDrops.Items.Clear();
-
-            var drops = mEditorItem.Drops.ToArray();
-            foreach (var drop in drops)
-            {
-                if (ItemBase.Get(drop.ItemId) == null)
-                {
-                    mEditorItem.Drops.Remove(drop);
-                }
-            }
-
-            for (var i = 0; i < mEditorItem.Drops.Count; i++)
-            {
-                if (mEditorItem.Drops[i].ItemId != Guid.Empty)
-                {
-                    lstDrops.Items.Add(
-                        Strings.NpcEditor.dropdisplay.ToString(
-                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
-                            mEditorItem.Drops[i].Chance
-                        )
-                    );
-                }
-                else
-                {
-                    lstDrops.Items.Add(TextUtils.None);
-                }
-            }
-
-            if (keepIndex && index < lstDrops.Items.Count)
-            {
-                lstDrops.SelectedIndex = index;
-            }
-        }
-
-        private void frmNpc_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void btnAdd_Click(object sender, EventArgs e)
-        {
-            mEditorItem.Spells.Add(SpellBase.IdFromList(cmbSpell.SelectedIndex));
-            var n = lstSpells.SelectedIndex;
+            // Add the spells to the list
             lstSpells.Items.Clear();
             for (var i = 0; i < mEditorItem.Spells.Count; i++)
             {
-                lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
+                if (mEditorItem.Spells[i] != Guid.Empty)
+                {
+                    lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
+                }
+                else
+                {
+                    lstSpells.Items.Add(Strings.General.None);
+                }
             }
 
-            lstSpells.SelectedIndex = n;
-        }
-
-        private void btnRemove_Click(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex > -1)
+            if (lstSpells.Items.Count > 0)
             {
-                var i = lstSpells.SelectedIndex;
-                lstSpells.Items.RemoveAt(i);
-                mEditorItem.Spells.RemoveAt(i);
+                lstSpells.SelectedIndex = 0;
+                cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex]);
             }
-        }
 
-        private void cmbFreq_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SpellFrequency = cmbFreq.SelectedIndex;
-        }
+            cmbFreq.SelectedIndex = mEditorItem.SpellFrequency;
 
-        private void chkEnabled_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.NpcVsNpcEnabled = chkEnabled.Checked;
-        }
-
-        private void chkAttackAllies_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackAllies = chkAttackAllies.Checked;
-        }
-
-        private void btnAddAggro_Click(object sender, EventArgs e)
-        {
-            mEditorItem.AggroList.Add(NpcBase.IdFromList(cmbHostileNPC.SelectedIndex));
+            // Add the aggro NPC's to the list
             lstAggro.Items.Clear();
             for (var i = 0; i < mEditorItem.AggroList.Count; i++)
             {
@@ -522,585 +353,752 @@ namespace Intersect.Editor.Forms.Editors
                     lstAggro.Items.Add(Strings.General.None);
                 }
             }
-        }
-
-        private void btnRemoveAggro_Click(object sender, EventArgs e)
-        {
-            if (lstAggro.SelectedIndex > -1)
-            {
-                var i = lstAggro.SelectedIndex;
-                lstAggro.Items.RemoveAt(i);
-                mEditorItem.AggroList.RemoveAt(i);
-            }
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Npc);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.NpcEditor.deleteprompt, Strings.NpcEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
-                UpdateEditor();
-            }
-        }
-
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.NpcEditor.undoprompt, Strings.NpcEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void UpdateImmunities()
-        {
-            chkKnockback.Checked = mEditorItem.Immunities.Contains(SpellEffect.Knockback);
-            chkSilence.Checked = mEditorItem.Immunities.Contains(SpellEffect.Silence);
-            chkSnare.Checked = mEditorItem.Immunities.Contains(SpellEffect.Snare);
-            chkStun.Checked = mEditorItem.Immunities.Contains(SpellEffect.Stun);
-            chkSleep.Checked = mEditorItem.Immunities.Contains(SpellEffect.Sleep);
-            chkTransform.Checked = mEditorItem.Immunities.Contains(SpellEffect.Transform);
-            chkTaunt.Checked = mEditorItem.Immunities.Contains(SpellEffect.Taunt);
-            chkBlind.Checked = mEditorItem.Immunities.Contains(SpellEffect.Blind);
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackAnimation =
-                AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DamageType = cmbDamageType.SelectedIndex;
-        }
-
-        private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
-        }
-
-        private void lstSpells_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex > -1)
-            {
-                cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex]);
-            }
-        }
-
-        private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstSpells.SelectedIndex > -1 && lstSpells.SelectedIndex < mEditorItem.Spells.Count)
-            {
-                mEditorItem.Spells[lstSpells.SelectedIndex] = SpellBase.IdFromList(cmbSpell.SelectedIndex);
-            }
-
-            var n = lstSpells.SelectedIndex;
-            lstSpells.Items.Clear();
-            for (var i = 0; i < mEditorItem.Spells.Count; i++)
-            {
-                lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
-            }
-
-            lstSpells.SelectedIndex = n;
-        }
-
-        private void nudScaling_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Scaling = (int)nudScaling.Value;
-        }
-
-        private void nudSpawnDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SpawnDuration = (int)nudSpawnDuration.Value;
-        }
-
-        private void nudSightRange_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SightRange = (int)nudSightRange.Value;
-        }
-
-        private void nudStr_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stats[(int)Stat.Attack] = (int)nudStr.Value;
-        }
-
-        private void nudMag_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stats[(int)Stat.AbilityPower] = (int)nudMag.Value;
-        }
-
-        private void nudDef_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stats[(int)Stat.Defense] = (int)nudDef.Value;
-        }
-
-        private void nudMR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stats[(int)Stat.MagicResist] = (int)nudMR.Value;
-        }
-
-        private void nudSpd_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Stats[(int)Stat.Speed] = (int)nudSpd.Value;
-        }
-
-        private void nudDamage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Damage = (int)nudDamage.Value;
-        }
-
-        private void nudCritChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritChance = (int)nudCritChance.Value;
-        }
-
-        private void nudHp_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MaxVital[(int)Vital.Health] = (int)nudHp.Value;
-        }
-
-        private void nudMana_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MaxVital[(int)Vital.Mana] = (int)nudMana.Value;
-        }
-
-        private void nudExp_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Experience = (int)nudExp.Value;
-        }
-
-        private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
-            {
-                mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
-            }
-
-            UpdateDropValues(true);
-        }
-
-        private void nudDropAmount_ValueChanged(object sender, EventArgs e)
-        {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
-
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
-            {
-                return;
-            }
-
-            mEditorItem.Drops[(int)lstDrops.SelectedIndex].Quantity = (int)nudDropAmount.Value;
-            UpdateDropValues(true);
-        }
-
-        private void lstDrops_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex > -1)
-            {
-                cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
-                nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
-                nudDropChance.Value = (decimal)mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
-            }
-        }
-
-        private void btnDropAdd_Click(object sender, EventArgs e)
-        {
-            mEditorItem.Drops.Add(new Drop());
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int)nudDropAmount.Value;
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double)nudDropChance.Value;
 
             UpdateDropValues();
-        }
+            chkIndividualLoot.Checked = mEditorItem.IndividualizedLoot;
 
-        private void btnDropRemove_Click(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex > -1)
-            {
-                var i = lstDrops.SelectedIndex;
-                lstDrops.Items.RemoveAt(i);
-                mEditorItem.Drops.RemoveAt(i);
-            }
-
-            UpdateDropValues(true);
-        }
-
-        private void nudDropChance_ValueChanged(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
-            {
-                return;
-            }
-
-            mEditorItem.Drops[(int)lstDrops.SelectedIndex].Chance = (double)nudDropChance.Value;
-            UpdateDropValues(true);
-        }
-
-        private void chkIndividualLoot_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IndividualizedLoot = chkIndividualLoot.Checked;
-        }
-
-        private void nudLevel_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Level = (int)nudLevel.Value;
-        }
-
-        private void nudHpRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalRegen[(int)Vital.Health] = (int)nudHpRegen.Value;
-        }
-
-        private void nudMpRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalRegen[(int)Vital.Mana] = (int)nudMpRegen.Value;
-        }
-
-        private void chkAggressive_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Aggressive = chkAggressive.Checked;
-            if (mEditorItem.Aggressive)
-            {
-                btnAttackOnSightCond.Text = Strings.NpcEditor.dontattackonsightconditions;
-            }
-            else
-            {
-                btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
-            }
-        }
-
-        private void cmbMovement_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Movement = (byte)cmbMovement.SelectedIndex;
-        }
-
-        private void chkSwarm_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Swarm = chkSwarm.Checked;
-        }
-
-        private void nudFlee_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.FleeHealthPercentage = (byte)nudFlee.Value;
-        }
-
-        private void btnPlayerFriendProtectorCond_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.PlayerFriendConditions, RequirementType.NpcFriend);
-            frm.TopMost = true;
-            frm.ShowDialog();
-        }
-
-        private void btnAttackOnSightCond_Click(object sender, EventArgs e)
-        {
-            if (chkAggressive.Checked)
-            {
-                var frm = new FrmDynamicRequirements(
-                    mEditorItem.AttackOnSightConditions, RequirementType.NpcDontAttackOnSight
-                );
-
-                frm.TopMost = true;
-                frm.ShowDialog();
-            }
-            else
-            {
-                var frm = new FrmDynamicRequirements(
-                    mEditorItem.AttackOnSightConditions, RequirementType.NpcAttackOnSight
-                );
-
-                frm.TopMost = true;
-                frm.ShowDialog();
-            }
-        }
-
-        private void btnPlayerCanAttackCond_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(
-                mEditorItem.PlayerCanAttackConditions, RequirementType.NpcCanBeAttacked
-            );
-
-            frm.TopMost = true;
-            frm.ShowDialog();
-        }
-
-        private void cmbOnDeathEventKiller_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.OnDeathEvent = EventBase.Get(EventBase.IdFromList(cmbOnDeathEventKiller.SelectedIndex - 1));
-        }
-
-        private void cmbOnDeathEventParty_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.OnDeathPartyEvent = EventBase.Get(EventBase.IdFromList(cmbOnDeathEventParty.SelectedIndex - 1));
-        }
-
-        private void chkFocusDamageDealer_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.FocusHighestDamageDealer = chkFocusDamageDealer.Checked;
-        }
-
-        private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CritMultiplier = (double)nudCritMultiplier.Value;
-        }
-
-        private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
-            nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
-        }
-
-        private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AttackSpeedValue = (int)nudAttackSpeedValue.Value;
-        }
-
-        private void nudRgbaR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.R = (byte)nudRgbaR.Value;
             DrawNpcSprite();
-        }
-
-        private void nudRgbaG_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.G = (byte)nudRgbaG.Value;
-            DrawNpcSprite();
-        }
-
-        private void nudRgbaB_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.B = (byte)nudRgbaB.Value;
-            DrawNpcSprite();
-        }
-
-        private void nudRgbaA_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Color.A = (byte)nudRgbaA.Value;
-            DrawNpcSprite();
-        }
-
-        private void nudResetRadius_ValueChanged(object sender, EventArgs e)
-        {
-            // So, the pathfinder on the server maintains a set max distance of whichever the largest value is, map height or width. Limit ourselves to this!
-            var maxPathFindingDistance = Math.Max(Options.MapWidth, Options.MapHeight);
-            var maxUserEnteredValue = Math.Max(Options.Npc.ResetRadius, nudResetRadius.Value);
-
-            // Use whatever is the lowest, either the maximum path find distance or the user entered value.
-            nudResetRadius.Value = Math.Min(maxPathFindingDistance, maxUserEnteredValue);
-            mEditorItem.ResetRadius = (int)nudResetRadius.Value;
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in NpcBase.Lookup)
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                if (!string.IsNullOrEmpty(((NpcBase)itm.Value).Folder) &&
-                    !mFolders.Contains(((NpcBase)itm.Value).Folder))
-                {
-                    mFolders.Add(((NpcBase)itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((NpcBase)itm.Value).Folder))
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
+            }
+
+            // Tenacity and immunities
+            nudTenacity.Value = (decimal)mEditorItem.Tenacity;
+
+            UpdateImmunities();
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Sprite = TextUtils.SanitizeNone(cmbSprite.Text);
+        DrawNpcSprite();
+    }
+
+    private void DrawNpcSprite()
+    {
+        var picSpriteBmp = new Bitmap(picNpc.Width, picNpc.Height);
+        var gfx = Graphics.FromImage(picSpriteBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picNpc.Width, picNpc.Height));
+        if (cmbSprite.SelectedIndex > 0)
+        {
+            var img = Image.FromFile("resources/entities/" + cmbSprite.Text);
+            var imgAttributes = new ImageAttributes();
+
+            // Microsoft, what the heck is this crap?
+            imgAttributes.SetColorMatrix(
+                new ColorMatrix(
+                    new float[][]
                     {
-                        mKnownFolders.Add(((NpcBase)itm.Value).Folder);
+                        new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},  // Modify the red space
+                        new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},    // Modify the green space
+                        new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},    // Modify the blue space
+                        new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},    // Modify the alpha space
+                        new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
                     }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = NpcBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((NpcBase)pair.Value)?.Name ?? Models.DatabaseObject<NpcBase>.Deleted, ((NpcBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.NpcEditor.folderprompt, Strings.NpcEditor.foldertitle, ref folderName, DarkDialogButton.OkCancel
+                )
             );
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+            gfx.DrawImage(
+                img, new Rectangle(0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions),
+                0, 0, img.Width / Options.Instance.Sprites.NormalFrames, img.Height / Options.Instance.Sprites.Directions, GraphicsUnit.Pixel, imgAttributes
+            );
+
+            img.Dispose();
+            imgAttributes.Dispose();
+        }
+
+        gfx.Dispose();
+
+        picNpc.BackgroundImage = picSpriteBmp;
+    }
+
+    private void UpdateDropValues(bool keepIndex = false)
+    {
+        var index = lstDrops.SelectedIndex;
+        lstDrops.Items.Clear();
+
+        var drops = mEditorItem.Drops.ToArray();
+        foreach (var drop in drops)
+        {
+            if (ItemBase.Get(drop.ItemId) == null)
             {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.UpdateText(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
+                mEditorItem.Drops.Remove(drop);
             }
         }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+        for (var i = 0; i < mEditorItem.Drops.Count; i++)
         {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            if (mEditorItem.Drops[i].ItemId != Guid.Empty)
             {
-                txtSearch.Text = Strings.NpcEditor.searchplaceholder;
+                lstDrops.Items.Add(
+                    Strings.NpcEditor.dropdisplay.ToString(
+                        ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
+                        mEditorItem.Drops[i].Chance
+                    )
+                );
+            }
+            else
+            {
+                lstDrops.Items.Add(TextUtils.None);
             }
         }
 
-        private void txtSearch_Enter(object sender, EventArgs e)
+        if (keepIndex && index < lstDrops.Items.Count)
         {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.NpcEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.NpcEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.NpcEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
-
-        private void ChangeImmunity(SpellEffect status, bool isImmune)
-        {
-            if (isImmune && !mEditorItem.Immunities.Contains(status))
-            {
-                mEditorItem.Immunities.Add(status);
-            }
-            else if (!isImmune)
-            {
-                mEditorItem.Immunities.Remove(status);
-            }
-        }
-
-        private void chkKnockback_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Knockback, chkKnockback.Checked);
-        }
-
-        private void chkSilence_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Silence, chkSilence.Checked);
-        }
-
-        private void chkStun_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Stun, chkStun.Checked);
-        }
-
-        private void chkSnare_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Snare, chkSnare.Checked);
-        }
-
-        private void chkBlind_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Blind, chkBlind.Checked);
-        }
-
-        private void chkTransform_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Transform, chkTransform.Checked);
-        }
-
-        private void chkSleep_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Sleep, chkSleep.Checked);
-        }
-
-        private void chkTaunt_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeImmunity(SpellEffect.Taunt, chkTaunt.Checked);
-        }
-
-        private void nudTenacity_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Tenacity = (double)nudTenacity.Value;
+            lstDrops.SelectedIndex = index;
         }
     }
 
+    private void frmNpc_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
+
+    private void btnAdd_Click(object sender, EventArgs e)
+    {
+        mEditorItem.Spells.Add(SpellBase.IdFromList(cmbSpell.SelectedIndex));
+        var n = lstSpells.SelectedIndex;
+        lstSpells.Items.Clear();
+        for (var i = 0; i < mEditorItem.Spells.Count; i++)
+        {
+            lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
+        }
+
+        lstSpells.SelectedIndex = n;
+    }
+
+    private void btnRemove_Click(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex > -1)
+        {
+            var i = lstSpells.SelectedIndex;
+            lstSpells.Items.RemoveAt(i);
+            mEditorItem.Spells.RemoveAt(i);
+        }
+    }
+
+    private void cmbFreq_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SpellFrequency = cmbFreq.SelectedIndex;
+    }
+
+    private void chkEnabled_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.NpcVsNpcEnabled = chkEnabled.Checked;
+    }
+
+    private void chkAttackAllies_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackAllies = chkAttackAllies.Checked;
+    }
+
+    private void btnAddAggro_Click(object sender, EventArgs e)
+    {
+        mEditorItem.AggroList.Add(NpcBase.IdFromList(cmbHostileNPC.SelectedIndex));
+        lstAggro.Items.Clear();
+        for (var i = 0; i < mEditorItem.AggroList.Count; i++)
+        {
+            if (mEditorItem.AggroList[i] != Guid.Empty)
+            {
+                lstAggro.Items.Add(NpcBase.GetName(mEditorItem.AggroList[i]));
+            }
+            else
+            {
+                lstAggro.Items.Add(Strings.General.None);
+            }
+        }
+    }
+
+    private void btnRemoveAggro_Click(object sender, EventArgs e)
+    {
+        if (lstAggro.SelectedIndex > -1)
+        {
+            var i = lstAggro.SelectedIndex;
+            lstAggro.Items.RemoveAt(i);
+            mEditorItem.AggroList.RemoveAt(i);
+        }
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Npc);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.NpcEditor.deleteprompt, Strings.NpcEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.NpcEditor.undoprompt, Strings.NpcEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void UpdateImmunities()
+    {
+        chkKnockback.Checked = mEditorItem.Immunities.Contains(SpellEffect.Knockback);
+        chkSilence.Checked = mEditorItem.Immunities.Contains(SpellEffect.Silence);
+        chkSnare.Checked = mEditorItem.Immunities.Contains(SpellEffect.Snare);
+        chkStun.Checked = mEditorItem.Immunities.Contains(SpellEffect.Stun);
+        chkSleep.Checked = mEditorItem.Immunities.Contains(SpellEffect.Sleep);
+        chkTransform.Checked = mEditorItem.Immunities.Contains(SpellEffect.Transform);
+        chkTaunt.Checked = mEditorItem.Immunities.Contains(SpellEffect.Taunt);
+        chkBlind.Checked = mEditorItem.Immunities.Contains(SpellEffect.Blind);
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackAnimation =
+            AnimationBase.Get(AnimationBase.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.ScalingStat = cmbScalingStat.SelectedIndex;
+    }
+
+    private void lstSpells_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex > -1)
+        {
+            cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.Spells[lstSpells.SelectedIndex]);
+        }
+    }
+
+    private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstSpells.SelectedIndex > -1 && lstSpells.SelectedIndex < mEditorItem.Spells.Count)
+        {
+            mEditorItem.Spells[lstSpells.SelectedIndex] = SpellBase.IdFromList(cmbSpell.SelectedIndex);
+        }
+
+        var n = lstSpells.SelectedIndex;
+        lstSpells.Items.Clear();
+        for (var i = 0; i < mEditorItem.Spells.Count; i++)
+        {
+            lstSpells.Items.Add(SpellBase.GetName(mEditorItem.Spells[i]));
+        }
+
+        lstSpells.SelectedIndex = n;
+    }
+
+    private void nudScaling_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Scaling = (int)nudScaling.Value;
+    }
+
+    private void nudSpawnDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SpawnDuration = (int)nudSpawnDuration.Value;
+    }
+
+    private void nudSightRange_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SightRange = (int)nudSightRange.Value;
+    }
+
+    private void nudStr_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stats[(int)Stat.Attack] = (int)nudStr.Value;
+    }
+
+    private void nudMag_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stats[(int)Stat.AbilityPower] = (int)nudMag.Value;
+    }
+
+    private void nudDef_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stats[(int)Stat.Defense] = (int)nudDef.Value;
+    }
+
+    private void nudMR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stats[(int)Stat.MagicResist] = (int)nudMR.Value;
+    }
+
+    private void nudSpd_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Stats[(int)Stat.Speed] = (int)nudSpd.Value;
+    }
+
+    private void nudDamage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Damage = (int)nudDamage.Value;
+    }
+
+    private void nudCritChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritChance = (int)nudCritChance.Value;
+    }
+
+    private void nudHp_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MaxVital[(int)Vital.Health] = (int)nudHp.Value;
+    }
+
+    private void nudMana_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MaxVital[(int)Vital.Mana] = (int)nudMana.Value;
+    }
+
+    private void nudExp_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Experience = (int)nudExp.Value;
+    }
+
+    private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
+        {
+            mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+        }
+
+        UpdateDropValues(true);
+    }
+
+    private void nudDropAmount_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving 0 items!
+        nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
+
+        if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+        {
+            return;
+        }
+
+        mEditorItem.Drops[(int)lstDrops.SelectedIndex].Quantity = (int)nudDropAmount.Value;
+        UpdateDropValues(true);
+    }
+
+    private void lstDrops_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1)
+        {
+            cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
+            nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
+            nudDropChance.Value = (decimal)mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
+        }
+    }
+
+    private void btnDropAdd_Click(object sender, EventArgs e)
+    {
+        mEditorItem.Drops.Add(new Drop());
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int)nudDropAmount.Value;
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double)nudDropChance.Value;
+
+        UpdateDropValues();
+    }
+
+    private void btnDropRemove_Click(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1)
+        {
+            var i = lstDrops.SelectedIndex;
+            lstDrops.Items.RemoveAt(i);
+            mEditorItem.Drops.RemoveAt(i);
+        }
+
+        UpdateDropValues(true);
+    }
+
+    private void nudDropChance_ValueChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+        {
+            return;
+        }
+
+        mEditorItem.Drops[(int)lstDrops.SelectedIndex].Chance = (double)nudDropChance.Value;
+        UpdateDropValues(true);
+    }
+
+    private void chkIndividualLoot_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IndividualizedLoot = chkIndividualLoot.Checked;
+    }
+
+    private void nudLevel_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Level = (int)nudLevel.Value;
+    }
+
+    private void nudHpRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalRegen[(int)Vital.Health] = (int)nudHpRegen.Value;
+    }
+
+    private void nudMpRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalRegen[(int)Vital.Mana] = (int)nudMpRegen.Value;
+    }
+
+    private void chkAggressive_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Aggressive = chkAggressive.Checked;
+        if (mEditorItem.Aggressive)
+        {
+            btnAttackOnSightCond.Text = Strings.NpcEditor.dontattackonsightconditions;
+        }
+        else
+        {
+            btnAttackOnSightCond.Text = Strings.NpcEditor.attackonsightconditions;
+        }
+    }
+
+    private void cmbMovement_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Movement = (byte)cmbMovement.SelectedIndex;
+    }
+
+    private void chkSwarm_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Swarm = chkSwarm.Checked;
+    }
+
+    private void nudFlee_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.FleeHealthPercentage = (byte)nudFlee.Value;
+    }
+
+    private void btnPlayerFriendProtectorCond_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.PlayerFriendConditions, RequirementType.NpcFriend);
+        frm.TopMost = true;
+        frm.ShowDialog();
+    }
+
+    private void btnAttackOnSightCond_Click(object sender, EventArgs e)
+    {
+        if (chkAggressive.Checked)
+        {
+            var frm = new FrmDynamicRequirements(
+                mEditorItem.AttackOnSightConditions, RequirementType.NpcDontAttackOnSight
+            );
+
+            frm.TopMost = true;
+            frm.ShowDialog();
+        }
+        else
+        {
+            var frm = new FrmDynamicRequirements(
+                mEditorItem.AttackOnSightConditions, RequirementType.NpcAttackOnSight
+            );
+
+            frm.TopMost = true;
+            frm.ShowDialog();
+        }
+    }
+
+    private void btnPlayerCanAttackCond_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(
+            mEditorItem.PlayerCanAttackConditions, RequirementType.NpcCanBeAttacked
+        );
+
+        frm.TopMost = true;
+        frm.ShowDialog();
+    }
+
+    private void cmbOnDeathEventKiller_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.OnDeathEvent = EventBase.Get(EventBase.IdFromList(cmbOnDeathEventKiller.SelectedIndex - 1));
+    }
+
+    private void cmbOnDeathEventParty_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.OnDeathPartyEvent = EventBase.Get(EventBase.IdFromList(cmbOnDeathEventParty.SelectedIndex - 1));
+    }
+
+    private void chkFocusDamageDealer_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.FocusHighestDamageDealer = chkFocusDamageDealer.Checked;
+    }
+
+    private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CritMultiplier = (double)nudCritMultiplier.Value;
+    }
+
+    private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
+        nudAttackSpeedValue.Enabled = cmbAttackSpeedModifier.SelectedIndex > 0;
+    }
+
+    private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AttackSpeedValue = (int)nudAttackSpeedValue.Value;
+    }
+
+    private void nudRgbaR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.R = (byte)nudRgbaR.Value;
+        DrawNpcSprite();
+    }
+
+    private void nudRgbaG_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.G = (byte)nudRgbaG.Value;
+        DrawNpcSprite();
+    }
+
+    private void nudRgbaB_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.B = (byte)nudRgbaB.Value;
+        DrawNpcSprite();
+    }
+
+    private void nudRgbaA_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Color.A = (byte)nudRgbaA.Value;
+        DrawNpcSprite();
+    }
+
+    private void nudResetRadius_ValueChanged(object sender, EventArgs e)
+    {
+        // So, the pathfinder on the server maintains a set max distance of whichever the largest value is, map height or width. Limit ourselves to this!
+        var maxPathFindingDistance = Math.Max(Options.MapWidth, Options.MapHeight);
+        var maxUserEnteredValue = Math.Max(Options.Npc.ResetRadius, nudResetRadius.Value);
+
+        // Use whatever is the lowest, either the maximum path find distance or the user entered value.
+        nudResetRadius.Value = Math.Min(maxPathFindingDistance, maxUserEnteredValue);
+        mEditorItem.ResetRadius = (int)nudResetRadius.Value;
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in NpcBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((NpcBase)itm.Value).Folder) &&
+                !mFolders.Contains(((NpcBase)itm.Value).Folder))
+            {
+                mFolders.Add(((NpcBase)itm.Value).Folder);
+                if (!mKnownFolders.Contains(((NpcBase)itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((NpcBase)itm.Value).Folder);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = NpcBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((NpcBase)pair.Value)?.Name ?? Models.DatabaseObject<NpcBase>.Deleted, ((NpcBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.NpcEditor.folderprompt, Strings.NpcEditor.foldertitle, ref folderName, DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.UpdateText(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.NpcEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.NpcEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.NpcEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.NpcEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
+
+    private void ChangeImmunity(SpellEffect status, bool isImmune)
+    {
+        if (isImmune && !mEditorItem.Immunities.Contains(status))
+        {
+            mEditorItem.Immunities.Add(status);
+        }
+        else if (!isImmune)
+        {
+            mEditorItem.Immunities.Remove(status);
+        }
+    }
+
+    private void chkKnockback_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Knockback, chkKnockback.Checked);
+    }
+
+    private void chkSilence_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Silence, chkSilence.Checked);
+    }
+
+    private void chkStun_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Stun, chkStun.Checked);
+    }
+
+    private void chkSnare_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Snare, chkSnare.Checked);
+    }
+
+    private void chkBlind_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Blind, chkBlind.Checked);
+    }
+
+    private void chkTransform_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Transform, chkTransform.Checked);
+    }
+
+    private void chkSleep_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Sleep, chkSleep.Checked);
+    }
+
+    private void chkTaunt_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeImmunity(SpellEffect.Taunt, chkTaunt.Checked);
+    }
+
+    private void nudTenacity_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Tenacity = (double)nudTenacity.Value;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmProjectile.cs
+++ b/Intersect.Editor/Forms/Editors/frmProjectile.cs
@@ -7,847 +7,845 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmProjectile : EditorForm
 {
 
-    public partial class FrmProjectile : EditorForm
+    private List<ProjectileBase> mChanged = new List<ProjectileBase>();
+
+    private string mCopiedItem;
+
+    private Bitmap mDirectionGrid;
+
+    private ProjectileBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmProjectile()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<ProjectileBase> mChanged = new List<ProjectileBase>();
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = ProjectileBase.Get(id);
+        UpdateEditor();
+    }
 
-        private string mCopiedItem;
-
-        private Bitmap mDirectionGrid;
-
-        private ProjectileBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        public FrmProjectile()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Projectile)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = ProjectileBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Projectile)
+            InitEditor();
+            if (mEditorItem != null && !ProjectileBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !ProjectileBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            foreach (var item in mChanged)
-            {
-                item.GrappleHookOptions.Sort();
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            item.GrappleHookOptions.Sort();
+            item.RestoreBackup();
+            item.DeleteBackup();
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                item.GrappleHookOptions.Sort();
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            item.GrappleHookOptions.Sort();
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
         }
 
-        private void frmProjectile_Load(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmProjectile_Load(object sender, EventArgs e)
+    {
+        mDirectionGrid = new Bitmap("resources/misc/directions.png");
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+
+        cmbItem.Items.Clear();
+        cmbItem.Items.Add(Strings.General.None);
+        cmbItem.Items.AddRange(ItemBase.Names);
+
+        cmbSpell.Items.Clear();
+        cmbSpell.Items.Add(Strings.General.None);
+        cmbSpell.Items.AddRange(SpellBase.Names);
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.ProjectileEditor.title;
+        toolStripItemNew.Text = Strings.ProjectileEditor.New;
+        toolStripItemDelete.Text = Strings.ProjectileEditor.delete;
+        toolStripItemCopy.Text = Strings.ProjectileEditor.copy;
+        toolStripItemPaste.Text = Strings.ProjectileEditor.paste;
+        toolStripItemUndo.Text = Strings.ProjectileEditor.undo;
+
+        grpProjectiles.Text = Strings.ProjectileEditor.projectiles;
+
+        grpProperties.Text = Strings.ProjectileEditor.properties;
+        lblName.Text = Strings.ProjectileEditor.name;
+        lblSpeed.Text = Strings.ProjectileEditor.speed;
+        lblSpawn.Text = Strings.ProjectileEditor.spawndelay;
+        lblAmount.Text = Strings.ProjectileEditor.quantity;
+        lblRange.Text = Strings.ProjectileEditor.range;
+        lblKnockback.Text = Strings.ProjectileEditor.knockback;
+        lblSpell.Text = Strings.ProjectileEditor.spell;
+
+        grpGrappleOptions.Text = Strings.ProjectileEditor.GrappleOptionsTitle;
+        chkGrappleOnMap.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.MapAttribute];
+        chkGrappleOnPlayer.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.Player];
+        chkGrappleOnNpc.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.NPC];
+        chkGrappleOnResource.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.Resource];
+
+        grpSpawns.Text = Strings.ProjectileEditor.spawns;
+
+        grpAnimations.Text = Strings.ProjectileEditor.animations;
+        lblAnimation.Text = Strings.ProjectileEditor.animation;
+        chkRotation.Text = Strings.ProjectileEditor.autorotate;
+        btnAdd.Text = Strings.ProjectileEditor.addanimation;
+        btnRemove.Text = Strings.ProjectileEditor.removeanimation;
+
+        grpCollisions.Text = Strings.ProjectileEditor.collisions;
+        chkIgnoreMapBlocks.Text = Strings.ProjectileEditor.ignoreblocks;
+        chkIgnoreActiveResources.Text = Strings.ProjectileEditor.ignoreactiveresources;
+        chkIgnoreInactiveResources.Text = Strings.ProjectileEditor.ignoreinactiveresources;
+        chkIgnoreZDimensionBlocks.Text = Strings.ProjectileEditor.ignorezdimension;
+        chkPierce.Text = Strings.ProjectileEditor.piercetarget;
+
+        grpAmmo.Text = Strings.ProjectileEditor.ammo;
+        lblAmmoItem.Text = Strings.ProjectileEditor.ammoitem;
+        lblAmmoAmount.Text = Strings.ProjectileEditor.ammoamount;
+
+        grpTargettingOptions.Text = Strings.ProjectileEditor.TargettingOptions;
+        rdoBehaviorDefault.Text = Strings.ProjectileEditor.BehaviorDefault;
+        rdoBehaviorDirectShot.Text = Strings.ProjectileEditor.BehaviorDirectShot;
+        rdoBehaviorHoming.Text = Strings.ProjectileEditor.BehaviorHoming;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.ProjectileEditor.sortalphabetically;
+        txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
+        lblFolder.Text = Strings.ProjectileEditor.folderlabel;
+
+        btnSave.Text = Strings.ProjectileEditor.save;
+        btnCancel.Text = Strings.ProjectileEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
         {
-            mDirectionGrid = new Bitmap("resources/misc/directions.png");
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.Add(Strings.General.None);
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
+            pnlContainer.Show();
 
-            cmbItem.Items.Clear();
-            cmbItem.Items.Add(Strings.General.None);
-            cmbItem.Items.AddRange(ItemBase.Names);
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            nudSpeed.Value = mEditorItem.Speed;
+            nudSpawn.Value = mEditorItem.Delay;
+            nudAmount.Value = mEditorItem.Quantity;
+            nudRange.Value = mEditorItem.Range;
+            cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.SpellId) + 1;
+            nudKnockback.Value = mEditorItem.Knockback;
+            chkIgnoreMapBlocks.Checked = mEditorItem.IgnoreMapBlocks;
+            chkIgnoreActiveResources.Checked = mEditorItem.IgnoreActiveResources;
+            chkIgnoreInactiveResources.Checked = mEditorItem.IgnoreExhaustedResources;
+            chkIgnoreZDimensionBlocks.Checked = mEditorItem.IgnoreZDimension;
+            chkPierce.Checked = mEditorItem.PierceTarget;
+            cmbItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.AmmoItemId) + 1;
+            nudConsume.Value = mEditorItem.AmmoRequired;
 
-            cmbSpell.Items.Clear();
-            cmbSpell.Items.Add(Strings.General.None);
-            cmbSpell.Items.AddRange(SpellBase.Names);
-
-            InitLocalization();
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.ProjectileEditor.title;
-            toolStripItemNew.Text = Strings.ProjectileEditor.New;
-            toolStripItemDelete.Text = Strings.ProjectileEditor.delete;
-            toolStripItemCopy.Text = Strings.ProjectileEditor.copy;
-            toolStripItemPaste.Text = Strings.ProjectileEditor.paste;
-            toolStripItemUndo.Text = Strings.ProjectileEditor.undo;
-
-            grpProjectiles.Text = Strings.ProjectileEditor.projectiles;
-
-            grpProperties.Text = Strings.ProjectileEditor.properties;
-            lblName.Text = Strings.ProjectileEditor.name;
-            lblSpeed.Text = Strings.ProjectileEditor.speed;
-            lblSpawn.Text = Strings.ProjectileEditor.spawndelay;
-            lblAmount.Text = Strings.ProjectileEditor.quantity;
-            lblRange.Text = Strings.ProjectileEditor.range;
-            lblKnockback.Text = Strings.ProjectileEditor.knockback;
-            lblSpell.Text = Strings.ProjectileEditor.spell;
-
-            grpGrappleOptions.Text = Strings.ProjectileEditor.GrappleOptionsTitle;
-            chkGrappleOnMap.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.MapAttribute];
-            chkGrappleOnPlayer.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.Player];
-            chkGrappleOnNpc.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.NPC];
-            chkGrappleOnResource.Text = Strings.ProjectileEditor.GrappleOpts[GrappleOption.Resource];
-
-            grpSpawns.Text = Strings.ProjectileEditor.spawns;
-
-            grpAnimations.Text = Strings.ProjectileEditor.animations;
-            lblAnimation.Text = Strings.ProjectileEditor.animation;
-            chkRotation.Text = Strings.ProjectileEditor.autorotate;
-            btnAdd.Text = Strings.ProjectileEditor.addanimation;
-            btnRemove.Text = Strings.ProjectileEditor.removeanimation;
-
-            grpCollisions.Text = Strings.ProjectileEditor.collisions;
-            chkIgnoreMapBlocks.Text = Strings.ProjectileEditor.ignoreblocks;
-            chkIgnoreActiveResources.Text = Strings.ProjectileEditor.ignoreactiveresources;
-            chkIgnoreInactiveResources.Text = Strings.ProjectileEditor.ignoreinactiveresources;
-            chkIgnoreZDimensionBlocks.Text = Strings.ProjectileEditor.ignorezdimension;
-            chkPierce.Text = Strings.ProjectileEditor.piercetarget;
-
-            grpAmmo.Text = Strings.ProjectileEditor.ammo;
-            lblAmmoItem.Text = Strings.ProjectileEditor.ammoitem;
-            lblAmmoAmount.Text = Strings.ProjectileEditor.ammoamount;
-
-            grpTargettingOptions.Text = Strings.ProjectileEditor.TargettingOptions;
-            rdoBehaviorDefault.Text = Strings.ProjectileEditor.BehaviorDefault;
-            rdoBehaviorDirectShot.Text = Strings.ProjectileEditor.BehaviorDirectShot;
-            rdoBehaviorHoming.Text = Strings.ProjectileEditor.BehaviorHoming;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.ProjectileEditor.sortalphabetically;
-            txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
-            lblFolder.Text = Strings.ProjectileEditor.folderlabel;
-
-            btnSave.Text = Strings.ProjectileEditor.save;
-            btnCancel.Text = Strings.ProjectileEditor.cancel;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                nudSpeed.Value = mEditorItem.Speed;
-                nudSpawn.Value = mEditorItem.Delay;
-                nudAmount.Value = mEditorItem.Quantity;
-                nudRange.Value = mEditorItem.Range;
-                cmbSpell.SelectedIndex = SpellBase.ListIndex(mEditorItem.SpellId) + 1;
-                nudKnockback.Value = mEditorItem.Knockback;
-                chkIgnoreMapBlocks.Checked = mEditorItem.IgnoreMapBlocks;
-                chkIgnoreActiveResources.Checked = mEditorItem.IgnoreActiveResources;
-                chkIgnoreInactiveResources.Checked = mEditorItem.IgnoreExhaustedResources;
-                chkIgnoreZDimensionBlocks.Checked = mEditorItem.IgnoreZDimension;
-                chkPierce.Checked = mEditorItem.PierceTarget;
-                cmbItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.AmmoItemId) + 1;
-                nudConsume.Value = mEditorItem.AmmoRequired;
-
-                if (lstAnimations.SelectedIndex < 0)
-                {
-                    lstAnimations.SelectedIndex = 0;
-                }
-
-                if (!mEditorItem.HomingBehavior && !mEditorItem.DirectShotBehavior)
-                {
-                    rdoBehaviorDefault.Checked = true;
-                }
-                else if (mEditorItem.HomingBehavior)
-                {
-                    rdoBehaviorHoming.Checked = true;
-                }
-                else if (mEditorItem.DirectShotBehavior)
-                {
-                    rdoBehaviorDirectShot.Checked = true;
-                }
-
-                UpdateAnimationData(0);
-                lstAnimations.SelectedIndex = 0;
-
-                Render();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-
-                UpdateGrappleOptions();
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void UpdateAnimationData(int index)
-        {
-            UpdateAnimations(true);
-            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.Animations[index].AnimationId) + 1;
-            scrlSpawnRange.Value = Math.Min(mEditorItem.Animations[index].SpawnRange, scrlSpawnRange.Maximum);
-            chkRotation.Checked = mEditorItem.Animations[index].AutoRotate;
-            UpdateAnimations(true);
-        }
-
-        private void UpdateAnimations(bool saveIndex = true)
-        {
-            var n = 1;
-            var selectedIndex = 0;
-
-            // if there are no animations, add one by default.
-            if (mEditorItem.Animations.Count == 0)
-            {
-                mEditorItem.Animations.Add(new ProjectileAnimation(Guid.Empty, mEditorItem.Quantity, false));
-            }
-
-            //Update the spawn range maximum
-            if (nudAmount.Value < scrlSpawnRange.Value)
-            {
-                scrlSpawnRange.Value = (int)nudAmount.Value;
-            }
-
-            scrlSpawnRange.Maximum = (int)nudAmount.Value;
-
-            //Save the index
-            if (saveIndex == true)
-            {
-                selectedIndex = lstAnimations.SelectedIndex;
-            }
-
-            // Add the animations to the list
-            lstAnimations.Items.Clear();
-            for (var i = 0; i < mEditorItem.Animations.Count; i++)
-            {
-                if (mEditorItem.Animations[i].AnimationId != Guid.Empty)
-                {
-                    lstAnimations.Items.Add(
-                        Strings.ProjectileEditor.animationline.ToString(
-                            n, mEditorItem.Animations[i].SpawnRange,
-                            AnimationBase.GetName(mEditorItem.Animations[i].AnimationId)
-                        )
-                    );
-                }
-                else
-                {
-                    lstAnimations.Items.Add(
-                        Strings.ProjectileEditor.animationline.ToString(
-                            n, mEditorItem.Animations[i].SpawnRange, Strings.General.None
-                        )
-                    );
-                }
-
-                n = mEditorItem.Animations[i].SpawnRange + 1;
-            }
-
-            lstAnimations.SelectedIndex = selectedIndex;
             if (lstAnimations.SelectedIndex < 0)
             {
                 lstAnimations.SelectedIndex = 0;
             }
 
-            if (lstAnimations.SelectedIndex > 0)
+            if (!mEditorItem.HomingBehavior && !mEditorItem.DirectShotBehavior)
             {
-                lblSpawnRange.Text = Strings.ProjectileEditor.spawnrange.ToString(
-                    mEditorItem.Animations[lstAnimations.SelectedIndex - 1].SpawnRange + 1,
-                    mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange
-                );
+                rdoBehaviorDefault.Checked = true;
             }
-            else
+            else if (mEditorItem.HomingBehavior)
             {
-                lblSpawnRange.Text = Strings.ProjectileEditor.spawnrange.ToString(
-                    1, mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange
-                );
+                rdoBehaviorHoming.Checked = true;
             }
-        }
-
-        private void UpdateGrappleOptions()
-        {
-            chkGrappleOnMap.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.MapAttribute);
-            chkGrappleOnPlayer.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.Player);
-            chkGrappleOnNpc.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.NPC);
-            chkGrappleOnResource.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.Resource);
-        }
-
-        private void ChangeGrappleOptions(GrappleOption option, bool chkValue)
-        {
-            if (chkValue && !mEditorItem.GrappleHookOptions.Contains(option))
+            else if (mEditorItem.DirectShotBehavior)
             {
-                mEditorItem.GrappleHookOptions.Add(option);
-            }
-            else if (!chkValue)
-            {
-                mEditorItem.GrappleHookOptions.Remove(option);
-            }
-        }
-
-        private void Render()
-        {
-            Bitmap img;
-            if (picSpawns.BackgroundImage == null)
-            {
-                img = new Bitmap(160, 160);
-                picSpawns.BackgroundImage = img;
-            }
-            else
-            {
-                img = (Bitmap)picSpawns.BackgroundImage;
+                rdoBehaviorDirectShot.Checked = true;
             }
 
-            var gfx = Graphics.FromImage(img);
-            gfx.FillRectangle(Brushes.White, new Rectangle(0, 0, picSpawns.Width, picSpawns.Height));
-
-            for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
-            {
-                for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
-                {
-                    gfx.DrawImage(
-                        mDirectionGrid, new Rectangle(x * 32, y * 32, 32, 32), new Rectangle(0, 0, 32, 32),
-                        GraphicsUnit.Pixel
-                    );
-
-                    for (var i = 0; i < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; i++)
-                    {
-                        if (mEditorItem.SpawnLocations[x, y].Directions[i] == true)
-                        {
-                            gfx.DrawImage(
-                                mDirectionGrid,
-                                new Rectangle(
-                                    x * 32 + DirectionOffsetX(i), y * 32 + DirectionOffsetY(i), (32 - 2) / 3,
-                                    (32 - 2) / 3
-                                ),
-                                new Rectangle(
-                                    32 + DirectionOffsetX(i), DirectionOffsetY(i), (32 - 2) / 3, (32 - 2) / 3
-                                ), GraphicsUnit.Pixel
-                            );
-                        }
-                    }
-                }
-            }
-
-            gfx.DrawImage(
-                mDirectionGrid,
-                new Rectangle(160 / 2 - (32 - 2) / 3 / 2, 160 / 2 - (32 - 2) / 3 / 2, (32 - 2) / 3, (32 - 2) / 3),
-                new Rectangle(43, 11, (32 - 2) / 3, (32 - 2) / 3), GraphicsUnit.Pixel
-            );
-
-            gfx.Dispose();
-            picSpawns.Refresh();
-        }
-
-        private int DirectionOffsetX(int dir)
-        {
-            switch (dir)
-            {
-                case 0: //Up
-                    return 10;
-                case 1: //Down
-                    return 10;
-                case 2: //Left
-                    return 1;
-                case 3: //Right
-                    return 20;
-                case 4: //UpLeft
-                    return 1;
-                case 5: //UpRight
-                    return 20;
-                case 6: //DownLeft
-                    return 1;
-                case 7: //DownRight
-                    return 20;
-                default:
-                    return 1;
-            }
-        }
-
-        private int DirectionOffsetY(int dir)
-        {
-            switch (dir)
-            {
-                case 0: //Up
-                    return 1;
-                case 1: //Down
-                    return 20;
-                case 2: //Left
-                    return 10;
-                case 3: //Right
-                    return 10;
-                case 4: //UpLeft
-                    return 1;
-                case 5: //UpRight
-                    return 1;
-                case 6: //DownLeft
-                    return 20;
-                case 7: //DownRight
-                    return 20;
-                default:
-                    return 1;
-            }
-        }
-
-        private int FindDirection(int x, int y)
-        {
-            switch (x)
-            {
-                case 0: //Left
-                    switch (y)
-                    {
-                        case 0: //Up
-                            return 4;
-                        case 1: //Center
-                            return 2;
-                        case 2: //Down
-                            return 6;
-                    }
-
-                    return 0;
-                case 1: //Center
-                    switch (y)
-                    {
-                        case 0: //Up
-                            return 0;
-                        case 2: //Down
-                            return 1;
-                    }
-
-                    return 0;
-                case 2: //Right
-                    switch (y)
-                    {
-                        case 0: //Up
-                            return 5;
-                        case 1: //Center
-                            return 3;
-                        case 2: //Down
-                            return 7;
-                    }
-
-                    return 0;
-                default:
-                    return 0;
-            }
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void chkRotation_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Animations[lstAnimations.SelectedIndex].AutoRotate = chkRotation.Checked;
-        }
-
-        private void picSpawns_MouseDown(object sender, MouseEventArgs e)
-        {
-            double scaledX = e.X * (160f / picSpawns.Width);
-            double scaledY = e.Y * (160f / picSpawns.Height);
-            var x = scaledX / 32;
-            var y = scaledY / 32;
-            double i, j;
-
-            x = Math.Floor(x);
-            y = Math.Floor(y);
-
-            if (x > 4 || y > 4)
-            {
-                return;
-            }
-
-            i = (scaledX - x * 32) / (32 / 3);
-            j = (scaledY - y * 32) / (32 / 3);
-
-            i = Math.Floor(i);
-            j = Math.Floor(j);
-
-            mEditorItem.SpawnLocations[(int)x, (int)y].Directions[FindDirection((int)i, (int)j)] =
-                !mEditorItem.SpawnLocations[(int)x, (int)y].Directions[FindDirection((int)i, (int)j)];
+            UpdateAnimationData(0);
+            lstAnimations.SelectedIndex = 0;
 
             Render();
-        }
-
-        private void chkIgnoreMapBlocks_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreMapBlocks = chkIgnoreMapBlocks.Checked;
-        }
-
-        private void chkIgnoreActiveResources_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreActiveResources = chkIgnoreActiveResources.Checked;
-        }
-
-        private void chkIgnoreInactiveResources_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreExhaustedResources = chkIgnoreInactiveResources.Checked;
-        }
-
-        private void chkIgnoreZDimensionBlocks_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreZDimension = chkIgnoreZDimensionBlocks.Checked;
-        }
-
-        private void chkPierce_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.PierceTarget = chkPierce.Checked;
-        }
-
-        private void btnAdd_Click(object sender, EventArgs e)
-        {
-            //Clone the previous animation to save time, set the end point to always be the quantity of spawns.
-            mEditorItem.Animations.Add(
-                new ProjectileAnimation(
-                    mEditorItem.Animations[mEditorItem.Animations.Count - 1].AnimationId, mEditorItem.Quantity,
-                    mEditorItem.Animations[mEditorItem.Animations.Count - 1].AutoRotate
-                )
-            );
-
-            UpdateAnimations();
-        }
-
-        private void btnRemove_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem.Animations.Count > 1)
+            if (mChanged.IndexOf(mEditorItem) == -1)
             {
-                mEditorItem.Animations.RemoveAt(mEditorItem.Animations.Count - 1);
-                lstAnimations.SelectedIndex = 0;
-                UpdateAnimations(false);
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
             }
+
+            UpdateGrappleOptions();
+        }
+        else
+        {
+            pnlContainer.Hide();
         }
 
-        private void scrlSpawnRange_Scroll(object sender, ScrollValueEventArgs e)
+        UpdateToolStripItems();
+    }
+
+    private void UpdateAnimationData(int index)
+    {
+        UpdateAnimations(true);
+        cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.Animations[index].AnimationId) + 1;
+        scrlSpawnRange.Value = Math.Min(mEditorItem.Animations[index].SpawnRange, scrlSpawnRange.Maximum);
+        chkRotation.Checked = mEditorItem.Animations[index].AutoRotate;
+        UpdateAnimations(true);
+    }
+
+    private void UpdateAnimations(bool saveIndex = true)
+    {
+        var n = 1;
+        var selectedIndex = 0;
+
+        // if there are no animations, add one by default.
+        if (mEditorItem.Animations.Count == 0)
         {
-            mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange = scrlSpawnRange.Value;
-            UpdateAnimations();
+            mEditorItem.Animations.Add(new ProjectileAnimation(Guid.Empty, mEditorItem.Quantity, false));
         }
 
-        private void lstAnimations_Click(object sender, EventArgs e)
+        //Update the spawn range maximum
+        if (nudAmount.Value < scrlSpawnRange.Value)
         {
-            if (lstAnimations.SelectedIndex > -1)
+            scrlSpawnRange.Value = (int)nudAmount.Value;
+        }
+
+        scrlSpawnRange.Maximum = (int)nudAmount.Value;
+
+        //Save the index
+        if (saveIndex == true)
+        {
+            selectedIndex = lstAnimations.SelectedIndex;
+        }
+
+        // Add the animations to the list
+        lstAnimations.Items.Clear();
+        for (var i = 0; i < mEditorItem.Animations.Count; i++)
+        {
+            if (mEditorItem.Animations[i].AnimationId != Guid.Empty)
             {
-                UpdateAnimationData(lstAnimations.SelectedIndex);
-            }
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Projectile);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ProjectileEditor.deleteprompt, Strings.ProjectileEditor.deletetitle,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
-                UpdateEditor();
-            }
-        }
-
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ProjectileEditor.undoprompt, Strings.ProjectileEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void cmbItem_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Ammo = ItemBase.Get(ItemBase.IdFromList(cmbItem.SelectedIndex - 1));
-        }
-
-        private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Animations[lstAnimations.SelectedIndex].AnimationId =
-                AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
-
-            UpdateAnimations();
-        }
-
-        private void nudSpeed_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Speed = (int)nudSpeed.Value;
-        }
-
-        private void nudSpawnDelay_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Delay = (int)nudSpawn.Value;
-        }
-
-        private void nudAmount_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Quantity = (int)nudAmount.Value;
-            UpdateAnimations();
-        }
-
-        private void nudRange_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Range = (int)nudRange.Value;
-        }
-
-        private void nudKnockback_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Knockback = (int)nudKnockback.Value;
-        }
-
-        private void nudConsume_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.AmmoRequired = (int)nudConsume.Value;
-        }
-
-        private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cmbSpell.SelectedIndex > 0)
-            {
-                mEditorItem.Spell = SpellBase.Get(SpellBase.IdFromList(cmbSpell.SelectedIndex - 1));
+                lstAnimations.Items.Add(
+                    Strings.ProjectileEditor.animationline.ToString(
+                        n, mEditorItem.Animations[i].SpawnRange,
+                        AnimationBase.GetName(mEditorItem.Animations[i].AnimationId)
+                    )
+                );
             }
             else
             {
-                mEditorItem.Spell = null;
+                lstAnimations.Items.Add(
+                    Strings.ProjectileEditor.animationline.ToString(
+                        n, mEditorItem.Animations[i].SpawnRange, Strings.General.None
+                    )
+                );
             }
-        }
-        private void chkGrappleOnMap_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeGrappleOptions(GrappleOption.MapAttribute, chkGrappleOnMap.Checked);
+
+            n = mEditorItem.Animations[i].SpawnRange + 1;
         }
 
-        private void chkGrappleOnPlayer_CheckedChanged(object sender, EventArgs e)
+        lstAnimations.SelectedIndex = selectedIndex;
+        if (lstAnimations.SelectedIndex < 0)
         {
-            ChangeGrappleOptions(GrappleOption.Player, chkGrappleOnPlayer.Checked);
+            lstAnimations.SelectedIndex = 0;
         }
 
-        private void chkGrappleOnNpc_CheckedChanged(object sender, EventArgs e)
+        if (lstAnimations.SelectedIndex > 0)
         {
-            ChangeGrappleOptions(GrappleOption.NPC, chkGrappleOnNpc.Checked);
+            lblSpawnRange.Text = Strings.ProjectileEditor.spawnrange.ToString(
+                mEditorItem.Animations[lstAnimations.SelectedIndex - 1].SpawnRange + 1,
+                mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange
+            );
+        }
+        else
+        {
+            lblSpawnRange.Text = Strings.ProjectileEditor.spawnrange.ToString(
+                1, mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange
+            );
+        }
+    }
+
+    private void UpdateGrappleOptions()
+    {
+        chkGrappleOnMap.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.MapAttribute);
+        chkGrappleOnPlayer.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.Player);
+        chkGrappleOnNpc.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.NPC);
+        chkGrappleOnResource.Checked = mEditorItem.GrappleHookOptions.Contains(GrappleOption.Resource);
+    }
+
+    private void ChangeGrappleOptions(GrappleOption option, bool chkValue)
+    {
+        if (chkValue && !mEditorItem.GrappleHookOptions.Contains(option))
+        {
+            mEditorItem.GrappleHookOptions.Add(option);
+        }
+        else if (!chkValue)
+        {
+            mEditorItem.GrappleHookOptions.Remove(option);
+        }
+    }
+
+    private void Render()
+    {
+        Bitmap img;
+        if (picSpawns.BackgroundImage == null)
+        {
+            img = new Bitmap(160, 160);
+            picSpawns.BackgroundImage = img;
+        }
+        else
+        {
+            img = (Bitmap)picSpawns.BackgroundImage;
         }
 
-        private void chkGrappleOnResource_CheckedChanged(object sender, EventArgs e)
-        {
-            ChangeGrappleOptions(GrappleOption.Resource, chkGrappleOnResource.Checked);
-        }
+        var gfx = Graphics.FromImage(img);
+        gfx.FillRectangle(Brushes.White, new Rectangle(0, 0, picSpawns.Width, picSpawns.Height));
 
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
+        for (var x = 0; x < ProjectileBase.SPAWN_LOCATIONS_WIDTH; x++)
         {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in ProjectileBase.Lookup)
+            for (var y = 0; y < ProjectileBase.SPAWN_LOCATIONS_HEIGHT; y++)
             {
-                if (!string.IsNullOrEmpty(((ProjectileBase)itm.Value).Folder) &&
-                    !mFolders.Contains(((ProjectileBase)itm.Value).Folder))
+                gfx.DrawImage(
+                    mDirectionGrid, new Rectangle(x * 32, y * 32, 32, 32), new Rectangle(0, 0, 32, 32),
+                    GraphicsUnit.Pixel
+                );
+
+                for (var i = 0; i < ProjectileBase.MAX_PROJECTILE_DIRECTIONS; i++)
                 {
-                    mFolders.Add(((ProjectileBase)itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ProjectileBase)itm.Value).Folder))
+                    if (mEditorItem.SpawnLocations[x, y].Directions[i] == true)
                     {
-                        mKnownFolders.Add(((ProjectileBase)itm.Value).Folder);
+                        gfx.DrawImage(
+                            mDirectionGrid,
+                            new Rectangle(
+                                x * 32 + DirectionOffsetX(i), y * 32 + DirectionOffsetY(i), (32 - 2) / 3,
+                                (32 - 2) / 3
+                            ),
+                            new Rectangle(
+                                32 + DirectionOffsetX(i), DirectionOffsetY(i), (32 - 2) / 3, (32 - 2) / 3
+                            ), GraphicsUnit.Pixel
+                        );
                     }
                 }
             }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = ProjectileBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((ProjectileBase)pair.Value)?.Name ?? Models.DatabaseObject<ProjectileBase>.Deleted, ((ProjectileBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
         }
 
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ProjectileEditor.folderprompt, Strings.ProjectileEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
+        gfx.DrawImage(
+            mDirectionGrid,
+            new Rectangle(160 / 2 - (32 - 2) / 3 / 2, 160 / 2 - (32 - 2) / 3 / 2, (32 - 2) / 3, (32 - 2) / 3),
+            new Rectangle(43, 11, (32 - 2) / 3, (32 - 2) / 3), GraphicsUnit.Pixel
+        );
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
+        gfx.Dispose();
+        picSpawns.Refresh();
+    }
+
+    private int DirectionOffsetX(int dir)
+    {
+        switch (dir)
+        {
+            case 0: //Up
+                return 10;
+            case 1: //Down
+                return 10;
+            case 2: //Left
+                return 1;
+            case 3: //Right
+                return 20;
+            case 4: //UpLeft
+                return 1;
+            case 5: //UpRight
+                return 20;
+            case 6: //DownLeft
+                return 1;
+            case 7: //DownRight
+                return 20;
+            default:
+                return 1;
+        }
+    }
+
+    private int DirectionOffsetY(int dir)
+    {
+        switch (dir)
+        {
+            case 0: //Up
+                return 1;
+            case 1: //Down
+                return 20;
+            case 2: //Left
+                return 10;
+            case 3: //Right
+                return 10;
+            case 4: //UpLeft
+                return 1;
+            case 5: //UpRight
+                return 1;
+            case 6: //DownLeft
+                return 20;
+            case 7: //DownRight
+                return 20;
+            default:
+                return 1;
+        }
+    }
+
+    private int FindDirection(int x, int y)
+    {
+        switch (x)
+        {
+            case 0: //Left
+                switch (y)
                 {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
+                    case 0: //Up
+                        return 4;
+                    case 1: //Center
+                        return 2;
+                    case 2: //Down
+                        return 6;
                 }
-            }
+
+                return 0;
+            case 1: //Center
+                switch (y)
+                {
+                    case 0: //Up
+                        return 0;
+                    case 2: //Down
+                        return 1;
+                }
+
+                return 0;
+            case 2: //Right
+                switch (y)
+                {
+                    case 0: //Up
+                        return 5;
+                    case 1: //Center
+                        return 3;
+                    case 2: //Down
+                        return 7;
+                }
+
+                return 0;
+            default:
+                return 0;
+        }
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void chkRotation_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Animations[lstAnimations.SelectedIndex].AutoRotate = chkRotation.Checked;
+    }
+
+    private void picSpawns_MouseDown(object sender, MouseEventArgs e)
+    {
+        double scaledX = e.X * (160f / picSpawns.Width);
+        double scaledY = e.Y * (160f / picSpawns.Height);
+        var x = scaledX / 32;
+        var y = scaledY / 32;
+        double i, j;
+
+        x = Math.Floor(x);
+        y = Math.Floor(y);
+
+        if (x > 4 || y > 4)
+        {
+            return;
         }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
+        i = (scaledX - x * 32) / (32 / 3);
+        j = (scaledY - y * 32) / (32 / 3);
 
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
+        i = Math.Floor(i);
+        j = Math.Floor(j);
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+        mEditorItem.SpawnLocations[(int)x, (int)y].Directions[FindDirection((int)i, (int)j)] =
+            !mEditorItem.SpawnLocations[(int)x, (int)y].Directions[FindDirection((int)i, (int)j)];
 
-        private void txtSearch_Leave(object sender, EventArgs e)
+        Render();
+    }
+
+    private void chkIgnoreMapBlocks_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreMapBlocks = chkIgnoreMapBlocks.Checked;
+    }
+
+    private void chkIgnoreActiveResources_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreActiveResources = chkIgnoreActiveResources.Checked;
+    }
+
+    private void chkIgnoreInactiveResources_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreExhaustedResources = chkIgnoreInactiveResources.Checked;
+    }
+
+    private void chkIgnoreZDimensionBlocks_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreZDimension = chkIgnoreZDimensionBlocks.Checked;
+    }
+
+    private void chkPierce_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.PierceTarget = chkPierce.Checked;
+    }
+
+    private void btnAdd_Click(object sender, EventArgs e)
+    {
+        //Clone the previous animation to save time, set the end point to always be the quantity of spawns.
+        mEditorItem.Animations.Add(
+            new ProjectileAnimation(
+                mEditorItem.Animations[mEditorItem.Animations.Count - 1].AnimationId, mEditorItem.Quantity,
+                mEditorItem.Animations[mEditorItem.Animations.Count - 1].AutoRotate
+            )
+        );
+
+        UpdateAnimations();
+    }
+
+    private void btnRemove_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem.Animations.Count > 1)
         {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            mEditorItem.Animations.RemoveAt(mEditorItem.Animations.Count - 1);
+            lstAnimations.SelectedIndex = 0;
+            UpdateAnimations(false);
+        }
+    }
+
+    private void scrlSpawnRange_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        mEditorItem.Animations[lstAnimations.SelectedIndex].SpawnRange = scrlSpawnRange.Value;
+        UpdateAnimations();
+    }
+
+    private void lstAnimations_Click(object sender, EventArgs e)
+    {
+        if (lstAnimations.SelectedIndex > -1)
+        {
+            UpdateAnimationData(lstAnimations.SelectedIndex);
+        }
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Projectile);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ProjectileEditor.deleteprompt, Strings.ProjectileEditor.deletetitle,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
             {
-                txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.ProjectileEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.ProjectileEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
-
-        private void rdoBehaviorDefault_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateTargettingOptions();
-        }
-
-        private void rdoBehaviorDirectShot_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateTargettingOptions();
-        }
-
-        private void rdoBehaviorHoming_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateTargettingOptions();
-        }
-
-        private void UpdateTargettingOptions()
-        {
-            if (rdoBehaviorDefault.Checked)
-            {
-                mEditorItem.HomingBehavior = false;
-                mEditorItem.DirectShotBehavior = false;
-            }
-            else if (rdoBehaviorHoming.Checked)
-            {
-                mEditorItem.HomingBehavior = true;
-                mEditorItem.DirectShotBehavior = false;
-            }
-            else if (rdoBehaviorDirectShot.Checked)
-            {
-                mEditorItem.HomingBehavior = false;
-                mEditorItem.DirectShotBehavior = true;
+                PacketSender.SendDeleteObject(mEditorItem);
             }
         }
     }
 
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ProjectileEditor.undoprompt, Strings.ProjectileEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void cmbItem_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Ammo = ItemBase.Get(ItemBase.IdFromList(cmbItem.SelectedIndex - 1));
+    }
+
+    private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Animations[lstAnimations.SelectedIndex].AnimationId =
+            AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1);
+
+        UpdateAnimations();
+    }
+
+    private void nudSpeed_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Speed = (int)nudSpeed.Value;
+    }
+
+    private void nudSpawnDelay_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Delay = (int)nudSpawn.Value;
+    }
+
+    private void nudAmount_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Quantity = (int)nudAmount.Value;
+        UpdateAnimations();
+    }
+
+    private void nudRange_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Range = (int)nudRange.Value;
+    }
+
+    private void nudKnockback_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Knockback = (int)nudKnockback.Value;
+    }
+
+    private void nudConsume_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.AmmoRequired = (int)nudConsume.Value;
+    }
+
+    private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbSpell.SelectedIndex > 0)
+        {
+            mEditorItem.Spell = SpellBase.Get(SpellBase.IdFromList(cmbSpell.SelectedIndex - 1));
+        }
+        else
+        {
+            mEditorItem.Spell = null;
+        }
+    }
+    private void chkGrappleOnMap_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeGrappleOptions(GrappleOption.MapAttribute, chkGrappleOnMap.Checked);
+    }
+
+    private void chkGrappleOnPlayer_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeGrappleOptions(GrappleOption.Player, chkGrappleOnPlayer.Checked);
+    }
+
+    private void chkGrappleOnNpc_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeGrappleOptions(GrappleOption.NPC, chkGrappleOnNpc.Checked);
+    }
+
+    private void chkGrappleOnResource_CheckedChanged(object sender, EventArgs e)
+    {
+        ChangeGrappleOptions(GrappleOption.Resource, chkGrappleOnResource.Checked);
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in ProjectileBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((ProjectileBase)itm.Value).Folder) &&
+                !mFolders.Contains(((ProjectileBase)itm.Value).Folder))
+            {
+                mFolders.Add(((ProjectileBase)itm.Value).Folder);
+                if (!mKnownFolders.Contains(((ProjectileBase)itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((ProjectileBase)itm.Value).Folder);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        var items = ProjectileBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((ProjectileBase)pair.Value)?.Name ?? Models.DatabaseObject<ProjectileBase>.Deleted, ((ProjectileBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ProjectileEditor.folderprompt, Strings.ProjectileEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.ProjectileEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.ProjectileEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.ProjectileEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
+
+    private void rdoBehaviorDefault_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateTargettingOptions();
+    }
+
+    private void rdoBehaviorDirectShot_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateTargettingOptions();
+    }
+
+    private void rdoBehaviorHoming_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateTargettingOptions();
+    }
+
+    private void UpdateTargettingOptions()
+    {
+        if (rdoBehaviorDefault.Checked)
+        {
+            mEditorItem.HomingBehavior = false;
+            mEditorItem.DirectShotBehavior = false;
+        }
+        else if (rdoBehaviorHoming.Checked)
+        {
+            mEditorItem.HomingBehavior = true;
+            mEditorItem.DirectShotBehavior = false;
+        }
+        else if (rdoBehaviorDirectShot.Checked)
+        {
+            mEditorItem.HomingBehavior = false;
+            mEditorItem.DirectShotBehavior = true;
+        }
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmResource.cs
+++ b/Intersect.Editor/Forms/Editors/frmResource.cs
@@ -10,708 +10,402 @@ using Intersect.GameObjects.Events;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmResource : EditorForm
 {
 
-    public partial class FrmResource : EditorForm
+    private List<ResourceBase> mChanged = new List<ResourceBase>();
+
+    private string mCopiedItem;
+
+    private ResourceBase mEditorItem;
+
+    private Bitmap mEndBitmap;
+
+    private Bitmap mEndGraphic;
+
+    private Bitmap mInitialBitmap;
+
+    private Bitmap mInitialGraphic;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private bool mMouseDown;
+
+    //General Editting Variables
+    bool mTMouseDown;
+
+    public FrmResource()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<ResourceBase> mChanged = new List<ResourceBase>();
+        cmbToolType.Items.Clear();
+        cmbToolType.Items.Add(Strings.General.None);
+        cmbToolType.Items.AddRange(Options.ToolTypes.ToArray());
+        cmbEvent.Items.Clear();
+        cmbEvent.Items.Add(Strings.General.None);
+        cmbEvent.Items.AddRange(EventBase.Names);
 
-        private string mCopiedItem;
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = ResourceBase.Get(id);
+        UpdateEditor();
+    }
 
-        private ResourceBase mEditorItem;
-
-        private Bitmap mEndBitmap;
-
-        private Bitmap mEndGraphic;
-
-        private Bitmap mInitialBitmap;
-
-        private Bitmap mInitialGraphic;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        private bool mMouseDown;
-
-        //General Editting Variables
-        bool mTMouseDown;
-
-        public FrmResource()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Resource)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            cmbToolType.Items.Clear();
-            cmbToolType.Items.Add(Strings.General.None);
-            cmbToolType.Items.AddRange(Options.ToolTypes.ToArray());
-            cmbEvent.Items.Clear();
-            cmbEvent.Items.Add(Strings.General.None);
-            cmbEvent.Items.AddRange(EventBase.Names);
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = ResourceBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Resource)
+            InitEditor();
+            if (mEditorItem != null && !ResourceBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !ResourceBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void frmResource_Load(object sender, EventArgs e)
-        {
-            mInitialBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
-            mEndBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
-
-            cmbAnimation.Items.Clear();
-            cmbAnimation.Items.Add(Strings.General.None);
-            cmbAnimation.Items.AddRange(AnimationBase.Names);
-            cmbDropItem.Items.Clear();
-            cmbDropItem.Items.Add(Strings.General.None);
-            cmbDropItem.Items.AddRange(ItemBase.Names);
-            InitLocalization();
-            UpdateEditor();
-        }
-
-        private void PopulateInitialGraphicList()
-        {
-            cmbInitialSprite.Items.Clear();
-            cmbInitialSprite.Items.Add(Strings.General.None);
-            var resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Resource);
-            if (mEditorItem.Initial.GraphicFromTileset)
-            {
-                resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
-            }
-
-            for (var i = 0; i < resources.Length; i++)
-            {
-                cmbInitialSprite.Items.Add(resources[i]);
-            }
-
-            if (mEditorItem != null)
-            {
-                if (mEditorItem.Initial.Graphic != null && cmbInitialSprite.Items.Contains(mEditorItem.Initial.Graphic))
-                {
-                    cmbInitialSprite.SelectedIndex = cmbInitialSprite.FindString(
-                        TextUtils.NullToNone(TextUtils.NullToNone(mEditorItem.Initial.Graphic))
-                    );
-
-                    return;
-                }
-            }
-
-            cmbInitialSprite.SelectedIndex = 0;
-        }
-
-        private void PopulateExhaustedGraphicList()
-        {
-            cmbEndSprite.Items.Clear();
-            cmbEndSprite.Items.Add(Strings.General.None);
-            var resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Resource);
-            if (mEditorItem.Exhausted.GraphicFromTileset)
-            {
-                resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
-            }
-
-            for (var i = 0; i < resources.Length; i++)
-            {
-                cmbEndSprite.Items.Add(resources[i]);
-            }
-
-            if (mEditorItem != null)
-            {
-                if (mEditorItem.Exhausted.Graphic != null && cmbEndSprite.Items.Contains(mEditorItem.Exhausted.Graphic))
-                {
-                    cmbEndSprite.SelectedIndex = cmbEndSprite.FindString(
-                        TextUtils.NullToNone(TextUtils.NullToNone(mEditorItem.Exhausted.Graphic))
-                    );
-
-                    return;
-                }
-            }
-
-            cmbEndSprite.SelectedIndex = 0;
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.ResourceEditor.title;
-            toolStripItemNew.Text = Strings.ResourceEditor.New;
-            toolStripItemDelete.Text = Strings.ResourceEditor.delete;
-            toolStripItemCopy.Text = Strings.ResourceEditor.copy;
-            toolStripItemPaste.Text = Strings.ResourceEditor.paste;
-            toolStripItemUndo.Text = Strings.ResourceEditor.undo;
-
-            grpResources.Text = Strings.ResourceEditor.resources;
-
-            grpGeneral.Text = Strings.ResourceEditor.general;
-            lblName.Text = Strings.ResourceEditor.name;
-            lblToolType.Text = Strings.ResourceEditor.tooltype;
-            lblHP.Text = Strings.ResourceEditor.minhp;
-            lblMaxHp.Text = Strings.ResourceEditor.maxhp;
-            lblSpawnDuration.Text = Strings.ResourceEditor.spawnduration;
-            lblAnimation.Text = Strings.ResourceEditor.animation;
-            chkWalkableBefore.Text = Strings.ResourceEditor.walkablebefore;
-            chkWalkableAfter.Text = Strings.ResourceEditor.walkableafter;
-
-            grpDrops.Text = Strings.ResourceEditor.drops;
-            lblDropItem.Text = Strings.ResourceEditor.dropitem;
-            lblDropAmount.Text = Strings.ResourceEditor.dropamount;
-            lblDropChance.Text = Strings.ResourceEditor.dropchance;
-            btnDropAdd.Text = Strings.ResourceEditor.dropadd;
-            btnDropRemove.Text = Strings.ResourceEditor.dropremove;
-
-            grpRegen.Text = Strings.ResourceEditor.regen;
-            lblHpRegen.Text = Strings.ResourceEditor.hpregen;
-            lblRegenHint.Text = Strings.ResourceEditor.regenhint;
-
-            grpGraphics.Text = Strings.ResourceEditor.graphics;
-            lblPic.Text = Strings.ResourceEditor.initialgraphic;
-            lblPic2.Text = Strings.ResourceEditor.exhaustedgraphic;
-
-            chkExhaustedBelowEntities.Text = Strings.ResourceEditor.belowentities;
-            chkInitialBelowEntities.Text = Strings.ResourceEditor.belowentities;
-            chkInitialFromTileset.Text = Strings.ResourceEditor.fromtileset;
-            chkExhaustedFromTileset.Text = Strings.ResourceEditor.fromtileset;
-
-            grpCommonEvent.Text = Strings.ResourceEditor.commonevent;
-            lblEvent.Text = Strings.ResourceEditor.harvestevent;
-
-            grpRequirements.Text = Strings.ResourceEditor.requirementsgroup;
-            lblCannotHarvest.Text = Strings.ResourceEditor.cannotharvest;
-            btnRequirements.Text = Strings.ResourceEditor.requirements;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.ResourceEditor.sortalphabetically;
-            txtSearch.Text = Strings.ResourceEditor.searchplaceholder;
-            lblFolder.Text = Strings.ResourceEditor.folderlabel;
-
-            btnSave.Text = Strings.ResourceEditor.save;
-            btnCancel.Text = Strings.ResourceEditor.cancel;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
-                nudSpawnDuration.Value = mEditorItem.SpawnDuration;
-                cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AnimationId) + 1;
-                nudMinHp.Value = mEditorItem.MinHp;
-                nudMaxHp.Value = mEditorItem.MaxHp;
-                chkWalkableBefore.Checked = mEditorItem.WalkableBefore;
-                chkWalkableAfter.Checked = mEditorItem.WalkableAfter;
-                chkInitialFromTileset.Checked = mEditorItem.Initial.GraphicFromTileset;
-                chkExhaustedFromTileset.Checked = mEditorItem.Exhausted.GraphicFromTileset;
-                cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
-                chkInitialBelowEntities.Checked = mEditorItem.Initial.RenderBelowEntities;
-                chkExhaustedBelowEntities.Checked = mEditorItem.Exhausted.RenderBelowEntities;
-                txtCannotHarvest.Text = mEditorItem.CannotHarvestMessage;
-
-                //Regen
-                nudHpRegen.Value = mEditorItem.VitalRegen;
-                PopulateInitialGraphicList();
-                PopulateExhaustedGraphicList();
-                UpdateDropValues();
-                Render();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void UpdateDropValues(bool keepIndex = false)
-        {
-            var index = lstDrops.SelectedIndex;
-            lstDrops.Items.Clear();
-
-            var drops = mEditorItem.Drops.ToArray();
-            foreach (var drop in drops)
-            {
-                if (ItemBase.Get(drop.ItemId) == null)
-                {
-                    mEditorItem.Drops.Remove(drop);
-                }
-            }
-
-            for (var i = 0; i < mEditorItem.Drops.Count; i++)
-            {
-                if (mEditorItem.Drops[i].ItemId != Guid.Empty)
-                {
-                    lstDrops.Items.Add(
-                        Strings.ResourceEditor.dropdisplay.ToString(
-                            ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
-                            mEditorItem.Drops[i].Chance
-                        )
-                    );
-                }
-                else
-                {
-                    lstDrops.Items.Add(TextUtils.None);
-                }
-            }
-
-            if (keepIndex && index < lstDrops.Items.Count)
-            {
-                lstDrops.SelectedIndex = index;
-            }
-        }
-
-        private void nudSpawnDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SpawnDuration = (int) nudSpawnDuration.Value;
-        }
-
-        private void cmbToolType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Tool = cmbToolType.SelectedIndex - 1;
-        }
-
-        private void chkWalkableBefore_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.WalkableBefore = chkWalkableBefore.Checked;
-        }
-
-        private void chkWalkableAfter_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.WalkableAfter = chkWalkableAfter.Checked;
-        }
-
-        private void cmbInitialSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mInitialGraphic?.Dispose();
-            mInitialGraphic = null;
-            if (cmbInitialSprite.SelectedIndex > 0)
-            {
-                mEditorItem.Initial.Graphic = cmbInitialSprite.Text;
-                var graphic = Path.Combine(
-                    "resources", mEditorItem.Initial.GraphicFromTileset ? "tilesets" : "resources",
-                    cmbInitialSprite.Text
-                );
-
-                if (File.Exists(graphic))
-                {
-                    mInitialGraphic = (Bitmap) Image.FromFile(graphic);
-                    picInitialResource.Width = mInitialGraphic.Width;
-                    picInitialResource.Height = mInitialGraphic.Height;
-                    mInitialBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
-                }
-            }
-            else
-            {
-                mEditorItem.Initial.Graphic = null;
-            }
-
-            picInitialResource.Visible = mInitialGraphic != null;
-            Render();
-        }
-
-        private void cmbEndSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEndGraphic?.Dispose();
-            mEndGraphic = null;
-            if (cmbEndSprite.SelectedIndex > 0)
-            {
-                mEditorItem.Exhausted.Graphic = cmbEndSprite.Text;
-                var graphic = Path.Combine(
-                    "resources", mEditorItem.Exhausted.GraphicFromTileset ? "tilesets" : "resources", cmbEndSprite.Text
-                );
-
-                if (File.Exists(graphic))
-                {
-                    mEndGraphic = (Bitmap) Image.FromFile(graphic);
-                    picEndResource.Width = mEndGraphic.Width;
-                    picEndResource.Height = mEndGraphic.Height;
-                    mEndBitmap = new Bitmap(picEndResource.Width, picEndResource.Height);
-                }
-            }
-            else
-            {
-                mEditorItem.Exhausted.Graphic = null;
-            }
-
-            picEndResource.Visible = mEndGraphic != null;
-            Render();
-        }
-
-        public void Render()
-        {
-            if (mEditorItem == null)
-            {
-                return;
-            }
-
-            // Initial Sprite
-            var gfx = Graphics.FromImage(mInitialBitmap);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picInitialResource.Width, picInitialResource.Height));
-            if (cmbInitialSprite.SelectedIndex > 0 && mInitialGraphic != null)
-            {
-                gfx.DrawImage(
-                    mInitialGraphic, new Rectangle(0, 0, mInitialGraphic.Width, mInitialGraphic.Height),
-                    new Rectangle(0, 0, mInitialGraphic.Width, mInitialGraphic.Height), GraphicsUnit.Pixel
-                );
-            }
-
-            if (mEditorItem.Initial.GraphicFromTileset)
-            {
-                var selX = mEditorItem.Initial.X;
-                var selY = mEditorItem.Initial.Y;
-                var selW = mEditorItem.Initial.Width;
-                var selH = mEditorItem.Initial.Height;
-                if (selW < 0)
-                {
-                    selX -= Math.Abs(selW);
-                    selW = Math.Abs(selW);
-                }
-
-                if (selH < 0)
-                {
-                    selY -= Math.Abs(selH);
-                    selH = Math.Abs(selH);
-                }
-
-                gfx.DrawRectangle(
-                    new Pen(System.Drawing.Color.White, 2f),
-                    new Rectangle(
-                        selX * Options.TileWidth, selY * Options.TileHeight,
-                        Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
-                    )
-                );
-            }
-
-            gfx.Dispose();
-            gfx = picInitialResource.CreateGraphics();
-            gfx.DrawImageUnscaled(mInitialBitmap, new System.Drawing.Point(0, 0));
-
-            gfx.Dispose();
-
-            // End Sprite
-            gfx = Graphics.FromImage(mEndBitmap);
-            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picEndResource.Width, picEndResource.Height));
-            if (cmbEndSprite.SelectedIndex > 0 && mEndGraphic != null)
-            {
-                gfx.DrawImage(
-                    mEndGraphic, new Rectangle(0, 0, mEndGraphic.Width, mEndGraphic.Height),
-                    new Rectangle(0, 0, mEndGraphic.Width, mEndGraphic.Height), GraphicsUnit.Pixel
-                );
-            }
-
-            if (mEditorItem.Exhausted.GraphicFromTileset)
-            {
-                var selX = mEditorItem.Exhausted.X;
-                var selY = mEditorItem.Exhausted.Y;
-                var selW = mEditorItem.Exhausted.Width;
-                var selH = mEditorItem.Exhausted.Height;
-                if (selW < 0)
-                {
-                    selX -= Math.Abs(selW);
-                    selW = Math.Abs(selW);
-                }
-
-                if (selH < 0)
-                {
-                    selY -= Math.Abs(selH);
-                    selH = Math.Abs(selH);
-                }
-
-                gfx.DrawRectangle(
-                    new Pen(System.Drawing.Color.White, 2f),
-                    new Rectangle(
-                        selX * Options.TileWidth, selY * Options.TileHeight,
-                        Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
-                    )
-                );
-            }
-
-            gfx.Dispose();
-            gfx = picEndResource.CreateGraphics();
-            gfx.DrawImageUnscaled(mEndBitmap, new System.Drawing.Point(0, 0));
-            gfx.Dispose();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void frmResource_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void tmrRender_Tick(object sender, EventArgs e)
-        {
-            Render();
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Resource);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ResourceEditor.deleteprompt, Strings.ResourceEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
+                mEditorItem = null;
                 UpdateEditor();
             }
         }
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmResource_Load(object sender, EventArgs e)
+    {
+        mInitialBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
+        mEndBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
+
+        cmbAnimation.Items.Clear();
+        cmbAnimation.Items.Add(Strings.General.None);
+        cmbAnimation.Items.AddRange(AnimationBase.Names);
+        cmbDropItem.Items.Clear();
+        cmbDropItem.Items.Add(Strings.General.None);
+        cmbDropItem.Items.AddRange(ItemBase.Names);
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void PopulateInitialGraphicList()
+    {
+        cmbInitialSprite.Items.Clear();
+        cmbInitialSprite.Items.Add(Strings.General.None);
+        var resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Resource);
+        if (mEditorItem.Initial.GraphicFromTileset)
+        {
+            resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+        }
+
+        for (var i = 0; i < resources.Length; i++)
+        {
+            cmbInitialSprite.Items.Add(resources[i]);
+        }
+
+        if (mEditorItem != null)
+        {
+            if (mEditorItem.Initial.Graphic != null && cmbInitialSprite.Items.Contains(mEditorItem.Initial.Graphic))
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ResourceEditor.undoprompt, Strings.ResourceEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
+                cmbInitialSprite.SelectedIndex = cmbInitialSprite.FindString(
+                    TextUtils.NullToNone(TextUtils.NullToNone(mEditorItem.Initial.Graphic))
+                );
 
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void form_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void btnRequirements_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.HarvestingRequirements, RequirementType.Resource);
-            frm.ShowDialog();
-        }
-
-        private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Animation = AnimationBase.Get(AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1));
-        }
-
-        private void nudMinHp_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MinHp = (int) nudMinHp.Value;
-        }
-
-        private void nudMaxHp_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.MaxHp = (int) nudMaxHp.Value;
-        }
-
-        private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
-            {
-                mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
-            }
-
-            UpdateDropValues(true);
-        }
-
-        private void nudDropAmount_ValueChanged(object sender, EventArgs e)
-        {
-            // This should never be below 1. We shouldn't accept giving 0 items!
-            nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
-
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
-            {
                 return;
             }
-
-            mEditorItem.Drops[(int) lstDrops.SelectedIndex].Quantity = (int) nudDropAmount.Value;
-            UpdateDropValues(true);
         }
 
-        private void lstDrops_SelectedIndexChanged(object sender, EventArgs e)
+        cmbInitialSprite.SelectedIndex = 0;
+    }
+
+    private void PopulateExhaustedGraphicList()
+    {
+        cmbEndSprite.Items.Clear();
+        cmbEndSprite.Items.Add(Strings.General.None);
+        var resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Resource);
+        if (mEditorItem.Exhausted.GraphicFromTileset)
         {
-            if (lstDrops.SelectedIndex > -1)
+            resources = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Tileset);
+        }
+
+        for (var i = 0; i < resources.Length; i++)
+        {
+            cmbEndSprite.Items.Add(resources[i]);
+        }
+
+        if (mEditorItem != null)
+        {
+            if (mEditorItem.Exhausted.Graphic != null && cmbEndSprite.Items.Contains(mEditorItem.Exhausted.Graphic))
             {
-                cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
-                nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
-                nudDropChance.Value = (decimal) mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
-            }
-        }
+                cmbEndSprite.SelectedIndex = cmbEndSprite.FindString(
+                    TextUtils.NullToNone(TextUtils.NullToNone(mEditorItem.Exhausted.Graphic))
+                );
 
-        private void btnDropAdd_Click(object sender, EventArgs e)
-        {
-            mEditorItem.Drops.Add(new Drop());
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int) nudDropAmount.Value;
-            mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double) nudDropChance.Value;
-
-            UpdateDropValues();
-        }
-
-        private void btnDropRemove_Click(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex > -1)
-            {
-                var i = lstDrops.SelectedIndex;
-                lstDrops.Items.RemoveAt(i);
-                mEditorItem.Drops.RemoveAt(i);
-            }
-
-            UpdateDropValues(true);
-        }
-
-        private void nudDropChance_ValueChanged(object sender, EventArgs e)
-        {
-            if (lstDrops.SelectedIndex < lstDrops.Items.Count)
-            {
                 return;
             }
-
-            mEditorItem.Drops[(int) lstDrops.SelectedIndex].Chance = (double) nudDropChance.Value;
-            UpdateDropValues(true);
         }
 
-        private void chkInitialFromTileset_CheckedChanged(object sender, EventArgs e)
+        cmbEndSprite.SelectedIndex = 0;
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.ResourceEditor.title;
+        toolStripItemNew.Text = Strings.ResourceEditor.New;
+        toolStripItemDelete.Text = Strings.ResourceEditor.delete;
+        toolStripItemCopy.Text = Strings.ResourceEditor.copy;
+        toolStripItemPaste.Text = Strings.ResourceEditor.paste;
+        toolStripItemUndo.Text = Strings.ResourceEditor.undo;
+
+        grpResources.Text = Strings.ResourceEditor.resources;
+
+        grpGeneral.Text = Strings.ResourceEditor.general;
+        lblName.Text = Strings.ResourceEditor.name;
+        lblToolType.Text = Strings.ResourceEditor.tooltype;
+        lblHP.Text = Strings.ResourceEditor.minhp;
+        lblMaxHp.Text = Strings.ResourceEditor.maxhp;
+        lblSpawnDuration.Text = Strings.ResourceEditor.spawnduration;
+        lblAnimation.Text = Strings.ResourceEditor.animation;
+        chkWalkableBefore.Text = Strings.ResourceEditor.walkablebefore;
+        chkWalkableAfter.Text = Strings.ResourceEditor.walkableafter;
+
+        grpDrops.Text = Strings.ResourceEditor.drops;
+        lblDropItem.Text = Strings.ResourceEditor.dropitem;
+        lblDropAmount.Text = Strings.ResourceEditor.dropamount;
+        lblDropChance.Text = Strings.ResourceEditor.dropchance;
+        btnDropAdd.Text = Strings.ResourceEditor.dropadd;
+        btnDropRemove.Text = Strings.ResourceEditor.dropremove;
+
+        grpRegen.Text = Strings.ResourceEditor.regen;
+        lblHpRegen.Text = Strings.ResourceEditor.hpregen;
+        lblRegenHint.Text = Strings.ResourceEditor.regenhint;
+
+        grpGraphics.Text = Strings.ResourceEditor.graphics;
+        lblPic.Text = Strings.ResourceEditor.initialgraphic;
+        lblPic2.Text = Strings.ResourceEditor.exhaustedgraphic;
+
+        chkExhaustedBelowEntities.Text = Strings.ResourceEditor.belowentities;
+        chkInitialBelowEntities.Text = Strings.ResourceEditor.belowentities;
+        chkInitialFromTileset.Text = Strings.ResourceEditor.fromtileset;
+        chkExhaustedFromTileset.Text = Strings.ResourceEditor.fromtileset;
+
+        grpCommonEvent.Text = Strings.ResourceEditor.commonevent;
+        lblEvent.Text = Strings.ResourceEditor.harvestevent;
+
+        grpRequirements.Text = Strings.ResourceEditor.requirementsgroup;
+        lblCannotHarvest.Text = Strings.ResourceEditor.cannotharvest;
+        btnRequirements.Text = Strings.ResourceEditor.requirements;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.ResourceEditor.sortalphabetically;
+        txtSearch.Text = Strings.ResourceEditor.searchplaceholder;
+        lblFolder.Text = Strings.ResourceEditor.folderlabel;
+
+        btnSave.Text = Strings.ResourceEditor.save;
+        btnCancel.Text = Strings.ResourceEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
         {
-            mEditorItem.Initial.GraphicFromTileset = chkInitialFromTileset.Checked;
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            cmbToolType.SelectedIndex = mEditorItem.Tool + 1;
+            nudSpawnDuration.Value = mEditorItem.SpawnDuration;
+            cmbAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.AnimationId) + 1;
+            nudMinHp.Value = mEditorItem.MinHp;
+            nudMaxHp.Value = mEditorItem.MaxHp;
+            chkWalkableBefore.Checked = mEditorItem.WalkableBefore;
+            chkWalkableAfter.Checked = mEditorItem.WalkableAfter;
+            chkInitialFromTileset.Checked = mEditorItem.Initial.GraphicFromTileset;
+            chkExhaustedFromTileset.Checked = mEditorItem.Exhausted.GraphicFromTileset;
+            cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
+            chkInitialBelowEntities.Checked = mEditorItem.Initial.RenderBelowEntities;
+            chkExhaustedBelowEntities.Checked = mEditorItem.Exhausted.RenderBelowEntities;
+            txtCannotHarvest.Text = mEditorItem.CannotHarvestMessage;
+
+            //Regen
+            nudHpRegen.Value = mEditorItem.VitalRegen;
             PopulateInitialGraphicList();
-        }
-
-        private void chkExhaustedFromTileset_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Exhausted.GraphicFromTileset = chkExhaustedFromTileset.Checked;
             PopulateExhaustedGraphicList();
-        }
-
-        private void picInitialResource_MouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
-            {
-                return;
-            }
-
-            if (!chkInitialFromTileset.Checked)
-            {
-                return;
-            }
-
-            mMouseDown = true;
-            mEditorItem.Initial.X = (int) Math.Floor((double) e.X / Options.TileWidth);
-            mEditorItem.Initial.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
-            mEditorItem.Initial.Width = 0;
-            mEditorItem.Initial.Height = 0;
-            if (mEditorItem.Initial.X < 0)
-            {
-                mEditorItem.Initial.X = 0;
-            }
-
-            if (mEditorItem.Initial.Y < 0)
-            {
-                mEditorItem.Initial.Y = 0;
-            }
-
+            UpdateDropValues();
             Render();
+            if (mChanged.IndexOf(mEditorItem) == -1)
+            {
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
         }
 
-        private void picInitialResource_MouseUp(object sender, MouseEventArgs e)
+        UpdateToolStripItems();
+    }
+
+    private void UpdateDropValues(bool keepIndex = false)
+    {
+        var index = lstDrops.SelectedIndex;
+        lstDrops.Items.Clear();
+
+        var drops = mEditorItem.Drops.ToArray();
+        foreach (var drop in drops)
         {
-            if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
+            if (ItemBase.Get(drop.ItemId) == null)
             {
-                return;
+                mEditorItem.Drops.Remove(drop);
             }
+        }
 
-            if (!chkInitialFromTileset.Checked)
+        for (var i = 0; i < mEditorItem.Drops.Count; i++)
+        {
+            if (mEditorItem.Drops[i].ItemId != Guid.Empty)
             {
-                return;
+                lstDrops.Items.Add(
+                    Strings.ResourceEditor.dropdisplay.ToString(
+                        ItemBase.GetName(mEditorItem.Drops[i].ItemId), mEditorItem.Drops[i].Quantity,
+                        mEditorItem.Drops[i].Chance
+                    )
+                );
             }
+            else
+            {
+                lstDrops.Items.Add(TextUtils.None);
+            }
+        }
 
+        if (keepIndex && index < lstDrops.Items.Count)
+        {
+            lstDrops.SelectedIndex = index;
+        }
+    }
+
+    private void nudSpawnDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SpawnDuration = (int) nudSpawnDuration.Value;
+    }
+
+    private void cmbToolType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Tool = cmbToolType.SelectedIndex - 1;
+    }
+
+    private void chkWalkableBefore_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.WalkableBefore = chkWalkableBefore.Checked;
+    }
+
+    private void chkWalkableAfter_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.WalkableAfter = chkWalkableAfter.Checked;
+    }
+
+    private void cmbInitialSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mInitialGraphic?.Dispose();
+        mInitialGraphic = null;
+        if (cmbInitialSprite.SelectedIndex > 0)
+        {
+            mEditorItem.Initial.Graphic = cmbInitialSprite.Text;
+            var graphic = Path.Combine(
+                "resources", mEditorItem.Initial.GraphicFromTileset ? "tilesets" : "resources",
+                cmbInitialSprite.Text
+            );
+
+            if (File.Exists(graphic))
+            {
+                mInitialGraphic = (Bitmap) Image.FromFile(graphic);
+                picInitialResource.Width = mInitialGraphic.Width;
+                picInitialResource.Height = mInitialGraphic.Height;
+                mInitialBitmap = new Bitmap(picInitialResource.Width, picInitialResource.Height);
+            }
+        }
+        else
+        {
+            mEditorItem.Initial.Graphic = null;
+        }
+
+        picInitialResource.Visible = mInitialGraphic != null;
+        Render();
+    }
+
+    private void cmbEndSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEndGraphic?.Dispose();
+        mEndGraphic = null;
+        if (cmbEndSprite.SelectedIndex > 0)
+        {
+            mEditorItem.Exhausted.Graphic = cmbEndSprite.Text;
+            var graphic = Path.Combine(
+                "resources", mEditorItem.Exhausted.GraphicFromTileset ? "tilesets" : "resources", cmbEndSprite.Text
+            );
+
+            if (File.Exists(graphic))
+            {
+                mEndGraphic = (Bitmap) Image.FromFile(graphic);
+                picEndResource.Width = mEndGraphic.Width;
+                picEndResource.Height = mEndGraphic.Height;
+                mEndBitmap = new Bitmap(picEndResource.Width, picEndResource.Height);
+            }
+        }
+        else
+        {
+            mEditorItem.Exhausted.Graphic = null;
+        }
+
+        picEndResource.Visible = mEndGraphic != null;
+        Render();
+    }
+
+    public void Render()
+    {
+        if (mEditorItem == null)
+        {
+            return;
+        }
+
+        // Initial Sprite
+        var gfx = Graphics.FromImage(mInitialBitmap);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picInitialResource.Width, picInitialResource.Height));
+        if (cmbInitialSprite.SelectedIndex > 0 && mInitialGraphic != null)
+        {
+            gfx.DrawImage(
+                mInitialGraphic, new Rectangle(0, 0, mInitialGraphic.Width, mInitialGraphic.Height),
+                new Rectangle(0, 0, mInitialGraphic.Width, mInitialGraphic.Height), GraphicsUnit.Pixel
+            );
+        }
+
+        if (mEditorItem.Initial.GraphicFromTileset)
+        {
             var selX = mEditorItem.Initial.X;
             var selY = mEditorItem.Initial.Y;
             var selW = mEditorItem.Initial.Width;
@@ -728,79 +422,34 @@ namespace Intersect.Editor.Forms.Editors
                 selH = Math.Abs(selH);
             }
 
-            mEditorItem.Initial.X = selX;
-            mEditorItem.Initial.Y = selY;
-            mEditorItem.Initial.Width = selW;
-            mEditorItem.Initial.Height = selH;
-            mMouseDown = false;
-            Render();
+            gfx.DrawRectangle(
+                new Pen(System.Drawing.Color.White, 2f),
+                new Rectangle(
+                    selX * Options.TileWidth, selY * Options.TileHeight,
+                    Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
+                )
+            );
         }
 
-        private void picInitialResource_MouseMove(object sender, MouseEventArgs e)
+        gfx.Dispose();
+        gfx = picInitialResource.CreateGraphics();
+        gfx.DrawImageUnscaled(mInitialBitmap, new System.Drawing.Point(0, 0));
+
+        gfx.Dispose();
+
+        // End Sprite
+        gfx = Graphics.FromImage(mEndBitmap);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picEndResource.Width, picEndResource.Height));
+        if (cmbEndSprite.SelectedIndex > 0 && mEndGraphic != null)
         {
-            if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
-            {
-                return;
-            }
-
-            if (!chkInitialFromTileset.Checked)
-            {
-                return;
-            }
-
-            if (mMouseDown)
-            {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
-                mEditorItem.Initial.Width = tmpX - mEditorItem.Initial.X;
-                mEditorItem.Initial.Height = tmpY - mEditorItem.Initial.Y;
-            }
-
-            Render();
+            gfx.DrawImage(
+                mEndGraphic, new Rectangle(0, 0, mEndGraphic.Width, mEndGraphic.Height),
+                new Rectangle(0, 0, mEndGraphic.Width, mEndGraphic.Height), GraphicsUnit.Pixel
+            );
         }
 
-        private void picExhustedResource_MouseDown(object sender, MouseEventArgs e)
+        if (mEditorItem.Exhausted.GraphicFromTileset)
         {
-            if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
-            {
-                return;
-            }
-
-            if (!chkExhaustedFromTileset.Checked)
-            {
-                return;
-            }
-
-            mMouseDown = true;
-            mEditorItem.Exhausted.X = (int) Math.Floor((double) e.X / Options.TileWidth);
-            mEditorItem.Exhausted.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
-            mEditorItem.Exhausted.Width = 0;
-            mEditorItem.Exhausted.Height = 0;
-            if (mEditorItem.Exhausted.X < 0)
-            {
-                mEditorItem.Exhausted.X = 0;
-            }
-
-            if (mEditorItem.Exhausted.Y < 0)
-            {
-                mEditorItem.Exhausted.Y = 0;
-            }
-
-            Render();
-        }
-
-        private void picExhaustedResource_MouseUp(object sender, MouseEventArgs e)
-        {
-            if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
-            {
-                return;
-            }
-
-            if (!chkExhaustedFromTileset.Checked)
-            {
-                return;
-            }
-
             var selX = mEditorItem.Exhausted.X;
             var selY = mEditorItem.Exhausted.Y;
             var selW = mEditorItem.Exhausted.Width;
@@ -817,163 +466,512 @@ namespace Intersect.Editor.Forms.Editors
                 selH = Math.Abs(selH);
             }
 
-            mEditorItem.Exhausted.X = selX;
-            mEditorItem.Exhausted.Y = selY;
-            mEditorItem.Exhausted.Width = selW;
-            mEditorItem.Exhausted.Height = selH;
-            mMouseDown = false;
-            Render();
-        }
-
-        private void picExhaustedResource_MouseMove(object sender, MouseEventArgs e)
-        {
-            if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
-            {
-                return;
-            }
-
-            if (!chkExhaustedFromTileset.Checked)
-            {
-                return;
-            }
-
-            if (mMouseDown)
-            {
-                var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
-                var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
-                mEditorItem.Exhausted.Width = tmpX - mEditorItem.Exhausted.X;
-                mEditorItem.Exhausted.Height = tmpY - mEditorItem.Exhausted.Y;
-            }
-
-            Render();
-        }
-
-        private void nudHpRegen_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalRegen = (int) nudHpRegen.Value;
-        }
-
-        private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
-        }
-
-        private void chkInitialBelowEntities_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Initial.RenderBelowEntities = chkInitialBelowEntities.Checked;
-        }
-
-        private void chkExhaustedBelowEntities_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Exhausted.RenderBelowEntities = chkExhaustedBelowEntities.Checked;
-        }
-
-        private void txtCannotHarvest_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CannotHarvestMessage = txtCannotHarvest.Text;
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in ResourceBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((ResourceBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((ResourceBase) itm.Value).Folder))
-                {
-                    mFolders.Add(((ResourceBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ResourceBase) itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((ResourceBase) itm.Value).Folder);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = ResourceBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((ResourceBase)pair.Value)?.Name ?? Models.DatabaseObject<ResourceBase>.Deleted, ((ResourceBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ResourceEditor.folderprompt, Strings.ResourceEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
+            gfx.DrawRectangle(
+                new Pen(System.Drawing.Color.White, 2f),
+                new Rectangle(
+                    selX * Options.TileWidth, selY * Options.TileHeight,
+                    Options.TileWidth + selW * Options.TileWidth, Options.TileHeight + selH * Options.TileHeight
+                )
             );
+        }
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        gfx.Dispose();
+        gfx = picEndResource.CreateGraphics();
+        gfx.DrawImageUnscaled(mEndBitmap, new System.Drawing.Point(0, 0));
+        gfx.Dispose();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void frmResource_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
+
+    private void tmrRender_Tick(object sender, EventArgs e)
+    {
+        Render();
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Resource);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ResourceEditor.deleteprompt, Strings.ResourceEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
             {
-                if (!cmbFolder.Items.Contains(folderName))
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ResourceEditor.undoprompt, Strings.ResourceEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void btnRequirements_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.HarvestingRequirements, RequirementType.Resource);
+        frm.ShowDialog();
+    }
+
+    private void cmbAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Animation = AnimationBase.Get(AnimationBase.IdFromList(cmbAnimation.SelectedIndex - 1));
+    }
+
+    private void nudMinHp_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MinHp = (int) nudMinHp.Value;
+    }
+
+    private void nudMaxHp_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.MaxHp = (int) nudMaxHp.Value;
+    }
+
+    private void cmbDropItem_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1 && lstDrops.SelectedIndex < mEditorItem.Drops.Count)
+        {
+            mEditorItem.Drops[lstDrops.SelectedIndex].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+        }
+
+        UpdateDropValues(true);
+    }
+
+    private void nudDropAmount_ValueChanged(object sender, EventArgs e)
+    {
+        // This should never be below 1. We shouldn't accept giving 0 items!
+        nudDropAmount.Value = Math.Max(1, nudDropAmount.Value);
+
+        if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+        {
+            return;
+        }
+
+        mEditorItem.Drops[(int) lstDrops.SelectedIndex].Quantity = (int) nudDropAmount.Value;
+        UpdateDropValues(true);
+    }
+
+    private void lstDrops_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1)
+        {
+            cmbDropItem.SelectedIndex = ItemBase.ListIndex(mEditorItem.Drops[lstDrops.SelectedIndex].ItemId) + 1;
+            nudDropAmount.Value = mEditorItem.Drops[lstDrops.SelectedIndex].Quantity;
+            nudDropChance.Value = (decimal) mEditorItem.Drops[lstDrops.SelectedIndex].Chance;
+        }
+    }
+
+    private void btnDropAdd_Click(object sender, EventArgs e)
+    {
+        mEditorItem.Drops.Add(new Drop());
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].ItemId = ItemBase.IdFromList(cmbDropItem.SelectedIndex - 1);
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].Quantity = (int) nudDropAmount.Value;
+        mEditorItem.Drops[mEditorItem.Drops.Count - 1].Chance = (double) nudDropChance.Value;
+
+        UpdateDropValues();
+    }
+
+    private void btnDropRemove_Click(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex > -1)
+        {
+            var i = lstDrops.SelectedIndex;
+            lstDrops.Items.RemoveAt(i);
+            mEditorItem.Drops.RemoveAt(i);
+        }
+
+        UpdateDropValues(true);
+    }
+
+    private void nudDropChance_ValueChanged(object sender, EventArgs e)
+    {
+        if (lstDrops.SelectedIndex < lstDrops.Items.Count)
+        {
+            return;
+        }
+
+        mEditorItem.Drops[(int) lstDrops.SelectedIndex].Chance = (double) nudDropChance.Value;
+        UpdateDropValues(true);
+    }
+
+    private void chkInitialFromTileset_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Initial.GraphicFromTileset = chkInitialFromTileset.Checked;
+        PopulateInitialGraphicList();
+    }
+
+    private void chkExhaustedFromTileset_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Exhausted.GraphicFromTileset = chkExhaustedFromTileset.Checked;
+        PopulateExhaustedGraphicList();
+    }
+
+    private void picInitialResource_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
+        {
+            return;
+        }
+
+        if (!chkInitialFromTileset.Checked)
+        {
+            return;
+        }
+
+        mMouseDown = true;
+        mEditorItem.Initial.X = (int) Math.Floor((double) e.X / Options.TileWidth);
+        mEditorItem.Initial.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        mEditorItem.Initial.Width = 0;
+        mEditorItem.Initial.Height = 0;
+        if (mEditorItem.Initial.X < 0)
+        {
+            mEditorItem.Initial.X = 0;
+        }
+
+        if (mEditorItem.Initial.Y < 0)
+        {
+            mEditorItem.Initial.Y = 0;
+        }
+
+        Render();
+    }
+
+    private void picInitialResource_MouseUp(object sender, MouseEventArgs e)
+    {
+        if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
+        {
+            return;
+        }
+
+        if (!chkInitialFromTileset.Checked)
+        {
+            return;
+        }
+
+        var selX = mEditorItem.Initial.X;
+        var selY = mEditorItem.Initial.Y;
+        var selW = mEditorItem.Initial.Width;
+        var selH = mEditorItem.Initial.Height;
+        if (selW < 0)
+        {
+            selX -= Math.Abs(selW);
+            selW = Math.Abs(selW);
+        }
+
+        if (selH < 0)
+        {
+            selY -= Math.Abs(selH);
+            selH = Math.Abs(selH);
+        }
+
+        mEditorItem.Initial.X = selX;
+        mEditorItem.Initial.Y = selY;
+        mEditorItem.Initial.Width = selW;
+        mEditorItem.Initial.Height = selH;
+        mMouseDown = false;
+        Render();
+    }
+
+    private void picInitialResource_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.X > picInitialResource.Width || e.Y > picInitialResource.Height)
+        {
+            return;
+        }
+
+        if (!chkInitialFromTileset.Checked)
+        {
+            return;
+        }
+
+        if (mMouseDown)
+        {
+            var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
+            var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            mEditorItem.Initial.Width = tmpX - mEditorItem.Initial.X;
+            mEditorItem.Initial.Height = tmpY - mEditorItem.Initial.Y;
+        }
+
+        Render();
+    }
+
+    private void picExhustedResource_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
+        {
+            return;
+        }
+
+        if (!chkExhaustedFromTileset.Checked)
+        {
+            return;
+        }
+
+        mMouseDown = true;
+        mEditorItem.Exhausted.X = (int) Math.Floor((double) e.X / Options.TileWidth);
+        mEditorItem.Exhausted.Y = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        mEditorItem.Exhausted.Width = 0;
+        mEditorItem.Exhausted.Height = 0;
+        if (mEditorItem.Exhausted.X < 0)
+        {
+            mEditorItem.Exhausted.X = 0;
+        }
+
+        if (mEditorItem.Exhausted.Y < 0)
+        {
+            mEditorItem.Exhausted.Y = 0;
+        }
+
+        Render();
+    }
+
+    private void picExhaustedResource_MouseUp(object sender, MouseEventArgs e)
+    {
+        if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
+        {
+            return;
+        }
+
+        if (!chkExhaustedFromTileset.Checked)
+        {
+            return;
+        }
+
+        var selX = mEditorItem.Exhausted.X;
+        var selY = mEditorItem.Exhausted.Y;
+        var selW = mEditorItem.Exhausted.Width;
+        var selH = mEditorItem.Exhausted.Height;
+        if (selW < 0)
+        {
+            selX -= Math.Abs(selW);
+            selW = Math.Abs(selW);
+        }
+
+        if (selH < 0)
+        {
+            selY -= Math.Abs(selH);
+            selH = Math.Abs(selH);
+        }
+
+        mEditorItem.Exhausted.X = selX;
+        mEditorItem.Exhausted.Y = selY;
+        mEditorItem.Exhausted.Width = selW;
+        mEditorItem.Exhausted.Height = selH;
+        mMouseDown = false;
+        Render();
+    }
+
+    private void picExhaustedResource_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.X > picEndResource.Width || e.Y > picEndResource.Height)
+        {
+            return;
+        }
+
+        if (!chkExhaustedFromTileset.Checked)
+        {
+            return;
+        }
+
+        if (mMouseDown)
+        {
+            var tmpX = (int) Math.Floor((double) e.X / Options.TileWidth);
+            var tmpY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+            mEditorItem.Exhausted.Width = tmpX - mEditorItem.Exhausted.X;
+            mEditorItem.Exhausted.Height = tmpY - mEditorItem.Exhausted.Y;
+        }
+
+        Render();
+    }
+
+    private void nudHpRegen_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalRegen = (int) nudHpRegen.Value;
+    }
+
+    private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Event = EventBase.Get(EventBase.IdFromList(cmbEvent.SelectedIndex - 1));
+    }
+
+    private void chkInitialBelowEntities_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Initial.RenderBelowEntities = chkInitialBelowEntities.Checked;
+    }
+
+    private void chkExhaustedBelowEntities_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Exhausted.RenderBelowEntities = chkExhaustedBelowEntities.Checked;
+    }
+
+    private void txtCannotHarvest_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CannotHarvestMessage = txtCannotHarvest.Text;
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in ResourceBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((ResourceBase) itm.Value).Folder) &&
+                !mFolders.Contains(((ResourceBase) itm.Value).Folder))
+            {
+                mFolders.Add(((ResourceBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((ResourceBase) itm.Value).Folder))
                 {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
+                    mKnownFolders.Add(((ResourceBase) itm.Value).Folder);
                 }
             }
         }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
 
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
+        var items = ResourceBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((ResourceBase)pair.Value)?.Name ?? Models.DatabaseObject<ResourceBase>.Deleted, ((ResourceBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ResourceEditor.folderprompt, Strings.ResourceEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
 
-        private void txtSearch_Leave(object sender, EventArgs e)
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                txtSearch.Text = Strings.ResourceEditor.searchplaceholder;
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
         }
+    }
 
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
 
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.ResourceEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.ResourceEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.ResourceEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.ResourceEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.ResourceEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.ResourceEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmShop.cs
+++ b/Intersect.Editor/Forms/Editors/frmShop.cs
@@ -7,559 +7,557 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmShop : EditorForm
 {
 
-    public partial class FrmShop : EditorForm
+    private List<ShopBase> mChanged = new List<ShopBase>();
+
+    private string mCopiedItem;
+
+    private ShopBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    public FrmShop()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<ShopBase> mChanged = new List<ShopBase>();
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = ShopBase.Get(id);
+        UpdateEditor();
+    }
 
-        private string mCopiedItem;
-
-        private ShopBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        public FrmShop()
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Shop)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = ShopBase.Get(id);
-            UpdateEditor();
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.Shop)
+            InitEditor();
+            if (mEditorItem != null && !ShopBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !ShopBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void frmShop_Load(object sender, EventArgs e)
-        {
-            cmbAddBoughtItem.Items.Clear();
-            cmbAddSoldItem.Items.Clear();
-            cmbBuyFor.Items.Clear();
-            cmbSellFor.Items.Clear();
-            cmbDefaultCurrency.Items.Clear();
-            cmbAddBoughtItem.Items.AddRange(ItemBase.Names);
-            cmbAddSoldItem.Items.AddRange(ItemBase.Names);
-            cmbBuyFor.Items.AddRange(ItemBase.Names);
-            cmbSellFor.Items.AddRange(ItemBase.Names);
-            cmbDefaultCurrency.Items.AddRange(ItemBase.Names);
-            if (cmbAddBoughtItem.Items.Count > 0)
-            {
-                cmbAddBoughtItem.SelectedIndex = 0;
-            }
-
-            if (cmbAddSoldItem.Items.Count > 0)
-            {
-                cmbAddSoldItem.SelectedIndex = 0;
-            }
-
-            if (cmbBuyFor.Items.Count > 0)
-            {
-                cmbBuyFor.SelectedIndex = 0;
-            }
-
-            if (cmbSellFor.Items.Count > 0)
-            {
-                cmbSellFor.SelectedIndex = 0;
-            }
-
-            cmbBuySound.Items.Clear();
-            cmbBuySound.Items.Add(Strings.General.None);
-            cmbBuySound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-
-            cmbSellSound.Items.Clear();
-            cmbSellSound.Items.Add(Strings.General.None);
-            cmbSellSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
-
-            InitLocalization();
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.ShopEditor.title;
-            toolStripItemNew.Text = Strings.ShopEditor.New;
-            toolStripItemDelete.Text = Strings.ShopEditor.delete;
-            toolStripItemCopy.Text = Strings.ShopEditor.copy;
-            toolStripItemPaste.Text = Strings.ShopEditor.paste;
-            toolStripItemUndo.Text = Strings.ShopEditor.undo;
-
-            grpGeneral.Text = Strings.ShopEditor.general;
-            lblName.Text = Strings.ShopEditor.name;
-            lblDefaultCurrency.Text = Strings.ShopEditor.defaultcurrency;
-
-            grpItemsSold.Text = Strings.ShopEditor.itemssold;
-            lblAddSoldItem.Text = Strings.ShopEditor.addlabel;
-            lblSellFor.Text = Strings.ShopEditor.sellfor;
-            lblSellCost.Text = Strings.ShopEditor.sellcost;
-            btnAddSoldItem.Text = Strings.ShopEditor.addsolditem;
-            btnDelSoldItem.Text = Strings.ShopEditor.removesolditem;
-
-            grpItemsBought.Text = Strings.ShopEditor.itemsboughtwhitelist;
-            rdoBuyWhitelist.Text = Strings.ShopEditor.whitelist;
-            rdoBuyBlacklist.Text = Strings.ShopEditor.blacklist;
-            lblItemBought.Text = Strings.ShopEditor.addboughtitem;
-            lblBuyFor.Text = Strings.ShopEditor.buyfor;
-            lblBuyAmount.Text = Strings.ShopEditor.buycost;
-            btnAddBoughtItem.Text = Strings.ShopEditor.addboughtitem;
-            btnDelBoughtItem.Text = Strings.ShopEditor.removeboughtitem;
-
-            lblBuySound.Text = Strings.ShopEditor.buysound;
-            lblSellSound.Text = Strings.ShopEditor.sellsound;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.ShopEditor.sortalphabetically;
-            txtSearch.Text = Strings.ShopEditor.searchplaceholder;
-            lblFolder.Text = Strings.ShopEditor.folderlabel;
-
-            btnSave.Text = Strings.ShopEditor.save;
-            btnCancel.Text = Strings.ShopEditor.cancel;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                cmbDefaultCurrency.SelectedIndex = ItemBase.ListIndex(mEditorItem.DefaultCurrencyId);
-                if (mEditorItem.BuyingWhitelist)
-                {
-                    rdoBuyWhitelist.Checked = true;
-                }
-                else
-                {
-                    rdoBuyBlacklist.Checked = true;
-                }
-
-                cmbBuySound.SelectedIndex = cmbBuySound.FindString(TextUtils.NullToNone(mEditorItem.BuySound));
-                cmbSellSound.SelectedIndex = cmbSellSound.FindString(TextUtils.NullToNone(mEditorItem.SellSound));
-
-                UpdateWhitelist();
-                UpdateLists();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
-        }
-
-        private void UpdateWhitelist()
-        {
-            if (rdoBuyWhitelist.Checked)
-            {
-                cmbBuyFor.Enabled = true;
-                nudBuyAmount.Enabled = true;
-                grpItemsBought.Text = Strings.ShopEditor.itemsboughtwhitelist;
-            }
-            else
-            {
-                cmbBuyFor.Enabled = false;
-                nudBuyAmount.Enabled = false;
-                grpItemsBought.Text = Strings.ShopEditor.itemsboughtblacklist;
-            }
-        }
-
-        private void rdoBuyWhitelist_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BuyingWhitelist = rdoBuyWhitelist.Checked;
-            UpdateLists();
-            UpdateWhitelist();
-        }
-
-        private void rdoBuyBlacklist_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BuyingWhitelist = rdoBuyWhitelist.Checked;
-            UpdateLists();
-            UpdateWhitelist();
-        }
-
-        private void txtName_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
-        }
-
-        private void UpdateLists()
-        {
-            lstSoldItems.Items.Clear();
-            for (var i = 0; i < mEditorItem.SellingItems.Count; i++)
-            {
-                lstSoldItems.Items.Add(
-                    Strings.ShopEditor.selldesc.ToString(
-                        ItemBase.GetName(mEditorItem.SellingItems[i].ItemId),
-                        mEditorItem.SellingItems[i].CostItemQuantity,
-                        ItemBase.GetName(mEditorItem.SellingItems[i].CostItemId)
-                    )
-                );
-            }
-
-            lstBoughtItems.Items.Clear();
-            if (mEditorItem.BuyingWhitelist)
-            {
-                for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
-                {
-                    lstBoughtItems.Items.Add(
-                        Strings.ShopEditor.buydesc.ToString(
-                            ItemBase.GetName(mEditorItem.BuyingItems[i].ItemId),
-                            mEditorItem.BuyingItems[i].CostItemQuantity,
-                            ItemBase.GetName(mEditorItem.BuyingItems[i].CostItemId)
-                        )
-                    );
-                }
-            }
-            else
-            {
-                for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
-                {
-                    lstBoughtItems.Items.Add(
-                        Strings.ShopEditor.dontbuy.ToString(ItemBase.GetName(mEditorItem.BuyingItems[i].ItemId))
-                    );
-                }
-            }
-        }
-
-        private void btnAddSoldItem_Click(object sender, EventArgs e)
-        {
-            var addedItem = false;
-            var cost = (int) nudSellCost.Value;
-            var newItem = new ShopItem(
-                ItemBase.IdFromList(cmbAddSoldItem.SelectedIndex), ItemBase.IdFromList(cmbSellFor.SelectedIndex), cost
-            );
-
-            for (var i = 0; i < mEditorItem.SellingItems.Count; i++)
-            {
-                if (mEditorItem.SellingItems[i].ItemId == newItem.ItemId)
-                {
-                    mEditorItem.SellingItems[i] = newItem;
-                    addedItem = true;
-
-                    break;
-                }
-            }
-
-            if (!addedItem)
-            {
-                mEditorItem.SellingItems.Add(newItem);
-            }
-
-            UpdateLists();
-        }
-
-        private void btnDelSoldItem_Click(object sender, EventArgs e)
-        {
-            if (lstSoldItems.SelectedIndex > -1)
-            {
-                mEditorItem.SellingItems.RemoveAt(lstSoldItems.SelectedIndex);
-            }
-
-            UpdateLists();
-        }
-
-        private void btnAddBoughtItem_Click(object sender, EventArgs e)
-        {
-            var addedItem = false;
-            var cost = (int) nudBuyAmount.Value;
-            var newItem = new ShopItem(
-                ItemBase.IdFromList(cmbAddBoughtItem.SelectedIndex), ItemBase.IdFromList(cmbBuyFor.SelectedIndex), cost
-            );
-
-            for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
-            {
-                if (mEditorItem.BuyingItems[i].ItemId == newItem.ItemId)
-                {
-                    mEditorItem.BuyingItems[i] = newItem;
-                    addedItem = true;
-
-                    break;
-                }
-            }
-
-            if (!addedItem)
-            {
-                mEditorItem.BuyingItems.Add(newItem);
-            }
-
-            UpdateLists();
-        }
-
-        private void btnDelBoughtItem_Click(object sender, EventArgs e)
-        {
-            if (lstBoughtItems.SelectedIndex > -1)
-            {
-                mEditorItem.BuyingItems.RemoveAt(lstBoughtItems.SelectedIndex);
-            }
-
-            UpdateLists();
-        }
-
-        private void cmbDefaultCurrency_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.DefaultCurrency = ItemBase.FromList(cmbDefaultCurrency.SelectedIndex);
-        }
-
-        private void btnItemUp_Click(object sender, EventArgs e)
-        {
-            if (lstSoldItems.SelectedIndex > 0 && lstSoldItems.Items.Count > 1)
-            {
-                var index = lstSoldItems.SelectedIndex;
-                var swapWith = mEditorItem.SellingItems[index - 1];
-                mEditorItem.SellingItems[index - 1] = mEditorItem.SellingItems[index];
-                mEditorItem.SellingItems[index] = swapWith;
-                UpdateLists();
-                lstSoldItems.SelectedIndex = index - 1;
-            }
-        }
-
-        private void btnItemDown_Click(object sender, EventArgs e)
-        {
-            if (lstSoldItems.SelectedIndex > -1 && lstSoldItems.SelectedIndex + 1 != lstSoldItems.Items.Count)
-            {
-                var index = lstSoldItems.SelectedIndex;
-                var swapWith = mEditorItem.SellingItems[index + 1];
-                mEditorItem.SellingItems[index + 1] = mEditorItem.SellingItems[index];
-                mEditorItem.SellingItems[index] = swapWith;
-                UpdateLists();
-                lstSoldItems.SelectedIndex = index + 1;
-            }
-        }
-
-        private void cmbBuySound_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.BuySound = TextUtils.SanitizeNone(cmbBuySound?.Text);
-        }
-
-        private void cmbSellSound_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.SellSound = TextUtils.SanitizeNone(cmbSellSound?.Text);
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Shop);
-        }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ShopEditor.deleteprompt, Strings.ShopEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
-
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
+                mEditorItem = null;
                 UpdateEditor();
             }
         }
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmShop_Load(object sender, EventArgs e)
+    {
+        cmbAddBoughtItem.Items.Clear();
+        cmbAddSoldItem.Items.Clear();
+        cmbBuyFor.Items.Clear();
+        cmbSellFor.Items.Clear();
+        cmbDefaultCurrency.Items.Clear();
+        cmbAddBoughtItem.Items.AddRange(ItemBase.Names);
+        cmbAddSoldItem.Items.AddRange(ItemBase.Names);
+        cmbBuyFor.Items.AddRange(ItemBase.Names);
+        cmbSellFor.Items.AddRange(ItemBase.Names);
+        cmbDefaultCurrency.Items.AddRange(ItemBase.Names);
+        if (cmbAddBoughtItem.Items.Count > 0)
+        {
+            cmbAddBoughtItem.SelectedIndex = 0;
+        }
+
+        if (cmbAddSoldItem.Items.Count > 0)
+        {
+            cmbAddSoldItem.SelectedIndex = 0;
+        }
+
+        if (cmbBuyFor.Items.Count > 0)
+        {
+            cmbBuyFor.SelectedIndex = 0;
+        }
+
+        if (cmbSellFor.Items.Count > 0)
+        {
+            cmbSellFor.SelectedIndex = 0;
+        }
+
+        cmbBuySound.Items.Clear();
+        cmbBuySound.Items.Add(Strings.General.None);
+        cmbBuySound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+
+        cmbSellSound.Items.Clear();
+        cmbSellSound.Items.Add(Strings.General.None);
+        cmbSellSound.Items.AddRange(GameContentManager.SmartSortedSoundNames);
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.ShopEditor.title;
+        toolStripItemNew.Text = Strings.ShopEditor.New;
+        toolStripItemDelete.Text = Strings.ShopEditor.delete;
+        toolStripItemCopy.Text = Strings.ShopEditor.copy;
+        toolStripItemPaste.Text = Strings.ShopEditor.paste;
+        toolStripItemUndo.Text = Strings.ShopEditor.undo;
+
+        grpGeneral.Text = Strings.ShopEditor.general;
+        lblName.Text = Strings.ShopEditor.name;
+        lblDefaultCurrency.Text = Strings.ShopEditor.defaultcurrency;
+
+        grpItemsSold.Text = Strings.ShopEditor.itemssold;
+        lblAddSoldItem.Text = Strings.ShopEditor.addlabel;
+        lblSellFor.Text = Strings.ShopEditor.sellfor;
+        lblSellCost.Text = Strings.ShopEditor.sellcost;
+        btnAddSoldItem.Text = Strings.ShopEditor.addsolditem;
+        btnDelSoldItem.Text = Strings.ShopEditor.removesolditem;
+
+        grpItemsBought.Text = Strings.ShopEditor.itemsboughtwhitelist;
+        rdoBuyWhitelist.Text = Strings.ShopEditor.whitelist;
+        rdoBuyBlacklist.Text = Strings.ShopEditor.blacklist;
+        lblItemBought.Text = Strings.ShopEditor.addboughtitem;
+        lblBuyFor.Text = Strings.ShopEditor.buyfor;
+        lblBuyAmount.Text = Strings.ShopEditor.buycost;
+        btnAddBoughtItem.Text = Strings.ShopEditor.addboughtitem;
+        btnDelBoughtItem.Text = Strings.ShopEditor.removeboughtitem;
+
+        lblBuySound.Text = Strings.ShopEditor.buysound;
+        lblSellSound.Text = Strings.ShopEditor.sellsound;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.ShopEditor.sortalphabetically;
+        txtSearch.Text = Strings.ShopEditor.searchplaceholder;
+        lblFolder.Text = Strings.ShopEditor.folderlabel;
+
+        btnSave.Text = Strings.ShopEditor.save;
+        btnCancel.Text = Strings.ShopEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            cmbDefaultCurrency.SelectedIndex = ItemBase.ListIndex(mEditorItem.DefaultCurrencyId);
+            if (mEditorItem.BuyingWhitelist)
             {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.ShopEditor.undoprompt, Strings.ShopEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
+                rdoBuyWhitelist.Checked = true;
+            }
+            else
+            {
+                rdoBuyBlacklist.Checked = true;
+            }
+
+            cmbBuySound.SelectedIndex = cmbBuySound.FindString(TextUtils.NullToNone(mEditorItem.BuySound));
+            cmbSellSound.SelectedIndex = cmbSellSound.FindString(TextUtils.NullToNone(mEditorItem.SellSound));
+
+            UpdateWhitelist();
+            UpdateLists();
+            if (mChanged.IndexOf(mEditorItem) == -1)
+            {
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
             }
         }
-
-        private void UpdateToolStripItems()
+        else
         {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+            pnlContainer.Hide();
         }
 
-        private void form_KeyDown(object sender, KeyEventArgs e)
+        UpdateToolStripItems();
+    }
+
+    private void UpdateWhitelist()
+    {
+        if (rdoBuyWhitelist.Checked)
         {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
+            cmbBuyFor.Enabled = true;
+            nudBuyAmount.Enabled = true;
+            grpItemsBought.Text = Strings.ShopEditor.itemsboughtwhitelist;
         }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
+        else
         {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in ShopBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((ShopBase) itm.Value).Folder) &&
-                    !mFolders.Contains(((ShopBase) itm.Value).Folder))
-                {
-                    mFolders.Add(((ShopBase) itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((ShopBase) itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((ShopBase) itm.Value).Folder);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            var items = ShopBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((ShopBase)pair.Value)?.Name ?? Models.DatabaseObject<ShopBase>.Deleted, ((ShopBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+            cmbBuyFor.Enabled = false;
+            nudBuyAmount.Enabled = false;
+            grpItemsBought.Text = Strings.ShopEditor.itemsboughtblacklist;
         }
+    }
 
-        private void btnAddFolder_Click(object sender, EventArgs e)
+    private void rdoBuyWhitelist_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BuyingWhitelist = rdoBuyWhitelist.Checked;
+        UpdateLists();
+        UpdateWhitelist();
+    }
+
+    private void rdoBuyBlacklist_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BuyingWhitelist = rdoBuyWhitelist.Checked;
+        UpdateLists();
+        UpdateWhitelist();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void UpdateLists()
+    {
+        lstSoldItems.Items.Clear();
+        for (var i = 0; i < mEditorItem.SellingItems.Count; i++)
         {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.ShopEditor.folderprompt, Strings.ShopEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
+            lstSoldItems.Items.Add(
+                Strings.ShopEditor.selldesc.ToString(
+                    ItemBase.GetName(mEditorItem.SellingItems[i].ItemId),
+                    mEditorItem.SellingItems[i].CostItemQuantity,
+                    ItemBase.GetName(mEditorItem.SellingItems[i].CostItemId)
+                )
             );
+        }
 
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        lstBoughtItems.Items.Clear();
+        if (mEditorItem.BuyingWhitelist)
+        {
+            for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
             {
-                if (!cmbFolder.Items.Contains(folderName))
+                lstBoughtItems.Items.Add(
+                    Strings.ShopEditor.buydesc.ToString(
+                        ItemBase.GetName(mEditorItem.BuyingItems[i].ItemId),
+                        mEditorItem.BuyingItems[i].CostItemQuantity,
+                        ItemBase.GetName(mEditorItem.BuyingItems[i].CostItemId)
+                    )
+                );
+            }
+        }
+        else
+        {
+            for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
+            {
+                lstBoughtItems.Items.Add(
+                    Strings.ShopEditor.dontbuy.ToString(ItemBase.GetName(mEditorItem.BuyingItems[i].ItemId))
+                );
+            }
+        }
+    }
+
+    private void btnAddSoldItem_Click(object sender, EventArgs e)
+    {
+        var addedItem = false;
+        var cost = (int) nudSellCost.Value;
+        var newItem = new ShopItem(
+            ItemBase.IdFromList(cmbAddSoldItem.SelectedIndex), ItemBase.IdFromList(cmbSellFor.SelectedIndex), cost
+        );
+
+        for (var i = 0; i < mEditorItem.SellingItems.Count; i++)
+        {
+            if (mEditorItem.SellingItems[i].ItemId == newItem.ItemId)
+            {
+                mEditorItem.SellingItems[i] = newItem;
+                addedItem = true;
+
+                break;
+            }
+        }
+
+        if (!addedItem)
+        {
+            mEditorItem.SellingItems.Add(newItem);
+        }
+
+        UpdateLists();
+    }
+
+    private void btnDelSoldItem_Click(object sender, EventArgs e)
+    {
+        if (lstSoldItems.SelectedIndex > -1)
+        {
+            mEditorItem.SellingItems.RemoveAt(lstSoldItems.SelectedIndex);
+        }
+
+        UpdateLists();
+    }
+
+    private void btnAddBoughtItem_Click(object sender, EventArgs e)
+    {
+        var addedItem = false;
+        var cost = (int) nudBuyAmount.Value;
+        var newItem = new ShopItem(
+            ItemBase.IdFromList(cmbAddBoughtItem.SelectedIndex), ItemBase.IdFromList(cmbBuyFor.SelectedIndex), cost
+        );
+
+        for (var i = 0; i < mEditorItem.BuyingItems.Count; i++)
+        {
+            if (mEditorItem.BuyingItems[i].ItemId == newItem.ItemId)
+            {
+                mEditorItem.BuyingItems[i] = newItem;
+                addedItem = true;
+
+                break;
+            }
+        }
+
+        if (!addedItem)
+        {
+            mEditorItem.BuyingItems.Add(newItem);
+        }
+
+        UpdateLists();
+    }
+
+    private void btnDelBoughtItem_Click(object sender, EventArgs e)
+    {
+        if (lstBoughtItems.SelectedIndex > -1)
+        {
+            mEditorItem.BuyingItems.RemoveAt(lstBoughtItems.SelectedIndex);
+        }
+
+        UpdateLists();
+    }
+
+    private void cmbDefaultCurrency_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DefaultCurrency = ItemBase.FromList(cmbDefaultCurrency.SelectedIndex);
+    }
+
+    private void btnItemUp_Click(object sender, EventArgs e)
+    {
+        if (lstSoldItems.SelectedIndex > 0 && lstSoldItems.Items.Count > 1)
+        {
+            var index = lstSoldItems.SelectedIndex;
+            var swapWith = mEditorItem.SellingItems[index - 1];
+            mEditorItem.SellingItems[index - 1] = mEditorItem.SellingItems[index];
+            mEditorItem.SellingItems[index] = swapWith;
+            UpdateLists();
+            lstSoldItems.SelectedIndex = index - 1;
+        }
+    }
+
+    private void btnItemDown_Click(object sender, EventArgs e)
+    {
+        if (lstSoldItems.SelectedIndex > -1 && lstSoldItems.SelectedIndex + 1 != lstSoldItems.Items.Count)
+        {
+            var index = lstSoldItems.SelectedIndex;
+            var swapWith = mEditorItem.SellingItems[index + 1];
+            mEditorItem.SellingItems[index + 1] = mEditorItem.SellingItems[index];
+            mEditorItem.SellingItems[index] = swapWith;
+            UpdateLists();
+            lstSoldItems.SelectedIndex = index + 1;
+        }
+    }
+
+    private void cmbBuySound_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BuySound = TextUtils.SanitizeNone(cmbBuySound?.Text);
+    }
+
+    private void cmbSellSound_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SellSound = TextUtils.SanitizeNone(cmbSellSound?.Text);
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Shop);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ShopEditor.deleteprompt, Strings.ShopEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.ShopEditor.undoprompt, Strings.ShopEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in ShopBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((ShopBase) itm.Value).Folder) &&
+                !mFolders.Contains(((ShopBase) itm.Value).Folder))
+            {
+                mFolders.Add(((ShopBase) itm.Value).Folder);
+                if (!mKnownFolders.Contains(((ShopBase) itm.Value).Folder))
                 {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
+                    mKnownFolders.Add(((ShopBase) itm.Value).Folder);
                 }
             }
         }
 
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
 
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
+        var items = ShopBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((ShopBase)pair.Value)?.Name ?? Models.DatabaseObject<ShopBase>.Deleted, ((ShopBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.ShopEditor.folderprompt, Strings.ShopEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
 
-        private void txtSearch_Leave(object sender, EventArgs e)
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
         {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            if (!cmbFolder.Items.Contains(folderName))
             {
-                txtSearch.Text = Strings.ShopEditor.searchplaceholder;
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
             }
         }
+    }
 
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
 
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.ShopEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.ShopEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.ShopEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
     }
 
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.ShopEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.ShopEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.ShopEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 }

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -12,591 +12,533 @@ using Intersect.GameObjects.Maps.MapList;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmSpell : EditorForm
 {
 
-    public partial class FrmSpell : EditorForm
+    private List<SpellBase> mChanged = new List<SpellBase>();
+
+    private string mCopiedItem;
+
+    private SpellBase mEditorItem;
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private List<string> mKnownCooldownGroups = new List<string>();
+
+    public FrmSpell()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<SpellBase> mChanged = new List<SpellBase>();
-
-        private string mCopiedItem;
-
-        private SpellBase mEditorItem;
-
-        private List<string> mKnownFolders = new List<string>();
-
-        private List<string> mKnownCooldownGroups = new List<string>();
-
-        public FrmSpell()
+        cmbScalingStat.Items.Clear();
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            cmbScalingStat.Items.Clear();
-            for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
-            {
-                cmbScalingStat.Items.Add(Globals.GetStatName(i));
-            }
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
-        }
-        private void AssignEditorItem(Guid id)
-        {
-            mEditorItem = SpellBase.Get(id);
-            UpdateEditor();
+            cmbScalingStat.Items.Add(Globals.GetStatName(i));
         }
 
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+    }
+    private void AssignEditorItem(Guid id)
+    {
+        mEditorItem = SpellBase.Get(id);
+        UpdateEditor();
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Spell)
         {
-            if (type == GameObjectType.Spell)
+            InitEditor();
+            if (mEditorItem != null && !SpellBase.Lookup.Values.Contains(mEditorItem))
             {
-                InitEditor();
-                if (mEditorItem != null && !SpellBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
+                mEditorItem = null;
+                UpdateEditor();
             }
         }
+    }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
         {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+            item.RestoreBackup();
+            item.DeleteBackup();
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
         }
 
-        private void frmSpell_Load(object sender, EventArgs e)
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmSpell_Load(object sender, EventArgs e)
+    {
+        cmbProjectile.Items.Clear();
+        cmbProjectile.Items.AddRange(ProjectileBase.Names);
+        cmbCastAnimation.Items.Clear();
+        cmbCastAnimation.Items.Add(Strings.General.None);
+        cmbCastAnimation.Items.AddRange(AnimationBase.Names);
+        cmbHitAnimation.Items.Clear();
+        cmbHitAnimation.Items.Add(Strings.General.None);
+        cmbHitAnimation.Items.AddRange(AnimationBase.Names);
+        cmbEvent.Items.Clear();
+        cmbEvent.Items.Add(Strings.General.None);
+        cmbEvent.Items.AddRange(EventBase.Names);
+        cmbTickAnimation.Items.Clear();
+        cmbTickAnimation.Items.Add(Strings.General.None);
+        cmbTickAnimation.Items.AddRange(AnimationBase.Names);
+
+        cmbSprite.Items.Clear();
+        cmbSprite.Items.Add(Strings.General.None);
+        var spellNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Spell);
+        cmbSprite.Items.AddRange(spellNames);
+
+        cmbTransform.Items.Clear();
+        cmbTransform.Items.Add(Strings.General.None);
+        var spriteNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
+        cmbTransform.Items.AddRange(spriteNames);
+
+        cmbCastSprite.Items.Clear();
+        cmbCastSprite.Items.Add(Strings.General.None);
+        cmbCastSprite.Items.AddRange(
+            GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "cast").ToArray()
+        );
+
+        nudWarpX.Maximum = (int)Options.MapWidth;
+        nudWarpY.Maximum = (int)Options.MapHeight;
+
+        cmbWarpMap.Items.Clear();
+        cmbWarpMap.Items.AddRange(MapList.OrderedMaps.Select(map => map?.Name).ToArray());
+        cmbWarpMap.SelectedIndex = 0;
+
+        nudStr.Maximum = Options.MaxStatValue;
+        nudMag.Maximum = Options.MaxStatValue;
+        nudDef.Maximum = Options.MaxStatValue;
+        nudMR.Maximum = Options.MaxStatValue;
+        nudSpd.Maximum = Options.MaxStatValue;
+        nudStr.Minimum = -Options.MaxStatValue;
+        nudMag.Minimum = -Options.MaxStatValue;
+        nudDef.Minimum = -Options.MaxStatValue;
+        nudMR.Minimum = -Options.MaxStatValue;
+        nudSpd.Minimum = -Options.MaxStatValue;
+
+        nudCastDuration.Maximum = Int32.MaxValue;
+        nudCooldownDuration.Maximum = Int32.MaxValue;
+
+        InitLocalization();
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.SpellEditor.title;
+        toolStripItemNew.Text = Strings.SpellEditor.New;
+        toolStripItemDelete.Text = Strings.SpellEditor.delete;
+        toolStripItemCopy.Text = Strings.SpellEditor.copy;
+        toolStripItemPaste.Text = Strings.SpellEditor.paste;
+        toolStripItemUndo.Text = Strings.SpellEditor.undo;
+
+        grpSpells.Text = Strings.SpellEditor.spells;
+
+        grpGeneral.Text = Strings.SpellEditor.general;
+        lblName.Text = Strings.SpellEditor.name;
+        lblType.Text = Strings.SpellEditor.type;
+        cmbType.Items.Clear();
+        for (var i = 0; i < Strings.SpellEditor.types.Count; i++)
         {
-            cmbProjectile.Items.Clear();
-            cmbProjectile.Items.AddRange(ProjectileBase.Names);
-            cmbCastAnimation.Items.Clear();
-            cmbCastAnimation.Items.Add(Strings.General.None);
-            cmbCastAnimation.Items.AddRange(AnimationBase.Names);
-            cmbHitAnimation.Items.Clear();
-            cmbHitAnimation.Items.Add(Strings.General.None);
-            cmbHitAnimation.Items.AddRange(AnimationBase.Names);
-            cmbEvent.Items.Clear();
-            cmbEvent.Items.Add(Strings.General.None);
-            cmbEvent.Items.AddRange(EventBase.Names);
-            cmbTickAnimation.Items.Clear();
-            cmbTickAnimation.Items.Add(Strings.General.None);
-            cmbTickAnimation.Items.AddRange(AnimationBase.Names);
+            cmbType.Items.Add(Strings.SpellEditor.types[i]);
+        }
 
-            cmbSprite.Items.Clear();
-            cmbSprite.Items.Add(Strings.General.None);
-            var spellNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Spell);
-            cmbSprite.Items.AddRange(spellNames);
+        lblIcon.Text = Strings.SpellEditor.icon;
+        lblDesc.Text = Strings.SpellEditor.description;
+        lblCastAnimation.Text = Strings.SpellEditor.castanimation;
+        lblSpriteCastAnimation.Text = Strings.SpellEditor.CastSpriteOverride;
+        lblHitAnimation.Text = Strings.SpellEditor.hitanimation;
+        chkBound.Text = Strings.SpellEditor.bound;
 
-            cmbTransform.Items.Clear();
-            cmbTransform.Items.Add(Strings.General.None);
-            var spriteNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity);
-            cmbTransform.Items.AddRange(spriteNames);
+        grpRequirements.Text = Strings.SpellEditor.requirements;
+        lblCannotCast.Text = Strings.SpellEditor.cannotcast;
+        btnDynamicRequirements.Text = Strings.SpellEditor.requirementsbutton;
 
-            cmbCastSprite.Items.Clear();
-            cmbCastSprite.Items.Add(Strings.General.None);
-            cmbCastSprite.Items.AddRange(
-                GameContentManager.GetOverridesFor(GameContentManager.TextureType.Entity, "cast").ToArray()
+        grpSpellCost.Text = Strings.SpellEditor.cost;
+        lblHPCost.Text = Strings.SpellEditor.hpcost;
+        lblMPCost.Text = Strings.SpellEditor.manacost;
+        lblCastDuration.Text = Strings.SpellEditor.casttime;
+        lblCooldownDuration.Text = Strings.SpellEditor.cooldown;
+        lblCooldownGroup.Text = Strings.SpellEditor.CooldownGroup;
+        chkIgnoreGlobalCooldown.Text = Strings.SpellEditor.IgnoreGlobalCooldown;
+        chkIgnoreCdr.Text = Strings.SpellEditor.IgnoreCooldownReduction;
+
+        grpTargetInfo.Text = Strings.SpellEditor.targetting;
+        lblTargetType.Text = Strings.SpellEditor.targettype;
+        cmbTargetType.Items.Clear();
+        for (var i = 0; i < Strings.SpellEditor.targettypes.Count; i++)
+        {
+            cmbTargetType.Items.Add(Strings.SpellEditor.targettypes[i]);
+        }
+
+        lblCastRange.Text = Strings.SpellEditor.castrange;
+        lblProjectile.Text = Strings.SpellEditor.projectile;
+        lblHitRadius.Text = Strings.SpellEditor.hitradius;
+        lblDuration.Text = Strings.SpellEditor.duration;
+
+        grpCombat.Text = Strings.SpellEditor.combatspell;
+        grpDamage.Text = Strings.SpellEditor.damagegroup;
+        lblCritChance.Text = Strings.SpellEditor.critchance;
+        lblCritMultiplier.Text = Strings.SpellEditor.critmultiplier;
+        lblDamageType.Text = Strings.SpellEditor.damagetype;
+        lblHPDamage.Text = Strings.SpellEditor.hpdamage;
+        lblManaDamage.Text = Strings.SpellEditor.mpdamage;
+        chkFriendly.Text = Strings.SpellEditor.friendly;
+        cmbDamageType.Items.Clear();
+        for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
+        {
+            cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
+        }
+
+        lblScalingStat.Text = Strings.SpellEditor.scalingstat;
+        lblScaling.Text = Strings.SpellEditor.scalingamount;
+
+        grpHotDot.Text = Strings.SpellEditor.hotdot;
+        chkHOTDOT.Text = Strings.SpellEditor.ishotdot;
+        lblTick.Text = Strings.SpellEditor.hotdottick;
+        lblTickAnimation.Text = Strings.SpellEditor.TickAnimation;
+
+        grpStats.Text = Strings.SpellEditor.stats;
+        lblStr.Text = Strings.SpellEditor.attack;
+        lblDef.Text = Strings.SpellEditor.defense;
+        lblSpd.Text = Strings.SpellEditor.speed;
+        lblMag.Text = Strings.SpellEditor.abilitypower;
+        lblMR.Text = Strings.SpellEditor.magicresist;
+
+        grpEffectDuration.Text = Strings.SpellEditor.boostduration;
+        lblBuffDuration.Text = Strings.SpellEditor.duration;
+        grpEffect.Text = Strings.SpellEditor.effectgroup;
+        lblEffect.Text = Strings.SpellEditor.effectlabel;
+        cmbExtraEffect.Items.Clear();
+        for (var i = 0; i < Strings.SpellEditor.effects.Count; i++)
+        {
+            cmbExtraEffect.Items.Add(Strings.SpellEditor.effects[i]);
+        }
+
+        lblSprite.Text = Strings.SpellEditor.transformsprite;
+
+        grpDash.Text = Strings.SpellEditor.dash;
+        lblRange.Text = Strings.SpellEditor.dashrange.ToString(scrlRange.Value);
+        grpDashCollisions.Text = Strings.SpellEditor.dashcollisions;
+        chkIgnoreMapBlocks.Text = Strings.SpellEditor.ignoreblocks;
+        chkIgnoreActiveResources.Text = Strings.SpellEditor.ignoreactiveresources;
+        chkIgnoreInactiveResources.Text = Strings.SpellEditor.ignoreinactiveresources;
+        chkIgnoreZDimensionBlocks.Text = Strings.SpellEditor.ignorezdimension;
+
+        grpWarp.Text = Strings.SpellEditor.warptomap;
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y.ToString("");
+        lblWarpDir.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = -1; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        btnVisualMapSelector.Text = Strings.Warping.visual;
+
+        grpEvent.Text = Strings.SpellEditor.Event;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.SpellEditor.sortalphabetically;
+        txtSearch.Text = Strings.SpellEditor.searchplaceholder;
+        lblFolder.Text = Strings.SpellEditor.folderlabel;
+
+        btnSave.Text = Strings.SpellEditor.save;
+        btnCancel.Text = Strings.SpellEditor.cancel;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            pnlContainer.Show();
+
+            txtName.Text = mEditorItem.Name;
+            cmbFolder.Text = mEditorItem.Folder;
+            txtDesc.Text = mEditorItem.Description;
+            cmbType.SelectedIndex = (int)mEditorItem.SpellType;
+
+            nudCastDuration.Value = mEditorItem.CastDuration;
+            nudCooldownDuration.Value = mEditorItem.CooldownDuration;
+            cmbCooldownGroup.SelectedItem = mEditorItem.CooldownGroup;
+            chkIgnoreGlobalCooldown.Checked = mEditorItem.IgnoreGlobalCooldown;
+            chkIgnoreCdr.Checked = mEditorItem.IgnoreCooldownReduction;
+
+            cmbCastAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.CastAnimationId) + 1;
+            cmbHitAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.HitAnimationId) + 1;
+            cmbTickAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.TickAnimationId) + 1;
+            cmbCastSprite.SelectedIndex = cmbCastSprite.FindString(
+                    TextUtils.NullToNone(mEditorItem.CastSpriteOverride)
             );
 
-            nudWarpX.Maximum = (int)Options.MapWidth;
-            nudWarpY.Maximum = (int)Options.MapHeight;
+            chkBound.Checked = mEditorItem.Bound;
 
-            cmbWarpMap.Items.Clear();
-            cmbWarpMap.Items.AddRange(MapList.OrderedMaps.Select(map => map?.Name).ToArray());
-            cmbWarpMap.SelectedIndex = 0;
+            cmbSprite.SelectedIndex = cmbSprite.FindString(TextUtils.NullToNone(mEditorItem.Icon));
+            picSpell.BackgroundImage?.Dispose();
+            picSpell.BackgroundImage = null;
+            if (cmbSprite.SelectedIndex > 0)
+            {
+                picSpell.BackgroundImage = Image.FromFile("resources/spells/" + cmbSprite.Text);
+            }
 
-            nudStr.Maximum = Options.MaxStatValue;
-            nudMag.Maximum = Options.MaxStatValue;
-            nudDef.Maximum = Options.MaxStatValue;
-            nudMR.Maximum = Options.MaxStatValue;
-            nudSpd.Maximum = Options.MaxStatValue;
-            nudStr.Minimum = -Options.MaxStatValue;
-            nudMag.Minimum = -Options.MaxStatValue;
-            nudDef.Minimum = -Options.MaxStatValue;
-            nudMR.Minimum = -Options.MaxStatValue;
-            nudSpd.Minimum = -Options.MaxStatValue;
+            nudHPCost.Value = mEditorItem.VitalCost[(int)Vital.Health];
+            nudMpCost.Value = mEditorItem.VitalCost[(int)Vital.Mana];
 
-            nudCastDuration.Maximum = Int32.MaxValue;
-            nudCooldownDuration.Maximum = Int32.MaxValue;
+            txtCannotCast.Text = mEditorItem.CannotCastMessage;
 
-            InitLocalization();
-            UpdateEditor();
+            UpdateSpellTypePanels();
+            if (mChanged.IndexOf(mEditorItem) == -1)
+            {
+                mChanged.Add(mEditorItem);
+                mEditorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
         }
 
-        private void InitLocalization()
+        UpdateToolStripItems();
+    }
+
+    private void UpdateSpellTypePanels()
+    {
+        grpTargetInfo.Hide();
+        grpCombat.Hide();
+        grpWarp.Hide();
+        grpDash.Hide();
+        grpEvent.Hide();
+        cmbTargetType.Enabled = true;
+
+        // Reset our combat data location, since event type spells can move it.
+        grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y);
+
+        if (cmbType.SelectedIndex == (int)SpellType.CombatSpell ||
+            cmbType.SelectedIndex == (int)SpellType.WarpTo ||
+            cmbType.SelectedIndex == (int)SpellType.Event)
         {
-            Text = Strings.SpellEditor.title;
-            toolStripItemNew.Text = Strings.SpellEditor.New;
-            toolStripItemDelete.Text = Strings.SpellEditor.delete;
-            toolStripItemCopy.Text = Strings.SpellEditor.copy;
-            toolStripItemPaste.Text = Strings.SpellEditor.paste;
-            toolStripItemUndo.Text = Strings.SpellEditor.undo;
+            grpTargetInfo.Show();
+            grpCombat.Show();
+            cmbTargetType.SelectedIndex = (int)mEditorItem.Combat.TargetType;
+            UpdateTargetTypePanel();
 
-            grpSpells.Text = Strings.SpellEditor.spells;
+            nudHPDamage.Value = mEditorItem.Combat.VitalDiff[(int)Vital.Health];
+            nudMPDamage.Value = mEditorItem.Combat.VitalDiff[(int)Vital.Mana];
 
-            grpGeneral.Text = Strings.SpellEditor.general;
-            lblName.Text = Strings.SpellEditor.name;
-            lblType.Text = Strings.SpellEditor.type;
-            cmbType.Items.Clear();
-            for (var i = 0; i < Strings.SpellEditor.types.Count; i++)
+            nudStr.Value = mEditorItem.Combat.StatDiff[(int)Stat.Attack];
+            nudDef.Value = mEditorItem.Combat.StatDiff[(int)Stat.Defense];
+            nudSpd.Value = mEditorItem.Combat.StatDiff[(int)Stat.Speed];
+            nudMag.Value = mEditorItem.Combat.StatDiff[(int)Stat.AbilityPower];
+            nudMR.Value = mEditorItem.Combat.StatDiff[(int)Stat.MagicResist];
+
+            nudStrPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Attack];
+            nudDefPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Defense];
+            nudMagPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.AbilityPower];
+            nudMRPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.MagicResist];
+            nudSpdPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Speed];
+
+            chkFriendly.Checked = Convert.ToBoolean(mEditorItem.Combat.Friendly);
+            cmbDamageType.SelectedIndex = mEditorItem.Combat.DamageType;
+            cmbScalingStat.SelectedIndex = mEditorItem.Combat.ScalingStat;
+            nudScaling.Value = mEditorItem.Combat.Scaling;
+            nudCritChance.Value = mEditorItem.Combat.CritChance;
+            nudCritMultiplier.Value = (decimal)mEditorItem.Combat.CritMultiplier;
+
+            chkHOTDOT.Checked = mEditorItem.Combat.HoTDoT;
+            nudBuffDuration.Value = mEditorItem.Combat.Duration;
+            nudTick.Value = mEditorItem.Combat.HotDotInterval;
+            cmbExtraEffect.SelectedIndex = (int)mEditorItem.Combat.Effect;
+            cmbExtraEffect_SelectedIndexChanged(null, null);
+        }
+        else if (cmbType.SelectedIndex == (int)SpellType.Warp)
+        {
+            grpWarp.Show();
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
             {
-                cmbType.Items.Add(Strings.SpellEditor.types[i]);
+                if (MapList.OrderedMaps[i].MapId == mEditorItem.Warp.MapId)
+                {
+                    cmbWarpMap.SelectedIndex = i;
+
+                    break;
+                }
             }
 
-            lblIcon.Text = Strings.SpellEditor.icon;
-            lblDesc.Text = Strings.SpellEditor.description;
-            lblCastAnimation.Text = Strings.SpellEditor.castanimation;
-            lblSpriteCastAnimation.Text = Strings.SpellEditor.CastSpriteOverride;
-            lblHitAnimation.Text = Strings.SpellEditor.hitanimation;
-            chkBound.Text = Strings.SpellEditor.bound;
-
-            grpRequirements.Text = Strings.SpellEditor.requirements;
-            lblCannotCast.Text = Strings.SpellEditor.cannotcast;
-            btnDynamicRequirements.Text = Strings.SpellEditor.requirementsbutton;
-
-            grpSpellCost.Text = Strings.SpellEditor.cost;
-            lblHPCost.Text = Strings.SpellEditor.hpcost;
-            lblMPCost.Text = Strings.SpellEditor.manacost;
-            lblCastDuration.Text = Strings.SpellEditor.casttime;
-            lblCooldownDuration.Text = Strings.SpellEditor.cooldown;
-            lblCooldownGroup.Text = Strings.SpellEditor.CooldownGroup;
-            chkIgnoreGlobalCooldown.Text = Strings.SpellEditor.IgnoreGlobalCooldown;
-            chkIgnoreCdr.Text = Strings.SpellEditor.IgnoreCooldownReduction;
-
-            grpTargetInfo.Text = Strings.SpellEditor.targetting;
-            lblTargetType.Text = Strings.SpellEditor.targettype;
-            cmbTargetType.Items.Clear();
-            for (var i = 0; i < Strings.SpellEditor.targettypes.Count; i++)
-            {
-                cmbTargetType.Items.Add(Strings.SpellEditor.targettypes[i]);
-            }
-
-            lblCastRange.Text = Strings.SpellEditor.castrange;
-            lblProjectile.Text = Strings.SpellEditor.projectile;
-            lblHitRadius.Text = Strings.SpellEditor.hitradius;
-            lblDuration.Text = Strings.SpellEditor.duration;
-
-            grpCombat.Text = Strings.SpellEditor.combatspell;
-            grpDamage.Text = Strings.SpellEditor.damagegroup;
-            lblCritChance.Text = Strings.SpellEditor.critchance;
-            lblCritMultiplier.Text = Strings.SpellEditor.critmultiplier;
-            lblDamageType.Text = Strings.SpellEditor.damagetype;
-            lblHPDamage.Text = Strings.SpellEditor.hpdamage;
-            lblManaDamage.Text = Strings.SpellEditor.mpdamage;
-            chkFriendly.Text = Strings.SpellEditor.friendly;
-            cmbDamageType.Items.Clear();
-            for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
-            {
-                cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
-            }
-
-            lblScalingStat.Text = Strings.SpellEditor.scalingstat;
-            lblScaling.Text = Strings.SpellEditor.scalingamount;
-
-            grpHotDot.Text = Strings.SpellEditor.hotdot;
-            chkHOTDOT.Text = Strings.SpellEditor.ishotdot;
-            lblTick.Text = Strings.SpellEditor.hotdottick;
-            lblTickAnimation.Text = Strings.SpellEditor.TickAnimation;
-
-            grpStats.Text = Strings.SpellEditor.stats;
-            lblStr.Text = Strings.SpellEditor.attack;
-            lblDef.Text = Strings.SpellEditor.defense;
-            lblSpd.Text = Strings.SpellEditor.speed;
-            lblMag.Text = Strings.SpellEditor.abilitypower;
-            lblMR.Text = Strings.SpellEditor.magicresist;
-
-            grpEffectDuration.Text = Strings.SpellEditor.boostduration;
-            lblBuffDuration.Text = Strings.SpellEditor.duration;
-            grpEffect.Text = Strings.SpellEditor.effectgroup;
-            lblEffect.Text = Strings.SpellEditor.effectlabel;
-            cmbExtraEffect.Items.Clear();
-            for (var i = 0; i < Strings.SpellEditor.effects.Count; i++)
-            {
-                cmbExtraEffect.Items.Add(Strings.SpellEditor.effects[i]);
-            }
-
-            lblSprite.Text = Strings.SpellEditor.transformsprite;
-
-            grpDash.Text = Strings.SpellEditor.dash;
+            nudWarpX.Value = mEditorItem.Warp.X;
+            nudWarpY.Value = mEditorItem.Warp.Y;
+            cmbDirection.SelectedIndex = mEditorItem.Warp.Dir;
+        }
+        else if (cmbType.SelectedIndex == (int)SpellType.Dash)
+        {
+            grpDash.Show();
+            scrlRange.Value = mEditorItem.Combat.CastRange;
             lblRange.Text = Strings.SpellEditor.dashrange.ToString(scrlRange.Value);
-            grpDashCollisions.Text = Strings.SpellEditor.dashcollisions;
-            chkIgnoreMapBlocks.Text = Strings.SpellEditor.ignoreblocks;
-            chkIgnoreActiveResources.Text = Strings.SpellEditor.ignoreactiveresources;
-            chkIgnoreInactiveResources.Text = Strings.SpellEditor.ignoreinactiveresources;
-            chkIgnoreZDimensionBlocks.Text = Strings.SpellEditor.ignorezdimension;
-
-            grpWarp.Text = Strings.SpellEditor.warptomap;
-            lblMap.Text = Strings.Warping.map.ToString("");
-            lblX.Text = Strings.Warping.x.ToString("");
-            lblY.Text = Strings.Warping.y.ToString("");
-            lblWarpDir.Text = Strings.Warping.direction.ToString("");
-            cmbDirection.Items.Clear();
-            for (var i = -1; i < 4; i++)
-            {
-                cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
-            }
-
-            btnVisualMapSelector.Text = Strings.Warping.visual;
-
-            grpEvent.Text = Strings.SpellEditor.Event;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.SpellEditor.sortalphabetically;
-            txtSearch.Text = Strings.SpellEditor.searchplaceholder;
-            lblFolder.Text = Strings.SpellEditor.folderlabel;
-
-            btnSave.Text = Strings.SpellEditor.save;
-            btnCancel.Text = Strings.SpellEditor.cancel;
+            chkIgnoreMapBlocks.Checked = mEditorItem.Dash.IgnoreMapBlocks;
+            chkIgnoreActiveResources.Checked = mEditorItem.Dash.IgnoreActiveResources;
+            chkIgnoreInactiveResources.Checked = mEditorItem.Dash.IgnoreInactiveResources;
+            chkIgnoreZDimensionBlocks.Checked = mEditorItem.Dash.IgnoreZDimensionAttributes;
         }
 
-        private void UpdateEditor()
+        if (cmbType.SelectedIndex == (int)SpellType.Event)
         {
-            if (mEditorItem != null)
-            {
-                pnlContainer.Show();
-
-                txtName.Text = mEditorItem.Name;
-                cmbFolder.Text = mEditorItem.Folder;
-                txtDesc.Text = mEditorItem.Description;
-                cmbType.SelectedIndex = (int)mEditorItem.SpellType;
-
-                nudCastDuration.Value = mEditorItem.CastDuration;
-                nudCooldownDuration.Value = mEditorItem.CooldownDuration;
-                cmbCooldownGroup.SelectedItem = mEditorItem.CooldownGroup;
-                chkIgnoreGlobalCooldown.Checked = mEditorItem.IgnoreGlobalCooldown;
-                chkIgnoreCdr.Checked = mEditorItem.IgnoreCooldownReduction;
-
-                cmbCastAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.CastAnimationId) + 1;
-                cmbHitAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.HitAnimationId) + 1;
-                cmbTickAnimation.SelectedIndex = AnimationBase.ListIndex(mEditorItem.TickAnimationId) + 1;
-                cmbCastSprite.SelectedIndex = cmbCastSprite.FindString(
-                        TextUtils.NullToNone(mEditorItem.CastSpriteOverride)
-                );
-
-                chkBound.Checked = mEditorItem.Bound;
-
-                cmbSprite.SelectedIndex = cmbSprite.FindString(TextUtils.NullToNone(mEditorItem.Icon));
-                picSpell.BackgroundImage?.Dispose();
-                picSpell.BackgroundImage = null;
-                if (cmbSprite.SelectedIndex > 0)
-                {
-                    picSpell.BackgroundImage = Image.FromFile("resources/spells/" + cmbSprite.Text);
-                }
-
-                nudHPCost.Value = mEditorItem.VitalCost[(int)Vital.Health];
-                nudMpCost.Value = mEditorItem.VitalCost[(int)Vital.Mana];
-
-                txtCannotCast.Text = mEditorItem.CannotCastMessage;
-
-                UpdateSpellTypePanels();
-                if (mChanged.IndexOf(mEditorItem) == -1)
-                {
-                    mChanged.Add(mEditorItem);
-                    mEditorItem.MakeBackup();
-                }
-            }
-            else
-            {
-                pnlContainer.Hide();
-            }
-
-            UpdateToolStripItems();
+            grpEvent.Show();
+            cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
+            // Move our combat data down a little bit, it's not a very clean solution but it'll let us display it properly.
+            grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y + grpEvent.Size.Height + 5);
         }
 
-        private void UpdateSpellTypePanels()
+        if (cmbType.SelectedIndex == (int)SpellType.WarpTo)
         {
-            grpTargetInfo.Hide();
-            grpCombat.Hide();
-            grpWarp.Hide();
-            grpDash.Hide();
-            grpEvent.Hide();
-            cmbTargetType.Enabled = true;
-
-            // Reset our combat data location, since event type spells can move it.
-            grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y);
-
-            if (cmbType.SelectedIndex == (int)SpellType.CombatSpell ||
-                cmbType.SelectedIndex == (int)SpellType.WarpTo ||
-                cmbType.SelectedIndex == (int)SpellType.Event)
-            {
-                grpTargetInfo.Show();
-                grpCombat.Show();
-                cmbTargetType.SelectedIndex = (int)mEditorItem.Combat.TargetType;
-                UpdateTargetTypePanel();
-
-                nudHPDamage.Value = mEditorItem.Combat.VitalDiff[(int)Vital.Health];
-                nudMPDamage.Value = mEditorItem.Combat.VitalDiff[(int)Vital.Mana];
-
-                nudStr.Value = mEditorItem.Combat.StatDiff[(int)Stat.Attack];
-                nudDef.Value = mEditorItem.Combat.StatDiff[(int)Stat.Defense];
-                nudSpd.Value = mEditorItem.Combat.StatDiff[(int)Stat.Speed];
-                nudMag.Value = mEditorItem.Combat.StatDiff[(int)Stat.AbilityPower];
-                nudMR.Value = mEditorItem.Combat.StatDiff[(int)Stat.MagicResist];
-
-                nudStrPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Attack];
-                nudDefPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Defense];
-                nudMagPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.AbilityPower];
-                nudMRPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.MagicResist];
-                nudSpdPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Speed];
-
-                chkFriendly.Checked = Convert.ToBoolean(mEditorItem.Combat.Friendly);
-                cmbDamageType.SelectedIndex = mEditorItem.Combat.DamageType;
-                cmbScalingStat.SelectedIndex = mEditorItem.Combat.ScalingStat;
-                nudScaling.Value = mEditorItem.Combat.Scaling;
-                nudCritChance.Value = mEditorItem.Combat.CritChance;
-                nudCritMultiplier.Value = (decimal)mEditorItem.Combat.CritMultiplier;
-
-                chkHOTDOT.Checked = mEditorItem.Combat.HoTDoT;
-                nudBuffDuration.Value = mEditorItem.Combat.Duration;
-                nudTick.Value = mEditorItem.Combat.HotDotInterval;
-                cmbExtraEffect.SelectedIndex = (int)mEditorItem.Combat.Effect;
-                cmbExtraEffect_SelectedIndexChanged(null, null);
-            }
-            else if (cmbType.SelectedIndex == (int)SpellType.Warp)
-            {
-                grpWarp.Show();
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == mEditorItem.Warp.MapId)
-                    {
-                        cmbWarpMap.SelectedIndex = i;
-
-                        break;
-                    }
-                }
-
-                nudWarpX.Value = mEditorItem.Warp.X;
-                nudWarpY.Value = mEditorItem.Warp.Y;
-                cmbDirection.SelectedIndex = mEditorItem.Warp.Dir;
-            }
-            else if (cmbType.SelectedIndex == (int)SpellType.Dash)
-            {
-                grpDash.Show();
-                scrlRange.Value = mEditorItem.Combat.CastRange;
-                lblRange.Text = Strings.SpellEditor.dashrange.ToString(scrlRange.Value);
-                chkIgnoreMapBlocks.Checked = mEditorItem.Dash.IgnoreMapBlocks;
-                chkIgnoreActiveResources.Checked = mEditorItem.Dash.IgnoreActiveResources;
-                chkIgnoreInactiveResources.Checked = mEditorItem.Dash.IgnoreInactiveResources;
-                chkIgnoreZDimensionBlocks.Checked = mEditorItem.Dash.IgnoreZDimensionAttributes;
-            }
-
-            if (cmbType.SelectedIndex == (int)SpellType.Event)
-            {
-                grpEvent.Show();
-                cmbEvent.SelectedIndex = EventBase.ListIndex(mEditorItem.EventId) + 1;
-                // Move our combat data down a little bit, it's not a very clean solution but it'll let us display it properly.
-                grpCombat.Location = new System.Drawing.Point(grpEvent.Location.X, grpEvent.Location.Y + grpEvent.Size.Height + 5);
-            }
-
-            if (cmbType.SelectedIndex == (int)SpellType.WarpTo)
-            {
-                grpTargetInfo.Show();
-                cmbTargetType.SelectedIndex = (int)SpellTargetType.Single;
-                cmbTargetType.Enabled = false;
-                UpdateTargetTypePanel();
-            }
+            grpTargetInfo.Show();
+            cmbTargetType.SelectedIndex = (int)SpellTargetType.Single;
+            cmbTargetType.Enabled = false;
+            UpdateTargetTypePanel();
         }
+    }
 
-        private void UpdateTargetTypePanel()
+    private void UpdateTargetTypePanel()
+    {
+        lblHitRadius.Hide();
+        nudHitRadius.Hide();
+        lblCastRange.Hide();
+        nudCastRange.Hide();
+        lblProjectile.Hide();
+        cmbProjectile.Hide();
+        lblDuration.Hide();
+        nudDuration.Hide();
+
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Single)
         {
-            lblHitRadius.Hide();
-            nudHitRadius.Hide();
-            lblCastRange.Hide();
-            nudCastRange.Hide();
-            lblProjectile.Hide();
-            cmbProjectile.Hide();
-            lblDuration.Hide();
-            nudDuration.Hide();
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Single)
-            {
-                lblCastRange.Show();
-                nudCastRange.Show();
-                nudCastRange.Value = mEditorItem.Combat.CastRange;
-                if (cmbType.SelectedIndex == (int)SpellType.CombatSpell)
-                {
-                    lblHitRadius.Show();
-                    nudHitRadius.Show();
-                    nudHitRadius.Value = mEditorItem.Combat.HitRadius;
-                }
-            }
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.AoE &&
-                cmbType.SelectedIndex == (int)SpellType.CombatSpell)
+            lblCastRange.Show();
+            nudCastRange.Show();
+            nudCastRange.Value = mEditorItem.Combat.CastRange;
+            if (cmbType.SelectedIndex == (int)SpellType.CombatSpell)
             {
                 lblHitRadius.Show();
                 nudHitRadius.Show();
                 nudHitRadius.Value = mEditorItem.Combat.HitRadius;
             }
-
-            if (cmbTargetType.SelectedIndex < (int)SpellTargetType.Self)
-            {
-                lblCastRange.Show();
-                nudCastRange.Show();
-                nudCastRange.Value = mEditorItem.Combat.CastRange;
-            }
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Projectile)
-            {
-                lblProjectile.Show();
-                cmbProjectile.Show();
-                cmbProjectile.SelectedIndex = ProjectileBase.ListIndex(mEditorItem.Combat.ProjectileId);
-            }
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.OnHit)
-            {
-                lblDuration.Show();
-                nudDuration.Show();
-                nudDuration.Value = mEditorItem.Combat.OnHitDuration;
-            }
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Trap)
-            {
-                lblDuration.Show();
-                nudDuration.Show();
-                nudDuration.Value = mEditorItem.Combat.TrapDuration;
-            }
         }
 
-        private void txtName_TextChanged(object sender, EventArgs e)
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.AoE &&
+            cmbType.SelectedIndex == (int)SpellType.CombatSpell)
         {
-            mEditorItem.Name = txtName.Text;
-            lstGameObjects.UpdateText(txtName.Text);
+            lblHitRadius.Show();
+            nudHitRadius.Show();
+            nudHitRadius.Value = mEditorItem.Combat.HitRadius;
         }
 
-        private void cmbType_SelectedIndexChanged(object sender, EventArgs e)
+        if (cmbTargetType.SelectedIndex < (int)SpellTargetType.Self)
         {
-            if (cmbType.SelectedIndex != (int)mEditorItem.SpellType)
-            {
-                mEditorItem.SpellType = (SpellType)cmbType.SelectedIndex;
-                UpdateSpellTypePanels();
-            }
+            lblCastRange.Show();
+            nudCastRange.Show();
+            nudCastRange.Value = mEditorItem.Combat.CastRange;
         }
 
-        private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Projectile)
         {
-            mEditorItem.Icon = cmbSprite.Text;
-            picSpell.BackgroundImage?.Dispose();
-            picSpell.BackgroundImage = null;
-            picSpell.BackgroundImage = cmbSprite.SelectedIndex > 0
-                ? Image.FromFile("resources/spells/" + cmbSprite.Text)
-                : null;
+            lblProjectile.Show();
+            cmbProjectile.Show();
+            cmbProjectile.SelectedIndex = ProjectileBase.ListIndex(mEditorItem.Combat.ProjectileId);
         }
 
-        private void cmbTargetType_SelectedIndexChanged(object sender, EventArgs e)
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.OnHit)
         {
-            mEditorItem.Combat.TargetType = (SpellTargetType)cmbTargetType.SelectedIndex;
-            UpdateTargetTypePanel();
+            lblDuration.Show();
+            nudDuration.Show();
+            nudDuration.Value = mEditorItem.Combat.OnHitDuration;
         }
 
-        private void chkHOTDOT_CheckedChanged(object sender, EventArgs e)
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Trap)
         {
-            mEditorItem.Combat.HoTDoT = chkHOTDOT.Checked;
+            lblDuration.Show();
+            nudDuration.Show();
+            nudDuration.Value = mEditorItem.Combat.TrapDuration;
         }
+    }
 
-        private void txtDesc_TextChanged(object sender, EventArgs e)
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void cmbType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbType.SelectedIndex != (int)mEditorItem.SpellType)
         {
-            mEditorItem.Description = txtDesc.Text;
+            mEditorItem.SpellType = (SpellType)cmbType.SelectedIndex;
+            UpdateSpellTypePanels();
         }
+    }
 
-        private void cmbExtraEffect_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Icon = cmbSprite.Text;
+        picSpell.BackgroundImage?.Dispose();
+        picSpell.BackgroundImage = null;
+        picSpell.BackgroundImage = cmbSprite.SelectedIndex > 0
+            ? Image.FromFile("resources/spells/" + cmbSprite.Text)
+            : null;
+    }
+
+    private void cmbTargetType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.TargetType = (SpellTargetType)cmbTargetType.SelectedIndex;
+        UpdateTargetTypePanel();
+    }
+
+    private void chkHOTDOT_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.HoTDoT = chkHOTDOT.Checked;
+    }
+
+    private void txtDesc_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Description = txtDesc.Text;
+    }
+
+    private void cmbExtraEffect_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.Effect = (SpellEffect)cmbExtraEffect.SelectedIndex;
+
+        lblSprite.Visible = false;
+        cmbTransform.Visible = false;
+        picSprite.Visible = false;
+
+        if (cmbExtraEffect.SelectedIndex == 6) //Transform
         {
-            mEditorItem.Combat.Effect = (SpellEffect)cmbExtraEffect.SelectedIndex;
+            lblSprite.Visible = true;
+            cmbTransform.Visible = true;
+            picSprite.Visible = true;
 
-            lblSprite.Visible = false;
-            cmbTransform.Visible = false;
-            picSprite.Visible = false;
+            cmbTransform.SelectedIndex =
+                cmbTransform.FindString(TextUtils.NullToNone(mEditorItem.Combat.TransformSprite));
 
-            if (cmbExtraEffect.SelectedIndex == 6) //Transform
-            {
-                lblSprite.Visible = true;
-                cmbTransform.Visible = true;
-                picSprite.Visible = true;
-
-                cmbTransform.SelectedIndex =
-                    cmbTransform.FindString(TextUtils.NullToNone(mEditorItem.Combat.TransformSprite));
-
-                if (cmbTransform.SelectedIndex > 0)
-                {
-                    var bmp = new Bitmap(picSprite.Width, picSprite.Height);
-                    var g = Graphics.FromImage(bmp);
-                    var src = Image.FromFile("resources/entities/" + cmbTransform.Text);
-                    g.DrawImage(
-                        src,
-                        new Rectangle(
-                            picSprite.Width / 2 - src.Width / (Options.Instance.Sprites.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.Sprites.Directions * 2), src.Width / Options.Instance.Sprites.NormalFrames,
-                            src.Height / Options.Instance.Sprites.Directions
-                        ), new Rectangle(0, 0, src.Width / Options.Instance.Sprites.NormalFrames, src.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
-                    );
-
-                    g.Dispose();
-                    src.Dispose();
-                    picSprite.BackgroundImage = bmp;
-                }
-                else
-                {
-                    picSprite.BackgroundImage = null;
-                }
-            }
-        }
-
-        private void frmSpell_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Globals.CurrentEditor = -1;
-        }
-
-        private void scrlRange_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            lblRange.Text = Strings.SpellEditor.dashrange.ToString(scrlRange.Value);
-            mEditorItem.Combat.CastRange = scrlRange.Value;
-        }
-
-        private void chkIgnoreMapBlocks_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Dash.IgnoreMapBlocks = chkIgnoreMapBlocks.Checked;
-        }
-
-        private void chkIgnoreActiveResources_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Dash.IgnoreActiveResources = chkIgnoreActiveResources.Checked;
-        }
-
-        private void chkIgnoreInactiveResources_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Dash.IgnoreInactiveResources = chkIgnoreInactiveResources.Checked;
-        }
-
-        private void chkIgnoreZDimensionBlocks_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Dash.IgnoreZDimensionAttributes = chkIgnoreZDimensionBlocks.Checked;
-        }
-
-        private void cmbTransform_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.TransformSprite = cmbTransform.Text;
             if (cmbTransform.SelectedIndex > 0)
             {
                 var bmp = new Bitmap(picSprite.Width, picSprite.Height);
@@ -619,481 +561,537 @@ namespace Intersect.Editor.Forms.Editors
                 picSprite.BackgroundImage = null;
             }
         }
+    }
 
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendCreateObject(GameObjectType.Spell);
-        }
+    private void frmSpell_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+    }
 
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.SpellEditor.deleteprompt, Strings.SpellEditor.deletetitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
+    private void scrlRange_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        lblRange.Text = Strings.SpellEditor.dashrange.ToString(scrlRange.Value);
+        mEditorItem.Combat.CastRange = scrlRange.Value;
+    }
 
-        private void toolStripItemCopy_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && lstGameObjects.Focused)
-            {
-                mCopiedItem = mEditorItem.JsonData;
-                toolStripItemPaste.Enabled = true;
-            }
-        }
+    private void chkIgnoreMapBlocks_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Dash.IgnoreMapBlocks = chkIgnoreMapBlocks.Checked;
+    }
 
-        private void toolStripItemPaste_Click(object sender, EventArgs e)
-        {
-            if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
-            {
-                mEditorItem.Load(mCopiedItem, true);
-                UpdateEditor();
-            }
-        }
+    private void chkIgnoreActiveResources_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Dash.IgnoreActiveResources = chkIgnoreActiveResources.Checked;
+    }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
-        {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.SpellEditor.undoprompt, Strings.SpellEditor.undotitle, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    mEditorItem.RestoreBackup();
-                    UpdateEditor();
-                }
-            }
-        }
+    private void chkIgnoreInactiveResources_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Dash.IgnoreInactiveResources = chkIgnoreInactiveResources.Checked;
+    }
 
-        private void UpdateToolStripItems()
-        {
-            toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
+    private void chkIgnoreZDimensionBlocks_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Dash.IgnoreZDimensionAttributes = chkIgnoreZDimensionBlocks.Checked;
+    }
 
-        private void form_KeyDown(object sender, KeyEventArgs e)
+    private void cmbTransform_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.TransformSprite = cmbTransform.Text;
+        if (cmbTransform.SelectedIndex > 0)
         {
-            if (e.Control)
-            {
-                if (e.KeyCode == Keys.N)
-                {
-                    toolStripItemNew_Click(null, null);
-                }
-            }
-        }
-
-        private void chkFriendly_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.Friendly = chkFriendly.Checked;
-        }
-
-        private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.DamageType = cmbDamageType.SelectedIndex;
-        }
-
-        private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.ScalingStat = cmbScalingStat.SelectedIndex;
-        }
-
-        private void btnDynamicRequirements_Click(object sender, EventArgs e)
-        {
-            var frm = new FrmDynamicRequirements(mEditorItem.CastingRequirements, RequirementType.Spell);
-            frm.ShowDialog();
-        }
-
-        private void cmbCastSprite_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CastSpriteOverride = TextUtils.SanitizeNone(cmbCastSprite?.Text);
-        }
-
-        private void cmbCastAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CastAnimation = AnimationBase.Get(AnimationBase.IdFromList(cmbCastAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbHitAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.HitAnimation = AnimationBase.Get(AnimationBase.IdFromList(cmbHitAnimation.SelectedIndex - 1));
-        }
-
-        private void cmbProjectile_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.ProjectileId = ProjectileBase.IdFromList(cmbProjectile.SelectedIndex);
-        }
-
-        private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.EventId = EventBase.IdFromList(cmbEvent.SelectedIndex - 1);
-        }
-
-        private void btnVisualMapSelector_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.SelectTile(
-                MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int)nudWarpX.Value, (int)nudWarpY.Value
+            var bmp = new Bitmap(picSprite.Width, picSprite.Height);
+            var g = Graphics.FromImage(bmp);
+            var src = Image.FromFile("resources/entities/" + cmbTransform.Text);
+            g.DrawImage(
+                src,
+                new Rectangle(
+                    picSprite.Width / 2 - src.Width / (Options.Instance.Sprites.NormalFrames * 2), picSprite.Height / 2 - src.Height / (Options.Instance.Sprites.Directions * 2), src.Width / Options.Instance.Sprites.NormalFrames,
+                    src.Height / Options.Instance.Sprites.Directions
+                ), new Rectangle(0, 0, src.Width / Options.Instance.Sprites.NormalFrames, src.Height / Options.Instance.Sprites.Directions), GraphicsUnit.Pixel
             );
 
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
-                    {
-                        cmbWarpMap.SelectedIndex = i;
-                        mEditorItem.Warp.MapId = MapList.OrderedMaps[i].MapId;
-
-                        break;
-                    }
-                }
-
-                nudWarpX.Value = frmWarpSelection.GetX();
-                mEditorItem.Warp.X = frmWarpSelection.GetX();
-                nudWarpY.Value = frmWarpSelection.GetY();
-                mEditorItem.Warp.Y = frmWarpSelection.GetY();
-            }
+            g.Dispose();
+            src.Dispose();
+            picSprite.BackgroundImage = bmp;
         }
-
-        private void cmbWarpMap_SelectedIndexChanged(object sender, EventArgs e)
+        else
         {
-            if (cmbWarpMap.SelectedIndex > -1 && mEditorItem != null)
-            {
-                mEditorItem.Warp.MapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
-            }
-        }
-
-        private void nudWarpX_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Warp.X = (byte)nudWarpX.Value;
-        }
-
-        private void nudWarpY_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Warp.Y = (byte)nudWarpY.Value;
-        }
-
-        private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Warp.Dir = (byte)cmbDirection.SelectedIndex;
-        }
-
-        private void nudCastDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CastDuration = (int)nudCastDuration.Value;
-        }
-
-        private void nudCooldownDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CooldownDuration = (int)nudCooldownDuration.Value;
-        }
-
-        private void nudHitRadius_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.HitRadius = (int)nudHitRadius.Value;
-        }
-
-        private void nudHPCost_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalCost[(int)Vital.Health] = (int)nudHPCost.Value;
-        }
-
-        private void nudMpCost_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.VitalCost[(int)Vital.Mana] = (int)nudMpCost.Value;
-        }
-
-        private void nudHPDamage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.VitalDiff[(int)Vital.Health] = (int)nudHPDamage.Value;
-        }
-
-        private void nudMPDamage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.VitalDiff[(int)Vital.Mana] = (int)nudMPDamage.Value;
-        }
-
-        private void nudStr_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.StatDiff[(int)Stat.Attack] = (int)nudStr.Value;
-        }
-
-        private void nudMag_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.StatDiff[(int)Stat.AbilityPower] = (int)nudMag.Value;
-        }
-
-        private void nudDef_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.StatDiff[(int)Stat.Defense] = (int)nudDef.Value;
-        }
-
-        private void nudMR_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.StatDiff[(int)Stat.MagicResist] = (int)nudMR.Value;
-        }
-
-        private void nudSpd_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.StatDiff[(int)Stat.Speed] = (int)nudSpd.Value;
-        }
-
-        private void nudStrPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.PercentageStatDiff[(int)Stat.Attack] = (int)nudStrPercentage.Value;
-        }
-
-        private void nudMagPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.PercentageStatDiff[(int)Stat.AbilityPower] = (int)nudMagPercentage.Value;
-        }
-
-        private void nudDefPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.PercentageStatDiff[(int)Stat.Defense] = (int)nudDefPercentage.Value;
-        }
-
-        private void nudMRPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.PercentageStatDiff[(int)Stat.MagicResist] = (int)nudMRPercentage.Value;
-        }
-
-        private void nudSpdPercentage_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.PercentageStatDiff[(int)Stat.Speed] = (int)nudSpdPercentage.Value;
-        }
-
-        private void nudBuffDuration_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.Duration = (int)nudBuffDuration.Value;
-        }
-
-        private void nudTick_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.HotDotInterval = (int)nudTick.Value;
-        }
-
-        private void nudCritChance_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.CritChance = (int)nudCritChance.Value;
-        }
-
-        private void nudScaling_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.Scaling = (int)nudScaling.Value;
-        }
-
-        private void nudCastRange_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.CastRange = (int)nudCastRange.Value;
-        }
-
-        private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Combat.CritMultiplier = (double)nudCritMultiplier.Value;
-        }
-
-        private void nudOnHitDuration_ValueChanged(object sender, EventArgs e)
-        {
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.OnHit)
-            {
-                mEditorItem.Combat.OnHitDuration = (int)nudDuration.Value;
-            }
-
-            if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Trap)
-            {
-                mEditorItem.Combat.TrapDuration = (int)nudDuration.Value;
-            }
-        }
-
-        private void chkBound_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Bound = chkBound.Checked;
-        }
-
-        private void btnAddCooldownGroup_Click(object sender, EventArgs e)
-        {
-            var cdGroupName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.SpellEditor.CooldownGroupPrompt, Strings.SpellEditor.CooldownGroupTitle, ref cdGroupName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(cdGroupName))
-            {
-                if (!cmbCooldownGroup.Items.Contains(cdGroupName))
-                {
-                    mEditorItem.CooldownGroup = cdGroupName;
-                    mKnownCooldownGroups.Add(cdGroupName);
-                    InitEditor();
-                    cmbCooldownGroup.Text = cdGroupName;
-                }
-            }
-        }
-
-        private void cmbCooldownGroup_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CooldownGroup = cmbCooldownGroup.Text;
-        }
-
-        private void chkIgnoreGlobalCooldown_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreGlobalCooldown = chkIgnoreGlobalCooldown.Checked;
-        }
-
-        private void chkIgnoreCdr_CheckedChanged(object sender, EventArgs e)
-        {
-            mEditorItem.IgnoreCooldownReduction = chkIgnoreCdr.Checked;
-        }
-
-        private void txtCannotCast_TextChanged(object sender, EventArgs e)
-        {
-            mEditorItem.CannotCastMessage = txtCannotCast.Text;
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Collect folders
-            var mFolders = new List<string>();
-            foreach (var itm in SpellBase.Lookup)
-            {
-                if (!string.IsNullOrEmpty(((SpellBase)itm.Value).Folder) &&
-                    !mFolders.Contains(((SpellBase)itm.Value).Folder))
-                {
-                    mFolders.Add(((SpellBase)itm.Value).Folder);
-                    if (!mKnownFolders.Contains(((SpellBase)itm.Value).Folder))
-                    {
-                        mKnownFolders.Add(((SpellBase)itm.Value).Folder);
-                    }
-                }
-
-                if (!string.IsNullOrWhiteSpace(((SpellBase)itm.Value).CooldownGroup) &&
-                    !mKnownCooldownGroups.Contains(((SpellBase)itm.Value).CooldownGroup))
-                {
-                    mKnownCooldownGroups.Add(((SpellBase)itm.Value).CooldownGroup);
-                }
-            }
-
-            // Do we add item cooldown groups as well?
-            if (Options.Combat.LinkSpellAndItemCooldowns)
-            {
-                foreach (var itm in ItemBase.Lookup)
-                {
-                    if (!string.IsNullOrWhiteSpace(((ItemBase)itm.Value).CooldownGroup) &&
-                    !mKnownCooldownGroups.Contains(((ItemBase)itm.Value).CooldownGroup))
-                    {
-                        mKnownCooldownGroups.Add(((ItemBase)itm.Value).CooldownGroup);
-                    }
-                }
-            }
-
-            mFolders.Sort();
-            mKnownFolders.Sort();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-
-            mKnownCooldownGroups.Sort();
-            cmbCooldownGroup.Items.Clear();
-            cmbCooldownGroup.Items.Add(string.Empty);
-            cmbCooldownGroup.Items.AddRange(mKnownCooldownGroups.ToArray());
-
-            var items = SpellBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                new KeyValuePair<string, string>(((SpellBase)pair.Value)?.Name ?? Models.DatabaseObject<SpellBase>.Deleted, ((SpellBase)pair.Value)?.Folder ?? ""))).ToArray();
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.SpellEditor.folderprompt, Strings.SpellEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    mEditorItem.Folder = folderName;
-                    lstGameObjects.ExpandFolder(folderName);
-                    InitEditor();
-                    cmbFolder.Text = folderName;
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mEditorItem.Folder = cmbFolder.Text;
-            InitEditor();
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
-            InitEditor();
-        }
-
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
-
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.SpellEditor.searchplaceholder;
-            }
-        }
-
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
-        {
-            txtSearch.Text = Strings.SpellEditor.searchplaceholder;
-        }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.SpellEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.SpellEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
-
-        private void cmbTickAnimation_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Guid animationId = AnimationBase.IdFromList(cmbTickAnimation.SelectedIndex - 1);
-            mEditorItem.TickAnimation = AnimationBase.Get(animationId);
+            picSprite.BackgroundImage = null;
         }
     }
 
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Spell);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.SpellEditor.deleteprompt, Strings.SpellEditor.deletetitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && lstGameObjects.Focused)
+        {
+            mCopiedItem = mEditorItem.JsonData;
+            toolStripItemPaste.Enabled = true;
+        }
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused)
+        {
+            mEditorItem.Load(mCopiedItem, true);
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.SpellEditor.undoprompt, Strings.SpellEditor.undotitle, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                mEditorItem.RestoreBackup();
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = mEditorItem != null && mCopiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control)
+        {
+            if (e.KeyCode == Keys.N)
+            {
+                toolStripItemNew_Click(null, null);
+            }
+        }
+    }
+
+    private void chkFriendly_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.Friendly = chkFriendly.Checked;
+    }
+
+    private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.ScalingStat = cmbScalingStat.SelectedIndex;
+    }
+
+    private void btnDynamicRequirements_Click(object sender, EventArgs e)
+    {
+        var frm = new FrmDynamicRequirements(mEditorItem.CastingRequirements, RequirementType.Spell);
+        frm.ShowDialog();
+    }
+
+    private void cmbCastSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CastSpriteOverride = TextUtils.SanitizeNone(cmbCastSprite?.Text);
+    }
+
+    private void cmbCastAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CastAnimation = AnimationBase.Get(AnimationBase.IdFromList(cmbCastAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbHitAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.HitAnimation = AnimationBase.Get(AnimationBase.IdFromList(cmbHitAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbProjectile_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.ProjectileId = ProjectileBase.IdFromList(cmbProjectile.SelectedIndex);
+    }
+
+    private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.EventId = EventBase.IdFromList(cmbEvent.SelectedIndex - 1);
+    }
+
+    private void btnVisualMapSelector_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId, (int)nudWarpX.Value, (int)nudWarpY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbWarpMap.SelectedIndex = i;
+                    mEditorItem.Warp.MapId = MapList.OrderedMaps[i].MapId;
+
+                    break;
+                }
+            }
+
+            nudWarpX.Value = frmWarpSelection.GetX();
+            mEditorItem.Warp.X = frmWarpSelection.GetX();
+            nudWarpY.Value = frmWarpSelection.GetY();
+            mEditorItem.Warp.Y = frmWarpSelection.GetY();
+        }
+    }
+
+    private void cmbWarpMap_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbWarpMap.SelectedIndex > -1 && mEditorItem != null)
+        {
+            mEditorItem.Warp.MapId = MapList.OrderedMaps[cmbWarpMap.SelectedIndex].MapId;
+        }
+    }
+
+    private void nudWarpX_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Warp.X = (byte)nudWarpX.Value;
+    }
+
+    private void nudWarpY_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Warp.Y = (byte)nudWarpY.Value;
+    }
+
+    private void cmbDirection_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Warp.Dir = (byte)cmbDirection.SelectedIndex;
+    }
+
+    private void nudCastDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CastDuration = (int)nudCastDuration.Value;
+    }
+
+    private void nudCooldownDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CooldownDuration = (int)nudCooldownDuration.Value;
+    }
+
+    private void nudHitRadius_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.HitRadius = (int)nudHitRadius.Value;
+    }
+
+    private void nudHPCost_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalCost[(int)Vital.Health] = (int)nudHPCost.Value;
+    }
+
+    private void nudMpCost_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.VitalCost[(int)Vital.Mana] = (int)nudMpCost.Value;
+    }
+
+    private void nudHPDamage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.VitalDiff[(int)Vital.Health] = (int)nudHPDamage.Value;
+    }
+
+    private void nudMPDamage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.VitalDiff[(int)Vital.Mana] = (int)nudMPDamage.Value;
+    }
+
+    private void nudStr_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.StatDiff[(int)Stat.Attack] = (int)nudStr.Value;
+    }
+
+    private void nudMag_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.StatDiff[(int)Stat.AbilityPower] = (int)nudMag.Value;
+    }
+
+    private void nudDef_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.StatDiff[(int)Stat.Defense] = (int)nudDef.Value;
+    }
+
+    private void nudMR_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.StatDiff[(int)Stat.MagicResist] = (int)nudMR.Value;
+    }
+
+    private void nudSpd_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.StatDiff[(int)Stat.Speed] = (int)nudSpd.Value;
+    }
+
+    private void nudStrPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.PercentageStatDiff[(int)Stat.Attack] = (int)nudStrPercentage.Value;
+    }
+
+    private void nudMagPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.PercentageStatDiff[(int)Stat.AbilityPower] = (int)nudMagPercentage.Value;
+    }
+
+    private void nudDefPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.PercentageStatDiff[(int)Stat.Defense] = (int)nudDefPercentage.Value;
+    }
+
+    private void nudMRPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.PercentageStatDiff[(int)Stat.MagicResist] = (int)nudMRPercentage.Value;
+    }
+
+    private void nudSpdPercentage_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.PercentageStatDiff[(int)Stat.Speed] = (int)nudSpdPercentage.Value;
+    }
+
+    private void nudBuffDuration_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.Duration = (int)nudBuffDuration.Value;
+    }
+
+    private void nudTick_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.HotDotInterval = (int)nudTick.Value;
+    }
+
+    private void nudCritChance_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.CritChance = (int)nudCritChance.Value;
+    }
+
+    private void nudScaling_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.Scaling = (int)nudScaling.Value;
+    }
+
+    private void nudCastRange_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.CastRange = (int)nudCastRange.Value;
+    }
+
+    private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.CritMultiplier = (double)nudCritMultiplier.Value;
+    }
+
+    private void nudOnHitDuration_ValueChanged(object sender, EventArgs e)
+    {
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.OnHit)
+        {
+            mEditorItem.Combat.OnHitDuration = (int)nudDuration.Value;
+        }
+
+        if (cmbTargetType.SelectedIndex == (int)SpellTargetType.Trap)
+        {
+            mEditorItem.Combat.TrapDuration = (int)nudDuration.Value;
+        }
+    }
+
+    private void chkBound_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Bound = chkBound.Checked;
+    }
+
+    private void btnAddCooldownGroup_Click(object sender, EventArgs e)
+    {
+        var cdGroupName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.SpellEditor.CooldownGroupPrompt, Strings.SpellEditor.CooldownGroupTitle, ref cdGroupName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(cdGroupName))
+        {
+            if (!cmbCooldownGroup.Items.Contains(cdGroupName))
+            {
+                mEditorItem.CooldownGroup = cdGroupName;
+                mKnownCooldownGroups.Add(cdGroupName);
+                InitEditor();
+                cmbCooldownGroup.Text = cdGroupName;
+            }
+        }
+    }
+
+    private void cmbCooldownGroup_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CooldownGroup = cmbCooldownGroup.Text;
+    }
+
+    private void chkIgnoreGlobalCooldown_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreGlobalCooldown = chkIgnoreGlobalCooldown.Checked;
+    }
+
+    private void chkIgnoreCdr_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IgnoreCooldownReduction = chkIgnoreCdr.Checked;
+    }
+
+    private void txtCannotCast_TextChanged(object sender, EventArgs e)
+    {
+        mEditorItem.CannotCastMessage = txtCannotCast.Text;
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Collect folders
+        var mFolders = new List<string>();
+        foreach (var itm in SpellBase.Lookup)
+        {
+            if (!string.IsNullOrEmpty(((SpellBase)itm.Value).Folder) &&
+                !mFolders.Contains(((SpellBase)itm.Value).Folder))
+            {
+                mFolders.Add(((SpellBase)itm.Value).Folder);
+                if (!mKnownFolders.Contains(((SpellBase)itm.Value).Folder))
+                {
+                    mKnownFolders.Add(((SpellBase)itm.Value).Folder);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(((SpellBase)itm.Value).CooldownGroup) &&
+                !mKnownCooldownGroups.Contains(((SpellBase)itm.Value).CooldownGroup))
+            {
+                mKnownCooldownGroups.Add(((SpellBase)itm.Value).CooldownGroup);
+            }
+        }
+
+        // Do we add item cooldown groups as well?
+        if (Options.Combat.LinkSpellAndItemCooldowns)
+        {
+            foreach (var itm in ItemBase.Lookup)
+            {
+                if (!string.IsNullOrWhiteSpace(((ItemBase)itm.Value).CooldownGroup) &&
+                !mKnownCooldownGroups.Contains(((ItemBase)itm.Value).CooldownGroup))
+                {
+                    mKnownCooldownGroups.Add(((ItemBase)itm.Value).CooldownGroup);
+                }
+            }
+        }
+
+        mFolders.Sort();
+        mKnownFolders.Sort();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+        cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+        mKnownCooldownGroups.Sort();
+        cmbCooldownGroup.Items.Clear();
+        cmbCooldownGroup.Items.Add(string.Empty);
+        cmbCooldownGroup.Items.AddRange(mKnownCooldownGroups.ToArray());
+
+        var items = SpellBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+            new KeyValuePair<string, string>(((SpellBase)pair.Value)?.Name ?? Models.DatabaseObject<SpellBase>.Deleted, ((SpellBase)pair.Value)?.Folder ?? ""))).ToArray();
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.SpellEditor.folderprompt, Strings.SpellEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                mEditorItem.Folder = folderName;
+                lstGameObjects.ExpandFolder(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.SpellEditor.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.SpellEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.SpellEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.SpellEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
+
+    private void cmbTickAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        Guid animationId = AnimationBase.IdFromList(cmbTickAnimation.SelectedIndex - 1);
+        mEditorItem.TickAnimation = AnimationBase.Get(animationId);
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmTime.cs
+++ b/Intersect.Editor/Forms/Editors/frmTime.cs
@@ -7,178 +7,176 @@ using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
 using Intersect.GameObjects;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmTime : Form
 {
 
-    public partial class FrmTime : Form
+    private TimeBase mBackupTime;
+
+    private Bitmap mTileBackbuffer;
+
+    private TimeBase mYTime;
+
+    public FrmTime()
     {
+        InitializeComponent();
+        InitLocalization();
+    }
 
-        private TimeBase mBackupTime;
-
-        private Bitmap mTileBackbuffer;
-
-        private TimeBase mYTime;
-
-        public FrmTime()
+    private void InitLocalization()
+    {
+        Text = Strings.TimeEditor.title;
+        lblTimes.Text = Strings.TimeEditor.times;
+        grpSettings.Text = Strings.TimeEditor.settings;
+        lblIntervals.Text = Strings.TimeEditor.interval;
+        cmbIntervals.Items.Clear();
+        for (var i = 0; i < Strings.TimeEditor.intervals.Count; i++)
         {
-            InitializeComponent();
-            InitLocalization();
+            cmbIntervals.Items.Add(Strings.TimeEditor.intervals[i]);
         }
 
-        private void InitLocalization()
+        chkSync.Text = Strings.TimeEditor.sync;
+        lblRate.Text = Strings.TimeEditor.rate;
+        lblRateSuffix.Text = Strings.TimeEditor.ratesuffix;
+        lblRateDesc.Text = Strings.TimeEditor.ratedesc;
+        grpRangeOptions.Text = Strings.TimeEditor.overlay;
+        lblColorDesc.Text = Strings.TimeEditor.colorpaneldesc;
+        btnSave.Text = Strings.TimeEditor.save;
+        btnCancel.Text = Strings.TimeEditor.cancel;
+    }
+
+    public void InitEditor(TimeBase time)
+    {
+        //Create a backup in case we want to revert
+        mYTime = time;
+        mBackupTime = new TimeBase();
+        mBackupTime.LoadFromJson(time.GetInstanceJson());
+
+        mTileBackbuffer = new Bitmap(pnlColor.Width, pnlColor.Height);
+        UpdateList(TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex));
+        typeof(Panel).InvokeMember(
+            "DoubleBuffered", BindingFlags.SetProperty | BindingFlags.Instance | BindingFlags.NonPublic, null,
+            pnlColor, new object[] {true}
+        );
+
+        chkSync.Checked = mYTime.SyncTime;
+        txtTimeRate.Text = mYTime.Rate.ToString();
+        cmbIntervals.SelectedIndex = TimeBase.GetIntervalIndex(mYTime.RangeInterval);
+        UpdateList(mYTime.RangeInterval);
+        txtTimeRate.Enabled = !mYTime.SyncTime;
+    }
+
+    private void cmbIntervals_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (mYTime.RangeInterval != TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex))
         {
-            Text = Strings.TimeEditor.title;
-            lblTimes.Text = Strings.TimeEditor.times;
-            grpSettings.Text = Strings.TimeEditor.settings;
-            lblIntervals.Text = Strings.TimeEditor.interval;
-            cmbIntervals.Items.Clear();
-            for (var i = 0; i < Strings.TimeEditor.intervals.Count; i++)
-            {
-                cmbIntervals.Items.Add(Strings.TimeEditor.intervals[i]);
-            }
-
-            chkSync.Text = Strings.TimeEditor.sync;
-            lblRate.Text = Strings.TimeEditor.rate;
-            lblRateSuffix.Text = Strings.TimeEditor.ratesuffix;
-            lblRateDesc.Text = Strings.TimeEditor.ratedesc;
-            grpRangeOptions.Text = Strings.TimeEditor.overlay;
-            lblColorDesc.Text = Strings.TimeEditor.colorpaneldesc;
-            btnSave.Text = Strings.TimeEditor.save;
-            btnCancel.Text = Strings.TimeEditor.cancel;
-        }
-
-        public void InitEditor(TimeBase time)
-        {
-            //Create a backup in case we want to revert
-            mYTime = time;
-            mBackupTime = new TimeBase();
-            mBackupTime.LoadFromJson(time.GetInstanceJson());
-
-            mTileBackbuffer = new Bitmap(pnlColor.Width, pnlColor.Height);
-            UpdateList(TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex));
-            typeof(Panel).InvokeMember(
-                "DoubleBuffered", BindingFlags.SetProperty | BindingFlags.Instance | BindingFlags.NonPublic, null,
-                pnlColor, new object[] {true}
-            );
-
-            chkSync.Checked = mYTime.SyncTime;
-            txtTimeRate.Text = mYTime.Rate.ToString();
-            cmbIntervals.SelectedIndex = TimeBase.GetIntervalIndex(mYTime.RangeInterval);
+            mYTime.RangeInterval = TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex);
             UpdateList(mYTime.RangeInterval);
-            txtTimeRate.Enabled = !mYTime.SyncTime;
+            mYTime.ResetColors();
+            grpRangeOptions.Hide();
         }
+    }
 
-        private void cmbIntervals_SelectedIndexChanged(object sender, EventArgs e)
+    private void UpdateList(int duration)
+    {
+        lstTimes.Items.Clear();
+        var time = new DateTime(2000, 1, 1, 0, 0, 0);
+        for (var i = 0; i < 1440; i += duration)
         {
-            if (mYTime.RangeInterval != TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex))
-            {
-                mYTime.RangeInterval = TimeBase.GetTimeInterval(cmbIntervals.SelectedIndex);
-                UpdateList(mYTime.RangeInterval);
-                mYTime.ResetColors();
-                grpRangeOptions.Hide();
-            }
+            var addRange = time.ToString("h:mm:ss tt") + " " + Strings.TimeEditor.to + " ";
+            time = time.AddMinutes(duration);
+            addRange += time.ToString("h:mm:ss tt");
+            lstTimes.Items.Add(addRange);
         }
+    }
 
-        private void UpdateList(int duration)
+    private void pnlColor_DoubleClick(object sender, EventArgs e)
+    {
+        clrSelector.Color = pnlColor.BackColor;
+        if (clrSelector.ShowDialog() == DialogResult.OK)
         {
-            lstTimes.Items.Clear();
-            var time = new DateTime(2000, 1, 1, 0, 0, 0);
-            for (var i = 0; i < 1440; i += duration)
-            {
-                var addRange = time.ToString("h:mm:ss tt") + " " + Strings.TimeEditor.to + " ";
-                time = time.AddMinutes(duration);
-                addRange += time.ToString("h:mm:ss tt");
-                lstTimes.Items.Add(addRange);
-            }
+            pnlColor.BackColor = clrSelector.Color;
+            mYTime.DaylightHues[lstTimes.SelectedIndex].R = pnlColor.BackColor.R;
+            mYTime.DaylightHues[lstTimes.SelectedIndex].G = pnlColor.BackColor.G;
+            mYTime.DaylightHues[lstTimes.SelectedIndex].B = pnlColor.BackColor.B;
         }
+    }
 
-        private void pnlColor_DoubleClick(object sender, EventArgs e)
+    private void pnlColor_Paint(object sender, PaintEventArgs e)
+    {
+        var g = System.Drawing.Graphics.FromImage(mTileBackbuffer);
+        g.Clear(System.Drawing.Color.Transparent);
+        g.DrawImage(pnlColor.BackgroundImage, new System.Drawing.Point(0, 0));
+        Brush brush = new SolidBrush(
+            System.Drawing.Color.FromArgb(
+                scrlAlpha.Value, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
+            )
+        );
+
+        g.FillRectangle(brush, new Rectangle(0, 0, pnlColor.Width, pnlColor.Height));
+        e.Graphics.DrawImage(mTileBackbuffer, new System.Drawing.Point(0, 0));
+    }
+
+    private void scrlAlpha_Scroll(object sender, ScrollValueEventArgs e)
+    {
+        var brightness = (int) ((255 - scrlAlpha.Value) / 255f * 100);
+        lblBrightness.Text = Strings.TimeEditor.brightness.ToString(brightness.ToString());
+        mYTime.DaylightHues[lstTimes.SelectedIndex].A = (byte) scrlAlpha.Value;
+        pnlColor.Refresh();
+    }
+
+    private void lstTimes_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstTimes.SelectedIndex == -1)
         {
-            clrSelector.Color = pnlColor.BackColor;
-            if (clrSelector.ShowDialog() == DialogResult.OK)
-            {
-                pnlColor.BackColor = clrSelector.Color;
-                mYTime.DaylightHues[lstTimes.SelectedIndex].R = pnlColor.BackColor.R;
-                mYTime.DaylightHues[lstTimes.SelectedIndex].G = pnlColor.BackColor.G;
-                mYTime.DaylightHues[lstTimes.SelectedIndex].B = pnlColor.BackColor.B;
-            }
+            grpRangeOptions.Hide();
+
+            return;
         }
 
-        private void pnlColor_Paint(object sender, PaintEventArgs e)
+        grpRangeOptions.Show();
+        pnlColor.BackColor = System.Drawing.Color.FromArgb(
+            255, mYTime.DaylightHues[lstTimes.SelectedIndex].R, mYTime.DaylightHues[lstTimes.SelectedIndex].G,
+            mYTime.DaylightHues[lstTimes.SelectedIndex].B
+        );
+
+        scrlAlpha.Value = mYTime.DaylightHues[lstTimes.SelectedIndex].A;
+        var brightness = (int) ((255 - scrlAlpha.Value) / 255f * 100);
+        lblBrightness.Text = Strings.TimeEditor.brightness.ToString(brightness);
+        pnlColor.Refresh();
+        Core.Graphics.LightColor = mYTime.DaylightHues[lstTimes.SelectedIndex];
+    }
+
+    private void chkSync_CheckedChanged(object sender, EventArgs e)
+    {
+        mYTime.SyncTime = chkSync.Checked;
+        txtTimeRate.Enabled = !mYTime.SyncTime;
+    }
+
+    private void txtTimeRate_TextChanged(object sender, EventArgs e)
+    {
+        if (float.TryParse(txtTimeRate.Text, out var val))
         {
-            var g = System.Drawing.Graphics.FromImage(mTileBackbuffer);
-            g.Clear(System.Drawing.Color.Transparent);
-            g.DrawImage(pnlColor.BackgroundImage, new System.Drawing.Point(0, 0));
-            Brush brush = new SolidBrush(
-                System.Drawing.Color.FromArgb(
-                    scrlAlpha.Value, pnlColor.BackColor.R, pnlColor.BackColor.G, pnlColor.BackColor.B
-                )
-            );
-
-            g.FillRectangle(brush, new Rectangle(0, 0, pnlColor.Width, pnlColor.Height));
-            e.Graphics.DrawImage(mTileBackbuffer, new System.Drawing.Point(0, 0));
+            mYTime.Rate = val;
         }
+    }
 
-        private void scrlAlpha_Scroll(object sender, ScrollValueEventArgs e)
-        {
-            var brightness = (int) ((255 - scrlAlpha.Value) / 255f * 100);
-            lblBrightness.Text = Strings.TimeEditor.brightness.ToString(brightness.ToString());
-            mYTime.DaylightHues[lstTimes.SelectedIndex].A = (byte) scrlAlpha.Value;
-            pnlColor.Refresh();
-        }
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendSaveTime(mYTime.GetInstanceJson());
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
 
-        private void lstTimes_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstTimes.SelectedIndex == -1)
-            {
-                grpRangeOptions.Hide();
-
-                return;
-            }
-
-            grpRangeOptions.Show();
-            pnlColor.BackColor = System.Drawing.Color.FromArgb(
-                255, mYTime.DaylightHues[lstTimes.SelectedIndex].R, mYTime.DaylightHues[lstTimes.SelectedIndex].G,
-                mYTime.DaylightHues[lstTimes.SelectedIndex].B
-            );
-
-            scrlAlpha.Value = mYTime.DaylightHues[lstTimes.SelectedIndex].A;
-            var brightness = (int) ((255 - scrlAlpha.Value) / 255f * 100);
-            lblBrightness.Text = Strings.TimeEditor.brightness.ToString(brightness);
-            pnlColor.Refresh();
-            Core.Graphics.LightColor = mYTime.DaylightHues[lstTimes.SelectedIndex];
-        }
-
-        private void chkSync_CheckedChanged(object sender, EventArgs e)
-        {
-            mYTime.SyncTime = chkSync.Checked;
-            txtTimeRate.Enabled = !mYTime.SyncTime;
-        }
-
-        private void txtTimeRate_TextChanged(object sender, EventArgs e)
-        {
-            if (float.TryParse(txtTimeRate.Text, out var val))
-            {
-                mYTime.Rate = val;
-            }
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendSaveTime(mYTime.GetInstanceJson());
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            mYTime.LoadFromJson(mBackupTime.GetInstanceJson());
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mYTime.LoadFromJson(mBackupTime.GetInstanceJson());
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
     }
 
 }

--- a/Intersect.Editor/Forms/Editors/frmVariable.cs
+++ b/Intersect.Editor/Forms/Editors/frmVariable.cs
@@ -7,790 +7,788 @@ using Intersect.Enums;
 using Intersect.GameObjects;
 using Intersect.Models;
 
-namespace Intersect.Editor.Forms.Editors
+namespace Intersect.Editor.Forms.Editors;
+
+
+public partial class FrmSwitchVariable : EditorForm
 {
 
-    public partial class FrmSwitchVariable : EditorForm
+    private List<IDatabaseObject> mChanged = new List<IDatabaseObject>();
+
+    private IDatabaseObject mEditorItem;
+
+    private List<string> mExpandedFolders = new List<string>();
+
+    private List<string> mGlobalExpandedFolders = new List<string>();
+
+    private List<string> mGlobalKnownFolders = new List<string>();
+
+    private List<string> mKnownFolders = new List<string>();
+
+    private List<string> mGuildKnownFolders = new List<string>();
+
+    private List<string> mGuildExpandedFolders = new List<string>();
+
+    private List<string> mUserKnownFolders = new List<string>();
+
+    private List<string> mUserExpandedFolders = new List<string>();
+
+    public FrmSwitchVariable()
     {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private List<IDatabaseObject> mChanged = new List<IDatabaseObject>();
+        InitLocalization();
+        nudVariableValue.Minimum = long.MinValue;
+        nudVariableValue.Maximum = long.MaxValue;
 
-        private IDatabaseObject mEditorItem;
+        lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, null, toolStripItemUndo_Click, null, toolStripItemDelete_Click);
+    }
 
-        private List<string> mExpandedFolders = new List<string>();
-
-        private List<string> mGlobalExpandedFolders = new List<string>();
-
-        private List<string> mGlobalKnownFolders = new List<string>();
-
-        private List<string> mKnownFolders = new List<string>();
-
-        private List<string> mGuildKnownFolders = new List<string>();
-
-        private List<string> mGuildExpandedFolders = new List<string>();
-
-        private List<string> mUserKnownFolders = new List<string>();
-
-        private List<string> mUserExpandedFolders = new List<string>();
-
-        public FrmSwitchVariable()
+    private void AssignEditorItem(Guid id)
+    {
+        if (id != Guid.Empty)
         {
-            ApplyHooks();
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            InitLocalization();
-            nudVariableValue.Minimum = long.MinValue;
-            nudVariableValue.Maximum = long.MaxValue;
-
-            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, null, toolStripItemUndo_Click, null, toolStripItemDelete_Click);
-        }
-
-        private void AssignEditorItem(Guid id)
-        {
-            if (id != Guid.Empty)
-            {
-                IDatabaseObject obj = null;
-                if (rdoPlayerVariables.Checked)
-                {
-                    obj = PlayerVariableBase.Get(id);
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    obj = ServerVariableBase.Get(id);
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    obj = GuildVariableBase.Get(id);
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    obj = UserVariableBase.Get(id);
-                }
-
-                if (obj != null)
-                {
-                    mEditorItem = obj;
-                    if (!mChanged.Contains(obj))
-                    {
-                        mChanged.Add(obj);
-                        obj.MakeBackup();
-                    }
-                }
-            }
-
-            UpdateEditor();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.VariableEditor.title;
-            grpTypes.Text = Strings.VariableEditor.type;
-            grpList.Text = Strings.VariableEditor.list;
-            rdoPlayerVariables.Text = Strings.VariableEditor.playervariables;
-            rdoGlobalVariables.Text = Strings.VariableEditor.globalvariables;
-            rdoGuildVariables.Text = Strings.VariableEditor.guildvariables;
-            rdoUserVariables.Text = Strings.GameObjectStrings.UserVariables;
-            grpEditor.Text = Strings.VariableEditor.editor;
-            lblName.Text = Strings.VariableEditor.name;
-            grpValue.Text = Strings.VariableEditor.value;
-            cmbBooleanValue.Items.Clear();
-            cmbBooleanValue.Items.Add(Strings.VariableEditor.False);
-            cmbBooleanValue.Items.Add(Strings.VariableEditor.True);
-            cmbVariableType.Items.Clear();
-            foreach (var itm in Strings.VariableEditor.types)
-            {
-                cmbVariableType.Items.Add(itm.Value);
-            }
-
-            toolStripItemNew.ToolTipText = Strings.VariableEditor.New;
-            toolStripItemDelete.ToolTipText = Strings.VariableEditor.delete;
-            toolStripItemUndo.ToolTipText = Strings.VariableEditor.undo;
-
-            //Searching/Sorting
-            btnAlphabetical.ToolTipText = Strings.VariableEditor.sortalphabetically;
-            txtSearch.Text = Strings.VariableEditor.searchplaceholder;
-            lblFolder.Text = Strings.VariableEditor.folderlabel;
-
-            btnSave.Text = Strings.VariableEditor.save;
-            btnCancel.Text = Strings.VariableEditor.cancel;
-        }
-
-        protected override void GameObjectUpdatedDelegate(GameObjectType type)
-        {
-            if (type == GameObjectType.PlayerVariable)
-            {
-                InitEditor();
-                if (mEditorItem != null && !PlayerVariableBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-            else if (type == GameObjectType.ServerVariable)
-            {
-                InitEditor();
-                if (mEditorItem != null && !ServerVariableBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-            else if (type == GameObjectType.GuildVariable)
-            {
-                InitEditor();
-                if (mEditorItem != null && !GuildVariableBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-            else if (type == GameObjectType.UserVariable)
-            {
-                InitEditor();
-                if (mEditorItem != null && !UserVariableBase.Lookup.Values.Contains(mEditorItem))
-                {
-                    mEditorItem = null;
-                    UpdateEditor();
-                }
-            }
-        }
-
-        private void toolStripItemNew_Click(object sender, EventArgs e)
-        {
+            IDatabaseObject obj = null;
             if (rdoPlayerVariables.Checked)
             {
-                PacketSender.SendCreateObject(GameObjectType.PlayerVariable);
+                obj = PlayerVariableBase.Get(id);
             }
             else if (rdoGlobalVariables.Checked)
             {
-                PacketSender.SendCreateObject(GameObjectType.ServerVariable);
+                obj = ServerVariableBase.Get(id);
             }
             else if (rdoGuildVariables.Checked)
             {
-                PacketSender.SendCreateObject(GameObjectType.GuildVariable);
+                obj = GuildVariableBase.Get(id);
             }
             else if (rdoUserVariables.Checked)
             {
-                PacketSender.SendCreateObject(GameObjectType.UserVariable);
+                obj = UserVariableBase.Get(id);
+            }
+
+            if (obj != null)
+            {
+                mEditorItem = obj;
+                if (!mChanged.Contains(obj))
+                {
+                    mChanged.Add(obj);
+                    obj.MakeBackup();
+                }
             }
         }
 
-        private void toolStripItemUndo_Click(object sender, EventArgs e)
+        UpdateEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.VariableEditor.title;
+        grpTypes.Text = Strings.VariableEditor.type;
+        grpList.Text = Strings.VariableEditor.list;
+        rdoPlayerVariables.Text = Strings.VariableEditor.playervariables;
+        rdoGlobalVariables.Text = Strings.VariableEditor.globalvariables;
+        rdoGuildVariables.Text = Strings.VariableEditor.guildvariables;
+        rdoUserVariables.Text = Strings.GameObjectStrings.UserVariables;
+        grpEditor.Text = Strings.VariableEditor.editor;
+        lblName.Text = Strings.VariableEditor.name;
+        grpValue.Text = Strings.VariableEditor.value;
+        cmbBooleanValue.Items.Clear();
+        cmbBooleanValue.Items.Add(Strings.VariableEditor.False);
+        cmbBooleanValue.Items.Add(Strings.VariableEditor.True);
+        cmbVariableType.Items.Clear();
+        foreach (var itm in Strings.VariableEditor.types)
         {
-            if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+            cmbVariableType.Items.Add(itm.Value);
+        }
+
+        toolStripItemNew.ToolTipText = Strings.VariableEditor.New;
+        toolStripItemDelete.ToolTipText = Strings.VariableEditor.delete;
+        toolStripItemUndo.ToolTipText = Strings.VariableEditor.undo;
+
+        //Searching/Sorting
+        btnAlphabetical.ToolTipText = Strings.VariableEditor.sortalphabetically;
+        txtSearch.Text = Strings.VariableEditor.searchplaceholder;
+        lblFolder.Text = Strings.VariableEditor.folderlabel;
+
+        btnSave.Text = Strings.VariableEditor.save;
+        btnCancel.Text = Strings.VariableEditor.cancel;
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.PlayerVariable)
+        {
+            InitEditor();
+            if (mEditorItem != null && !PlayerVariableBase.Lookup.Values.Contains(mEditorItem))
             {
-                mEditorItem.RestoreBackup();
+                mEditorItem = null;
                 UpdateEditor();
             }
         }
-
-        private void toolStripItemDelete_Click(object sender, EventArgs e)
+        else if (type == GameObjectType.ServerVariable)
         {
-            if (mEditorItem != null)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.VariableEditor.deleteprompt, Strings.VariableEditor.deletecaption,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendDeleteObject(mEditorItem);
-                }
-            }
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            foreach (var item in mChanged)
-            {
-                item.RestoreBackup();
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void btnSave_Click(object sender, EventArgs e)
-        {
-            //Send Changed items
-            foreach (var item in mChanged)
-            {
-                PacketSender.SendSaveObject(item);
-                item.DeleteBackup();
-            }
-
-            Hide();
-            Globals.CurrentEditor = -1;
-            Dispose();
-        }
-
-        private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-
-        }
-
-        private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-
-        }
-        private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
-        {
-            VariableRadioChanged();
-        }
-
-        private void VariableRadioChanged()
-        {
-            mEditorItem = null;
-            lstGameObjects.ClearExpandedFolders();
             InitEditor();
-        }
-
-        private void UpdateToolStripItems()
-        {
-            toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
-            toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
-        }
-
-        private void UpdateEditor()
-        {
-            if (mEditorItem != null)
+            if (mEditorItem != null && !ServerVariableBase.Lookup.Values.Contains(mEditorItem))
             {
-                grpEditor.Show();
+                mEditorItem = null;
+                UpdateEditor();
+            }
+        }
+        else if (type == GameObjectType.GuildVariable)
+        {
+            InitEditor();
+            if (mEditorItem != null && !GuildVariableBase.Lookup.Values.Contains(mEditorItem))
+            {
+                mEditorItem = null;
+                UpdateEditor();
+            }
+        }
+        else if (type == GameObjectType.UserVariable)
+        {
+            InitEditor();
+            if (mEditorItem != null && !UserVariableBase.Lookup.Values.Contains(mEditorItem))
+            {
+                mEditorItem = null;
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        if (rdoPlayerVariables.Checked)
+        {
+            PacketSender.SendCreateObject(GameObjectType.PlayerVariable);
+        }
+        else if (rdoGlobalVariables.Checked)
+        {
+            PacketSender.SendCreateObject(GameObjectType.ServerVariable);
+        }
+        else if (rdoGuildVariables.Checked)
+        {
+            PacketSender.SendCreateObject(GameObjectType.GuildVariable);
+        }
+        else if (rdoUserVariables.Checked)
+        {
+            PacketSender.SendCreateObject(GameObjectType.UserVariable);
+        }
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (mChanged.Contains(mEditorItem) && mEditorItem != null)
+        {
+            mEditorItem.RestoreBackup();
+            UpdateEditor();
+        }
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (mEditorItem != null)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.VariableEditor.deleteprompt, Strings.VariableEditor.deletecaption,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendDeleteObject(mEditorItem);
+            }
+        }
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        foreach (var item in mChanged)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        //Send Changed items
+        foreach (var item in mChanged)
+        {
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void rdoPlayerVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void rdoGlobalVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+
+    }
+
+    private void rdoGuildVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+
+    }
+    private void rdoUserVariables_CheckedChanged(object sender, EventArgs e)
+    {
+        VariableRadioChanged();
+    }
+
+    private void VariableRadioChanged()
+    {
+        mEditorItem = null;
+        lstGameObjects.ClearExpandedFolders();
+        InitEditor();
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemDelete.Enabled = mEditorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = mEditorItem != null && lstGameObjects.Focused;
+    }
+
+    private void UpdateEditor()
+    {
+        if (mEditorItem != null)
+        {
+            grpEditor.Show();
+            grpValue.Hide();
+            if (rdoPlayerVariables.Checked)
+            {
+                lblObject.Text = Strings.VariableEditor.playervariable;
+                txtObjectName.Text = ((PlayerVariableBase) mEditorItem).Name;
+                txtId.Text = ((PlayerVariableBase) mEditorItem).TextId;
+                cmbFolder.Text = ((PlayerVariableBase) mEditorItem).Folder;
+                cmbVariableType.SelectedIndex = (int) (((PlayerVariableBase) mEditorItem).Type - 1);
+            }
+            else if (rdoGlobalVariables.Checked)
+            {
+                lblObject.Text = Strings.VariableEditor.globalvariable;
+                txtObjectName.Text = ((ServerVariableBase) mEditorItem).Name;
+                txtId.Text = ((ServerVariableBase) mEditorItem).TextId;
+                cmbFolder.Text = ((ServerVariableBase) mEditorItem).Folder;
+                cmbVariableType.SelectedIndex = (int) (((ServerVariableBase) mEditorItem).Type - 1);
+                grpValue.Show();
+            }
+            else if (rdoGuildVariables.Checked)
+            {
+                lblObject.Text = Strings.VariableEditor.guildvariable;
+                txtObjectName.Text = ((GuildVariableBase)mEditorItem).Name;
+                txtId.Text = ((GuildVariableBase)mEditorItem).TextId;
+                cmbFolder.Text = ((GuildVariableBase)mEditorItem).Folder;
+                cmbVariableType.SelectedIndex = (int)(((GuildVariableBase)mEditorItem).Type - 1);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                lblObject.Text = Strings.GameObjectStrings.UserVariable;
+                txtObjectName.Text = ((UserVariableBase)mEditorItem).Name;
+                txtId.Text = ((UserVariableBase)mEditorItem).TextId;
+                cmbFolder.Text = ((UserVariableBase)mEditorItem).Folder;
+                cmbVariableType.SelectedIndex = (int)(((UserVariableBase)mEditorItem).Type - 1);
+            }
+
+            InitValueGroup();
+        }
+        else
+        {
+            grpEditor.Hide();
+        }
+
+        UpdateToolStripItems();
+    }
+
+    private void UpdateSelection()
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            grpEditor.Show();
+            if (rdoPlayerVariables.Checked)
+            {
+                var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                lstGameObjects.SelectedNode.Text = obj.Name;
                 grpValue.Hide();
-                if (rdoPlayerVariables.Checked)
-                {
-                    lblObject.Text = Strings.VariableEditor.playervariable;
-                    txtObjectName.Text = ((PlayerVariableBase) mEditorItem).Name;
-                    txtId.Text = ((PlayerVariableBase) mEditorItem).TextId;
-                    cmbFolder.Text = ((PlayerVariableBase) mEditorItem).Folder;
-                    cmbVariableType.SelectedIndex = (int) (((PlayerVariableBase) mEditorItem).Type - 1);
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    lblObject.Text = Strings.VariableEditor.globalvariable;
-                    txtObjectName.Text = ((ServerVariableBase) mEditorItem).Name;
-                    txtId.Text = ((ServerVariableBase) mEditorItem).TextId;
-                    cmbFolder.Text = ((ServerVariableBase) mEditorItem).Folder;
-                    cmbVariableType.SelectedIndex = (int) (((ServerVariableBase) mEditorItem).Type - 1);
-                    grpValue.Show();
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    lblObject.Text = Strings.VariableEditor.guildvariable;
-                    txtObjectName.Text = ((GuildVariableBase)mEditorItem).Name;
-                    txtId.Text = ((GuildVariableBase)mEditorItem).TextId;
-                    cmbFolder.Text = ((GuildVariableBase)mEditorItem).Folder;
-                    cmbVariableType.SelectedIndex = (int)(((GuildVariableBase)mEditorItem).Type - 1);
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    lblObject.Text = Strings.GameObjectStrings.UserVariable;
-                    txtObjectName.Text = ((UserVariableBase)mEditorItem).Name;
-                    txtId.Text = ((UserVariableBase)mEditorItem).TextId;
-                    cmbFolder.Text = ((UserVariableBase)mEditorItem).Folder;
-                    cmbVariableType.SelectedIndex = (int)(((UserVariableBase)mEditorItem).Type - 1);
-                }
-
-                InitValueGroup();
             }
-            else
+            else if (rdoGlobalVariables.Checked)
             {
-                grpEditor.Hide();
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                lstGameObjects.SelectedNode.Text = obj.Name + " = " + obj.Value.ToString(obj.Type);
             }
-
-            UpdateToolStripItems();
-        }
-
-        private void UpdateSelection()
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+            else if (rdoPlayerVariables.Checked)
             {
-                grpEditor.Show();
-                if (rdoPlayerVariables.Checked)
-                {
-                    var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    lstGameObjects.SelectedNode.Text = obj.Name;
-                    grpValue.Hide();
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    lstGameObjects.SelectedNode.Text = obj.Name + " = " + obj.Value.ToString(obj.Type);
-                }
-                else if (rdoPlayerVariables.Checked)
-                {
-                    var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    lstGameObjects.SelectedNode.Text = obj.Name;
-                    grpValue.Hide();
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    lstGameObjects.SelectedNode.Text = obj.Name;
-                    grpValue.Hide();
-                }
-            }
-        }
-
-        private void txtObjectName_TextChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                grpEditor.Show();
-                grpValue.Hide();
-                if (rdoPlayerVariables.Checked)
-                {
-                    var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Name = txtObjectName.Text;
-                    lstGameObjects.UpdateText(obj.Name);
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Name = txtObjectName.Text;
-                    lstGameObjects.UpdateText(obj.Name + " = " + obj.Value.ToString());
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Name = txtObjectName.Text;
-                    lstGameObjects.UpdateText(obj.Name);
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Name = txtObjectName.Text;
-                    lstGameObjects.UpdateText(obj.Name);
-                }
-            }
-        }
-
-        private void txtId_KeyPress(object sender, KeyPressEventArgs e)
-        {
-            e.Handled = e.KeyChar == ' ';
-        }
-
-        private void txtId_TextChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoPlayerVariables.Checked)
-                {
-                    var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.TextId = txtId.Text;
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.TextId = txtId.Text;
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.TextId = txtId.Text;
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.TextId = txtId.Text;
-                }
-            }
-        }
-
-        private void cmbVariableType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoPlayerVariables.Checked)
-                {
-                    var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Type = (VariableDataType) (cmbVariableType.SelectedIndex + 1);
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Type = (VariableDataType) (cmbVariableType.SelectedIndex + 1);
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Type = (VariableDataType)(cmbVariableType.SelectedIndex + 1);
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Type = (VariableDataType)(cmbVariableType.SelectedIndex + 1);
-                }
-
-                InitValueGroup();
-                UpdateSelection();
-            }
-        }
-
-        private void InitValueGroup()
-        {
-            if (rdoPlayerVariables.Checked || rdoGuildVariables.Checked || rdoUserVariables.Checked)
-            {
+                var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                lstGameObjects.SelectedNode.Text = obj.Name;
                 grpValue.Hide();
             }
-            else
+            else if (rdoUserVariables.Checked)
+            {
+                var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                lstGameObjects.SelectedNode.Text = obj.Name;
+                grpValue.Hide();
+            }
+        }
+    }
+
+    private void txtObjectName_TextChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            grpEditor.Show();
+            grpValue.Hide();
+            if (rdoPlayerVariables.Checked)
+            {
+                var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Name = txtObjectName.Text;
+                lstGameObjects.UpdateText(obj.Name);
+            }
+            else if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Name = txtObjectName.Text;
+                lstGameObjects.UpdateText(obj.Name + " = " + obj.Value.ToString());
+            }
+            else if (rdoGuildVariables.Checked)
+            {
+                var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Name = txtObjectName.Text;
+                lstGameObjects.UpdateText(obj.Name);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Name = txtObjectName.Text;
+                lstGameObjects.UpdateText(obj.Name);
+            }
+        }
+    }
+
+    private void txtId_KeyPress(object sender, KeyPressEventArgs e)
+    {
+        e.Handled = e.KeyChar == ' ';
+    }
+
+    private void txtId_TextChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            if (rdoPlayerVariables.Checked)
+            {
+                var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.TextId = txtId.Text;
+            }
+            else if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.TextId = txtId.Text;
+            }
+            else if (rdoGuildVariables.Checked)
+            {
+                var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.TextId = txtId.Text;
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.TextId = txtId.Text;
+            }
+        }
+    }
+
+    private void cmbVariableType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            if (rdoPlayerVariables.Checked)
+            {
+                var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Type = (VariableDataType) (cmbVariableType.SelectedIndex + 1);
+            }
+            else if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Type = (VariableDataType) (cmbVariableType.SelectedIndex + 1);
+            }
+            else if (rdoGuildVariables.Checked)
+            {
+                var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Type = (VariableDataType)(cmbVariableType.SelectedIndex + 1);
+            }
+            else if (rdoUserVariables.Checked)
+            {
+                var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Type = (VariableDataType)(cmbVariableType.SelectedIndex + 1);
+            }
+
+            InitValueGroup();
+            UpdateSelection();
+        }
+    }
+
+    private void InitValueGroup()
+    {
+        if (rdoPlayerVariables.Checked || rdoGuildVariables.Checked || rdoUserVariables.Checked)
+        {
+            grpValue.Hide();
+        }
+        else
+        {
+            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                cmbBooleanValue.Hide();
+                nudVariableValue.Hide();
+                txtStringValue.Hide();
+                switch (obj.Type)
+                {
+                    case VariableDataType.Boolean:
+                        cmbBooleanValue.Show();
+                        cmbBooleanValue.SelectedIndex = Convert.ToInt32(obj.Value.Boolean);
+
+                        break;
+
+                    case VariableDataType.Integer:
+                        nudVariableValue.Show();
+                        nudVariableValue.Value = obj.Value.Integer;
+
+                        break;
+
+                    case VariableDataType.Number:
+                        break;
+
+                    case VariableDataType.String:
+                        txtStringValue.Show();
+                        txtStringValue.Text = obj.Value.String;
+
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+    }
+
+    private void nudVariableValue_ValueChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                if (obj != null)
+                {
+                    obj.Value.Integer = (long)nudVariableValue.Value;
+                    UpdateSelection();
+                }
+            }
+        }
+    }
+
+    private void cmbBooleanValue_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                if (obj != null)
+                {
+                    obj.Value.Boolean = Convert.ToBoolean(cmbBooleanValue.SelectedIndex);
+                    UpdateSelection();
+                }
+            }
+
+            UpdateSelection();
+        }
+    }
+
+    private void txtStringValue_TextChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
+        {
+            if (rdoGlobalVariables.Checked)
+            {
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                if (obj != null)
+                {
+                    obj.Value.String = txtStringValue.Text;
+                    UpdateSelection();
+                }
+            }
+        }
+    }
+
+    #region "Item List - Folders, Searching, Sorting, Etc"
+
+    public void InitEditor()
+    {
+        //Fix Title
+        if (rdoPlayerVariables.Checked)
+        {
+            grpVariables.Text = rdoPlayerVariables.Text;
+        }
+        else if (rdoGlobalVariables.Checked)
+        {
+            grpVariables.Text = rdoGlobalVariables.Text;
+        }
+        else if (rdoGuildVariables.Checked)
+        {
+            grpVariables.Text = rdoGuildVariables.Text;
+        }
+        else if (rdoUserVariables.Checked)
+        {
+            grpVariables.Text = rdoUserVariables.Text;
+        }
+
+        grpEditor.Hide();
+        cmbBooleanValue.Hide();
+        nudVariableValue.Hide();
+        txtStringValue.Hide();
+
+        //Collect folders
+        var mFolders = new List<string>();
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add("");
+
+        if (rdoPlayerVariables.Checked)
+        {
+            foreach (var itm in PlayerVariableBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((PlayerVariableBase) itm.Value).Folder) &&
+                    !mFolders.Contains(((PlayerVariableBase) itm.Value).Folder))
+                {
+                    mFolders.Add(((PlayerVariableBase) itm.Value).Folder);
+                    if (!mKnownFolders.Contains(((PlayerVariableBase) itm.Value).Folder))
+                    {
+                        mKnownFolders.Add(((PlayerVariableBase) itm.Value).Folder);
+                    }
+                }
+            }
+
+            mKnownFolders.Sort();
+            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+            lblId.Text = Strings.VariableEditor.textidpv;
+        }
+        else if (rdoGlobalVariables.Checked)
+        {
+            foreach (var itm in ServerVariableBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((ServerVariableBase) itm.Value).Folder) &&
+                    !mFolders.Contains(((ServerVariableBase) itm.Value).Folder))
+                {
+                    mFolders.Add(((ServerVariableBase) itm.Value).Folder);
+                    if (!mGlobalKnownFolders.Contains(((ServerVariableBase) itm.Value).Folder))
+                    {
+                        mGlobalKnownFolders.Add(((ServerVariableBase) itm.Value).Folder);
+                    }
+                }
+            }
+
+            mGlobalKnownFolders.Sort();
+            cmbFolder.Items.AddRange(mGlobalKnownFolders.ToArray());
+            lblId.Text = Strings.VariableEditor.textidgv;
+        }
+        else if (rdoGuildVariables.Checked)
+        {
+            foreach (var itm in GuildVariableBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((GuildVariableBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((GuildVariableBase)itm.Value).Folder))
+                {
+                    mFolders.Add(((GuildVariableBase)itm.Value).Folder);
+                    if (!mGuildKnownFolders.Contains(((GuildVariableBase)itm.Value).Folder))
+                    {
+                        mGuildKnownFolders.Add(((GuildVariableBase)itm.Value).Folder);
+                    }
+                }
+            }
+
+            mGuildKnownFolders.Sort();
+            cmbFolder.Items.AddRange(mGuildKnownFolders.ToArray());
+            lblId.Text = Strings.VariableEditor.textidguildvar;
+        }
+        else if (rdoUserVariables.Checked)
+        {
+            foreach (var itm in UserVariableBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((UserVariableBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((UserVariableBase)itm.Value).Folder))
+                {
+                    mFolders.Add(((UserVariableBase)itm.Value).Folder);
+                    if (!mUserKnownFolders.Contains(((UserVariableBase)itm.Value).Folder))
+                    {
+                        mUserKnownFolders.Add(((UserVariableBase)itm.Value).Folder);
+                    }
+                }
+            }
+
+            mUserKnownFolders.Sort();
+            cmbFolder.Items.AddRange(mUserKnownFolders.ToArray());
+            lblId.Text = Strings.VariableEditor.UserVariableId;
+        }
+
+        mFolders.Sort();
+
+        KeyValuePair<Guid, KeyValuePair<string, string>>[] items = null;
+
+        if (rdoPlayerVariables.Checked)
+        {
+            items = PlayerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((PlayerVariableBase)pair.Value)?.Name ?? DatabaseObject<PlayerVariableBase>.Deleted, ((PlayerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+        }
+        else if (rdoGlobalVariables.Checked)
+        {
+            items = ServerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((ServerVariableBase)pair.Value)?.Name ?? DatabaseObject<ServerVariableBase>.Deleted + " = " + ((ServerVariableBase)pair.Value)?.Value.ToString(((ServerVariableBase)pair.Value).Type) ?? "", ((ServerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+        }
+        else if (rdoGuildVariables.Checked)
+        {
+            items = GuildVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((GuildVariableBase)pair.Value)?.Name ?? DatabaseObject<GuildVariableBase>.Deleted, ((GuildVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+        }
+        else if (rdoUserVariables.Checked)
+        {
+            items = UserVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((UserVariableBase)pair.Value)?.Name ?? DatabaseObject<UserVariableBase>.Deleted, ((UserVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
+        }
+
+        lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+
+        UpdateEditor();
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        var folderName = "";
+        var result = DarkInputBox.ShowInformation(
+            Strings.VariableEditor.folderprompt, Strings.VariableEditor.foldertitle, ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
             {
                 if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
                 {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    cmbBooleanValue.Hide();
-                    nudVariableValue.Hide();
-                    txtStringValue.Hide();
-                    switch (obj.Type)
+                    if (rdoPlayerVariables.Checked)
                     {
-                        case VariableDataType.Boolean:
-                            cmbBooleanValue.Show();
-                            cmbBooleanValue.SelectedIndex = Convert.ToInt32(obj.Value.Boolean);
-
-                            break;
-
-                        case VariableDataType.Integer:
-                            nudVariableValue.Show();
-                            nudVariableValue.Value = obj.Value.Integer;
-
-                            break;
-
-                        case VariableDataType.Number:
-                            break;
-
-                        case VariableDataType.String:
-                            txtStringValue.Show();
-                            txtStringValue.Text = obj.Value.String;
-
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException();
+                        var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                        obj.Folder = folderName;
+                        mExpandedFolders.Add(folderName);
                     }
+                    else if (rdoGlobalVariables.Checked)
+                    {
+                        var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                        obj.Folder = folderName;
+                        mGlobalExpandedFolders.Add(folderName);
+                    }
+                    else if (rdoGuildVariables.Checked)
+                    {
+                        var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                        obj.Folder = folderName;
+                        mGuildExpandedFolders.Add(folderName);
+                    }
+                    else if (rdoUserVariables.Checked)
+                    {
+                        var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                        obj.Folder = folderName;
+                        mUserExpandedFolders.Add(folderName);
+                    }
+
+                    InitEditor();
+                    cmbFolder.Text = folderName;
                 }
             }
         }
+    }
 
-        private void nudVariableValue_ValueChanged(object sender, EventArgs e)
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
         {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    if (obj != null)
-                    {
-                        obj.Value.Integer = (long)nudVariableValue.Value;
-                        UpdateSelection();
-                    }
-                }
-            }
-        }
-
-        private void cmbBooleanValue_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    if (obj != null)
-                    {
-                        obj.Value.Boolean = Convert.ToBoolean(cmbBooleanValue.SelectedIndex);
-                        UpdateSelection();
-                    }
-                }
-
-                UpdateSelection();
-            }
-        }
-
-        private void txtStringValue_TextChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    if (obj != null)
-                    {
-                        obj.Value.String = txtStringValue.Text;
-                        UpdateSelection();
-                    }
-                }
-            }
-        }
-
-        #region "Item List - Folders, Searching, Sorting, Etc"
-
-        public void InitEditor()
-        {
-            //Fix Title
             if (rdoPlayerVariables.Checked)
             {
-                grpVariables.Text = rdoPlayerVariables.Text;
+                var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Folder = cmbFolder.Text;
             }
             else if (rdoGlobalVariables.Checked)
             {
-                grpVariables.Text = rdoGlobalVariables.Text;
+                var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
+                obj.Folder = cmbFolder.Text;
             }
             else if (rdoGuildVariables.Checked)
             {
-                grpVariables.Text = rdoGuildVariables.Text;
+                var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Folder = cmbFolder.Text;
             }
             else if (rdoUserVariables.Checked)
             {
-                grpVariables.Text = rdoUserVariables.Text;
+                var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
+                obj.Folder = cmbFolder.Text;
             }
 
-            grpEditor.Hide();
-            cmbBooleanValue.Hide();
-            nudVariableValue.Hide();
-            txtStringValue.Hide();
-
-            //Collect folders
-            var mFolders = new List<string>();
-            cmbFolder.Items.Clear();
-            cmbFolder.Items.Add("");
-
-            if (rdoPlayerVariables.Checked)
-            {
-                foreach (var itm in PlayerVariableBase.Lookup)
-                {
-                    if (!string.IsNullOrEmpty(((PlayerVariableBase) itm.Value).Folder) &&
-                        !mFolders.Contains(((PlayerVariableBase) itm.Value).Folder))
-                    {
-                        mFolders.Add(((PlayerVariableBase) itm.Value).Folder);
-                        if (!mKnownFolders.Contains(((PlayerVariableBase) itm.Value).Folder))
-                        {
-                            mKnownFolders.Add(((PlayerVariableBase) itm.Value).Folder);
-                        }
-                    }
-                }
-
-                mKnownFolders.Sort();
-                cmbFolder.Items.AddRange(mKnownFolders.ToArray());
-                lblId.Text = Strings.VariableEditor.textidpv;
-            }
-            else if (rdoGlobalVariables.Checked)
-            {
-                foreach (var itm in ServerVariableBase.Lookup)
-                {
-                    if (!string.IsNullOrEmpty(((ServerVariableBase) itm.Value).Folder) &&
-                        !mFolders.Contains(((ServerVariableBase) itm.Value).Folder))
-                    {
-                        mFolders.Add(((ServerVariableBase) itm.Value).Folder);
-                        if (!mGlobalKnownFolders.Contains(((ServerVariableBase) itm.Value).Folder))
-                        {
-                            mGlobalKnownFolders.Add(((ServerVariableBase) itm.Value).Folder);
-                        }
-                    }
-                }
-
-                mGlobalKnownFolders.Sort();
-                cmbFolder.Items.AddRange(mGlobalKnownFolders.ToArray());
-                lblId.Text = Strings.VariableEditor.textidgv;
-            }
-            else if (rdoGuildVariables.Checked)
-            {
-                foreach (var itm in GuildVariableBase.Lookup)
-                {
-                    if (!string.IsNullOrEmpty(((GuildVariableBase)itm.Value).Folder) &&
-                        !mFolders.Contains(((GuildVariableBase)itm.Value).Folder))
-                    {
-                        mFolders.Add(((GuildVariableBase)itm.Value).Folder);
-                        if (!mGuildKnownFolders.Contains(((GuildVariableBase)itm.Value).Folder))
-                        {
-                            mGuildKnownFolders.Add(((GuildVariableBase)itm.Value).Folder);
-                        }
-                    }
-                }
-
-                mGuildKnownFolders.Sort();
-                cmbFolder.Items.AddRange(mGuildKnownFolders.ToArray());
-                lblId.Text = Strings.VariableEditor.textidguildvar;
-            }
-            else if (rdoUserVariables.Checked)
-            {
-                foreach (var itm in UserVariableBase.Lookup)
-                {
-                    if (!string.IsNullOrEmpty(((UserVariableBase)itm.Value).Folder) &&
-                        !mFolders.Contains(((UserVariableBase)itm.Value).Folder))
-                    {
-                        mFolders.Add(((UserVariableBase)itm.Value).Folder);
-                        if (!mUserKnownFolders.Contains(((UserVariableBase)itm.Value).Folder))
-                        {
-                            mUserKnownFolders.Add(((UserVariableBase)itm.Value).Folder);
-                        }
-                    }
-                }
-
-                mUserKnownFolders.Sort();
-                cmbFolder.Items.AddRange(mUserKnownFolders.ToArray());
-                lblId.Text = Strings.VariableEditor.UserVariableId;
-            }
-
-            mFolders.Sort();
-
-            KeyValuePair<Guid, KeyValuePair<string, string>>[] items = null;
-
-            if (rdoPlayerVariables.Checked)
-            {
-                items = PlayerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((PlayerVariableBase)pair.Value)?.Name ?? DatabaseObject<PlayerVariableBase>.Deleted, ((PlayerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
-            }
-            else if (rdoGlobalVariables.Checked)
-            {
-                items = ServerVariableBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((ServerVariableBase)pair.Value)?.Name ?? DatabaseObject<ServerVariableBase>.Deleted + " = " + ((ServerVariableBase)pair.Value)?.Value.ToString(((ServerVariableBase)pair.Value).Type) ?? "", ((ServerVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
-            }
-            else if (rdoGuildVariables.Checked)
-            {
-                items = GuildVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((GuildVariableBase)pair.Value)?.Name ?? DatabaseObject<GuildVariableBase>.Deleted, ((GuildVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
-            }
-            else if (rdoUserVariables.Checked)
-            {
-                items = UserVariableBase.Lookup.OrderBy(p => p.Value?.TimeCreated).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
-                    new KeyValuePair<string, string>(((UserVariableBase)pair.Value)?.Name ?? DatabaseObject<UserVariableBase>.Deleted, ((UserVariableBase)pair.Value)?.Folder ?? ""))).ToArray();
-            }
-
-            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
-
-            UpdateEditor();
-        }
-
-        private void btnAddFolder_Click(object sender, EventArgs e)
-        {
-            var folderName = "";
-            var result = DarkInputBox.ShowInformation(
-                Strings.VariableEditor.folderprompt, Strings.VariableEditor.foldertitle, ref folderName,
-                DarkDialogButton.OkCancel
-            );
-
-            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
-            {
-                if (!cmbFolder.Items.Contains(folderName))
-                {
-                    if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-                    {
-                        if (rdoPlayerVariables.Checked)
-                        {
-                            var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                            obj.Folder = folderName;
-                            mExpandedFolders.Add(folderName);
-                        }
-                        else if (rdoGlobalVariables.Checked)
-                        {
-                            var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                            obj.Folder = folderName;
-                            mGlobalExpandedFolders.Add(folderName);
-                        }
-                        else if (rdoGuildVariables.Checked)
-                        {
-                            var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                            obj.Folder = folderName;
-                            mGuildExpandedFolders.Add(folderName);
-                        }
-                        else if (rdoUserVariables.Checked)
-                        {
-                            var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                            obj.Folder = folderName;
-                            mUserExpandedFolders.Add(folderName);
-                        }
-
-                        InitEditor();
-                        cmbFolder.Text = folderName;
-                    }
-                }
-            }
-        }
-
-        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (lstGameObjects.SelectedNode != null && lstGameObjects.SelectedNode.Tag != null)
-            {
-                if (rdoPlayerVariables.Checked)
-                {
-                    var obj = PlayerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Folder = cmbFolder.Text;
-                }
-                else if (rdoGlobalVariables.Checked)
-                {
-                    var obj = ServerVariableBase.Get((Guid) lstGameObjects.SelectedNode.Tag);
-                    obj.Folder = cmbFolder.Text;
-                }
-                else if (rdoGuildVariables.Checked)
-                {
-                    var obj = GuildVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Folder = cmbFolder.Text;
-                }
-                else if (rdoUserVariables.Checked)
-                {
-                    var obj = UserVariableBase.Get((Guid)lstGameObjects.SelectedNode.Tag);
-                    obj.Folder = cmbFolder.Text;
-                }
-
-                InitEditor();
-            }
-        }
-
-        private void btnAlphabetical_Click(object sender, EventArgs e)
-        {
-            btnAlphabetical.Checked = !btnAlphabetical.Checked;
             InitEditor();
         }
+    }
 
-        private void txtSearch_TextChanged(object sender, EventArgs e)
-        {
-            InitEditor();
-        }
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
 
-        private void txtSearch_Leave(object sender, EventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(txtSearch.Text))
-            {
-                txtSearch.Text = Strings.VariableEditor.searchplaceholder;
-            }
-        }
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
 
-        private void txtSearch_Enter(object sender, EventArgs e)
-        {
-            txtSearch.SelectAll();
-            txtSearch.Focus();
-        }
-
-        private void btnClearSearch_Click(object sender, EventArgs e)
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
         {
             txtSearch.Text = Strings.VariableEditor.searchplaceholder;
         }
-
-        private bool CustomSearch()
-        {
-            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
-                   txtSearch.Text != Strings.VariableEditor.searchplaceholder;
-        }
-
-        private void txtSearch_Click(object sender, EventArgs e)
-        {
-            if (txtSearch.Text == Strings.VariableEditor.searchplaceholder)
-            {
-                txtSearch.SelectAll();
-            }
-        }
-
-        #endregion
-
     }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+        txtSearch.Focus();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.VariableEditor.searchplaceholder;
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+               txtSearch.Text != Strings.VariableEditor.searchplaceholder;
+    }
+
+    private void txtSearch_Click(object sender, EventArgs e)
+    {
+        if (txtSearch.Text == Strings.VariableEditor.searchplaceholder)
+        {
+            txtSearch.SelectAll();
+        }
+    }
+
+    #endregion
 
 }

--- a/Intersect.Editor/Forms/Helpers/GridHelper.cs
+++ b/Intersect.Editor/Forms/Helpers/GridHelper.cs
@@ -1,276 +1,275 @@
-namespace Intersect.Editor.Forms.Helpers
+namespace Intersect.Editor.Forms.Helpers;
+
+using Color = System.Drawing.Color;
+using Graphics = System.Drawing.Graphics;
+
+public partial struct GridCell
 {
-    using Color = System.Drawing.Color;
-    using Graphics = System.Drawing.Graphics;
+    public int X { get; private set; }
 
-    public partial struct GridCell
+    public int Y { get; private set; }
+
+    public Color? Color { get; private set; }
+
+    public string Label { get; private set; }
+
+    public Color? LabelColor { get; private set; }
+
+    public GridCell(int x, int y, Color? color = default, string label = null, Color? labelColor = default)
     {
-        public int X { get; private set; }
-
-        public int Y { get; private set; }
-
-        public Color? Color { get; private set; }
-
-        public string Label { get; private set; }
-
-        public Color? LabelColor { get; private set; }
-
-        public GridCell(int x, int y, Color? color = default, string label = null, Color? labelColor = default)
-        {
-            X = x;
-            Y = y;
-            Color = color;
-            Label = label;
-            LabelColor = labelColor;
-        }
-
-        public GridCell At(int x, int y)
-        {
-            if (X == x && Y == y)
-            {
-                return this;
-            }
-
-            return new GridCell(x, y, Color, Label);
-        }
-
-        public GridCell WithColor(Color color)
-        {
-            if (Color == color)
-            {
-                return this;
-            }
-
-            return new GridCell(X, Y, color, Label);
-        }
-
-        public GridCell WithLabel(string label)
-        {
-            if (String.Equals(Label, label, StringComparison.Ordinal))
-            {
-                return this;
-            }
-
-            return new GridCell(X, Y, Color, label);
-        }
-
-        public GridCell WithLabelColor(Color labelColor)
-        {
-            if (LabelColor == labelColor)
-            {
-                return this;
-            }
-
-            return new GridCell(X, Y, Color, Label, labelColor);
-        }
-
-        public static int CalculatePrecedenceKey(GridCell gridCell) =>
-            (String.IsNullOrEmpty(gridCell.Label) ? 0 : 2) + (gridCell.Color == null ? 0 : 1);
+        X = x;
+        Y = y;
+        Color = color;
+        Label = label;
+        LabelColor = labelColor;
     }
 
-    public struct Grid
+    public GridCell At(int x, int y)
     {
-        public int DisplayWidth;
-        public int DisplayHeight;
-        public int Columns;
-        public int Rows;
-        public GridCell[] Cells;
+        if (X == x && Y == y)
+        {
+            return this;
+        }
 
-        public Grid WithAdditionalCells(params GridCell[] additionalCells) =>
-            new Grid
-            {
-                DisplayWidth = DisplayWidth,
-                DisplayHeight = DisplayHeight,
-                Columns = Columns,
-                Rows = Rows,
-                Cells = Cells.Concat(additionalCells).ToArray()
-            };
+        return new GridCell(x, y, Color, Label);
+    }
+
+    public GridCell WithColor(Color color)
+    {
+        if (Color == color)
+        {
+            return this;
+        }
+
+        return new GridCell(X, Y, color, Label);
+    }
+
+    public GridCell WithLabel(string label)
+    {
+        if (String.Equals(Label, label, StringComparison.Ordinal))
+        {
+            return this;
+        }
+
+        return new GridCell(X, Y, Color, label);
+    }
+
+    public GridCell WithLabelColor(Color labelColor)
+    {
+        if (LabelColor == labelColor)
+        {
+            return this;
+        }
+
+        return new GridCell(X, Y, Color, Label, labelColor);
+    }
+
+    public static int CalculatePrecedenceKey(GridCell gridCell) =>
+        (String.IsNullOrEmpty(gridCell.Label) ? 0 : 2) + (gridCell.Color == null ? 0 : 1);
+}
+
+public struct Grid
+{
+    public int DisplayWidth;
+    public int DisplayHeight;
+    public int Columns;
+    public int Rows;
+    public GridCell[] Cells;
+
+    public Grid WithAdditionalCells(params GridCell[] additionalCells) =>
+        new Grid
+        {
+            DisplayWidth = DisplayWidth,
+            DisplayHeight = DisplayHeight,
+            Columns = Columns,
+            Rows = Rows,
+            Cells = Cells.Concat(additionalCells).ToArray()
+        };
+}
+
+/// <summary>
+/// Helper class for drawing grids on <see cref="Bitmap"/>s.
+/// </summary>
+public static partial class GridHelper
+{
+    /// <summary>
+    /// Mutable background color for all grids, default <see cref="Color.White"/>.
+    /// </summary>
+    public static Color ColorBackground { get; set; } = Color.White;
+
+    /// <summary>
+    /// Mutable foreground color for all grids (only affects the grid lines, not text color), default <see cref="Color.Black"/>.
+    /// </summary>
+    public static Color ColorForeground { get; set; } = Color.Black;
+
+    /// <summary>
+    /// Interpolates between two colors by a given ratio.
+    /// </summary>
+    public static Color ColorInterpolate(Color color1, Color color2, float ratio)
+    {
+        byte a = (byte)((color2.A - color1.A) * ratio + color1.A);
+        byte r = (byte)((color2.R - color1.R) * ratio + color1.R);
+        byte g = (byte)((color2.G - color1.G) * ratio + color1.G);
+        byte b = (byte)((color2.B - color1.B) * ratio + color1.B);
+        return Color.FromArgb(a, r, g, b);
     }
 
     /// <summary>
-    /// Helper class for drawing grids on <see cref="Bitmap"/>s.
+    /// Mutable selection tile color for all grids, default <see cref="Color.Red"/>.
     /// </summary>
-    public static partial class GridHelper
+    public static Color ColorSelection { get; set; } = Color.Red;
+
+    /// <summary>
+    /// Mutable fallback font for text rendering on grids, default Arial 14pt.
+    /// </summary>
+    public static Font DefaultFont { get; set; } = new Font(new FontFamily("Arial"), 14);
+
+    public static (int x, int y)? CellFromPoint(Grid grid, int x, int y)
     {
-        /// <summary>
-        /// Mutable background color for all grids, default <see cref="Color.White"/>.
-        /// </summary>
-        public static Color ColorBackground { get; set; } = Color.White;
-
-        /// <summary>
-        /// Mutable foreground color for all grids (only affects the grid lines, not text color), default <see cref="Color.Black"/>.
-        /// </summary>
-        public static Color ColorForeground { get; set; } = Color.Black;
-
-        /// <summary>
-        /// Interpolates between two colors by a given ratio.
-        /// </summary>
-        public static Color ColorInterpolate(Color color1, Color color2, float ratio)
+        if (x < 0 || y < 0 || grid.DisplayWidth <= x || grid.DisplayHeight <= y)
         {
-            byte a = (byte)((color2.A - color1.A) * ratio + color1.A);
-            byte r = (byte)((color2.R - color1.R) * ratio + color1.R);
-            byte g = (byte)((color2.G - color1.G) * ratio + color1.G);
-            byte b = (byte)((color2.B - color1.B) * ratio + color1.B);
-            return Color.FromArgb(a, r, g, b);
+            return null;
         }
 
-        /// <summary>
-        /// Mutable selection tile color for all grids, default <see cref="Color.Red"/>.
-        /// </summary>
-        public static Color ColorSelection { get; set; } = Color.Red;
+        var cellWidth = grid.DisplayWidth / grid.Columns;
+        var cellHeight = grid.DisplayHeight / grid.Rows;
+        return (
+            (int)Math.Floor((double)x / cellWidth) - 2,
+            (int)Math.Floor((double)y / cellHeight) - 2
+        );
 
-        /// <summary>
-        /// Mutable fallback font for text rendering on grids, default Arial 14pt.
-        /// </summary>
-        public static Font DefaultFont { get; set; } = new Font(new FontFamily("Arial"), 14);
+    }
 
-        public static (int x, int y)? CellFromPoint(Grid grid, int x, int y)
+    /// <summary>
+    /// Creates a bitmap of the given grid.
+    /// </summary>
+    /// <param name="grid">the grid to draw</param>
+    /// <returns>a bitmap with the configured grid drawn on it</returns>
+    public static Bitmap DrawGrid(Grid grid) =>
+        DrawGrid(grid.DisplayWidth, grid.DisplayHeight, grid.Columns, grid.Rows, grid.Cells);
+
+    /// <summary>
+    /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
+    /// </summary>
+    /// <param name="bitmapWidth">width of the bitmap in pixels</param>
+    /// <param name="bitmapHeight">height of the bitmap in pixels</param>
+    /// <param name="gridColumns">number of columns the grid should have</param>
+    /// <param name="gridRows">number of rows the grid should have</param>
+    /// <param name="gridCells">the optional cell contents</param>
+    /// <returns>a bitmap with the configured grid drawn on it</returns>
+    public static Bitmap DrawGrid(
+        int bitmapWidth,
+        int bitmapHeight,
+        int gridColumns,
+        int gridRows,
+        params GridCell[] gridCells
+    ) =>
+        DrawGrid(bitmapWidth, bitmapHeight, gridColumns, gridRows, DefaultFont, gridCells);
+
+    /// <summary>
+    /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
+    /// </summary>
+    /// <param name="bitmapWidth">width of the bitmap in pixels</param>
+    /// <param name="bitmapHeight">height of the bitmap in pixels</param>
+    /// <param name="gridColumns">number of columns the grid should have</param>
+    /// <param name="gridRows">number of rows the grid should have</param>
+    /// <param name="font">the font to use for text rendering</param>
+    /// <param name="gridCells">the optional cell contents</param>
+    /// <returns>a bitmap with the configured grid drawn on it</returns>
+    public static Bitmap DrawGrid(
+        int bitmapWidth,
+        int bitmapHeight,
+        int gridColumns,
+        int gridRows,
+        Font font,
+        params GridCell[] gridCells
+    ) =>
+        DrawGrid(new Bitmap(bitmapWidth, bitmapHeight), gridColumns, gridRows, font, gridCells);
+
+    /// <summary>
+    /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
+    /// </summary>
+    /// <param name="bitmap">the bitmap to render the grid on</param>
+    /// <param name="gridColumns">number of columns the grid should have</param>
+    /// <param name="gridRows">number of rows the grid should have</param>
+    /// <param name="gridCells">the optional cell contents</param>
+    /// <returns>a bitmap with the configured grid drawn on it</returns>
+    public static Bitmap DrawGrid(Bitmap bitmap, int gridColumns, int gridRows, params GridCell[] gridCells) =>
+        DrawGrid(bitmap, gridColumns, gridRows, DefaultFont, gridCells);
+
+    /// <summary>
+    /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
+    /// </summary>
+    /// <param name="bitmap">the bitmap to render the grid on</param>
+    /// <param name="gridColumns">number of columns the grid should have</param>
+    /// <param name="gridRows">number of rows the grid should have</param>
+    /// <param name="font">the font to use for text rendering</param>
+    /// <param name="gridCells">the optional cell contents</param>
+    /// <returns>a bitmap with the configured grid drawn on it</returns>
+    public static Bitmap DrawGrid(
+        Bitmap bitmap,
+        int gridColumns,
+        int gridRows,
+        Font font,
+        params GridCell[] gridCells
+    )
+    {
+        if (bitmap == null)
         {
-            if (x < 0 || y < 0 || grid.DisplayWidth <= x || grid.DisplayHeight <= y)
-            {
-                return null;
-            }
-
-            var cellWidth = grid.DisplayWidth / grid.Columns;
-            var cellHeight = grid.DisplayHeight / grid.Rows;
-            return (
-                (int)Math.Floor((double)x / cellWidth) - 2,
-                (int)Math.Floor((double)y / cellHeight) - 2
-            );
-
+            throw new ArgumentNullException(nameof(bitmap));
         }
 
-        /// <summary>
-        /// Creates a bitmap of the given grid.
-        /// </summary>
-        /// <param name="grid">the grid to draw</param>
-        /// <returns>a bitmap with the configured grid drawn on it</returns>
-        public static Bitmap DrawGrid(Grid grid) =>
-            DrawGrid(grid.DisplayWidth, grid.DisplayHeight, grid.Columns, grid.Rows, grid.Cells);
+        var gridWidth = bitmap.Width;
+        var cellWidth = gridWidth / gridColumns;
 
-        /// <summary>
-        /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
-        /// </summary>
-        /// <param name="bitmapWidth">width of the bitmap in pixels</param>
-        /// <param name="bitmapHeight">height of the bitmap in pixels</param>
-        /// <param name="gridColumns">number of columns the grid should have</param>
-        /// <param name="gridRows">number of rows the grid should have</param>
-        /// <param name="gridCells">the optional cell contents</param>
-        /// <returns>a bitmap with the configured grid drawn on it</returns>
-        public static Bitmap DrawGrid(
-            int bitmapWidth,
-            int bitmapHeight,
-            int gridColumns,
-            int gridRows,
-            params GridCell[] gridCells
-        ) =>
-            DrawGrid(bitmapWidth, bitmapHeight, gridColumns, gridRows, DefaultFont, gridCells);
+        var gridHeight = bitmap.Height;
+        var cellHeight = gridHeight / gridRows;
 
-        /// <summary>
-        /// Creates a bitmap of the given dimensions and renders a grid with the specified dimensions and optional cell contents.
-        /// </summary>
-        /// <param name="bitmapWidth">width of the bitmap in pixels</param>
-        /// <param name="bitmapHeight">height of the bitmap in pixels</param>
-        /// <param name="gridColumns">number of columns the grid should have</param>
-        /// <param name="gridRows">number of rows the grid should have</param>
-        /// <param name="font">the font to use for text rendering</param>
-        /// <param name="gridCells">the optional cell contents</param>
-        /// <returns>a bitmap with the configured grid drawn on it</returns>
-        public static Bitmap DrawGrid(
-            int bitmapWidth,
-            int bitmapHeight,
-            int gridColumns,
-            int gridRows,
-            Font font,
-            params GridCell[] gridCells
-        ) =>
-            DrawGrid(new Bitmap(bitmapWidth, bitmapHeight), gridColumns, gridRows, font, gridCells);
-
-        /// <summary>
-        /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
-        /// </summary>
-        /// <param name="bitmap">the bitmap to render the grid on</param>
-        /// <param name="gridColumns">number of columns the grid should have</param>
-        /// <param name="gridRows">number of rows the grid should have</param>
-        /// <param name="gridCells">the optional cell contents</param>
-        /// <returns>a bitmap with the configured grid drawn on it</returns>
-        public static Bitmap DrawGrid(Bitmap bitmap, int gridColumns, int gridRows, params GridCell[] gridCells) =>
-            DrawGrid(bitmap, gridColumns, gridRows, DefaultFont, gridCells);
-
-        /// <summary>
-        /// Renders a grid on the provided bitmap with the specified dimensions and optional cell contents.
-        /// </summary>
-        /// <param name="bitmap">the bitmap to render the grid on</param>
-        /// <param name="gridColumns">number of columns the grid should have</param>
-        /// <param name="gridRows">number of rows the grid should have</param>
-        /// <param name="font">the font to use for text rendering</param>
-        /// <param name="gridCells">the optional cell contents</param>
-        /// <returns>a bitmap with the configured grid drawn on it</returns>
-        public static Bitmap DrawGrid(
-            Bitmap bitmap,
-            int gridColumns,
-            int gridRows,
-            Font font,
-            params GridCell[] gridCells
-        )
+        using (var graphics = Graphics.FromImage(bitmap))
         {
-            if (bitmap == null)
+            graphics.Clear(ColorBackground);
+
+            // Draw the cell contents in order of precedence (color-only first, then text, so that text doesn't get rendered under background colors)
+            foreach (var gridCell in gridCells.OrderBy(GridCell.CalculatePrecedenceKey))
             {
-                throw new ArgumentNullException(nameof(bitmap));
-            }
+                var x = gridCell.X * cellWidth;
+                var y = gridCell.Y * cellHeight;
 
-            var gridWidth = bitmap.Width;
-            var cellWidth = gridWidth / gridColumns;
-
-            var gridHeight = bitmap.Height;
-            var cellHeight = gridHeight / gridRows;
-
-            using (var graphics = Graphics.FromImage(bitmap))
-            {
-                graphics.Clear(ColorBackground);
-
-                // Draw the cell contents in order of precedence (color-only first, then text, so that text doesn't get rendered under background colors)
-                foreach (var gridCell in gridCells.OrderBy(GridCell.CalculatePrecedenceKey))
+                // Draw the background color (if any for this cell)
+                if (gridCell.Color != null && gridCell.Color != Color.Transparent && gridCell.Color.Value.A != 0)
                 {
-                    var x = gridCell.X * cellWidth;
-                    var y = gridCell.Y * cellHeight;
-
-                    // Draw the background color (if any for this cell)
-                    if (gridCell.Color != null && gridCell.Color != Color.Transparent && gridCell.Color.Value.A != 0)
-                    {
-                        graphics.FillRectangle(
-                            new SolidBrush(ColorSelection), new Rectangle(x, y, cellWidth, cellHeight)
-                        );
-                    }
-
-                    // Draw the text (if any for this cell)
-                    if (!string.IsNullOrWhiteSpace(gridCell.Label))
-                    {
-                        var measurement = graphics.MeasureString(gridCell.Label, font);
-                        graphics.DrawString(
-                            gridCell.Label, font, new SolidBrush(gridCell.LabelColor ?? ColorForeground),
-                            x + (cellWidth - measurement.Width) / 2, y + (cellHeight - measurement.Height) / 2
-                        );
-                    }
+                    graphics.FillRectangle(
+                        new SolidBrush(ColorSelection), new Rectangle(x, y, cellWidth, cellHeight)
+                    );
                 }
 
-                // Draw separator lines (1 less than the number of columns/rows
-                // Columns and rows are combined into a single for-loop to reduce the number of iterations
-                for (var lineIndex = 1; lineIndex < Math.Max(gridColumns, gridRows); ++lineIndex)
+                // Draw the text (if any for this cell)
+                if (!string.IsNullOrWhiteSpace(gridCell.Label))
                 {
-                    if (lineIndex < gridColumns)
-                    {
-                        graphics.DrawLine(Pens.Black, cellWidth * lineIndex, 0, cellWidth * lineIndex, gridHeight);
-                    }
-
-                    if (lineIndex < gridRows)
-                    {
-                        graphics.DrawLine(Pens.Black, 0, cellHeight * lineIndex, gridWidth, cellHeight * lineIndex);
-                    }
+                    var measurement = graphics.MeasureString(gridCell.Label, font);
+                    graphics.DrawString(
+                        gridCell.Label, font, new SolidBrush(gridCell.LabelColor ?? ColorForeground),
+                        x + (cellWidth - measurement.Width) / 2, y + (cellHeight - measurement.Height) / 2
+                    );
                 }
             }
 
-            return bitmap;
+            // Draw separator lines (1 less than the number of columns/rows
+            // Columns and rows are combined into a single for-loop to reduce the number of iterations
+            for (var lineIndex = 1; lineIndex < Math.Max(gridColumns, gridRows); ++lineIndex)
+            {
+                if (lineIndex < gridColumns)
+                {
+                    graphics.DrawLine(Pens.Black, cellWidth * lineIndex, 0, cellWidth * lineIndex, gridHeight);
+                }
+
+                if (lineIndex < gridRows)
+                {
+                    graphics.DrawLine(Pens.Black, 0, cellHeight * lineIndex, gridWidth, cellHeight * lineIndex);
+                }
+            }
         }
+
+        return bitmap;
     }
 }

--- a/Intersect.Editor/Forms/frmAbout.cs
+++ b/Intersect.Editor/Forms/frmAbout.cs
@@ -1,35 +1,33 @@
 using Intersect.Editor.Localization;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmAbout : Form
 {
 
-    public partial class FrmAbout : Form
+    public FrmAbout()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
+    }
 
-        public FrmAbout()
-        {
-            InitializeComponent();
-            Icon = Program.Icon;
-        }
+    private void lblWebsite_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("http://ascensiongamedev.com");
+    }
 
-        private void lblWebsite_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("http://ascensiongamedev.com");
-        }
+    private void frmAbout_Load(object sender, EventArgs e)
+    {
+        InitLocalization();
+    }
 
-        private void frmAbout_Load(object sender, EventArgs e)
-        {
-            InitLocalization();
-        }
-
-        private void InitLocalization()
-        {
-            Text = Strings.About.title;
-            lblVersion.Text = Strings.About.version.ToString(Application.ProductVersion);
-            lblWebsite.Text = Strings.About.site;
-        }
-
+    private void InitLocalization()
+    {
+        Text = Strings.About.title;
+        lblVersion.Text = Strings.About.version.ToString(Application.ProductVersion);
+        lblWebsite.Text = Strings.About.site;
     }
 
 }

--- a/Intersect.Editor/Forms/frmLogin.cs
+++ b/Intersect.Editor/Forms/frmLogin.cs
@@ -12,267 +12,265 @@ using Intersect.Logging;
 using Intersect.Network;
 using Intersect.Utilities;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmLogin : Form
 {
 
-    public partial class FrmLogin : Form
+    //Cross Thread Delegates
+    public delegate void BeginEditorLoop();
+
+    public BeginEditorLoop EditorLoopDelegate;
+
+    private bool mOptionsLoaded = false;
+
+    private string mSavedPassword = "";
+
+    public FrmLogin()
     {
+        CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+        InitializeComponent();
+        Icon = Program.Icon;
+    }
 
-        //Cross Thread Delegates
-        public delegate void BeginEditorLoop();
-
-        public BeginEditorLoop EditorLoopDelegate;
-
-        private bool mOptionsLoaded = false;
-
-        private string mSavedPassword = "";
-
-        public FrmLogin()
+    private void frmLogin_Load(object sender, EventArgs e)
+    {
+        AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
+        try
         {
-            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
-            InitializeComponent();
-            Icon = Program.Icon;
+            Strings.Load();
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+        GameContentManager.CheckForResources();
+        Database.LoadOptions();
+        mOptionsLoaded = true;
+        EditorLoopDelegate = Main.StartLoop;
+        if (Preferences.LoadPreference("username").Trim().Length > 0)
+        {
+            txtUsername.Text = Preferences.LoadPreference("Username");
+            txtPassword.Text = "*****";
+            mSavedPassword = Preferences.LoadPreference("Password");
+            chkRemember.Checked = true;
         }
 
-        private void frmLogin_Load(object sender, EventArgs e)
-        {
-            AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
-            try
-            {
-                Strings.Load();
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-            GameContentManager.CheckForResources();
-            Database.LoadOptions();
-            mOptionsLoaded = true;
-            EditorLoopDelegate = Main.StartLoop;
-            if (Preferences.LoadPreference("username").Trim().Length > 0)
-            {
-                txtUsername.Text = Preferences.LoadPreference("Username");
-                txtPassword.Text = "*****";
-                mSavedPassword = Preferences.LoadPreference("Password");
-                chkRemember.Checked = true;
-            }
+        Database.InitMapCache();
+        InitLocalization();
+    }
 
-            Database.InitMapCache();
-            InitLocalization();
+    private void InitLocalization()
+    {
+        Text = Strings.Login.title;
+        lblVersion.Text = Strings.Login.version.ToString(Application.ProductVersion);
+        lblGettingStarted.Text = Strings.Login.gettingstarted;
+        lblUsername.Text = Strings.Login.username;
+        lblPassword.Text = Strings.Login.password;
+        chkRemember.Text = Strings.Login.rememberme;
+        btnLogin.Text = Strings.Login.login;
+        lblStatus.Text = Strings.Login.connecting;
+    }
+
+    public long LastNetworkStatusChangeTime { get; private set; }
+
+    private NetworkStatus _networkStatus;
+
+    public void SetNetworkStatus(NetworkStatus networkStatus)
+    {
+        _networkStatus = networkStatus;
+        LastNetworkStatusChangeTime = Timing.Global.MillisecondsUtc;
+    }
+
+    private void tmrSocket_Tick(object sender, EventArgs e)
+    {
+        if (!mOptionsLoaded)
+        {
+            return;
         }
 
-        private void InitLocalization()
+        Networking.Network.Update();
+        btnLogin.Enabled = _networkStatus == NetworkStatus.Online || Networking.Network.Connected;
+
+        string statusString = _networkStatus switch
         {
-            Text = Strings.Login.title;
-            lblVersion.Text = Strings.Login.version.ToString(Application.ProductVersion);
-            lblGettingStarted.Text = Strings.Login.gettingstarted;
-            lblUsername.Text = Strings.Login.username;
-            lblPassword.Text = Strings.Login.password;
-            chkRemember.Text = Strings.Login.rememberme;
-            btnLogin.Text = Strings.Login.login;
-            lblStatus.Text = Strings.Login.connecting;
-        }
+            NetworkStatus.Unknown => Strings.Login.Denied,
+            NetworkStatus.Connecting => Strings.Login.connecting,
+            NetworkStatus.Online => Strings.Login.connected,
+            NetworkStatus.Offline => Strings.Login.failedtoconnect.ToString(((Globals.NextServerStatusPing - Timing.Global.MillisecondsUtc) / 1000).ToString("0")),
+            NetworkStatus.Failed => Strings.Login.Denied,
+            NetworkStatus.VersionMismatch => Strings.Login.Denied,
+            NetworkStatus.ServerFull => Strings.Login.Denied,
+            NetworkStatus.HandshakeFailure => Strings.Login.Denied,
+            NetworkStatus.Quitting => Strings.Login.Denied,
+            _ => throw new UnreachableException(),
+        };
 
-        public long LastNetworkStatusChangeTime { get; private set; }
-
-        private NetworkStatus _networkStatus;
-
-        public void SetNetworkStatus(NetworkStatus networkStatus)
+        var hasRaptr = Process.GetProcesses()
+            .ToArray()
+            .Any(process => process.ProcessName.Contains("raptr"));
+        if (hasRaptr)
         {
-            _networkStatus = networkStatus;
-            LastNetworkStatusChangeTime = Timing.Global.MillisecondsUtc;
-        }
-
-        private void tmrSocket_Tick(object sender, EventArgs e)
-        {
-            if (!mOptionsLoaded)
-            {
-                return;
-            }
-
-            Networking.Network.Update();
-            btnLogin.Enabled = _networkStatus == NetworkStatus.Online || Networking.Network.Connected;
-
-            string statusString = _networkStatus switch
-            {
-                NetworkStatus.Unknown => Strings.Login.Denied,
-                NetworkStatus.Connecting => Strings.Login.connecting,
-                NetworkStatus.Online => Strings.Login.connected,
-                NetworkStatus.Offline => Strings.Login.failedtoconnect.ToString(((Globals.NextServerStatusPing - Timing.Global.MillisecondsUtc) / 1000).ToString("0")),
-                NetworkStatus.Failed => Strings.Login.Denied,
-                NetworkStatus.VersionMismatch => Strings.Login.Denied,
-                NetworkStatus.ServerFull => Strings.Login.Denied,
-                NetworkStatus.HandshakeFailure => Strings.Login.Denied,
-                NetworkStatus.Quitting => Strings.Login.Denied,
-                _ => throw new UnreachableException(),
-            };
-
-            var hasRaptr = Process.GetProcesses()
-                .ToArray()
-                .Any(process => process.ProcessName.Contains("raptr"));
-            if (hasRaptr)
-            {
-                statusString = Strings.Login.raptr;
-                btnLogin.Enabled = false;
-            }
-
-            Globals.LoginForm.lblStatus.Text = statusString;
-
-            if (_loginPending && Networking.Network.Connected)
-            {
-                _loginPending = false;
-                if (txtUsername.Text.Trim().Length > 0 && txtPassword.Text.Trim().Length > 0)
-                {
-                    using (var sha = new SHA256Managed())
-                    {
-                        if (mSavedPassword != "")
-                        {
-                            PacketSender.SendLogin(txtUsername.Text.Trim(), mSavedPassword);
-                        }
-                        else
-                        {
-                            PacketSender.SendLogin(
-                                txtUsername.Text.Trim(),
-                                BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(txtPassword.Text.Trim())))
-                                    .Replace("-", "")
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        private bool _loginPending = false;
-
-        private void btnLogin_Click(object sender, EventArgs e)
-        {
-            if (!Networking.Network.Connected)
-            {
-                Networking.Network.Connect();
-            }
-
-            _loginPending = true;
+            statusString = Strings.Login.raptr;
             btnLogin.Enabled = false;
         }
 
-        protected override void OnKeyPress(KeyPressEventArgs e)
+        Globals.LoginForm.lblStatus.Text = statusString;
+
+        if (_loginPending && Networking.Network.Connected)
         {
-            base.OnKeyPress(e);
-            if (e.KeyChar != 13)
+            _loginPending = false;
+            if (txtUsername.Text.Trim().Length > 0 && txtPassword.Text.Trim().Length > 0)
             {
-                return;
-            }
-
-            e.Handled = true;
-            btnLogin_Click(null, null);
-        }
-
-        protected override void OnClosed(EventArgs e)
-        {
-            Networking.Network.EditorLidgrenNetwork?.Disconnect(NetworkStatus.Quitting.ToString());
-            base.OnClosed(e);
-            Application.Exit();
-        }
-
-        public void TryRemembering()
-        {
-            using (var sha = new SHA256Managed())
-            {
-                if (chkRemember.Checked)
+                using (var sha = new SHA256Managed())
                 {
-                    Preferences.SavePreference("Username", txtUsername.Text);
                     if (mSavedPassword != "")
                     {
-                        Preferences.SavePreference("Password", mSavedPassword);
+                        PacketSender.SendLogin(txtUsername.Text.Trim(), mSavedPassword);
                     }
                     else
                     {
-                        Preferences.SavePreference(
-                            "Password",
+                        PacketSender.SendLogin(
+                            txtUsername.Text.Trim(),
                             BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(txtPassword.Text.Trim())))
                                 .Replace("-", "")
                         );
                     }
                 }
+            }
+        }
+    }
+
+    private bool _loginPending = false;
+
+    private void btnLogin_Click(object sender, EventArgs e)
+    {
+        if (!Networking.Network.Connected)
+        {
+            Networking.Network.Connect();
+        }
+
+        _loginPending = true;
+        btnLogin.Enabled = false;
+    }
+
+    protected override void OnKeyPress(KeyPressEventArgs e)
+    {
+        base.OnKeyPress(e);
+        if (e.KeyChar != 13)
+        {
+            return;
+        }
+
+        e.Handled = true;
+        btnLogin_Click(null, null);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        Networking.Network.EditorLidgrenNetwork?.Disconnect(NetworkStatus.Quitting.ToString());
+        base.OnClosed(e);
+        Application.Exit();
+    }
+
+    public void TryRemembering()
+    {
+        using (var sha = new SHA256Managed())
+        {
+            if (chkRemember.Checked)
+            {
+                Preferences.SavePreference("Username", txtUsername.Text);
+                if (mSavedPassword != "")
+                {
+                    Preferences.SavePreference("Password", mSavedPassword);
+                }
                 else
                 {
-                    Preferences.SavePreference("Username", "");
-                    Preferences.SavePreference("Password", "");
+                    Preferences.SavePreference(
+                        "Password",
+                        BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(txtPassword.Text.Trim())))
+                            .Replace("-", "")
+                    );
                 }
-            }
-        }
-
-        private void txtPassword_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Return)
-            {
-                return;
-            }
-
-            if (mSavedPassword != "")
-            {
-                mSavedPassword = "";
-                txtPassword.Text = "";
-                chkRemember.Checked = false;
-            }
-        }
-
-        private void txtUsername_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Return)
-            {
-                return;
-            }
-
-            if (mSavedPassword != "")
-            {
-                mSavedPassword = "";
-                txtUsername.Text = "";
-                txtPassword.Text = "";
-                chkRemember.Checked = false;
-            }
-        }
-
-        private void FrmLogin_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.F1)
-            {
-                new FrmOptions().ShowDialog();
-            }
-        }
-
-        public void HideSafe()
-        {
-            ShowSafe(false);
-        }
-
-        public void ShowSafe(bool show = true)
-        {
-            var doShow = new Action<Form>(
-                instance =>
-                {
-                    if (show)
-                    {
-                        instance?.Show();
-                    }
-                    else
-                    {
-                        instance?.Hide();
-                    }
-                }
-            );
-
-            if (!InvokeRequired)
-            {
-                doShow(this);
             }
             else
             {
-                Invoke(doShow, this);
+                Preferences.SavePreference("Username", "");
+                Preferences.SavePreference("Password", "");
             }
         }
+    }
 
+    private void txtPassword_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Return)
+        {
+            return;
+        }
+
+        if (mSavedPassword != "")
+        {
+            mSavedPassword = "";
+            txtPassword.Text = "";
+            chkRemember.Checked = false;
+        }
+    }
+
+    private void txtUsername_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Return)
+        {
+            return;
+        }
+
+        if (mSavedPassword != "")
+        {
+            mSavedPassword = "";
+            txtUsername.Text = "";
+            txtPassword.Text = "";
+            chkRemember.Checked = false;
+        }
+    }
+
+    private void FrmLogin_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.F1)
+        {
+            new FrmOptions().ShowDialog();
+        }
+    }
+
+    public void HideSafe()
+    {
+        ShowSafe(false);
+    }
+
+    public void ShowSafe(bool show = true)
+    {
+        var doShow = new Action<Form>(
+            instance =>
+            {
+                if (show)
+                {
+                    instance?.Show();
+                }
+                else
+                {
+                    instance?.Hide();
+                }
+            }
+        );
+
+        if (!InvokeRequired)
+        {
+            doShow(this);
+        }
+        else
+        {
+            Invoke(doShow, this);
+        }
     }
 
 }

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -26,2217 +26,2215 @@ using Newtonsoft.Json.Linq;
 
 using WeifenLuo.WinFormsUI.Docking;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmMain : Form
 {
 
-    public partial class FrmMain : Form
+    public delegate void HandleDisconnect();
+
+    //Cross Thread Delegates
+    public delegate void TryOpenEditor(GameObjectType type);
+
+    public delegate void UpdateTimeList();
+
+    public HandleDisconnect DisconnectDelegate;
+
+    public TryOpenEditor EditorDelegate;
+
+    //Editor References
+    private FrmAnimation mAnimationEditor;
+
+    private FrmClass mClassEditor;
+
+    private FrmCommonEvent mCommonEventEditor;
+
+    private FrmCraftingTables mCraftingTablesEditor;
+
+    private FrmCrafts mCraftsEditor;
+
+    private FrmItem mItemEditor;
+
+    private FrmNpc mNpcEditor;
+
+    private FrmProjectile mProjectileEditor;
+
+    private FrmQuest mQuestEditor;
+
+    private FrmResource mResourceEditor;
+
+    private FrmShop mShopEditor;
+
+    private FrmSpell mSpellEditor;
+
+    private FrmSwitchVariable mSwitchVariableEditor;
+
+    private FrmTime mTimeEditor;
+
+    //General Editting Variables
+    bool mTMouseDown;
+
+    public UpdateTimeList TimeDelegate;
+
+    //Initialization & Setup Functions
+    public FrmMain()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        public delegate void HandleDisconnect();
+        dockLeft.Theme = new VS2015DarkTheme();
+        Globals.MapListWindow = new FrmMapList();
+        Globals.MapLayersWindow = new FrmMapLayers();
+        Globals.MapGridWindowNew = new FrmMapGrid();
+        Globals.MapEditorWindow = new FrmMapEditor();
 
-        //Cross Thread Delegates
-        public delegate void TryOpenEditor(GameObjectType type);
+        Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
+        Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
+        Globals.MapGridWindowNew.Show(dockLeft, DockState.Document);
+        Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
+    }
 
-        public delegate void UpdateTimeList();
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern IntPtr WindowFromPoint(System.Drawing.Point pnt);
 
-        public HandleDisconnect DisconnectDelegate;
+    private void frmMain_Load(object sender, EventArgs e)
+    {
+        //Init Delegates
+        EditorDelegate = TryOpenEditorMethod;
+        DisconnectDelegate = HandleServerDisconnect;
+        TimeDelegate = UpdateTimeSimulationList;
 
-        public TryOpenEditor EditorDelegate;
+        // Initilise the editor.
+        InitEditor();
 
-        //Editor References
-        private FrmAnimation mAnimationEditor;
+        //Init Map Properties
+        InitMapProperties();
+        InitLocalization();
+        InitExternalTools();
+        Show();
 
-        private FrmClass mClassEditor;
+        //Init Forms with RenderTargets
+        Globals.MapEditorWindow.InitMapEditor();
+        Globals.MapLayersWindow.InitMapLayers();
+        Globals.MapGridWindowNew.InitGridWindow();
+        UpdateTimeSimulationList();
 
-        private FrmCommonEvent mCommonEventEditor;
+        WindowState = FormWindowState.Maximized;
+    }
 
-        private FrmCraftingTables mCraftingTablesEditor;
+    private void InitLocalization()
+    {
+        InitLocalizationMenus();
+        InitLocalizationToolstrip();
+    }
 
-        private FrmCrafts mCraftsEditor;
+    private void InitLocalizationMenus()
+    {
+        InitLocalizationMenuFile();
+        InitLocalizationMenuEdit();
+        InitLocalizationMenuView();
+        InitLocalizationMenuGameEditors();
+        InitLocalizationMenuTools();
+        InitLocalizationMenuHelp();
+    }
 
-        private FrmItem mItemEditor;
+    private void InitLocalizationMenuFile()
+    {
+        fileToolStripMenuItem.Text = Strings.MainForm.file;
+        saveMapToolStripMenuItem.Text = Strings.MainForm.SaveMap;
+        newMapToolStripMenuItem.Text = Strings.MainForm.newmap;
+        importMapToolStripMenuItem.Text = Strings.MainForm.importmap;
+        exportMapToolStripMenuItem.Text = Strings.MainForm.exportmap;
+        optionsToolStripMenuItem.Text = Strings.MainForm.options;
+        exitToolStripMenuItem.Text = Strings.MainForm.exit;
+    }
 
-        private FrmNpc mNpcEditor;
+    private void InitLocalizationMenuEdit()
+    {
+        editToolStripMenuItem.Text = Strings.MainForm.edit;
+        undoToolStripMenuItem.Text = Strings.MainForm.Undo;
+        redoToolStripMenuItem.Text = Strings.MainForm.Redo;
+        cutToolStripMenuItem.Text = Strings.MainForm.Cut;
+        copyToolStripMenuItem.Text = Strings.MainForm.Copy;
+        pasteToolStripMenuItem.Text = Strings.MainForm.Paste;
+        fillToolStripMenuItem.Text = Strings.MainForm.Fill;
+        eraseLayerToolStripMenuItem.Text = Strings.MainForm.Erase;
+        selectToolStripMenuItem.Text = Strings.MainForm.selectlayers;
+        allLayersToolStripMenuItem.Text = Strings.MainForm.alllayers;
+        currentLayerOnlyToolStripMenuItem.Text = Strings.MainForm.currentonly;
+    }
 
-        private FrmProjectile mProjectileEditor;
+    private void InitLocalizationMenuView()
+    {
+        viewToolStripMenuItem.Text = Strings.MainForm.view;
+        hideDarknessToolStripMenuItem.Text = Strings.MainForm.darkness;
+        hideFogToolStripMenuItem.Text = Strings.MainForm.fog;
+        hideOverlayToolStripMenuItem.Text = Strings.MainForm.overlay;
+        hideResourcesToolStripMenuItem.Text = Strings.MainForm.resources;
+        hideEventsToolStripMenuItem.Text = Strings.MainForm.Events;
+        hideTilePreviewToolStripMenuItem.Text = Strings.MainForm.tilepreview;
+        mapGridToolStripMenuItem.Text = Strings.MainForm.grid;
+    }
 
-        private FrmQuest mQuestEditor;
+    private void InitLocalizationMenuGameEditors()
+    {
+        contentEditorsToolStripMenuItem.Text = Strings.MainForm.editors;
+        animationEditorToolStripMenuItem.Text = Strings.MainForm.animationeditor;
+        classEditorToolStripMenuItem.Text = Strings.MainForm.classeditor;
+        commonEventEditorToolStripMenuItem.Text = Strings.MainForm.commoneventeditor;
+        craftingTableEditorToolStripMenuItem.Text = Strings.MainForm.craftingtableeditor;
+        craftsEditorToolStripMenuItem.Text = Strings.MainForm.craftingeditor;
+        itemEditorToolStripMenuItem.Text = Strings.MainForm.itemeditor;
+        npcEditorToolStripMenuItem.Text = Strings.MainForm.npceditor;
+        projectileEditorToolStripMenuItem.Text = Strings.MainForm.projectileeditor;
+        questEditorToolStripMenuItem.Text = Strings.MainForm.questeditor;
+        resourceEditorToolStripMenuItem.Text = Strings.MainForm.resourceeditor;
+        shopEditorToolStripMenuItem.Text = Strings.MainForm.shopeditor;
+        spellEditorToolStripMenuItem.Text = Strings.MainForm.spelleditor;
+        variableEditorToolStripMenuItem.Text = Strings.MainForm.variableeditor;
+        timeEditorToolStripMenuItem.Text = Strings.MainForm.timeeditor;
+    }
 
-        private FrmResource mResourceEditor;
+    private void InitLocalizationMenuTools()
+    {
+        toolsToolStripMenuItem.Text = Strings.MainForm.tools;
+        packageUpdateToolStripMenuItem.Text = Strings.MainForm.MenuToolsPackageUpdate;
+    }
 
-        private FrmShop mShopEditor;
+    private void InitLocalizationMenuHelp()
+    {
+        helpToolStripMenuItem.Text = Strings.MainForm.help;
+        postQuestionToolStripMenuItem.Text = Strings.MainForm.postquestion;
+        toolStripButtonQuestion.Text = Strings.MainForm.postquestion;
+        reportBugToolStripMenuItem.Text = Strings.MainForm.reportbug;
+        toolStripButtonBug.Text = Strings.MainForm.reportbug;
+        aboutToolStripMenuItem.Text = Strings.MainForm.about;
+    }
 
-        private FrmSpell mSpellEditor;
+    private void InitLocalizationToolstrip()
+    {
+        toolStripBtnNewMap.Text = Strings.MainForm.newmap;
+        toolStripBtnSaveMap.Text = Strings.MainForm.SaveMap;
 
-        private FrmSwitchVariable mSwitchVariableEditor;
+        toolStripBtnCut.Text = Strings.MainForm.Cut;
+        toolStripBtnCopy.Text = Strings.MainForm.Copy;
+        toolStripBtnPaste.Text = Strings.MainForm.Paste;
 
-        private FrmTime mTimeEditor;
+        toolStripBtnUndo.Text = Strings.MainForm.Undo;
+        toolStripBtnRedo.Text = Strings.MainForm.Redo;
 
-        //General Editting Variables
-        bool mTMouseDown;
+        toolStripBtnBrush.Text = Strings.MainForm.Brush;
+        toolStripBtnSelect.Text = Strings.MainForm.Selection;
+        toolStripBtnRect.Text = Strings.MainForm.Rectangle;
 
-        public UpdateTimeList TimeDelegate;
+        toolStripBtnFlipVertical.Text = Strings.MainForm.FlipVertical;
+        toolStripBtnFlipHorizontal.Text = Strings.MainForm.FlipHorizontal;
 
-        //Initialization & Setup Functions
-        public FrmMain()
+        toolStripBtnFill.Text = Strings.MainForm.Fill;
+        toolStripBtnErase.Text = Strings.MainForm.Erase;
+        toolStripBtnDropper.Text = Strings.MainForm.Dropper;
+
+        toolStripTimeButton.Text = Strings.MainForm.lighting;
+
+        toolStripBtnScreenshot.Text = Strings.MainForm.screenshot;
+
+        toolStripBtnRun.Text = Strings.MainForm.run;
+    }
+
+    private void InitExternalTools()
+    {
+        var foundTools = false;
+        if (Directory.Exists(Strings.MainForm.toolsdir))
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            dockLeft.Theme = new VS2015DarkTheme();
-            Globals.MapListWindow = new FrmMapList();
-            Globals.MapLayersWindow = new FrmMapLayers();
-            Globals.MapGridWindowNew = new FrmMapGrid();
-            Globals.MapEditorWindow = new FrmMapEditor();
-
-            Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
-            Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
-            Globals.MapGridWindowNew.Show(dockLeft, DockState.Document);
-            Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
-        }
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr WindowFromPoint(System.Drawing.Point pnt);
-
-        private void frmMain_Load(object sender, EventArgs e)
-        {
-            //Init Delegates
-            EditorDelegate = TryOpenEditorMethod;
-            DisconnectDelegate = HandleServerDisconnect;
-            TimeDelegate = UpdateTimeSimulationList;
-
-            // Initilise the editor.
-            InitEditor();
-
-            //Init Map Properties
-            InitMapProperties();
-            InitLocalization();
-            InitExternalTools();
-            Show();
-
-            //Init Forms with RenderTargets
-            Globals.MapEditorWindow.InitMapEditor();
-            Globals.MapLayersWindow.InitMapLayers();
-            Globals.MapGridWindowNew.InitGridWindow();
-            UpdateTimeSimulationList();
-
-            WindowState = FormWindowState.Maximized;
-        }
-
-        private void InitLocalization()
-        {
-            InitLocalizationMenus();
-            InitLocalizationToolstrip();
-        }
-
-        private void InitLocalizationMenus()
-        {
-            InitLocalizationMenuFile();
-            InitLocalizationMenuEdit();
-            InitLocalizationMenuView();
-            InitLocalizationMenuGameEditors();
-            InitLocalizationMenuTools();
-            InitLocalizationMenuHelp();
-        }
-
-        private void InitLocalizationMenuFile()
-        {
-            fileToolStripMenuItem.Text = Strings.MainForm.file;
-            saveMapToolStripMenuItem.Text = Strings.MainForm.SaveMap;
-            newMapToolStripMenuItem.Text = Strings.MainForm.newmap;
-            importMapToolStripMenuItem.Text = Strings.MainForm.importmap;
-            exportMapToolStripMenuItem.Text = Strings.MainForm.exportmap;
-            optionsToolStripMenuItem.Text = Strings.MainForm.options;
-            exitToolStripMenuItem.Text = Strings.MainForm.exit;
-        }
-
-        private void InitLocalizationMenuEdit()
-        {
-            editToolStripMenuItem.Text = Strings.MainForm.edit;
-            undoToolStripMenuItem.Text = Strings.MainForm.Undo;
-            redoToolStripMenuItem.Text = Strings.MainForm.Redo;
-            cutToolStripMenuItem.Text = Strings.MainForm.Cut;
-            copyToolStripMenuItem.Text = Strings.MainForm.Copy;
-            pasteToolStripMenuItem.Text = Strings.MainForm.Paste;
-            fillToolStripMenuItem.Text = Strings.MainForm.Fill;
-            eraseLayerToolStripMenuItem.Text = Strings.MainForm.Erase;
-            selectToolStripMenuItem.Text = Strings.MainForm.selectlayers;
-            allLayersToolStripMenuItem.Text = Strings.MainForm.alllayers;
-            currentLayerOnlyToolStripMenuItem.Text = Strings.MainForm.currentonly;
-        }
-
-        private void InitLocalizationMenuView()
-        {
-            viewToolStripMenuItem.Text = Strings.MainForm.view;
-            hideDarknessToolStripMenuItem.Text = Strings.MainForm.darkness;
-            hideFogToolStripMenuItem.Text = Strings.MainForm.fog;
-            hideOverlayToolStripMenuItem.Text = Strings.MainForm.overlay;
-            hideResourcesToolStripMenuItem.Text = Strings.MainForm.resources;
-            hideEventsToolStripMenuItem.Text = Strings.MainForm.Events;
-            hideTilePreviewToolStripMenuItem.Text = Strings.MainForm.tilepreview;
-            mapGridToolStripMenuItem.Text = Strings.MainForm.grid;
-        }
-
-        private void InitLocalizationMenuGameEditors()
-        {
-            contentEditorsToolStripMenuItem.Text = Strings.MainForm.editors;
-            animationEditorToolStripMenuItem.Text = Strings.MainForm.animationeditor;
-            classEditorToolStripMenuItem.Text = Strings.MainForm.classeditor;
-            commonEventEditorToolStripMenuItem.Text = Strings.MainForm.commoneventeditor;
-            craftingTableEditorToolStripMenuItem.Text = Strings.MainForm.craftingtableeditor;
-            craftsEditorToolStripMenuItem.Text = Strings.MainForm.craftingeditor;
-            itemEditorToolStripMenuItem.Text = Strings.MainForm.itemeditor;
-            npcEditorToolStripMenuItem.Text = Strings.MainForm.npceditor;
-            projectileEditorToolStripMenuItem.Text = Strings.MainForm.projectileeditor;
-            questEditorToolStripMenuItem.Text = Strings.MainForm.questeditor;
-            resourceEditorToolStripMenuItem.Text = Strings.MainForm.resourceeditor;
-            shopEditorToolStripMenuItem.Text = Strings.MainForm.shopeditor;
-            spellEditorToolStripMenuItem.Text = Strings.MainForm.spelleditor;
-            variableEditorToolStripMenuItem.Text = Strings.MainForm.variableeditor;
-            timeEditorToolStripMenuItem.Text = Strings.MainForm.timeeditor;
-        }
-
-        private void InitLocalizationMenuTools()
-        {
-            toolsToolStripMenuItem.Text = Strings.MainForm.tools;
-            packageUpdateToolStripMenuItem.Text = Strings.MainForm.MenuToolsPackageUpdate;
-        }
-
-        private void InitLocalizationMenuHelp()
-        {
-            helpToolStripMenuItem.Text = Strings.MainForm.help;
-            postQuestionToolStripMenuItem.Text = Strings.MainForm.postquestion;
-            toolStripButtonQuestion.Text = Strings.MainForm.postquestion;
-            reportBugToolStripMenuItem.Text = Strings.MainForm.reportbug;
-            toolStripButtonBug.Text = Strings.MainForm.reportbug;
-            aboutToolStripMenuItem.Text = Strings.MainForm.about;
-        }
-
-        private void InitLocalizationToolstrip()
-        {
-            toolStripBtnNewMap.Text = Strings.MainForm.newmap;
-            toolStripBtnSaveMap.Text = Strings.MainForm.SaveMap;
-
-            toolStripBtnCut.Text = Strings.MainForm.Cut;
-            toolStripBtnCopy.Text = Strings.MainForm.Copy;
-            toolStripBtnPaste.Text = Strings.MainForm.Paste;
-
-            toolStripBtnUndo.Text = Strings.MainForm.Undo;
-            toolStripBtnRedo.Text = Strings.MainForm.Redo;
-
-            toolStripBtnBrush.Text = Strings.MainForm.Brush;
-            toolStripBtnSelect.Text = Strings.MainForm.Selection;
-            toolStripBtnRect.Text = Strings.MainForm.Rectangle;
-
-            toolStripBtnFlipVertical.Text = Strings.MainForm.FlipVertical;
-            toolStripBtnFlipHorizontal.Text = Strings.MainForm.FlipHorizontal;
-
-            toolStripBtnFill.Text = Strings.MainForm.Fill;
-            toolStripBtnErase.Text = Strings.MainForm.Erase;
-            toolStripBtnDropper.Text = Strings.MainForm.Dropper;
-
-            toolStripTimeButton.Text = Strings.MainForm.lighting;
-
-            toolStripBtnScreenshot.Text = Strings.MainForm.screenshot;
-
-            toolStripBtnRun.Text = Strings.MainForm.run;
-        }
-
-        private void InitExternalTools()
-        {
-            var foundTools = false;
-            if (Directory.Exists(Strings.MainForm.toolsdir))
+            var childDirs = Directory.GetDirectories("tools");
+            for (var i = 0; i < childDirs.Length; i++)
             {
-                var childDirs = Directory.GetDirectories("tools");
-                for (var i = 0; i < childDirs.Length; i++)
+                var executables = Directory.GetFiles(childDirs[i], "*.exe");
+                for (var x = 0; x < executables.Length; x++)
                 {
-                    var executables = Directory.GetFiles(childDirs[i], "*.exe");
-                    for (var x = 0; x < executables.Length; x++)
-                    {
-                        var item = toolsToolStripMenuItem.DropDownItems.Add(
-                            executables[x]
-                                .Replace(childDirs[i], "")
-                                .Replace(".exe", "")
-                                .Replace(Path.DirectorySeparatorChar.ToString(), "")
-                        );
-
-                        item.Tag = executables[x];
-                        item.Click += externalToolItem_Click;
-                    }
-                }
-            }
-        }
-
-        private void externalToolItem_Click(object sender, EventArgs e)
-        {
-            if (!string.IsNullOrEmpty((string) ((ToolStripItem) sender).Tag))
-            {
-                var psi = new ProcessStartInfo(Path.GetFileName((string) ((ToolStripItem) sender).Tag))
-                {
-                    WorkingDirectory = Path.GetDirectoryName((string) ((ToolStripItem) sender).Tag)
-                };
-
-                Process.Start(psi);
-            }
-        }
-
-        private void FrmMain_KeyDown(object sender, KeyEventArgs e)
-        {
-            switch (e.KeyData)
-            {
-                case Keys.Control | Keys.Z:
-                    toolStripBtnUndo_Click(null, null);
-                    return;
-
-                case Keys.Control | Keys.Y:
-                    toolStripBtnRedo_Click(null, null);
-                    return;
-
-                case Keys.Control | Keys.X:
-                    toolStripBtnCut_Click(null, null);
-                    return;
-
-                case Keys.Control | Keys.C:
-                    toolStripBtnCopy_Click(null, null);
-                    return;
-
-                case Keys.Control | Keys.V:
-                    toolStripBtnPaste_Click(null, null);
-                    return;
-
-                case Keys.Control | Keys.S:
-                    toolStripBtnSaveMap_Click(null, null);
-                    return;
-            }
-
-            var xDiff = 0;
-            var yDiff = 0;
-            if (dockLeft.ActiveContent == Globals.MapEditorWindow ||
-                dockLeft.ActiveContent == null &&
-                Globals.MapEditorWindow.DockPanel.ActiveDocument == Globals.MapEditorWindow)
-            {
-                switch (e.KeyCode)
-                {
-                    // Shortcuts: Map grid scrolling.
-                    case Keys.W:
-                    case Keys.Up:
-                        yDiff -= 20;
-                        break;
-
-                    case Keys.S:
-                    case Keys.Down:
-                        yDiff += 20;
-                        break;
-
-                    case Keys.A:
-                    case Keys.Left:
-                        xDiff -= 20;
-                        break;
-
-                    case Keys.D:
-                    case Keys.Right:
-                        xDiff += 20;
-                        break;
-
-                    // Shortcuts: Map grid Tools.
-                    case Keys.B: // Brush.
-                        toolStripBtnBrush_Click(null, null);
-                        break;
-
-                    case Keys.M: // Marquee Selection.
-                        toolStripBtnSelect_Click(null, null);
-                        break;
-
-                    case Keys.R: // Rectangle.
-                        toolStripBtnRect_Click(null, null);
-                        break;
-
-                    case Keys.PageUp: // Vertical Flip Selection.
-                        toolStripBtnFlipVertical_Click(null, null);
-                        break;
-
-                    case Keys.PageDown: // Horizontal Flip Selection.
-                        toolStripBtnFlipHorizontal_Click(null, null);
-                        break;
-
-                    case Keys.F: // Fill Tool.
-                        toolStripBtnFill_Click(null, null);
-                        break;
-
-                    case Keys.E: // Erase.
-                        toolStripBtnErase_Click(null, null);
-                        break;
-
-                    case Keys.I: // Dropper Tool.
-                        toolStripBtnDropper_Click(null, null);
-                        break;
-
-                    case Keys.Delete: // Delete Selection.
-                        ToolKeyDelete();
-                        break;
-                }
-
-                if (xDiff != 0 || yDiff != 0)
-                {
-                    var hWnd = WindowFromPoint(MousePosition);
-                    if (hWnd != IntPtr.Zero)
-                    {
-                        var ctl = FromHandle(hWnd);
-                        if (ctl != null)
-                        {
-                            if (ctl is ComboBox || ctl is DarkComboBox)
-                            {
-                                return;
-                            }
-                        }
-                    }
-
-                    Core.Graphics.CurrentView.X -= xDiff;
-                    Core.Graphics.CurrentView.Y -= yDiff;
-                    if (Core.Graphics.CurrentView.X > Options.MapWidth * Options.TileWidth)
-                    {
-                        Core.Graphics.CurrentView.X = Options.MapWidth * Options.TileWidth;
-                    }
-
-                    if (Core.Graphics.CurrentView.Y > Options.MapHeight * Options.TileHeight)
-                    {
-                        Core.Graphics.CurrentView.Y = Options.MapHeight * Options.TileHeight;
-                    }
-
-                    if (Core.Graphics.CurrentView.X - Globals.MapEditorWindow.picMap.Width <
-                        -Options.TileWidth * Options.MapWidth * 2)
-                    {
-                        Core.Graphics.CurrentView.X = -Options.TileWidth * Options.MapWidth * 2 +
-                                                      Globals.MapEditorWindow.picMap.Width;
-                    }
-
-                    if (Core.Graphics.CurrentView.Y - Globals.MapEditorWindow.picMap.Height <
-                        -Options.TileHeight * Options.MapHeight * 2)
-                    {
-                        Core.Graphics.CurrentView.Y = -Options.TileHeight * Options.MapHeight * 2 +
-                                                      Globals.MapEditorWindow.picMap.Height;
-                    }
-                }
-            }
-        }
-
-        private void InitMapProperties()
-        {
-            var unhiddenPane = dockLeft.Panes[0];
-            Globals.MapPropertiesWindow = new FrmMapProperties();
-            Globals.MapPropertiesWindow.Show(unhiddenPane, DockAlignment.Bottom, .4);
-            Globals.MapPropertiesWindow.Init(Globals.CurrentMap);
-            Globals.MapEditorWindow.DockPanel.Focus();
-        }
-
-        private void InitEditor()
-        {
-            Core.Graphics.InitMonogame();
-            Globals.MapLayersWindow.InitTilesets();
-            Globals.MapLayersWindow.Init();
-            Globals.InEditor = true;
-            GrabMouseDownEvents();
-            UpdateRunState();
-
-            //Init layer visibility buttons
-            foreach (var layer in Options.Instance.MapOpts.Layers.All)
-            {
-                Strings.Tiles.maplayers.TryGetValue(layer.ToLower(), out LocalizedString layerName);
-                if (layerName == null) layerName = layer;
-                var btn = new ToolStripMenuItem(layerName);
-                btn.Checked = true;
-                btn.Click += HideLayerBtn_Click;
-                btn.Tag = layer;
-                layersToolStripMenuItem.DropDownItems.Add(btn);
-            }
-        }
-
-        protected override void OnClosed(EventArgs e)
-        {
-            Networking.Network.EditorLidgrenNetwork?.Disconnect(NetworkStatus.Quitting.ToString());
-            base.OnClosed(e);
-            Application.Exit();
-        }
-
-        public void ShowDialogForm(Form form)
-        {
-            if (InvokeRequired)
-            {
-                Invoke((MethodInvoker) delegate { ShowDialogForm(form); });
-
-                return;
-            }
-
-            form.ShowDialog(this);
-        }
-
-        public void EnterMap(Guid mapId, bool userEntered = false)
-        {
-            if (InvokeRequired)
-            {
-                Invoke((MethodInvoker) delegate { EnterMap(mapId, userEntered); });
-
-                return;
-            }
-
-            Globals.CurrentMap = MapInstance.Get(mapId);
-            Globals.LoadingMap = mapId;
-            if (Globals.CurrentMap == null)
-            {
-                Text = @"Intersect Editor";
-            }
-            else
-            {
-                if (Globals.MapPropertiesWindow != null)
-                {
-                    Globals.MapPropertiesWindow.Init(Globals.CurrentMap);
-                }
-            }
-
-            Globals.MapEditorWindow.UnloadMap();
-            PacketSender.SendEnterMap(mapId);
-            PacketSender.SendNeedMap(mapId);
-            PacketSender.SendNeedGrid(mapId);
-            Core.Graphics.TilePreviewUpdated = true;
-
-            // Save that we've opened this map last if this was a user triggered action. This way we can load it again should we restart the editor.
-            if (userEntered)
-            {
-                Preferences.SavePreference("LastMapOpened", mapId.ToString());
-            }
-        }
-
-        private void GrabMouseDownEvents()
-        {
-            GrabMouseDownEvents(this);
-        }
-
-        private void GrabMouseDownEvents(Control e)
-        {
-            foreach (Control t in e.Controls)
-            {
-                if (t is MenuStrip menuStrip)
-                {
-                    foreach (ToolStripMenuItem t1 in menuStrip.Items)
-                    {
-                        t1.MouseDown += MouseDownHandler;
-                    }
-
-                    t.MouseDown += MouseDownHandler;
-                }
-                else if (t is PropertyGrid)
-                {
-                }
-                else
-                {
-                    GrabMouseDownEvents(t);
-                }
-            }
-
-            e.MouseDown += MouseDownHandler;
-        }
-
-        public void MouseDownHandler(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Middle || e.Button == MouseButtons.None)
-            {
-                return;
-            }
-
-            if (sender != Globals.MapEditorWindow &&
-                sender != Globals.MapEditorWindow.pnlMapContainer &&
-                sender != Globals.MapEditorWindow.picMap)
-            {
-                Globals.MapEditorWindow.PlaceSelection();
-            }
-        }
-
-        //Update
-        public void Update()
-        {
-            if (Globals.CurrentMap != null)
-            {
-                toolStripLabelCoords.Text = Strings.MainForm.loc.ToString(Globals.CurTileX, Globals.CurTileY);
-                toolStripLabelRevision.Text = Strings.MainForm.revision.ToString(Globals.CurrentMap.Revision);
-                if (Text != Strings.MainForm.title.ToString(Globals.CurrentMap.Name))
-                {
-                    Text = Strings.MainForm.title.ToString(Globals.CurrentMap.Name);
-                }
-            }
-
-            //Process the Undo/Redo Buttons
-            if (Globals.MapEditorWindow.MapUndoStates.Count > 0)
-            {
-                toolStripBtnUndo.Enabled = true;
-                undoToolStripMenuItem.Enabled = true;
-            }
-            else
-            {
-                toolStripBtnUndo.Enabled = false;
-                undoToolStripMenuItem.Enabled = false;
-            }
-
-            if (Globals.MapEditorWindow.MapRedoStates.Count > 0)
-            {
-                toolStripBtnRedo.Enabled = true;
-                redoToolStripMenuItem.Enabled = true;
-            }
-            else
-            {
-                toolStripBtnRedo.Enabled = false;
-                redoToolStripMenuItem.Enabled = false;
-            }
-
-            //Process the Fill/Erase Buttons, these should display for all valid map layers as well as Attributes.
-            if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer) || Globals.CurrentLayer == LayerOptions.Attributes)
-            {
-                toolStripBtnFill.Enabled = true;
-                fillToolStripMenuItem.Enabled = true;
-                toolStripBtnErase.Enabled = true;
-                eraseLayerToolStripMenuItem.Enabled = true;
-            }
-            else
-            {
-                toolStripBtnFill.Enabled = false;
-                fillToolStripMenuItem.Enabled = false;
-                toolStripBtnErase.Enabled = false;
-                eraseLayerToolStripMenuItem.Enabled = false;
-            }
-
-            //Process the Tool Buttons
-            toolStripBtnBrush.Enabled = false;
-            toolStripBtnSelect.Enabled = true;
-            toolStripBtnRect.Enabled = false;
-            toolStripBtnDropper.Enabled = false;
-            if (Globals.CurrentLayer == LayerOptions.Attributes)
-            {
-                toolStripBtnBrush.Enabled = true;
-                toolStripBtnRect.Enabled = true;
-            }
-            else if (Globals.CurrentLayer == LayerOptions.Lights)
-            {
-                Globals.CurrentTool = EditingTool.Selection;
-            }
-            else if (Globals.CurrentLayer == LayerOptions.Events)
-            {
-                Globals.CurrentTool = EditingTool.Selection;
-            }
-            else if (Globals.CurrentLayer == LayerOptions.Npcs)
-            {
-                Globals.CurrentTool = EditingTool.Selection;
-            }
-            else
-            {
-                toolStripBtnBrush.Enabled = true;
-                toolStripBtnRect.Enabled = true;
-                toolStripBtnDropper.Enabled = true;
-            }
-
-            switch (Globals.CurrentTool)
-            {
-                case EditingTool.Brush:
-                    if (!toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = true;
-                    }
-
-                    if (toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = false;
-                    }
-
-                    if (toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = false;
-                    }
-
-                    if (toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = false;
-                    }
-
-                    if (toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = false;
-                    }
-
-                    if (toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = false;
-                    }
-
-                    if (toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = false;
-                    }
-
-                    if (toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = false;
-                    }
-
-                    if (cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = false;
-                    }
-
-                    if (copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = false;
-                    }
-
-                    break;
-                case EditingTool.Selection:
-                    if (toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = false;
-                    }
-
-                    if (!toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = true;
-                    }
-
-                    if (toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = false;
-                    }
-
-                    if (toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = false;
-                    }
-
-                    if (toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = false;
-                    }
-
-                    if (toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = false;
-                    }
-
-                    if (!toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = true;
-                    }
-
-                    if (!toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = true;
-                    }
-
-                    if (!cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = true;
-                    }
-
-                    if (!copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = true;
-                    }
-
-                    break;
-                case EditingTool.Rectangle:
-                    if (toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = false;
-                    }
-
-                    if (toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = false;
-                    }
-
-                    if (!toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = true;
-                    }
-
-                    if (toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = false;
-                    }
-
-                    if (toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = false;
-                    }
-
-                    if (toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = false;
-                    }
-
-                    if (toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = false;
-                    }
-
-                    if (toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = false;
-                    }
-
-                    if (cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = false;
-                    }
-
-                    if (copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = false;
-                    }
-
-                    break;
-                case EditingTool.Fill:
-                    if (toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = false;
-                    }
-
-                    if (toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = false;
-                    }
-
-                    if (toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = false;
-                    }
-
-                    if (!toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = true;
-                    }
-
-                    if (toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = false;
-                    }
-
-                    if (toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = false;
-                    }
-
-                    if (toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = false;
-                    }
-
-                    if (toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = false;
-                    }
-
-                    if (cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = false;
-                    }
-
-                    if (copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = false;
-                    }
-
-                    break;
-                case EditingTool.Erase:
-                    if (toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = false;
-                    }
-
-                    if (toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = false;
-                    }
-
-                    if (toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = false;
-                    }
-
-                    if (toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = false;
-                    }
-
-                    if (!toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = true;
-                    }
-
-                    if (toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = false;
-                    }
-
-                    if (toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = false;
-                    }
-
-                    if (toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = false;
-                    }
-
-                    if (cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = false;
-                    }
-
-                    if (copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = false;
-                    }
-
-                    break;
-                case EditingTool.Dropper:
-                    if (toolStripBtnBrush.Checked)
-                    {
-                        toolStripBtnBrush.Checked = false;
-                    }
-
-                    if (toolStripBtnSelect.Checked)
-                    {
-                        toolStripBtnSelect.Checked = false;
-                    }
-
-                    if (toolStripBtnRect.Checked)
-                    {
-                        toolStripBtnRect.Checked = false;
-                    }
-
-                    if (toolStripBtnFill.Checked)
-                    {
-                        toolStripBtnFill.Checked = false;
-                    }
-
-                    if (toolStripBtnErase.Checked)
-                    {
-                        toolStripBtnErase.Checked = false;
-                    }
-
-                    if (!toolStripBtnDropper.Checked)
-                    {
-                        toolStripBtnDropper.Checked = true;
-                    }
-
-                    if (toolStripBtnCut.Enabled)
-                    {
-                        toolStripBtnCut.Enabled = false;
-                    }
-
-                    if (toolStripBtnCopy.Enabled)
-                    {
-                        toolStripBtnCopy.Enabled = false;
-                    }
-
-                    if (cutToolStripMenuItem.Enabled)
-                    {
-                        cutToolStripMenuItem.Enabled = false;
-                    }
-
-                    if (copyToolStripMenuItem.Enabled)
-                    {
-                        copyToolStripMenuItem.Enabled = false;
-                    }
-
-                    break;
-            }
-
-            if (Globals.HasCopy)
-            {
-                toolStripBtnPaste.Enabled = true;
-                pasteToolStripMenuItem.Enabled = true;
-            }
-            else
-            {
-                toolStripBtnPaste.Enabled = false;
-                pasteToolStripMenuItem.Enabled = false;
-            }
-
-            if (Globals.Dragging)
-            {
-                if (Globals.MainForm.ActiveControl is DockPane dockPane)
-                {
-                    var ctrl = dockPane.ActiveControl;
-                    if (ctrl != Globals.MapEditorWindow)
-                    {
-                        Globals.MapEditorWindow.PlaceSelection();
-                    }
-                }
-            }
-        }
-
-        //Disconnection
-        private void HandleServerDisconnect()
-        {
-            if (!Globals.ClosingEditor)
-            {
-                Globals.ClosingEditor = true;
-
-                //Offer to export map
-                if (Globals.CurrentMap != null)
-                {
-                    if (DarkMessageBox.ShowError(
-                            Strings.Errors.disconnectedsave, Strings.Errors.disconnectedsavecaption,
-                            DarkDialogButton.YesNo, Icon
-                        ) ==
-                        DialogResult.Yes)
-                    {
-                        exportMapToolStripMenuItem_Click(null, null);
-                        Application.Exit();
-                    }
-                    else
-                    {
-                        Application.Exit();
-                    }
-                }
-                else
-                {
-                    DarkMessageBox.ShowError(
-                        Strings.Errors.disconnectedclosing, Strings.Errors.disconnected, DarkDialogButton.Ok,
-                        Icon
+                    var item = toolsToolStripMenuItem.DropDownItems.Add(
+                        executables[x]
+                            .Replace(childDirs[i], "")
+                            .Replace(".exe", "")
+                            .Replace(Path.DirectorySeparatorChar.ToString(), "")
                     );
 
+                    item.Tag = executables[x];
+                    item.Click += externalToolItem_Click;
+                }
+            }
+        }
+    }
+
+    private void externalToolItem_Click(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrEmpty((string) ((ToolStripItem) sender).Tag))
+        {
+            var psi = new ProcessStartInfo(Path.GetFileName((string) ((ToolStripItem) sender).Tag))
+            {
+                WorkingDirectory = Path.GetDirectoryName((string) ((ToolStripItem) sender).Tag)
+            };
+
+            Process.Start(psi);
+        }
+    }
+
+    private void FrmMain_KeyDown(object sender, KeyEventArgs e)
+    {
+        switch (e.KeyData)
+        {
+            case Keys.Control | Keys.Z:
+                toolStripBtnUndo_Click(null, null);
+                return;
+
+            case Keys.Control | Keys.Y:
+                toolStripBtnRedo_Click(null, null);
+                return;
+
+            case Keys.Control | Keys.X:
+                toolStripBtnCut_Click(null, null);
+                return;
+
+            case Keys.Control | Keys.C:
+                toolStripBtnCopy_Click(null, null);
+                return;
+
+            case Keys.Control | Keys.V:
+                toolStripBtnPaste_Click(null, null);
+                return;
+
+            case Keys.Control | Keys.S:
+                toolStripBtnSaveMap_Click(null, null);
+                return;
+        }
+
+        var xDiff = 0;
+        var yDiff = 0;
+        if (dockLeft.ActiveContent == Globals.MapEditorWindow ||
+            dockLeft.ActiveContent == null &&
+            Globals.MapEditorWindow.DockPanel.ActiveDocument == Globals.MapEditorWindow)
+        {
+            switch (e.KeyCode)
+            {
+                // Shortcuts: Map grid scrolling.
+                case Keys.W:
+                case Keys.Up:
+                    yDiff -= 20;
+                    break;
+
+                case Keys.S:
+                case Keys.Down:
+                    yDiff += 20;
+                    break;
+
+                case Keys.A:
+                case Keys.Left:
+                    xDiff -= 20;
+                    break;
+
+                case Keys.D:
+                case Keys.Right:
+                    xDiff += 20;
+                    break;
+
+                // Shortcuts: Map grid Tools.
+                case Keys.B: // Brush.
+                    toolStripBtnBrush_Click(null, null);
+                    break;
+
+                case Keys.M: // Marquee Selection.
+                    toolStripBtnSelect_Click(null, null);
+                    break;
+
+                case Keys.R: // Rectangle.
+                    toolStripBtnRect_Click(null, null);
+                    break;
+
+                case Keys.PageUp: // Vertical Flip Selection.
+                    toolStripBtnFlipVertical_Click(null, null);
+                    break;
+
+                case Keys.PageDown: // Horizontal Flip Selection.
+                    toolStripBtnFlipHorizontal_Click(null, null);
+                    break;
+
+                case Keys.F: // Fill Tool.
+                    toolStripBtnFill_Click(null, null);
+                    break;
+
+                case Keys.E: // Erase.
+                    toolStripBtnErase_Click(null, null);
+                    break;
+
+                case Keys.I: // Dropper Tool.
+                    toolStripBtnDropper_Click(null, null);
+                    break;
+
+                case Keys.Delete: // Delete Selection.
+                    ToolKeyDelete();
+                    break;
+            }
+
+            if (xDiff != 0 || yDiff != 0)
+            {
+                var hWnd = WindowFromPoint(MousePosition);
+                if (hWnd != IntPtr.Zero)
+                {
+                    var ctl = FromHandle(hWnd);
+                    if (ctl != null)
+                    {
+                        if (ctl is ComboBox || ctl is DarkComboBox)
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                Core.Graphics.CurrentView.X -= xDiff;
+                Core.Graphics.CurrentView.Y -= yDiff;
+                if (Core.Graphics.CurrentView.X > Options.MapWidth * Options.TileWidth)
+                {
+                    Core.Graphics.CurrentView.X = Options.MapWidth * Options.TileWidth;
+                }
+
+                if (Core.Graphics.CurrentView.Y > Options.MapHeight * Options.TileHeight)
+                {
+                    Core.Graphics.CurrentView.Y = Options.MapHeight * Options.TileHeight;
+                }
+
+                if (Core.Graphics.CurrentView.X - Globals.MapEditorWindow.picMap.Width <
+                    -Options.TileWidth * Options.MapWidth * 2)
+                {
+                    Core.Graphics.CurrentView.X = -Options.TileWidth * Options.MapWidth * 2 +
+                                                  Globals.MapEditorWindow.picMap.Width;
+                }
+
+                if (Core.Graphics.CurrentView.Y - Globals.MapEditorWindow.picMap.Height <
+                    -Options.TileHeight * Options.MapHeight * 2)
+                {
+                    Core.Graphics.CurrentView.Y = -Options.TileHeight * Options.MapHeight * 2 +
+                                                  Globals.MapEditorWindow.picMap.Height;
+                }
+            }
+        }
+    }
+
+    private void InitMapProperties()
+    {
+        var unhiddenPane = dockLeft.Panes[0];
+        Globals.MapPropertiesWindow = new FrmMapProperties();
+        Globals.MapPropertiesWindow.Show(unhiddenPane, DockAlignment.Bottom, .4);
+        Globals.MapPropertiesWindow.Init(Globals.CurrentMap);
+        Globals.MapEditorWindow.DockPanel.Focus();
+    }
+
+    private void InitEditor()
+    {
+        Core.Graphics.InitMonogame();
+        Globals.MapLayersWindow.InitTilesets();
+        Globals.MapLayersWindow.Init();
+        Globals.InEditor = true;
+        GrabMouseDownEvents();
+        UpdateRunState();
+
+        //Init layer visibility buttons
+        foreach (var layer in Options.Instance.MapOpts.Layers.All)
+        {
+            Strings.Tiles.maplayers.TryGetValue(layer.ToLower(), out LocalizedString layerName);
+            if (layerName == null) layerName = layer;
+            var btn = new ToolStripMenuItem(layerName);
+            btn.Checked = true;
+            btn.Click += HideLayerBtn_Click;
+            btn.Tag = layer;
+            layersToolStripMenuItem.DropDownItems.Add(btn);
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        Networking.Network.EditorLidgrenNetwork?.Disconnect(NetworkStatus.Quitting.ToString());
+        base.OnClosed(e);
+        Application.Exit();
+    }
+
+    public void ShowDialogForm(Form form)
+    {
+        if (InvokeRequired)
+        {
+            Invoke((MethodInvoker) delegate { ShowDialogForm(form); });
+
+            return;
+        }
+
+        form.ShowDialog(this);
+    }
+
+    public void EnterMap(Guid mapId, bool userEntered = false)
+    {
+        if (InvokeRequired)
+        {
+            Invoke((MethodInvoker) delegate { EnterMap(mapId, userEntered); });
+
+            return;
+        }
+
+        Globals.CurrentMap = MapInstance.Get(mapId);
+        Globals.LoadingMap = mapId;
+        if (Globals.CurrentMap == null)
+        {
+            Text = @"Intersect Editor";
+        }
+        else
+        {
+            if (Globals.MapPropertiesWindow != null)
+            {
+                Globals.MapPropertiesWindow.Init(Globals.CurrentMap);
+            }
+        }
+
+        Globals.MapEditorWindow.UnloadMap();
+        PacketSender.SendEnterMap(mapId);
+        PacketSender.SendNeedMap(mapId);
+        PacketSender.SendNeedGrid(mapId);
+        Core.Graphics.TilePreviewUpdated = true;
+
+        // Save that we've opened this map last if this was a user triggered action. This way we can load it again should we restart the editor.
+        if (userEntered)
+        {
+            Preferences.SavePreference("LastMapOpened", mapId.ToString());
+        }
+    }
+
+    private void GrabMouseDownEvents()
+    {
+        GrabMouseDownEvents(this);
+    }
+
+    private void GrabMouseDownEvents(Control e)
+    {
+        foreach (Control t in e.Controls)
+        {
+            if (t is MenuStrip menuStrip)
+            {
+                foreach (ToolStripMenuItem t1 in menuStrip.Items)
+                {
+                    t1.MouseDown += MouseDownHandler;
+                }
+
+                t.MouseDown += MouseDownHandler;
+            }
+            else if (t is PropertyGrid)
+            {
+            }
+            else
+            {
+                GrabMouseDownEvents(t);
+            }
+        }
+
+        e.MouseDown += MouseDownHandler;
+    }
+
+    public void MouseDownHandler(object sender, MouseEventArgs e)
+    {
+        if (e.Button == MouseButtons.Middle || e.Button == MouseButtons.None)
+        {
+            return;
+        }
+
+        if (sender != Globals.MapEditorWindow &&
+            sender != Globals.MapEditorWindow.pnlMapContainer &&
+            sender != Globals.MapEditorWindow.picMap)
+        {
+            Globals.MapEditorWindow.PlaceSelection();
+        }
+    }
+
+    //Update
+    public void Update()
+    {
+        if (Globals.CurrentMap != null)
+        {
+            toolStripLabelCoords.Text = Strings.MainForm.loc.ToString(Globals.CurTileX, Globals.CurTileY);
+            toolStripLabelRevision.Text = Strings.MainForm.revision.ToString(Globals.CurrentMap.Revision);
+            if (Text != Strings.MainForm.title.ToString(Globals.CurrentMap.Name))
+            {
+                Text = Strings.MainForm.title.ToString(Globals.CurrentMap.Name);
+            }
+        }
+
+        //Process the Undo/Redo Buttons
+        if (Globals.MapEditorWindow.MapUndoStates.Count > 0)
+        {
+            toolStripBtnUndo.Enabled = true;
+            undoToolStripMenuItem.Enabled = true;
+        }
+        else
+        {
+            toolStripBtnUndo.Enabled = false;
+            undoToolStripMenuItem.Enabled = false;
+        }
+
+        if (Globals.MapEditorWindow.MapRedoStates.Count > 0)
+        {
+            toolStripBtnRedo.Enabled = true;
+            redoToolStripMenuItem.Enabled = true;
+        }
+        else
+        {
+            toolStripBtnRedo.Enabled = false;
+            redoToolStripMenuItem.Enabled = false;
+        }
+
+        //Process the Fill/Erase Buttons, these should display for all valid map layers as well as Attributes.
+        if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer) || Globals.CurrentLayer == LayerOptions.Attributes)
+        {
+            toolStripBtnFill.Enabled = true;
+            fillToolStripMenuItem.Enabled = true;
+            toolStripBtnErase.Enabled = true;
+            eraseLayerToolStripMenuItem.Enabled = true;
+        }
+        else
+        {
+            toolStripBtnFill.Enabled = false;
+            fillToolStripMenuItem.Enabled = false;
+            toolStripBtnErase.Enabled = false;
+            eraseLayerToolStripMenuItem.Enabled = false;
+        }
+
+        //Process the Tool Buttons
+        toolStripBtnBrush.Enabled = false;
+        toolStripBtnSelect.Enabled = true;
+        toolStripBtnRect.Enabled = false;
+        toolStripBtnDropper.Enabled = false;
+        if (Globals.CurrentLayer == LayerOptions.Attributes)
+        {
+            toolStripBtnBrush.Enabled = true;
+            toolStripBtnRect.Enabled = true;
+        }
+        else if (Globals.CurrentLayer == LayerOptions.Lights)
+        {
+            Globals.CurrentTool = EditingTool.Selection;
+        }
+        else if (Globals.CurrentLayer == LayerOptions.Events)
+        {
+            Globals.CurrentTool = EditingTool.Selection;
+        }
+        else if (Globals.CurrentLayer == LayerOptions.Npcs)
+        {
+            Globals.CurrentTool = EditingTool.Selection;
+        }
+        else
+        {
+            toolStripBtnBrush.Enabled = true;
+            toolStripBtnRect.Enabled = true;
+            toolStripBtnDropper.Enabled = true;
+        }
+
+        switch (Globals.CurrentTool)
+        {
+            case EditingTool.Brush:
+                if (!toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = true;
+                }
+
+                if (toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = false;
+                }
+
+                if (toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = false;
+                }
+
+                if (toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = false;
+                }
+
+                if (toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = false;
+                }
+
+                if (toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = false;
+                }
+
+                if (toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = false;
+                }
+
+                if (toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = false;
+                }
+
+                if (cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = false;
+                }
+
+                if (copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = false;
+                }
+
+                break;
+            case EditingTool.Selection:
+                if (toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = false;
+                }
+
+                if (!toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = true;
+                }
+
+                if (toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = false;
+                }
+
+                if (toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = false;
+                }
+
+                if (toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = false;
+                }
+
+                if (toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = false;
+                }
+
+                if (!toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = true;
+                }
+
+                if (!toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = true;
+                }
+
+                if (!cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = true;
+                }
+
+                if (!copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = true;
+                }
+
+                break;
+            case EditingTool.Rectangle:
+                if (toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = false;
+                }
+
+                if (toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = false;
+                }
+
+                if (!toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = true;
+                }
+
+                if (toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = false;
+                }
+
+                if (toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = false;
+                }
+
+                if (toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = false;
+                }
+
+                if (toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = false;
+                }
+
+                if (toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = false;
+                }
+
+                if (cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = false;
+                }
+
+                if (copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = false;
+                }
+
+                break;
+            case EditingTool.Fill:
+                if (toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = false;
+                }
+
+                if (toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = false;
+                }
+
+                if (toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = false;
+                }
+
+                if (!toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = true;
+                }
+
+                if (toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = false;
+                }
+
+                if (toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = false;
+                }
+
+                if (toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = false;
+                }
+
+                if (toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = false;
+                }
+
+                if (cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = false;
+                }
+
+                if (copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = false;
+                }
+
+                break;
+            case EditingTool.Erase:
+                if (toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = false;
+                }
+
+                if (toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = false;
+                }
+
+                if (toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = false;
+                }
+
+                if (toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = false;
+                }
+
+                if (!toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = true;
+                }
+
+                if (toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = false;
+                }
+
+                if (toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = false;
+                }
+
+                if (toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = false;
+                }
+
+                if (cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = false;
+                }
+
+                if (copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = false;
+                }
+
+                break;
+            case EditingTool.Dropper:
+                if (toolStripBtnBrush.Checked)
+                {
+                    toolStripBtnBrush.Checked = false;
+                }
+
+                if (toolStripBtnSelect.Checked)
+                {
+                    toolStripBtnSelect.Checked = false;
+                }
+
+                if (toolStripBtnRect.Checked)
+                {
+                    toolStripBtnRect.Checked = false;
+                }
+
+                if (toolStripBtnFill.Checked)
+                {
+                    toolStripBtnFill.Checked = false;
+                }
+
+                if (toolStripBtnErase.Checked)
+                {
+                    toolStripBtnErase.Checked = false;
+                }
+
+                if (!toolStripBtnDropper.Checked)
+                {
+                    toolStripBtnDropper.Checked = true;
+                }
+
+                if (toolStripBtnCut.Enabled)
+                {
+                    toolStripBtnCut.Enabled = false;
+                }
+
+                if (toolStripBtnCopy.Enabled)
+                {
+                    toolStripBtnCopy.Enabled = false;
+                }
+
+                if (cutToolStripMenuItem.Enabled)
+                {
+                    cutToolStripMenuItem.Enabled = false;
+                }
+
+                if (copyToolStripMenuItem.Enabled)
+                {
+                    copyToolStripMenuItem.Enabled = false;
+                }
+
+                break;
+        }
+
+        if (Globals.HasCopy)
+        {
+            toolStripBtnPaste.Enabled = true;
+            pasteToolStripMenuItem.Enabled = true;
+        }
+        else
+        {
+            toolStripBtnPaste.Enabled = false;
+            pasteToolStripMenuItem.Enabled = false;
+        }
+
+        if (Globals.Dragging)
+        {
+            if (Globals.MainForm.ActiveControl is DockPane dockPane)
+            {
+                var ctrl = dockPane.ActiveControl;
+                if (ctrl != Globals.MapEditorWindow)
+                {
+                    Globals.MapEditorWindow.PlaceSelection();
+                }
+            }
+        }
+    }
+
+    //Disconnection
+    private void HandleServerDisconnect()
+    {
+        if (!Globals.ClosingEditor)
+        {
+            Globals.ClosingEditor = true;
+
+            //Offer to export map
+            if (Globals.CurrentMap != null)
+            {
+                if (DarkMessageBox.ShowError(
+                        Strings.Errors.disconnectedsave, Strings.Errors.disconnectedsavecaption,
+                        DarkDialogButton.YesNo, Icon
+                    ) ==
+                    DialogResult.Yes)
+                {
+                    exportMapToolStripMenuItem_Click(null, null);
+                    Application.Exit();
+                }
+                else
+                {
                     Application.Exit();
                 }
             }
-        }
-
-        //MenuBar Functions -- File
-        private void saveMapToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentMap.Changed() &&
-                DarkMessageBox.ShowInformation(
-                    Strings.Mapping.savemapdialoguesure, Strings.Mapping.savemap, DarkDialogButton.YesNo,
+            else
+            {
+                DarkMessageBox.ShowError(
+                    Strings.Errors.disconnectedclosing, Strings.Errors.disconnected, DarkDialogButton.Ok,
                     Icon
-                ) ==
-                DialogResult.Yes)
-            {
-                SaveMap();
-            }
-        }
-
-        private static void SaveMap()
-        {
-            if (Globals.CurrentTool == EditingTool.Selection)
-            {
-                if (Globals.Dragging)
-                {
-                    //Place the change, we done!
-                    Globals.MapEditorWindow?.ProcessSelectionMovement(Globals.CurrentMap, true);
-                    Globals.MapEditorWindow?.PlaceSelection();
-                }
-            }
-
-            PacketSender.SendMap(Globals.CurrentMap);
-        }
-
-        private void NewMapToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (DarkMessageBox.ShowWarning(
-                    Strings.Mapping.newmap, Strings.Mapping.newmapcaption, DarkDialogButton.YesNo,
-                    Icon
-                ) !=
-                DialogResult.Yes)
-            {
-                return;
-            }
-
-            if (Globals.CurrentMap.Changed() &&
-                DarkMessageBox.ShowInformation(
-                    Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
-                    Icon
-                ) ==
-                DialogResult.Yes)
-            {
-                SaveMap();
-            }
-
-            PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, null);
-        }
-
-        private void exportMapToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var fileDialog = new SaveFileDialog()
-            {
-                Filter = "Intersect Map|*.imap",
-                Title = Strings.MainForm.exportmap
-            };
-
-            //TODO Reimplement
-            //fileDialog.ShowDialog();
-            //var buff = new ByteBuffer();
-            //buff.WriteString(Application.ProductVersion);
-            //buff.WriteBytes(Globals.CurrentMap.SaveInternal());
-            //if (fileDialog.FileName != "")
-            //{
-            //    File.WriteAllBytes(fileDialog.FileName, buff.ToArray());
-            //}
-            //buff.Dispose();
-        }
-
-        private void importMapToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var fileDialog = new OpenFileDialog()
-            {
-                Filter = "Intersect Map|*.imap",
-                Title = Strings.MainForm.importmap
-            };
-
-            //TODO Reimplement
-            //fileDialog.ShowDialog();
-
-            //if (fileDialog.FileName != "")
-            //{
-            //    var data = File.ReadAllBytes(fileDialog.FileName);
-            //    var buff = new ByteBuffer();
-            //    buff.WriteBytes(data);
-            //    if (buff.ReadString() == Application.ProductVersion)
-            //    {
-            //        Globals.MapEditorWindow.PrepUndoState();
-            //        Globals.CurrentMap.LoadInternal(buff.ReadBytes(buff.Length(), true));
-            //        Globals.MapEditorWindow.AddUndoState();
-            //    }
-            //    else
-            //    {
-            //        DarkMessageBox.ShowError(Strings.Errors.importfailed,
-            //            Strings.Errors.importfailedcaption, DarkDialogButton.Ok, Icon);
-            //    }
-            //}
-        }
-
-        private void optionsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var optionsForm = new FrmOptions();
-            optionsForm.ShowDialog();
-            UpdateRunState();
-        }
-
-        private void exitToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Application.Exit();
-        }
-
-        //Edit
-        private void fillToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
-            {
-                Globals.MapEditorWindow.FillLayer();
-            }
-        }
-
-        private void eraseLayerToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
-            {
-                Globals.MapEditorWindow.EraseLayer();
-            }
-        }
-
-        private void allLayersToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Globals.SelectionType = (int) SelectionTypes.AllLayers;
-            allLayersToolStripMenuItem.Checked = true;
-            currentLayerOnlyToolStripMenuItem.Checked = false;
-        }
-
-        private void currentLayerOnlyToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Globals.SelectionType = (int) SelectionTypes.CurrentLayer;
-            allLayersToolStripMenuItem.Checked = false;
-            currentLayerOnlyToolStripMenuItem.Checked = true;
-        }
-
-        private void undoToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripBtnUndo_Click(null, null);
-        }
-
-        private void redoToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripBtnRedo_Click(null, null);
-        }
-
-        private void cutToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripBtnCut_Click(null, null);
-        }
-
-        private void copyToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripBtnCopy_Click(null, null);
-        }
-
-        private void pasteToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripBtnPaste_Click(null, null);
-        }
-
-        //View
-        private void hideDarknessToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideDarkness = !Core.Graphics.HideDarkness;
-            hideDarknessToolStripMenuItem.Checked = !Core.Graphics.HideDarkness;
-        }
-
-        private void hideFogToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideFog = !Core.Graphics.HideFog;
-            hideFogToolStripMenuItem.Checked = !Core.Graphics.HideFog;
-        }
-
-        private void hideOverlayToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideOverlay = !Core.Graphics.HideOverlay;
-            hideOverlayToolStripMenuItem.Checked = !Core.Graphics.HideOverlay;
-        }
-
-        private void hideTilePreviewToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideTilePreview = !Core.Graphics.HideTilePreview;
-            hideTilePreviewToolStripMenuItem.Checked = !Core.Graphics.HideTilePreview;
-        }
-
-        private void hideResourcesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideResources = !Core.Graphics.HideResources;
-            hideResourcesToolStripMenuItem.Checked = !Core.Graphics.HideResources;
-        }
-
-        private void hideEventsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideEvents = !Core.Graphics.HideEvents;
-            hideEventsToolStripMenuItem.Checked = !Core.Graphics.HideEvents;
-        }
-
-        private void mapGridToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Core.Graphics.HideGrid = !Core.Graphics.HideGrid;
-            mapGridToolStripMenuItem.Checked = !Core.Graphics.HideGrid;
-        }
-
-        //Content Editors
-        private void itemEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Item);
-        }
-
-        private void npcEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Npc);
-        }
-
-        private void spellEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Spell);
-        }
-
-        private void craftingTablesEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.CraftTables);
-        }
-
-        private void craftsEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Crafts);
-        }
-
-        private void animationEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Animation);
-        }
-
-        private void resourceEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Resource);
-        }
-
-        private void classEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Class);
-        }
-
-        private void questEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Quest);
-        }
-
-        private void projectileEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Projectile);
-        }
-
-        private void commonEventEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Event);
-        }
-
-        private void variableEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.PlayerVariable);
-        }
-
-        private void shopEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Shop);
-        }
-
-        private void timeEditorToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            PacketSender.SendOpenEditor(GameObjectType.Time);
-        }
-
-        private void layersToolStripMenuItem_DropDownOpened(object sender, EventArgs e)
-        {
-            foreach (var itm in ((ToolStripMenuItem)sender).DropDownItems)
-            {
-                var btn = (ToolStripMenuItem)itm;
-                btn.Checked = Globals.MapLayersWindow.LayerVisibility[(string)btn.Tag];
-            }
-        }
-
-        private void HideLayerBtn_Click(object sender, EventArgs e)
-        {
-            var btn = ((ToolStripMenuItem)sender);
-            var tag = (string)btn.Tag;
-            btn.Checked = !btn.Checked;
-            Globals.MapLayersWindow.LayerVisibility[tag] = btn.Checked;
-            Globals.MapLayersWindow.SetLayer(Globals.CurrentLayer);
-        }
-
-        //Help
-        private void postQuestionToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripButtonQuestion_Click(null, null);
-        }
-
-        private void reportBugToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            toolStripButtonBug_Click(null, null);
-        }
-
-        private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var aboutfrm = new FrmAbout();
-            aboutfrm.ShowDialog();
-        }
-
-        //ToolStrip Functions
-        private void toolStripBtnNewMap_Click(object sender, EventArgs e)
-        {
-            NewMapToolStripMenuItem_Click(null, null);
-        }
-
-        private void toolStripBtnSaveMap_Click(object sender, EventArgs e)
-        {
-            saveMapToolStripMenuItem_Click(null, null);
-        }
-
-        private void toolStripBtnUndo_Click(object sender, EventArgs e)
-        {
-            var tmpMap = Globals.CurrentMap;
-            if (Globals.MapEditorWindow.MapUndoStates.Count > 0)
-            {
-                tmpMap.LoadInternal(
-                    Globals.MapEditorWindow.MapUndoStates[Globals.MapEditorWindow.MapUndoStates.Count - 1]
                 );
 
-                Globals.MapEditorWindow.MapRedoStates.Add(Globals.MapEditorWindow.CurrentMapState);
-                Globals.MapEditorWindow.CurrentMapState =
-                    Globals.MapEditorWindow.MapUndoStates[Globals.MapEditorWindow.MapUndoStates.Count - 1];
+                Application.Exit();
+            }
+        }
+    }
 
-                Globals.MapEditorWindow.MapUndoStates.RemoveAt(Globals.MapEditorWindow.MapUndoStates.Count - 1);
-                Globals.MapPropertiesWindow.Update();
-                Core.Graphics.TilePreviewUpdated = true;
+    //MenuBar Functions -- File
+    private void saveMapToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentMap.Changed() &&
+            DarkMessageBox.ShowInformation(
+                Strings.Mapping.savemapdialoguesure, Strings.Mapping.savemap, DarkDialogButton.YesNo,
+                Icon
+            ) ==
+            DialogResult.Yes)
+        {
+            SaveMap();
+        }
+    }
+
+    private static void SaveMap()
+    {
+        if (Globals.CurrentTool == EditingTool.Selection)
+        {
+            if (Globals.Dragging)
+            {
+                //Place the change, we done!
+                Globals.MapEditorWindow?.ProcessSelectionMovement(Globals.CurrentMap, true);
+                Globals.MapEditorWindow?.PlaceSelection();
             }
         }
 
-        private void toolStripBtnRedo_Click(object sender, EventArgs e)
+        PacketSender.SendMap(Globals.CurrentMap);
+    }
+
+    private void NewMapToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        if (DarkMessageBox.ShowWarning(
+                Strings.Mapping.newmap, Strings.Mapping.newmapcaption, DarkDialogButton.YesNo,
+                Icon
+            ) !=
+            DialogResult.Yes)
         {
-            var tmpMap = Globals.CurrentMap;
-            if (Globals.MapEditorWindow.MapRedoStates.Count > 0)
+            return;
+        }
+
+        if (Globals.CurrentMap.Changed() &&
+            DarkMessageBox.ShowInformation(
+                Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
+                Icon
+            ) ==
+            DialogResult.Yes)
+        {
+            SaveMap();
+        }
+
+        PacketSender.SendCreateMap(-1, Globals.CurrentMap.Id, null);
+    }
+
+    private void exportMapToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var fileDialog = new SaveFileDialog()
+        {
+            Filter = "Intersect Map|*.imap",
+            Title = Strings.MainForm.exportmap
+        };
+
+        //TODO Reimplement
+        //fileDialog.ShowDialog();
+        //var buff = new ByteBuffer();
+        //buff.WriteString(Application.ProductVersion);
+        //buff.WriteBytes(Globals.CurrentMap.SaveInternal());
+        //if (fileDialog.FileName != "")
+        //{
+        //    File.WriteAllBytes(fileDialog.FileName, buff.ToArray());
+        //}
+        //buff.Dispose();
+    }
+
+    private void importMapToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var fileDialog = new OpenFileDialog()
+        {
+            Filter = "Intersect Map|*.imap",
+            Title = Strings.MainForm.importmap
+        };
+
+        //TODO Reimplement
+        //fileDialog.ShowDialog();
+
+        //if (fileDialog.FileName != "")
+        //{
+        //    var data = File.ReadAllBytes(fileDialog.FileName);
+        //    var buff = new ByteBuffer();
+        //    buff.WriteBytes(data);
+        //    if (buff.ReadString() == Application.ProductVersion)
+        //    {
+        //        Globals.MapEditorWindow.PrepUndoState();
+        //        Globals.CurrentMap.LoadInternal(buff.ReadBytes(buff.Length(), true));
+        //        Globals.MapEditorWindow.AddUndoState();
+        //    }
+        //    else
+        //    {
+        //        DarkMessageBox.ShowError(Strings.Errors.importfailed,
+        //            Strings.Errors.importfailedcaption, DarkDialogButton.Ok, Icon);
+        //    }
+        //}
+    }
+
+    private void optionsToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var optionsForm = new FrmOptions();
+        optionsForm.ShowDialog();
+        UpdateRunState();
+    }
+
+    private void exitToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Application.Exit();
+    }
+
+    //Edit
+    private void fillToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
+        {
+            Globals.MapEditorWindow.FillLayer();
+        }
+    }
+
+    private void eraseLayerToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        if (Options.Instance.MapOpts.Layers.All.Contains(Globals.CurrentLayer))
+        {
+            Globals.MapEditorWindow.EraseLayer();
+        }
+    }
+
+    private void allLayersToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Globals.SelectionType = (int) SelectionTypes.AllLayers;
+        allLayersToolStripMenuItem.Checked = true;
+        currentLayerOnlyToolStripMenuItem.Checked = false;
+    }
+
+    private void currentLayerOnlyToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Globals.SelectionType = (int) SelectionTypes.CurrentLayer;
+        allLayersToolStripMenuItem.Checked = false;
+        currentLayerOnlyToolStripMenuItem.Checked = true;
+    }
+
+    private void undoToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripBtnUndo_Click(null, null);
+    }
+
+    private void redoToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripBtnRedo_Click(null, null);
+    }
+
+    private void cutToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripBtnCut_Click(null, null);
+    }
+
+    private void copyToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripBtnCopy_Click(null, null);
+    }
+
+    private void pasteToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripBtnPaste_Click(null, null);
+    }
+
+    //View
+    private void hideDarknessToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideDarkness = !Core.Graphics.HideDarkness;
+        hideDarknessToolStripMenuItem.Checked = !Core.Graphics.HideDarkness;
+    }
+
+    private void hideFogToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideFog = !Core.Graphics.HideFog;
+        hideFogToolStripMenuItem.Checked = !Core.Graphics.HideFog;
+    }
+
+    private void hideOverlayToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideOverlay = !Core.Graphics.HideOverlay;
+        hideOverlayToolStripMenuItem.Checked = !Core.Graphics.HideOverlay;
+    }
+
+    private void hideTilePreviewToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideTilePreview = !Core.Graphics.HideTilePreview;
+        hideTilePreviewToolStripMenuItem.Checked = !Core.Graphics.HideTilePreview;
+    }
+
+    private void hideResourcesToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideResources = !Core.Graphics.HideResources;
+        hideResourcesToolStripMenuItem.Checked = !Core.Graphics.HideResources;
+    }
+
+    private void hideEventsToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideEvents = !Core.Graphics.HideEvents;
+        hideEventsToolStripMenuItem.Checked = !Core.Graphics.HideEvents;
+    }
+
+    private void mapGridToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        Core.Graphics.HideGrid = !Core.Graphics.HideGrid;
+        mapGridToolStripMenuItem.Checked = !Core.Graphics.HideGrid;
+    }
+
+    //Content Editors
+    private void itemEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Item);
+    }
+
+    private void npcEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Npc);
+    }
+
+    private void spellEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Spell);
+    }
+
+    private void craftingTablesEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.CraftTables);
+    }
+
+    private void craftsEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Crafts);
+    }
+
+    private void animationEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Animation);
+    }
+
+    private void resourceEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Resource);
+    }
+
+    private void classEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Class);
+    }
+
+    private void questEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Quest);
+    }
+
+    private void projectileEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Projectile);
+    }
+
+    private void commonEventEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Event);
+    }
+
+    private void variableEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.PlayerVariable);
+    }
+
+    private void shopEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Shop);
+    }
+
+    private void timeEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Time);
+    }
+
+    private void layersToolStripMenuItem_DropDownOpened(object sender, EventArgs e)
+    {
+        foreach (var itm in ((ToolStripMenuItem)sender).DropDownItems)
+        {
+            var btn = (ToolStripMenuItem)itm;
+            btn.Checked = Globals.MapLayersWindow.LayerVisibility[(string)btn.Tag];
+        }
+    }
+
+    private void HideLayerBtn_Click(object sender, EventArgs e)
+    {
+        var btn = ((ToolStripMenuItem)sender);
+        var tag = (string)btn.Tag;
+        btn.Checked = !btn.Checked;
+        Globals.MapLayersWindow.LayerVisibility[tag] = btn.Checked;
+        Globals.MapLayersWindow.SetLayer(Globals.CurrentLayer);
+    }
+
+    //Help
+    private void postQuestionToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripButtonQuestion_Click(null, null);
+    }
+
+    private void reportBugToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        toolStripButtonBug_Click(null, null);
+    }
+
+    private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var aboutfrm = new FrmAbout();
+        aboutfrm.ShowDialog();
+    }
+
+    //ToolStrip Functions
+    private void toolStripBtnNewMap_Click(object sender, EventArgs e)
+    {
+        NewMapToolStripMenuItem_Click(null, null);
+    }
+
+    private void toolStripBtnSaveMap_Click(object sender, EventArgs e)
+    {
+        saveMapToolStripMenuItem_Click(null, null);
+    }
+
+    private void toolStripBtnUndo_Click(object sender, EventArgs e)
+    {
+        var tmpMap = Globals.CurrentMap;
+        if (Globals.MapEditorWindow.MapUndoStates.Count > 0)
+        {
+            tmpMap.LoadInternal(
+                Globals.MapEditorWindow.MapUndoStates[Globals.MapEditorWindow.MapUndoStates.Count - 1]
+            );
+
+            Globals.MapEditorWindow.MapRedoStates.Add(Globals.MapEditorWindow.CurrentMapState);
+            Globals.MapEditorWindow.CurrentMapState =
+                Globals.MapEditorWindow.MapUndoStates[Globals.MapEditorWindow.MapUndoStates.Count - 1];
+
+            Globals.MapEditorWindow.MapUndoStates.RemoveAt(Globals.MapEditorWindow.MapUndoStates.Count - 1);
+            Globals.MapPropertiesWindow.Update();
+            Core.Graphics.TilePreviewUpdated = true;
+        }
+    }
+
+    private void toolStripBtnRedo_Click(object sender, EventArgs e)
+    {
+        var tmpMap = Globals.CurrentMap;
+        if (Globals.MapEditorWindow.MapRedoStates.Count > 0)
+        {
+            tmpMap.LoadInternal(
+                Globals.MapEditorWindow.MapRedoStates[Globals.MapEditorWindow.MapRedoStates.Count - 1]
+            );
+
+            Globals.MapEditorWindow.MapUndoStates.Add(Globals.MapEditorWindow.CurrentMapState);
+            Globals.MapEditorWindow.CurrentMapState =
+                Globals.MapEditorWindow.MapRedoStates[Globals.MapEditorWindow.MapRedoStates.Count - 1];
+
+            Globals.MapEditorWindow.MapRedoStates.RemoveAt(Globals.MapEditorWindow.MapRedoStates.Count - 1);
+            Globals.MapPropertiesWindow.Update();
+            Core.Graphics.TilePreviewUpdated = true;
+        }
+    }
+
+    private void toolStripBtnFill_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Fill;
+    }
+
+    private void toolStripBtnErase_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Erase;
+    }
+
+    private void toolStripBtnScreenshot_Click(object sender, EventArgs e)
+    {
+        var fileDialog = new SaveFileDialog()
+        {
+            Filter = "Png Image|*.png|JPeg Image|*.jpg|Bitmap Image|*.bmp|Gif Image|*.gif",
+            Title = Strings.MainForm.screenshot
+        };
+
+        fileDialog.ShowDialog();
+
+        if (fileDialog.FileName != "")
+        {
+            using (var fs = new FileStream(fileDialog.FileName, FileMode.OpenOrCreate))
             {
-                tmpMap.LoadInternal(
-                    Globals.MapEditorWindow.MapRedoStates[Globals.MapEditorWindow.MapRedoStates.Count - 1]
-                );
-
-                Globals.MapEditorWindow.MapUndoStates.Add(Globals.MapEditorWindow.CurrentMapState);
-                Globals.MapEditorWindow.CurrentMapState =
-                    Globals.MapEditorWindow.MapRedoStates[Globals.MapEditorWindow.MapRedoStates.Count - 1];
-
-                Globals.MapEditorWindow.MapRedoStates.RemoveAt(Globals.MapEditorWindow.MapRedoStates.Count - 1);
-                Globals.MapPropertiesWindow.Update();
-                Core.Graphics.TilePreviewUpdated = true;
+                var screenshotTexture = Core.Graphics.ScreenShotMap();
+                screenshotTexture.Save(fs, System.Drawing.Imaging.ImageFormat.Png);
             }
         }
+    }
 
-        private void toolStripBtnFill_Click(object sender, EventArgs e)
+    private void toolStripBtnBrush_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Brush;
+    }
+
+    private void toolStripBtnSelect_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Selection;
+        Globals.CurMapSelX = 0;
+        Globals.CurMapSelY = 0;
+        Globals.CurMapSelW = 0;
+        Globals.CurMapSelH = 0;
+    }
+
+    private void toolStripBtnRect_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Rectangle;
+        Globals.CurMapSelX = 0;
+        Globals.CurMapSelY = 0;
+        Globals.CurMapSelW = 0;
+        Globals.CurMapSelH = 0;
+    }
+
+    private void toolStripBtnDropper_Click(object sender, EventArgs e)
+    {
+        Globals.CurrentTool = EditingTool.Dropper;
+        Globals.CurMapSelX = 0;
+        Globals.CurMapSelY = 0;
+    }
+
+    private void toolStripBtnCopy_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentTool != EditingTool.Selection)
         {
-            Globals.CurrentTool = EditingTool.Fill;
+            return;
         }
 
-        private void toolStripBtnErase_Click(object sender, EventArgs e)
+        Globals.MapEditorWindow.Copy();
+    }
+
+    private void toolStripBtnPaste_Click(object sender, EventArgs e)
+    {
+        if (!Globals.HasCopy)
         {
-            Globals.CurrentTool = EditingTool.Erase;
+            return;
         }
 
-        private void toolStripBtnScreenshot_Click(object sender, EventArgs e)
+        Globals.MapEditorWindow.Paste();
+    }
+
+    private void toolStripBtnCut_Click(object sender, EventArgs e)
+    {
+        if (Globals.CurrentTool != EditingTool.Selection)
         {
-            var fileDialog = new SaveFileDialog()
+            return;
+        }
+
+        Globals.MapEditorWindow.Cut();
+    }
+
+    private static void ToolKeyDelete()
+    {
+        if (Globals.CurrentTool != EditingTool.Selection)
+        {
+            return;
+        }
+
+        Globals.MapEditorWindow.Delete();
+    }
+
+    private void toolStripTimeButton_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void toolStripBtnRun_Click(object sender, EventArgs e)
+    {
+        var path = Preferences.LoadPreference("ClientPath");
+        if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+        {
+            var processStartInfo = new ProcessStartInfo(path)
             {
-                Filter = "Png Image|*.png|JPeg Image|*.jpg|Bitmap Image|*.bmp|Gif Image|*.gif",
-                Title = Strings.MainForm.screenshot
+                WorkingDirectory = Directory.GetParent(path).FullName
             };
 
-            fileDialog.ShowDialog();
+            _ = Process.Start(processStartInfo);
+        }
+    }
 
-            if (fileDialog.FileName != "")
+    private void toolStripButtonQuestion_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("https://www.ascensiongamedev.com/community/forum/53-questions-and-answers/");
+    }
+
+    private void toolStripButtonBug_Click(object sender, EventArgs e)
+    {
+        BrowserUtils.Open("https://github.com/AscensionGameDev/Intersect-Engine/issues/new/choose");
+    }
+
+    private void UpdateTimeSimulationList()
+    {
+        Bitmap transtile = null;
+        if (File.Exists("resources/misc/transtile.png"))
+        {
+            transtile = new Bitmap("resources/misc/transtile.png");
+        }
+
+        toolStripTimeButton.DropDownItems.Clear();
+        var time = new DateTime(2000, 1, 1, 0, 0, 0);
+        var x = 0;
+        var btn = new ToolStripDropDownButton(Strings.General.None)
+        {
+            Tag = null
+        };
+
+        btn.Click += TimeDropdownButton_Click;
+        toolStripTimeButton.DropDownItems.Add(btn);
+        for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
+        {
+            var addRange = time.ToString("h:mm:ss tt") + " to ";
+            time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
+            addRange += time.ToString("h:mm:ss tt");
+
+            //Create image of overlay color
+            var img = new Bitmap(16, 16);
+            var g = System.Drawing.Graphics.FromImage(img);
+            g.Clear(System.Drawing.Color.Transparent);
+
+            //Draw the trans tile if we have it
+            if (transtile != null)
             {
-                using (var fs = new FileStream(fileDialog.FileName, FileMode.OpenOrCreate))
-                {
-                    var screenshotTexture = Core.Graphics.ScreenShotMap();
-                    screenshotTexture.Save(fs, System.Drawing.Imaging.ImageFormat.Png);
-                }
-            }
-        }
-
-        private void toolStripBtnBrush_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = EditingTool.Brush;
-        }
-
-        private void toolStripBtnSelect_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = EditingTool.Selection;
-            Globals.CurMapSelX = 0;
-            Globals.CurMapSelY = 0;
-            Globals.CurMapSelW = 0;
-            Globals.CurMapSelH = 0;
-        }
-
-        private void toolStripBtnRect_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = EditingTool.Rectangle;
-            Globals.CurMapSelX = 0;
-            Globals.CurMapSelY = 0;
-            Globals.CurMapSelW = 0;
-            Globals.CurMapSelH = 0;
-        }
-
-        private void toolStripBtnDropper_Click(object sender, EventArgs e)
-        {
-            Globals.CurrentTool = EditingTool.Dropper;
-            Globals.CurMapSelX = 0;
-            Globals.CurMapSelY = 0;
-        }
-
-        private void toolStripBtnCopy_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentTool != EditingTool.Selection)
-            {
-                return;
-            }
-
-            Globals.MapEditorWindow.Copy();
-        }
-
-        private void toolStripBtnPaste_Click(object sender, EventArgs e)
-        {
-            if (!Globals.HasCopy)
-            {
-                return;
+                g.DrawImage(transtile, new System.Drawing.Point(0, 0));
             }
 
-            Globals.MapEditorWindow.Paste();
-        }
+            var clr = TimeBase.GetTimeBase().DaylightHues[x];
+            Brush brush = new SolidBrush(System.Drawing.Color.FromArgb(clr.A, clr.R, clr.G, clr.B));
+            g.FillRectangle(brush, new System.Drawing.Rectangle(0, 0, 32, 32));
 
-        private void toolStripBtnCut_Click(object sender, EventArgs e)
-        {
-            if (Globals.CurrentTool != EditingTool.Selection)
+            //Draw the overlay color
+            g.Dispose();
+
+            btn = new ToolStripDropDownButton(addRange, img)
             {
-                return;
-            }
-
-            Globals.MapEditorWindow.Cut();
-        }
-
-        private static void ToolKeyDelete()
-        {
-            if (Globals.CurrentTool != EditingTool.Selection)
-            {
-                return;
-            }
-
-            Globals.MapEditorWindow.Delete();
-        }
-
-        private void toolStripTimeButton_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void toolStripBtnRun_Click(object sender, EventArgs e)
-        {
-            var path = Preferences.LoadPreference("ClientPath");
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                var processStartInfo = new ProcessStartInfo(path)
-                {
-                    WorkingDirectory = Directory.GetParent(path).FullName
-                };
-
-                _ = Process.Start(processStartInfo);
-            }
-        }
-
-        private void toolStripButtonQuestion_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("https://www.ascensiongamedev.com/community/forum/53-questions-and-answers/");
-        }
-
-        private void toolStripButtonBug_Click(object sender, EventArgs e)
-        {
-            BrowserUtils.Open("https://github.com/AscensionGameDev/Intersect-Engine/issues/new/choose");
-        }
-
-        private void UpdateTimeSimulationList()
-        {
-            Bitmap transtile = null;
-            if (File.Exists("resources/misc/transtile.png"))
-            {
-                transtile = new Bitmap("resources/misc/transtile.png");
-            }
-
-            toolStripTimeButton.DropDownItems.Clear();
-            var time = new DateTime(2000, 1, 1, 0, 0, 0);
-            var x = 0;
-            var btn = new ToolStripDropDownButton(Strings.General.None)
-            {
-                Tag = null
+                Tag = clr
             };
 
             btn.Click += TimeDropdownButton_Click;
             toolStripTimeButton.DropDownItems.Add(btn);
-            for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
-            {
-                var addRange = time.ToString("h:mm:ss tt") + " to ";
-                time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
-                addRange += time.ToString("h:mm:ss tt");
-
-                //Create image of overlay color
-                var img = new Bitmap(16, 16);
-                var g = System.Drawing.Graphics.FromImage(img);
-                g.Clear(System.Drawing.Color.Transparent);
-
-                //Draw the trans tile if we have it
-                if (transtile != null)
-                {
-                    g.DrawImage(transtile, new System.Drawing.Point(0, 0));
-                }
-
-                var clr = TimeBase.GetTimeBase().DaylightHues[x];
-                Brush brush = new SolidBrush(System.Drawing.Color.FromArgb(clr.A, clr.R, clr.G, clr.B));
-                g.FillRectangle(brush, new System.Drawing.Rectangle(0, 0, 32, 32));
-
-                //Draw the overlay color
-                g.Dispose();
-
-                btn = new ToolStripDropDownButton(addRange, img)
-                {
-                    Tag = clr
-                };
-
-                btn.Click += TimeDropdownButton_Click;
-                toolStripTimeButton.DropDownItems.Add(btn);
-                x++;
-            }
-
-            if (transtile != null)
-            {
-                transtile.Dispose();
-            }
+            x++;
         }
 
-        private void TimeDropdownButton_Click(object sender, EventArgs e)
+        if (transtile != null)
         {
-            if (((ToolStripDropDownButton) sender).Tag == null)
-            {
-                Core.Graphics.LightColor = null;
-            }
-            else
-            {
-                Core.Graphics.LightColor = (Color) ((ToolStripDropDownButton) sender).Tag;
-            }
+            transtile.Dispose();
         }
+    }
 
-        private void UpdateRunState()
+    private void TimeDropdownButton_Click(object sender, EventArgs e)
+    {
+        if (((ToolStripDropDownButton) sender).Tag == null)
         {
-            toolStripBtnRun.Enabled = false;
-            var path = Preferences.LoadPreference("ClientPath");
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                toolStripBtnRun.Enabled = true;
-            }
+            Core.Graphics.LightColor = null;
         }
-
-        //Cross Threading Delegate Methods
-        private void TryOpenEditorMethod(GameObjectType type)
+        else
         {
-            if (Globals.CurrentEditor == -1)
-            {
-                switch (type)
-                {
-                    case GameObjectType.Animation:
-                        if (mAnimationEditor == null || mAnimationEditor.Visible == false)
-                        {
-                            mAnimationEditor = new FrmAnimation();
-                            mAnimationEditor.InitEditor();
-                            mAnimationEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Item:
-                        if (mItemEditor == null || mItemEditor.Visible == false)
-                        {
-                            mItemEditor = new FrmItem();
-                            mItemEditor.InitEditor();
-                            mItemEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Npc:
-                        if (mNpcEditor == null || mNpcEditor.Visible == false)
-                        {
-                            mNpcEditor = new FrmNpc();
-                            mNpcEditor.InitEditor();
-                            mNpcEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Resource:
-                        if (mResourceEditor == null || mResourceEditor.Visible == false)
-                        {
-                            mResourceEditor = new FrmResource();
-                            mResourceEditor.InitEditor();
-                            mResourceEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Spell:
-                        if (mSpellEditor == null || mSpellEditor.Visible == false)
-                        {
-                            mSpellEditor = new FrmSpell();
-                            mSpellEditor.InitEditor();
-                            mSpellEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.CraftTables:
-                        if (mCraftingTablesEditor == null || mCraftingTablesEditor.Visible == false)
-                        {
-                            mCraftingTablesEditor = new FrmCraftingTables();
-                            mCraftingTablesEditor.InitEditor();
-                            mCraftingTablesEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Crafts:
-                        if (mCraftsEditor == null || mCraftsEditor.Visible == false)
-                        {
-                            mCraftsEditor = new FrmCrafts();
-                            mCraftsEditor.InitEditor();
-                            mCraftsEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Class:
-                        if (mClassEditor == null || mClassEditor.Visible == false)
-                        {
-                            mClassEditor = new FrmClass();
-                            mClassEditor.InitEditor();
-                            mClassEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Quest:
-                        if (mQuestEditor == null || mQuestEditor.Visible == false)
-                        {
-                            mQuestEditor = new FrmQuest();
-                            mQuestEditor.InitEditor();
-                            mQuestEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Projectile:
-                        if (mProjectileEditor == null || mProjectileEditor.Visible == false)
-                        {
-                            mProjectileEditor = new FrmProjectile();
-                            mProjectileEditor.InitEditor();
-                            mProjectileEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Event:
-                        if (mCommonEventEditor == null || mCommonEventEditor.Visible == false)
-                        {
-                            mCommonEventEditor = new FrmCommonEvent();
-                            mCommonEventEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.PlayerVariable:
-                        if (mSwitchVariableEditor == null || mSwitchVariableEditor.Visible == false)
-                        {
-                            mSwitchVariableEditor = new FrmSwitchVariable();
-                            mSwitchVariableEditor.InitEditor();
-                            mSwitchVariableEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Shop:
-                        if (mShopEditor == null || mShopEditor.Visible == false)
-                        {
-                            mShopEditor = new FrmShop();
-                            mShopEditor.InitEditor();
-                            mShopEditor.Show();
-                        }
-
-                        break;
-                    case GameObjectType.Time:
-                        if (mTimeEditor == null || mTimeEditor.Visible == false)
-                        {
-                            mTimeEditor = new FrmTime();
-                            mTimeEditor.InitEditor(TimeBase.GetTimeBase());
-                            mTimeEditor.Show();
-                        }
-
-                        break;
-                    default:
-                        return;
-                }
-
-                Globals.CurrentEditor = (int) type;
-            }
+            Core.Graphics.LightColor = (Color) ((ToolStripDropDownButton) sender).Tag;
         }
+    }
 
-        private void frmMain_FormClosing(object sender, FormClosingEventArgs e)
+    private void UpdateRunState()
+    {
+        toolStripBtnRun.Enabled = false;
+        var path = Preferences.LoadPreference("ClientPath");
+        if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
         {
-            if (!Globals.ClosingEditor &&
-                Globals.CurrentMap != null &&
-                Globals.CurrentMap.Changed() &&
-                DarkMessageBox.ShowWarning(
-                    Strings.Mapping.maphaschangesdialog, Strings.Mapping.mapnotsaved, DarkDialogButton.YesNo,
-                    Icon
-                ) ==
-                DialogResult.No)
-            {
-                e.Cancel = true;
-
-                return;
-            }
-
-            Globals.ClosingEditor = true;
+            toolStripBtnRun.Enabled = true;
         }
+    }
 
-        private void toolStripBtnFlipVertical_Click(object sender, EventArgs e)
+    //Cross Threading Delegate Methods
+    private void TryOpenEditorMethod(GameObjectType type)
+    {
+        if (Globals.CurrentEditor == -1)
         {
-            Globals.MapEditorWindow.FlipVertical();
-        }
-
-        private void toolStripBtnFlipHorizontal_Click(object sender, EventArgs e)
-        {
-            Globals.MapEditorWindow.FlipHorizontal();
-        }
-
-        private void packClientTexturesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void packAssets(string rootDirectory)
-        {
-            //TODO: Make packing heuristic that the texture packer class should use configurable.
-            var preferenceMusicPackSize = Preferences.LoadPreference("MusicPackSize");
-            var preferenceSoundPackSize = Preferences.LoadPreference("SoundPackSize");
-            var preferenceTexturePackSize = Preferences.LoadPreference("TexturePackSize");
-
-            if (!int.TryParse(preferenceMusicPackSize, out var musicPackSize))
+            switch (type)
             {
-                _ = MessageBox.Show(
-                    this,
-                    Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceMusicPackSize),
-                    Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.MusicPackSize),
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-                return;
-            }
-
-            if (!int.TryParse(preferenceSoundPackSize, out var soundPackSize))
-            {
-                _ = MessageBox.Show(
-                    this,
-                    Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceSoundPackSize),
-                    Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.SoundPackSize),
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-                return;
-            }
-
-            if (!int.TryParse(preferenceTexturePackSize, out var texturePackSize))
-            {
-                _ = MessageBox.Show(
-                    this,
-                    Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceTexturePackSize),
-                    Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.TextureSize),
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-                return;
-            }
-
-            var resourcesDirectory = Path.Combine(rootDirectory, "resources");
-            var packsDirectory = Path.Combine(resourcesDirectory, "packs");
-
-            //Delete Old Packs
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.deleting, 10, false);
-            Application.DoEvents();
-            if (Directory.Exists(packsDirectory))
-            {
-                var di = new DirectoryInfo(packsDirectory);
-
-                foreach (var file in di.GetFiles())
-                {
-                    file.Delete();
-                }
-
-                foreach (var dir in di.GetDirectories())
-                {
-                    dir.Delete(true);
-                }
-            }
-            else
-            {
-                Directory.CreateDirectory(packsDirectory);
-            }
-
-            //Create two 'sets' of graphics we want to pack. Tilesets + Fogs in one set, everything else in the other.
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.collecting, 20, false);
-            Application.DoEvents();
-            var toPack = new HashSet<Texture>();
-            foreach (var tex in GameContentManager.TilesetTextures)
-            {
-                toPack.Add(tex);
-            }
-
-            foreach (var tex in GameContentManager.FogTextures)
-            {
-                toPack.Add(tex);
-            }
-
-            foreach (var tex in GameContentManager.AllTextures)
-            {
-                if (!toPack.Contains(tex))
-                {
-                    toPack.Add(tex);
-                }
-            }
-
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.calculating, 30, false);
-            Application.DoEvents();
-            var packs = new List<TexturePacker>();
-            while (toPack.Count > 0)
-            {
-                var tex = toPack.First();
-                var inserted = false;
-                toPack.Remove(tex);
-
-                foreach (var pack in packs)
-                {
-                    if (pack.InsertTex(tex))
+                case GameObjectType.Animation:
+                    if (mAnimationEditor == null || mAnimationEditor.Visible == false)
                     {
-                        inserted = true;
-
-                        break;
-                    }
-                }
-
-                if (!inserted)
-                {
-                    if (tex.GetWidth() > texturePackSize || tex.GetHeight() > texturePackSize)
-                    {
-                        //Own texture
-                        var pack = new TexturePacker(resourcesDirectory, tex.GetWidth(), tex.GetHeight(), false);
-                        packs.Add(pack);
-                        pack.InsertTex(tex);
-                    }
-                    else
-                    {
-                        var pack = new TexturePacker(resourcesDirectory, texturePackSize, texturePackSize, true);
-                        packs.Add(pack);
-                        if (!pack.InsertTex(tex))
-                        {
-                            throw new Exception("This shouldn't happen!");
-                        }
-                    }
-                }
-            }
-
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.exporting, 40, false);
-            Application.DoEvents();
-            var packIndex = 0;
-            foreach (var pack in packs)
-            {
-                pack.Export(packIndex);
-                packIndex++;
-            }
-
-            // Package up sounds!
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.sounds, 80, false);
-            Application.DoEvents();
-            AssetPacker.PackageAssets(Path.Combine(resourcesDirectory, "sounds"), "*.wav", packsDirectory, "sound.index", "sound", ".asset", soundPackSize);
-
-            // Package up music!
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.music, 90, false);
-            Application.DoEvents();
-            AssetPacker.PackageAssets(Path.Combine(resourcesDirectory, "music"), "*.ogg", packsDirectory, "music.index", "music", ".asset", musicPackSize);
-
-            Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.done, 100, false);
-            Application.DoEvents();
-            Thread.Sleep(1000);
-
-            Globals.PackingProgressForm.NotifyClose();
-        }
-
-        private string SelectDirectoryWithRetry(string description, string initialPath, bool showNewFolderButton)
-        {
-            var attempts = 0;
-            while (attempts < 2)
-            {
-                using (var folderBrowserDialog = new FolderBrowserDialog()
-                {
-                    Description = description,
-                    SelectedPath = initialPath,
-                    ShowNewFolderButton = showNewFolderButton,
-                })
-                {
-                    var selectionDialogResult = folderBrowserDialog.ShowDialog();
-                    switch (selectionDialogResult)
-                    {
-                        case DialogResult.OK:
-                            var selectedPath = folderBrowserDialog.SelectedPath;
-                            if (string.IsNullOrWhiteSpace(selectedPath) || !Directory.Exists(selectedPath))
-                            {
-                                var retryDialogueResult = DarkMessageBox.ShowError(
-                                    Strings.Errors.InvalidDirectory,
-                                    Strings.Errors.InvalidDirectoryCaption,
-                                    DarkDialogButton.RetryCancel,
-                                    Icon
-                                );
-
-                                switch (retryDialogueResult)
-                                {
-                                    case DialogResult.Retry:
-                                        break;
-
-                                    case DialogResult.Cancel:
-                                        return default;
-                                }
-                                break;
-                            }
-
-                            return selectedPath;
-
-                        case DialogResult.Cancel:
-                            return default;
-
-                        case DialogResult.None:
-                        case DialogResult.Abort:
-                        case DialogResult.Retry:
-                        case DialogResult.Ignore:
-                        case DialogResult.Yes:
-                        case DialogResult.No:
-                            throw new NotImplementedException($"No handler defined for {selectionDialogResult}, should be {DialogResult.OK} or {DialogResult.Cancel}.");
-
-                        default:
-                            throw new IndexOutOfRangeException($"{selectionDialogResult} is not a valid {nameof(System.Windows.Forms.DialogResult)}.");
-                    }
-                }
-            }
-
-            return default;
-        }
-
-        private void packageUpdateToolStripMenuItem_Click(object sender, EventArgs e) => PackageUpdate();
-
-        private void PackageUpdate()
-        {
-            var lastSourceDirectory = Preferences.LoadPreference("update_sourceDirectory");
-            var lastTargetDirectory = Preferences.LoadPreference("update_targetDirectory");
-
-            var sourceDirectory = SelectDirectoryWithRetry(Strings.UpdatePacking.SourceDirectoryPromptDescription, string.IsNullOrWhiteSpace(lastSourceDirectory) ? Environment.CurrentDirectory : lastSourceDirectory, false);
-            if (sourceDirectory == default)
-            {
-                return;
-            }
-
-            var targetDirectory = SelectDirectoryWithRetry(Strings.UpdatePacking.TargetDirectoryPromptDescription, string.IsNullOrWhiteSpace(lastTargetDirectory) ? Environment.CurrentDirectory : lastTargetDirectory, true);
-            if (targetDirectory == default)
-            {
-                return;
-            }
-
-            Preferences.SavePreference("update_sourceDirectory", sourceDirectory);
-            Preferences.SavePreference("update_targetDirectory", targetDirectory);
-
-            var baseDir = new Uri($@"{sourceDirectory}\");
-            var selectedDir = new Uri($@"{targetDirectory}\");
-
-            if (baseDir.IsBaseOf(selectedDir))
-            {
-                // Error, cannot be put within editor folder else it would try to include itself?
-                _ = DarkMessageBox.ShowError(
-                    Strings.UpdatePacking.InvalidBase,
-                    Strings.UpdatePacking.Error,
-                    DarkDialogButton.Ok,
-                    Icon
-                );
-                return;
-            }
-
-            Update existingUpdate = null;
-            var targetUpdateFile = Path.Combine(targetDirectory, "update.json");
-            if (File.Exists(targetUpdateFile))
-            {
-                //Existing update! Offer to create a differential folder where the only files within will be those that have changed
-                if (DarkMessageBox.ShowError(
-                        Strings.UpdatePacking.Differential,
-                        Strings.UpdatePacking.DifferentialTitle,
-                        DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    existingUpdate = JsonConvert.DeserializeObject<Update>(File.ReadAllText(targetUpdateFile));
-                }
-            }
-            else if (Directory.EnumerateFileSystemEntries(targetDirectory).Any())
-            {
-                //Folder must be empty!
-                _ = DarkMessageBox.ShowError(
-                    Strings.UpdatePacking.Empty,
-                    Strings.UpdatePacking.Error,
-                    DarkDialogButton.Ok,
-                    Icon
-                );
-                return;
-            }
-
-            // Are we configured to package up our assets for an update?
-            var packageUpdateAssets = Preferences.LoadPreference("PackageUpdateAssets");
-            if (!string.IsNullOrWhiteSpace(packageUpdateAssets) && Convert.ToBoolean(packageUpdateAssets, CultureInfo.InvariantCulture))
-            {
-                Globals.PackingProgressForm = new FrmProgress();
-                Globals.PackingProgressForm.SetTitle(Strings.AssetPacking.title);
-                var assetThread = new Thread(() => packAssets(sourceDirectory));
-                assetThread.Start();
-                _ = Globals.PackingProgressForm.ShowDialog();
-            }
-
-            Globals.UpdateCreationProgressForm = new FrmProgress();
-            Globals.UpdateCreationProgressForm.SetTitle(Strings.UpdatePacking.Title);
-            Globals.UpdateCreationProgressForm.SetProgress(Strings.UpdatePacking.Deleting, 10, false);
-            var packingthread = new Thread(() => createUpdate(sourceDirectory, targetDirectory, existingUpdate));
-            packingthread.Start();
-            _ = Globals.UpdateCreationProgressForm.ShowDialog();
-        }
-
-        private void createUpdate(string sourceDirectory, string targetDirectory, Update existingUpdate)
-        {
-            if (!Directory.Exists(targetDirectory))
-            {
-                Directory.CreateDirectory((targetDirectory));
-            }
-
-            if (Directory.Exists(targetDirectory))
-            {
-                DirectoryInfo di = new DirectoryInfo(targetDirectory);
-
-                foreach (FileInfo file in di.GetFiles())
-                {
-                    file.Delete();
-                }
-
-                foreach (DirectoryInfo dir in di.GetDirectories())
-                {
-                    dir.Delete(true);
-                }
-
-                // Intersect excluded files
-                var editorBaseName = Process.GetCurrentProcess()?.ProcessName.ToLowerInvariant() ?? "intersect editor";
-                var editorFileNameExe = $"{editorBaseName}.exe";
-                var editorFileNamePdb = $"{editorBaseName}.pdb";
-                var excludeFiles = new string[] { "resources/mapcache.db", "update.json", "version.json" };
-                var clientExcludeFiles = new List<string>(){ editorFileNameExe, editorFileNamePdb, "resources/editor_strings.json" };
-                var editorExcludeFiles = new List<string>() { "resources/client_strings.json" };
-                var excludeExtensions = new string[] { ".dll", ".xml", ".config", ".php" };
-                var excludeDirectories = new string[] { "logs", "screenshots" };
-
-                var resourcesDirectory = Path.Combine(sourceDirectory, "resources");
-                var packsDirectory = Path.Combine(resourcesDirectory, "packs");
-                if (Directory.Exists(packsDirectory))
-                {
-                    var packs = Directory.GetFiles(packsDirectory, "*.meta");
-                    editorExcludeFiles.AddRange(packs);
-                    foreach (var pack in packs)
-                    {
-                        var obj = JObject.Parse(GzipCompression.ReadDecompressedString(pack))["frames"];
-                        foreach (var frame in obj.Children())
-                        {
-                            var filename = frame["filename"].ToString();
-                            clientExcludeFiles.Add(filename);
-                        }
+                        mAnimationEditor = new FrmAnimation();
+                        mAnimationEditor.InitEditor();
+                        mAnimationEditor.Show();
                     }
 
-                    var soundIndex = Path.Combine(packsDirectory, "sound.index");
-                    if (File.Exists(soundIndex))
+                    break;
+                case GameObjectType.Item:
+                    if (mItemEditor == null || mItemEditor.Visible == false)
                     {
-                        editorExcludeFiles.Add(soundIndex);
-                        using (var soundPacker = new AssetPacker(soundIndex, packsDirectory))
-                        {
-                            editorExcludeFiles.AddRange(soundPacker.CachedPackages.Select(cachedPackage => Path.Combine(soundPacker.PackageLocation, cachedPackage)));
-                            foreach (var sound in soundPacker.FileList)
-                            {
-                                // Add as lowercase as our update generator checks for lowercases!
-                                clientExcludeFiles.Add(Path.Combine(resourcesDirectory, "sounds", sound.ToLower(CultureInfo.CurrentCulture)).Replace('\\', '/'));
-                            }
-                        }
+                        mItemEditor = new FrmItem();
+                        mItemEditor.InitEditor();
+                        mItemEditor.Show();
                     }
 
-                    var musicIndex = Path.Combine(packsDirectory, "music.index");
-                    if (File.Exists(musicIndex))
+                    break;
+                case GameObjectType.Npc:
+                    if (mNpcEditor == null || mNpcEditor.Visible == false)
                     {
-                        editorExcludeFiles.Add(musicIndex);
-                        using (var musicPacker = new AssetPacker(musicIndex, packsDirectory))
-                        {
-                            editorExcludeFiles.AddRange(musicPacker.CachedPackages.Select(cachedPackage => Path.Combine(musicPacker.PackageLocation, cachedPackage)));
-                            foreach (var music in musicPacker.FileList)
-                            {
-                                // Add as lowercase as our update generator checks for lowercases!
-                                clientExcludeFiles.Add(Path.Combine(resourcesDirectory, "music", music.ToLower(CultureInfo.CurrentCulture)).Replace('\\', '/'));
-                            }
-                        }
+                        mNpcEditor = new FrmNpc();
+                        mNpcEditor.InitEditor();
+                        mNpcEditor.Show();
                     }
 
-                }
+                    break;
+                case GameObjectType.Resource:
+                    if (mResourceEditor == null || mResourceEditor.Visible == false)
+                    {
+                        mResourceEditor = new FrmResource();
+                        mResourceEditor.InitEditor();
+                        mResourceEditor.Show();
+                    }
 
-                var fileCount = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.*", SearchOption.AllDirectories).Length;
+                    break;
+                case GameObjectType.Spell:
+                    if (mSpellEditor == null || mSpellEditor.Visible == false)
+                    {
+                        mSpellEditor = new FrmSpell();
+                        mSpellEditor.InitEditor();
+                        mSpellEditor.Show();
+                    }
 
-                var update = new Update();
-                queryFilesForUpdate(update, excludeFiles, clientExcludeFiles, editorExcludeFiles, excludeExtensions, excludeDirectories, sourceDirectory, sourceDirectory, sourceDirectory, targetDirectory, 0, fileCount, existingUpdate);
+                    break;
+                case GameObjectType.CraftTables:
+                    if (mCraftingTablesEditor == null || mCraftingTablesEditor.Visible == false)
+                    {
+                        mCraftingTablesEditor = new FrmCraftingTables();
+                        mCraftingTablesEditor.InitEditor();
+                        mCraftingTablesEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Crafts:
+                    if (mCraftsEditor == null || mCraftsEditor.Visible == false)
+                    {
+                        mCraftsEditor = new FrmCrafts();
+                        mCraftsEditor.InitEditor();
+                        mCraftsEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Class:
+                    if (mClassEditor == null || mClassEditor.Visible == false)
+                    {
+                        mClassEditor = new FrmClass();
+                        mClassEditor.InitEditor();
+                        mClassEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Quest:
+                    if (mQuestEditor == null || mQuestEditor.Visible == false)
+                    {
+                        mQuestEditor = new FrmQuest();
+                        mQuestEditor.InitEditor();
+                        mQuestEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Projectile:
+                    if (mProjectileEditor == null || mProjectileEditor.Visible == false)
+                    {
+                        mProjectileEditor = new FrmProjectile();
+                        mProjectileEditor.InitEditor();
+                        mProjectileEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Event:
+                    if (mCommonEventEditor == null || mCommonEventEditor.Visible == false)
+                    {
+                        mCommonEventEditor = new FrmCommonEvent();
+                        mCommonEventEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.PlayerVariable:
+                    if (mSwitchVariableEditor == null || mSwitchVariableEditor.Visible == false)
+                    {
+                        mSwitchVariableEditor = new FrmSwitchVariable();
+                        mSwitchVariableEditor.InitEditor();
+                        mSwitchVariableEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Shop:
+                    if (mShopEditor == null || mShopEditor.Visible == false)
+                    {
+                        mShopEditor = new FrmShop();
+                        mShopEditor.InitEditor();
+                        mShopEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Time:
+                    if (mTimeEditor == null || mTimeEditor.Visible == false)
+                    {
+                        mTimeEditor = new FrmTime();
+                        mTimeEditor.InitEditor(TimeBase.GetTimeBase());
+                        mTimeEditor.Show();
+                    }
+
+                    break;
+                default:
+                    return;
             }
+
+            Globals.CurrentEditor = (int) type;
+        }
+    }
+
+    private void frmMain_FormClosing(object sender, FormClosingEventArgs e)
+    {
+        if (!Globals.ClosingEditor &&
+            Globals.CurrentMap != null &&
+            Globals.CurrentMap.Changed() &&
+            DarkMessageBox.ShowWarning(
+                Strings.Mapping.maphaschangesdialog, Strings.Mapping.mapnotsaved, DarkDialogButton.YesNo,
+                Icon
+            ) ==
+            DialogResult.No)
+        {
+            e.Cancel = true;
+
+            return;
         }
 
-        private int queryFilesForUpdate(Update update, string[] excludeFiles, IEnumerable<string> clientExcludeFiles, IEnumerable<string> editorExcludeFiles, string[] excludeExtensions, string[] excludeDirectories, string workingDirectory, string sourcePath, string currentSourcePath, string targetPath, int filesProcessed, int fileCount, Update existingUpdate)
+        Globals.ClosingEditor = true;
+    }
+
+    private void toolStripBtnFlipVertical_Click(object sender, EventArgs e)
+    {
+        Globals.MapEditorWindow.FlipVertical();
+    }
+
+    private void toolStripBtnFlipHorizontal_Click(object sender, EventArgs e)
+    {
+        Globals.MapEditorWindow.FlipHorizontal();
+    }
+
+    private void packClientTexturesToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+
+    }
+
+    private void packAssets(string rootDirectory)
+    {
+        //TODO: Make packing heuristic that the texture packer class should use configurable.
+        var preferenceMusicPackSize = Preferences.LoadPreference("MusicPackSize");
+        var preferenceSoundPackSize = Preferences.LoadPreference("SoundPackSize");
+        var preferenceTexturePackSize = Preferences.LoadPreference("TexturePackSize");
+
+        if (!int.TryParse(preferenceMusicPackSize, out var musicPackSize))
         {
-            var di = new DirectoryInfo(currentSourcePath);
-            var workingDir = new Uri(workingDirectory + "/");
+            _ = MessageBox.Show(
+                this,
+                Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceMusicPackSize),
+                Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.MusicPackSize),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return;
+        }
+
+        if (!int.TryParse(preferenceSoundPackSize, out var soundPackSize))
+        {
+            _ = MessageBox.Show(
+                this,
+                Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceSoundPackSize),
+                Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.SoundPackSize),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return;
+        }
+
+        if (!int.TryParse(preferenceTexturePackSize, out var texturePackSize))
+        {
+            _ = MessageBox.Show(
+                this,
+                Strings.Errors.UnableToParseInvalidIntegerFormat.ToString(preferenceTexturePackSize),
+                Strings.Errors.InvalidInputXCaption.ToString(Strings.Options.TextureSize),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+            return;
+        }
+
+        var resourcesDirectory = Path.Combine(rootDirectory, "resources");
+        var packsDirectory = Path.Combine(resourcesDirectory, "packs");
+
+        //Delete Old Packs
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.deleting, 10, false);
+        Application.DoEvents();
+        if (Directory.Exists(packsDirectory))
+        {
+            var di = new DirectoryInfo(packsDirectory);
 
             foreach (var file in di.GetFiles())
             {
-                var relativePath = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(Path.Combine(currentSourcePath, file.Name))).ToString().Replace('\\', '/'));
-                if (!excludeFiles.Contains(relativePath) && !excludeExtensions.Contains(file.Extension))
-                {
-                    var md5Hash = string.Empty;
-                    using (var md5 = MD5.Create())
-                    {
-                        using (var stream = new BufferedStream(File.OpenRead(file.FullName), 1200000))
-                        {
-                            md5Hash = BitConverter.ToString(md5.ComputeHash(stream)).Replace("-", string.Empty).ToLower(CultureInfo.InvariantCulture);
-                        }
-                    }
-
-                    var updateFile = new UpdateFile(relativePath, md5Hash, file.Length)
-                    {
-                        ClientIgnore = clientExcludeFiles.Contains(relativePath.ToLower(CultureInfo.CurrentCulture)),
-                        EditorIgnore = editorExcludeFiles.Contains(relativePath.ToLower(CultureInfo.CurrentCulture)),
-                    };
-
-                    update.Files.Add(updateFile);
-
-                    //Copy File (If not in existing update)
-                    UpdateFile existingFile = null;
-                    if (existingUpdate != null)
-                    {
-                        existingFile = existingUpdate.Files.FirstOrDefault(f => f.Path == updateFile.Path);
-                    }
-
-                    if (existingFile == null || existingFile.Size != updateFile.Size || existingFile.Hash != updateFile.Hash) {
-                        var relativeFolder = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(currentSourcePath + "/")).ToString().Replace('\\', '/'));
-                        if (!string.IsNullOrEmpty(relativeFolder))
-                        {
-                            _ = Directory.CreateDirectory(Path.Combine(targetPath, relativeFolder));
-                            File.Copy(file.FullName, Path.Combine(targetPath, relativeFolder, file.Name));
-                        }
-                        else
-                        {
-                            File.Copy(file.FullName, Path.Combine(targetPath, file.Name));
-                        }
-                    }
-                }
-                else
-                {
-                    //MessageBox.Show("File not added to update! " + relativePath);
-                }
-
-                filesProcessed++;
-
-                var percentage = (float) (filesProcessed / (float) (fileCount + 1));
-                var outofeighty = (int)(percentage * 80f);
-
-                Globals.UpdateCreationProgressForm.SetProgress(
-                    Strings.UpdatePacking.Calculating, outofeighty + 10, false
-                );
-
-                Application.DoEvents();
+                file.Delete();
             }
 
             foreach (var dir in di.GetDirectories())
             {
-                var relativePath = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(Path.Combine(currentSourcePath, dir.Name))).ToString().Replace('\\', '/'));
-                if (!excludeDirectories.Contains(relativePath))
+                dir.Delete(true);
+            }
+        }
+        else
+        {
+            Directory.CreateDirectory(packsDirectory);
+        }
+
+        //Create two 'sets' of graphics we want to pack. Tilesets + Fogs in one set, everything else in the other.
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.collecting, 20, false);
+        Application.DoEvents();
+        var toPack = new HashSet<Texture>();
+        foreach (var tex in GameContentManager.TilesetTextures)
+        {
+            toPack.Add(tex);
+        }
+
+        foreach (var tex in GameContentManager.FogTextures)
+        {
+            toPack.Add(tex);
+        }
+
+        foreach (var tex in GameContentManager.AllTextures)
+        {
+            if (!toPack.Contains(tex))
+            {
+                toPack.Add(tex);
+            }
+        }
+
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.calculating, 30, false);
+        Application.DoEvents();
+        var packs = new List<TexturePacker>();
+        while (toPack.Count > 0)
+        {
+            var tex = toPack.First();
+            var inserted = false;
+            toPack.Remove(tex);
+
+            foreach (var pack in packs)
+            {
+                if (pack.InsertTex(tex))
                 {
-                    filesProcessed = queryFilesForUpdate(update, excludeFiles, clientExcludeFiles, editorExcludeFiles, excludeExtensions, excludeFiles, workingDirectory, sourcePath, Path.Combine(currentSourcePath, dir.Name), targetPath, filesProcessed, fileCount, existingUpdate);
+                    inserted = true;
+
+                    break;
+                }
+            }
+
+            if (!inserted)
+            {
+                if (tex.GetWidth() > texturePackSize || tex.GetHeight() > texturePackSize)
+                {
+                    //Own texture
+                    var pack = new TexturePacker(resourcesDirectory, tex.GetWidth(), tex.GetHeight(), false);
+                    packs.Add(pack);
+                    pack.InsertTex(tex);
                 }
                 else
                 {
-                    //MessageBox.Show("Directory not added to update! " + relativePath);
+                    var pack = new TexturePacker(resourcesDirectory, texturePackSize, texturePackSize, true);
+                    packs.Add(pack);
+                    if (!pack.InsertTex(tex))
+                    {
+                        throw new Exception("This shouldn't happen!");
+                    }
                 }
             }
-
-            if (string.Equals(sourcePath, currentSourcePath, StringComparison.Ordinal))
-            {
-                Globals.UpdateCreationProgressForm.SetProgress(Strings.UpdatePacking.Done, 100, false);
-                Application.DoEvents();
-                Thread.Sleep(1000);
-
-                //TODO: Open folder with update files
-                var targetJsonPath = Path.Combine(targetPath, "update.json");
-                File.WriteAllText(targetJsonPath, JsonConvert.SerializeObject(update, Formatting.Indented, new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore }));
-
-                Globals.UpdateCreationProgressForm.NotifyClose();
-            }
-
-            return filesProcessed;
         }
 
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.exporting, 40, false);
+        Application.DoEvents();
+        var packIndex = 0;
+        foreach (var pack in packs)
+        {
+            pack.Export(packIndex);
+            packIndex++;
+        }
+
+        // Package up sounds!
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.sounds, 80, false);
+        Application.DoEvents();
+        AssetPacker.PackageAssets(Path.Combine(resourcesDirectory, "sounds"), "*.wav", packsDirectory, "sound.index", "sound", ".asset", soundPackSize);
+
+        // Package up music!
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.music, 90, false);
+        Application.DoEvents();
+        AssetPacker.PackageAssets(Path.Combine(resourcesDirectory, "music"), "*.ogg", packsDirectory, "music.index", "music", ".asset", musicPackSize);
+
+        Globals.PackingProgressForm.SetProgress(Strings.AssetPacking.done, 100, false);
+        Application.DoEvents();
+        Thread.Sleep(1000);
+
+        Globals.PackingProgressForm.NotifyClose();
+    }
+
+    private string SelectDirectoryWithRetry(string description, string initialPath, bool showNewFolderButton)
+    {
+        var attempts = 0;
+        while (attempts < 2)
+        {
+            using (var folderBrowserDialog = new FolderBrowserDialog()
+            {
+                Description = description,
+                SelectedPath = initialPath,
+                ShowNewFolderButton = showNewFolderButton,
+            })
+            {
+                var selectionDialogResult = folderBrowserDialog.ShowDialog();
+                switch (selectionDialogResult)
+                {
+                    case DialogResult.OK:
+                        var selectedPath = folderBrowserDialog.SelectedPath;
+                        if (string.IsNullOrWhiteSpace(selectedPath) || !Directory.Exists(selectedPath))
+                        {
+                            var retryDialogueResult = DarkMessageBox.ShowError(
+                                Strings.Errors.InvalidDirectory,
+                                Strings.Errors.InvalidDirectoryCaption,
+                                DarkDialogButton.RetryCancel,
+                                Icon
+                            );
+
+                            switch (retryDialogueResult)
+                            {
+                                case DialogResult.Retry:
+                                    break;
+
+                                case DialogResult.Cancel:
+                                    return default;
+                            }
+                            break;
+                        }
+
+                        return selectedPath;
+
+                    case DialogResult.Cancel:
+                        return default;
+
+                    case DialogResult.None:
+                    case DialogResult.Abort:
+                    case DialogResult.Retry:
+                    case DialogResult.Ignore:
+                    case DialogResult.Yes:
+                    case DialogResult.No:
+                        throw new NotImplementedException($"No handler defined for {selectionDialogResult}, should be {DialogResult.OK} or {DialogResult.Cancel}.");
+
+                    default:
+                        throw new IndexOutOfRangeException($"{selectionDialogResult} is not a valid {nameof(System.Windows.Forms.DialogResult)}.");
+                }
+            }
+        }
+
+        return default;
+    }
+
+    private void packageUpdateToolStripMenuItem_Click(object sender, EventArgs e) => PackageUpdate();
+
+    private void PackageUpdate()
+    {
+        var lastSourceDirectory = Preferences.LoadPreference("update_sourceDirectory");
+        var lastTargetDirectory = Preferences.LoadPreference("update_targetDirectory");
+
+        var sourceDirectory = SelectDirectoryWithRetry(Strings.UpdatePacking.SourceDirectoryPromptDescription, string.IsNullOrWhiteSpace(lastSourceDirectory) ? Environment.CurrentDirectory : lastSourceDirectory, false);
+        if (sourceDirectory == default)
+        {
+            return;
+        }
+
+        var targetDirectory = SelectDirectoryWithRetry(Strings.UpdatePacking.TargetDirectoryPromptDescription, string.IsNullOrWhiteSpace(lastTargetDirectory) ? Environment.CurrentDirectory : lastTargetDirectory, true);
+        if (targetDirectory == default)
+        {
+            return;
+        }
+
+        Preferences.SavePreference("update_sourceDirectory", sourceDirectory);
+        Preferences.SavePreference("update_targetDirectory", targetDirectory);
+
+        var baseDir = new Uri($@"{sourceDirectory}\");
+        var selectedDir = new Uri($@"{targetDirectory}\");
+
+        if (baseDir.IsBaseOf(selectedDir))
+        {
+            // Error, cannot be put within editor folder else it would try to include itself?
+            _ = DarkMessageBox.ShowError(
+                Strings.UpdatePacking.InvalidBase,
+                Strings.UpdatePacking.Error,
+                DarkDialogButton.Ok,
+                Icon
+            );
+            return;
+        }
+
+        Update existingUpdate = null;
+        var targetUpdateFile = Path.Combine(targetDirectory, "update.json");
+        if (File.Exists(targetUpdateFile))
+        {
+            //Existing update! Offer to create a differential folder where the only files within will be those that have changed
+            if (DarkMessageBox.ShowError(
+                    Strings.UpdatePacking.Differential,
+                    Strings.UpdatePacking.DifferentialTitle,
+                    DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                existingUpdate = JsonConvert.DeserializeObject<Update>(File.ReadAllText(targetUpdateFile));
+            }
+        }
+        else if (Directory.EnumerateFileSystemEntries(targetDirectory).Any())
+        {
+            //Folder must be empty!
+            _ = DarkMessageBox.ShowError(
+                Strings.UpdatePacking.Empty,
+                Strings.UpdatePacking.Error,
+                DarkDialogButton.Ok,
+                Icon
+            );
+            return;
+        }
+
+        // Are we configured to package up our assets for an update?
+        var packageUpdateAssets = Preferences.LoadPreference("PackageUpdateAssets");
+        if (!string.IsNullOrWhiteSpace(packageUpdateAssets) && Convert.ToBoolean(packageUpdateAssets, CultureInfo.InvariantCulture))
+        {
+            Globals.PackingProgressForm = new FrmProgress();
+            Globals.PackingProgressForm.SetTitle(Strings.AssetPacking.title);
+            var assetThread = new Thread(() => packAssets(sourceDirectory));
+            assetThread.Start();
+            _ = Globals.PackingProgressForm.ShowDialog();
+        }
+
+        Globals.UpdateCreationProgressForm = new FrmProgress();
+        Globals.UpdateCreationProgressForm.SetTitle(Strings.UpdatePacking.Title);
+        Globals.UpdateCreationProgressForm.SetProgress(Strings.UpdatePacking.Deleting, 10, false);
+        var packingthread = new Thread(() => createUpdate(sourceDirectory, targetDirectory, existingUpdate));
+        packingthread.Start();
+        _ = Globals.UpdateCreationProgressForm.ShowDialog();
+    }
+
+    private void createUpdate(string sourceDirectory, string targetDirectory, Update existingUpdate)
+    {
+        if (!Directory.Exists(targetDirectory))
+        {
+            Directory.CreateDirectory((targetDirectory));
+        }
+
+        if (Directory.Exists(targetDirectory))
+        {
+            DirectoryInfo di = new DirectoryInfo(targetDirectory);
+
+            foreach (FileInfo file in di.GetFiles())
+            {
+                file.Delete();
+            }
+
+            foreach (DirectoryInfo dir in di.GetDirectories())
+            {
+                dir.Delete(true);
+            }
+
+            // Intersect excluded files
+            var editorBaseName = Process.GetCurrentProcess()?.ProcessName.ToLowerInvariant() ?? "intersect editor";
+            var editorFileNameExe = $"{editorBaseName}.exe";
+            var editorFileNamePdb = $"{editorBaseName}.pdb";
+            var excludeFiles = new string[] { "resources/mapcache.db", "update.json", "version.json" };
+            var clientExcludeFiles = new List<string>(){ editorFileNameExe, editorFileNamePdb, "resources/editor_strings.json" };
+            var editorExcludeFiles = new List<string>() { "resources/client_strings.json" };
+            var excludeExtensions = new string[] { ".dll", ".xml", ".config", ".php" };
+            var excludeDirectories = new string[] { "logs", "screenshots" };
+
+            var resourcesDirectory = Path.Combine(sourceDirectory, "resources");
+            var packsDirectory = Path.Combine(resourcesDirectory, "packs");
+            if (Directory.Exists(packsDirectory))
+            {
+                var packs = Directory.GetFiles(packsDirectory, "*.meta");
+                editorExcludeFiles.AddRange(packs);
+                foreach (var pack in packs)
+                {
+                    var obj = JObject.Parse(GzipCompression.ReadDecompressedString(pack))["frames"];
+                    foreach (var frame in obj.Children())
+                    {
+                        var filename = frame["filename"].ToString();
+                        clientExcludeFiles.Add(filename);
+                    }
+                }
+
+                var soundIndex = Path.Combine(packsDirectory, "sound.index");
+                if (File.Exists(soundIndex))
+                {
+                    editorExcludeFiles.Add(soundIndex);
+                    using (var soundPacker = new AssetPacker(soundIndex, packsDirectory))
+                    {
+                        editorExcludeFiles.AddRange(soundPacker.CachedPackages.Select(cachedPackage => Path.Combine(soundPacker.PackageLocation, cachedPackage)));
+                        foreach (var sound in soundPacker.FileList)
+                        {
+                            // Add as lowercase as our update generator checks for lowercases!
+                            clientExcludeFiles.Add(Path.Combine(resourcesDirectory, "sounds", sound.ToLower(CultureInfo.CurrentCulture)).Replace('\\', '/'));
+                        }
+                    }
+                }
+
+                var musicIndex = Path.Combine(packsDirectory, "music.index");
+                if (File.Exists(musicIndex))
+                {
+                    editorExcludeFiles.Add(musicIndex);
+                    using (var musicPacker = new AssetPacker(musicIndex, packsDirectory))
+                    {
+                        editorExcludeFiles.AddRange(musicPacker.CachedPackages.Select(cachedPackage => Path.Combine(musicPacker.PackageLocation, cachedPackage)));
+                        foreach (var music in musicPacker.FileList)
+                        {
+                            // Add as lowercase as our update generator checks for lowercases!
+                            clientExcludeFiles.Add(Path.Combine(resourcesDirectory, "music", music.ToLower(CultureInfo.CurrentCulture)).Replace('\\', '/'));
+                        }
+                    }
+                }
+
+            }
+
+            var fileCount = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.*", SearchOption.AllDirectories).Length;
+
+            var update = new Update();
+            queryFilesForUpdate(update, excludeFiles, clientExcludeFiles, editorExcludeFiles, excludeExtensions, excludeDirectories, sourceDirectory, sourceDirectory, sourceDirectory, targetDirectory, 0, fileCount, existingUpdate);
+        }
+    }
+
+    private int queryFilesForUpdate(Update update, string[] excludeFiles, IEnumerable<string> clientExcludeFiles, IEnumerable<string> editorExcludeFiles, string[] excludeExtensions, string[] excludeDirectories, string workingDirectory, string sourcePath, string currentSourcePath, string targetPath, int filesProcessed, int fileCount, Update existingUpdate)
+    {
+        var di = new DirectoryInfo(currentSourcePath);
+        var workingDir = new Uri(workingDirectory + "/");
+
+        foreach (var file in di.GetFiles())
+        {
+            var relativePath = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(Path.Combine(currentSourcePath, file.Name))).ToString().Replace('\\', '/'));
+            if (!excludeFiles.Contains(relativePath) && !excludeExtensions.Contains(file.Extension))
+            {
+                var md5Hash = string.Empty;
+                using (var md5 = MD5.Create())
+                {
+                    using (var stream = new BufferedStream(File.OpenRead(file.FullName), 1200000))
+                    {
+                        md5Hash = BitConverter.ToString(md5.ComputeHash(stream)).Replace("-", string.Empty).ToLower(CultureInfo.InvariantCulture);
+                    }
+                }
+
+                var updateFile = new UpdateFile(relativePath, md5Hash, file.Length)
+                {
+                    ClientIgnore = clientExcludeFiles.Contains(relativePath.ToLower(CultureInfo.CurrentCulture)),
+                    EditorIgnore = editorExcludeFiles.Contains(relativePath.ToLower(CultureInfo.CurrentCulture)),
+                };
+
+                update.Files.Add(updateFile);
+
+                //Copy File (If not in existing update)
+                UpdateFile existingFile = null;
+                if (existingUpdate != null)
+                {
+                    existingFile = existingUpdate.Files.FirstOrDefault(f => f.Path == updateFile.Path);
+                }
+
+                if (existingFile == null || existingFile.Size != updateFile.Size || existingFile.Hash != updateFile.Hash) {
+                    var relativeFolder = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(currentSourcePath + "/")).ToString().Replace('\\', '/'));
+                    if (!string.IsNullOrEmpty(relativeFolder))
+                    {
+                        _ = Directory.CreateDirectory(Path.Combine(targetPath, relativeFolder));
+                        File.Copy(file.FullName, Path.Combine(targetPath, relativeFolder, file.Name));
+                    }
+                    else
+                    {
+                        File.Copy(file.FullName, Path.Combine(targetPath, file.Name));
+                    }
+                }
+            }
+            else
+            {
+                //MessageBox.Show("File not added to update! " + relativePath);
+            }
+
+            filesProcessed++;
+
+            var percentage = (float) (filesProcessed / (float) (fileCount + 1));
+            var outofeighty = (int)(percentage * 80f);
+
+            Globals.UpdateCreationProgressForm.SetProgress(
+                Strings.UpdatePacking.Calculating, outofeighty + 10, false
+            );
+
+            Application.DoEvents();
+        }
+
+        foreach (var dir in di.GetDirectories())
+        {
+            var relativePath = Uri.UnescapeDataString(workingDir.MakeRelativeUri(new Uri(Path.Combine(currentSourcePath, dir.Name))).ToString().Replace('\\', '/'));
+            if (!excludeDirectories.Contains(relativePath))
+            {
+                filesProcessed = queryFilesForUpdate(update, excludeFiles, clientExcludeFiles, editorExcludeFiles, excludeExtensions, excludeFiles, workingDirectory, sourcePath, Path.Combine(currentSourcePath, dir.Name), targetPath, filesProcessed, fileCount, existingUpdate);
+            }
+            else
+            {
+                //MessageBox.Show("Directory not added to update! " + relativePath);
+            }
+        }
+
+        if (string.Equals(sourcePath, currentSourcePath, StringComparison.Ordinal))
+        {
+            Globals.UpdateCreationProgressForm.SetProgress(Strings.UpdatePacking.Done, 100, false);
+            Application.DoEvents();
+            Thread.Sleep(1000);
+
+            //TODO: Open folder with update files
+            var targetJsonPath = Path.Combine(targetPath, "update.json");
+            File.WriteAllText(targetJsonPath, JsonConvert.SerializeObject(update, Formatting.Indented, new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore }));
+
+            Globals.UpdateCreationProgressForm.NotifyClose();
+        }
+
+        return filesProcessed;
     }
 
 }

--- a/Intersect.Editor/Forms/frmOptions.cs
+++ b/Intersect.Editor/Forms/frmOptions.cs
@@ -2,156 +2,154 @@
 
 using Intersect.Editor.Localization;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmOptions : Form
 {
 
-    public partial class FrmOptions : Form
+    public FrmOptions()
+    {
+        InitializeComponent();
+        Icon = Program.Icon;
+
+        InitForm();
+        InitLocalization();
+    }
+
+    private void InitForm()
     {
 
-        public FrmOptions()
-        {
-            InitializeComponent();
-            Icon = Program.Icon;
+        // Show only the General tab by default.
+        HidePanels();
+        pnlGeneral.Visible = true;
 
-            InitForm();
-            InitLocalization();
+        // Load settings for the General tab
+        var suppressTilesetWarning = Preferences.LoadPreference("SuppressTextureWarning");
+        var enableCursorSprites = Preferences.LoadPreference("EnableCursorSprites");
+
+        if (suppressTilesetWarning == "")
+        {
+            chkSuppressTilesetWarning.Checked = false;
+        }
+        else
+        {
+            chkSuppressTilesetWarning.Checked = Convert.ToBoolean(suppressTilesetWarning);
         }
 
-        private void InitForm()
+        chkCursorSprites.Checked = !string.IsNullOrEmpty(enableCursorSprites) &&
+                                   Convert.ToBoolean(enableCursorSprites);
+
+        txtGamePath.Text = Preferences.LoadPreference("ClientPath");
+
+        // Load settings for the Update tab
+        var packageUpdateAssets = Preferences.LoadPreference("PackageUpdateAssets");
+        if (packageUpdateAssets == "")
         {
-
-            // Show only the General tab by default.
-            HidePanels();
-            pnlGeneral.Visible = true;
-
-            // Load settings for the General tab
-            var suppressTilesetWarning = Preferences.LoadPreference("SuppressTextureWarning");
-            var enableCursorSprites = Preferences.LoadPreference("EnableCursorSprites");
-
-            if (suppressTilesetWarning == "")
-            {
-                chkSuppressTilesetWarning.Checked = false;
-            }
-            else
-            {
-                chkSuppressTilesetWarning.Checked = Convert.ToBoolean(suppressTilesetWarning);
-            }
-
-            chkCursorSprites.Checked = !string.IsNullOrEmpty(enableCursorSprites) &&
-                                       Convert.ToBoolean(enableCursorSprites);
-
-            txtGamePath.Text = Preferences.LoadPreference("ClientPath");
-
-            // Load settings for the Update tab
-            var packageUpdateAssets = Preferences.LoadPreference("PackageUpdateAssets");
-            if (packageUpdateAssets == "")
-            {
-                chkPackageAssets.Checked = false;
-            }
-            else
-            {
-                chkPackageAssets.Checked = Convert.ToBoolean(packageUpdateAssets);
-            }
-
-            var soundBatchSize = Preferences.LoadPreference("SoundPackSize");
-            if (soundBatchSize != "")
-            {
-                nudSoundBatch.Value = Convert.ToInt32(soundBatchSize);
-            }
-
-            var musicBatchSize = Preferences.LoadPreference("MusicPackSize");
-            if (musicBatchSize != "")
-            {
-                nudMusicBatch.Value = Convert.ToInt32(musicBatchSize);
-            }
-
-            var texturePackSize = Preferences.LoadPreference("TexturePackSize");
-            if (texturePackSize != "")
-            {
-                cmbTextureSize.SelectedIndex = cmbTextureSize.FindStringExact(texturePackSize);
-            }
-            else
-            {
-                cmbTextureSize.SelectedIndex = cmbTextureSize.FindStringExact("2048");
-            }
+            chkPackageAssets.Checked = false;
+        }
+        else
+        {
+            chkPackageAssets.Checked = Convert.ToBoolean(packageUpdateAssets);
         }
 
-        private void InitLocalization()
+        var soundBatchSize = Preferences.LoadPreference("SoundPackSize");
+        if (soundBatchSize != "")
         {
-            Text = Strings.Options.title;
-            btnGeneralOptions.Text = Strings.Options.generaltab.ToString(Application.ProductVersion);
-            chkSuppressTilesetWarning.Text = Strings.Options.tilesetwarning;
-            chkCursorSprites.Text = Strings.Options.CursorSprites;
-            grpClientPath.Text = Strings.Options.pathgroup;
-            btnBrowseClient.Text = Strings.Options.browsebtn;
-            btnUpdateOptions.Text = Strings.Options.UpdateTab;
-            grpAssetPackingOptions.Text = Strings.Options.PackageOptions;
-            lblMusicBatch.Text = Strings.Options.MusicPackSize;
-            lblSoundBatch.Text = Strings.Options.SoundPackSize;
-            lblTextureSize.Text = Strings.Options.TextureSize;
-
+            nudSoundBatch.Value = Convert.ToInt32(soundBatchSize);
         }
 
-        private void frmOptions_FormClosing(object sender, FormClosingEventArgs e)
+        var musicBatchSize = Preferences.LoadPreference("MusicPackSize");
+        if (musicBatchSize != "")
         {
-            Preferences.SavePreference("SuppressTextureWarning", chkSuppressTilesetWarning.Checked.ToString());
-            Preferences.SavePreference("EnableCursorSprites", chkCursorSprites.Checked.ToString());
-            Preferences.SavePreference("ClientPath", txtGamePath.Text);
-            Preferences.SavePreference("PackageUpdateAssets", chkPackageAssets.Checked.ToString());
-            Preferences.SavePreference("SoundPackSize", nudSoundBatch.Value.ToString(CultureInfo.InvariantCulture));
-            Preferences.SavePreference("MusicPackSize", nudMusicBatch.Value.ToString(CultureInfo.InvariantCulture));
-            Preferences.SavePreference("TexturePackSize", cmbTextureSize.GetItemText(cmbTextureSize.SelectedItem));
+            nudMusicBatch.Value = Convert.ToInt32(musicBatchSize);
         }
 
-        private void btnBrowseClient_Click(object sender, EventArgs e)
+        var texturePackSize = Preferences.LoadPreference("TexturePackSize");
+        if (texturePackSize != "")
         {
-            var dialogue = new OpenFileDialog()
-            {
-                Title = Strings.Options.dialogueheader,
-                CheckFileExists = true,
-                CheckPathExists = true,
-                DefaultExt = "exe",
-                Filter = "(*.exe)|*.exe|" + Strings.Options.dialogueallfiles + "(*.*)|*.*",
-                RestoreDirectory = true,
-                ReadOnlyChecked = true,
-                ShowReadOnly = true
-            };
-
-            using (dialogue)
-            {
-                if (dialogue.ShowDialog() == DialogResult.OK)
-                {
-                    txtGamePath.Text = dialogue.FileName;
-                }
-            }
+            cmbTextureSize.SelectedIndex = cmbTextureSize.FindStringExact(texturePackSize);
         }
-
-        private void HidePanels()
+        else
         {
-            pnlGeneral.Visible = false;
-            pnlUpdate.Visible = false;
-        }
-
-        private void btnGeneralOptions_Click(object sender, EventArgs e)
-        {
-            // Hide other panels.
-            HidePanels();
-
-            pnlGeneral.Visible = true;
-        }
-
-        private void btnUpdateOptions_Click(object sender, EventArgs e)
-        {
-            // Hide other panels.
-            HidePanels();
-
-            pnlUpdate.Visible = true;
-        }
-
-        private void nudSoundBatch_ValueChanged(object sender, EventArgs e)
-        {
-
+            cmbTextureSize.SelectedIndex = cmbTextureSize.FindStringExact("2048");
         }
     }
 
+    private void InitLocalization()
+    {
+        Text = Strings.Options.title;
+        btnGeneralOptions.Text = Strings.Options.generaltab.ToString(Application.ProductVersion);
+        chkSuppressTilesetWarning.Text = Strings.Options.tilesetwarning;
+        chkCursorSprites.Text = Strings.Options.CursorSprites;
+        grpClientPath.Text = Strings.Options.pathgroup;
+        btnBrowseClient.Text = Strings.Options.browsebtn;
+        btnUpdateOptions.Text = Strings.Options.UpdateTab;
+        grpAssetPackingOptions.Text = Strings.Options.PackageOptions;
+        lblMusicBatch.Text = Strings.Options.MusicPackSize;
+        lblSoundBatch.Text = Strings.Options.SoundPackSize;
+        lblTextureSize.Text = Strings.Options.TextureSize;
+
+    }
+
+    private void frmOptions_FormClosing(object sender, FormClosingEventArgs e)
+    {
+        Preferences.SavePreference("SuppressTextureWarning", chkSuppressTilesetWarning.Checked.ToString());
+        Preferences.SavePreference("EnableCursorSprites", chkCursorSprites.Checked.ToString());
+        Preferences.SavePreference("ClientPath", txtGamePath.Text);
+        Preferences.SavePreference("PackageUpdateAssets", chkPackageAssets.Checked.ToString());
+        Preferences.SavePreference("SoundPackSize", nudSoundBatch.Value.ToString(CultureInfo.InvariantCulture));
+        Preferences.SavePreference("MusicPackSize", nudMusicBatch.Value.ToString(CultureInfo.InvariantCulture));
+        Preferences.SavePreference("TexturePackSize", cmbTextureSize.GetItemText(cmbTextureSize.SelectedItem));
+    }
+
+    private void btnBrowseClient_Click(object sender, EventArgs e)
+    {
+        var dialogue = new OpenFileDialog()
+        {
+            Title = Strings.Options.dialogueheader,
+            CheckFileExists = true,
+            CheckPathExists = true,
+            DefaultExt = "exe",
+            Filter = "(*.exe)|*.exe|" + Strings.Options.dialogueallfiles + "(*.*)|*.*",
+            RestoreDirectory = true,
+            ReadOnlyChecked = true,
+            ShowReadOnly = true
+        };
+
+        using (dialogue)
+        {
+            if (dialogue.ShowDialog() == DialogResult.OK)
+            {
+                txtGamePath.Text = dialogue.FileName;
+            }
+        }
+    }
+
+    private void HidePanels()
+    {
+        pnlGeneral.Visible = false;
+        pnlUpdate.Visible = false;
+    }
+
+    private void btnGeneralOptions_Click(object sender, EventArgs e)
+    {
+        // Hide other panels.
+        HidePanels();
+
+        pnlGeneral.Visible = true;
+    }
+
+    private void btnUpdateOptions_Click(object sender, EventArgs e)
+    {
+        // Hide other panels.
+        HidePanels();
+
+        pnlUpdate.Visible = true;
+    }
+
+    private void nudSoundBatch_ValueChanged(object sender, EventArgs e)
+    {
+
+    }
 }

--- a/Intersect.Editor/Forms/frmProgress.cs
+++ b/Intersect.Editor/Forms/frmProgress.cs
@@ -1,77 +1,76 @@
 using Intersect.Editor.Localization;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmProgress : Form
 {
 
-    public partial class FrmProgress : Form
+    private int mProgressVal;
+
+    private bool mShouldClose;
+
+    private bool mShowCancelBtn;
+
+    private string mStatusText;
+
+    public FrmProgress()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private int mProgressVal;
+        InitLocalization();
+    }
 
-        private bool mShouldClose;
+    private void InitLocalization()
+    {
+        btnCancel.Text = Strings.ProgressForm.cancel;
+    }
 
-        private bool mShowCancelBtn;
+    public void SetTitle(string title)
+    {
+        Text = title;
+    }
 
-        private string mStatusText;
-
-        public FrmProgress()
+    public void SetProgress(string label, int progress, bool showCancel)
+    {
+        mStatusText = label;
+        if (progress < 0)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            InitLocalization();
+            mProgressVal = 0;
+            progressBar.Style = ProgressBarStyle.Marquee;
+        }
+        else
+        {
+            mProgressVal = progress;
+            progressBar.Style = ProgressBarStyle.Blocks;
         }
 
-        private void InitLocalization()
+        mShowCancelBtn = showCancel;
+        tmrUpdater_Tick(null, null);
+        Application.DoEvents();
+    }
+
+    public void NotifyClose()
+    {
+        mShouldClose = true;
+    }
+
+    private void tmrUpdater_Tick(object sender, EventArgs e)
+    {
+        if (!IsHandleCreated)
         {
-            btnCancel.Text = Strings.ProgressForm.cancel;
+            return;
         }
 
-        public void SetTitle(string title)
+        if (!InvokeRequired)
         {
-            Text = title;
-        }
-
-        public void SetProgress(string label, int progress, bool showCancel)
-        {
-            mStatusText = label;
-            if (progress < 0)
+            lblStatus.Text = mStatusText;
+            progressBar.Value = mProgressVal;
+            btnCancel.Visible = mShowCancelBtn;
+            if (mShouldClose)
             {
-                mProgressVal = 0;
-                progressBar.Style = ProgressBarStyle.Marquee;
-            }
-            else
-            {
-                mProgressVal = progress;
-                progressBar.Style = ProgressBarStyle.Blocks;
-            }
-
-            mShowCancelBtn = showCancel;
-            tmrUpdater_Tick(null, null);
-            Application.DoEvents();
-        }
-
-        public void NotifyClose()
-        {
-            mShouldClose = true;
-        }
-
-        private void tmrUpdater_Tick(object sender, EventArgs e)
-        {
-            if (!IsHandleCreated)
-            {
-                return;
-            }
-
-            if (!InvokeRequired)
-            {
-                lblStatus.Text = mStatusText;
-                progressBar.Value = mProgressVal;
-                btnCancel.Visible = mShowCancelBtn;
-                if (mShouldClose)
-                {
-                    Close();
-                }
+                Close();
             }
         }
     }

--- a/Intersect.Editor/Forms/frmUpdate.cs
+++ b/Intersect.Editor/Forms/frmUpdate.cs
@@ -8,118 +8,116 @@ using Intersect.Editor.Localization;
 using Intersect.Logging;
 using Intersect.Updater;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmUpdate : Form
 {
 
-    public partial class FrmUpdate : Form
+    private Updater.Updater mUpdater;
+
+    public FrmUpdate()
     {
+        CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+        InitializeComponent();
+        Icon = Program.Icon;
+    }
 
-        private Updater.Updater mUpdater;
-
-        public FrmUpdate()
+    private void frmUpdate_Load(object sender, EventArgs e)
+    {
+        AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
+        try
         {
-            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
-            InitializeComponent();
-            Icon = Program.Icon;
+            Strings.Load();
         }
-
-        private void frmUpdate_Load(object sender, EventArgs e)
+        catch (Exception exception)
         {
-            AppDomain.CurrentDomain.UnhandledException += Program.CurrentDomain_UnhandledException;
-            try
+            Log.Error(exception);
+            throw;
+        }
+        GameContentManager.CheckForResources();
+        Database.LoadOptions();
+        InitLocalization();
+        mUpdater = new Updater.Updater(ClientConfiguration.Instance.UpdateUrl, Path.Combine("version.json"), false, 5);
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.Update.Title;
+        lblVersion.Text = Strings.Login.version.ToString(Application.ProductVersion);
+        lblStatus.Text = Strings.Update.Checking;
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        mUpdater.Stop();
+        base.OnClosed(e);
+        Application.Exit();
+    }
+
+    private void tmrUpdate_Tick(object sender, EventArgs e)
+    {
+        if (mUpdater != null)
+        {
+
+            progressBar.Style = mUpdater.Status == UpdateStatus.Checking
+                ? ProgressBarStyle.Marquee
+                : ProgressBarStyle.Continuous;
+
+            switch (mUpdater.Status)
             {
-                Strings.Load();
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-            GameContentManager.CheckForResources();
-            Database.LoadOptions();
-            InitLocalization();
-            mUpdater = new Updater.Updater(ClientConfiguration.Instance.UpdateUrl, Path.Combine("version.json"), false, 5);
-        }
+                case UpdateStatus.Checking:
+                    lblStatus.Text = Strings.Update.Checking;
+                    break;
+                case UpdateStatus.Updating:
+                    lblFiles.Show();
+                    lblSize.Show();
+                    lblFiles.Text = Strings.Update.Files.ToString(mUpdater.FilesRemaining);
+                    lblSize.Text = Strings.Update.Size.ToString(mUpdater.GetHumanReadableFileSize(mUpdater.SizeRemaining));
+                    lblStatus.Text = Strings.Update.Updating.ToString((int)mUpdater.Progress);
+                    progressBar.Value = (int) mUpdater.Progress;
+                    break;
+                case UpdateStatus.Restart:
+                    lblFiles.Hide();
+                    lblSize.Hide();
+                    progressBar.Value = 100;
+                    lblStatus.Text = Strings.Update.Restart.ToString();
+                    tmrUpdate.Enabled = false;
+                    Process.Start(
+                        Environment.GetCommandLineArgs()[0],
+                        Environment.GetCommandLineArgs().Length > 1
+                            ? string.Join(" ", Environment.GetCommandLineArgs().Skip(1))
+                            : null
+                    );
 
-        private void InitLocalization()
-        {
-            Text = Strings.Update.Title;
-            lblVersion.Text = Strings.Login.version.ToString(Application.ProductVersion);
-            lblStatus.Text = Strings.Update.Checking;
-        }
+                    this.Close();
 
-        protected override void OnClosed(EventArgs e)
-        {
-            mUpdater.Stop();
-            base.OnClosed(e);
-            Application.Exit();
-        }
-
-        private void tmrUpdate_Tick(object sender, EventArgs e)
-        {
-            if (mUpdater != null)
-            {
-
-                progressBar.Style = mUpdater.Status == UpdateStatus.Checking
-                    ? ProgressBarStyle.Marquee
-                    : ProgressBarStyle.Continuous;
-
-                switch (mUpdater.Status)
-                {
-                    case UpdateStatus.Checking:
-                        lblStatus.Text = Strings.Update.Checking;
-                        break;
-                    case UpdateStatus.Updating:
-                        lblFiles.Show();
-                        lblSize.Show();
-                        lblFiles.Text = Strings.Update.Files.ToString(mUpdater.FilesRemaining);
-                        lblSize.Text = Strings.Update.Size.ToString(mUpdater.GetHumanReadableFileSize(mUpdater.SizeRemaining));
-                        lblStatus.Text = Strings.Update.Updating.ToString((int)mUpdater.Progress);
-                        progressBar.Value = (int) mUpdater.Progress;
-                        break;
-                    case UpdateStatus.Restart:
-                        lblFiles.Hide();
-                        lblSize.Hide();
-                        progressBar.Value = 100;
-                        lblStatus.Text = Strings.Update.Restart.ToString();
-                        tmrUpdate.Enabled = false;
-                        Process.Start(
-                            Environment.GetCommandLineArgs()[0],
-                            Environment.GetCommandLineArgs().Length > 1
-                                ? string.Join(" ", Environment.GetCommandLineArgs().Skip(1))
-                                : null
-                        );
-
-                        this.Close();
-
-                        break;
-                    case UpdateStatus.Done:
-                        lblFiles.Hide();
-                        lblSize.Hide();
-                        progressBar.Value = 100;
-                        lblStatus.Text = Strings.Update.Done;
-                        tmrUpdate.Enabled = false;
-                        Hide();
-                        Globals.LoginForm.Show();
-                        break;
-                    case UpdateStatus.Error:
-                        lblFiles.Hide();
-                        lblSize.Hide();
-                        progressBar.Value = 100;
-                        lblStatus.Text = Strings.Update.Error.ToString(mUpdater.Exception?.Message ?? "");
-                        break;
-                    case UpdateStatus.None:
-                        lblFiles.Hide();
-                        lblSize.Hide();
-                        tmrUpdate.Enabled = false;
-                        Hide();
-                        Globals.LoginForm.Show();
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                    break;
+                case UpdateStatus.Done:
+                    lblFiles.Hide();
+                    lblSize.Hide();
+                    progressBar.Value = 100;
+                    lblStatus.Text = Strings.Update.Done;
+                    tmrUpdate.Enabled = false;
+                    Hide();
+                    Globals.LoginForm.Show();
+                    break;
+                case UpdateStatus.Error:
+                    lblFiles.Hide();
+                    lblSize.Hide();
+                    progressBar.Value = 100;
+                    lblStatus.Text = Strings.Update.Error.ToString(mUpdater.Exception?.Message ?? "");
+                    break;
+                case UpdateStatus.None:
+                    lblFiles.Hide();
+                    lblSize.Hide();
+                    tmrUpdate.Enabled = false;
+                    Hide();
+                    Globals.LoginForm.Show();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
     }
-
 }

--- a/Intersect.Editor/Forms/frmWarpSelection.cs
+++ b/Intersect.Editor/Forms/frmWarpSelection.cs
@@ -6,251 +6,249 @@ using Intersect.Editor.Networking;
 using Intersect.GameObjects.Maps.MapList;
 using Graphics = System.Drawing.Graphics;
 
-namespace Intersect.Editor.Forms
+namespace Intersect.Editor.Forms;
+
+
+public partial class FrmWarpSelection : Form
 {
 
-    public partial class FrmWarpSelection : Form
+    private Guid mCurrentMapId = Guid.Empty;
+
+    private int mCurrentX;
+
+    private int mCurrentY;
+
+    private Guid mDrawnMap = Guid.Empty;
+
+    private Image mMapImage;
+
+    private List<Guid> mRestrictMaps;
+
+    private bool mResult;
+
+    private bool mTileSelection = true;
+
+    public FrmWarpSelection()
     {
+        InitializeComponent();
+        Icon = Program.Icon;
 
-        private Guid mCurrentMapId = Guid.Empty;
+        InitLocalization();
+        mapTreeList1.UpdateMapList(mCurrentMapId);
+        pnlMap.Width = Options.TileWidth * Options.MapWidth;
+        pnlMap.Height = Options.TileHeight * Options.MapHeight;
+        pnlMap.BackColor = System.Drawing.Color.Black;
+        mapTreeList1.SetSelect(NodeDoubleClick);
 
-        private int mCurrentX;
+        typeof(Panel).InvokeMember(
+            "DoubleBuffered", BindingFlags.SetProperty | BindingFlags.Instance | BindingFlags.NonPublic, null,
+            pnlMap, new object[] {true}
+        );
+    }
 
-        private int mCurrentY;
-
-        private Guid mDrawnMap = Guid.Empty;
-
-        private Image mMapImage;
-
-        private List<Guid> mRestrictMaps;
-
-        private bool mResult;
-
-        private bool mTileSelection = true;
-
-        public FrmWarpSelection()
+    public void InitForm(bool tileSelection = true, List<Guid> restrictMaps = null)
+    {
+        mapTreeList1.UpdateMapList(mCurrentMapId, restrictMaps);
+        mRestrictMaps = restrictMaps;
+        if (!tileSelection)
         {
-            InitializeComponent();
-            Icon = Program.Icon;
-
-            InitLocalization();
-            mapTreeList1.UpdateMapList(mCurrentMapId);
-            pnlMap.Width = Options.TileWidth * Options.MapWidth;
-            pnlMap.Height = Options.TileHeight * Options.MapHeight;
-            pnlMap.BackColor = System.Drawing.Color.Black;
-            mapTreeList1.SetSelect(NodeDoubleClick);
-
-            typeof(Panel).InvokeMember(
-                "DoubleBuffered", BindingFlags.SetProperty | BindingFlags.Instance | BindingFlags.NonPublic, null,
-                pnlMap, new object[] {true}
-            );
+            mTileSelection = false;
+            Text = Strings.WarpSelection.mapselectiontitle;
         }
+    }
 
-        public void InitForm(bool tileSelection = true, List<Guid> restrictMaps = null)
+    private void InitLocalization()
+    {
+        Text = Strings.WarpSelection.title;
+        chkAlphabetical.Text = Strings.WarpSelection.alphabetical;
+        btnOk.Text = Strings.WarpSelection.okay;
+        btnCancel.Text = Strings.WarpSelection.cancel;
+        grpMapList.Text = Strings.WarpSelection.maplist;
+        grpMapPreview.Text = Strings.WarpSelection.mappreview;
+    }
+
+    private void NodeDoubleClick(object sender, TreeViewEventArgs e)
+    {
+        if (e.Node?.Tag is MapListMap mapListMap)
         {
-            mapTreeList1.UpdateMapList(mCurrentMapId, restrictMaps);
-            mRestrictMaps = restrictMaps;
-            if (!tileSelection)
-            {
-                mTileSelection = false;
-                Text = Strings.WarpSelection.mapselectiontitle;
-            }
+            SelectTile(mapListMap.MapId, mCurrentX, mCurrentY);
         }
+    }
 
-        private void InitLocalization()
+    public void SelectTile(Guid mapId, int x, int y)
+    {
+        if (mCurrentMapId != mapId || x != mCurrentX || y != mCurrentY)
         {
-            Text = Strings.WarpSelection.title;
-            chkAlphabetical.Text = Strings.WarpSelection.alphabetical;
-            btnOk.Text = Strings.WarpSelection.okay;
-            btnCancel.Text = Strings.WarpSelection.cancel;
-            grpMapList.Text = Strings.WarpSelection.maplist;
-            grpMapPreview.Text = Strings.WarpSelection.mappreview;
-        }
-
-        private void NodeDoubleClick(object sender, TreeViewEventArgs e)
-        {
-            if (e.Node?.Tag is MapListMap mapListMap)
-            {
-                SelectTile(mapListMap.MapId, mCurrentX, mCurrentY);
-            }
-        }
-
-        public void SelectTile(Guid mapId, int x, int y)
-        {
-            if (mCurrentMapId != mapId || x != mCurrentX || y != mCurrentY)
-            {
-                mCurrentMapId = mapId;
-                mCurrentX = x;
-                mCurrentY = y;
-                mapTreeList1.UpdateMapList(mapId, mRestrictMaps);
-                UpdatePreview();
-            }
-
-            btnRefreshPreview.Enabled = mCurrentMapId != Guid.Empty;
-        }
-
-        private void UpdatePreview()
-        {
-            if (mCurrentMapId != Guid.Empty)
-            {
-                if (mCurrentMapId != mDrawnMap)
-                {
-                    var img = Database.LoadMapCacheLegacy(mCurrentMapId, -1);
-                    if (img != null)
-                    {
-                        mMapImage = img;
-                    }
-                    else
-                    {
-                        if (MapInstance.Get(mCurrentMapId) != null)
-                        {
-                            MapInstance.Get(mCurrentMapId).Delete();
-                        }
-
-                        Globals.MapsToFetch = new List<Guid>() {mCurrentMapId};
-                        if (!Globals.MapsToScreenshot.Contains(mCurrentMapId))
-                        {
-                            Globals.MapsToScreenshot.Add(mCurrentMapId);
-                        }
-
-                        PacketSender.SendNeedMap(mCurrentMapId);
-                        pnlMap.BackgroundImage = null;
-
-                        //Use a timer to check when we have the map.
-                        tmrMapCheck.Enabled = true;
-
-                        return;
-                    }
-                }
-
-                var newBitmap = new Bitmap(pnlMap.Width, pnlMap.Height);
-                var g = Graphics.FromImage(newBitmap);
-                g.DrawImage(
-                    mMapImage, new Rectangle(0, 0, pnlMap.Width, pnlMap.Height),
-                    new Rectangle(0, 0, pnlMap.Width, pnlMap.Height), GraphicsUnit.Pixel
-                );
-
-                if (mTileSelection)
-                {
-                    g.DrawRectangle(
-                        new Pen(System.Drawing.Color.White, 2f),
-                        new Rectangle(
-                            mCurrentX * Options.TileWidth, mCurrentY * Options.TileHeight, Options.TileWidth,
-                            Options.TileHeight
-                        )
-                    );
-                }
-
-                g.Dispose();
-                pnlMap.BackgroundImage = newBitmap;
-                tmrMapCheck.Enabled = false;
-                mDrawnMap = mCurrentMapId;
-
-                return;
-            }
-            else
-            {
-                pnlMap.BackgroundImage = null;
-            }
-        }
-
-        private void chkChronological_CheckedChanged(object sender, EventArgs e)
-        {
-            mapTreeList1.Chronological = chkAlphabetical.Checked;
-            mapTreeList1.UpdateMapList(mCurrentMapId, mRestrictMaps);
-        }
-
-        private void frmWarpSelection_Load(object sender, EventArgs e)
-        {
-            mapTreeList1.BeginInvoke(mapTreeList1.MapListDelegate, mCurrentMapId, mRestrictMaps);
+            mCurrentMapId = mapId;
+            mCurrentX = x;
+            mCurrentY = y;
+            mapTreeList1.UpdateMapList(mapId, mRestrictMaps);
             UpdatePreview();
         }
 
-        private void tmrMapCheck_Tick(object sender, EventArgs e)
+        btnRefreshPreview.Enabled = mCurrentMapId != Guid.Empty;
+    }
+
+    private void UpdatePreview()
+    {
+        if (mCurrentMapId != Guid.Empty)
         {
-            if (mCurrentMapId != Guid.Empty)
+            if (mCurrentMapId != mDrawnMap)
             {
                 var img = Database.LoadMapCacheLegacy(mCurrentMapId, -1);
                 if (img != null)
                 {
-                    UpdatePreview();
-                    tmrMapCheck.Enabled = false;
-                    img.Dispose();
+                    mMapImage = img;
+                }
+                else
+                {
+                    if (MapInstance.Get(mCurrentMapId) != null)
+                    {
+                        MapInstance.Get(mCurrentMapId).Delete();
+                    }
+
+                    Globals.MapsToFetch = new List<Guid>() {mCurrentMapId};
+                    if (!Globals.MapsToScreenshot.Contains(mCurrentMapId))
+                    {
+                        Globals.MapsToScreenshot.Add(mCurrentMapId);
+                    }
+
+                    PacketSender.SendNeedMap(mCurrentMapId);
+                    pnlMap.BackgroundImage = null;
+
+                    //Use a timer to check when we have the map.
+                    tmrMapCheck.Enabled = true;
+
+                    return;
                 }
             }
-            else
+
+            var newBitmap = new Bitmap(pnlMap.Width, pnlMap.Height);
+            var g = Graphics.FromImage(newBitmap);
+            g.DrawImage(
+                mMapImage, new Rectangle(0, 0, pnlMap.Width, pnlMap.Height),
+                new Rectangle(0, 0, pnlMap.Width, pnlMap.Height), GraphicsUnit.Pixel
+            );
+
+            if (mTileSelection)
             {
+                g.DrawRectangle(
+                    new Pen(System.Drawing.Color.White, 2f),
+                    new Rectangle(
+                        mCurrentX * Options.TileWidth, mCurrentY * Options.TileHeight, Options.TileWidth,
+                        Options.TileHeight
+                    )
+                );
+            }
+
+            g.Dispose();
+            pnlMap.BackgroundImage = newBitmap;
+            tmrMapCheck.Enabled = false;
+            mDrawnMap = mCurrentMapId;
+
+            return;
+        }
+        else
+        {
+            pnlMap.BackgroundImage = null;
+        }
+    }
+
+    private void chkChronological_CheckedChanged(object sender, EventArgs e)
+    {
+        mapTreeList1.Chronological = chkAlphabetical.Checked;
+        mapTreeList1.UpdateMapList(mCurrentMapId, mRestrictMaps);
+    }
+
+    private void frmWarpSelection_Load(object sender, EventArgs e)
+    {
+        mapTreeList1.BeginInvoke(mapTreeList1.MapListDelegate, mCurrentMapId, mRestrictMaps);
+        UpdatePreview();
+    }
+
+    private void tmrMapCheck_Tick(object sender, EventArgs e)
+    {
+        if (mCurrentMapId != Guid.Empty)
+        {
+            var img = Database.LoadMapCacheLegacy(mCurrentMapId, -1);
+            if (img != null)
+            {
+                UpdatePreview();
                 tmrMapCheck.Enabled = false;
+                img.Dispose();
             }
         }
-
-        private void pnlMap_MouseDown(object sender, MouseEventArgs e)
+        else
         {
-            if (e.X >= pnlMap.Width || e.Y >= pnlMap.Height)
-            {
-                return;
-            }
+            tmrMapCheck.Enabled = false;
+        }
+    }
 
-            if (e.X < 0 || e.Y < 0)
-            {
-                return;
-            }
+    private void pnlMap_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.X >= pnlMap.Width || e.Y >= pnlMap.Height)
+        {
+            return;
+        }
 
-            mCurrentX = (int) Math.Floor((double) e.X / Options.TileWidth);
-            mCurrentY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        if (e.X < 0 || e.Y < 0)
+        {
+            return;
+        }
+
+        mCurrentX = (int) Math.Floor((double) e.X / Options.TileWidth);
+        mCurrentY = (int) Math.Floor((double) e.Y / Options.TileHeight);
+        UpdatePreview();
+    }
+
+    private void pnlMap_DoubleClick(object sender, EventArgs e)
+    {
+        btnOk_Click(null, null);
+    }
+
+    private void btnOk_Click(object sender, EventArgs e)
+    {
+        if (mCurrentMapId != Guid.Empty)
+        {
+            mResult = true;
+        }
+
+        Close();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        Close();
+    }
+
+    public bool GetResult()
+    {
+        return mResult;
+    }
+
+    public Guid GetMap()
+    {
+        return mCurrentMapId;
+    }
+
+    public int GetX()
+    {
+        return mCurrentX;
+    }
+
+    public int GetY()
+    {
+        return mCurrentY;
+    }
+
+    private void btnRefreshPreview_Click(object sender, EventArgs e)
+    {
+        if (mCurrentMapId != Guid.Empty)
+        {
+            mDrawnMap = Guid.Empty;
+            Database.ClearMapCache(mCurrentMapId);
             UpdatePreview();
         }
-
-        private void pnlMap_DoubleClick(object sender, EventArgs e)
-        {
-            btnOk_Click(null, null);
-        }
-
-        private void btnOk_Click(object sender, EventArgs e)
-        {
-            if (mCurrentMapId != Guid.Empty)
-            {
-                mResult = true;
-            }
-
-            Close();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            Close();
-        }
-
-        public bool GetResult()
-        {
-            return mResult;
-        }
-
-        public Guid GetMap()
-        {
-            return mCurrentMapId;
-        }
-
-        public int GetX()
-        {
-            return mCurrentX;
-        }
-
-        public int GetY()
-        {
-            return mCurrentY;
-        }
-
-        private void btnRefreshPreview_Click(object sender, EventArgs e)
-        {
-            if (mCurrentMapId != Guid.Empty)
-            {
-                mDrawnMap = Guid.Empty;
-                Database.ClearMapCache(mCurrentMapId);
-                UpdatePreview();
-            }
-        }
-
     }
 
 }

--- a/Intersect.Editor/General/Enums.cs
+++ b/Intersect.Editor/General/Enums.cs
@@ -1,72 +1,70 @@
-﻿namespace Intersect.Editor.General
+﻿namespace Intersect.Editor.General;
+
+
+public enum EditorTypes
 {
 
-    public enum EditorTypes
-    {
+    Animation = 0,
 
-        Animation = 0,
+    Item = 1,
 
-        Item = 1,
+    Npc = 2,
 
-        Npc = 2,
+    Resource = 3,
 
-        Resource = 3,
+    Spell = 4,
 
-        Spell = 4,
+    Class = 5,
 
-        Class = 5,
+    Quest = 6,
 
-        Quest = 6,
+    Projectile = 7,
 
-        Projectile = 7,
+    Event = 8,
 
-        Event = 8,
+    CommonEvent = 9,
 
-        CommonEvent = 9,
+    SwitchVariable = 10,
 
-        SwitchVariable = 10,
+    Shop = 11,
 
-        Shop = 11,
+}
 
-    }
+public enum MapListUpdates
+{
 
-    public enum MapListUpdates
-    {
+    MoveItem = 0,
 
-        MoveItem = 0,
+    AddFolder = 1,
 
-        AddFolder = 1,
+    Rename = 2,
 
-        Rename = 2,
+    Delete = 3,
 
-        Delete = 3,
+}
 
-    }
+public enum EditingTool
+{
 
-    public enum EditingTool
-    {
+    Brush = 0,
 
-        Brush = 0,
+    Selection = 1,
 
-        Selection = 1,
+    Rectangle = 2,
 
-        Rectangle = 2,
+    Fill = 3,
 
-        Fill = 3,
+    Erase = 4,
 
-        Erase = 4,
+    Dropper = 5,
 
-        Dropper = 5,
+}
 
-    }
+public enum SelectionTypes
+{
 
-    public enum SelectionTypes
-    {
+    AllLayers = 0,
 
-        AllLayers = 0,
-
-        CurrentLayer = 1,
-
-    }
+    CurrentLayer = 1,
 
 }

--- a/Intersect.Editor/General/Globals.cs
+++ b/Intersect.Editor/General/Globals.cs
@@ -6,194 +6,192 @@ using Intersect.Editor.Maps;
 using Intersect.Enums;
 using Intersect.GameObjects;
 
-namespace Intersect.Editor.General
+namespace Intersect.Editor.General;
+
+
+public static partial class Globals
 {
 
-    public static partial class Globals
+    public static int AutotileFrame = 0;
+
+    //Animation Frame Variables
+    public static int Autotilemode = 0;
+
+    public static LightBase BackupLight;
+
+    public static bool ClosingEditor;
+
+    public static int CopyMapSelH;
+
+    public static int CopyMapSelW;
+
+    public static int CopyMapSelX;
+
+    public static int CopyMapSelY;
+
+    //Cut/Copy Variables
+    public static MapInstance CopySource;
+
+    public static int CurMapSelH;
+
+    public static int CurMapSelW;
+
+    public static int CurMapSelX;
+
+    public static int CurMapSelY;
+
+    public static int CurrentEditor = -1;
+
+    public static string CurrentLayer = string.Empty;
+
+    //Editor Variables
+    public static MapInstance CurrentMap = null;
+
+    public static TilesetBase CurrentTileset = null;
+
+    public static EditingTool CurrentTool = EditingTool.Brush;
+
+    public static int CurSelH;
+
+    public static int CurSelW;
+
+    public static int CurSelX;
+
+    public static int CurSelY;
+
+    public static int CurTileX;
+
+    public static int CurTileY;
+
+    public static bool Dragging = false;
+
+    public static LightBase EditingLight;
+
+    //Editor Loop Variables
+    public static Thread EditorThread;
+
+    public static int FetchCount;
+
+    //Preview Fetching Variables
+    public static bool FetchingMapPreviews = false;
+
+    public static bool GridView;
+
+    public static bool HasCopy;
+
+    public static bool HasGameData = false;
+
+    public static bool InEditor;
+
+    public static bool IsPaste;
+
+    public static Guid LoadingMap = Guid.Empty;
+
+    public static FrmUpdate UpdateForm;
+
+    public static FrmLogin LoginForm;
+
+    public static FrmMain MainForm;
+
+    public static FrmMapEditor MapEditorWindow;
+
+    public static MapGrid MapGrid;
+
+    public static FrmMapGrid MapGridWindowNew;
+
+    //Docking Window References
+    public static FrmMapLayers MapLayersWindow;
+
+    public static FrmMapList MapListWindow;
+
+    public static FrmMapProperties MapPropertiesWindow;
+
+    public static List<Guid> MapsToFetch;
+
+    public static List<Guid> MapsToScreenshot = new List<Guid>();
+
+    public static int MouseButton = -1;
+
+    public static int MouseX;
+
+    public static int MouseY;
+
+    public static int MyIndex;
+
+    public static FrmProgress PackingProgressForm;
+
+    public static FrmProgress PreviewProgressForm;
+
+    public static FrmProgress UpdateCreationProgressForm;
+
+    //Network Variables
+    public static int ReconnectTime = 3000;
+
+    public static long NextServerStatusPing { get; set; }
+
+    //Game Object Editors
+    public static FrmResource ResourceEditor;
+
+    public static EditingTool SavedTool = EditingTool.Brush;
+
+    public static bool SavingOnClose;
+
+    public static MapInstance SelectionSource;
+
+    //Selection Moving Copying and Pasting
+    public static int SelectionType = (int) SelectionTypes.AllLayers;
+
+    public static int TileDragX = 0;
+
+    public static int TileDragY = 0;
+
+    public static int TotalTileDragX = 0;
+
+    public static int TotalTileDragY = 0;
+
+    public static bool ViewingMapProperties = false;
+
+    public static int WaterfallFrame = 0;
+
+    public static string IntToDir(int index)
     {
-
-        public static int AutotileFrame = 0;
-
-        //Animation Frame Variables
-        public static int Autotilemode = 0;
-
-        public static LightBase BackupLight;
-
-        public static bool ClosingEditor;
-
-        public static int CopyMapSelH;
-
-        public static int CopyMapSelW;
-
-        public static int CopyMapSelX;
-
-        public static int CopyMapSelY;
-
-        //Cut/Copy Variables
-        public static MapInstance CopySource;
-
-        public static int CurMapSelH;
-
-        public static int CurMapSelW;
-
-        public static int CurMapSelX;
-
-        public static int CurMapSelY;
-
-        public static int CurrentEditor = -1;
-
-        public static string CurrentLayer = string.Empty;
-
-        //Editor Variables
-        public static MapInstance CurrentMap = null;
-
-        public static TilesetBase CurrentTileset = null;
-
-        public static EditingTool CurrentTool = EditingTool.Brush;
-
-        public static int CurSelH;
-
-        public static int CurSelW;
-
-        public static int CurSelX;
-
-        public static int CurSelY;
-
-        public static int CurTileX;
-
-        public static int CurTileY;
-
-        public static bool Dragging = false;
-
-        public static LightBase EditingLight;
-
-        //Editor Loop Variables
-        public static Thread EditorThread;
-
-        public static int FetchCount;
-
-        //Preview Fetching Variables
-        public static bool FetchingMapPreviews = false;
-
-        public static bool GridView;
-
-        public static bool HasCopy;
-
-        public static bool HasGameData = false;
-
-        public static bool InEditor;
-
-        public static bool IsPaste;
-
-        public static Guid LoadingMap = Guid.Empty;
-
-        public static FrmUpdate UpdateForm;
-
-        public static FrmLogin LoginForm;
-
-        public static FrmMain MainForm;
-
-        public static FrmMapEditor MapEditorWindow;
-
-        public static MapGrid MapGrid;
-
-        public static FrmMapGrid MapGridWindowNew;
-
-        //Docking Window References
-        public static FrmMapLayers MapLayersWindow;
-
-        public static FrmMapList MapListWindow;
-
-        public static FrmMapProperties MapPropertiesWindow;
-
-        public static List<Guid> MapsToFetch;
-
-        public static List<Guid> MapsToScreenshot = new List<Guid>();
-
-        public static int MouseButton = -1;
-
-        public static int MouseX;
-
-        public static int MouseY;
-
-        public static int MyIndex;
-
-        public static FrmProgress PackingProgressForm;
-
-        public static FrmProgress PreviewProgressForm;
-
-        public static FrmProgress UpdateCreationProgressForm;
-
-        //Network Variables
-        public static int ReconnectTime = 3000;
-
-        public static long NextServerStatusPing { get; set; }
-
-        //Game Object Editors
-        public static FrmResource ResourceEditor;
-
-        public static EditingTool SavedTool = EditingTool.Brush;
-
-        public static bool SavingOnClose;
-
-        public static MapInstance SelectionSource;
-
-        //Selection Moving Copying and Pasting
-        public static int SelectionType = (int) SelectionTypes.AllLayers;
-
-        public static int TileDragX = 0;
-
-        public static int TileDragY = 0;
-
-        public static int TotalTileDragX = 0;
-
-        public static int TotalTileDragY = 0;
-
-        public static bool ViewingMapProperties = false;
-
-        public static int WaterfallFrame = 0;
-
-        public static string IntToDir(int index)
+        switch (index)
         {
-            switch (index)
-            {
-                case 0:
-                    return "Up";
-                case 1:
-                    return "Down";
-                case 2:
-                    return "Left";
-                case 3:
-                    return "Right";
-                default:
-                    return "Unknown Direction";
-            }
+            case 0:
+                return "Up";
+            case 1:
+                return "Down";
+            case 2:
+                return "Left";
+            case 3:
+                return "Right";
+            default:
+                return "Unknown Direction";
         }
+    }
 
-        public static string GetColorName(Color.ChatColor color)
+    public static string GetColorName(Color.ChatColor color)
+    {
+        return Strings.Colors.presets[(int) color];
+    }
+
+    public static string GetStatName(int statnum)
+    {
+        switch (statnum)
         {
-            return Strings.Colors.presets[(int) color];
+            case (int) Stat.Attack:
+                return "Attack";
+            case (int) Stat.AbilityPower:
+                return "Ability Power";
+            case (int) Stat.Defense:
+                return "Defense";
+            case (int) Stat.MagicResist:
+                return "Magic Resist";
+            case (int) Stat.Speed:
+                return "Speed";
+            default:
+                return "Invalid Stat";
         }
-
-        public static string GetStatName(int statnum)
-        {
-            switch (statnum)
-            {
-                case (int) Stat.Attack:
-                    return "Attack";
-                case (int) Stat.AbilityPower:
-                    return "Ability Power";
-                case (int) Stat.Defense:
-                    return "Defense";
-                case (int) Stat.MagicResist:
-                    return "Magic Resist";
-                case (int) Stat.Speed:
-                    return "Speed";
-                default:
-                    return "Invalid Stat";
-            }
-        }
-
     }
 
 }

--- a/Intersect.Editor/Localization/Localizer.cs
+++ b/Intersect.Editor/Localization/Localizer.cs
@@ -4,142 +4,141 @@ using Intersect.GameObjects.Annotations;
 using Intersect.Localization;
 using Intersect.Logging;
 
-namespace Intersect.Editor.Localization
+namespace Intersect.Editor.Localization;
+
+public class EditorProperty : IComparable<EditorProperty>
 {
-    public class EditorProperty : IComparable<EditorProperty>
+    public EditorProperty(PropertyInfo propertyInfo, EditorDisplayAttribute displayAttribute, EditorLabelAttribute labelAttribute)
     {
-        public EditorProperty(PropertyInfo propertyInfo, EditorDisplayAttribute displayAttribute, EditorLabelAttribute labelAttribute)
+        DisplayAttribute = displayAttribute ?? throw new ArgumentNullException(nameof(displayAttribute));
+        LabelAttribute = labelAttribute ?? throw new ArgumentNullException(nameof(labelAttribute));
+        PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+    }
+
+    public EditorDisplayAttribute DisplayAttribute { get; }
+
+    public EditorLabelAttribute LabelAttribute { get; }
+
+    public PropertyInfo PropertyInfo { get; }
+
+    public int CompareTo(EditorProperty other)
+    {
+        if (other == default)
         {
-            DisplayAttribute = displayAttribute ?? throw new ArgumentNullException(nameof(displayAttribute));
-            LabelAttribute = labelAttribute ?? throw new ArgumentNullException(nameof(labelAttribute));
-            PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+            return -1;
         }
 
-        public EditorDisplayAttribute DisplayAttribute { get; }
+        var thisFieldType = DisplayAttribute.FieldType;
+        var otherFieldType = other.DisplayAttribute.FieldType;
 
-        public EditorLabelAttribute LabelAttribute { get; }
-
-        public PropertyInfo PropertyInfo { get; }
-
-        public int CompareTo(EditorProperty other)
+        if (thisFieldType == otherFieldType)
         {
-            if (other == default)
-            {
-                return -1;
-            }
-
-            var thisFieldType = DisplayAttribute.FieldType;
-            var otherFieldType = other.DisplayAttribute.FieldType;
-
-            if (thisFieldType == otherFieldType)
-            {
-                return string.Compare(PropertyInfo.Name, other.PropertyInfo.Name, StringComparison.Ordinal);
-            }
-
-            return thisFieldType == EditorFieldType.Pivot ? -1 : 1;
+            return string.Compare(PropertyInfo.Name, other.PropertyInfo.Name, StringComparison.Ordinal);
         }
 
-        public object GetValue(object parent) => PropertyInfo.GetValue(parent);
+        return thisFieldType == EditorFieldType.Pivot ? -1 : 1;
+    }
 
-        public T GetValue<T>(object parent) => PropertyInfo.GetValue(parent) is T value ? value : default;
+    public object GetValue(object parent) => PropertyInfo.GetValue(parent);
 
-        public static bool TryCreate(PropertyInfo propertyInfo, out EditorProperty editorProperty)
+    public T GetValue<T>(object parent) => PropertyInfo.GetValue(parent) is T value ? value : default;
+
+    public static bool TryCreate(PropertyInfo propertyInfo, out EditorProperty editorProperty)
+    {
+        if (propertyInfo == default)
         {
-            if (propertyInfo == default)
+            throw new ArgumentNullException(nameof(propertyInfo));
+        }
+
+        var attributes = Attribute.GetCustomAttributes(propertyInfo, true);
+        var labelAttribute = attributes.FirstOrDefault(attribute => attribute is EditorLabelAttribute) as EditorLabelAttribute;
+        var displayAttribute = attributes.FirstOrDefault(attribute => attribute is EditorDisplayAttribute) as EditorDisplayAttribute;
+
+        if (labelAttribute == default || displayAttribute == default)
+        {
+            // TODO: Re-enable this, disabled for spamming the logs
+            // Log.Warn($"{propertyInfo.DeclaringType.FullName}.{propertyInfo.Name} must have both a label and display attribute.");
+            editorProperty = default;
+            return false;
+        }
+
+        editorProperty = new EditorProperty(
+            displayAttribute: displayAttribute,
+            labelAttribute: labelAttribute,
+            propertyInfo: propertyInfo
+        );
+
+        return true;
+    }
+}
+
+public class Localizer
+{
+    private readonly List<Assembly> _indexedAssemblies;
+    private readonly List<Type> _indexedTypes;
+    private readonly Dictionary<Type, List<EditorProperty>> _indexedEditorProperties;
+
+    public Localizer()
+    {
+        _indexedAssemblies = new List<Assembly>();
+        _indexedTypes = new List<Type>();
+        _indexedEditorProperties = new Dictionary<Type, List<EditorProperty>>();
+
+        IndexAssembly(typeof(Localized).Assembly);
+    }
+
+    public void IndexAssembly(Assembly assembly)
+    {
+        if (assembly == default)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
+        if (_indexedAssemblies.Contains(assembly))
+        {
+            Log.Debug($"Skipping re-index of {assembly.FullName}");
+            return;
+        }
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (_indexedTypes.Contains(type))
             {
-                throw new ArgumentNullException(nameof(propertyInfo));
+                Log.Debug($"Skipping re-index of {type.FullName}");
+                continue;
             }
 
-            var attributes = Attribute.GetCustomAttributes(propertyInfo, true);
-            var labelAttribute = attributes.FirstOrDefault(attribute => attribute is EditorLabelAttribute) as EditorLabelAttribute;
-            var displayAttribute = attributes.FirstOrDefault(attribute => attribute is EditorDisplayAttribute) as EditorDisplayAttribute;
+            var editorPropertiesQuery = type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .SelectMany(
+                    propertyInfo => EditorProperty.TryCreate(propertyInfo, out var editorProperty)
+                        ? new[] { editorProperty }
+                        : Array.Empty<EditorProperty>()
+                );
 
-            if (labelAttribute == default || displayAttribute == default)
-            {
-                // TODO: Re-enable this, disabled for spamming the logs
-                // Log.Warn($"{propertyInfo.DeclaringType.FullName}.{propertyInfo.Name} must have both a label and display attribute.");
-                editorProperty = default;
-                return false;
-            }
-
-            editorProperty = new EditorProperty(
-                displayAttribute: displayAttribute,
-                labelAttribute: labelAttribute,
-                propertyInfo: propertyInfo
-            );
-
-            return true;
+            _indexedEditorProperties[type] = editorPropertiesQuery.ToList();
         }
     }
 
-    public class Localizer
+    [Obsolete("We want to re-implement strings to be object-oriented.")]
+    public List<KeyValuePair<string, string>> Localize(Type stringsType, object value)
     {
-        private readonly List<Assembly> _indexedAssemblies;
-        private readonly List<Type> _indexedTypes;
-        private readonly Dictionary<Type, List<EditorProperty>> _indexedEditorProperties;
-
-        public Localizer()
+        if (value == default || !_indexedEditorProperties.TryGetValue(value.GetType(), out var editorProperties))
         {
-            _indexedAssemblies = new List<Assembly>();
-            _indexedTypes = new List<Type>();
-            _indexedEditorProperties = new Dictionary<Type, List<EditorProperty>>();
-
-            IndexAssembly(typeof(Localized).Assembly);
+            return new List<KeyValuePair<string, string>>();
         }
 
-        public void IndexAssembly(Assembly assembly)
-        {
-            if (assembly == default)
+        return editorProperties
+            .Select(editorProperty =>
             {
-                throw new ArgumentNullException(nameof(assembly));
-            }
+                var labelAttribute = editorProperty.LabelAttribute;
+                var label = labelAttribute.Evaluate(typeof(Strings));
 
-            if (_indexedAssemblies.Contains(assembly))
-            {
-                Log.Debug($"Skipping re-index of {assembly.FullName}");
-                return;
-            }
-
-            foreach (var type in assembly.GetTypes())
-            {
-                if (_indexedTypes.Contains(type))
-                {
-                    Log.Debug($"Skipping re-index of {type.FullName}");
-                    continue;
-                }
-
-                var editorPropertiesQuery = type
-                    .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                    .SelectMany(
-                        propertyInfo => EditorProperty.TryCreate(propertyInfo, out var editorProperty)
-                            ? new[] { editorProperty }
-                            : Array.Empty<EditorProperty>()
-                    );
-
-                _indexedEditorProperties[type] = editorPropertiesQuery.ToList();
-            }
-        }
-
-        [Obsolete("We want to re-implement strings to be object-oriented.")]
-        public List<KeyValuePair<string, string>> Localize(Type stringsType, object value)
-        {
-            if (value == default || !_indexedEditorProperties.TryGetValue(value.GetType(), out var editorProperties))
-            {
-                return new List<KeyValuePair<string, string>>();
-            }
-
-            return editorProperties
-                .Select(editorProperty =>
-                {
-                    var labelAttribute = editorProperty.LabelAttribute;
-                    var label = labelAttribute.Evaluate(typeof(Strings));
-
-                    var displayAttribute = editorProperty.DisplayAttribute;
-                    var propertyValue = editorProperty.GetValue(value);
-                    var displayValue = displayAttribute.Format(typeof(Strings), propertyValue);
-                    return new KeyValuePair<string, string>(label, displayValue);
-                })
-                .ToList();
-        }
+                var displayAttribute = editorProperty.DisplayAttribute;
+                var propertyValue = editorProperty.GetValue(value);
+                var displayValue = displayAttribute.Format(typeof(Strings), propertyValue);
+                return new KeyValuePair<string, string>(label, displayValue);
+            })
+            .ToList();
     }
 }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -9,661 +9,706 @@ using Intersect.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Intersect.Editor.Localization
+namespace Intersect.Editor.Localization;
+
+public static partial class Strings
 {
-    public static partial class Strings
+    private const string StringsFileName = "editor_strings.json";
+
+    public static string FormatBoolean(bool value, BooleanStyle booleanStyle)
     {
-        private const string StringsFileName = "editor_strings.json";
-
-        public static string FormatBoolean(bool value, BooleanStyle booleanStyle)
+        switch (booleanStyle)
         {
-            switch (booleanStyle)
-            {
-                case BooleanStyle.TrueFalse: return value ? General.True : General.False;
-                case BooleanStyle.YesNo: return value ? General.Yes : General.No;
-                default: throw new ArgumentOutOfRangeException(nameof(booleanStyle));
-            }
+            case BooleanStyle.TrueFalse: return value ? General.True : General.False;
+            case BooleanStyle.YesNo: return value ? General.Yes : General.No;
+            default: throw new ArgumentOutOfRangeException(nameof(booleanStyle));
+        }
+    }
+
+    public static string FormatTimeMilliseconds(long milliseconds, int? splitMagnitude = default)
+    {
+        if (milliseconds < 1000 * Math.Pow(10, splitMagnitude ?? 1))
+        {
+            return Time.SuffixMilliseconds.ToString(milliseconds);
         }
 
-        public static string FormatTimeMilliseconds(long milliseconds, int? splitMagnitude = default)
+        var seconds = milliseconds / 1000.0;
+        if (seconds < 60 * Math.Pow(10, splitMagnitude ?? 0))
         {
-            if (milliseconds < 1000 * Math.Pow(10, splitMagnitude ?? 1))
-            {
-                return Time.SuffixMilliseconds.ToString(milliseconds);
-            }
-
-            var seconds = milliseconds / 1000.0;
-            if (seconds < 60 * Math.Pow(10, splitMagnitude ?? 0))
-            {
-                return Time.SuffixSeconds.ToString(seconds);
-            }
-
-            var minutes = seconds / 60;
-            if (minutes < 60 * Math.Pow(10, splitMagnitude ?? 0))
-            {
-                return Time.SuffixMinutes.ToString(minutes);
-            }
-
-            var hours = minutes / 60;
-            if (hours < 24 * (splitMagnitude ?? 1))
-            {
-                return Time.SuffixHours.ToString(hours);
-            }
-
-            var days = hours / 24;
-            if (days < 7 * (splitMagnitude ?? 1))
-            {
-                return Time.SuffixDays.ToString(days);
-            }
-
-            var weeks = days / 7;
-            return Time.SuffixWeeks.ToString(weeks);
+            return Time.SuffixSeconds.ToString(seconds);
         }
 
-        public static string GetEventConditionalDesc(VariableIsCondition condition)
+        var minutes = seconds / 60;
+        if (minutes < 60 * Math.Pow(10, splitMagnitude ?? 0))
         {
-            var pVar = GetVariableComparisonString((dynamic)condition.Comparison);
-
-            if (condition.VariableType == VariableType.PlayerVariable)
-            {
-                return EventConditionDesc.playervariable.ToString(
-                    PlayerVariableBase.GetName(condition.VariableId), pVar
-                );
-            }
-            else if (condition.VariableType == VariableType.ServerVariable)
-            {
-                return EventConditionDesc.globalvariable.ToString(
-                    ServerVariableBase.GetName(condition.VariableId), pVar
-                );
-            }
-            else if (condition.VariableType == VariableType.GuildVariable)
-            {
-                return EventConditionDesc.guildvariable.ToString(
-                    GuildVariableBase.GetName(condition.VariableId), pVar
-                );
-            }
-            else if (condition.VariableType == VariableType.UserVariable)
-            {
-                return EventConditionDesc.UserVariable.ToString(
-                    Strings.GameObjectStrings.UserVariable,
-                    UserVariableBase.GetName(condition.VariableId),
-                    pVar
-                );
-            }
-
-            return "";
+            return Time.SuffixMinutes.ToString(minutes);
         }
 
-        public static string GetEventConditionalDesc(HasItemCondition condition)
+        var hours = minutes / 60;
+        if (hours < 24 * (splitMagnitude ?? 1))
         {
-            if (condition.UseVariable)
-            {
-                var amount = string.Empty;
-                switch (condition.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.playervariable, PlayerVariableBase.GetName(condition.VariableId));
-                        break;
-                    case VariableType.ServerVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.globalvariable, ServerVariableBase.GetName(condition.VariableId));
-                        break;
-                    case VariableType.GuildVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.guildvariable, GuildVariableBase.GetName(condition.VariableId));
-                        break;
-                }
-
-                return EventConditionDesc.hasitem.ToString(amount, ItemBase.GetName(condition.ItemId));
-            }
-            else
-            {
-                return EventConditionDesc.hasitem.ToString(condition.Quantity, ItemBase.GetName(condition.ItemId));
-            }
+            return Time.SuffixHours.ToString(hours);
         }
 
-        public static string GetEventConditionalDesc(IsItemEquippedCondition condition)
+        var days = hours / 24;
+        if (days < 7 * (splitMagnitude ?? 1))
         {
-            return EventConditionDesc.hasitemequipped.ToString(ItemBase.GetName(condition.ItemId));
+            return Time.SuffixDays.ToString(days);
         }
 
-        public static string GetEventConditionalDesc(ClassIsCondition condition)
+        var weeks = days / 7;
+        return Time.SuffixWeeks.ToString(weeks);
+    }
+
+    public static string GetEventConditionalDesc(VariableIsCondition condition)
+    {
+        var pVar = GetVariableComparisonString((dynamic)condition.Comparison);
+
+        if (condition.VariableType == VariableType.PlayerVariable)
         {
-            return EventConditionDesc.Class.ToString(ClassBase.GetName(condition.ClassId));
+            return EventConditionDesc.playervariable.ToString(
+                PlayerVariableBase.GetName(condition.VariableId), pVar
+            );
         }
-
-        public static string GetEventConditionalDesc(KnowsSpellCondition condition)
+        else if (condition.VariableType == VariableType.ServerVariable)
         {
-            return EventConditionDesc.knowsspell.ToString(SpellBase.GetName(condition.SpellId));
+            return EventConditionDesc.globalvariable.ToString(
+                ServerVariableBase.GetName(condition.VariableId), pVar
+            );
         }
-
-        public static string GetEventConditionalDesc(LevelOrStatCondition condition)
+        else if (condition.VariableType == VariableType.GuildVariable)
         {
-            var pLvl = "";
-            switch (condition.Comparator)
-            {
-                case VariableComparator.Equal:
-                    pLvl = EventConditionDesc.equal.ToString(condition.Value);
-
-                    break;
-                case VariableComparator.GreaterOrEqual:
-                    pLvl = EventConditionDesc.greaterequal.ToString(condition.Value);
-
-                    break;
-                case VariableComparator.LesserOrEqual:
-                    pLvl = EventConditionDesc.lessthanequal.ToString(condition.Value);
-
-                    break;
-                case VariableComparator.Greater:
-                    pLvl = EventConditionDesc.greater.ToString(condition.Value);
-
-                    break;
-                case VariableComparator.Less:
-                    pLvl = EventConditionDesc.lessthan.ToString(condition.Value);
-
-                    break;
-                case VariableComparator.NotEqual:
-                    pLvl = EventConditionDesc.notequal.ToString(condition.Value);
-
-                    break;
-            }
-
-            var lvlorstat = "";
-            if (condition.ComparingLevel)
-            {
-                lvlorstat = EventConditionDesc.level;
-            }
-            else
-            {
-                lvlorstat = Combat.stats[(int)condition.Stat];
-            }
-
-            return EventConditionDesc.levelorstat.ToString(lvlorstat, pLvl);
+            return EventConditionDesc.guildvariable.ToString(
+                GuildVariableBase.GetName(condition.VariableId), pVar
+            );
         }
-
-        public static string GetEventConditionalDesc(SelfSwitchCondition condition)
+        else if (condition.VariableType == VariableType.UserVariable)
         {
-            var sValue = EventConditionDesc.False;
-            if (condition.Value)
-            {
-                sValue = EventConditionDesc.True;
-            }
-
-            return EventConditionDesc.selfswitch.ToString(
-                EventConditionDesc.selfswitches[condition.SwitchIndex], sValue
+            return EventConditionDesc.UserVariable.ToString(
+                Strings.GameObjectStrings.UserVariable,
+                UserVariableBase.GetName(condition.VariableId),
+                pVar
             );
         }
 
-        public static string GetEventConditionalDesc(AccessIsCondition condition)
+        return "";
+    }
+
+    public static string GetEventConditionalDesc(HasItemCondition condition)
+    {
+        if (condition.UseVariable)
         {
-            if (condition.Access == Access.None)
+            var amount = string.Empty;
+            switch (condition.VariableType)
             {
-                return EventConditionDesc.power.ToString(EventConditionDesc.modadmin);
+                case VariableType.PlayerVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.playervariable, PlayerVariableBase.GetName(condition.VariableId));
+                    break;
+                case VariableType.ServerVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.globalvariable, ServerVariableBase.GetName(condition.VariableId));
+                    break;
+                case VariableType.GuildVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.guildvariable, GuildVariableBase.GetName(condition.VariableId));
+                    break;
             }
-            else
-            {
-                return EventConditionDesc.power.ToString(EventConditionDesc.admin);
-            }
+
+            return EventConditionDesc.hasitem.ToString(amount, ItemBase.GetName(condition.ItemId));
+        }
+        else
+        {
+            return EventConditionDesc.hasitem.ToString(condition.Quantity, ItemBase.GetName(condition.ItemId));
+        }
+    }
+
+    public static string GetEventConditionalDesc(IsItemEquippedCondition condition)
+    {
+        return EventConditionDesc.hasitemequipped.ToString(ItemBase.GetName(condition.ItemId));
+    }
+
+    public static string GetEventConditionalDesc(ClassIsCondition condition)
+    {
+        return EventConditionDesc.Class.ToString(ClassBase.GetName(condition.ClassId));
+    }
+
+    public static string GetEventConditionalDesc(KnowsSpellCondition condition)
+    {
+        return EventConditionDesc.knowsspell.ToString(SpellBase.GetName(condition.SpellId));
+    }
+
+    public static string GetEventConditionalDesc(LevelOrStatCondition condition)
+    {
+        var pLvl = "";
+        switch (condition.Comparator)
+        {
+            case VariableComparator.Equal:
+                pLvl = EventConditionDesc.equal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.GreaterOrEqual:
+                pLvl = EventConditionDesc.greaterequal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.LesserOrEqual:
+                pLvl = EventConditionDesc.lessthanequal.ToString(condition.Value);
+
+                break;
+            case VariableComparator.Greater:
+                pLvl = EventConditionDesc.greater.ToString(condition.Value);
+
+                break;
+            case VariableComparator.Less:
+                pLvl = EventConditionDesc.lessthan.ToString(condition.Value);
+
+                break;
+            case VariableComparator.NotEqual:
+                pLvl = EventConditionDesc.notequal.ToString(condition.Value);
+
+                break;
         }
 
-        public static string GetEventConditionalDesc(TimeBetweenCondition condition)
+        var lvlorstat = "";
+        if (condition.ComparingLevel)
         {
-            var timeRanges = new List<string>();
-            var time = new DateTime(2000, 1, 1, 0, 0, 0);
-            for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
-            {
-                var addRange = time.ToString("h:mm:ss tt") + " to ";
-                time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
-                addRange += time.ToString("h:mm:ss tt");
-                timeRanges.Add(addRange);
-            }
-
-            var time1 = "";
-            var time2 = "";
-            if (condition.Ranges[0] > -1 && condition.Ranges[0] < timeRanges.Count)
-            {
-                time1 = timeRanges[condition.Ranges[0]];
-            }
-            else
-            {
-                time1 = EventConditionDesc.timeinvalid;
-            }
-
-            if (condition.Ranges[1] > -1 && condition.Ranges[1] < timeRanges.Count)
-            {
-                time2 = timeRanges[condition.Ranges[1]];
-            }
-            else
-            {
-                time2 = EventConditionDesc.timeinvalid;
-            }
-
-            return EventConditionDesc.time.ToString(time1, time2);
+            lvlorstat = EventConditionDesc.level;
+        }
+        else
+        {
+            lvlorstat = Combat.stats[(int)condition.Stat];
         }
 
-        public static string GetEventConditionalDesc(CanStartQuestCondition condition)
+        return EventConditionDesc.levelorstat.ToString(lvlorstat, pLvl);
+    }
+
+    public static string GetEventConditionalDesc(SelfSwitchCondition condition)
+    {
+        var sValue = EventConditionDesc.False;
+        if (condition.Value)
         {
-            return EventConditionDesc.startquest.ToString(QuestBase.GetName(condition.QuestId));
+            sValue = EventConditionDesc.True;
         }
 
-        public static string GetEventConditionalDesc(QuestInProgressCondition condition)
+        return EventConditionDesc.selfswitch.ToString(
+            EventConditionDesc.selfswitches[condition.SwitchIndex], sValue
+        );
+    }
+
+    public static string GetEventConditionalDesc(AccessIsCondition condition)
+    {
+        if (condition.Access == Access.None)
         {
-            var quest = QuestBase.Get(condition.QuestId);
-            if (quest != null)
+            return EventConditionDesc.power.ToString(EventConditionDesc.modadmin);
+        }
+        else
+        {
+            return EventConditionDesc.power.ToString(EventConditionDesc.admin);
+        }
+    }
+
+    public static string GetEventConditionalDesc(TimeBetweenCondition condition)
+    {
+        var timeRanges = new List<string>();
+        var time = new DateTime(2000, 1, 1, 0, 0, 0);
+        for (var i = 0; i < 1440; i += TimeBase.GetTimeBase().RangeInterval)
+        {
+            var addRange = time.ToString("h:mm:ss tt") + " to ";
+            time = time.AddMinutes(TimeBase.GetTimeBase().RangeInterval);
+            addRange += time.ToString("h:mm:ss tt");
+            timeRanges.Add(addRange);
+        }
+
+        var time1 = "";
+        var time2 = "";
+        if (condition.Ranges[0] > -1 && condition.Ranges[0] < timeRanges.Count)
+        {
+            time1 = timeRanges[condition.Ranges[0]];
+        }
+        else
+        {
+            time1 = EventConditionDesc.timeinvalid;
+        }
+
+        if (condition.Ranges[1] > -1 && condition.Ranges[1] < timeRanges.Count)
+        {
+            time2 = timeRanges[condition.Ranges[1]];
+        }
+        else
+        {
+            time2 = EventConditionDesc.timeinvalid;
+        }
+
+        return EventConditionDesc.time.ToString(time1, time2);
+    }
+
+    public static string GetEventConditionalDesc(CanStartQuestCondition condition)
+    {
+        return EventConditionDesc.startquest.ToString(QuestBase.GetName(condition.QuestId));
+    }
+
+    public static string GetEventConditionalDesc(QuestInProgressCondition condition)
+    {
+        var quest = QuestBase.Get(condition.QuestId);
+        if (quest != null)
+        {
+            QuestBase.QuestTask task = null;
+            foreach (var tsk in quest.Tasks)
             {
-                QuestBase.QuestTask task = null;
-                foreach (var tsk in quest.Tasks)
+                if (tsk.Id == condition.TaskId)
                 {
-                    if (tsk.Id == condition.TaskId)
-                    {
-                        task = tsk;
-                    }
+                    task = tsk;
                 }
-
-                var taskName = task != null
-                    ? task.GetTaskString(TaskEditor.descriptions)
-                    : EventConditionDesc.tasknotfound.ToString();
-
-                switch (condition.Progress)
-                {
-                    case QuestProgressState.BeforeTask:
-                        return EventConditionDesc.questinprogress.ToString(
-                            QuestBase.GetName(condition.QuestId),
-                            EventConditionDesc.beforetask.ToString(taskName)
-                        );
-                    case QuestProgressState.AfterTask:
-                        return EventConditionDesc.questinprogress.ToString(
-                            QuestBase.GetName(condition.QuestId),
-                            EventConditionDesc.aftertask.ToString(taskName)
-                        );
-                    case QuestProgressState.OnTask:
-                        return EventConditionDesc.questinprogress.ToString(
-                            QuestBase.GetName(condition.QuestId), EventConditionDesc.ontask.ToString(taskName)
-                        );
-                    default: //On Any task
-                        return EventConditionDesc.questinprogress.ToString(
-                            QuestBase.GetName(condition.QuestId), EventConditionDesc.onanytask
-                        );
-                }
             }
 
-            return EventConditionDesc.questinprogress.ToString(QuestBase.GetName(condition.QuestId));
-        }
+            var taskName = task != null
+                ? task.GetTaskString(TaskEditor.descriptions)
+                : EventConditionDesc.tasknotfound.ToString();
 
-        public static string GetEventConditionalDesc(QuestCompletedCondition condition)
-        {
-            return EventConditionDesc.questcompleted.ToString(QuestBase.GetName(condition.QuestId));
-        }
-
-        public static string GetEventConditionalDesc(NoNpcsOnMapCondition condition)
-        {
-            return condition.SpecificNpc ?
-                EventConditionDesc.NoNpcsOfTypeOnMap.ToString(NpcBase.GetName(condition.NpcId)) :
-                EventConditionDesc.NoNpcsOnMap.ToString();
-        }
-
-        public static string GetEventConditionalDesc(GenderIsCondition condition)
-        {
-            return EventConditionDesc.gender.ToString(
-                condition.Gender == 0 ? EventConditionDesc.male : EventConditionDesc.female
-            );
-        }
-
-        public static string GetEventConditionalDesc(MapIsCondition condition)
-        {
-            var map = GameObjects.Maps.MapList.MapList.List.FindMap(condition.MapId);
-            if (map != null)
+            switch (condition.Progress)
             {
-                return EventConditionDesc.map.ToString(map.Name);
-            }
-
-            return EventConditionDesc.map.ToString(EventConditionDesc.mapnotfound);
-        }
-
-        public static string GetEventConditionalDesc(InGuildWithRank condition)
-        {
-            return EventConditionDesc.guild.ToString(Intersect.Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Intersect.Options.Instance.Guild.Ranks.Length - 1, condition.Rank))].Title);
-        }
-
-        public static string GetEventConditionalDesc(HasFreeInventorySlots condition)
-        {
-            if (condition.UseVariable)
-            {
-                var amount = string.Empty;
-                switch (condition.VariableType)
-                {
-                    case VariableType.PlayerVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.playervariable, PlayerVariableBase.GetName(condition.VariableId));
-                        break;
-                    case VariableType.ServerVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.globalvariable, ServerVariableBase.GetName(condition.VariableId));
-                        break;
-                    case VariableType.GuildVariable:
-                        amount = string.Format(@"({0}: {1})", EventConditional.guildvariable, GuildVariableBase.GetName(condition.VariableId));
-                        break;
-                }
-
-                return EventConditionDesc.HasFreeInventorySlots.ToString(amount);
-            }
-            else
-            {
-                return EventConditionDesc.HasFreeInventorySlots.ToString(condition.Quantity);
-            }
-        }
-
-        public static string GetEventConditionalDesc(MapZoneTypeIs condition)
-        {
-            return EventConditionDesc.MapZoneTypeIs.ToString(MapProperties.zones[(int)condition.ZoneType]);
-        }
-
-        public static string GetEventConditionalDesc(CheckEquippedSlot condition)
-        {
-            return EventConditionDesc.checkequippedslot.ToString(condition.Name);
-        }
-
-        public static string GetVariableComparisonString(VariableComparison comparison)
-        {
-            return "";
-        }
-
-        public static string GetVariableComparisonString(BooleanVariableComparison comparison)
-        {
-            var value = "";
-            var pVar = "";
-
-            if (comparison.CompareVariableId == Guid.Empty)
-            {
-                value = comparison.Value.ToString();
-            }
-            else
-            {
-                if (comparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    value = EventConditionDesc.playervariablevalue.ToString(
-                        PlayerVariableBase.GetName(comparison.CompareVariableId)
+                case QuestProgressState.BeforeTask:
+                    return EventConditionDesc.questinprogress.ToString(
+                        QuestBase.GetName(condition.QuestId),
+                        EventConditionDesc.beforetask.ToString(taskName)
                     );
-                }
-                else if (comparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    value = EventConditionDesc.globalvariablevalue.ToString(
-                        ServerVariableBase.GetName(comparison.CompareVariableId)
+                case QuestProgressState.AfterTask:
+                    return EventConditionDesc.questinprogress.ToString(
+                        QuestBase.GetName(condition.QuestId),
+                        EventConditionDesc.aftertask.ToString(taskName)
                     );
-                }
-                else if (comparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    value = EventConditionDesc.guildvariablevalue.ToString(
-                        GuildVariableBase.GetName(comparison.CompareVariableId)
+                case QuestProgressState.OnTask:
+                    return EventConditionDesc.questinprogress.ToString(
+                        QuestBase.GetName(condition.QuestId), EventConditionDesc.ontask.ToString(taskName)
                     );
-                }
+                default: //On Any task
+                    return EventConditionDesc.questinprogress.ToString(
+                        QuestBase.GetName(condition.QuestId), EventConditionDesc.onanytask
+                    );
+            }
+        }
+
+        return EventConditionDesc.questinprogress.ToString(QuestBase.GetName(condition.QuestId));
+    }
+
+    public static string GetEventConditionalDesc(QuestCompletedCondition condition)
+    {
+        return EventConditionDesc.questcompleted.ToString(QuestBase.GetName(condition.QuestId));
+    }
+
+    public static string GetEventConditionalDesc(NoNpcsOnMapCondition condition)
+    {
+        return condition.SpecificNpc ?
+            EventConditionDesc.NoNpcsOfTypeOnMap.ToString(NpcBase.GetName(condition.NpcId)) :
+            EventConditionDesc.NoNpcsOnMap.ToString();
+    }
+
+    public static string GetEventConditionalDesc(GenderIsCondition condition)
+    {
+        return EventConditionDesc.gender.ToString(
+            condition.Gender == 0 ? EventConditionDesc.male : EventConditionDesc.female
+        );
+    }
+
+    public static string GetEventConditionalDesc(MapIsCondition condition)
+    {
+        var map = GameObjects.Maps.MapList.MapList.List.FindMap(condition.MapId);
+        if (map != null)
+        {
+            return EventConditionDesc.map.ToString(map.Name);
+        }
+
+        return EventConditionDesc.map.ToString(EventConditionDesc.mapnotfound);
+    }
+
+    public static string GetEventConditionalDesc(InGuildWithRank condition)
+    {
+        return EventConditionDesc.guild.ToString(Intersect.Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(Intersect.Options.Instance.Guild.Ranks.Length - 1, condition.Rank))].Title);
+    }
+
+    public static string GetEventConditionalDesc(HasFreeInventorySlots condition)
+    {
+        if (condition.UseVariable)
+        {
+            var amount = string.Empty;
+            switch (condition.VariableType)
+            {
+                case VariableType.PlayerVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.playervariable, PlayerVariableBase.GetName(condition.VariableId));
+                    break;
+                case VariableType.ServerVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.globalvariable, ServerVariableBase.GetName(condition.VariableId));
+                    break;
+                case VariableType.GuildVariable:
+                    amount = string.Format(@"({0}: {1})", EventConditional.guildvariable, GuildVariableBase.GetName(condition.VariableId));
+                    break;
             }
 
-            if (comparison.ComparingEqual)
+            return EventConditionDesc.HasFreeInventorySlots.ToString(amount);
+        }
+        else
+        {
+            return EventConditionDesc.HasFreeInventorySlots.ToString(condition.Quantity);
+        }
+    }
+
+    public static string GetEventConditionalDesc(MapZoneTypeIs condition)
+    {
+        return EventConditionDesc.MapZoneTypeIs.ToString(MapProperties.zones[(int)condition.ZoneType]);
+    }
+
+    public static string GetEventConditionalDesc(CheckEquippedSlot condition)
+    {
+        return EventConditionDesc.checkequippedslot.ToString(condition.Name);
+    }
+
+    public static string GetVariableComparisonString(VariableComparison comparison)
+    {
+        return "";
+    }
+
+    public static string GetVariableComparisonString(BooleanVariableComparison comparison)
+    {
+        var value = "";
+        var pVar = "";
+
+        if (comparison.CompareVariableId == Guid.Empty)
+        {
+            value = comparison.Value.ToString();
+        }
+        else
+        {
+            if (comparison.CompareVariableType == VariableType.PlayerVariable)
             {
+                value = EventConditionDesc.playervariablevalue.ToString(
+                    PlayerVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+            else if (comparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                value = EventConditionDesc.globalvariablevalue.ToString(
+                    ServerVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+            else if (comparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                value = EventConditionDesc.guildvariablevalue.ToString(
+                    GuildVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+        }
+
+        if (comparison.ComparingEqual)
+        {
+            pVar = EventConditionDesc.equal.ToString(value);
+        }
+        else
+        {
+            pVar = EventConditionDesc.notequal.ToString(value);
+        }
+
+        return pVar;
+    }
+
+    public static string GetVariableComparisonString(IntegerVariableComparison comparison)
+    {
+        var value = "";
+        var pVar = "";
+
+        if (comparison.CompareVariableId == Guid.Empty)
+        {
+            value = comparison.Value.ToString();
+
+            if (comparison.TimeSystem)
+            {
+                value = EventConditionDesc.SystemTime;
+            }
+        }
+        else
+        {
+            if (comparison.CompareVariableType == VariableType.PlayerVariable)
+            {
+                value = EventConditionDesc.playervariablevalue.ToString(
+                    PlayerVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+            else if (comparison.CompareVariableType == VariableType.ServerVariable)
+            {
+                value = EventConditionDesc.globalvariablevalue.ToString(
+                    ServerVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+            else if (comparison.CompareVariableType == VariableType.GuildVariable)
+            {
+                value = EventConditionDesc.guildvariablevalue.ToString(
+                    GuildVariableBase.GetName(comparison.CompareVariableId)
+                );
+            }
+        }
+
+        switch (comparison.Comparator)
+        {
+            case VariableComparator.Equal:
                 pVar = EventConditionDesc.equal.ToString(value);
-            }
-            else
-            {
+
+                break;
+            case VariableComparator.GreaterOrEqual:
+                pVar = EventConditionDesc.greaterequal.ToString(value);
+
+                break;
+            case VariableComparator.LesserOrEqual:
+                pVar = EventConditionDesc.lessthanequal.ToString(value);
+
+                break;
+            case VariableComparator.Greater:
+                pVar = EventConditionDesc.greater.ToString(value);
+
+                break;
+            case VariableComparator.Less:
+                pVar = EventConditionDesc.lessthan.ToString(value);
+
+                break;
+            case VariableComparator.NotEqual:
                 pVar = EventConditionDesc.notequal.ToString(value);
-            }
 
-            return pVar;
+                break;
         }
 
-        public static string GetVariableComparisonString(IntegerVariableComparison comparison)
+        return pVar;
+    }
+
+    public static string GetVariableComparisonString(StringVariableComparison comparison)
+    {
+        switch (comparison.Comparator)
         {
-            var value = "";
-            var pVar = "";
-
-            if (comparison.CompareVariableId == Guid.Empty)
-            {
-                value = comparison.Value.ToString();
-
-                if (comparison.TimeSystem)
-                {
-                    value = EventConditionDesc.SystemTime;
-                }
-            }
-            else
-            {
-                if (comparison.CompareVariableType == VariableType.PlayerVariable)
-                {
-                    value = EventConditionDesc.playervariablevalue.ToString(
-                        PlayerVariableBase.GetName(comparison.CompareVariableId)
-                    );
-                }
-                else if (comparison.CompareVariableType == VariableType.ServerVariable)
-                {
-                    value = EventConditionDesc.globalvariablevalue.ToString(
-                        ServerVariableBase.GetName(comparison.CompareVariableId)
-                    );
-                }
-                else if (comparison.CompareVariableType == VariableType.GuildVariable)
-                {
-                    value = EventConditionDesc.guildvariablevalue.ToString(
-                        GuildVariableBase.GetName(comparison.CompareVariableId)
-                    );
-                }
-            }
-
-            switch (comparison.Comparator)
-            {
-                case VariableComparator.Equal:
-                    pVar = EventConditionDesc.equal.ToString(value);
-
-                    break;
-                case VariableComparator.GreaterOrEqual:
-                    pVar = EventConditionDesc.greaterequal.ToString(value);
-
-                    break;
-                case VariableComparator.LesserOrEqual:
-                    pVar = EventConditionDesc.lessthanequal.ToString(value);
-
-                    break;
-                case VariableComparator.Greater:
-                    pVar = EventConditionDesc.greater.ToString(value);
-
-                    break;
-                case VariableComparator.Less:
-                    pVar = EventConditionDesc.lessthan.ToString(value);
-
-                    break;
-                case VariableComparator.NotEqual:
-                    pVar = EventConditionDesc.notequal.ToString(value);
-
-                    break;
-            }
-
-            return pVar;
+            case StringVariableComparator.Equal:
+                return EventConditionDesc.equal.ToString(comparison.Value);
+            case StringVariableComparator.Contains:
+                return EventConditionDesc.contains.ToString(comparison.Value);
         }
 
-        public static string GetVariableComparisonString(StringVariableComparison comparison)
-        {
-            switch (comparison.Comparator)
-            {
-                case StringVariableComparator.Equal:
-                    return EventConditionDesc.equal.ToString(comparison.Value);
-                case StringVariableComparator.Contains:
-                    return EventConditionDesc.contains.ToString(comparison.Value);
-            }
+        return "";
+    }
 
-            return "";
+    private static void SynchronizeConfigurableStrings()
+    {
+        if (Intersect.Options.Instance == default)
+        {
+            return;
         }
 
-        private static void SynchronizeConfigurableStrings()
+        for (var rarityCode = 0; rarityCode < Intersect.Options.Instance.Items.RarityTiers.Count; rarityCode++)
         {
-            if (Intersect.Options.Instance == default)
+            var rarityName = Intersect.Options.Instance.Items.RarityTiers[rarityCode];
+            if (!ItemEditor.rarity.ContainsKey(rarityName))
             {
-                return;
+                ItemEditor.rarity[rarityName] = $"{rarityCode}:{rarityName}";
             }
+        }
+    }
 
-            for (var rarityCode = 0; rarityCode < Intersect.Options.Instance.Items.RarityTiers.Count; rarityCode++)
+    private static void PostLoad()
+    {
+    }
+
+    public static void Load()
+    {
+        SynchronizeConfigurableStrings();
+
+        try
+        {
+            var serialized = new Dictionary<string, Dictionary<string, object>>();
+            serialized = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(
+                File.ReadAllText(Path.Combine("resources", StringsFileName))
+            );
+
+            var rootType = typeof(Strings);
+            var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
+            var missingStrings = new List<string>();
+            foreach (var groupType in groupTypes)
             {
-                var rarityName = Intersect.Options.Instance.Items.RarityTiers[rarityCode];
-                if (!ItemEditor.rarity.ContainsKey(rarityName))
+                if (!serialized.TryGetValue(groupType.Name, out var serializedGroup))
                 {
-                    ItemEditor.rarity[rarityName] = $"{rarityCode}:{rarityName}";
+                    missingStrings.Add($"{groupType.Name}");
+                    serialized[groupType.Name] = SerializeGroup(groupType);
+                    continue;
                 }
-            }
-        }
 
-        private static void PostLoad()
-        {
-        }
-
-        public static void Load()
-        {
-            SynchronizeConfigurableStrings();
-
-            try
-            {
-                var serialized = new Dictionary<string, Dictionary<string, object>>();
-                serialized = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(
-                    File.ReadAllText(Path.Combine("resources", StringsFileName))
-                );
-
-                var rootType = typeof(Strings);
-                var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
-                var missingStrings = new List<string>();
-                foreach (var groupType in groupTypes)
+                foreach (var fieldInfo in groupType.GetFields(BindingFlags.Public | BindingFlags.Static))
                 {
-                    if (!serialized.TryGetValue(groupType.Name, out var serializedGroup))
+                    var fieldValue = fieldInfo.GetValue(null);
+                    if (!serializedGroup.TryGetValue(fieldInfo.Name, out var serializedValue))
                     {
-                        missingStrings.Add($"{groupType.Name}");
-                        serialized[groupType.Name] = SerializeGroup(groupType);
-                        continue;
+                        var foundKey = serializedGroup.Keys.FirstOrDefault(key => string.Equals(fieldInfo.Name, key, StringComparison.OrdinalIgnoreCase));
+                        if (foundKey != default)
+                        {
+                            _ = serializedGroup.TryGetValue(foundKey, out serializedValue);
+                        }
                     }
 
-                    foreach (var fieldInfo in groupType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                    switch (fieldValue)
                     {
-                        var fieldValue = fieldInfo.GetValue(null);
-                        if (!serializedGroup.TryGetValue(fieldInfo.Name, out var serializedValue))
-                        {
-                            var foundKey = serializedGroup.Keys.FirstOrDefault(key => string.Equals(fieldInfo.Name, key, StringComparison.OrdinalIgnoreCase));
-                            if (foundKey != default)
+                        case LocalizedString localizedString:
+                            var jsonString = (string)serializedValue;
+                            if (jsonString == default)
                             {
-                                _ = serializedGroup.TryGetValue(foundKey, out serializedValue);
+                                Log.Warn($"{groupType.Name}.{fieldInfo.Name} is null.");
+                                missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string)");
+                                serializedGroup[fieldInfo.Name] = (string)localizedString;
                             }
-                        }
+                            else
+                            {
+                                fieldInfo.SetValue(null, new LocalizedString(jsonString));
+                            }
+                            break;
 
-                        switch (fieldValue)
-                        {
-                            case LocalizedString localizedString:
-                                var jsonString = (string)serializedValue;
-                                if (jsonString == default)
+                        case Dictionary<int, LocalizedString> intDictionary:
+                            DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, intDictionary);
+                            break;
+
+                        case Dictionary<string, LocalizedString> stringDictionary:
+                            DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, stringDictionary);
+                            break;
+
+                        default:
+                            {
+                                var fieldType = fieldInfo.FieldType;
+                                if (!fieldType.IsGenericType || typeof(Dictionary<,>) != fieldType.GetGenericTypeDefinition())
                                 {
-                                    Log.Warn($"{groupType.Name}.{fieldInfo.Name} is null.");
-                                    missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string)");
-                                    serializedGroup[fieldInfo.Name] = (string)localizedString;
-                                }
-                                else
-                                {
-                                    fieldInfo.SetValue(null, new LocalizedString(jsonString));
-                                }
-                                break;
-
-                            case Dictionary<int, LocalizedString> intDictionary:
-                                DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, intDictionary);
-                                break;
-
-                            case Dictionary<string, LocalizedString> stringDictionary:
-                                DeserializeDictionary(missingStrings, groupType, fieldInfo, fieldValue, serializedGroup, serializedValue, stringDictionary);
-                                break;
-
-                            default:
-                                {
-                                    var fieldType = fieldInfo.FieldType;
-                                    if (!fieldType.IsGenericType || typeof(Dictionary<,>) != fieldType.GetGenericTypeDefinition())
-                                    {
-                                        Log.Error(new NotSupportedException($"Unsupported localization type for {groupType.Name}.{fieldInfo.Name}: {fieldInfo.FieldType.FullName}"));
-                                        break;
-                                    }
-
-                                    var parameters = fieldType.GenericTypeArguments;
-                                    var localizedParameterType = parameters.Last();
-                                    if (localizedParameterType != typeof(LocalizedString))
-                                    {
-                                        Log.Error(new NotSupportedException($"Unsupported localization dictionary value type for {groupType.Name}.{fieldInfo.Name}: {localizedParameterType.FullName}"));
-                                        break;
-                                    }
-
-                                    _ = _methodInfoDeserializeDictionary.MakeGenericMethod(parameters.First()).Invoke(default, new object[]
-                                    {
-                                                missingStrings,
-                                                groupType,
-                                                fieldInfo,
-                                                fieldValue,
-                                                serializedGroup,
-                                                serializedValue,
-                                                fieldValue
-                                    });
+                                    Log.Error(new NotSupportedException($"Unsupported localization type for {groupType.Name}.{fieldInfo.Name}: {fieldInfo.FieldType.FullName}"));
                                     break;
                                 }
-                        }
+
+                                var parameters = fieldType.GenericTypeArguments;
+                                var localizedParameterType = parameters.Last();
+                                if (localizedParameterType != typeof(LocalizedString))
+                                {
+                                    Log.Error(new NotSupportedException($"Unsupported localization dictionary value type for {groupType.Name}.{fieldInfo.Name}: {localizedParameterType.FullName}"));
+                                    break;
+                                }
+
+                                _ = _methodInfoDeserializeDictionary.MakeGenericMethod(parameters.First()).Invoke(default, new object[]
+                                {
+                                            missingStrings,
+                                            groupType,
+                                            fieldInfo,
+                                            fieldValue,
+                                            serializedGroup,
+                                            serializedValue,
+                                            fieldValue
+                                });
+                                break;
+                            }
                     }
                 }
-
-                if (missingStrings.Count > 0)
-                {
-                    Log.Warn($"Missing strings, overwriting strings file:\n\t{string.Join(",\n\t", missingStrings)}");
-                    SaveSerialized(serialized);
-                }
-            }
-            catch (Exception exception)
-            {
-                Log.Warn(exception);
-                Save();
             }
 
-            PostLoad();
-        }
-
-        private static readonly MethodInfo _methodInfoDeserializeDictionary = typeof(Strings).GetMethod(
-                                                nameof(DeserializeDictionary),
-                                                BindingFlags.NonPublic | BindingFlags.Static
-                                            ) ?? throw new InvalidOperationException();
-
-        private static void DeserializeDictionary<TKey>(
-            List<string> missingStrings,
-            Type groupType,
-            FieldInfo fieldInfo,
-            object fieldValue,
-            Dictionary<string, object> serializedGroup,
-            object serializedValue,
-            Dictionary<TKey, LocalizedString> dictionary
-        )
-        {
-            var serializedDictionary = serializedValue as JObject;
-            var serializedField = JToken.FromObject(fieldValue);
-            if (serializedValue == default)
+            if (missingStrings.Count > 0)
             {
-                missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string dictionary)");
-                serializedGroup[fieldInfo.Name] = serializedField;
-            }
-            else
-            {
-                var keys = dictionary.Keys.ToList();
-                foreach (var key in keys)
-                {
-                    var stringKey = key.ToString();
-                    if (!serializedDictionary.TryGetValue(stringKey, out var token) || token?.Type != JTokenType.String)
-                    {
-                        missingStrings.Add($"{groupType.Name}.{fieldInfo.Name}[{key}]");
-                        serializedDictionary[stringKey] = (string)dictionary[key];
-                        continue;
-                    }
-
-                    dictionary[key] = new LocalizedString((string)token);
-                }
+                Log.Warn($"Missing strings, overwriting strings file:\n\t{string.Join(",\n\t", missingStrings)}");
+                SaveSerialized(serialized);
             }
         }
-
-        private static Dictionary<string, string> SerializeDictionary<TKey>(Dictionary<TKey, LocalizedString> localizedDictionary)
+        catch (Exception exception)
         {
-            return localizedDictionary.ToDictionary(
-                pair => pair.Key.ToString(),
-                pair => pair.Value.ToString()
+            Log.Warn(exception);
+            Save();
+        }
+
+        PostLoad();
+    }
+
+    private static readonly MethodInfo _methodInfoDeserializeDictionary = typeof(Strings).GetMethod(
+                                            nameof(DeserializeDictionary),
+                                            BindingFlags.NonPublic | BindingFlags.Static
+                                        ) ?? throw new InvalidOperationException();
+
+    private static void DeserializeDictionary<TKey>(
+        List<string> missingStrings,
+        Type groupType,
+        FieldInfo fieldInfo,
+        object fieldValue,
+        Dictionary<string, object> serializedGroup,
+        object serializedValue,
+        Dictionary<TKey, LocalizedString> dictionary
+    )
+    {
+        var serializedDictionary = serializedValue as JObject;
+        var serializedField = JToken.FromObject(fieldValue);
+        if (serializedValue == default)
+        {
+            missingStrings.Add($"{groupType.Name}.{fieldInfo.Name} (string dictionary)");
+            serializedGroup[fieldInfo.Name] = serializedField;
+        }
+        else
+        {
+            var keys = dictionary.Keys.ToList();
+            foreach (var key in keys)
+            {
+                var stringKey = key.ToString();
+                if (!serializedDictionary.TryGetValue(stringKey, out var token) || token?.Type != JTokenType.String)
+                {
+                    missingStrings.Add($"{groupType.Name}.{fieldInfo.Name}[{key}]");
+                    serializedDictionary[stringKey] = (string)dictionary[key];
+                    continue;
+                }
+
+                dictionary[key] = new LocalizedString((string)token);
+            }
+        }
+    }
+
+    private static Dictionary<string, string> SerializeDictionary<TKey>(Dictionary<TKey, LocalizedString> localizedDictionary)
+    {
+        return localizedDictionary.ToDictionary(
+            pair => pair.Key.ToString(),
+            pair => pair.Value.ToString()
+        );
+    }
+
+    private static Dictionary<string, object> SerializeGroup(Type groupType)
+    {
+        var serializedGroup = new Dictionary<string, object>();
+        foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
+        {
+            switch (fieldInfo.GetValue(null))
+            {
+                case LocalizedString localizedString:
+                    serializedGroup.Add(fieldInfo.Name, localizedString.ToString());
+                    break;
+
+                case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedIntKeyDictionary));
+                    break;
+
+                case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedStringKeyDictionary));
+                    break;
+
+                case Dictionary<ChatboxTab, LocalizedString> localizedChatboxTabKeyDictionary:
+                    serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedChatboxTabKeyDictionary));
+                    break;
+            }
+        }
+        return serializedGroup;
+    }
+
+    private static void SaveSerialized(Dictionary<string, Dictionary<string, object>> serialized)
+    {
+        var languageDirectory = Path.Combine("resources");
+        if (Directory.Exists(languageDirectory))
+        {
+            File.WriteAllText(
+                Path.Combine(languageDirectory, StringsFileName),
+                JsonConvert.SerializeObject(serialized, Formatting.Indented)
             );
         }
+    }
 
-        private static Dictionary<string, object> SerializeGroup(Type groupType)
+    public static void Save()
+    {
+        var serialized = new Dictionary<string, Dictionary<string, object>>();
+        var rootType = typeof(Strings);
+        var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
+
+        foreach (var groupType in groupTypes)
         {
             var serializedGroup = new Dictionary<string, object>();
             foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
@@ -675,5034 +720,4987 @@ namespace Intersect.Editor.Localization
                         break;
 
                     case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedIntKeyDictionary));
+                        serializedGroup.Add(fieldInfo.Name, localizedIntKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
                         break;
 
                     case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedStringKeyDictionary));
-                        break;
-
-                    case Dictionary<ChatboxTab, LocalizedString> localizedChatboxTabKeyDictionary:
-                        serializedGroup.Add(fieldInfo.Name, SerializeDictionary(localizedChatboxTabKeyDictionary));
+                        serializedGroup.Add(fieldInfo.Name, localizedStringKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
                         break;
                 }
             }
-            return serializedGroup;
+
+            serialized.Add(groupType.Name, serializedGroup);
         }
 
-        private static void SaveSerialized(Dictionary<string, Dictionary<string, object>> serialized)
+        SaveSerialized(serialized);
+    }
+
+    public static Localizer Localizer { get; } = new Localizer();
+
+    public partial struct About
+    {
+
+        public static LocalizedString site =
+            @"Click here to visit the Ascension Game Dev community for support, updates and more!";
+
+        public static LocalizedString title = @"About";
+
+        public static LocalizedString version = @"v{00}";
+
+    }
+
+    public partial struct AnimationEditor
+    {
+
+        public static LocalizedString animations = @"Animations";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString copy = @"Copy Animation";
+
+        public static LocalizedString delete = @"Delete Animation";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this animation? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Animation";
+
+        public static LocalizedString extraoptions = @"Extra Options:";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        public static LocalizedString general = @"General";
+
+        public static LocalizedString CloneFromPrevious = @"Clone From Previous";
+
+        public static LocalizedString FrameX = @"Frame: {00}";
+
+        public static LocalizedString FrameCount = @"Frames";
+
+        public static LocalizedString FrameDuration = @"Frame Duration (ms)";
+
+        public static LocalizedString FrameOptions = @"Frame Options";
+
+        public static LocalizedString Graphic = @"Graphic";
+
+        public static LocalizedString lowergroup = @"Lower Layer (Below Target) ";
+
+        public static LocalizedString HorizontalFrames = @"Horizontal";
+
+        public static LocalizedString LoopCount = @"Loop Count";
+
+        public static LocalizedString DisableRotations = @"Disable Rotations";
+
+        public static LocalizedString Playback = @"Playback";
+
+        public static LocalizedString Play = @"Play";
+
+        public static LocalizedString Pause = @"Pause";
+
+        public static LocalizedString VerticalFrames = @"Graphic Vertical Frames:";
+
+        public static LocalizedString name = @"Name";
+
+        public static LocalizedString New = @"New Animation";
+
+        public static LocalizedString paste = @"Paste Animation";
+
+        public static LocalizedString renderaboveplayer = @"Render Above Player";
+
+        public static LocalizedString renderbelowfringe = @"Render Below Fringe";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        public static LocalizedString simulatedarkness = @"Simulate Darkness: {00}";
+
+        public static LocalizedString sound = @"Sound:";
+
+        public static LocalizedString soundcomplete = @"Complete Sound Playback After Anim Dies";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LoopSoundDuringPreview = @"Loop sound during preview";
+
+        public static LocalizedString swap = @"Swap Upper/Lower";
+
+        public static LocalizedString title = @"Animation Editor";
+
+        public static LocalizedString undo = @"Undo Changes";
+
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this animation? This action cannot be reverted!";
+
+        public static LocalizedString undotitle = @"Undo Changes";
+
+        public static LocalizedString uppergroup = @"Upper Layer (Above Target) ";
+
+    }
+
+    public partial struct Attributes
+    {
+        public static Dictionary<int, LocalizedString> AttributeTypes = new Dictionary<int, LocalizedString>
         {
-            var languageDirectory = Path.Combine("resources");
-            if (Directory.Exists(languageDirectory))
+            {(int) MapAttribute.Animation, @"Map Animation" },
+            {(int) MapAttribute.Blocked, @"Blocked" },
+            {(int) MapAttribute.Critter, @"Critter" },
+            {(int) MapAttribute.GrappleStone, @"Grapple Stone" },
+            {(int) MapAttribute.Item, @"Item Spawn" },
+            {(int) MapAttribute.NpcAvoid, @"Npc Avoid" },
+            {(int) MapAttribute.Resource, @"Resource Spawn" },
+            {(int) MapAttribute.Slide, @"Slide" },
+            {(int) MapAttribute.Sound, @"Map Sound" },
+            {(int) MapAttribute.Walkable, @"Walkable" },
+            {(int) MapAttribute.Warp, @"Warp" },
+            {(int) MapAttribute.ZDimension, @"Z-Dimension" },
+        };
+
+        public static string FormatSpawnLevel(int level)
+        {
+            switch (level)
             {
-                File.WriteAllText(
-                    Path.Combine(languageDirectory, StringsFileName),
-                    JsonConvert.SerializeObject(serialized, Formatting.Indented)
-                );
+                case 0: return ZLevel1;
+                case 1: return ZLevel2;
+                default: throw new ArgumentOutOfRangeException(nameof(level));
             }
         }
 
-        public static void Save()
+        public static string FormatZLevel(int level)
         {
-            var serialized = new Dictionary<string, Dictionary<string, object>>();
-            var rootType = typeof(Strings);
-            var groupTypes = rootType.GetNestedTypes(BindingFlags.Static | BindingFlags.Public);
-
-            foreach (var groupType in groupTypes)
+            switch (level)
             {
-                var serializedGroup = new Dictionary<string, object>();
-                foreach (var fieldInfo in groupType.GetFields(BindingFlags.Static | BindingFlags.Public))
-                {
-                    switch (fieldInfo.GetValue(null))
-                    {
-                        case LocalizedString localizedString:
-                            serializedGroup.Add(fieldInfo.Name, localizedString.ToString());
-                            break;
-
-                        case Dictionary<int, LocalizedString> localizedIntKeyDictionary:
-                            serializedGroup.Add(fieldInfo.Name, localizedIntKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
-                            break;
-
-                        case Dictionary<string, LocalizedString> localizedStringKeyDictionary:
-                            serializedGroup.Add(fieldInfo.Name, localizedStringKeyDictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToString()));
-                            break;
-                    }
-                }
-
-                serialized.Add(groupType.Name, serializedGroup);
+                case 0: return ZNone;
+                case 1: return ZLevel1;
+                case 2: return ZLevel2;
+                default: throw new ArgumentOutOfRangeException(nameof(level));
             }
-
-            SaveSerialized(serialized);
         }
 
-        public static Localizer Localizer { get; } = new Localizer();
+        public static LocalizedString Animation = @"Animation";
 
-        public partial struct About
+        public static LocalizedString AttributeType = @"Attribute Type";
+
+        public static LocalizedString Blocked = @"Blocked";
+
+        public static LocalizedString Critter = @"Critter";
+
+        public static Dictionary<int, LocalizedString> CritterMovements = new Dictionary<int, LocalizedString>
         {
+            {0, @"Move Randomly"},
+            {1, @"Turn Randomly"},
+            {2, @"Stand Still"},
+        };
 
-            public static LocalizedString site =
-                @"Click here to visit the Ascension Game Dev community for support, updates and more!";
-
-            public static LocalizedString title = @"About";
-
-            public static LocalizedString version = @"v{00}";
-
-        }
-
-        public partial struct AnimationEditor
+        public static Dictionary<int, LocalizedString> CritterLayers = new Dictionary<int, LocalizedString>
         {
+            {0, @"Below Player"},
+            {1, @"Same as Player"},
+            {2, @"Above Player"},
+        };
 
-            public static LocalizedString animations = @"Animations";
+        public static LocalizedString CritterSprite = @"Sprite";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString CritterAnimation = @"Animation";
 
-            public static LocalizedString copy = @"Copy Animation";
+        public static LocalizedString CritterMovement = @"Movement";
 
-            public static LocalizedString delete = @"Delete Animation";
+        public static LocalizedString CritterLayer = @"Layer";
 
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this animation? This action cannot be reverted!";
+        public static LocalizedString CritterSpeed = @"Speed (ms)";
 
-            public static LocalizedString deletetitle = @"Delete Animation";
+        public static LocalizedString CritterFrequency = @"Frequency (ms)";
 
-            public static LocalizedString extraoptions = @"Extra Options:";
+        public static LocalizedString CritterIgnoreNpcAvoids = @"Ignore Npc Avoids";
 
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString CritterBlockPlayers = @"Block Players";
 
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString CritterDirection = @"Direction";
 
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString Direction = @"Direction";
 
-            public static LocalizedString general = @"General";
+        public static LocalizedString Distance = @"Distance (In Tiles)";
 
-            public static LocalizedString CloneFromPrevious = @"Clone From Previous";
+        public static LocalizedString DistanceFormat = @"{00} tiles";
 
-            public static LocalizedString FrameX = @"Frame: {00}";
+        public static LocalizedString Grapple = @"Grapple Stone";
 
-            public static LocalizedString FrameCount = @"Frames";
+        public static LocalizedString Item = @"Item";
 
-            public static LocalizedString FrameDuration = @"Frame Duration (ms)";
+        public static LocalizedString ItemSpawn = @"Item Spawn";
 
-            public static LocalizedString FrameOptions = @"Frame Options";
+        public static LocalizedString Map = @"Map";
 
-            public static LocalizedString Graphic = @"Graphic";
+        public static LocalizedString MapAnimation = @"Animation";
 
-            public static LocalizedString lowergroup = @"Lower Layer (Below Target) ";
+        public static LocalizedString MapAnimationBlock = @"Block Tile";
 
-            public static LocalizedString HorizontalFrames = @"Horizontal";
+        public static LocalizedString MapSound = @"Map Sound";
 
-            public static LocalizedString LoopCount = @"Loop Count";
+        public static LocalizedString NpcAvoid = @"NPC Avoid";
 
-            public static LocalizedString DisableRotations = @"Disable Rotations";
+        public static LocalizedString Quantity = @"Quantity";
 
-            public static LocalizedString Playback = @"Playback";
+        public static LocalizedString Resource = @"Resource";
 
-            public static LocalizedString Play = @"Play";
+        public static LocalizedString ResourceSpawn = @"Resource";
 
-            public static LocalizedString Pause = @"Pause";
+        public static LocalizedString RespawnTime = @"Respawn Time (ms)";
 
-            public static LocalizedString VerticalFrames = @"Graphic Vertical Frames:";
+        public static LocalizedString RespawnTimeTooltip = @"0 for server default";
 
-            public static LocalizedString name = @"Name";
+        public static LocalizedString Slide = @"Slide";
 
-            public static LocalizedString New = @"New Animation";
+        public static LocalizedString Sound = @"Sound";
 
-            public static LocalizedString paste = @"Paste Animation";
+        public static LocalizedString SoundDistance = @"Distance";
 
-            public static LocalizedString renderaboveplayer = @"Render Above Player";
+        public static LocalizedString SoundInterval = @"Loop Interval";
 
-            public static LocalizedString renderbelowfringe = @"Render Below Fringe";
+        public static LocalizedString Warp = @"Warp";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString WarpX = @"X";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString WarpY = @"Y";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        public static LocalizedString WarpDirection = @"Direction";
 
-            public static LocalizedString simulatedarkness = @"Simulate Darkness: {00}";
+        public static LocalizedString WarpSound = @"Sound";
 
-            public static LocalizedString sound = @"Sound:";
+        public static LocalizedString ZBlock = @"Block";
 
-            public static LocalizedString soundcomplete = @"Complete Sound Playback After Anim Dies";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LoopSoundDuringPreview = @"Loop sound during preview";
+        public static LocalizedString ZDimension = @"Z-Dimension";
 
-            public static LocalizedString swap = @"Swap Upper/Lower";
+        public static LocalizedString ZGateway = @"Gateway";
 
-            public static LocalizedString title = @"Animation Editor";
+        public static LocalizedString ZLevel1 = @"Level 1";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString ZLevel2 = @"Level 2";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this animation? This action cannot be reverted!";
+        public static LocalizedString ZNone = @"None";
+    }
 
-            public static LocalizedString undotitle = @"Undo Changes";
+    public partial struct ClassEditor
+    {
 
-            public static LocalizedString uppergroup = @"Upper Layer (Above Target) ";
+        public static LocalizedString abilitypowerboost = @"Ability Pwr (+{00}):";
 
-        }
+        public static LocalizedString addsprite = @"Add Sprite";
 
-        public partial struct Attributes
+        public static LocalizedString addspell = @"Add Spell";
+
+        public static LocalizedString armorboost = @"Armor (+{00}):";
+
+        public static LocalizedString attackanimation = @"Extra Attack Animation:";
+
+        public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
+
+        public static LocalizedString attackboost = @"Attack (+{00}):";
+
+        public static LocalizedString attackspeed = @"Attack Speed";
+
+        public static LocalizedString attackspeedmodifier = @"Modifier:";
+
+        public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
         {
-            public static Dictionary<int, LocalizedString> AttributeTypes = new Dictionary<int, LocalizedString>
-            {
-                {(int) MapAttribute.Animation, @"Map Animation" },
-                {(int) MapAttribute.Blocked, @"Blocked" },
-                {(int) MapAttribute.Critter, @"Critter" },
-                {(int) MapAttribute.GrappleStone, @"Grapple Stone" },
-                {(int) MapAttribute.Item, @"Item Spawn" },
-                {(int) MapAttribute.NpcAvoid, @"Npc Avoid" },
-                {(int) MapAttribute.Resource, @"Resource Spawn" },
-                {(int) MapAttribute.Slide, @"Slide" },
-                {(int) MapAttribute.Sound, @"Map Sound" },
-                {(int) MapAttribute.Walkable, @"Walkable" },
-                {(int) MapAttribute.Warp, @"Warp" },
-                {(int) MapAttribute.ZDimension, @"Z-Dimension" },
-            };
+            {0, @"Disabled"},
+            {1, @"Static (ms)"},
+        };
 
-            public static string FormatSpawnLevel(int level)
-            {
-                switch (level)
-                {
-                    case 0: return ZLevel1;
-                    case 1: return ZLevel2;
-                    default: throw new ArgumentOutOfRangeException(nameof(level));
-                }
-            }
+        public static LocalizedString attackspeedvalue = @"Value:";
 
-            public static string FormatZLevel(int level)
-            {
-                switch (level)
-                {
-                    case 0: return ZNone;
-                    case 1: return ZLevel1;
-                    case 2: return ZLevel2;
-                    default: throw new ArgumentOutOfRangeException(nameof(level));
-                }
-            }
+        public static LocalizedString baseabilitypower = @"Ability Pwr:";
 
-            public static LocalizedString Animation = @"Animation";
+        public static LocalizedString basearmor = @"Armor:";
 
-            public static LocalizedString AttributeType = @"Attribute Type";
+        public static LocalizedString baseattack = @"Attack:";
 
-            public static LocalizedString Blocked = @"Blocked";
+        public static LocalizedString basedamage = @"Base Damage:";
 
-            public static LocalizedString Critter = @"Critter";
+        public static LocalizedString basehp = @"HP:";
 
-            public static Dictionary<int, LocalizedString> CritterMovements = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Move Randomly"},
-                {1, @"Turn Randomly"},
-                {2, @"Stand Still"},
-            };
+        public static LocalizedString basemagicresist = @"Magic Resist:";
 
-            public static Dictionary<int, LocalizedString> CritterLayers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Below Player"},
-                {1, @"Same as Player"},
-                {2, @"Above Player"},
-            };
+        public static LocalizedString basemp = @"Mana:";
 
-            public static LocalizedString CritterSprite = @"Sprite";
+        public static LocalizedString basepoints = @"Points:";
 
-            public static LocalizedString CritterAnimation = @"Animation";
+        public static LocalizedString basespeed = @"Speed:";
 
-            public static LocalizedString CritterMovement = @"Movement";
+        public static LocalizedString basestats = @"Base Stats:";
 
-            public static LocalizedString CritterLayer = @"Layer";
+        public static LocalizedString boostpercent = @" %";
 
-            public static LocalizedString CritterSpeed = @"Speed (ms)";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString CritterFrequency = @"Frequency (ms)";
+        public static LocalizedString classes = @"Classes";
 
-            public static LocalizedString CritterIgnoreNpcAvoids = @"Ignore Npc Avoids";
+        public static LocalizedString combat = @"Combat (Unarmed)";
 
-            public static LocalizedString CritterBlockPlayers = @"Block Players";
+        public static LocalizedString copy = @"Copy Class";
 
-            public static LocalizedString CritterDirection = @"Direction";
+        public static LocalizedString critchance = @"Crit Chance (%):";
 
-            public static LocalizedString Direction = @"Direction";
+        public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
 
-            public static LocalizedString Distance = @"Distance (In Tiles)";
+        public static LocalizedString damagetype = @"Damage Type:";
 
-            public static LocalizedString DistanceFormat = @"{00} tiles";
+        public static LocalizedString delete = @"Delete Class";
 
-            public static LocalizedString Grapple = @"Grapple Stone";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this class? This action cannot be reverted!";
 
-            public static LocalizedString Item = @"Item";
+        public static LocalizedString deletetitle = @"Delete Class";
 
-            public static LocalizedString ItemSpawn = @"Item Spawn";
+        public static LocalizedString expgrid = "Exp Grid";
 
-            public static LocalizedString Map = @"Map";
+        public static LocalizedString experiencegrid = "Experience Grid";
 
-            public static LocalizedString MapAnimation = @"Animation";
+        public static LocalizedString face = @"Face:";
 
-            public static LocalizedString MapAnimationBlock = @"Block Tile";
+        public static LocalizedString female = @"Female";
 
-            public static LocalizedString MapSound = @"Map Sound";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            public static LocalizedString NpcAvoid = @"NPC Avoid";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            public static LocalizedString Quantity = @"Quantity";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            public static LocalizedString Resource = @"Resource";
+        public static LocalizedString gender = @"Gender";
 
-            public static LocalizedString ResourceSpawn = @"Resource";
+        public static LocalizedString general = @"General";
 
-            public static LocalizedString RespawnTime = @"Respawn Time (ms)";
+        public static LocalizedString gridlevel = "Level";
 
-            public static LocalizedString RespawnTimeTooltip = @"0 for server default";
+        public static LocalizedString gridpaste = "Paste";
 
-            public static LocalizedString Slide = @"Slide";
+        public static LocalizedString gridtnl = "Exp TNL";
 
-            public static LocalizedString Sound = @"Sound";
+        public static LocalizedString gridtotalexp = "Total Exp";
 
-            public static LocalizedString SoundDistance = @"Distance";
+        public static LocalizedString gridreset = "Reset";
 
-            public static LocalizedString SoundInterval = @"Loop Interval";
+        public static LocalizedString gridclose = "Close";
 
-            public static LocalizedString Warp = @"Warp";
+        public static LocalizedString hpboost = @"Max HP (+{00}):";
 
-            public static LocalizedString WarpX = @"X";
+        public static LocalizedString hpregen = @"HP (%);";
 
-            public static LocalizedString WarpY = @"Y";
+        public static LocalizedString learntspells = @"Spells";
 
-            public static LocalizedString WarpDirection = @"Direction";
+        public static LocalizedString levelboosts = @"Level Up Boosts";
 
-            public static LocalizedString WarpSound = @"Sound";
+        public static LocalizedString levelexp = @"Base Exp to Level:";
 
-            public static LocalizedString ZBlock = @"Block";
+        public static LocalizedString levelexpscale = @"Exp Increase (Per Level %):";
 
-            public static LocalizedString ZDimension = @"Z-Dimension";
+        public static LocalizedString leveling = @"Leveling Up";
 
-            public static LocalizedString ZGateway = @"Gateway";
+        public static LocalizedString locked = @"Class Locked";
 
-            public static LocalizedString ZLevel1 = @"Level 1";
+        public static LocalizedString magicresistboost = @"Magic Resist (+{00}):";
 
-            public static LocalizedString ZLevel2 = @"Level 2";
+        public static LocalizedString male = @"Male";
 
-            public static LocalizedString ZNone = @"None";
-        }
+        public static LocalizedString mpboost = @"Max MP (+{00}):";
 
-        public partial struct ClassEditor
-        {
+        public static LocalizedString mpregen = @"MP (%):";
 
-            public static LocalizedString abilitypowerboost = @"Ability Pwr (+{00}):";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString addsprite = @"Add Sprite";
+        public static LocalizedString New = @"New Class";
 
-            public static LocalizedString addspell = @"Add Spell";
+        public static LocalizedString paste = @"Paste Class";
 
-            public static LocalizedString armorboost = @"Armor (+{00}):";
+        public static LocalizedString percentageboost = @"Percentage";
 
-            public static LocalizedString attackanimation = @"Extra Attack Animation:";
+        public static LocalizedString pointsboost = @"Points (+):";
 
-            public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
+        public static LocalizedString regen = @"Regen";
 
-            public static LocalizedString attackboost = @"Attack (+{00}):";
-
-            public static LocalizedString attackspeed = @"Attack Speed";
-
-            public static LocalizedString attackspeedmodifier = @"Modifier:";
-
-            public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Disabled"},
-                {1, @"Static (ms)"},
-            };
-
-            public static LocalizedString attackspeedvalue = @"Value:";
-
-            public static LocalizedString baseabilitypower = @"Ability Pwr:";
-
-            public static LocalizedString basearmor = @"Armor:";
-
-            public static LocalizedString baseattack = @"Attack:";
-
-            public static LocalizedString basedamage = @"Base Damage:";
-
-            public static LocalizedString basehp = @"HP:";
-
-            public static LocalizedString basemagicresist = @"Magic Resist:";
-
-            public static LocalizedString basemp = @"Mana:";
-
-            public static LocalizedString basepoints = @"Points:";
-
-            public static LocalizedString basespeed = @"Speed:";
-
-            public static LocalizedString basestats = @"Base Stats:";
-
-            public static LocalizedString boostpercent = @" %";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString classes = @"Classes";
-
-            public static LocalizedString combat = @"Combat (Unarmed)";
-
-            public static LocalizedString copy = @"Copy Class";
-
-            public static LocalizedString critchance = @"Crit Chance (%):";
-
-            public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
-
-            public static LocalizedString damagetype = @"Damage Type:";
-
-            public static LocalizedString delete = @"Delete Class";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this class? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Class";
-
-            public static LocalizedString expgrid = "Exp Grid";
-
-            public static LocalizedString experiencegrid = "Experience Grid";
-
-            public static LocalizedString face = @"Face:";
-
-            public static LocalizedString female = @"Female";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString gender = @"Gender";
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString gridlevel = "Level";
-
-            public static LocalizedString gridpaste = "Paste";
-
-            public static LocalizedString gridtnl = "Exp TNL";
-
-            public static LocalizedString gridtotalexp = "Total Exp";
-
-            public static LocalizedString gridreset = "Reset";
-
-            public static LocalizedString gridclose = "Close";
-
-            public static LocalizedString hpboost = @"Max HP (+{00}):";
-
-            public static LocalizedString hpregen = @"HP (%);";
-
-            public static LocalizedString learntspells = @"Spells";
-
-            public static LocalizedString levelboosts = @"Level Up Boosts";
-
-            public static LocalizedString levelexp = @"Base Exp to Level:";
-
-            public static LocalizedString levelexpscale = @"Exp Increase (Per Level %):";
-
-            public static LocalizedString leveling = @"Leveling Up";
-
-            public static LocalizedString locked = @"Class Locked";
-
-            public static LocalizedString magicresistboost = @"Magic Resist (+{00}):";
-
-            public static LocalizedString male = @"Male";
-
-            public static LocalizedString mpboost = @"Max MP (+{00}):";
-
-            public static LocalizedString mpregen = @"MP (%):";
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString New = @"New Class";
-
-            public static LocalizedString paste = @"Paste Class";
-
-            public static LocalizedString percentageboost = @"Percentage";
-
-            public static LocalizedString pointsboost = @"Points (+):";
-
-            public static LocalizedString regen = @"Regen";
-
-            public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
+        public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
 
 Tick timer saved in server config.json.";
 
-            public static LocalizedString removeicon = @"Remove Sprite";
+        public static LocalizedString removeicon = @"Remove Sprite";
 
-            public static LocalizedString removespell = @"Remove Spell";
+        public static LocalizedString removespell = @"Remove Spell";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString scalingamount = @"Scaling Amount (%):";
+        public static LocalizedString scalingamount = @"Scaling Amount (%):";
 
-            public static LocalizedString scalingstat = @"Scaling Stat:";
+        public static LocalizedString scalingstat = @"Scaling Stat:";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString spawnitems = @"Spawn Items";
+        public static LocalizedString spawnitems = @"Spawn Items";
 
-            public static LocalizedString spawnitem = @"Item:";
+        public static LocalizedString spawnitem = @"Item:";
 
-            public static LocalizedString spawnamount = @"Amount:";
+        public static LocalizedString spawnamount = @"Amount:";
 
-            public static LocalizedString spawnitemadd = @"Add Item";
+        public static LocalizedString spawnitemadd = @"Add Item";
 
-            public static LocalizedString spawnitemremove = @"Remove Item";
+        public static LocalizedString spawnitemremove = @"Remove Item";
 
-            public static LocalizedString spawnitemdisplay = @"{00} x{01}";
+        public static LocalizedString spawnitemdisplay = @"{00} x{01}";
 
-            public static LocalizedString spawnpoint = @"Spawn Point";
+        public static LocalizedString spawnpoint = @"Spawn Point";
 
-            public static LocalizedString speedboost = @"Speed (+{00}):";
+        public static LocalizedString speedboost = @"Speed (+{00}):";
 
-            public static LocalizedString spell = @"Spell:";
+        public static LocalizedString spell = @"Spell:";
 
-            public static LocalizedString spellitem = @"{00}. {01} - Level: {02}";
+        public static LocalizedString spellitem = @"{00}. {01} - Level: {02}";
 
-            public static LocalizedString spelllevel = @"Level:";
+        public static LocalizedString spelllevel = @"Level:";
 
-            public static LocalizedString sprite = @"Sprite:";
+        public static LocalizedString sprite = @"Sprite:";
 
-            public static LocalizedString spriteface = @"Sprite and Face";
+        public static LocalizedString spriteface = @"Sprite and Face";
 
-            public static LocalizedString spriteitemfemale = @"{00}. {01} - F";
+        public static LocalizedString spriteitemfemale = @"{00}. {01} - F";
 
-            public static LocalizedString spriteitemmale = @"{00}. {01} - M";
+        public static LocalizedString spriteitemmale = @"{00}. {01} - M";
 
-            public static LocalizedString spriteoptions = @"Options:";
+        public static LocalizedString spriteoptions = @"Options:";
 
-            public static LocalizedString staticboost = @"Static";
+        public static LocalizedString staticboost = @"Static";
 
-            public static LocalizedString title = @"Class Editor";
+        public static LocalizedString title = @"Class Editor";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this class? This action cannot be reverted!";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this class? This action cannot be reverted!";
 
-            public static LocalizedString undotitle = @"Undo Changes";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-        }
+    }
 
-        public partial struct Colors
+    public partial struct Colors
+    {
+
+        public static Dictionary<int, LocalizedString> presets = new Dictionary<int, LocalizedString>
         {
+            {0, @"Black"},
+            {1, @"White"},
+            {2, @"Pink"},
+            {3, @"Blue"},
+            {4, @"Red"},
+            {5, @"Green"},
+            {6, @"Yellow"},
+            {7, @"Orange"},
+            {8, @"Purple"},
+            {9, @"Gray"},
+            {10, @"Cyan"}
+        };
 
-            public static Dictionary<int, LocalizedString> presets = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Black"},
-                {1, @"White"},
-                {2, @"Pink"},
-                {3, @"Blue"},
-                {4, @"Red"},
-                {5, @"Green"},
-                {6, @"Yellow"},
-                {7, @"Orange"},
-                {8, @"Purple"},
-                {9, @"Gray"},
-                {10, @"Cyan"}
-            };
+    }
 
-        }
+    public partial struct Combat
+    {
 
-        public partial struct Combat
+        public static Dictionary<int, LocalizedString> damagetypes = new Dictionary<int, LocalizedString>
         {
+            {0, @"Physical"},
+            {1, @"Magic"},
+            {2, @"True"},
+        };
 
-            public static Dictionary<int, LocalizedString> damagetypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Physical"},
-                {1, @"Magic"},
-                {2, @"True"},
-            };
+        public static LocalizedString exp = @"Experience";
 
-            public static LocalizedString exp = @"Experience";
-
-            public static Dictionary<int, LocalizedString> stats = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Attack"},
-                {1, @"Ability Power"},
-                {2, @"Defense"},
-                {3, @"Magic Resist"},
-                {4, @"Speed"},
-            };
-
-            public static Dictionary<int, LocalizedString> vitals = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Health"},
-                {1, @"Mana"},
-            };
-
-        }
-
-        public partial struct CommonEventEditor
+        public static Dictionary<int, LocalizedString> stats = new Dictionary<int, LocalizedString>
         {
+            {0, @"Attack"},
+            {1, @"Ability Power"},
+            {2, @"Defense"},
+            {3, @"Magic Resist"},
+            {4, @"Speed"},
+        };
 
-            public static LocalizedString copy = @"Copy Event";
-
-            public static LocalizedString delete = @"Delete";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this event? This action cannot be reverted!";
-
-            public static LocalizedString events = @"Common Events";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString New = @"New";
-
-            public static LocalizedString paste = @"Paste Event";
-
-            public static LocalizedString pasteprompt =
-                @"You cannot undo an event-paste operation! Are you sure you want to overwrite this event?";
-
-            public static LocalizedString pastetitle = @"Paste Warning!";
-
-            public static LocalizedString searchplaceholder = @"Search...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
-
-            public static LocalizedString title = @"Common Event Editor";
-
-        }
-
-        public partial struct CraftingTableEditor
+        public static Dictionary<int, LocalizedString> vitals = new Dictionary<int, LocalizedString>
         {
+            {0, @"Health"},
+            {1, @"Mana"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString cancel = @"Cancel";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString copy = @"Copy Table";
+    public partial struct CommonEventEditor
+    {
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString crafts = @"Available Crafts";
+        public static LocalizedString copy = @"Copy Event";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString delete = @"Delete Table";
+        public static LocalizedString delete = @"Delete";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this table? This action cannot be reverted!";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this event? This action cannot be reverted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString events = @"Common Events";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString general = @"General";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString New = @"New";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString New = @"New Table";
+        public static LocalizedString paste = @"Paste Event";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString paste = @"Paste Table";
+        public static LocalizedString pasteprompt =
+            @"You cannot undo an event-paste operation! Are you sure you want to overwrite this event?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString save = @"Save";
+        public static LocalizedString pastetitle = @"Paste Warning!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString tables = @"Tables";
+        public static LocalizedString title = @"Common Event Editor";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString title = @"Crafting Tables Editor";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undo = @"Undo Changes";
+    public partial struct CraftingTableEditor
+    {
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this table? This action cannot be reverted!";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString cancel = @"Cancel";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undotitle = @"Undo Changes";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString copy = @"Copy Table";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString addcraftlabel = @"Add Item To Be Crafted:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString crafts = @"Available Crafts";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString add = @"Add Selected";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString delete = @"Delete Table";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString remove = @"Remove Selected";
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this table? This action cannot be reverted!";
 
-        public partial struct CraftsEditor
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString folderlabel = @"Folder:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString general = @"General";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString name = @"Name:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString New = @"New Table";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString paste = @"Paste Table";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString save = @"Save";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString tables = @"Tables";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString title = @"Crafting Tables Editor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undo = @"Undo Changes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this table? This action cannot be reverted!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undotitle = @"Undo Changes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString addcraftlabel = @"Add Item To Be Crafted:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString add = @"Add Selected";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString remove = @"Remove Selected";
+    }
+
+    public partial struct CraftsEditor
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString copy = @"Copy Craft";
+
+        public static LocalizedString crafts = @"Crafts";
+
+        public static LocalizedString craftquantity = @"Quantity:";
+
+        public static LocalizedString delete = @"Delete Craft";
+
+        public static LocalizedString deletecraft = @"Delete";
+
+        public static LocalizedString deleteingredient = @"Delete";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this craft? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Craft";
+
+        public static LocalizedString duplicatecraft = @"Duplicate";
+
+        public static LocalizedString duplicateingredient = @"Duplicate";
+
+        public static LocalizedString FailureChance = @"Failure (%):";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        public static LocalizedString general = @"General";
+
+        public static LocalizedString ingredientitem = @"Item:";
+
+        public static LocalizedString ingredientlistitem = @"Ingredient: {00} x{01}";
+
+        public static LocalizedString ingredientnone = @"None";
+
+        public static LocalizedString ingredientquantity = @"Quantity:";
+
+        public static LocalizedString ingredients = @"Ingredients";
+
+        public static LocalizedString item = @"Item:";
+
+        public static LocalizedString ItemLossChance = @"Item Loss (%):";
+
+        public static LocalizedString Requirements = @"Craft Requirements";
+
+        public static LocalizedString name = @"Name:";
+
+        public static LocalizedString New = @"New Craft";
+
+        public static LocalizedString newingredient = @"New";
+
+        public static LocalizedString paste = @"Paste Craft";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        public static LocalizedString time = @"Time (ms):";
+
+        public static LocalizedString title = @"Crafts Editor";
+
+        public static LocalizedString undo = @"Undo Changes";
+
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this craft? This action cannot be reverted!";
+
+        public static LocalizedString undotitle = @"Undo Changes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString commonevent = @"Common Event:";
+
+    }
+
+    public partial struct Direction
+    {
+        public static Dictionary<int, LocalizedString> CritterDirection = new Dictionary<int, LocalizedString>()
         {
+            {0, @"Random"},
+            {1, @"Up"},
+            {2, @"Down"},
+            {3, @"Left"},
+            {4, @"Right"}
+        };
 
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString copy = @"Copy Craft";
-
-            public static LocalizedString crafts = @"Crafts";
-
-            public static LocalizedString craftquantity = @"Quantity:";
-
-            public static LocalizedString delete = @"Delete Craft";
-
-            public static LocalizedString deletecraft = @"Delete";
-
-            public static LocalizedString deleteingredient = @"Delete";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this craft? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Craft";
-
-            public static LocalizedString duplicatecraft = @"Duplicate";
-
-            public static LocalizedString duplicateingredient = @"Duplicate";
-
-            public static LocalizedString FailureChance = @"Failure (%):";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString ingredientitem = @"Item:";
-
-            public static LocalizedString ingredientlistitem = @"Ingredient: {00} x{01}";
-
-            public static LocalizedString ingredientnone = @"None";
-
-            public static LocalizedString ingredientquantity = @"Quantity:";
-
-            public static LocalizedString ingredients = @"Ingredients";
-
-            public static LocalizedString item = @"Item:";
-
-            public static LocalizedString ItemLossChance = @"Item Loss (%):";
-
-            public static LocalizedString Requirements = @"Craft Requirements";
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString New = @"New Craft";
-
-            public static LocalizedString newingredient = @"New";
-
-            public static LocalizedString paste = @"Paste Craft";
-
-            public static LocalizedString save = @"Save";
-
-            public static LocalizedString searchplaceholder = @"Search...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
-
-            public static LocalizedString time = @"Time (ms):";
-
-            public static LocalizedString title = @"Crafts Editor";
-
-            public static LocalizedString undo = @"Undo Changes";
-
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this craft? This action cannot be reverted!";
-
-            public static LocalizedString undotitle = @"Undo Changes";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString commonevent = @"Common Event:";
-
-        }
-
-        public partial struct Direction
+        public static Dictionary<Enums.Direction, LocalizedString> dir = new Dictionary<Enums.Direction, LocalizedString>()
         {
-            public static Dictionary<int, LocalizedString> CritterDirection = new Dictionary<int, LocalizedString>()
-            {
-                {0, @"Random"},
-                {1, @"Up"},
-                {2, @"Down"},
-                {3, @"Left"},
-                {4, @"Right"}
-            };
+            {Enums.Direction.None, @"Retain Direction"},
+            {Enums.Direction.Up, @"Up"},
+            {Enums.Direction.Down, @"Down"},
+            {Enums.Direction.Left, @"Left"},
+            {Enums.Direction.Right, @"Right"}
+        };
 
-            public static Dictionary<Enums.Direction, LocalizedString> dir = new Dictionary<Enums.Direction, LocalizedString>()
-            {
-                {Enums.Direction.None, @"Retain Direction"},
-                {Enums.Direction.Up, @"Up"},
-                {Enums.Direction.Down, @"Down"},
-                {Enums.Direction.Left, @"Left"},
-                {Enums.Direction.Right, @"Right"}
-            };
-
-            public static Dictionary<int, LocalizedString> WarpDirections = new Dictionary<int, LocalizedString>()
-            {
-                {(int)WarpDirection.Retain, @"Retain Direction"},
-                {(int)WarpDirection.Up, @"Up"},
-                {(int)WarpDirection.Down, @"Down"},
-                {(int)WarpDirection.Left, @"Left"},
-                {(int)WarpDirection.Right, @"Right"}
-            };
-        }
-
-        public partial struct DynamicRequirements
+        public static Dictionary<int, LocalizedString> WarpDirections = new Dictionary<int, LocalizedString>()
         {
+            {(int)WarpDirection.Retain, @"Retain Direction"},
+            {(int)WarpDirection.Up, @"Up"},
+            {(int)WarpDirection.Down, @"Down"},
+            {(int)WarpDirection.Left, @"Left"},
+            {(int)WarpDirection.Right, @"Right"}
+        };
+    }
 
-            public static LocalizedString addcondition = @"Add Condition";
+    public partial struct DynamicRequirements
+    {
 
-            public static LocalizedString addlist = @"Add List";
+        public static LocalizedString addcondition = @"Add Condition";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString addlist = @"Add List";
 
-            public static LocalizedString conditioneditor = @"Add/Edit Condition";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString conditionlist = @"Conditiond";
+        public static LocalizedString conditioneditor = @"Add/Edit Condition";
 
-            public static LocalizedString conditionlists = @"Condition Lists";
+        public static LocalizedString conditionlist = @"Conditiond";
 
-            public static LocalizedString instructionscraft =
-                @"Below are condition lists. If conditions are met on any of the lists then the player can craft this item.";
+        public static LocalizedString conditionlists = @"Condition Lists";
 
-            public static LocalizedString instructionsevent =
-                @"Below are condition lists. If conditions are met on any of the lists then the event can spawn/run.";
+        public static LocalizedString instructionscraft =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can craft this item.";
 
-            public static LocalizedString instructionsitem =
-                @"Below are condition lists. If conditions are met on any of the lists then the player can use the item.";
+        public static LocalizedString instructionsevent =
+            @"Below are condition lists. If conditions are met on any of the lists then the event can spawn/run.";
 
-            public static LocalizedString instructionsnpcfriend =
-                @"Below are condition lists. If conditions are met on any of the lists then the npc will be friendly/protect the player and cannot be hurt by the player.";
+        public static LocalizedString instructionsitem =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can use the item.";
 
-            public static LocalizedString instructionsnpcattackonsight =
-                @"Below are condition lists. If conditions are met on any of the lists player will be attacked on sight.";
+        public static LocalizedString instructionsnpcfriend =
+            @"Below are condition lists. If conditions are met on any of the lists then the npc will be friendly/protect the player and cannot be hurt by the player.";
 
-            public static LocalizedString instructionsnpcdontattackonsight =
-                @"Below are condition lists. If conditions are met on any of the lists then the player will not be attacked on sight by this npc.";
+        public static LocalizedString instructionsnpcattackonsight =
+            @"Below are condition lists. If conditions are met on any of the lists player will be attacked on sight.";
 
-            public static LocalizedString instructionsnpccanbeattacked =
-                @"Below are condition lists. If there are conditions, and they are not met, then the player will not be able to attack this npc.";
+        public static LocalizedString instructionsnpcdontattackonsight =
+            @"Below are condition lists. If conditions are met on any of the lists then the player will not be attacked on sight by this npc.";
 
-            public static LocalizedString instructionsquest =
-                @"Below are condition lists. If conditions are met on any of the lists then the player can start the quest.";
+        public static LocalizedString instructionsnpccanbeattacked =
+            @"Below are condition lists. If there are conditions, and they are not met, then the player will not be able to attack this npc.";
 
-            public static LocalizedString instructionsresource =
-                @"Below are condition lists. If conditions are met on any of the lists then the player can harvest the resource.";
+        public static LocalizedString instructionsquest =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can start the quest.";
 
-            public static LocalizedString instructionsspell =
-                @"Below are condition lists. If conditions are met on any of the lists then the player can use cast the spell.";
+        public static LocalizedString instructionsresource =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can harvest the resource.";
 
-            public static LocalizedString listname = @"Desc:";
+        public static LocalizedString instructionsspell =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can use cast the spell.";
 
-            public static LocalizedString removecondition = @"Remove Condition";
+        public static LocalizedString listname = @"Desc:";
 
-            public static LocalizedString removelist = @"Remove List";
+        public static LocalizedString removecondition = @"Remove Condition";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString removelist = @"Remove List";
 
-            public static LocalizedString title = @"Dynamic Requirements";
+        public static LocalizedString save = @"Save";
 
-        }
+        public static LocalizedString title = @"Dynamic Requirements";
 
-        public partial struct Errors
+    }
+
+    public partial struct Errors
+    {
+
+        public static LocalizedString disconnected = @"Disconnected!";
+
+        public static LocalizedString disconnectedclosing =
+            @"You have lost connection to the server. The editor will now close.";
+
+        public static LocalizedString disconnectedsave =
+            @"You have been disconnected from the server! Would you like to export this map before closing this editor?";
+
+        public static LocalizedString disconnectedsavecaption = @"Disconnected -- Export Map?";
+
+        public static LocalizedString InvalidDirectory = @"You have selected an invalid directory, would you like to try again?";
+
+        public static LocalizedString InvalidDirectoryCaption = @"Invalid Directory";
+
+        public static LocalizedString InvalidInputCaption = @"Invalid Input";
+
+        public static LocalizedString InvalidInputXCaption = @"Invalid Input - {0}";
+
+        public static LocalizedString importfailed =
+            @"Cannot import map. Currently selected map is not an Intersect map file or was exported with a different version of the Intersect editor!";
+
+        public static LocalizedString importfailedcaption = @"Failed to import map!";
+
+        public static LocalizedString resourcesnotfound =
+            @"The resources directory could not be found! Intersect will now close.";
+
+        public static LocalizedString resourcesnotfoundtitle = @"Resources not found!";
+
+        public static LocalizedString UnableToParseInvalidIntegerFormat = @"Unable to parse '{00}', the input should only be digits and the minus sign (-) for negative numbers.";
+
+    }
+
+    public partial struct EventChangeFace
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Face:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Face";
+
+    }
+
+    public partial struct EventShowPicture
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Picture:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Show Picture";
+
+        public static LocalizedString checkbox = @"Click To Close Image?";
+
+        public static LocalizedString size = @"Size:";
+
+        public static LocalizedString original = @"Original";
+
+        public static LocalizedString fullscreen = @"Full Screen";
+
+        public static LocalizedString halfscreen = @"Half Screen";
+
+        public static LocalizedString stretchtofit = @"Stretch To Fit";
+
+        public static LocalizedString hide = @"Hide After (ms):";
+
+        public static LocalizedString wait = @"Wait Until Closed?";
+
+    }
+
+    public partial struct EventChangeGender
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static Dictionary<int, LocalizedString> genders = new Dictionary<int, LocalizedString>
         {
+            {0, @"Male"},
+            {1, @"Female"}
+        };
 
-            public static LocalizedString disconnected = @"Disconnected!";
+        public static LocalizedString label = @"Gender:";
 
-            public static LocalizedString disconnectedclosing =
-                @"You have lost connection to the server. The editor will now close.";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString disconnectedsave =
-                @"You have been disconnected from the server! Would you like to export this map before closing this editor?";
+        public static LocalizedString title = @"Change Gender";
 
-            public static LocalizedString disconnectedsavecaption = @"Disconnected -- Export Map?";
+    }
 
-            public static LocalizedString InvalidDirectory = @"You have selected an invalid directory, would you like to try again?";
+    public partial struct EventChangeItems
+    {
 
-            public static LocalizedString InvalidDirectoryCaption = @"Invalid Directory";
+        public static LocalizedString action = @"Action:";
 
-            public static LocalizedString InvalidInputCaption = @"Invalid Input";
-
-            public static LocalizedString InvalidInputXCaption = @"Invalid Input - {0}";
-
-            public static LocalizedString importfailed =
-                @"Cannot import map. Currently selected map is not an Intersect map file or was exported with a different version of the Intersect editor!";
-
-            public static LocalizedString importfailedcaption = @"Failed to import map!";
-
-            public static LocalizedString resourcesnotfound =
-                @"The resources directory could not be found! Intersect will now close.";
-
-            public static LocalizedString resourcesnotfoundtitle = @"Resources not found!";
-
-            public static LocalizedString UnableToParseInvalidIntegerFormat = @"Unable to parse '{00}', the input should only be digits and the minus sign (-) for negative numbers.";
-
-        }
-
-        public partial struct EventChangeFace
+        public static Dictionary<int, LocalizedString> actions = new Dictionary<int, LocalizedString>
         {
+            {0, @"Give"},
+            {1, @"Take"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString amount = @"Amount:";
 
-            public static LocalizedString label = @"Face:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AmountType = @"Amount Type";
 
-            public static LocalizedString okay = @"Ok";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Variable = @"Variable";
 
-            public static LocalizedString title = @"Change Face";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Manual = @"Manual";
 
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PlayerVariable = @"Player Variable";
 
-        public partial struct EventShowPicture
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ServerVariable = @"Global Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildVariable = @"Guild Variable";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString item = @"Item:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Method = @"Method:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<int, LocalizedString> Methods = new Dictionary<int, LocalizedString>
         {
+            {0, @"Normal"},
+            {1, @"Allow Overflow"},
+            {2, @"Up to Amount" },
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString label = @"Picture:";
+        public static LocalizedString title = @"Change Player Items";
 
-            public static LocalizedString okay = @"Ok";
+    }
 
-            public static LocalizedString title = @"Show Picture";
+    public partial struct EventEquipItems
+    {
 
-            public static LocalizedString checkbox = @"Click To Close Image?";
+        public static LocalizedString EquipTitle = @"Equip Item";
 
-            public static LocalizedString size = @"Size:";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString original = @"Original";
+        public static LocalizedString item = @"Item:";
 
-            public static LocalizedString fullscreen = @"Full Screen";
+        public static LocalizedString slot = @"Slot:";
 
-            public static LocalizedString halfscreen = @"Half Screen";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString stretchtofit = @"Stretch To Fit";
+        public static LocalizedString title = @"Equip/Unequip Player Items";
 
-            public static LocalizedString hide = @"Hide After (ms):";
+        public static LocalizedString unequip = @"Unequip?";
 
-            public static LocalizedString wait = @"Wait Until Closed?";
+        public static LocalizedString TriggerCooldown = @"Trigger Cooldown?";
 
-        }
+    }
 
-        public partial struct EventChangeGender
+    public partial struct EventChangeVital
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString labelhealth = @"Set Health:";
+
+        public static LocalizedString labelmana = @"Set Mana:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Vital";
+
+    }
+
+    public partial struct EventChangeLevel
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Set Level:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Level";
+
+    }
+
+    public partial struct EventChangeNameColor
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Name Color";
+
+        public static LocalizedString select = @"Select Color";
+
+        public static LocalizedString adminoverride = @"Override Admin Name Color?";
+
+        public static LocalizedString remove = @"Remove Name Color?";
+
+    }
+
+    public partial struct EventChangeName
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Name";
+
+        public static LocalizedString variable = @"Player Variable:";
+
+    }
+
+    public partial struct EventChangeSpells
+    {
+
+        public static LocalizedString action = @"Action: ";
+
+        public static Dictionary<int, LocalizedString> actions = new Dictionary<int, LocalizedString>
         {
+            {0, @"Add"},
+            {1, @"Remove"}
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static Dictionary<int, LocalizedString> genders = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Male"},
-                {1, @"Female"}
-            };
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString label = @"Gender:";
+        public static LocalizedString RemoveBound = @"Remove Bound Spell ?";
+        
+        public static LocalizedString spell = @"Spell: ";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString title = @"Change Player Spells";
 
-            public static LocalizedString title = @"Change Gender";
+    }
 
-        }
+    public partial struct EventCastSpellOn
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
 
-        public partial struct EventChangeItems
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IncludeGuildies = @"Online Guild Members";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IncludePartyMembers = @"Party Members";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IncludeSelf = @"Self";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelSpell = @"Spell";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelTargets = @"Targets";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Okay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Cast Spell On";
+
+    }
+
+    public partial struct EventChangeSprite
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Sprite:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Sprite";
+
+    }
+
+    public partial struct EventChangePlayerLabel
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Change Player Label";
+
+        public static LocalizedString select = @"Select Color";
+
+        public static LocalizedString copyplayernamecolor = @"Copy Player Name Color?";
+
+        public static LocalizedString value = @"Value:";
+
+        public static LocalizedString hint = @"Text variables work with strings. Click here for info!";
+
+        public static LocalizedString position = @"Label Position:";
+
+        public static Dictionary<int, LocalizedString> positions = new Dictionary<int, LocalizedString>
         {
+            {0, @"Above Character Name"},
+            {1, @"Below Character Name"},
+        };
 
-            public static LocalizedString action = @"Action:";
+    }
 
-            public static Dictionary<int, LocalizedString> actions = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Give"},
-                {1, @"Take"},
-            };
+    public partial struct EventChatboxText
+    {
 
-            public static LocalizedString amount = @"Amount:";
+        public static LocalizedString cancel = @"Cancel";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AmountType = @"Amount Type";
+        public static LocalizedString channel = @"Channel:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Variable = @"Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Manual = @"Manual";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PlayerVariable = @"Player Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ServerVariable = @"Global Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildVariable = @"Guild Variable";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString item = @"Item:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Method = @"Method:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<int, LocalizedString> Methods = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Normal"},
-                {1, @"Allow Overflow"},
-                {2, @"Up to Amount" },
-            };
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Change Player Items";
-
-        }
-
-        public partial struct EventEquipItems
+        public static Dictionary<int, LocalizedString> channels = new Dictionary<int, LocalizedString>
         {
+            {0, @"Player / System"},
+            {1, @"Local"},
+            {2, @"Global"},
+            {3, @"Party"},
+            {4, @"Guild"},
+        };
 
-            public static LocalizedString EquipTitle = @"Equip Item";
+        public static LocalizedString color = @"Color:";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString commands = @"Chat Commands";
 
-            public static LocalizedString item = @"Item:";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString slot = @"Slot:";
+        public static LocalizedString text = @"Text:";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString title = @"Add Chatbox Text";
 
-            public static LocalizedString title = @"Equip/Unequip Player Items";
+        public static LocalizedString ShowChatBubble = @"Show Chat Bubble";
 
-            public static LocalizedString unequip = @"Unequip?";
+    }
 
-            public static LocalizedString TriggerCooldown = @"Trigger Cooldown?";
+    public partial struct EventCommandList
+    {
 
-        }
+        public static LocalizedString addvariable = @"Add {00}";
 
-        public partial struct EventChangeVital
+        public static LocalizedString admin = @"Owner/Developer";
+
+        public static LocalizedString animationonevent = @"On Event {00} [X Offset: {01} Y Offset: {02} {03}]";
+
+        public static LocalizedString animationonmap = @"[On Map {00} X: {01} Y: {02} Dir: {03}]";
+
+        public static LocalizedString animationonplayer = @"On Player [X Offset: {00} Y Offset: {01} {02}]";
+
+        public static LocalizedString animationrelativedir = @"Spawn Relative To Direction";
+
+        public static LocalizedString animationrelativerotate = @"Spawn And Rotate Relative To Direction";
+
+        public static LocalizedString animationrotatedir = @"Rotate Relative To Direction";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CastSpellOn = @"Cast Spell '{00}' [include self: {01}, include party: {02}; include guild: {03})";
+
+        public static LocalizedString changename = @"Change Name to Variable: {00}";
+
+        public static LocalizedString changeitems = @"Change Player Items [{00}]";
+
+        public static LocalizedString equipitem = @"Equip Player Item [{00}]";
+
+        public static LocalizedString unequipitem = @"Unequip Player Item [{00}]";
+
+        public static LocalizedString unequipslot = @"Unequip Player Slot [{00}]";
+
+        public static LocalizedString changespells = @"Change Player Spells [{00}]";
+
+        public static LocalizedString chatboxtext = @"Show Chatbox Text [Channel: {00}, Color: {01}] - {02}";
+
+        public static LocalizedString chatglobal = @"Global";
+
+        public static LocalizedString chatlocal = @"Local";
+
+        public static LocalizedString chatplayer = @"Player";
+
+        public static LocalizedString commonevent = @"Start Common Event: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CommonEventInstanced = @"Start Common Event For All on Instance: {00} (Allow in overworld: {01})";
+
+        public static LocalizedString completetask = @"Complete Quest Task [Quest: {00}, Task: {01}]";
+
+        public static LocalizedString conditionalbranch = @"Conditional Branch: [{00}]";
+
+        public static LocalizedString conditionalelse = @"Else";
+
+        public static LocalizedString conditionalend = @"End Branch";
+
+        public static LocalizedString deletedevent = @"Deleted Event!";
+
+        public static LocalizedString despawnnpcs = @"Despawn NPCs";
+
+        public static LocalizedString dividevariable = @"Divide {00}";
+
+        public static LocalizedString dupglobalvariable = @"Global Variable: {00}'s Value";
+
+        public static LocalizedString dupplayervariable = @"Player Variable: {00}'s Value";
+
+        public static LocalizedString dupguildvariable = @"Guild Variable: {00}'s Value";
+
+        public static LocalizedString DupUserVariable = @"{00}: {01}'s Value";
+
+        public static LocalizedString addglobalvariable = @"Add Global Variable: {00}'s Value";
+
+        public static LocalizedString addplayervariable = @"Add Player Variable: {00}'s Value";
+
+        public static LocalizedString addguildvariable = @"Add Guild Variable: {00}'s Value";
+
+        public static LocalizedString AddUserVariable = @"Add {00}: {01}'s Value";
+
+        public static LocalizedString subtractglobalvariable = @"Subtract Global Variable: {00}'s Value";
+
+        public static LocalizedString subtractplayervariable = @"Subtract Player Variable: {00}'s Value";
+
+        public static LocalizedString subtractguildvariable = @"Subtract Guild Variable: {00}'s Value";
+
+        public static LocalizedString SubtractUserVariable = @"Subtract {00}: {01}'s Value";
+
+        public static LocalizedString multiplyglobalvariable = @"Multiply Global Variable: {00}'s Value";
+
+        public static LocalizedString multiplyplayervariable = @"Multiply Player Variable: {00}'s Value";
+
+        public static LocalizedString multiplyguildvariable = @"Multiply Guild Variable: {00}'s Value";
+
+        public static LocalizedString MultiplyUserVariable = @"Multiply {00}: {01}'s Value";
+
+        public static LocalizedString divideglobalvariable = @"Divide Global Variable: {00}'s Value";
+
+        public static LocalizedString divideplayervariable = @"Divide Player Variable: {00}'s Value";
+
+        public static LocalizedString divideguildvariable = @"Divide Guild Variable: {00}'s Value";
+
+        public static LocalizedString DivideUserVariable = @"Divide {00}: {01}'s Value";
+
+        public static LocalizedString leftshiftglobalvariable = @"Left Bit Shift Global Variable: {00}'s Value";
+
+        public static LocalizedString leftshiftplayervariable = @"Left Bit Shift Player Variable: {00}'s Value";
+
+        public static LocalizedString leftshiftguildvariable = @"Left Bit Shift Guild Variable: {00}'s Value";
+
+        public static LocalizedString LeftShiftUserVariable = @"Left Bit Shift {00}: {01}'s Value";
+
+        public static LocalizedString rightshiftglobalvariable = @"Right Bit Shift Global Variable: {00}'s Value";
+
+        public static LocalizedString rightshiftplayervariable = @"Right Bit Shift Player Variable: {00}'s Value";
+
+        public static LocalizedString rightshiftguildvariable = @"Right Bit Shift Guild Variable: {00}'s Value";
+
+        public static LocalizedString RightShiftUserVariable = @"Right Bit Shift {00}: {01}'s Value";
+
+        public static LocalizedString enditemchange = @"End Item Change";
+
+        public static LocalizedString endoptions = @"End Options";
+
+        public static LocalizedString endquest = @"End Quest [{00}, {01}]";
+
+        public static LocalizedString endspell = @"End Spell Change";
+
+        public static LocalizedString endname = @"End Name Change";
+
+        public static LocalizedString endstartquest = @"End Start Quest";
+
+        public static LocalizedString exitevent = @"Exit Event Processing";
+
+        public static LocalizedString fadeoutbgm = @"Fadeout BGM";
+
+        public static LocalizedString False = @"False";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FadeIn = @"Screen Fade In";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fade = @"Screen Fade: {00} @ {02}ms (Wait for completion: {01})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FadeCancel = @"Screen Fade: {00} (Wait for completion: {01})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FadeOut = @"Screen Fade Out";
+
+        public static LocalizedString female = @"Female";
+
+        public static LocalizedString forcedstart = @"Forced Start";
+
+        public static LocalizedString forget = @"Remove: Spell {00}";
+
+        public static LocalizedString give = @"Give: Item {00}";
+
+        public static LocalizedString giveexp = @"Give Player {00} Experience";
+
+        public static LocalizedString globalswitch = @"Set Global Switch {00} to {01}";
+
+        public static LocalizedString globalvariable = @"Set Global Variable {00} ({01})";
+
+        public static LocalizedString guildvariable = @"Set Guild Variable {00} ({01})";
+
+        public static LocalizedString UserVariable = @"Set {00} {01} ({02})";
+
+        public static LocalizedString gotolabel = @"Go to Label {00}";
+
+        public static LocalizedString hidepicture = @"Hide Picture";
+
+        public static LocalizedString hideplayer = @"Hide Player";
+
+        public static LocalizedString holdplayer = @"Hold Player";
+
+        public static LocalizedString invalid = @"Invalid Command";
+
+        public static LocalizedString itemnotchanged = @"Item(s) Not Given/Taken (Doesn't have/Inventory full)";
+
+        public static LocalizedString itemschanged = @"Item(s) Given/Taken Successfully";
+
+        public static LocalizedString label = @"Label: {00}";
+
+        public static LocalizedString leftshiftvariable = @"Left Bit Shift {00}";
+
+        public static LocalizedString levelup = @"Level Up Player";
+
+        public static LocalizedString linestart = @"@>";
+
+        public static LocalizedString male = @"Male";
+
+        public static LocalizedString mapnotfound = @"NOT FOUND";
+
+        public static LocalizedString moderator = @"Moderator";
+
+        public static LocalizedString moveroute = @"Set Move Route for {00}";
+
+        public static LocalizedString moverouteevent = @"Event #{00}";
+
+        public static LocalizedString moverouteplayer = @"Player";
+
+        public static LocalizedString multiplyvariable = @"Multiply {00}";
+
+        public static LocalizedString notcommon = @"Cannot use this command in common events.";
+
+        public static LocalizedString notcommoncaption = @"Common Event Warning!";
+
+        public static LocalizedString openbank = @"Open Bank";
+
+        public static LocalizedString opencrafting = @"Open Crafting Table [{00}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OpenCraftingJournal = @"Open Crafting Journal [{00}]";
+
+        public static LocalizedString openshop = @"Open Shop [{00}]";
+
+        public static LocalizedString playanimation = @"Play Animation {00} {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PlayAnimationInstanced = @" (Instanced: {00})";
+
+        public static LocalizedString playbgm = @"Play BGM [File: {00}]";
+
+        public static LocalizedString playervariable = @"Set Player Variable {00} ({01})";
+
+        public static LocalizedString playsound = @"Play Sound [File: {00}]";
+
+        public static LocalizedString questnotstarted =
+            @"Quest Declined or Failed to Start (Reqs not met, already started, etc)";
+
+        public static LocalizedString queststarted = @"Quest Accepted/Started Successfully";
+
+        public static LocalizedString randvariable = @"Random Number {00} to {01}";
+
+        public static LocalizedString regularuser = @"Regulator User";
+
+        public static LocalizedString releaseplayer = @"Release Player";
+
+        public static LocalizedString restorehp = @"Restore Player HP";
+
+        public static LocalizedString restoremp = @"Restore Player MP";
+
+        public static LocalizedString restorehpby = @"Adjust Player HP ({00})";
+
+        public static LocalizedString restorempby = @"Adjust Player MP ({00})";
+
+        public static LocalizedString rightshiftvariable = @"Right Bit Shift {00}";
+
+        public static LocalizedString runcompletionevent = @"Running Completion Event";
+
+        public static LocalizedString selfswitch = @"Set Self Switch {00} to {01}";
+
+        public static LocalizedString showplayer = @"Show Player";
+
+        public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
         {
+            {0, @"A"},
+            {1, @"B"},
+            {2, @"C"},
+            {3, @"D"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString setaccess = @"Set Player Access to {00}";
 
-            public static LocalizedString labelhealth = @"Set Health:";
+        public static LocalizedString setclass = @"Set Class [{00}]";
 
-            public static LocalizedString labelmana = @"Set Mana:";
+        public static LocalizedString setface = @"Set Player Face to {00}";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString setnamecolor = @"Set Player Name Color";
 
-            public static LocalizedString title = @"Change Vital";
+        public static LocalizedString removenamecolor = @"Remove Player Name Color";
 
-        }
+        public static LocalizedString changeplayerlabel = @"Change Player Label to {00}";
 
-        public partial struct EventChangeLevel
+        public static LocalizedString setgender = @"Set Player Gender to {00}";
+
+        public static LocalizedString setlevel = @"Set Player Level To: {00}";
+
+        public static LocalizedString setsprite = @"Set Player Sprite to {00}";
+
+        public static LocalizedString setvariable = @"Set to {00}";
+
+        public static LocalizedString replace = @"Replace {00} with {01}";
+
+        public static LocalizedString showoffer = @"Show Offer Window";
+
+        public static LocalizedString showoptions = @"Show Options: {00}";
+
+        public static LocalizedString variableinput = @"Input Variable: {00}";
+
+        public static LocalizedString showpicture = @"Show Picture";
+
+        public static LocalizedString showtext = @"Show Text: {00}";
+
+        public static LocalizedString skipcompletionevent = @"Without Running Completion Event";
+
+        public static LocalizedString spawnnpc = @"Spawn Npc {00} {01}";
+
+        public static LocalizedString spawnonevent = @"On Event #{00} [X Offset: {01} Y Offset: {02} Dir: {03}]";
+
+        public static LocalizedString spawnonmap = @"[On Map {00} X: {01} Y: {02} Dir: {03}]";
+
+        public static LocalizedString spawnonplayer = @"On Player [X Offset: {00} Y Offset: {01} Dir: {02}]";
+
+        public static LocalizedString spellfailed =
+            @"Spell Not Taught/Moved (Already Knew/Spellbook full/Didn't Know)";
+
+        public static LocalizedString spellsucceeded = @"Spell Taught/Removed Successfully";
+
+        public static LocalizedString namesucceeded = @"Name Changed Successfully";
+
+        public static LocalizedString namefailed = @"Name Not Changed (Taken, Invalid etc.)";
+
+        public static LocalizedString startquest = @"Start Quest [{00}, {01}]";
+
+        public static LocalizedString stopsounds = @"Stop Sounds";
+
+        public static LocalizedString subtractvariable = @"Subtract {00}";
+
+        public static LocalizedString systemtimevariable = @"System Time (ms)";
+
+        public static LocalizedString take = @"Take: Item {00}";
+
+        public static LocalizedString taskundefined = @"Undefined";
+
+        public static LocalizedString teach = @"Teach: Spell {00}";
+
+        public static LocalizedString True = @"True";
+
+        public static LocalizedString unknown = @"Unknown Command";
+
+        public static LocalizedString unknownrole = @"Unknown Access";
+
+        public static LocalizedString wait = @"Wait {00}ms";
+
+        public static LocalizedString waitforroute = @"Wait for Move Route Completion of {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString warp = @"Warp Player [Map: {00} X: {01} Y: {02} Dir: {03}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InstancedWarp = @"Warp Player to {04} instance [Map: {00} X: {01} Y: {02} Dir: {03}]";
+
+        public static LocalizedString whenoption = @"When [{00}]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ChangePlayerColor = @"Change Player Color to: R: {00} G: {01} B: {02} A: {03}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString createguild = @"Create Guild [Player Variable {00} as name]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString guildcreated = @"Guild created successfully.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString guildfailed = @"Guild failed to create.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString endcreateguild = @"End Create Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString disbandguild = @"Disband Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString guildisbanded = @"Guild disbanded successfully.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString guilddisbandfailed = @"Guild failed to disband.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString enddisbandguild = @"End Disband Guild";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString openguildbank = @"Open Guild Bank";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString setguildbankslots = @"Set Guild Bank Slots";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString resetstatpointallocations = @"Reset Player Stat Point Allocations";
+    }
+
+    public partial struct EventChangePlayerColor
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Ok";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Change Player Color";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Red = @"Red:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Green = @"Green:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Blue = @"Blue:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Alpha = @"Alpha:";
+
+    }
+
+    public partial struct EventCommands
+    {
+
+        public static Dictionary<string, LocalizedString> commands = new Dictionary<string, LocalizedString>()
         {
+            {"addchatboxtext", @"Add Chatbox Text"},
+            {"changeclass", @"Change Class"},
+            {"changeface", @"Change Face"},
+            {"changegender", @"Change Gender"},
+            {"changeitems", @"Change Items"},
+            {"changelevel", @"Change Level"},
+            {"changespells", @"Change Spells"},
+            {"changesprite", @"Change Sprite"},
+            {"completequesttask", @"Complete Quest Task"},
+            {"conditionalbranch", @"Conditional Branch"},
+            {"despawnnpcs", @"Despawn NPC"},
+            {"dialogue", @"Dialogue"},
+            {"endquest", @"End Quest"},
+            {"etc", @"Etc"},
+            {"exiteventprocess", @"Exit Event Process"},
+            {"fadeoutbgm", @"Fadeout BGM"},
+            {"giveexperience", @"Give Experience"},
+            {"gotolabel", @"Go To Label"},
+            {"hidepicture", @"Hide Picture"},
+            {"holdplayer", @"Hold Player"},
+            {"label", @"Label"},
+            {"levelup", @"Level Up"},
+            {"logicflow", @"Logic Flow"},
+            {"movement", @"Movement"},
+            {"openbank", @"Open Bank"},
+            {"opencraftingstation", @"Open Crafting Station"},
+            {"openshop", @"Open Shop"},
+            {"playanimation", @"Play Animation"},
+            {"playbgm", @"Play BGM"},
+            {"playercontrol", @"Player Control"},
+            {"playsound", @"Play Sound"},
+            {"questcontrol", @"Quest Control"},
+            {"releaseplayer", @"Release Player"},
+            {"restorehp", @"Restore HP"},
+            {"restoremp", @"Restore MP"},
+            {"setaccess", @"Set Access"},
+            {"setmoveroute", @"Set Move Route"},
+            {"setselfswitch", @"Set Self Switch"},
+            {"setswitch", @"Set Switch"},
+            {"setvariable", @"Set Variable"},
+            {"shopandbank", @"Shop and Bank"},
+            {"showoptions", @"Show Options"},
+            {"showpicture", @"Show Picture"},
+            {"showtext", @"Show Text"},
+            {"spawnnpc", @"Spawn NPC"},
+            {"specialeffects", @"Special Effects"},
+            {"startcommonevent", @"Start Common Event"},
+            {"startquest", @"Start Quest"},
+            {"stopsounds", @"Stop Sounds"},
+            {"wait", @"Wait..."},
+            {"waitmoveroute", @"Wait for Route Completion"},
+            {"warpplayer", @"Warp Player"},
+            {"hideplayer", @"Hide Player"},
+            {"showplayer", @"Show Player"},
+            {"equipitem", @"Equip/Unequip Item"},
+            {"changenamecolor", @"Change Name Color"},
+            {"inputvariable", @"Input Variable"},
+            {"changeplayerlabel", @"Change Player Label"},
+            {"changeplayercolor", @"Change Player Color" },
+            {"changename", @"Change Player Name" },
+            {"guilds", @"Guilds"},
+            {"createguild", @"Create Guild"},
+            {"disbandguild", "Disband Guild" },
+            {"openguildbank", @"Open Guild Bank"},
+            {"setguildbankslots", @"Set Guild Bank Slots Count"},
+            {"resetstatallocations", @"Reset Stat Point Allocations"},
+            {"castspellon", @"Cast Spell On"},
+            {"fade", @"Screen Fade"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+    }
 
-            public static LocalizedString label = @"Set Level:";
+    public partial struct EventCompleteQuestTask
+    {
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString title = @"Change Level";
+        public static LocalizedString okay = @"Ok";
 
-        }
+        public static LocalizedString quest = @"Quest:";
 
-        public partial struct EventChangeNameColor
+        public static LocalizedString task = @"Task:";
+
+        public static LocalizedString title = @"Complete Quest Task";
+
+    }
+
+    public partial struct EventConditional
+    {
+
+        public static LocalizedString and = @"And";
+
+        public static LocalizedString booleanvariable = @"Boolean Variable:";
+
+        public static LocalizedString booleanequal = @"Equal To";
+
+        public static LocalizedString booleannotequal = @"Not Equal To";
+
+        public static LocalizedString stringvariable = @"String Variable:";
+
+        public static LocalizedString stringtip = @"Text variables work here. Click here for a list!";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString canstartquest = @"Can Start Quest";
+
+        public static LocalizedString EquipmentSlot = @"Slot";
+
+        public static LocalizedString CheckEquipment = @"Check Equipment";
+
+        public static LocalizedString Class = @"Class:";
+
+        public static LocalizedString classis = @"Class Is";
+
+        public static LocalizedString commoneventsonly = @"This condition works for Common Events activation only!";
+
+        public static LocalizedString comparator = @"Comparator:";
+
+        public static Dictionary<int, LocalizedString> stringcomparators = new Dictionary<int, LocalizedString>
         {
+            {0, @"Equal To"},
+            {1, @"Contains"}
+        };
 
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Change Name Color";
-
-            public static LocalizedString select = @"Select Color";
-
-            public static LocalizedString adminoverride = @"Override Admin Name Color?";
-
-            public static LocalizedString remove = @"Remove Name Color?";
-
-        }
-
-        public partial struct EventChangeName
+        public static Dictionary<int, LocalizedString> comparators = new Dictionary<int, LocalizedString>
         {
+            {0, @"Equal To"},
+            {1, @"Greater Than or Equal To"},
+            {2, @"Less Than or Equal To"},
+            {3, @"Greater Than"},
+            {4, @"Less Than"},
+            {5, @"Does Not Equal"}
+        };
 
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Change Name";
-
-            public static LocalizedString variable = @"Player Variable:";
-
-        }
-
-        public partial struct EventChangeSpells
+        public static Dictionary<int, LocalizedString> conditions = new Dictionary<int, LocalizedString>
         {
+            {0, @"Variable Is..."},
+            {4, @"Has item..."},
+            {5, @"Class is..."},
+            {6, @"Knows spell..."},
+            {7, @"Level or Stat is..."},
+            {8, @"Self Switch is..."},
+            {9, @"Power level is..."},
+            {10, @"Time is between..."},
+            {11, @"Can Start Quest..."},
+            {12, @"Quest In Progress..."},
+            {13, @"Quest Completed..."},
+            {14, @"No NPCs on Map..."},
+            {15, @"Gender is..."},
+            {16, @"Map is..."},
+            {17, @"Item Equipped is..."},
+            {18, @"Has X free Inventory slots..." },
+            {19, @"In Guild With At Least Rank..." },
+            {20, @"Map Zone Type is..." },
+            {21, @"Check Equipped Slot..." },
+        };
 
-            public static LocalizedString action = @"Action: ";
+        public static LocalizedString endrange = @"End Range:";
 
-            public static Dictionary<int, LocalizedString> actions = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Add"},
-                {1, @"Remove"}
-            };
+        public static LocalizedString False = @"False";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString female = @"Female";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString gender = @"Gender:";
 
-            public static LocalizedString RemoveBound = @"Remove Bound Spell ?";
-            
-            public static LocalizedString spell = @"Spell: ";
+        public static LocalizedString genderis = @"Gender Is..";
 
-            public static LocalizedString title = @"Change Player Spells";
+        public static LocalizedString globalswitch = @"Global Switch";
 
-        }
+        public static LocalizedString globalvariable = @"Global Variable";
 
-        public partial struct EventCastSpellOn
+        public static LocalizedString globalvariablevalue = @"Global Variable Value: ";
+
+        public static LocalizedString guildvariable = @"Guild Variable";
+
+        public static LocalizedString guildvariablevalue = @"Guild Variable Value: ";
+
+        public static LocalizedString hasatleast = @"Has at least:";
+
+        public static LocalizedString hasitem = @"Has Item";
+
+        public static LocalizedString hasitemequipped = @"Has Equipped Item";
+
+        public static LocalizedString ignorestatbuffs = @"Ignore equipment & spell buffs.";
+
+        public static LocalizedString item = @"Item:";
+
+        public static LocalizedString knowsspell = @"Knows Spell";
+
+        public static LocalizedString level = @"Level";
+
+        public static LocalizedString levelorstat = @"Level or Stat Is....";
+
+        public static LocalizedString levelstatitem = @"Level or Stat:";
+
+        public static LocalizedString levelstatvalue = @"Value:";
+
+        public static LocalizedString male = @"Male";
+
+        public static LocalizedString mapis = @"Map Is...";
+
+        public static LocalizedString negated = @"Negated";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString HasElse = @"Has Else";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NpcGroup = @"NPCs";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString NpcLabel = @"NPC:";
+
+        public static LocalizedString numericvariable = @"Numeric Variable:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString playervariable = @"Player Variable";
+
+        public static LocalizedString playervariablevalue = @"Player Variable Value: ";
+
+        public static LocalizedString power = @"Power:";
+
+        public static LocalizedString power0 = @"Mod or Admin";
+
+        public static LocalizedString power1 = @"Admin";
+
+        public static LocalizedString poweris = @"Power Is";
+
+        public static Dictionary<int, LocalizedString> questcomparators = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
+            {0, @"On Any Task"},
+            {1, @"Before Task..."},
+            {2, @"After Task..."},
+            {3, @"On Task..."},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IncludeGuildies = @"Online Guild Members";
+        public static LocalizedString questcompleted = @"Quest Completed";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IncludePartyMembers = @"Party Members";
+        public static LocalizedString questcompletedlabel = @"Quest:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IncludeSelf = @"Self";
+        public static LocalizedString questinprogress = @"Quest In Progress";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelSpell = @"Spell";
+        public static LocalizedString questis = @"Is:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelTargets = @"Targets";
+        public static LocalizedString questprogress = @"Quest:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Okay";
+        public static LocalizedString selectmap = @"Select Map";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Cast Spell On";
+        public static LocalizedString selectvariable = @"Select Variable:";
 
-        }
+        public static LocalizedString selfswitch = @"Self Switch:";
 
-        public partial struct EventChangeSprite
+        public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
         {
+            {0, @"A"},
+            {1, @"B"},
+            {2, @"C"},
+            {3, @"D"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString selfswitchis = @"Self Switch Is";
 
-            public static LocalizedString label = @"Sprite:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SpecificNpcCheck = @"Specify NPC?";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString spell = @"Spell:";
 
-            public static LocalizedString title = @"Change Sprite";
+        public static LocalizedString startquest = @"Quest:";
 
-        }
+        public static LocalizedString startrange = @"Start Range:";
 
-        public partial struct EventChangePlayerLabel
+        public static LocalizedString switchis = @"Is";
+
+        public static LocalizedString task = @"Task:";
+
+        public static LocalizedString time = @"Time is between:";
+
+        public static LocalizedString title = @"Conditional";
+
+        public static LocalizedString to = @"to";
+
+        public static LocalizedString True = @"True";
+
+        public static LocalizedString type = @"Condition Type:";
+
+        public static LocalizedString value = @"Static Value:";
+
+        public static LocalizedString variable = @"Variable Is...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FreeInventorySlots = @"Has X free Inventory slots";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AmountType = @"Amount Type";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString VariableLabel = @"Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Manual = @"Manual";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString inguild = @"In Guild With At Least Rank...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString rank = @"Rank:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapZoneTypeIs = @"Map Zone Type is:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapZoneTypeLabel = @"Zone Type:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CheckBank = @"Check Bank?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UserVariableValue = @"User Variable Value:";
+    }
+
+    public partial struct EventConditionDesc
+    {
+
+        public static LocalizedString admin = @"Admin";
+
+        public static LocalizedString aftertask = @", After Task: {00}";
+
+        public static LocalizedString beforetask = @", Before Task: {00}";
+
+        public static LocalizedString checkequippedslot = @"Player has slot {00} occupied";
+
+        public static LocalizedString Class = @"Player's class is {00}";
+
+        public static LocalizedString contains = @"contains {00}";
+
+        public static LocalizedString equal = @"is equal to {00}";
+
+        public static LocalizedString False = @"False";
+
+        public static LocalizedString female = @"Female";
+
+        public static LocalizedString gender = @"Player's Gender is {00}";
+
+        public static LocalizedString globalvariable = @"Global Variable: {00} {01}";
+
+        public static LocalizedString globalvariablevalue = @"Global Variable: {00}'s Value";
+
+        public static LocalizedString guildvariable = @"Guild Variable: {00} {01}";
+
+        public static LocalizedString guildvariablevalue = @"Guild Variable: {00}'s Value";
+
+        public static LocalizedString greater = @"is greater than {00}";
+
+        public static LocalizedString greaterequal = @"is greater than or equal to {00}";
+
+        public static LocalizedString guild = @"Player is in Guild with at least rank: {00}";
+
+        public static LocalizedString hasitem = @"Player has at least {00} of Item {01}";
+
+        public static LocalizedString hasitemequipped = @"Player has Item {00} equipped";
+
+        public static LocalizedString knowsspell = @"Player knows Spell {00}";
+
+        public static LocalizedString lessthan = @"is less than {00}";
+
+        public static LocalizedString lessthanequal = @"is less than or equal to {00}";
+
+        public static LocalizedString level = @"Level";
+
+        public static LocalizedString levelorstat = @"{00} {01}";
+
+        public static LocalizedString male = @"Male";
+
+        public static LocalizedString map = @"Player's Map is {00}";
+
+        public static LocalizedString mapnotfound = @"NOT FOUND";
+
+        public static LocalizedString modadmin = @"Mod or Admin";
+
+        public static LocalizedString negated = @"NOT [{00}]";
+
+        public static LocalizedString NoNpcsOnMap = @"No NPCs on the map";
+
+        public static LocalizedString NoNpcsOfTypeOnMap = @"No NPCs of type {00} on the map";
+
+        public static LocalizedString notequal = @"does not equal {00}";
+
+        public static LocalizedString onanytask = @", On Any Task";
+
+        public static LocalizedString ontask = @", On Task: {00}";
+
+        public static LocalizedString playerdeath = @"Player Death";
+
+        public static LocalizedString playervariable = @"Player Variable: {00} {01}";
+
+        public static LocalizedString playervariablevalue = @"Player Variable: {00}'s Value";
+
+        public static LocalizedString power = @"Player's Power is {00}";
+
+        public static LocalizedString questcompleted = @"Quest is Completed: {00}";
+
+        public static LocalizedString questinprogress = @"Quest In Progress: {00} {01}";
+
+        public static LocalizedString selfswitch = @"Self Switch {00} is {01}";
+
+        [JsonProperty]
+        public static LocalizedString HasFreeInventorySlots = @"Player has {00} free inventory slot(s)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapZoneTypeIs = @"Map Zone Type is {00}";
+
+        public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
         {
+            {0, @"A"},
+            {1, @"B"},
+            {2, @"C"},
+            {3, @"D"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString startquest = @"Can Start Quest: {00}";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString SystemTime = @"System Time (ms)";
 
-            public static LocalizedString title = @"Change Player Label";
+        public static LocalizedString tasknotfound = @"Not Found";
 
-            public static LocalizedString select = @"Select Color";
+        public static LocalizedString time = @"Time is between {00} and {01}";
 
-            public static LocalizedString copyplayernamecolor = @"Copy Player Name Color?";
+        public static LocalizedString timeinvalid = @"invalid";
 
-            public static LocalizedString value = @"Value:";
+        public static LocalizedString True = @"True";
 
-            public static LocalizedString hint = @"Text variables work with strings. Click here for info!";
+        public static LocalizedString UserVariable = @"{00}: {01} {02}";
 
-            public static LocalizedString position = @"Label Position:";
+    }
 
-            public static Dictionary<int, LocalizedString> positions = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Above Character Name"},
-                {1, @"Below Character Name"},
-            };
+    public partial struct EventCreateGuild
+    {
 
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
 
-        public partial struct EventChatboxText
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SelectVariable = @"Player Variable containing Guild Name:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Ok";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Create Guild";
+
+    }
+
+    public partial struct EventGuildSetBankSlotsCount
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Variable = @"Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PlayerVariable = @"Player Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ServerVariable = @"Global Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildVariable = @"Guild Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString okay = @"Ok";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString title = @"Set Guild Bank Slots Count";
+    }
+
+    public partial struct EventEditor
+    {
+
+        public static LocalizedString addcommand = @"Add Commands";
+
+        public static LocalizedString animation = @"Animation";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString clearpage = @"Clear Page";
+
+        public static LocalizedString command = @"/Command: /";
+
+        public static LocalizedString commandlist = @"Commands:";
+
+        public static Dictionary<int, LocalizedString> commontriggers = new Dictionary<int, LocalizedString>
         {
+            {0, @"None"},
+            {1, @"Login"},
+            {2, @"Level Up"},
+            {3, @"On Respawn"},
+            {4, @"/Command"},
+            {5, @"Autorun"},
+            {6, @"PVP Kill"},
+            {7, @"PVP Death"},
+            {8, @"Player Interact"},
+            {9, @"Equipment Changed"},
+            {10, @"Player Variable Changed"},
+            {11, @"Server Variable Changed"},
+            {12, @"Guild Member Joined"},
+            {13, @"Guild Member Left"},
+            {14, @"Guild Member Kicked"},
+            {15, @"Guild Variable Changed"},
+            {16, @"Inventory Changed"},
+            {17, @"Map Changed"},
+            {18, @"User Variable Changed"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString conditions = @"Conditions";
 
-            public static LocalizedString channel = @"Channel:";
+        public static LocalizedString copypage = @"Copy Page";
 
-            public static Dictionary<int, LocalizedString> channels = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Player / System"},
-                {1, @"Local"},
-                {2, @"Global"},
-                {3, @"Party"},
-                {4, @"Guild"},
-            };
+        public static LocalizedString copycommand = @"Copy";
 
-            public static LocalizedString color = @"Color:";
+        public static LocalizedString cutcommand = @"Cut";
 
-            public static LocalizedString commands = @"Chat Commands";
+        public static LocalizedString deletecommand = @"Delete";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString deletepage = @"Delete Page";
 
-            public static LocalizedString text = @"Text:";
+        public static LocalizedString directionfix = @"Dir Fix";
 
-            public static LocalizedString title = @"Add Chatbox Text";
+        public static LocalizedString disableinspector = @"Disable Inspector";
 
-            public static LocalizedString ShowChatBubble = @"Show Chat Bubble";
+        public static LocalizedString editcommand = @"Edit";
 
-        }
+        public static LocalizedString editconditions = @"Spawn/Execution Conditions";
 
-        public partial struct EventCommandList
+        public static LocalizedString entityoptions = @"Entity Options";
+
+        public static LocalizedString eventpreview = @"Preview";
+
+        public static LocalizedString extras = @"Extras:";
+
+        public static LocalizedString face = @"Face:";
+
+        public static LocalizedString frequency = @"Freq:";
+
+        public static Dictionary<int, LocalizedString> frequencies = new Dictionary<int, LocalizedString>
         {
+            {0, @"Not Very Often"},
+            {1, @"Not Often"},
+            {2, @"Normal"},
+            {3, @"Often"},
+            {4, @"Very Often"},
+        };
 
-            public static LocalizedString addvariable = @"Add {00}";
+        public static LocalizedString general = @"General";
 
-            public static LocalizedString admin = @"Owner/Developer";
+        public static LocalizedString global = @"Global Event";
 
-            public static LocalizedString animationonevent = @"On Event {00} [X Offset: {01} Y Offset: {02} {03}]";
+        public static LocalizedString hidename = @"Hide Name";
 
-            public static LocalizedString animationonmap = @"[On Map {00} X: {01} Y: {02} Dir: {03}]";
+        public static LocalizedString insertcommand = @"Insert";
 
-            public static LocalizedString animationonplayer = @"On Player [X Offset: {00} Y Offset: {01} {02}]";
+        public static LocalizedString inspector = @"Entity Inspector Options";
 
-            public static LocalizedString animationrelativedir = @"Spawn Relative To Direction";
+        public static LocalizedString inspectordesc = @"Inspector Description:";
 
-            public static LocalizedString animationrelativerotate = @"Spawn And Rotate Relative To Direction";
+        public static LocalizedString interactionfreeze = @"Interaction Freeze";
 
-            public static LocalizedString animationrotatedir = @"Rotate Relative To Direction";
+        public static LocalizedString ignorenpcavoids = @"Ignore Npc Avoids";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CastSpellOn = @"Cast Spell '{00}' [include self: {01}, include party: {02}; include guild: {03})";
+        public static LocalizedString layer = @"Layer:";
 
-            public static LocalizedString changename = @"Change Name to Variable: {00}";
-
-            public static LocalizedString changeitems = @"Change Player Items [{00}]";
-
-            public static LocalizedString equipitem = @"Equip Player Item [{00}]";
-
-            public static LocalizedString unequipitem = @"Unequip Player Item [{00}]";
-
-            public static LocalizedString unequipslot = @"Unequip Player Slot [{00}]";
-
-            public static LocalizedString changespells = @"Change Player Spells [{00}]";
-
-            public static LocalizedString chatboxtext = @"Show Chatbox Text [Channel: {00}, Color: {01}] - {02}";
-
-            public static LocalizedString chatglobal = @"Global";
-
-            public static LocalizedString chatlocal = @"Local";
-
-            public static LocalizedString chatplayer = @"Player";
-
-            public static LocalizedString commonevent = @"Start Common Event: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CommonEventInstanced = @"Start Common Event For All on Instance: {00} (Allow in overworld: {01})";
-
-            public static LocalizedString completetask = @"Complete Quest Task [Quest: {00}, Task: {01}]";
-
-            public static LocalizedString conditionalbranch = @"Conditional Branch: [{00}]";
-
-            public static LocalizedString conditionalelse = @"Else";
-
-            public static LocalizedString conditionalend = @"End Branch";
-
-            public static LocalizedString deletedevent = @"Deleted Event!";
-
-            public static LocalizedString despawnnpcs = @"Despawn NPCs";
-
-            public static LocalizedString dividevariable = @"Divide {00}";
-
-            public static LocalizedString dupglobalvariable = @"Global Variable: {00}'s Value";
-
-            public static LocalizedString dupplayervariable = @"Player Variable: {00}'s Value";
-
-            public static LocalizedString dupguildvariable = @"Guild Variable: {00}'s Value";
-
-            public static LocalizedString DupUserVariable = @"{00}: {01}'s Value";
-
-            public static LocalizedString addglobalvariable = @"Add Global Variable: {00}'s Value";
-
-            public static LocalizedString addplayervariable = @"Add Player Variable: {00}'s Value";
-
-            public static LocalizedString addguildvariable = @"Add Guild Variable: {00}'s Value";
-
-            public static LocalizedString AddUserVariable = @"Add {00}: {01}'s Value";
-
-            public static LocalizedString subtractglobalvariable = @"Subtract Global Variable: {00}'s Value";
-
-            public static LocalizedString subtractplayervariable = @"Subtract Player Variable: {00}'s Value";
-
-            public static LocalizedString subtractguildvariable = @"Subtract Guild Variable: {00}'s Value";
-
-            public static LocalizedString SubtractUserVariable = @"Subtract {00}: {01}'s Value";
-
-            public static LocalizedString multiplyglobalvariable = @"Multiply Global Variable: {00}'s Value";
-
-            public static LocalizedString multiplyplayervariable = @"Multiply Player Variable: {00}'s Value";
-
-            public static LocalizedString multiplyguildvariable = @"Multiply Guild Variable: {00}'s Value";
-
-            public static LocalizedString MultiplyUserVariable = @"Multiply {00}: {01}'s Value";
-
-            public static LocalizedString divideglobalvariable = @"Divide Global Variable: {00}'s Value";
-
-            public static LocalizedString divideplayervariable = @"Divide Player Variable: {00}'s Value";
-
-            public static LocalizedString divideguildvariable = @"Divide Guild Variable: {00}'s Value";
-
-            public static LocalizedString DivideUserVariable = @"Divide {00}: {01}'s Value";
-
-            public static LocalizedString leftshiftglobalvariable = @"Left Bit Shift Global Variable: {00}'s Value";
-
-            public static LocalizedString leftshiftplayervariable = @"Left Bit Shift Player Variable: {00}'s Value";
-
-            public static LocalizedString leftshiftguildvariable = @"Left Bit Shift Guild Variable: {00}'s Value";
-
-            public static LocalizedString LeftShiftUserVariable = @"Left Bit Shift {00}: {01}'s Value";
-
-            public static LocalizedString rightshiftglobalvariable = @"Right Bit Shift Global Variable: {00}'s Value";
-
-            public static LocalizedString rightshiftplayervariable = @"Right Bit Shift Player Variable: {00}'s Value";
-
-            public static LocalizedString rightshiftguildvariable = @"Right Bit Shift Guild Variable: {00}'s Value";
-
-            public static LocalizedString RightShiftUserVariable = @"Right Bit Shift {00}: {01}'s Value";
-
-            public static LocalizedString enditemchange = @"End Item Change";
-
-            public static LocalizedString endoptions = @"End Options";
-
-            public static LocalizedString endquest = @"End Quest [{00}, {01}]";
-
-            public static LocalizedString endspell = @"End Spell Change";
-
-            public static LocalizedString endname = @"End Name Change";
-
-            public static LocalizedString endstartquest = @"End Start Quest";
-
-            public static LocalizedString exitevent = @"Exit Event Processing";
-
-            public static LocalizedString fadeoutbgm = @"Fadeout BGM";
-
-            public static LocalizedString False = @"False";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FadeIn = @"Screen Fade In";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fade = @"Screen Fade: {00} @ {02}ms (Wait for completion: {01})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FadeCancel = @"Screen Fade: {00} (Wait for completion: {01})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FadeOut = @"Screen Fade Out";
-
-            public static LocalizedString female = @"Female";
-
-            public static LocalizedString forcedstart = @"Forced Start";
-
-            public static LocalizedString forget = @"Remove: Spell {00}";
-
-            public static LocalizedString give = @"Give: Item {00}";
-
-            public static LocalizedString giveexp = @"Give Player {00} Experience";
-
-            public static LocalizedString globalswitch = @"Set Global Switch {00} to {01}";
-
-            public static LocalizedString globalvariable = @"Set Global Variable {00} ({01})";
-
-            public static LocalizedString guildvariable = @"Set Guild Variable {00} ({01})";
-
-            public static LocalizedString UserVariable = @"Set {00} {01} ({02})";
-
-            public static LocalizedString gotolabel = @"Go to Label {00}";
-
-            public static LocalizedString hidepicture = @"Hide Picture";
-
-            public static LocalizedString hideplayer = @"Hide Player";
-
-            public static LocalizedString holdplayer = @"Hold Player";
-
-            public static LocalizedString invalid = @"Invalid Command";
-
-            public static LocalizedString itemnotchanged = @"Item(s) Not Given/Taken (Doesn't have/Inventory full)";
-
-            public static LocalizedString itemschanged = @"Item(s) Given/Taken Successfully";
-
-            public static LocalizedString label = @"Label: {00}";
-
-            public static LocalizedString leftshiftvariable = @"Left Bit Shift {00}";
-
-            public static LocalizedString levelup = @"Level Up Player";
-
-            public static LocalizedString linestart = @"@>";
-
-            public static LocalizedString male = @"Male";
-
-            public static LocalizedString mapnotfound = @"NOT FOUND";
-
-            public static LocalizedString moderator = @"Moderator";
-
-            public static LocalizedString moveroute = @"Set Move Route for {00}";
-
-            public static LocalizedString moverouteevent = @"Event #{00}";
-
-            public static LocalizedString moverouteplayer = @"Player";
-
-            public static LocalizedString multiplyvariable = @"Multiply {00}";
-
-            public static LocalizedString notcommon = @"Cannot use this command in common events.";
-
-            public static LocalizedString notcommoncaption = @"Common Event Warning!";
-
-            public static LocalizedString openbank = @"Open Bank";
-
-            public static LocalizedString opencrafting = @"Open Crafting Table [{00}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OpenCraftingJournal = @"Open Crafting Journal [{00}]";
-
-            public static LocalizedString openshop = @"Open Shop [{00}]";
-
-            public static LocalizedString playanimation = @"Play Animation {00} {01}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PlayAnimationInstanced = @" (Instanced: {00})";
-
-            public static LocalizedString playbgm = @"Play BGM [File: {00}]";
-
-            public static LocalizedString playervariable = @"Set Player Variable {00} ({01})";
-
-            public static LocalizedString playsound = @"Play Sound [File: {00}]";
-
-            public static LocalizedString questnotstarted =
-                @"Quest Declined or Failed to Start (Reqs not met, already started, etc)";
-
-            public static LocalizedString queststarted = @"Quest Accepted/Started Successfully";
-
-            public static LocalizedString randvariable = @"Random Number {00} to {01}";
-
-            public static LocalizedString regularuser = @"Regulator User";
-
-            public static LocalizedString releaseplayer = @"Release Player";
-
-            public static LocalizedString restorehp = @"Restore Player HP";
-
-            public static LocalizedString restoremp = @"Restore Player MP";
-
-            public static LocalizedString restorehpby = @"Adjust Player HP ({00})";
-
-            public static LocalizedString restorempby = @"Adjust Player MP ({00})";
-
-            public static LocalizedString rightshiftvariable = @"Right Bit Shift {00}";
-
-            public static LocalizedString runcompletionevent = @"Running Completion Event";
-
-            public static LocalizedString selfswitch = @"Set Self Switch {00} to {01}";
-
-            public static LocalizedString showplayer = @"Show Player";
-
-            public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
-            {
-                {0, @"A"},
-                {1, @"B"},
-                {2, @"C"},
-                {3, @"D"},
-            };
-
-            public static LocalizedString setaccess = @"Set Player Access to {00}";
-
-            public static LocalizedString setclass = @"Set Class [{00}]";
-
-            public static LocalizedString setface = @"Set Player Face to {00}";
-
-            public static LocalizedString setnamecolor = @"Set Player Name Color";
-
-            public static LocalizedString removenamecolor = @"Remove Player Name Color";
-
-            public static LocalizedString changeplayerlabel = @"Change Player Label to {00}";
-
-            public static LocalizedString setgender = @"Set Player Gender to {00}";
-
-            public static LocalizedString setlevel = @"Set Player Level To: {00}";
-
-            public static LocalizedString setsprite = @"Set Player Sprite to {00}";
-
-            public static LocalizedString setvariable = @"Set to {00}";
-
-            public static LocalizedString replace = @"Replace {00} with {01}";
-
-            public static LocalizedString showoffer = @"Show Offer Window";
-
-            public static LocalizedString showoptions = @"Show Options: {00}";
-
-            public static LocalizedString variableinput = @"Input Variable: {00}";
-
-            public static LocalizedString showpicture = @"Show Picture";
-
-            public static LocalizedString showtext = @"Show Text: {00}";
-
-            public static LocalizedString skipcompletionevent = @"Without Running Completion Event";
-
-            public static LocalizedString spawnnpc = @"Spawn Npc {00} {01}";
-
-            public static LocalizedString spawnonevent = @"On Event #{00} [X Offset: {01} Y Offset: {02} Dir: {03}]";
-
-            public static LocalizedString spawnonmap = @"[On Map {00} X: {01} Y: {02} Dir: {03}]";
-
-            public static LocalizedString spawnonplayer = @"On Player [X Offset: {00} Y Offset: {01} Dir: {02}]";
-
-            public static LocalizedString spellfailed =
-                @"Spell Not Taught/Moved (Already Knew/Spellbook full/Didn't Know)";
-
-            public static LocalizedString spellsucceeded = @"Spell Taught/Removed Successfully";
-
-            public static LocalizedString namesucceeded = @"Name Changed Successfully";
-
-            public static LocalizedString namefailed = @"Name Not Changed (Taken, Invalid etc.)";
-
-            public static LocalizedString startquest = @"Start Quest [{00}, {01}]";
-
-            public static LocalizedString stopsounds = @"Stop Sounds";
-
-            public static LocalizedString subtractvariable = @"Subtract {00}";
-
-            public static LocalizedString systemtimevariable = @"System Time (ms)";
-
-            public static LocalizedString take = @"Take: Item {00}";
-
-            public static LocalizedString taskundefined = @"Undefined";
-
-            public static LocalizedString teach = @"Teach: Spell {00}";
-
-            public static LocalizedString True = @"True";
-
-            public static LocalizedString unknown = @"Unknown Command";
-
-            public static LocalizedString unknownrole = @"Unknown Access";
-
-            public static LocalizedString wait = @"Wait {00}ms";
-
-            public static LocalizedString waitforroute = @"Wait for Move Route Completion of {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString warp = @"Warp Player [Map: {00} X: {01} Y: {02} Dir: {03}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InstancedWarp = @"Warp Player to {04} instance [Map: {00} X: {01} Y: {02} Dir: {03}]";
-
-            public static LocalizedString whenoption = @"When [{00}]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ChangePlayerColor = @"Change Player Color to: R: {00} G: {01} B: {02} A: {03}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString createguild = @"Create Guild [Player Variable {00} as name]";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString guildcreated = @"Guild created successfully.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString guildfailed = @"Guild failed to create.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString endcreateguild = @"End Create Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString disbandguild = @"Disband Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString guildisbanded = @"Guild disbanded successfully.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString guilddisbandfailed = @"Guild failed to disband.";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString enddisbandguild = @"End Disband Guild";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString openguildbank = @"Open Guild Bank";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString setguildbankslots = @"Set Guild Bank Slots";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString resetstatpointallocations = @"Reset Player Stat Point Allocations";
-        }
-
-        public partial struct EventChangePlayerColor
+        public static Dictionary<int, LocalizedString> layers = new Dictionary<int, LocalizedString>
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
+            {0, @"Below Player"},
+            {1, @"Same as Player"},
+            {2, @"Above Player"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Ok";
+        public static LocalizedString movement = @"Movement";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Change Player Color";
+        public static LocalizedString movementtype = @"Type:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Red = @"Red:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Green = @"Green:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Blue = @"Blue:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Alpha = @"Alpha:";
-
-        }
-
-        public partial struct EventCommands
+        public static Dictionary<int, LocalizedString> movementtypes = new Dictionary<int, LocalizedString>
         {
+            {0, @"None"},
+            {1, @"Random"},
+            {2, @"Move Route"},
+        };
 
-            public static Dictionary<string, LocalizedString> commands = new Dictionary<string, LocalizedString>()
-            {
-                {"addchatboxtext", @"Add Chatbox Text"},
-                {"changeclass", @"Change Class"},
-                {"changeface", @"Change Face"},
-                {"changegender", @"Change Gender"},
-                {"changeitems", @"Change Items"},
-                {"changelevel", @"Change Level"},
-                {"changespells", @"Change Spells"},
-                {"changesprite", @"Change Sprite"},
-                {"completequesttask", @"Complete Quest Task"},
-                {"conditionalbranch", @"Conditional Branch"},
-                {"despawnnpcs", @"Despawn NPC"},
-                {"dialogue", @"Dialogue"},
-                {"endquest", @"End Quest"},
-                {"etc", @"Etc"},
-                {"exiteventprocess", @"Exit Event Process"},
-                {"fadeoutbgm", @"Fadeout BGM"},
-                {"giveexperience", @"Give Experience"},
-                {"gotolabel", @"Go To Label"},
-                {"hidepicture", @"Hide Picture"},
-                {"holdplayer", @"Hold Player"},
-                {"label", @"Label"},
-                {"levelup", @"Level Up"},
-                {"logicflow", @"Logic Flow"},
-                {"movement", @"Movement"},
-                {"openbank", @"Open Bank"},
-                {"opencraftingstation", @"Open Crafting Station"},
-                {"openshop", @"Open Shop"},
-                {"playanimation", @"Play Animation"},
-                {"playbgm", @"Play BGM"},
-                {"playercontrol", @"Player Control"},
-                {"playsound", @"Play Sound"},
-                {"questcontrol", @"Quest Control"},
-                {"releaseplayer", @"Release Player"},
-                {"restorehp", @"Restore HP"},
-                {"restoremp", @"Restore MP"},
-                {"setaccess", @"Set Access"},
-                {"setmoveroute", @"Set Move Route"},
-                {"setselfswitch", @"Set Self Switch"},
-                {"setswitch", @"Set Switch"},
-                {"setvariable", @"Set Variable"},
-                {"shopandbank", @"Shop and Bank"},
-                {"showoptions", @"Show Options"},
-                {"showpicture", @"Show Picture"},
-                {"showtext", @"Show Text"},
-                {"spawnnpc", @"Spawn NPC"},
-                {"specialeffects", @"Special Effects"},
-                {"startcommonevent", @"Start Common Event"},
-                {"startquest", @"Start Quest"},
-                {"stopsounds", @"Stop Sounds"},
-                {"wait", @"Wait..."},
-                {"waitmoveroute", @"Wait for Route Completion"},
-                {"warpplayer", @"Warp Player"},
-                {"hideplayer", @"Hide Player"},
-                {"showplayer", @"Show Player"},
-                {"equipitem", @"Equip/Unequip Item"},
-                {"changenamecolor", @"Change Name Color"},
-                {"inputvariable", @"Input Variable"},
-                {"changeplayerlabel", @"Change Player Label"},
-                {"changeplayercolor", @"Change Player Color" },
-                {"changename", @"Change Player Name" },
-                {"guilds", @"Guilds"},
-                {"createguild", @"Create Guild"},
-                {"disbandguild", "Disband Guild" },
-                {"openguildbank", @"Open Guild Bank"},
-                {"setguildbankslots", @"Set Guild Bank Slots Count"},
-                {"resetstatallocations", @"Reset Stat Point Allocations"},
-                {"castspellon", @"Cast Spell On"},
-                {"fade", @"Screen Fade"},
-            };
+        public static LocalizedString name = @"Name:";
 
-        }
+        public static LocalizedString newpage = @"New Page";
 
-        public partial struct EventCompleteQuestTask
+        public static LocalizedString pageoptions = @"Page Options";
+
+        public static LocalizedString ParallelRun = @"Can run in Parallel?";
+
+        public static LocalizedString passable = @"Passable";
+
+        public static LocalizedString pastecommand = @"Paste";
+
+        public static LocalizedString pastepage = @"Paste Page";
+
+        public static LocalizedString projectile = @"Projectile:";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString savecaption = @"Save Event?";
+
+        public static LocalizedString savedialogue = @"Do you want to save changes to this event?";
+
+        public static LocalizedString setroute = @"Set Route...";
+
+        public static LocalizedString speed = @"Speed:";
+
+        public static Dictionary<int, LocalizedString> speeds = new Dictionary<int, LocalizedString>
         {
+            {0, @"Slowest"},
+            {1, @"Slower"},
+            {2, @"Normal"},
+            {3, @"Faster"},
+            {4, @"Fastest"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString title = @"Event Editor - {00}";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString trigger = @"Trigger";
 
-            public static LocalizedString quest = @"Quest:";
-
-            public static LocalizedString task = @"Task:";
-
-            public static LocalizedString title = @"Complete Quest Task";
-
-        }
-
-        public partial struct EventConditional
+        public static Dictionary<int, LocalizedString> triggers = new Dictionary<int, LocalizedString>
         {
+            {0, @"Action Button"},
+            {1, @"Player Collide"},
+            {2, @"Autorun"},
+            {3, "Player Bump"},
+        };
 
-            public static LocalizedString and = @"And";
+        public static LocalizedString VariableTrigger = @"Variable:";
 
-            public static LocalizedString booleanvariable = @"Boolean Variable:";
+        public static LocalizedString walkinganim = @"Walking Anim";
 
-            public static LocalizedString booleanequal = @"Equal To";
+    }
 
-            public static LocalizedString booleannotequal = @"Not Equal To";
+    public partial struct EventEndQuest
+    {
 
-            public static LocalizedString stringvariable = @"String Variable:";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString stringtip = @"Text variables work here. Click here for a list!";
+        public static LocalizedString label = @"Quest:";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString canstartquest = @"Can Start Quest";
+        public static LocalizedString skipcompletion = @"Do not run completion event?";
 
-            public static LocalizedString EquipmentSlot = @"Slot";
+        public static LocalizedString title = @"End Quest";
 
-            public static LocalizedString CheckEquipment = @"Check Equipment";
+    }
 
-            public static LocalizedString Class = @"Class:";
+    public partial struct EventGiveExperience
+    {
 
-            public static LocalizedString classis = @"Class Is";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString commoneventsonly = @"This condition works for Common Events activation only!";
+        public static LocalizedString label = @"Give Experience:";
 
-            public static LocalizedString comparator = @"Comparator:";
+        public static LocalizedString okay = @"Ok";
 
-            public static Dictionary<int, LocalizedString> stringcomparators = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Equal To"},
-                {1, @"Contains"}
-            };
+        public static LocalizedString title = @"Give Experience";
 
-            public static Dictionary<int, LocalizedString> comparators = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Equal To"},
-                {1, @"Greater Than or Equal To"},
-                {2, @"Less Than or Equal To"},
-                {3, @"Greater Than"},
-                {4, @"Less Than"},
-                {5, @"Does Not Equal"}
-            };
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AmountType = @"Amount Type";
 
-            public static Dictionary<int, LocalizedString> conditions = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Variable Is..."},
-                {4, @"Has item..."},
-                {5, @"Class is..."},
-                {6, @"Knows spell..."},
-                {7, @"Level or Stat is..."},
-                {8, @"Self Switch is..."},
-                {9, @"Power level is..."},
-                {10, @"Time is between..."},
-                {11, @"Can Start Quest..."},
-                {12, @"Quest In Progress..."},
-                {13, @"Quest Completed..."},
-                {14, @"No NPCs on Map..."},
-                {15, @"Gender is..."},
-                {16, @"Map is..."},
-                {17, @"Item Equipped is..."},
-                {18, @"Has X free Inventory slots..." },
-                {19, @"In Guild With At Least Rank..." },
-                {20, @"Map Zone Type is..." },
-                {21, @"Check Equipped Slot..." },
-            };
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Variable = @"Variable";
 
-            public static LocalizedString endrange = @"End Range:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Manual = @"Manual";
 
-            public static LocalizedString False = @"False";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PlayerVariable = @"Player Variable";
 
-            public static LocalizedString female = @"Female";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ServerVariable = @"Global Variable";
 
-            public static LocalizedString gender = @"Gender:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildVariable = @"Guild Variable";
 
-            public static LocalizedString genderis = @"Gender Is..";
+    }
 
-            public static LocalizedString globalswitch = @"Global Switch";
+    public partial struct EventGotoLabel
+    {
 
-            public static LocalizedString globalvariable = @"Global Variable";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString globalvariablevalue = @"Global Variable Value: ";
+        public static LocalizedString label = @"Label:";
 
-            public static LocalizedString guildvariable = @"Guild Variable";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString guildvariablevalue = @"Guild Variable Value: ";
+        public static LocalizedString title = @"Go To Label";
 
-            public static LocalizedString hasatleast = @"Has at least:";
+    }
 
-            public static LocalizedString hasitem = @"Has Item";
+    public partial struct EventGraphic
+    {
 
-            public static LocalizedString hasitemequipped = @"Has Equipped Item";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString ignorestatbuffs = @"Ignore equipment & spell buffs.";
+        public static LocalizedString graphic = @"Graphic:";
 
-            public static LocalizedString item = @"Item:";
+        public static LocalizedString graphictype0 = @"None";
 
-            public static LocalizedString knowsspell = @"Knows Spell";
+        public static LocalizedString graphictype1 = @"Sprite";
 
-            public static LocalizedString level = @"Level";
+        public static LocalizedString graphictype2 = @"Tileset";
 
-            public static LocalizedString levelorstat = @"Level or Stat Is....";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString levelstatitem = @"Level or Stat:";
+        public static LocalizedString preview = @"Graphic Preview";
 
-            public static LocalizedString levelstatvalue = @"Value:";
+        public static LocalizedString title = @"Graphic Selector";
 
-            public static LocalizedString male = @"Male";
+        public static LocalizedString type = @"Graphic Type:";
 
-            public static LocalizedString mapis = @"Map Is...";
+    }
 
-            public static LocalizedString negated = @"Negated";
+    public partial struct EventLabel
+    {
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString HasElse = @"Has Else";
+        public static LocalizedString cancel = @"Cancel";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NpcGroup = @"NPCs";
+        public static LocalizedString label = @"Label:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString NpcLabel = @"NPC:";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString numericvariable = @"Numeric Variable:";
+        public static LocalizedString title = @"Label";
 
-            public static LocalizedString okay = @"Ok";
+    }
 
-            public static LocalizedString playervariable = @"Player Variable";
+    public partial struct EventMoveRoute
+    {
 
-            public static LocalizedString playervariablevalue = @"Player Variable Value: ";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString power = @"Power:";
+        public static LocalizedString command = @"Commands";
 
-            public static LocalizedString power0 = @"Mod or Admin";
-
-            public static LocalizedString power1 = @"Admin";
-
-            public static LocalizedString poweris = @"Power Is";
-
-            public static Dictionary<int, LocalizedString> questcomparators = new Dictionary<int, LocalizedString>
-            {
-                {0, @"On Any Task"},
-                {1, @"Before Task..."},
-                {2, @"After Task..."},
-                {3, @"On Task..."},
-            };
-
-            public static LocalizedString questcompleted = @"Quest Completed";
-
-            public static LocalizedString questcompletedlabel = @"Quest:";
-
-            public static LocalizedString questinprogress = @"Quest In Progress";
-
-            public static LocalizedString questis = @"Is:";
-
-            public static LocalizedString questprogress = @"Quest:";
-
-            public static LocalizedString selectmap = @"Select Map";
-
-            public static LocalizedString selectvariable = @"Select Variable:";
-
-            public static LocalizedString selfswitch = @"Self Switch:";
-
-            public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
-            {
-                {0, @"A"},
-                {1, @"B"},
-                {2, @"C"},
-                {3, @"D"},
-            };
-
-            public static LocalizedString selfswitchis = @"Self Switch Is";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SpecificNpcCheck = @"Specify NPC?";
-
-            public static LocalizedString spell = @"Spell:";
-
-            public static LocalizedString startquest = @"Quest:";
-
-            public static LocalizedString startrange = @"Start Range:";
-
-            public static LocalizedString switchis = @"Is";
-
-            public static LocalizedString task = @"Task:";
-
-            public static LocalizedString time = @"Time is between:";
-
-            public static LocalizedString title = @"Conditional";
-
-            public static LocalizedString to = @"to";
-
-            public static LocalizedString True = @"True";
-
-            public static LocalizedString type = @"Condition Type:";
-
-            public static LocalizedString value = @"Static Value:";
-
-            public static LocalizedString variable = @"Variable Is...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FreeInventorySlots = @"Has X free Inventory slots";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AmountType = @"Amount Type";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString VariableLabel = @"Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Manual = @"Manual";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString inguild = @"In Guild With At Least Rank...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString rank = @"Rank:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapZoneTypeIs = @"Map Zone Type is:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapZoneTypeLabel = @"Zone Type:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CheckBank = @"Check Bank?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UserVariableValue = @"User Variable Value:";
-        }
-
-        public partial struct EventConditionDesc
+        public static Dictionary<string, LocalizedString> commands = new Dictionary<string, LocalizedString>()
         {
+            {"directionfixoff", @"Direction Fix: Off"},
+            {"directionfixon", @"Direction Fix: On"},
+            {"etc", @"Etc"},
+            {"facedown", @"Face Down"},
+            {"faceleft", @"Face Left"},
+            {"faceright", @"Face Right"},
+            {"faceup", @"Face Up"},
+            {"faster", @"Faster"},
+            {"fastest", @"Fastest"},
+            {"frequencynormal", @"Normal"},
+            {"hidename", @"Hide Name"},
+            {"higher", @"Higher"},
+            {"highest", @"Highest"},
+            {"lower", @"Lower"},
+            {"lowest", @"Lowest"},
+            {"move", @"Move"},
+            {"moveawayfromplayer", @"Move Away From Player"},
+            {"movedown", @"Move Down"},
+            {"moveleft", @"Move Left"},
+            {"moverandomly", @"Move Randomly"},
+            {"moveright", @"Move Right"},
+            {"movetowardplayer", @"Move Toward Player"},
+            {"moveup", @"Move Up"},
+            {"moveupleft", @"Move Up Left"},
+            {"moveupright", @"Move Up Right"},
+            {"movedownright", @"Move Down Right"},
+            {"movedownleft", @"Move Down Left"},
+            {"setanimation", @"Set Animation..."},
+            {"setattribute", @"Set Attribute"},
+            {"setgraphic", @"Set Graphic..."},
+            {"setlayerabove", @"Set Layer: Above Player"},
+            {"setlayerbelow", @"Set Layer: Below Player"},
+            {"setlayersame", @"Set Layer: Same as Player"},
+            {"setmovementfrequency", @"Set Movement Frequency"},
+            {"setspeed", @"Set Speed"},
+            {"showname", @"Show Name"},
+            {"slower", @"Slower"},
+            {"slowest", @"Slowest"},
+            {"speednormal", @"Normal"},
+            {"stepbackward", @"Step Backward"},
+            {"stepforward", @"Step Forward"},
+            {"turn", @"Turn"},
+            {"turn180", @"Turn 180*"},
+            {"turn90clockwise", @"Turn 90* Clockwise"},
+            {"turn90counterclockwise", @"Turn 90* Counter Clockwise"},
+            {"turnawayfromplayer", @"Turn Away From Player"},
+            {"turnrandomly", @"Turn Randomly"},
+            {"turntowardplayer", @"Turn Toward Player"},
+            {"wait100", @"Wait 100ms"},
+            {"wait1000", @"Wait 1000ms"},
+            {"wait500", @"Wait 500ms"},
+            {"walkinganimoff", @"Walking Animation: Off"},
+            {"walkinganimon", @"Walking Animation: On"},
+            {"walkthroughoff", @"Walkthrough: Off"},
+            {"walkthroughon", @"Walkthrough: On"},
+        };
 
-            public static LocalizedString admin = @"Admin";
+        public static LocalizedString ignoreblocked = @"Ignore if Blocked";
 
-            public static LocalizedString aftertask = @", After Task: {00}";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString beforetask = @", Before Task: {00}";
+        public static LocalizedString player = @"Player";
 
-            public static LocalizedString checkequippedslot = @"Player has slot {00} occupied";
+        public static LocalizedString repeatroute = @"Repeat Route";
 
-            public static LocalizedString Class = @"Player's class is {00}";
+        public static LocalizedString thisevent = @"[THIS EVENT]";
 
-            public static LocalizedString contains = @"contains {00}";
+        public static LocalizedString title = @"Move Route";
 
-            public static LocalizedString equal = @"is equal to {00}";
+    }
 
-            public static LocalizedString False = @"False";
+    public partial struct EventOpenCrafting
+    {
 
-            public static LocalizedString female = @"Female";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString gender = @"Player's Gender is {00}";
+        public static LocalizedString label = @"Table:";
 
-            public static LocalizedString globalvariable = @"Global Variable: {00} {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString JournalMode = @"Journal Mode?";
 
-            public static LocalizedString globalvariablevalue = @"Global Variable: {00}'s Value";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString JournalModeTooltip = @"Opens the crafting window without the option for the player to actually craft.";
 
-            public static LocalizedString guildvariable = @"Guild Variable: {00} {01}";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString guildvariablevalue = @"Guild Variable: {00}'s Value";
+        public static LocalizedString title = @"Open Crafting";
 
-            public static LocalizedString greater = @"is greater than {00}";
+    }
 
-            public static LocalizedString greaterequal = @"is greater than or equal to {00}";
+    public partial struct EventOpenShop
+    {
 
-            public static LocalizedString guild = @"Player is in Guild with at least rank: {00}";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString hasitem = @"Player has at least {00} of Item {01}";
+        public static LocalizedString label = @"Shop:";
 
-            public static LocalizedString hasitemequipped = @"Player has Item {00} equipped";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString knowsspell = @"Player knows Spell {00}";
+        public static LocalizedString title = @"Open Shop";
 
-            public static LocalizedString lessthan = @"is less than {00}";
+    }
 
-            public static LocalizedString lessthanequal = @"is less than or equal to {00}";
+    public partial struct EventPlayAnimation
+    {
 
-            public static LocalizedString level = @"Level";
+        public static LocalizedString animation = @"Animation:";
 
-            public static LocalizedString levelorstat = @"{00} {01}";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString male = @"Male";
+        public static LocalizedString entity = @"Entity:";
 
-            public static LocalizedString map = @"Player's Map is {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InstanceToPlayer = @"Instance to Player?";
 
-            public static LocalizedString mapnotfound = @"NOT FOUND";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InstanceToPlayerTooltip = @"When enabled, only the player running this event will see the animation.";
 
-            public static LocalizedString modadmin = @"Mod or Admin";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString negated = @"NOT [{00}]";
+        public static LocalizedString player = @"Player";
 
-            public static LocalizedString NoNpcsOnMap = @"No NPCs on the map";
+        public static LocalizedString relativelocation = @"Relative Location:";
 
-            public static LocalizedString NoNpcsOfTypeOnMap = @"No NPCs of type {00} on the map";
+        public static LocalizedString rotaterelative = @"Rotate Relative to Direction";
 
-            public static LocalizedString notequal = @"does not equal {00}";
+        public static LocalizedString spawnrelative = @"Spawn Relative to Direction";
 
-            public static LocalizedString onanytask = @", On Any Task";
+        public static LocalizedString spawntype = @"Spawn Type:";
 
-            public static LocalizedString ontask = @", On Task: {00}";
+        public static LocalizedString spawntype0 = @"Specific Tile";
 
-            public static LocalizedString playerdeath = @"Player Death";
+        public static LocalizedString spawntype1 = @"On/Around Entity";
 
-            public static LocalizedString playervariable = @"Player Variable: {00} {01}";
+        public static LocalizedString This = @"[THIS EVENT]";
 
-            public static LocalizedString playervariablevalue = @"Player Variable: {00}'s Value";
+        public static LocalizedString title = @"Play Animation";
 
-            public static LocalizedString power = @"Player's Power is {00}";
+    }
 
-            public static LocalizedString questcompleted = @"Quest is Completed: {00}";
+    public partial struct EventPlayBgm
+    {
 
-            public static LocalizedString questinprogress = @"Quest In Progress: {00} {01}";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString selfswitch = @"Self Switch {00} is {01}";
+        public static LocalizedString label = @"BGM:";
 
-            [JsonProperty]
-            public static LocalizedString HasFreeInventorySlots = @"Player has {00} free inventory slot(s)";
+        public static LocalizedString okay = @"Ok";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapZoneTypeIs = @"Map Zone Type is {00}";
+        public static LocalizedString title = @"Play BGM";
 
-            public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
-            {
-                {0, @"A"},
-                {1, @"B"},
-                {2, @"C"},
-                {3, @"D"},
-            };
+    }
 
-            public static LocalizedString startquest = @"Can Start Quest: {00}";
+    public partial struct EventPlayBgs
+    {
 
-            public static LocalizedString SystemTime = @"System Time (ms)";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString tasknotfound = @"Not Found";
+        public static LocalizedString label = @"Sound:";
 
-            public static LocalizedString time = @"Time is between {00} and {01}";
+        public static LocalizedString okay = @"Ok";
 
-            public static LocalizedString timeinvalid = @"invalid";
+        public static LocalizedString title = @"Play BGS";
 
-            public static LocalizedString True = @"True";
+    }
 
-            public static LocalizedString UserVariable = @"{00}: {01} {02}";
+    public partial struct EventSelfSwitch
+    {
 
-        }
+        public static LocalizedString cancel = @"Cancel";
 
-        public partial struct EventCreateGuild
+        public static LocalizedString False = @"False";
+
+        public static LocalizedString label = @"Set Self Switch:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
         {
+            {0, @"A"},
+            {1, @"B"},
+            {2, @"C"},
+            {3, @"D"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
+        public static LocalizedString title = @"Set Self Switch";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SelectVariable = @"Player Variable containing Guild Name:";
+        public static LocalizedString True = @"True";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Ok";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Create Guild";
+    public partial struct EventSetAccess
+    {
 
-        }
+        public static LocalizedString access0 = @"Regular User";
 
-        public partial struct EventGuildSetBankSlotsCount
+        public static LocalizedString access1 = @"In-Game Moderator";
+
+        public static LocalizedString access2 = @"Owner/Designer (Allows editor access)";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Access:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Set Access";
+
+    }
+
+    public partial struct EventSetAnimation
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Animation:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Set Animation";
+
+    }
+
+    public partial struct EventSetClass
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Class:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Set Class";
+
+    }
+
+    public partial struct EventSetVariable
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString global = @"Global Variable";
+
+        public static LocalizedString guild = @"Guild Variable";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString player = @"Player Variable";
+
+        public static LocalizedString title = @"Set Variable";
+
+        public static LocalizedString syncparty = @"Party Sync?";
+
+        public static LocalizedString label = @"Select Variable:";
+
+        public static LocalizedString booleanlabel = @"Boolean Variable:";
+
+        public static LocalizedString booleantrue = @"True";
+
+        public static LocalizedString booleanfalse = @"False";
+
+        public static LocalizedString numericlabel = @"Integer Variable:";
+
+        public static LocalizedString numericadd = @"Add";
+
+        public static LocalizedString numericdivide = @"Divide";
+
+        public static LocalizedString numericleftshift = @"LShift";
+
+        public static LocalizedString numericmultiply = @"Multiply";
+
+        public static LocalizedString numericrandom = @"Random";
+
+        public static LocalizedString numericrandomhigh = @"High:";
+
+        public static LocalizedString numericrandomlow = @"Low:";
+
+        public static LocalizedString numericrandomdesc = @"Random Number:";
+
+        public static LocalizedString numericrightshift = @"RShift";
+
+        public static LocalizedString numericset = @"Set";
+
+        public static LocalizedString numericsubtract = @"Subtract";
+
+        public static LocalizedString numericsystemtime = @"System Time (ms)";
+
+        public static LocalizedString stringlabel = @"String Variable:";
+
+        public static LocalizedString stringset = @"Set";
+
+        public static LocalizedString stringreplace = @"Replace";
+
+        public static LocalizedString stringsetvalue = @"Value:";
+
+        public static LocalizedString stringreplacefind = @"Find:";
+
+        public static LocalizedString stringreplacereplace = @"Replace:";
+
+        public static LocalizedString stringtip = @"Text variables work with strings. Click here for a list!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString VariableValue = @"Variable Value";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SetVariableGroup = @"Set to Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SelectVariableGroup = @"Select Variable";
+    }
+
+    public partial struct EventShowOptions
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString commands = @"Chat Commands";
+
+        public static LocalizedString face = @"Face:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString option1 = @"Option 1";
+
+        public static LocalizedString option2 = @"Option 2";
+
+        public static LocalizedString option3 = @"Option 3";
+
+        public static LocalizedString option4 = @"Option 4";
+
+        public static LocalizedString text = @"Text:";
+
+        public static LocalizedString title = @"Show Options";
+
+    }
+
+    public partial struct EventShowText
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString commands = @"Chat Commands";
+
+        public static LocalizedString face = @"Face:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString text = @"Text:";
+
+        public static LocalizedString title = @"Show Text";
+
+    }
+
+    public partial struct EventInput
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString commands = @"Chat Commands";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString text = @"Text:";
+
+        public static LocalizedString titlestr = @"Title:";
+
+        public static LocalizedString title = @"Input Variable";
+
+        public static LocalizedString playervariable = @"Player Variable";
+
+        public static LocalizedString globalvariable = @"Global Variable";
+
+        public static LocalizedString guildvariable = @"Guild Variable";
+
+        public static LocalizedString minval = @"Minimum Value";
+
+        public static LocalizedString maxval = @"Maximum Value";
+
+        public static LocalizedString minlength = @"Minimum Length";
+
+        public static LocalizedString maxlength = @"Maximum Length";
+
+    }
+
+    public partial struct EventScreenFade
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Action = @"Action";
+
+        public static Dictionary<int, LocalizedString> FadeTypes = new Dictionary<int, LocalizedString>
         {
+            {0, @"Cancel"},
+            {1, @"Fade In"},
+            {2, @"Fade Out"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Variable = @"Variable";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PlayerVariable = @"Player Variable";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Okay";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ServerVariable = @"Global Variable";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Duration = @"Duration (ms)";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildVariable = @"Guild Variable";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Screen Fade";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString cancel = @"Cancel";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WaitForComplete = @"Wait for Completion?";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString okay = @"Ok";
+    public partial struct EventSpawnNpc
+    {
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString title = @"Set Guild Bank Slots Count";
-        }
+        public static LocalizedString cancel = @"Cancel";
 
-        public partial struct EventEditor
+        public static LocalizedString entity = @"Entity:";
+
+        public static LocalizedString npc = @"NPC:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString player = @"Player";
+
+        public static LocalizedString relativelocation = @"Relative Location:";
+
+        public static LocalizedString spawnrelative = @"Relative to Entity Direction";
+
+        public static LocalizedString spawntype = @"Spawn Type:";
+
+        public static LocalizedString spawntype0 = @"Specific Tile";
+
+        public static LocalizedString spawntype1 = @"On/Around Entity";
+
+        public static LocalizedString This = @"[THIS EVENT]";
+
+        public static LocalizedString title = @"Spawn Npc";
+
+    }
+
+    public partial struct EventStartCommonEvent
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AllInInstance = "Run for all players in instance?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AllowInOverworld = "Even on Overworld?";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Common Event:";
+
+        public static LocalizedString okay = @"Ok";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OverworldOverrideTooltip = "WARNING: THIS WILL RUN FOR (ALMOST) ALL USERS, USE AT YOUR OWN RISK!";
+
+        public static LocalizedString title = @"Start Common Event";
+
+    }
+
+    public partial struct EventStartQuest
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Quest:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString showwindow = @"Show Offer Window?";
+
+        public static LocalizedString title = @"Start Quest";
+
+    }
+
+    public partial struct EventWait
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Wait (ms):";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Wait";
+
+    }
+
+    public partial struct EventWaitForRouteCompletion
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Entity:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString player = @"Player";
+
+        public static LocalizedString This = @"[THIS EVENT]";
+
+        public static LocalizedString title = @"Wait for Move Route Completion";
+
+    }
+
+    public partial struct EventWarp
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Warp";
+
+    }
+
+    public partial struct General
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString False = @"False";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Missing = @"Missing Translation";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString No = @"No";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString None = @"None";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Okay = @"Okay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString True = @"True";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Yes = @"Yes";
+    }
+
+    public partial struct GameObjectStrings
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString New = @"New {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UserVariable = @"User Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UserVariables = @"User Variables";
+    }
+
+    public partial struct Time
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixDays = @"{00}d";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixHours = @"{00}h";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixMilliseconds = @"{00}ms";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixMinutes = @"{00}m";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixSeconds = @"{00}s";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuffixWeeks = @"{00}w";
+    }
+
+    public partial struct ItemEditor
+    {
+
+        public static LocalizedString abilitypowerbonus = @"Ability Pwr:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AddBonusEffect = @"Add";
+
+        public static LocalizedString animation = @"Animation on Use:";
+
+        public static LocalizedString attackanimation = @"Extra Attack Animation:";
+
+        public static LocalizedString attackbonus = @"Attack:";
+
+        public static LocalizedString attackspeed = @"Attack Speed";
+
+        public static LocalizedString attackspeedmodifier = @"Modifier:";
+
+        public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
         {
+            {0, @"Disabled"},
+            {1, @"Static (ms)"},
+            {2, @"Percentage"},
+        };
 
-            public static LocalizedString addcommand = @"Add Commands";
+        public static LocalizedString attackspeedvalue = @"Value:";
 
-            public static LocalizedString animation = @"Animation";
+        public static LocalizedString bagpanel = @"Bag:";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString bagslots = @"Bag Slots:";
 
-            public static LocalizedString clearpage = @"Clear Page";
+        public static LocalizedString basedamage = @"Base Damage:";
 
-            public static LocalizedString command = @"/Command: /";
+        public static LocalizedString BlockChance = @"Block Chance (%):";
+        public static LocalizedString BlockAmount = @"Block Amount (%):";
+        public static LocalizedString BlockAbsorption = @"Block Damage Absorption (%):";
 
-            public static LocalizedString commandlist = @"Commands:";
+        public static LocalizedString bonusamount = @"Effect Amount (%):";
 
-            public static Dictionary<int, LocalizedString> commontriggers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Login"},
-                {2, @"Level Up"},
-                {3, @"On Respawn"},
-                {4, @"/Command"},
-                {5, @"Autorun"},
-                {6, @"PVP Kill"},
-                {7, @"PVP Death"},
-                {8, @"Player Interact"},
-                {9, @"Equipment Changed"},
-                {10, @"Player Variable Changed"},
-                {11, @"Server Variable Changed"},
-                {12, @"Guild Member Joined"},
-                {13, @"Guild Member Left"},
-                {14, @"Guild Member Kicked"},
-                {15, @"Guild Variable Changed"},
-                {16, @"Inventory Changed"},
-                {17, @"Map Changed"},
-                {18, @"User Variable Changed"},
-            };
+        public static LocalizedString bonuseffect = @"Bonus Effect:";
 
-            public static LocalizedString conditions = @"Conditions";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BonusEffectGroup = @"Bonus Effects";
 
-            public static LocalizedString copypage = @"Copy Page";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BonusEffectItem = @"{00}: {01}%";
 
-            public static LocalizedString copycommand = @"Copy";
-
-            public static LocalizedString cutcommand = @"Cut";
-
-            public static LocalizedString deletecommand = @"Delete";
-
-            public static LocalizedString deletepage = @"Delete Page";
-
-            public static LocalizedString directionfix = @"Dir Fix";
-
-            public static LocalizedString disableinspector = @"Disable Inspector";
-
-            public static LocalizedString editcommand = @"Edit";
-
-            public static LocalizedString editconditions = @"Spawn/Execution Conditions";
-
-            public static LocalizedString entityoptions = @"Entity Options";
-
-            public static LocalizedString eventpreview = @"Preview";
-
-            public static LocalizedString extras = @"Extras:";
-
-            public static LocalizedString face = @"Face:";
-
-            public static LocalizedString frequency = @"Freq:";
-
-            public static Dictionary<int, LocalizedString> frequencies = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Not Very Often"},
-                {1, @"Not Often"},
-                {2, @"Normal"},
-                {3, @"Often"},
-                {4, @"Very Often"},
-            };
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString global = @"Global Event";
-
-            public static LocalizedString hidename = @"Hide Name";
-
-            public static LocalizedString insertcommand = @"Insert";
-
-            public static LocalizedString inspector = @"Entity Inspector Options";
-
-            public static LocalizedString inspectordesc = @"Inspector Description:";
-
-            public static LocalizedString interactionfreeze = @"Interaction Freeze";
-
-            public static LocalizedString ignorenpcavoids = @"Ignore Npc Avoids";
-
-            public static LocalizedString layer = @"Layer:";
-
-            public static Dictionary<int, LocalizedString> layers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Below Player"},
-                {1, @"Same as Player"},
-                {2, @"Above Player"},
-            };
-
-            public static LocalizedString movement = @"Movement";
-
-            public static LocalizedString movementtype = @"Type:";
-
-            public static Dictionary<int, LocalizedString> movementtypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Random"},
-                {2, @"Move Route"},
-            };
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString newpage = @"New Page";
-
-            public static LocalizedString pageoptions = @"Page Options";
-
-            public static LocalizedString ParallelRun = @"Can run in Parallel?";
-
-            public static LocalizedString passable = @"Passable";
-
-            public static LocalizedString pastecommand = @"Paste";
-
-            public static LocalizedString pastepage = @"Paste Page";
-
-            public static LocalizedString projectile = @"Projectile:";
-
-            public static LocalizedString save = @"Save";
-
-            public static LocalizedString savecaption = @"Save Event?";
-
-            public static LocalizedString savedialogue = @"Do you want to save changes to this event?";
-
-            public static LocalizedString setroute = @"Set Route...";
-
-            public static LocalizedString speed = @"Speed:";
-
-            public static Dictionary<int, LocalizedString> speeds = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Slowest"},
-                {1, @"Slower"},
-                {2, @"Normal"},
-                {3, @"Faster"},
-                {4, @"Fastest"},
-            };
-
-            public static LocalizedString title = @"Event Editor - {00}";
-
-            public static LocalizedString trigger = @"Trigger";
-
-            public static Dictionary<int, LocalizedString> triggers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Action Button"},
-                {1, @"Player Collide"},
-                {2, @"Autorun"},
-                {3, "Player Bump"},
-            };
-
-            public static LocalizedString VariableTrigger = @"Variable:";
-
-            public static LocalizedString walkinganim = @"Walking Anim";
-
-        }
-
-        public partial struct EventEndQuest
+        public static Dictionary<int, LocalizedString> bonuseffects = new Dictionary<int, LocalizedString>
         {
+            {0, @"None"},
+            {1, @"Cooldown Reduction"},
+            {2, @"Life Steal"},
+            {3, @"Tenacity"},
+            {4, @"Luck"},
+            {5, @"EXP"},
+            {6, @"Mana Steal"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString bonuses = @"Stat Bonuses";
 
-            public static LocalizedString label = @"Quest:";
+        public static LocalizedString bonusrange = @"Stat Bonus Range (+-):";
 
-            public static LocalizedString okay = @"Ok";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanDrop = @"Can Drop?";
 
-            public static LocalizedString skipcompletion = @"Do not run completion event?";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DeathDropChance = @"Drop chance on Death (%):";
 
-            public static LocalizedString title = @"End Quest";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DespawnTime = @"Item Despawn Time (ms)";
 
-        }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString DespawnTimeTooltip = @"0 for server default";
 
-        public partial struct EventGiveExperience
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanBag = @"Can Bag?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanBank = @"Can Bank?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanGuildBank = @"Can Guild Bank?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanTrade = @"Can Trade?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CanSell = @"Can Sell?";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString consumeablepanel = @"Consumable";
+
+        public static LocalizedString consumeamount = @"Amount:";
+
+        public static LocalizedString cooldown = @"Cooldown (ms):";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroup = @"Cooldown Group:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroupTitle = @"Add Cooldown Group";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroupPrompt = @"Enter a name for the cooldown group you'd like to add:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreGlobalCooldown = @"Ignore Global Cooldown?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreCooldownReduction = @"Ignore Cooldown Reduction?";
+
+        public static LocalizedString CooldownOptions = @"Cooldown Options";
+
+        public static LocalizedString copy = @"Copy Item";
+
+        public static LocalizedString critchance = @"Crit Chance (%):";
+
+        public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
+
+        public static LocalizedString damagetype = @"Damage Type:";
+
+        public static LocalizedString defensebonus = @"Defense:";
+
+        public static LocalizedString delete = @"Delete Item";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this item? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Item";
+
+        public static LocalizedString description = @"Desc:";
+
+        public static LocalizedString equipment = @"Equipment";
+
+        public static LocalizedString equipmentanimation = @"Equipment Animation:";
+
+        public static LocalizedString Event = @"Event:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EventGroup = @"Event Triggers";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EventGroupLabel = @"Event";
+
+        public static Dictionary<ItemEventTriggers, LocalizedString> EventTriggerNames = new Dictionary<ItemEventTriggers, LocalizedString>
         {
+            {ItemEventTriggers.OnPickup, @"On Pickup"},
+            {ItemEventTriggers.OnDrop, @"On Drop"},
+            {ItemEventTriggers.OnUse, @"On Use"},
+            {ItemEventTriggers.OnEquip, @"On Equip"},
+            {ItemEventTriggers.OnUnequip, @"On Unequip"},
+            {ItemEventTriggers.OnHit, @"On Hit"},
+            {ItemEventTriggers.OnDamageReceived, @"On Damage Received"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Give Experience:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Give Experience";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AmountType = @"Amount Type";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Variable = @"Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Manual = @"Manual";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PlayerVariable = @"Player Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ServerVariable = @"Global Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GuildVariable = @"Guild Variable";
-
-        }
-
-        public partial struct EventGotoLabel
+        public static Dictionary<ItemEventTriggers, LocalizedString> EventTriggerSelections = new Dictionary<ItemEventTriggers, LocalizedString>
         {
+            {ItemEventTriggers.OnPickup, @"On Pickup: {00}"},
+            {ItemEventTriggers.OnDrop, @"On Drop: {00}"},
+            {ItemEventTriggers.OnUse, @"On Use: {00}"},
+            {ItemEventTriggers.OnEquip, @"On Equip: {00}"},
+            {ItemEventTriggers.OnUnequip, @"On Unequip: {00}"},
+            {ItemEventTriggers.OnHit, @"On Hit: {00}"},
+            {ItemEventTriggers.OnDamageReceived, @"On Damage Received: {00}"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString EventTriggerDisabled = @"'{00}' trigger is disabled for this item type";
 
-            public static LocalizedString label = @"Label:";
+        public static LocalizedString eventpanel = @"Event";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString femalepaperdoll = @"Female Paperdoll:";
 
-            public static LocalizedString title = @"Go To Label";
+        public static LocalizedString folderlabel = @"Folder:";
 
-        }
+        public static LocalizedString foldertitle = @"Add Folder";
 
-        public partial struct EventGraphic
-        {
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString general = @"General";
 
-            public static LocalizedString graphic = @"Graphic:";
+        public static LocalizedString health = @"Health:";
 
-            public static LocalizedString graphictype0 = @"None";
+        public static LocalizedString items = @"Items";
 
-            public static LocalizedString graphictype1 = @"Sprite";
+        public static LocalizedString magicresistbonus = @"Magic Resist:";
 
-            public static LocalizedString graphictype2 = @"Tileset";
+        public static LocalizedString malepaperdoll = @"Male Paperdoll:";
 
-            public static LocalizedString okay = @"Ok";
+        public static LocalizedString mana = @"Mana:";
 
-            public static LocalizedString preview = @"Graphic Preview";
+        public static LocalizedString regen = @"Regen";
 
-            public static LocalizedString title = @"Graphic Selector";
-
-            public static LocalizedString type = @"Graphic Type:";
-
-        }
-
-        public partial struct EventLabel
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Label:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Label";
-
-        }
-
-        public partial struct EventMoveRoute
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString command = @"Commands";
-
-            public static Dictionary<string, LocalizedString> commands = new Dictionary<string, LocalizedString>()
-            {
-                {"directionfixoff", @"Direction Fix: Off"},
-                {"directionfixon", @"Direction Fix: On"},
-                {"etc", @"Etc"},
-                {"facedown", @"Face Down"},
-                {"faceleft", @"Face Left"},
-                {"faceright", @"Face Right"},
-                {"faceup", @"Face Up"},
-                {"faster", @"Faster"},
-                {"fastest", @"Fastest"},
-                {"frequencynormal", @"Normal"},
-                {"hidename", @"Hide Name"},
-                {"higher", @"Higher"},
-                {"highest", @"Highest"},
-                {"lower", @"Lower"},
-                {"lowest", @"Lowest"},
-                {"move", @"Move"},
-                {"moveawayfromplayer", @"Move Away From Player"},
-                {"movedown", @"Move Down"},
-                {"moveleft", @"Move Left"},
-                {"moverandomly", @"Move Randomly"},
-                {"moveright", @"Move Right"},
-                {"movetowardplayer", @"Move Toward Player"},
-                {"moveup", @"Move Up"},
-                {"moveupleft", @"Move Up Left"},
-                {"moveupright", @"Move Up Right"},
-                {"movedownright", @"Move Down Right"},
-                {"movedownleft", @"Move Down Left"},
-                {"setanimation", @"Set Animation..."},
-                {"setattribute", @"Set Attribute"},
-                {"setgraphic", @"Set Graphic..."},
-                {"setlayerabove", @"Set Layer: Above Player"},
-                {"setlayerbelow", @"Set Layer: Below Player"},
-                {"setlayersame", @"Set Layer: Same as Player"},
-                {"setmovementfrequency", @"Set Movement Frequency"},
-                {"setspeed", @"Set Speed"},
-                {"showname", @"Show Name"},
-                {"slower", @"Slower"},
-                {"slowest", @"Slowest"},
-                {"speednormal", @"Normal"},
-                {"stepbackward", @"Step Backward"},
-                {"stepforward", @"Step Forward"},
-                {"turn", @"Turn"},
-                {"turn180", @"Turn 180*"},
-                {"turn90clockwise", @"Turn 90* Clockwise"},
-                {"turn90counterclockwise", @"Turn 90* Counter Clockwise"},
-                {"turnawayfromplayer", @"Turn Away From Player"},
-                {"turnrandomly", @"Turn Randomly"},
-                {"turntowardplayer", @"Turn Toward Player"},
-                {"wait100", @"Wait 100ms"},
-                {"wait1000", @"Wait 1000ms"},
-                {"wait500", @"Wait 500ms"},
-                {"walkinganimoff", @"Walking Animation: Off"},
-                {"walkinganimon", @"Walking Animation: On"},
-                {"walkthroughoff", @"Walkthrough: Off"},
-                {"walkthroughon", @"Walkthrough: On"},
-            };
-
-            public static LocalizedString ignoreblocked = @"Ignore if Blocked";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString player = @"Player";
-
-            public static LocalizedString repeatroute = @"Repeat Route";
-
-            public static LocalizedString thisevent = @"[THIS EVENT]";
-
-            public static LocalizedString title = @"Move Route";
-
-        }
-
-        public partial struct EventOpenCrafting
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Table:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString JournalMode = @"Journal Mode?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString JournalModeTooltip = @"Opens the crafting window without the option for the player to actually craft.";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Open Crafting";
-
-        }
-
-        public partial struct EventOpenShop
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Shop:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Open Shop";
-
-        }
-
-        public partial struct EventPlayAnimation
-        {
-
-            public static LocalizedString animation = @"Animation:";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString entity = @"Entity:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InstanceToPlayer = @"Instance to Player?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InstanceToPlayerTooltip = @"When enabled, only the player running this event will see the animation.";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString player = @"Player";
-
-            public static LocalizedString relativelocation = @"Relative Location:";
-
-            public static LocalizedString rotaterelative = @"Rotate Relative to Direction";
-
-            public static LocalizedString spawnrelative = @"Spawn Relative to Direction";
-
-            public static LocalizedString spawntype = @"Spawn Type:";
-
-            public static LocalizedString spawntype0 = @"Specific Tile";
-
-            public static LocalizedString spawntype1 = @"On/Around Entity";
-
-            public static LocalizedString This = @"[THIS EVENT]";
-
-            public static LocalizedString title = @"Play Animation";
-
-        }
-
-        public partial struct EventPlayBgm
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"BGM:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Play BGM";
-
-        }
-
-        public partial struct EventPlayBgs
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Sound:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Play BGS";
-
-        }
-
-        public partial struct EventSelfSwitch
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString False = @"False";
-
-            public static LocalizedString label = @"Set Self Switch:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static Dictionary<int, LocalizedString> selfswitches = new Dictionary<int, LocalizedString>
-            {
-                {0, @"A"},
-                {1, @"B"},
-                {2, @"C"},
-                {3, @"D"},
-            };
-
-            public static LocalizedString title = @"Set Self Switch";
-
-            public static LocalizedString True = @"True";
-
-        }
-
-        public partial struct EventSetAccess
-        {
-
-            public static LocalizedString access0 = @"Regular User";
-
-            public static LocalizedString access1 = @"In-Game Moderator";
-
-            public static LocalizedString access2 = @"Owner/Designer (Allows editor access)";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Access:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Set Access";
-
-        }
-
-        public partial struct EventSetAnimation
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Animation:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Set Animation";
-
-        }
-
-        public partial struct EventSetClass
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Class:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Set Class";
-
-        }
-
-        public partial struct EventSetVariable
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString global = @"Global Variable";
-
-            public static LocalizedString guild = @"Guild Variable";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString player = @"Player Variable";
-
-            public static LocalizedString title = @"Set Variable";
-
-            public static LocalizedString syncparty = @"Party Sync?";
-
-            public static LocalizedString label = @"Select Variable:";
-
-            public static LocalizedString booleanlabel = @"Boolean Variable:";
-
-            public static LocalizedString booleantrue = @"True";
-
-            public static LocalizedString booleanfalse = @"False";
-
-            public static LocalizedString numericlabel = @"Integer Variable:";
-
-            public static LocalizedString numericadd = @"Add";
-
-            public static LocalizedString numericdivide = @"Divide";
-
-            public static LocalizedString numericleftshift = @"LShift";
-
-            public static LocalizedString numericmultiply = @"Multiply";
-
-            public static LocalizedString numericrandom = @"Random";
-
-            public static LocalizedString numericrandomhigh = @"High:";
-
-            public static LocalizedString numericrandomlow = @"Low:";
-
-            public static LocalizedString numericrandomdesc = @"Random Number:";
-
-            public static LocalizedString numericrightshift = @"RShift";
-
-            public static LocalizedString numericset = @"Set";
-
-            public static LocalizedString numericsubtract = @"Subtract";
-
-            public static LocalizedString numericsystemtime = @"System Time (ms)";
-
-            public static LocalizedString stringlabel = @"String Variable:";
-
-            public static LocalizedString stringset = @"Set";
-
-            public static LocalizedString stringreplace = @"Replace";
-
-            public static LocalizedString stringsetvalue = @"Value:";
-
-            public static LocalizedString stringreplacefind = @"Find:";
-
-            public static LocalizedString stringreplacereplace = @"Replace:";
-
-            public static LocalizedString stringtip = @"Text variables work with strings. Click here for a list!";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString VariableValue = @"Variable Value";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SetVariableGroup = @"Set to Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SelectVariableGroup = @"Select Variable";
-        }
-
-        public partial struct EventShowOptions
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString commands = @"Chat Commands";
-
-            public static LocalizedString face = @"Face:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString option1 = @"Option 1";
-
-            public static LocalizedString option2 = @"Option 2";
-
-            public static LocalizedString option3 = @"Option 3";
-
-            public static LocalizedString option4 = @"Option 4";
-
-            public static LocalizedString text = @"Text:";
-
-            public static LocalizedString title = @"Show Options";
-
-        }
-
-        public partial struct EventShowText
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString commands = @"Chat Commands";
-
-            public static LocalizedString face = @"Face:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString text = @"Text:";
-
-            public static LocalizedString title = @"Show Text";
-
-        }
-
-        public partial struct EventInput
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString commands = @"Chat Commands";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString text = @"Text:";
-
-            public static LocalizedString titlestr = @"Title:";
-
-            public static LocalizedString title = @"Input Variable";
-
-            public static LocalizedString playervariable = @"Player Variable";
-
-            public static LocalizedString globalvariable = @"Global Variable";
-
-            public static LocalizedString guildvariable = @"Guild Variable";
-
-            public static LocalizedString minval = @"Minimum Value";
-
-            public static LocalizedString maxval = @"Maximum Value";
-
-            public static LocalizedString minlength = @"Minimum Length";
-
-            public static LocalizedString maxlength = @"Maximum Length";
-
-        }
-
-        public partial struct EventScreenFade
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Action = @"Action";
-
-            public static Dictionary<int, LocalizedString> FadeTypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Cancel"},
-                {1, @"Fade In"},
-                {2, @"Fade Out"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Okay";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Duration = @"Duration (ms)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Screen Fade";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WaitForComplete = @"Wait for Completion?";
-        }
-
-        public partial struct EventSpawnNpc
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString entity = @"Entity:";
-
-            public static LocalizedString npc = @"NPC:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString player = @"Player";
-
-            public static LocalizedString relativelocation = @"Relative Location:";
-
-            public static LocalizedString spawnrelative = @"Relative to Entity Direction";
-
-            public static LocalizedString spawntype = @"Spawn Type:";
-
-            public static LocalizedString spawntype0 = @"Specific Tile";
-
-            public static LocalizedString spawntype1 = @"On/Around Entity";
-
-            public static LocalizedString This = @"[THIS EVENT]";
-
-            public static LocalizedString title = @"Spawn Npc";
-
-        }
-
-        public partial struct EventStartCommonEvent
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AllInInstance = "Run for all players in instance?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AllowInOverworld = "Even on Overworld?";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Common Event:";
-
-            public static LocalizedString okay = @"Ok";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString OverworldOverrideTooltip = "WARNING: THIS WILL RUN FOR (ALMOST) ALL USERS, USE AT YOUR OWN RISK!";
-
-            public static LocalizedString title = @"Start Common Event";
-
-        }
-
-        public partial struct EventStartQuest
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Quest:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString showwindow = @"Show Offer Window?";
-
-            public static LocalizedString title = @"Start Quest";
-
-        }
-
-        public partial struct EventWait
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Wait (ms):";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Wait";
-
-        }
-
-        public partial struct EventWaitForRouteCompletion
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString label = @"Entity:";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString player = @"Player";
-
-            public static LocalizedString This = @"[THIS EVENT]";
-
-            public static LocalizedString title = @"Wait for Move Route Completion";
-
-        }
-
-        public partial struct EventWarp
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Warp";
-
-        }
-
-        public partial struct General
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cancel = @"Cancel";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString False = @"False";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Missing = @"Missing Translation";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString No = @"No";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString None = @"None";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Okay = @"Okay";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString True = @"True";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Yes = @"Yes";
-        }
-
-        public partial struct GameObjectStrings
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString New = @"New {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UserVariable = @"User Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UserVariables = @"User Variables";
-        }
-
-        public partial struct Time
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixDays = @"{00}d";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixHours = @"{00}h";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixMilliseconds = @"{00}ms";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixMinutes = @"{00}m";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixSeconds = @"{00}s";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SuffixWeeks = @"{00}w";
-        }
-
-        public partial struct ItemEditor
-        {
-
-            public static LocalizedString abilitypowerbonus = @"Ability Pwr:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AddBonusEffect = @"Add";
-
-            public static LocalizedString animation = @"Animation on Use:";
-
-            public static LocalizedString attackanimation = @"Extra Attack Animation:";
-
-            public static LocalizedString attackbonus = @"Attack:";
-
-            public static LocalizedString attackspeed = @"Attack Speed";
-
-            public static LocalizedString attackspeedmodifier = @"Modifier:";
-
-            public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Disabled"},
-                {1, @"Static (ms)"},
-                {2, @"Percentage"},
-            };
-
-            public static LocalizedString attackspeedvalue = @"Value:";
-
-            public static LocalizedString bagpanel = @"Bag:";
-
-            public static LocalizedString bagslots = @"Bag Slots:";
-
-            public static LocalizedString basedamage = @"Base Damage:";
-
-            public static LocalizedString BlockChance = @"Block Chance (%):";
-            public static LocalizedString BlockAmount = @"Block Amount (%):";
-            public static LocalizedString BlockAbsorption = @"Block Damage Absorption (%):";
-
-            public static LocalizedString bonusamount = @"Effect Amount (%):";
-
-            public static LocalizedString bonuseffect = @"Bonus Effect:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BonusEffectGroup = @"Bonus Effects";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BonusEffectItem = @"{00}: {01}%";
-
-            public static Dictionary<int, LocalizedString> bonuseffects = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Cooldown Reduction"},
-                {2, @"Life Steal"},
-                {3, @"Tenacity"},
-                {4, @"Luck"},
-                {5, @"EXP"},
-                {6, @"Mana Steal"},
-            };
-
-            public static LocalizedString bonuses = @"Stat Bonuses";
-
-            public static LocalizedString bonusrange = @"Stat Bonus Range (+-):";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanDrop = @"Can Drop?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DeathDropChance = @"Drop chance on Death (%):";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DespawnTime = @"Item Despawn Time (ms)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString DespawnTimeTooltip = @"0 for server default";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanBag = @"Can Bag?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanBank = @"Can Bank?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanGuildBank = @"Can Guild Bank?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanTrade = @"Can Trade?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CanSell = @"Can Sell?";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString consumeablepanel = @"Consumable";
-
-            public static LocalizedString consumeamount = @"Amount:";
-
-            public static LocalizedString cooldown = @"Cooldown (ms):";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroup = @"Cooldown Group:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroupTitle = @"Add Cooldown Group";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroupPrompt = @"Enter a name for the cooldown group you'd like to add:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreGlobalCooldown = @"Ignore Global Cooldown?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreCooldownReduction = @"Ignore Cooldown Reduction?";
-
-            public static LocalizedString CooldownOptions = @"Cooldown Options";
-
-            public static LocalizedString copy = @"Copy Item";
-
-            public static LocalizedString critchance = @"Crit Chance (%):";
-
-            public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
-
-            public static LocalizedString damagetype = @"Damage Type:";
-
-            public static LocalizedString defensebonus = @"Defense:";
-
-            public static LocalizedString delete = @"Delete Item";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this item? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Item";
-
-            public static LocalizedString description = @"Desc:";
-
-            public static LocalizedString equipment = @"Equipment";
-
-            public static LocalizedString equipmentanimation = @"Equipment Animation:";
-
-            public static LocalizedString Event = @"Event:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EventGroup = @"Event Triggers";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EventGroupLabel = @"Event";
-
-            public static Dictionary<ItemEventTriggers, LocalizedString> EventTriggerNames = new Dictionary<ItemEventTriggers, LocalizedString>
-            {
-                {ItemEventTriggers.OnPickup, @"On Pickup"},
-                {ItemEventTriggers.OnDrop, @"On Drop"},
-                {ItemEventTriggers.OnUse, @"On Use"},
-                {ItemEventTriggers.OnEquip, @"On Equip"},
-                {ItemEventTriggers.OnUnequip, @"On Unequip"},
-                {ItemEventTriggers.OnHit, @"On Hit"},
-                {ItemEventTriggers.OnDamageReceived, @"On Damage Received"},
-            };
-
-            public static Dictionary<ItemEventTriggers, LocalizedString> EventTriggerSelections = new Dictionary<ItemEventTriggers, LocalizedString>
-            {
-                {ItemEventTriggers.OnPickup, @"On Pickup: {00}"},
-                {ItemEventTriggers.OnDrop, @"On Drop: {00}"},
-                {ItemEventTriggers.OnUse, @"On Use: {00}"},
-                {ItemEventTriggers.OnEquip, @"On Equip: {00}"},
-                {ItemEventTriggers.OnUnequip, @"On Unequip: {00}"},
-                {ItemEventTriggers.OnHit, @"On Hit: {00}"},
-                {ItemEventTriggers.OnDamageReceived, @"On Damage Received: {00}"},
-            };
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString EventTriggerDisabled = @"'{00}' trigger is disabled for this item type";
-
-            public static LocalizedString eventpanel = @"Event";
-
-            public static LocalizedString femalepaperdoll = @"Female Paperdoll:";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString health = @"Health:";
-
-            public static LocalizedString items = @"Items";
-
-            public static LocalizedString magicresistbonus = @"Magic Resist:";
-
-            public static LocalizedString malepaperdoll = @"Male Paperdoll:";
-
-            public static LocalizedString mana = @"Mana:";
-
-            public static LocalizedString regen = @"Regen";
-
-            public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
+        public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
 Tick timer saved in server config.json.";
 
-            public static LocalizedString hpregen = @"HP (%);";
+        public static LocalizedString hpregen = @"HP (%);";
 
-            public static LocalizedString mpregen = @"MP (%):";
+        public static LocalizedString mpregen = @"MP (%):";
 
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString New = @"New Item";
+        public static LocalizedString New = @"New Item";
 
-            public static LocalizedString paste = @"Paste Item";
+        public static LocalizedString paste = @"Paste Item";
 
-            public static LocalizedString picture = @"Pic:";
+        public static LocalizedString picture = @"Pic:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Red = @"Red:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Red = @"Red:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Green = @"Green:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Green = @"Green:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Blue = @"Blue:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Blue = @"Blue:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Alpha = @"Alpha:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Alpha = @"Alpha:";
 
-            public static LocalizedString price = @"Price:";
+        public static LocalizedString price = @"Price:";
 
-            public static Dictionary<string, LocalizedString> rarity = new Dictionary<string, LocalizedString>
-            {
-                {"None", @"None"},
-                {"Common", @"Common"},
-                {"Uncommon", @"Uncommon"},
-                {"Rare", @"Rare"},
-                {"Epic", @"Epic"},
-                {"Legendary", @"Legendary"},
-            };
-
-            public static LocalizedString projectile = @"Projectile:";
-
-            public static LocalizedString requirementsgroup = @"Requirements";
-
-            public static LocalizedString cannotuse = @"Cannot Use Message:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString RemoveBonusEffect = @"Remove";
-
-            public static LocalizedString requirements = @"Edit Usage Requirements";
-
-            public static LocalizedString save = @"Save";
-
-            public static LocalizedString scalingamount = @"Scaling Amount (%):";
-
-            public static LocalizedString scalingstat = @"Scaling Stat:";
-
-            public static LocalizedString searchplaceholder = @"Search...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
-
-            public static LocalizedString slot = @"Equipment Slot:";
-
-            public static LocalizedString speedbonus = @"Speed:";
-
-            public static LocalizedString spell = @"Spell:";
-
-            public static LocalizedString spellpanel = @"Spell";
-
-            public static LocalizedString quickcast = @"Quick Cast Spell?";
-
-            public static LocalizedString destroyspell = @"Destroy On Use?";
-
-            public static LocalizedString SingleUseEvent = @"Destroy On Use?";
-
-            public static LocalizedString StackOptions = @"Stackable Options";
-
-            public static LocalizedString stackable = @"Stackable?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatRangeFrom = @"From";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatRangeItem = @"{00}: {01} to {02}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatRangeTitle = @"Stat Ranges";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString StatRangeTo = @"to";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InventoryStackLimit = @"Inventory Stack Limit:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString BankStackLimit = @"Bank Stack Limit:";
-
-            public static LocalizedString title = @"Item Editor";
-
-            public static LocalizedString tooltype = @"Tool Type:";
-
-            public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
-
-            public static LocalizedString twohanded = @"2 Hand";
-
-            public static LocalizedString type = @"Type:";
-
-            public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Equipment"},
-                {2, @"Consumable"},
-                {3, @"Currency"},
-                {4, @"Spell"},
-                {5, @"Event"},
-                {6, @"Bag"},
-            };
-
-            public static LocalizedString undo = @"Undo Changes";
-
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this item? This action cannot be reverted!";
-
-            public static LocalizedString undotitle = @"Undo Changes";
-
-            public static LocalizedString vital = @"Vital:";
-
-            public static LocalizedString vitalbonuses = @"Vital Bonuses";
-
-            public static LocalizedString ShieldProperties = @"Shield Properties:";
-
-            public static LocalizedString weaponproperties = @"Weapon Properties";
-
-        }
-
-        public partial struct LightEditor
+        public static Dictionary<string, LocalizedString> rarity = new Dictionary<string, LocalizedString>
         {
+            {"None", @"None"},
+            {"Common", @"Common"},
+            {"Uncommon", @"Uncommon"},
+            {"Rare", @"Rare"},
+            {"Epic", @"Epic"},
+            {"Legendary", @"Legendary"},
+        };
 
-            public static LocalizedString color = @"Color";
+        public static LocalizedString projectile = @"Projectile:";
 
-            public static LocalizedString expandamt = @"Expansion %";
+        public static LocalizedString requirementsgroup = @"Requirements";
 
-            public static LocalizedString intensity = @"Intensity";
+        public static LocalizedString cannotuse = @"Cannot Use Message:";
 
-            public static LocalizedString revert = @"Undo";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString RemoveBonusEffect = @"Remove";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString requirements = @"Edit Usage Requirements";
 
-            public static LocalizedString SelectColor = @"Select Color";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString size = @"Size (px)";
+        public static LocalizedString scalingamount = @"Scaling Amount (%):";
 
-            public static LocalizedString title = @"Light Editor";
+        public static LocalizedString scalingstat = @"Scaling Stat:";
 
-            public static LocalizedString xoffset = @"Offset X";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            public static LocalizedString yoffset = @"Offset Y";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-        }
+        public static LocalizedString slot = @"Equipment Slot:";
 
-        public partial struct Login
+        public static LocalizedString speedbonus = @"Speed:";
+
+        public static LocalizedString spell = @"Spell:";
+
+        public static LocalizedString spellpanel = @"Spell";
+
+        public static LocalizedString quickcast = @"Quick Cast Spell?";
+
+        public static LocalizedString destroyspell = @"Destroy On Use?";
+
+        public static LocalizedString SingleUseEvent = @"Destroy On Use?";
+
+        public static LocalizedString StackOptions = @"Stackable Options";
+
+        public static LocalizedString stackable = @"Stackable?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatRangeFrom = @"From";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatRangeItem = @"{00}: {01} to {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatRangeTitle = @"Stat Ranges";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StatRangeTo = @"to";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InventoryStackLimit = @"Inventory Stack Limit:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BankStackLimit = @"Bank Stack Limit:";
+
+        public static LocalizedString title = @"Item Editor";
+
+        public static LocalizedString tooltype = @"Tool Type:";
+
+        public static LocalizedString AttackSpriteOverride = @"Sprite Attack Animation:";
+
+        public static LocalizedString twohanded = @"2 Hand";
+
+        public static LocalizedString type = @"Type:";
+
+        public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
         {
+            {0, @"None"},
+            {1, @"Equipment"},
+            {2, @"Consumable"},
+            {3, @"Currency"},
+            {4, @"Spell"},
+            {5, @"Event"},
+            {6, @"Bag"},
+        };
 
-            public static LocalizedString connected = @"Connected to server. Ready to login!";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString connecting = @"Connecting to server...";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this item? This action cannot be reverted!";
 
-            public static LocalizedString failedtoconnect = @"Failed to connect, retrying in {00} seconds.";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            public static LocalizedString Denied = @"Connection denied. Version mismatch?";
+        public static LocalizedString vital = @"Vital:";
 
-            public static LocalizedString gettingstarted = @"Getting Started?
+        public static LocalizedString vitalbonuses = @"Vital Bonuses";
+
+        public static LocalizedString ShieldProperties = @"Shield Properties:";
+
+        public static LocalizedString weaponproperties = @"Weapon Properties";
+
+    }
+
+    public partial struct LightEditor
+    {
+
+        public static LocalizedString color = @"Color";
+
+        public static LocalizedString expandamt = @"Expansion %";
+
+        public static LocalizedString intensity = @"Intensity";
+
+        public static LocalizedString revert = @"Undo";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString SelectColor = @"Select Color";
+
+        public static LocalizedString size = @"Size (px)";
+
+        public static LocalizedString title = @"Light Editor";
+
+        public static LocalizedString xoffset = @"Offset X";
+
+        public static LocalizedString yoffset = @"Offset Y";
+
+    }
+
+    public partial struct Login
+    {
+
+        public static LocalizedString connected = @"Connected to server. Ready to login!";
+
+        public static LocalizedString connecting = @"Connecting to server...";
+
+        public static LocalizedString failedtoconnect = @"Failed to connect, retrying in {00} seconds.";
+
+        public static LocalizedString Denied = @"Connection denied. Version mismatch?";
+
+        public static LocalizedString gettingstarted = @"Getting Started?
         1. Start the Intersect Server
         2. Open the Intersect Client and Create an Account
         3. Login to that account here to start designing your game!";
 
-            public static LocalizedString login = @"Login";
+        public static LocalizedString login = @"Login";
 
-            public static LocalizedString password = @"Password: ";
+        public static LocalizedString password = @"Password: ";
 
-            public static LocalizedString raptr =
-                @"Please close AMD Gaming Evolved before logging into the Intersect editor.";
+        public static LocalizedString raptr =
+            @"Please close AMD Gaming Evolved before logging into the Intersect editor.";
 
-            public static LocalizedString rememberme = @"Remember Me";
+        public static LocalizedString rememberme = @"Remember Me";
 
-            public static LocalizedString title = @"Intersect Editor Login";
+        public static LocalizedString title = @"Intersect Editor Login";
 
-            public static LocalizedString username = @"Username: ";
+        public static LocalizedString username = @"Username: ";
 
-            public static LocalizedString version = @"Editor v{00}";
+        public static LocalizedString version = @"Editor v{00}";
 
-        }
+    }
 
-        public partial struct MainForm
+    public partial struct MainForm
+    {
+
+        public static LocalizedString about = @"About";
+
+        public static LocalizedString alllayers = @"All Layers";
+
+        public static LocalizedString animationeditor = @"Animation Editor";
+
+        public static LocalizedString classeditor = @"Class Editor";
+
+        public static LocalizedString commoneventeditor = @"Common Event Editor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Copy = @"Copy (Ctrl + C)";
+
+        public static LocalizedString craftingtableeditor = @"Crafting Table Editor";
+
+        public static LocalizedString craftingeditor = @"Crafts Editor";
+
+        public static LocalizedString currentonly = @"Current Layer Only";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cut = @"Cut (Ctrl + X)";
+
+        public static LocalizedString darkness = @"Darkness";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Dropper = @"Dropper (I)";
+
+        public static LocalizedString edit = @"Edit";
+
+        public static LocalizedString editors = @"Game Editors";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Erase = @"Erase (E)";
+
+        public static LocalizedString exit = @"Exit";
+
+        public static LocalizedString exportmap = @"Export Map";
+
+        public static LocalizedString file = @"File";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Fill = @"Fill (F)";
+
+        public static LocalizedString fog = @"Fog";
+
+        public static LocalizedString fps = @"FPS: {00}";
+
+        public static LocalizedString grid = @"Map Grid";
+
+        public static LocalizedString help = @"Help";
+
+        public static LocalizedString importmap = @"Import Map";
+
+        public static LocalizedString itemeditor = @"Item Editor";
+
+        public static LocalizedString lighting = @"Toggle Time of Day Simulation On/Off";
+
+        public static LocalizedString loc = @"CurX: {00}  CurY: {01}";
+
+        public static LocalizedString newmap = @"New Map";
+
+        public static LocalizedString npceditor = @"Npc Editor";
+
+        public static LocalizedString options = @"Options";
+
+        public static LocalizedString overlay = @"Overlay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Paste = @"Paste (Ctrl + V)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Brush = @"Brush (B)";
+
+        public static LocalizedString postquestion = @"Post Question";
+
+        public static LocalizedString projectileeditor = @"Projectile Editor";
+
+        public static LocalizedString questeditor = @"Quest Editor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Rectangle = @"Rectangle Fill (R)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Redo = @"Redo (Ctrl + Y)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FlipHorizontal = @"Horizontal Flip Selection (PageDown)";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FlipVertical = @"Vertical Flip Selection (PageUp)";
+
+        public static LocalizedString reportbug = @"Report Bug";
+
+        public static LocalizedString resourceeditor = @"Resource Editor";
+
+        public static LocalizedString resources = @"Resources";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Events = @"Events";
+
+        public static LocalizedString revision = @"Revision: {00}";
+
+        public static LocalizedString run = @"Run Client";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SaveMap = @"Save Map (Ctrl + S)";
+
+        public static LocalizedString screenshot = @"Screenshot Map";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Selection = @"Marquee Selection (M)";
+
+        public static LocalizedString selectlayers = @"Select...";
+
+        public static LocalizedString shopeditor = @"Shop Editor";
+
+        public static LocalizedString spelleditor = @"Spell Editor";
+
+        public static LocalizedString variableeditor = @"Variable Editor";
+
+        public static LocalizedString tilepreview = @"Tile Preview";
+
+        public static LocalizedString timeeditor = @"Time Editor";
+
+        public static LocalizedString title = @"Intersect Editor - {00}";
+
+        public static LocalizedString tools = @"Tools";
+
+        public static LocalizedString MenuToolsPackageUpdate = @"Package Update";
+
+        public static LocalizedString toolsdir = @"tools";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Undo = @"Undo (Ctrl + Z)";
+
+        public static LocalizedString view = @"View";
+
+    }
+
+    public partial struct MapCacheProgress
+    {
+
+        public static LocalizedString title = @"Saving Map Cache";
+
+        public static LocalizedString remaining = @"{00} maps remaining.";
+
+    }
+
+    public partial struct MapGrid
+    {
+
+        public static LocalizedString clearandfetch =
+            @"Are you sure you want to clear the existing previews and fetch previews for each map on this grid? This could take several minutes based on the number of maps in this grid!";
+
+        public static LocalizedString downloadall = @"Re-Download All Previews";
+
+        public static LocalizedString downloadmissing = @"Download Missing Previews";
+
+        public static LocalizedString fetchcaption = @"Fetch Preview?";
+
+        public static LocalizedString fetchingmaps = @"Fetching Map Previews";
+
+        public static LocalizedString fetchingprogress = @"Fetching Maps {00} / {01}";
+
+        public static LocalizedString gridlines = @"Show/Hide Grid Lines";
+
+        public static LocalizedString justfetch =
+            @"Are you sure you want to fetch previews for each map? This could take several minutes based on the number of maps in this grid!";
+
+        public static LocalizedString keepmapcache =
+            @"Use your current settings with the map cache? (No to disable lighting/fogs/other effects)";
+
+        public static LocalizedString link = @"Link Map";
+
+        public static LocalizedString mapcachecaption = @"Map Cache Options";
+
+        public static LocalizedString preview = @"Fetch Preview";
+
+        public static LocalizedString recache = @"Recache Map";
+
+        public static LocalizedString savescreenshotconfirm =
+            @"Are you sure you want to save a screenshot of your world to a file? This could take several minutes!";
+
+        public static LocalizedString savescreenshotdialogue = @"Save a screenshot of the world";
+
+        public static LocalizedString savescreenshottitle = @"Save Screenshot?";
+
+        public static LocalizedString savingrow = @"Saving Row: {00} / {01}";
+
+        public static LocalizedString savingscreenshot = @"Saving Screenshot";
+
+        public static LocalizedString screenshotworld = @"Take a world screenshot";
+
+        public static LocalizedString title = @"Map Grid";
+
+        public static LocalizedString unlink = @"Unlink Map";
+
+        public static LocalizedString unlinkcaption = @"Unlink Map";
+
+        public static LocalizedString unlinkprompt = @"Are you sure you want to unlink map {00}?";
+
+    }
+
+    public partial struct MapLayers
+    {
+
+        public static LocalizedString attributes = @"Attributes";
+
+        public static LocalizedString eventinstructions = @"Double click a tile on the map to create an event!";
+
+        public static LocalizedString events = @"Events";
+
+        public static LocalizedString lightinstructions =
+            @"Lower the maps brightness and double click on a tile to create a light!";
+
+        public static LocalizedString lights = @"Lights";
+
+        public static LocalizedString npcs = @"Npcs";
+
+        public static LocalizedString tiles = @"Tiles";
+
+        public static LocalizedString title = @"Map Layers";
+
+    }
+
+    public partial struct MapList
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString alphabetical = @"Alphabetical";
+
+        public static LocalizedString copyid = @"Copy Id";
+
+        public static LocalizedString delete = @"Delete";
+
+        public static LocalizedString deleteconfirm = @"Are you sure you want to delete {00}?";
+
+        public static LocalizedString newfolder = @"New Folder";
+
+        public static LocalizedString newmap = @"New Map";
+
+        public static LocalizedString rename = @"Rename";
+
+        public static LocalizedString selectcurrent = @"Select Current Map";
+
+        public static LocalizedString selecttodelete = @"Please select a folder or map to delete.";
+
+        public static LocalizedString selecttorename = @"Please select a folder or map to rename.";
+
+        public static LocalizedString title = @"Map List";
+
+    }
+
+    public partial struct Mapping
+    {
+        public static LocaleDictionary<MapInstanceType, LocalizedString> InstanceTypes = new LocaleDictionary<MapInstanceType, LocalizedString>()
         {
+            {MapInstanceType.Overworld, @"Overworld"},
+            {MapInstanceType.Personal, @"Personal"},
+            {MapInstanceType.Guild, @"Guild"},
+            {MapInstanceType.Shared, @"Shared"},
+        };
 
-            public static LocalizedString about = @"About";
+        public static LocalizedString createmap = @"Create new map.";
 
-            public static LocalizedString alllayers = @"All Layers";
+        public static LocalizedString createmapdialogue = @"Do you want to create a map here?";
 
-            public static LocalizedString animationeditor = @"Animation Editor";
+        public static LocalizedString diagonalwarning = @"Cannot create maps diagonally!";
 
-            public static LocalizedString classeditor = @"Class Editor";
+        public static LocalizedString editortitle = @"Map Editor";
 
-            public static LocalizedString commoneventeditor = @"Common Event Editor";
+        public static LocalizedString eraselayer = @"Erase Layer";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Copy = @"Copy (Ctrl + C)";
+        public static LocalizedString eraselayerdialogue = @"Are you sure you want to erase this layer?";
 
-            public static LocalizedString craftingtableeditor = @"Crafting Table Editor";
+        public static LocalizedString filllayer = @"Fill Layer";
 
-            public static LocalizedString craftingeditor = @"Crafts Editor";
+        public static LocalizedString filllayerdialogue = @"Are you sure you want to fill this layer?";
 
-            public static LocalizedString currentonly = @"Current Layer Only";
+        public static LocalizedString newmap = @"Are you sure you want to create a new, unconnected map?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Cut = @"Cut (Ctrl + X)";
+        public static LocalizedString newmapcaption = @"New Map";
 
-            public static LocalizedString darkness = @"Darkness";
+        public static LocalizedString savemap = @"Save current map?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Dropper = @"Dropper (I)";
+        public static LocalizedString savemapdialogue = @"Do you want to save your current map?";
 
-            public static LocalizedString edit = @"Edit";
+        public static LocalizedString savemapdialoguesure = @"Are you sure you want to save your current map?";
 
-            public static LocalizedString editors = @"Game Editors";
+        public static LocalizedString mapnotsaved = @"Unsaved changes!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Erase = @"Erase (E)";
+        public static LocalizedString maphaschangesdialog =
+            @"There are unsaved changes to this map, are you sure you want to exit?";
 
-            public static LocalizedString exit = @"Exit";
+    }
 
-            public static LocalizedString exportmap = @"Export Map";
+    public partial struct MapProperties
+    {
 
-            public static LocalizedString file = @"File";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Fill = @"Fill (F)";
-
-            public static LocalizedString fog = @"Fog";
-
-            public static LocalizedString fps = @"FPS: {00}";
-
-            public static LocalizedString grid = @"Map Grid";
-
-            public static LocalizedString help = @"Help";
-
-            public static LocalizedString importmap = @"Import Map";
-
-            public static LocalizedString itemeditor = @"Item Editor";
-
-            public static LocalizedString lighting = @"Toggle Time of Day Simulation On/Off";
-
-            public static LocalizedString loc = @"CurX: {00}  CurY: {01}";
-
-            public static LocalizedString newmap = @"New Map";
-
-            public static LocalizedString npceditor = @"Npc Editor";
-
-            public static LocalizedString options = @"Options";
-
-            public static LocalizedString overlay = @"Overlay";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Paste = @"Paste (Ctrl + V)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Brush = @"Brush (B)";
-
-            public static LocalizedString postquestion = @"Post Question";
-
-            public static LocalizedString projectileeditor = @"Projectile Editor";
-
-            public static LocalizedString questeditor = @"Quest Editor";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Rectangle = @"Rectangle Fill (R)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Redo = @"Redo (Ctrl + Y)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FlipHorizontal = @"Horizontal Flip Selection (PageDown)";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString FlipVertical = @"Vertical Flip Selection (PageUp)";
-
-            public static LocalizedString reportbug = @"Report Bug";
-
-            public static LocalizedString resourceeditor = @"Resource Editor";
-
-            public static LocalizedString resources = @"Resources";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Events = @"Events";
-
-            public static LocalizedString revision = @"Revision: {00}";
-
-            public static LocalizedString run = @"Run Client";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SaveMap = @"Save Map (Ctrl + S)";
-
-            public static LocalizedString screenshot = @"Screenshot Map";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Selection = @"Marquee Selection (M)";
-
-            public static LocalizedString selectlayers = @"Select...";
-
-            public static LocalizedString shopeditor = @"Shop Editor";
-
-            public static LocalizedString spelleditor = @"Spell Editor";
-
-            public static LocalizedString variableeditor = @"Variable Editor";
-
-            public static LocalizedString tilepreview = @"Tile Preview";
-
-            public static LocalizedString timeeditor = @"Time Editor";
-
-            public static LocalizedString title = @"Intersect Editor - {00}";
-
-            public static LocalizedString tools = @"Tools";
-
-            public static LocalizedString MenuToolsPackageUpdate = @"Package Update";
-
-            public static LocalizedString toolsdir = @"tools";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Undo = @"Undo (Ctrl + Z)";
-
-            public static LocalizedString view = @"View";
-
-        }
-
-        public partial struct MapCacheProgress
+        public static Dictionary<string, LocalizedString> categories = new Dictionary<string, LocalizedString>()
         {
+            {"general", @"General"},
+            {"lighting", @"Lighting"},
+            {"misc", @"Misc"},
+            {"overlay", @"Overlay"},
+            {"fog", @"Fog"},
+            {"audio", @"Audio"},
+            {"weather", @"Weather"},
+            {"player", @"Player"},
+        };
 
-            public static LocalizedString title = @"Saving Map Cache";
-
-            public static LocalizedString remaining = @"{00} maps remaining.";
-
-        }
-
-        public partial struct MapGrid
+        public static Dictionary<string, LocalizedString> displaynames = new Dictionary<string, LocalizedString>()
         {
+            {"ahue", @"AHue"},
+            {"bhue", @"BHue"},
+            {"brightness", @"Brightness"},
+            {"fog", @"Fog"},
+            {"fogalpha", @"Fog Alpha"},
+            {"fogxspeed", @"Fog X Speed"},
+            {"fogyspeed", @"Fog Y Speed"},
+            {"ghue", @"GHue"},
+            {"isindoors", @"Is Indoors"},
+            {"music", @"Music"},
+            {"name", @"Name"},
+            {"overlaygraphic", @"Overlay Graphic"},
+            {"panorama", @"Panorama"},
+            {"playerlightcolor", @"Player Light Color"},
+            {"playerlightexpand", @"Player Light Expand"},
+            {"playerlightintensity", @"Player Light Intensity"},
+            {"playerlightsize", @"Player Light Size"},
+            {"rhue", @"RHue"},
+            {"sound", @"Sound"},
+            {"zonetype", @"Zone Type"},
+            {"weather", @"Weather"},
+            {"weatherxspeed", @"Weather X Speed"},
+            {"weatheryspeed", @"Weather Y Speed"},
+            {"weatherintensity", @"Weather Intensity"},
+            {"hideequipment", @"Hide Equipment"},
+        };
 
-            public static LocalizedString clearandfetch =
-                @"Are you sure you want to clear the existing previews and fetch previews for each map on this grid? This could take several minutes based on the number of maps in this grid!";
-
-            public static LocalizedString downloadall = @"Re-Download All Previews";
-
-            public static LocalizedString downloadmissing = @"Download Missing Previews";
-
-            public static LocalizedString fetchcaption = @"Fetch Preview?";
-
-            public static LocalizedString fetchingmaps = @"Fetching Map Previews";
-
-            public static LocalizedString fetchingprogress = @"Fetching Maps {00} / {01}";
-
-            public static LocalizedString gridlines = @"Show/Hide Grid Lines";
-
-            public static LocalizedString justfetch =
-                @"Are you sure you want to fetch previews for each map? This could take several minutes based on the number of maps in this grid!";
-
-            public static LocalizedString keepmapcache =
-                @"Use your current settings with the map cache? (No to disable lighting/fogs/other effects)";
-
-            public static LocalizedString link = @"Link Map";
-
-            public static LocalizedString mapcachecaption = @"Map Cache Options";
-
-            public static LocalizedString preview = @"Fetch Preview";
-
-            public static LocalizedString recache = @"Recache Map";
-
-            public static LocalizedString savescreenshotconfirm =
-                @"Are you sure you want to save a screenshot of your world to a file? This could take several minutes!";
-
-            public static LocalizedString savescreenshotdialogue = @"Save a screenshot of the world";
-
-            public static LocalizedString savescreenshottitle = @"Save Screenshot?";
-
-            public static LocalizedString savingrow = @"Saving Row: {00} / {01}";
-
-            public static LocalizedString savingscreenshot = @"Saving Screenshot";
-
-            public static LocalizedString screenshotworld = @"Take a world screenshot";
-
-            public static LocalizedString title = @"Map Grid";
-
-            public static LocalizedString unlink = @"Unlink Map";
-
-            public static LocalizedString unlinkcaption = @"Unlink Map";
-
-            public static LocalizedString unlinkprompt = @"Are you sure you want to unlink map {00}?";
-
-        }
-
-        public partial struct MapLayers
+        public static Dictionary<string, LocalizedString> descriptions = new Dictionary<string, LocalizedString>()
         {
+            {
+                "ahuedesc",
+                @"How strong the overlay appears. (Range: 0 [transparent/invisible] to 255 [solid/can't see map])"
+            },
+            {"bhuedesc", @"The amount of blue in the overlay. (Range: 0 to 255)"},
+            {"brightnessdesc", @"How bright is this map? (Range: 0 to 100)."},
+            {
+                "fogalphadesc",
+                @"How strong the fog overlay appears. (Range: 0 [transparent/invisible] to 255 [solid/can't see map])"
+            },
+            {"fogdesc", @"The overlayed image on the map. Generally used for fogs or sun beam effects."},
+            {"fogxspeeddesc", @"Fog Horizontal Speed (Range: -5 to 5)"},
+            {"fogyspeeddesc", @"Fog Vertical Speed (Range: -5 to 5)"},
+            {"ghuedesc", @"The amount of green in the overlay. (Range: 0 to 255)"},
+            {"isindoorsdesc", @"Is this map indoors?"},
+            {"musicdesc", @"Looping background music for this map."},
+            {"namedesc", @"The name of this map."},
+            {"overlaygraphicdesc", @"This is an image that appears above the map. (Not shown in editor.)"},
+            {
+                "panoramadesc",
+                @"This is an image that appears behind the map. It can be seen where no tiles are placed."
+            },
+            {"playerlightcolordesc", @"Which color is the players light? (Default: White)"},
+            {"playerlightexpanddesc", @"How far into the light does the effect start fading? (0.00 to 1.00)"},
+            {"playerlightintensitydesc", @"How strong the light is at its brightest point. (0 to 255)"},
+            {"playerlightsizedesc", @"How large is the light around the player? (In pixels 0-1000)"},
+            {"rhuedesc", @"The amount of red in the overlay. (Range: 0 to 255)"},
+            {"sounddesc", @"Looping sound effect for this map."},
+            {"zonedesc", @"The type of map this is."},
+            {"weatherdesc", @"The animation for each weather particle."},
+            {
+                "weatherxspeeddesc",
+                @"How fast horizontally weather particles move across the screen. (Range -5 to 5)"
+            },
+            {"weatheryspeeddesc", @"How fast vertically weather particles move across the screen. (Range -5 to 5)"},
+            {"weatherintensitydesc", @"How intence the weather is (number of particles). (Range 0 to 100)"},
+            {"hideequipmentdesc", @"Toggling this on will stop rendering of item paperdolls while on this map."},
+        };
 
-            public static LocalizedString attributes = @"Attributes";
+        public static LocalizedString title = @"Map Properties";
 
-            public static LocalizedString eventinstructions = @"Double click a tile on the map to create an event!";
-
-            public static LocalizedString events = @"Events";
-
-            public static LocalizedString lightinstructions =
-                @"Lower the maps brightness and double click on a tile to create a light!";
-
-            public static LocalizedString lights = @"Lights";
-
-            public static LocalizedString npcs = @"Npcs";
-
-            public static LocalizedString tiles = @"Tiles";
-
-            public static LocalizedString title = @"Map Layers";
-
-        }
-
-        public partial struct MapList
+        public static Dictionary<int, LocalizedString> zones = new Dictionary<int, LocalizedString>
         {
+            {0, @"Normal"},
+            {1, @"Safe"},
+            {2, @"Arena"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString alphabetical = @"Alphabetical";
+    }
 
-            public static LocalizedString copyid = @"Copy Id";
+    public partial struct NpcEditor
+    {
 
-            public static LocalizedString delete = @"Delete";
+        public static LocalizedString abilitypower = @"Ability Pwr:";
 
-            public static LocalizedString deleteconfirm = @"Are you sure you want to delete {00}?";
+        public static LocalizedString addhostility = @"Add";
 
-            public static LocalizedString newfolder = @"New Folder";
+        public static LocalizedString addspell = @"Add";
 
-            public static LocalizedString newmap = @"New Map";
+        public static LocalizedString aggressive = @"Aggressive";
 
-            public static LocalizedString rename = @"Rename";
+        public static LocalizedString attack = @"Attack:";
 
-            public static LocalizedString selectcurrent = @"Select Current Map";
+        public static LocalizedString attackallies = @"Attack Allies?";
 
-            public static LocalizedString selecttodelete = @"Please select a folder or map to delete.";
+        public static LocalizedString attackanimation = @"Attack Animation:";
 
-            public static LocalizedString selecttorename = @"Please select a folder or map to rename.";
+        public static LocalizedString attackonsightconditions = @"Attack Player on Sight";
 
-            public static LocalizedString title = @"Map List";
+        public static LocalizedString attackspeed = @"Attack Speed";
 
-        }
+        public static LocalizedString attackspeedmodifier = @"Modifier:";
 
-        public partial struct Mapping
+        public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
         {
-            public static LocaleDictionary<MapInstanceType, LocalizedString> InstanceTypes = new LocaleDictionary<MapInstanceType, LocalizedString>()
-            {
-                {MapInstanceType.Overworld, @"Overworld"},
-                {MapInstanceType.Personal, @"Personal"},
-                {MapInstanceType.Guild, @"Guild"},
-                {MapInstanceType.Shared, @"Shared"},
-            };
+            {0, @"Disabled"},
+            {1, @"Static (ms)"},
+        };
 
-            public static LocalizedString createmap = @"Create new map.";
+        public static LocalizedString attackspeedvalue = @"Value:";
 
-            public static LocalizedString createmapdialogue = @"Do you want to create a map here?";
+        public static LocalizedString basedamage = @"Base Damage:";
 
-            public static LocalizedString diagonalwarning = @"Cannot create maps diagonally!";
+        public static LocalizedString behavior = @"Behavior:";
 
-            public static LocalizedString editortitle = @"Map Editor";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString eraselayer = @"Erase Layer";
+        public static LocalizedString combat = @"Combat";
 
-            public static LocalizedString eraselayerdialogue = @"Are you sure you want to erase this layer?";
+        public static LocalizedString commonevents = @"Common Events";
 
-            public static LocalizedString filllayer = @"Fill Layer";
+        public static LocalizedString conditions = @"Conditions";
 
-            public static LocalizedString filllayerdialogue = @"Are you sure you want to fill this layer?";
+        public static LocalizedString copy = @"Copy Npc";
 
-            public static LocalizedString newmap = @"Are you sure you want to create a new, unconnected map?";
+        public static LocalizedString critchance = @"Crit Chance (%):";
 
-            public static LocalizedString newmapcaption = @"New Map";
+        public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
 
-            public static LocalizedString savemap = @"Save current map?";
+        public static LocalizedString damagetype = @"Damage Type:";
 
-            public static LocalizedString savemapdialogue = @"Do you want to save your current map?";
+        public static LocalizedString defense = @"Defense:";
 
-            public static LocalizedString savemapdialoguesure = @"Are you sure you want to save your current map?";
+        public static LocalizedString delete = @"Delete Npc";
 
-            public static LocalizedString mapnotsaved = @"Unsaved changes!";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this npc? This action cannot be reverted!";
 
-            public static LocalizedString maphaschangesdialog =
-                @"There are unsaved changes to this map, are you sure you want to exit?";
+        public static LocalizedString deletetitle = @"Delete Item";
 
-        }
+        public static LocalizedString dontattackonsightconditions = @"Should Not Attack Player on Sight";
 
-        public partial struct MapProperties
+        public static LocalizedString drops = @"Drops";
+
+        public static LocalizedString dropitem = @"Item:";
+
+        public static LocalizedString dropamount = @"Amount:";
+
+        public static LocalizedString dropchance = @"Chance (%):";
+
+        public static LocalizedString dropadd = @"Add";
+
+        public static LocalizedString dropremove = @"Remove";
+
+        public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
+
+        public static LocalizedString enabled = @"Enabled?";
+
+        public static LocalizedString exp = @"Exp:";
+
+        public static LocalizedString flee = @"Flee Health %";
+
+        public static LocalizedString focusdamagedealer = @"Focus Highest Damage Dealer:";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        public static LocalizedString frequency = @"Frequency:";
+
+        public static Dictionary<int, LocalizedString> frequencies = new Dictionary<int, LocalizedString>
         {
+            {0, @"Not Very Often"},
+            {1, @"Not Often"},
+            {2, @"Normal"},
+            {3, @"Often"},
+            {4, @"Very Often"},
+        };
 
-            public static Dictionary<string, LocalizedString> categories = new Dictionary<string, LocalizedString>()
-            {
-                {"general", @"General"},
-                {"lighting", @"Lighting"},
-                {"misc", @"Misc"},
-                {"overlay", @"Overlay"},
-                {"fog", @"Fog"},
-                {"audio", @"Audio"},
-                {"weather", @"Weather"},
-                {"player", @"Player"},
-            };
+        public static LocalizedString general = @"General";
 
-            public static Dictionary<string, LocalizedString> displaynames = new Dictionary<string, LocalizedString>()
-            {
-                {"ahue", @"AHue"},
-                {"bhue", @"BHue"},
-                {"brightness", @"Brightness"},
-                {"fog", @"Fog"},
-                {"fogalpha", @"Fog Alpha"},
-                {"fogxspeed", @"Fog X Speed"},
-                {"fogyspeed", @"Fog Y Speed"},
-                {"ghue", @"GHue"},
-                {"isindoors", @"Is Indoors"},
-                {"music", @"Music"},
-                {"name", @"Name"},
-                {"overlaygraphic", @"Overlay Graphic"},
-                {"panorama", @"Panorama"},
-                {"playerlightcolor", @"Player Light Color"},
-                {"playerlightexpand", @"Player Light Expand"},
-                {"playerlightintensity", @"Player Light Intensity"},
-                {"playerlightsize", @"Player Light Size"},
-                {"rhue", @"RHue"},
-                {"sound", @"Sound"},
-                {"zonetype", @"Zone Type"},
-                {"weather", @"Weather"},
-                {"weatherxspeed", @"Weather X Speed"},
-                {"weatheryspeed", @"Weather Y Speed"},
-                {"weatherintensity", @"Weather Intensity"},
-                {"hideequipment", @"Hide Equipment"},
-            };
+        public static LocalizedString hp = @"HP:";
 
-            public static Dictionary<string, LocalizedString> descriptions = new Dictionary<string, LocalizedString>()
-            {
-                {
-                    "ahuedesc",
-                    @"How strong the overlay appears. (Range: 0 [transparent/invisible] to 255 [solid/can't see map])"
-                },
-                {"bhuedesc", @"The amount of blue in the overlay. (Range: 0 to 255)"},
-                {"brightnessdesc", @"How bright is this map? (Range: 0 to 100)."},
-                {
-                    "fogalphadesc",
-                    @"How strong the fog overlay appears. (Range: 0 [transparent/invisible] to 255 [solid/can't see map])"
-                },
-                {"fogdesc", @"The overlayed image on the map. Generally used for fogs or sun beam effects."},
-                {"fogxspeeddesc", @"Fog Horizontal Speed (Range: -5 to 5)"},
-                {"fogyspeeddesc", @"Fog Vertical Speed (Range: -5 to 5)"},
-                {"ghuedesc", @"The amount of green in the overlay. (Range: 0 to 255)"},
-                {"isindoorsdesc", @"Is this map indoors?"},
-                {"musicdesc", @"Looping background music for this map."},
-                {"namedesc", @"The name of this map."},
-                {"overlaygraphicdesc", @"This is an image that appears above the map. (Not shown in editor.)"},
-                {
-                    "panoramadesc",
-                    @"This is an image that appears behind the map. It can be seen where no tiles are placed."
-                },
-                {"playerlightcolordesc", @"Which color is the players light? (Default: White)"},
-                {"playerlightexpanddesc", @"How far into the light does the effect start fading? (0.00 to 1.00)"},
-                {"playerlightintensitydesc", @"How strong the light is at its brightest point. (0 to 255)"},
-                {"playerlightsizedesc", @"How large is the light around the player? (In pixels 0-1000)"},
-                {"rhuedesc", @"The amount of red in the overlay. (Range: 0 to 255)"},
-                {"sounddesc", @"Looping sound effect for this map."},
-                {"zonedesc", @"The type of map this is."},
-                {"weatherdesc", @"The animation for each weather particle."},
-                {
-                    "weatherxspeeddesc",
-                    @"How fast horizontally weather particles move across the screen. (Range -5 to 5)"
-                },
-                {"weatheryspeeddesc", @"How fast vertically weather particles move across the screen. (Range -5 to 5)"},
-                {"weatherintensitydesc", @"How intence the weather is (number of particles). (Range 0 to 100)"},
-                {"hideequipmentdesc", @"Toggling this on will stop rendering of item paperdolls while on this map."},
-            };
+        public static LocalizedString hpregen = @"HP (%);";
 
-            public static LocalizedString title = @"Map Properties";
+        public static LocalizedString individualizedloot = @"Spawn loot for all attackers?";
 
-            public static Dictionary<int, LocalizedString> zones = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Normal"},
-                {1, @"Safe"},
-                {2, @"Arena"},
-            };
+        public static LocalizedString magicresist = @"Magic Resist:";
 
-        }
+        public static LocalizedString mana = @"Mana:";
 
-        public partial struct NpcEditor
+        public static LocalizedString movement = @"Movement";
+
+        public static LocalizedString resetradius = @"Reset Radius:";
+
+        public static Dictionary<int, LocalizedString> movements = new Dictionary<int, LocalizedString>
         {
+            {0, @"Move Randomly"},
+            {1, @"Turn Randomly"},
+            {2, @"Stand Still"},
+            {3, @"Static"},
+        };
 
-            public static LocalizedString abilitypower = @"Ability Pwr:";
+        public static LocalizedString mpregen = @"MP (%):";
 
-            public static LocalizedString addhostility = @"Add";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString addspell = @"Add";
+        public static LocalizedString New = @"New Npc";
 
-            public static LocalizedString aggressive = @"Aggressive";
+        public static LocalizedString npc = @"NPC:";
 
-            public static LocalizedString attack = @"Attack:";
+        public static LocalizedString npcs = @"Npcs";
 
-            public static LocalizedString attackallies = @"Attack Allies?";
+        public static LocalizedString npcvsnpc = @"NPC vs NPC Combat/Hostility  ";
 
-            public static LocalizedString attackanimation = @"Attack Animation:";
+        public static LocalizedString ondeathevent = @"On Death (for killer):";
 
-            public static LocalizedString attackonsightconditions = @"Attack Player on Sight";
+        public static LocalizedString ondeathpartyevent = @"On Death (for party):";
 
-            public static LocalizedString attackspeed = @"Attack Speed";
+        public static LocalizedString paste = @"Paste Npc";
 
-            public static LocalizedString attackspeedmodifier = @"Modifier:";
+        public static LocalizedString playercanattackconditions = @"Player Can Attack (Default: True)";
 
-            public static Dictionary<int, LocalizedString> attackspeedmodifiers = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Disabled"},
-                {1, @"Static (ms)"},
-            };
+        public static LocalizedString playerfriendprotectorconditions = @"Player Friend/Protector";
 
-            public static LocalizedString attackspeedvalue = @"Value:";
+        public static LocalizedString regen = @"Regen";
 
-            public static LocalizedString basedamage = @"Base Damage:";
-
-            public static LocalizedString behavior = @"Behavior:";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString combat = @"Combat";
-
-            public static LocalizedString commonevents = @"Common Events";
-
-            public static LocalizedString conditions = @"Conditions";
-
-            public static LocalizedString copy = @"Copy Npc";
-
-            public static LocalizedString critchance = @"Crit Chance (%):";
-
-            public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
-
-            public static LocalizedString damagetype = @"Damage Type:";
-
-            public static LocalizedString defense = @"Defense:";
-
-            public static LocalizedString delete = @"Delete Npc";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this npc? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Item";
-
-            public static LocalizedString dontattackonsightconditions = @"Should Not Attack Player on Sight";
-
-            public static LocalizedString drops = @"Drops";
-
-            public static LocalizedString dropitem = @"Item:";
-
-            public static LocalizedString dropamount = @"Amount:";
-
-            public static LocalizedString dropchance = @"Chance (%):";
-
-            public static LocalizedString dropadd = @"Add";
-
-            public static LocalizedString dropremove = @"Remove";
-
-            public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
-
-            public static LocalizedString enabled = @"Enabled?";
-
-            public static LocalizedString exp = @"Exp:";
-
-            public static LocalizedString flee = @"Flee Health %";
-
-            public static LocalizedString focusdamagedealer = @"Focus Highest Damage Dealer:";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString frequency = @"Frequency:";
-
-            public static Dictionary<int, LocalizedString> frequencies = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Not Very Often"},
-                {1, @"Not Often"},
-                {2, @"Normal"},
-                {3, @"Often"},
-                {4, @"Very Often"},
-            };
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString hp = @"HP:";
-
-            public static LocalizedString hpregen = @"HP (%);";
-
-            public static LocalizedString individualizedloot = @"Spawn loot for all attackers?";
-
-            public static LocalizedString magicresist = @"Magic Resist:";
-
-            public static LocalizedString mana = @"Mana:";
-
-            public static LocalizedString movement = @"Movement";
-
-            public static LocalizedString resetradius = @"Reset Radius:";
-
-            public static Dictionary<int, LocalizedString> movements = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Move Randomly"},
-                {1, @"Turn Randomly"},
-                {2, @"Stand Still"},
-                {3, @"Static"},
-            };
-
-            public static LocalizedString mpregen = @"MP (%):";
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString New = @"New Npc";
-
-            public static LocalizedString npc = @"NPC:";
-
-            public static LocalizedString npcs = @"Npcs";
-
-            public static LocalizedString npcvsnpc = @"NPC vs NPC Combat/Hostility  ";
-
-            public static LocalizedString ondeathevent = @"On Death (for killer):";
-
-            public static LocalizedString ondeathpartyevent = @"On Death (for party):";
-
-            public static LocalizedString paste = @"Paste Npc";
-
-            public static LocalizedString playercanattackconditions = @"Player Can Attack (Default: True)";
-
-            public static LocalizedString playerfriendprotectorconditions = @"Player Friend/Protector";
-
-            public static LocalizedString regen = @"Regen";
-
-            public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
+        public static LocalizedString regenhint = @"% of HP/Mana to restore per tick.
 
 Tick timer saved in server config.json.";
 
-            public static LocalizedString removehostility = @"Remove";
+        public static LocalizedString removehostility = @"Remove";
 
-            public static LocalizedString removespell = @"Remove";
+        public static LocalizedString removespell = @"Remove";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString scalingamount = @"Scaling Amount (%):";
+        public static LocalizedString scalingamount = @"Scaling Amount (%):";
 
-            public static LocalizedString scalingstat = @"Scaling Stat:";
+        public static LocalizedString scalingstat = @"Scaling Stat:";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString sightrange = @"Sight Range:";
+        public static LocalizedString sightrange = @"Sight Range:";
 
-            public static LocalizedString spawnduration = @"Spawn Duration: (ms)";
+        public static LocalizedString spawnduration = @"Spawn Duration: (ms)";
 
-            public static LocalizedString speed = @"Speed:";
+        public static LocalizedString speed = @"Speed:";
 
-            public static LocalizedString spell = @"Spell:";
+        public static LocalizedString spell = @"Spell:";
 
-            public static LocalizedString spells = @"Spells";
+        public static LocalizedString spells = @"Spells";
 
-            public static LocalizedString sprite = @"Sprite";
+        public static LocalizedString sprite = @"Sprite";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Red = @"Red:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Red = @"Red:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Green = @"Green:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Green = @"Green:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Blue = @"Blue:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Blue = @"Blue:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Alpha = @"Alpha:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Alpha = @"Alpha:";
 
-            public static LocalizedString stats = @"Stats:";
+        public static LocalizedString stats = @"Stats:";
 
-            public static LocalizedString swarm = @"Swarm";
+        public static LocalizedString swarm = @"Swarm";
 
-            public static LocalizedString title = @"Npc Editor";
+        public static LocalizedString title = @"Npc Editor";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this npc? This action cannot be reverted!";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this npc? This action cannot be reverted!";
 
-            public static LocalizedString undotitle = @"Undo Changes";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ImmunitiesTitle = @"Immunities";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ImmunitiesTitle = @"Immunities";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Tenacity = @"Tenacity (%):";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Tenacity = @"Tenacity (%):";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<SpellEffect, LocalizedString> Immunities = new Dictionary<SpellEffect, LocalizedString>
-            {
-                {SpellEffect.Knockback, @"Knockback"},
-                {SpellEffect.Silence, @"Silence"},
-                {SpellEffect.Stun, @"Stun"},
-                {SpellEffect.Snare, @"Snare"},
-                {SpellEffect.Blind, @"Blind"},
-                {SpellEffect.Transform, @"Transform"},
-                {SpellEffect.Sleep, @"Sleep"},
-                {SpellEffect.Taunt, @"Taunt"},
-            };
-
-        }
-
-        public partial struct NpcSpawns
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<SpellEffect, LocalizedString> Immunities = new Dictionary<SpellEffect, LocalizedString>
         {
-            public static LocalizedString add = @"Add";
+            {SpellEffect.Knockback, @"Knockback"},
+            {SpellEffect.Silence, @"Silence"},
+            {SpellEffect.Stun, @"Stun"},
+            {SpellEffect.Snare, @"Snare"},
+            {SpellEffect.Blind, @"Blind"},
+            {SpellEffect.Transform, @"Transform"},
+            {SpellEffect.Sleep, @"Sleep"},
+            {SpellEffect.Taunt, @"Taunt"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString AddRemove = @"Add or Remove NPC Spawn:";
+    }
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PulseColorButton = @"Selected NPC highlight color";
+    public partial struct NpcSpawns
+    {
+        public static LocalizedString add = @"Add";
 
-            public static LocalizedString declaredlocation = @"Declared";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AddRemove = @"Add or Remove NPC Spawn:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Direction = @"Spawn Direction:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PulseColorButton = @"Selected NPC highlight color";
 
-            public static LocalizedString randomdirection = @"Random";
+        public static LocalizedString declaredlocation = @"Declared";
 
-            public static LocalizedString randomlocation = @"Random";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Direction = @"Spawn Direction:";
 
-            public static LocalizedString remove = @"Remove";
+        public static LocalizedString randomdirection = @"Random";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SpawnCount = @"Spawn Count: {00}";
+        public static LocalizedString randomlocation = @"Random";
 
-            public static LocalizedString spawndeclared = @"Spawn Location: Declared";
+        public static LocalizedString remove = @"Remove";
 
-            public static LocalizedString spawnrandom = @"Spawn Location: Random";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SpawnCount = @"Spawn Count: {00}";
 
-        }
+        public static LocalizedString spawndeclared = @"Spawn Location: Declared";
 
-        public partial struct Options
+        public static LocalizedString spawnrandom = @"Spawn Location: Random";
+
+    }
+
+    public partial struct Options
+    {
+
+        public static LocalizedString browsebtn = @"Browse";
+
+        public static LocalizedString dialogueallfiles = @"All Files";
+
+        public static LocalizedString dialogueheader = @"Browse for client...";
+
+        public static LocalizedString generaltab = @"General";
+
+        public static LocalizedString pathgroup = @"Client Path";
+
+        public static LocalizedString tilesetwarning = @"Suppress large tileset size warning.";
+
+        public static LocalizedString title = @"Options";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UpdateTab = @"Update";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PackageUpdates = @"Package assets when generating updates.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PackageOptions = @"Asset Packing Options";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MusicPackSize = @"Max Music Pack Size (MB):";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SoundPackSize = @"Max Sound Pack Size (MB):";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TextureSize = @"Max Texture Pack Size (Resolution):";
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CursorSprites = @"Enable cursor sprites for map tools.";
+    }
+
+    public partial struct ProgressForm
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+    }
+
+    public partial struct ProjectileEditor
+    {
+
+        public static LocalizedString addanimation = @"Add";
+
+        public static LocalizedString ammo = @"Ammunition Requirements:";
+
+        public static LocalizedString ammoamount = @"Amount:";
+
+        public static LocalizedString ammoitem = @"Item:";
+
+        public static LocalizedString animation = @"Animation:";
+
+        public static LocalizedString animationline = @"[Spawn Range: {00} - {01}]  Animation: {02}";
+
+        public static LocalizedString animations = @"Animations";
+
+        public static LocalizedString autorotate = @"Auto Rotate Animation?";
+
+        public static LocalizedString BehaviorDefault = @"Default";
+
+        public static LocalizedString BehaviorDirectShot = @"Direct Shot Behavior";
+
+        public static LocalizedString BehaviorHoming = @"Homing Behavior";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString collisions = @"Ignore Collision:";
+
+        public static LocalizedString copy = @"Copy Projectile";
+
+        public static LocalizedString delete = @"Delete Projectile";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this projectile? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Projectile";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GrappleOptionsTitle = @"Grapple Options";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static Dictionary<GrappleOption, LocalizedString> GrappleOpts = new Dictionary<GrappleOption, LocalizedString>
         {
+            {GrappleOption.MapAttribute, @"On Map Attribute"},
+            {GrappleOption.Player, @"On Player"},
+            {GrappleOption.NPC, @"On NPC"},
+            {GrappleOption.Resource, @"On Resource"},
+        };
 
-            public static LocalizedString browsebtn = @"Browse";
+        public static LocalizedString ignoreactiveresources = @"Active Resources";
 
-            public static LocalizedString dialogueallfiles = @"All Files";
+        public static LocalizedString ignoreblocks = @"Map Blocks";
 
-            public static LocalizedString dialogueheader = @"Browse for client...";
+        public static LocalizedString ignoreinactiveresources = @"Inactive Resources";
 
-            public static LocalizedString generaltab = @"General";
+        public static LocalizedString ignorezdimension = @"Z-Dimension Blocks";
 
-            public static LocalizedString pathgroup = @"Client Path";
+        public static LocalizedString piercetarget = @"Pierce Target?";
 
-            public static LocalizedString tilesetwarning = @"Suppress large tileset size warning.";
+        public static LocalizedString knockback = @"Knockback:";
 
-            public static LocalizedString title = @"Options";
+        public static LocalizedString name = @"Name:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString UpdateTab = @"Update";
+        public static LocalizedString New = @"New Projectile";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PackageUpdates = @"Package assets when generating updates.";
+        public static LocalizedString paste = @"Paste Projectile";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString PackageOptions = @"Asset Packing Options";
+        public static LocalizedString projectiles = @"Projectiles";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MusicPackSize = @"Max Music Pack Size (MB):";
+        public static LocalizedString properties = @"Properties";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString SoundPackSize = @"Max Sound Pack Size (MB):";
+        public static LocalizedString quantity = @"Quantity:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TextureSize = @"Max Texture Pack Size (Resolution):";
-            
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CursorSprites = @"Enable cursor sprites for map tools.";
-        }
+        public static LocalizedString range = @"Range:";
 
-        public partial struct ProgressForm
-        {
+        public static LocalizedString removeanimation = @"Remove";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString save = @"Save";
 
-        }
+        public static LocalizedString searchplaceholder = @"Search...";
 
-        public partial struct ProjectileEditor
-        {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString addanimation = @"Add";
+        public static LocalizedString spawndelay = @"Spawn Delay (ms):";
 
-            public static LocalizedString ammo = @"Ammunition Requirements:";
+        public static LocalizedString spawnrange = @"Spawn Range: {00} - {01}";
 
-            public static LocalizedString ammoamount = @"Amount:";
+        public static LocalizedString spawns = @"Projectile Spawns";
 
-            public static LocalizedString ammoitem = @"Item:";
+        public static LocalizedString speed = @"Speed (ms):";
 
-            public static LocalizedString animation = @"Animation:";
+        public static LocalizedString spell = @"Collision Spell:";
 
-            public static LocalizedString animationline = @"[Spawn Range: {00} - {01}]  Animation: {02}";
+        public static LocalizedString TargettingOptions = @"Targetting Options";
 
-            public static LocalizedString animations = @"Animations";
+        public static LocalizedString title = @"Projectile Editor";
 
-            public static LocalizedString autorotate = @"Auto Rotate Animation?";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString BehaviorDefault = @"Default";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this projectile? This action cannot be reverted!";
 
-            public static LocalizedString BehaviorDirectShot = @"Direct Shot Behavior";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            public static LocalizedString BehaviorHoming = @"Homing Behavior";
+    }
 
-            public static LocalizedString cancel = @"Cancel";
+    public partial struct QuestEditor
+    {
 
-            public static LocalizedString collisions = @"Ignore Collision:";
+        public static LocalizedString actions = @"Quest Actions:";
 
-            public static LocalizedString copy = @"Copy Projectile";
+        public static LocalizedString addtask = @"Add Task";
 
-            public static LocalizedString delete = @"Delete Projectile";
+        public static LocalizedString beforeofferdesc = @"Before Offer Description:";
 
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this projectile? This action cannot be reverted!";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString deletetitle = @"Delete Projectile";
+        public static LocalizedString completeddesc = @"Completed Description:";
 
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString copy = @"Copy Quest";
 
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString delete = @"Delete Quest";
 
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this quest? This action cannot be reverted!";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString GrappleOptionsTitle = @"Grapple Options";
+        public static LocalizedString deletetitle = @"Delete Quest";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static Dictionary<GrappleOption, LocalizedString> GrappleOpts = new Dictionary<GrappleOption, LocalizedString>
-            {
-                {GrappleOption.MapAttribute, @"On Map Attribute"},
-                {GrappleOption.Player, @"On Player"},
-                {GrappleOption.NPC, @"On NPC"},
-                {GrappleOption.Resource, @"On Resource"},
-            };
+        public static LocalizedString editendevent = @"Edit Quest Completion Event";
 
-            public static LocalizedString ignoreactiveresources = @"Active Resources";
+        public static LocalizedString editrequirements = @"Edit Quest Requirements";
 
-            public static LocalizedString ignoreblocks = @"Map Blocks";
+        public static LocalizedString editstartevent = @"Edit Quest Start Event";
 
-            public static LocalizedString ignoreinactiveresources = @"Inactive Resources";
+        public static LocalizedString endevent = @"Quest: {00} - Completion Event";
 
-            public static LocalizedString ignorezdimension = @"Z-Dimension Blocks";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            public static LocalizedString piercetarget = @"Pierce Target?";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            public static LocalizedString knockback = @"Knockback:";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString general = @"General";
 
-            public static LocalizedString New = @"New Projectile";
+        public static LocalizedString inprogressdesc = @"In Progress Description:";
 
-            public static LocalizedString paste = @"Paste Projectile";
+        public static LocalizedString logoptions = @"Quest Log Options";
 
-            public static LocalizedString projectiles = @"Projectiles";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString properties = @"Properties";
+        public static LocalizedString New = @"New Quest";
 
-            public static LocalizedString quantity = @"Quantity:";
+        public static LocalizedString offerdesc = @"Offer Description:";
 
-            public static LocalizedString range = @"Range:";
+        public static LocalizedString onend = @"On Quest Completion:";
 
-            public static LocalizedString removeanimation = @"Remove";
+        public static LocalizedString onstart = @"On Quest Start:";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString options = @"Progression Options";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString paste = @"Paste Quest";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        public static LocalizedString quests = @"Quests";
 
-            public static LocalizedString spawndelay = @"Spawn Delay (ms):";
+        public static LocalizedString quit = @"Can Quit Quest?";
 
-            public static LocalizedString spawnrange = @"Spawn Range: {00} - {01}";
+        public static LocalizedString removetask = @"Remove Task";
 
-            public static LocalizedString spawns = @"Projectile Spawns";
+        public static LocalizedString repeatable = @"Quest Repeatable?";
 
-            public static LocalizedString speed = @"Speed (ms):";
+        public static LocalizedString requirements = @"Quest Requirements";
 
-            public static LocalizedString spell = @"Collision Spell:";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString TargettingOptions = @"Targetting Options";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            public static LocalizedString title = @"Projectile Editor";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString showafter = @"Show in quest log after completing quest?";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this projectile? This action cannot be reverted!";
+        public static LocalizedString showbefore = @"Show in quest log before accepting quest?";
 
-            public static LocalizedString undotitle = @"Undo Changes";
+        public static LocalizedString startevent = @"Quest: {00} - Start Event";
 
-        }
+        public static LocalizedString tasks = @"Quest Tasks";
 
-        public partial struct QuestEditor
-        {
+        public static LocalizedString title = @"Quest Editor";
 
-            public static LocalizedString actions = @"Quest Actions:";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString addtask = @"Add Task";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this quest? This action cannot be reverted!";
 
-            public static LocalizedString beforeofferdesc = @"Before Offer Description:";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString unstartedcategory = @"Unstarted Category:";
 
-            public static LocalizedString completeddesc = @"Completed Description:";
+        public static LocalizedString inprogressgategory = @"In Progress Category:";
 
-            public static LocalizedString copy = @"Copy Quest";
+        public static LocalizedString completedcategory = @"Completed Category:";
 
-            public static LocalizedString delete = @"Delete Quest";
+        public static LocalizedString donotshowunlessreqsmet = @"Do not show in quest log unless requirements are met";
 
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this quest? This action cannot be reverted!";
+        public static LocalizedString order = @"Quest Log Sort Order:";
+    }
 
-            public static LocalizedString deletetitle = @"Delete Quest";
+    public partial struct ResourceEditor
+    {
 
-            public static LocalizedString editendevent = @"Edit Quest Completion Event";
+        public static LocalizedString animation = @"Animation:";
 
-            public static LocalizedString editrequirements = @"Edit Quest Requirements";
+        public static LocalizedString belowentities = @"Below Entities";
 
-            public static LocalizedString editstartevent = @"Edit Quest Start Event";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString endevent = @"Quest: {00} - Completion Event";
+        public static LocalizedString commonevent = @"Common Event";
 
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString copy = @"Copy Resource";
 
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString delete = @"Delete Resource";
 
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this resource? This action cannot be reverted!";
 
-            public static LocalizedString general = @"General";
+        public static LocalizedString deletetitle = @"Delete Item";
 
-            public static LocalizedString inprogressdesc = @"In Progress Description:";
+        public static LocalizedString drops = @"Drops";
 
-            public static LocalizedString logoptions = @"Quest Log Options";
+        public static LocalizedString dropitem = @"Item:";
 
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString dropamount = @"Amount:";
 
-            public static LocalizedString New = @"New Quest";
+        public static LocalizedString dropchance = @"Chance (%):";
 
-            public static LocalizedString offerdesc = @"Offer Description:";
+        public static LocalizedString dropadd = @"Add";
 
-            public static LocalizedString onend = @"On Quest Completion:";
+        public static LocalizedString dropremove = @"Remove";
 
-            public static LocalizedString onstart = @"On Quest Start:";
+        public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
 
-            public static LocalizedString options = @"Progression Options";
+        public static LocalizedString exhaustedgraphic = @"Exhausted Graphic:";
 
-            public static LocalizedString paste = @"Paste Quest";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            public static LocalizedString quests = @"Quests";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            public static LocalizedString quit = @"Can Quit Quest?";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            public static LocalizedString removetask = @"Remove Task";
+        public static LocalizedString fromtileset = @"From Tileset";
 
-            public static LocalizedString repeatable = @"Quest Repeatable?";
+        public static LocalizedString general = @"General";
 
-            public static LocalizedString requirements = @"Quest Requirements";
+        public static LocalizedString graphics = @"Graphics";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString harvestevent = @"Event:";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString hpregen = @"HP (%);";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        public static LocalizedString initialgraphic = @"Initial Graphic:";
 
-            public static LocalizedString showafter = @"Show in quest log after completing quest?";
+        public static LocalizedString maxhp = @"Max HP:";
 
-            public static LocalizedString showbefore = @"Show in quest log before accepting quest?";
+        public static LocalizedString minhp = @"Min HP:";
 
-            public static LocalizedString startevent = @"Quest: {00} - Start Event";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString tasks = @"Quest Tasks";
+        public static LocalizedString New = @"New Resource";
 
-            public static LocalizedString title = @"Quest Editor";
+        public static LocalizedString paste = @"Paste Resource";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString regen = @"Regen";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this quest? This action cannot be reverted!";
-
-            public static LocalizedString undotitle = @"Undo Changes";
-
-            public static LocalizedString unstartedcategory = @"Unstarted Category:";
-
-            public static LocalizedString inprogressgategory = @"In Progress Category:";
-
-            public static LocalizedString completedcategory = @"Completed Category:";
-
-            public static LocalizedString donotshowunlessreqsmet = @"Do not show in quest log unless requirements are met";
-
-            public static LocalizedString order = @"Quest Log Sort Order:";
-        }
-
-        public partial struct ResourceEditor
-        {
-
-            public static LocalizedString animation = @"Animation:";
-
-            public static LocalizedString belowentities = @"Below Entities";
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString commonevent = @"Common Event";
-
-            public static LocalizedString copy = @"Copy Resource";
-
-            public static LocalizedString delete = @"Delete Resource";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this resource? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Item";
-
-            public static LocalizedString drops = @"Drops";
-
-            public static LocalizedString dropitem = @"Item:";
-
-            public static LocalizedString dropamount = @"Amount:";
-
-            public static LocalizedString dropchance = @"Chance (%):";
-
-            public static LocalizedString dropadd = @"Add";
-
-            public static LocalizedString dropremove = @"Remove";
-
-            public static LocalizedString dropdisplay = @"{00} x{01} - {02}%";
-
-            public static LocalizedString exhaustedgraphic = @"Exhausted Graphic:";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString fromtileset = @"From Tileset";
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString graphics = @"Graphics";
-
-            public static LocalizedString harvestevent = @"Event:";
-
-            public static LocalizedString hpregen = @"HP (%);";
-
-            public static LocalizedString initialgraphic = @"Initial Graphic:";
-
-            public static LocalizedString maxhp = @"Max HP:";
-
-            public static LocalizedString minhp = @"Min HP:";
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString New = @"New Resource";
-
-            public static LocalizedString paste = @"Paste Resource";
-
-            public static LocalizedString regen = @"Regen";
-
-            public static LocalizedString regenhint = @"% of HP to restore per tick.
+        public static LocalizedString regenhint = @"% of HP to restore per tick.
 
 Tick timer saved in server config.json.";
 
-            public static LocalizedString requirementsgroup = @"Requirements";
+        public static LocalizedString requirementsgroup = @"Requirements";
 
-            public static LocalizedString requirements = @"Harvesting Requirements";
+        public static LocalizedString requirements = @"Harvesting Requirements";
 
-            public static LocalizedString cannotharvest = @"Cannot Harvest Message:";
+        public static LocalizedString cannotharvest = @"Cannot Harvest Message:";
 
-            public static LocalizedString resources = @"Resources";
+        public static LocalizedString resources = @"Resources";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString spawnduration = @"Spawn Duration: (ms)";
+        public static LocalizedString spawnduration = @"Spawn Duration: (ms)";
 
-            public static LocalizedString title = @"Resource Editor";
+        public static LocalizedString title = @"Resource Editor";
 
-            public static LocalizedString tooltype = @"Tool Type:";
+        public static LocalizedString tooltype = @"Tool Type:";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this resource? This action cannot be reverted!";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this resource? This action cannot be reverted!";
 
-            public static LocalizedString undotitle = @"Undo Changes";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            public static LocalizedString walkableafter = @"Walkable after resource removal?";
+        public static LocalizedString walkableafter = @"Walkable after resource removal?";
 
-            public static LocalizedString walkablebefore = @"Walkable before resource removal?";
+        public static LocalizedString walkablebefore = @"Walkable before resource removal?";
 
-        }
+    }
 
-        public partial struct ShopEditor
+    public partial struct ShopEditor
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString addboughtitem = @"Add Item:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString addlabel = @"Add Item to be Sold:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString addsolditem = @"Add Selected";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString blacklist = @"Blacklist";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString buycost = @"Sell Amount:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString buydesc = @"Buy Item {00} For ({01}) Item {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString buyfor = @"Buy For:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString cancel = @"Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString copy = @"Copy Shop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString defaultcurrency = @"Default Currency:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString delete = @"Delete Shop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this shop? This action cannot be reverted!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString deletetitle = @"Delete Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString dontbuy = @"Don't Buy Item {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString folderlabel = @"Folder:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString general = @"General";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString itemsboughtblacklist = @"Items Bought (Blacklist - Don't Buy Listed Items)  ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString itemsboughtwhitelist = @"Items Bought (Whitelist - Buy Listed Items)  ";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString itemssold = @"Items Sold";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString name = @"Name:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString New = @"New Shop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString paste = @"Paste Shop";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString removeboughtitem = @"Remove Selected";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString removesolditem = @"Remove Selected";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString save = @"Save";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sellcost = @"Sell Cost:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString selldesc = @"Sell Item {00} For ({01}) Item {02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sellfor = @"Sell for:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString shops = @"Shops";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString title = @"Shop Editor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undo = @"Undo Changes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this shop? This action cannot be reverted!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString undotitle = @"Undo Changes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString whitelist = @"Whitelist";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString buysound = @"Buy Sound:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sellsound = @"Sell Sound:";
+    }
+
+    public partial struct SpellEditor
+    {
+
+        public static LocalizedString abilitypower = @"Ability Pwr:";
+
+        public static LocalizedString attack = @"Attack:";
+
+        public static LocalizedString boostduration = @"Stat Boost/Effect Duration";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString castanimation = @"Extra Cast Anim.:";
+
+        public static LocalizedString CastSpriteOverride = @"Sprite Cast Anim.:";
+
+        public static LocalizedString castrange = @"Cast Range (tiles):";
+
+        public static LocalizedString casttime = @"Cast Time (ms):";
+
+        public static LocalizedString combatspell = @"Combat Spell";
+
+        public static LocalizedString cooldown = @"Cooldown (ms):";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroup = @"Cooldown Group:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroupTitle = @"Add Cooldown Group";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CooldownGroupPrompt = @"Enter a name for the cooldown group you'd like to add:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreGlobalCooldown = @"Ignore Global Cooldown?";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString IgnoreCooldownReduction = @"Ignore Cooldown Reduction?";
+
+        public static LocalizedString copy = @"Copy Spell";
+
+        public static LocalizedString cost = @"Spell Cost:";
+
+        public static LocalizedString critchance = @"Crit Chance (%):";
+
+        public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
+
+        public static LocalizedString damagegroup = @"Damage";
+
+        public static LocalizedString damagetype = @"Damage Type:";
+
+        public static LocalizedString dash = @"Dash";
+
+        public static LocalizedString dashcollisions = @"Ignore Collision:";
+
+        public static LocalizedString dashrange = @"Dash Range (tiles): {00}";
+
+        public static LocalizedString defense = @"Defense:";
+
+        public static LocalizedString delete = @"Delete Spell";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this spell? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Spell";
+
+        public static LocalizedString description = @"Desc:";
+
+        public static LocalizedString duration = @"Duration: (ms)";
+
+        public static Dictionary<int, LocalizedString> effects = new Dictionary<int, LocalizedString>
         {
+            {0, @"None"},
+            {1, @"Silence"},
+            {2, @"Stun"},
+            {3, @"Snare"},
+            {4, @"Blind"},
+            {5, @"Stealth"},
+            {6, @"Transform"},
+            {7, @"Cleanse"},
+            {8, @"Invulnerable"},
+            {9, @"Shield"},
+            {10, @"Sleep"},
+            {11, @"OnHit"},
+            {12, @"Taunt"},
+        };
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString addboughtitem = @"Add Item:";
+        public static LocalizedString effectgroup = @"Effect";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString addlabel = @"Add Item to be Sold:";
+        public static LocalizedString effectlabel = @"Extra Effect:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString addsolditem = @"Add Selected";
+        public static LocalizedString Event = @"Event";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString blacklist = @"Blacklist";
+        public static LocalizedString eventlabel = @"Event:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString buycost = @"Sell Amount:";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString buydesc = @"Buy Item {00} For ({01}) Item {02}";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString buyfor = @"Buy For:";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString friendly = @"Friendly";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString copy = @"Copy Shop";
+        public static LocalizedString general = @"General";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString defaultcurrency = @"Default Currency:";
+        public static LocalizedString hitanimation = @"Hit Animation:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString delete = @"Delete Shop";
+        public static LocalizedString bound = @"Bound?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this shop? This action cannot be reverted!";
+        public static LocalizedString hitradius = @"Hit Radius:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString deletetitle = @"Delete Item";
+        public static LocalizedString hotdot = @"Heal/Damage Over Time";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString dontbuy = @"Don't Buy Item {00}";
+        public static LocalizedString hotdottick = @"Tick (ms):";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString hpcost = @"HP Cost:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString hpdamage = @"HP Damage:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString icon = @"Icon:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString general = @"General";
+        public static LocalizedString ignoreactiveresources = @"Active Resources";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString itemsboughtblacklist = @"Items Bought (Blacklist - Don't Buy Listed Items)  ";
+        public static LocalizedString ignoreblocks = @"Map Blocks";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString itemsboughtwhitelist = @"Items Bought (Whitelist - Buy Listed Items)  ";
+        public static LocalizedString ignoreinactiveresources = @"Inactive Resources";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString itemssold = @"Items Sold";
+        public static LocalizedString ignorezdimension = @"Z-Dimension Blocks";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString ishotdot = @"HOT/DOT?";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString New = @"New Shop";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TickAnimation = @"Tick Animation:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString paste = @"Paste Shop";
+        public static LocalizedString magicresist = @"Magic Resist:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString removeboughtitem = @"Remove Selected";
+        public static LocalizedString manacost = @"Mana Cost:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString removesolditem = @"Remove Selected";
+        public static LocalizedString mpdamage = @"Mana Damage:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString save = @"Save";
+        public static LocalizedString name = @"Name:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString New = @"New Spell";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        public static LocalizedString paste = @"Paste Spell";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sellcost = @"Sell Cost:";
+        public static LocalizedString projectile = @"Projectile:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString selldesc = @"Sell Item {00} For ({01}) Item {02}";
+        public static LocalizedString requirements = @"Casting Requirements";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sellfor = @"Sell for:";
+        public static LocalizedString cannotcast = @"Cannot Cast Message:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString shops = @"Shops";
+        public static LocalizedString requirementsbutton = @"Edit Casting Requirements";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString title = @"Shop Editor";
+        public static LocalizedString save = @"Save";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString scalingamount = @"Scaling Amount (%):";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this shop? This action cannot be reverted!";
+        public static LocalizedString scalingstat = @"Scaling Stat:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString undotitle = @"Undo Changes";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString whitelist = @"Whitelist";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString buysound = @"Buy Sound:";
+        public static LocalizedString speed = @"Speed:";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sellsound = @"Sell Sound:";
-        }
+        public static LocalizedString spells = @"Spells";
 
-        public partial struct SpellEditor
+        public static LocalizedString stats = @"Stat Modifiers";
+
+        public static LocalizedString targetting = @"Targetting Info";
+
+        public static LocalizedString targettype = @"Target Type:";
+
+        public static Dictionary<int, LocalizedString> targettypes = new Dictionary<int, LocalizedString>
         {
+            {0, @"Self"},
+            {1, @"Single Target (includes self)"},
+            {2, @"AOE"},
+            {3, @"Linear (projectile)"},
+            {4, @"On Hit"},
+            {5, @"Trap"}
+        };
 
-            public static LocalizedString abilitypower = @"Ability Pwr:";
+        public static LocalizedString title = @"Spell Editor";
 
-            public static LocalizedString attack = @"Attack:";
+        public static LocalizedString transformsprite = @"Sprite:";
 
-            public static LocalizedString boostduration = @"Stat Boost/Effect Duration";
+        public static LocalizedString type = @"Type:";
 
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString castanimation = @"Extra Cast Anim.:";
-
-            public static LocalizedString CastSpriteOverride = @"Sprite Cast Anim.:";
-
-            public static LocalizedString castrange = @"Cast Range (tiles):";
-
-            public static LocalizedString casttime = @"Cast Time (ms):";
-
-            public static LocalizedString combatspell = @"Combat Spell";
-
-            public static LocalizedString cooldown = @"Cooldown (ms):";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroup = @"Cooldown Group:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroupTitle = @"Add Cooldown Group";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString CooldownGroupPrompt = @"Enter a name for the cooldown group you'd like to add:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreGlobalCooldown = @"Ignore Global Cooldown?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString IgnoreCooldownReduction = @"Ignore Cooldown Reduction?";
-
-            public static LocalizedString copy = @"Copy Spell";
-
-            public static LocalizedString cost = @"Spell Cost:";
-
-            public static LocalizedString critchance = @"Crit Chance (%):";
-
-            public static LocalizedString critmultiplier = @"Crit Multiplier (Default 1.5x):";
-
-            public static LocalizedString damagegroup = @"Damage";
-
-            public static LocalizedString damagetype = @"Damage Type:";
-
-            public static LocalizedString dash = @"Dash";
-
-            public static LocalizedString dashcollisions = @"Ignore Collision:";
-
-            public static LocalizedString dashrange = @"Dash Range (tiles): {00}";
-
-            public static LocalizedString defense = @"Defense:";
-
-            public static LocalizedString delete = @"Delete Spell";
-
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this spell? This action cannot be reverted!";
-
-            public static LocalizedString deletetitle = @"Delete Spell";
-
-            public static LocalizedString description = @"Desc:";
-
-            public static LocalizedString duration = @"Duration: (ms)";
-
-            public static Dictionary<int, LocalizedString> effects = new Dictionary<int, LocalizedString>
-            {
-                {0, @"None"},
-                {1, @"Silence"},
-                {2, @"Stun"},
-                {3, @"Snare"},
-                {4, @"Blind"},
-                {5, @"Stealth"},
-                {6, @"Transform"},
-                {7, @"Cleanse"},
-                {8, @"Invulnerable"},
-                {9, @"Shield"},
-                {10, @"Sleep"},
-                {11, @"OnHit"},
-                {12, @"Taunt"},
-            };
-
-            public static LocalizedString effectgroup = @"Effect";
-
-            public static LocalizedString effectlabel = @"Extra Effect:";
-
-            public static LocalizedString Event = @"Event";
-
-            public static LocalizedString eventlabel = @"Event:";
-
-            public static LocalizedString folderlabel = @"Folder:";
-
-            public static LocalizedString foldertitle = @"Add Folder";
-
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
-
-            public static LocalizedString friendly = @"Friendly";
-
-            public static LocalizedString general = @"General";
-
-            public static LocalizedString hitanimation = @"Hit Animation:";
-
-            public static LocalizedString bound = @"Bound?";
-
-            public static LocalizedString hitradius = @"Hit Radius:";
-
-            public static LocalizedString hotdot = @"Heal/Damage Over Time";
-
-            public static LocalizedString hotdottick = @"Tick (ms):";
-
-            public static LocalizedString hpcost = @"HP Cost:";
-
-            public static LocalizedString hpdamage = @"HP Damage:";
-
-            public static LocalizedString icon = @"Icon:";
-
-            public static LocalizedString ignoreactiveresources = @"Active Resources";
-
-            public static LocalizedString ignoreblocks = @"Map Blocks";
-
-            public static LocalizedString ignoreinactiveresources = @"Inactive Resources";
-
-            public static LocalizedString ignorezdimension = @"Z-Dimension Blocks";
-
-            public static LocalizedString ishotdot = @"HOT/DOT?";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString TickAnimation = @"Tick Animation:";
-
-            public static LocalizedString magicresist = @"Magic Resist:";
-
-            public static LocalizedString manacost = @"Mana Cost:";
-
-            public static LocalizedString mpdamage = @"Mana Damage:";
-
-            public static LocalizedString name = @"Name:";
-
-            public static LocalizedString New = @"New Spell";
-
-            public static LocalizedString paste = @"Paste Spell";
-
-            public static LocalizedString projectile = @"Projectile:";
-
-            public static LocalizedString requirements = @"Casting Requirements";
-
-            public static LocalizedString cannotcast = @"Cannot Cast Message:";
-
-            public static LocalizedString requirementsbutton = @"Edit Casting Requirements";
-
-            public static LocalizedString save = @"Save";
-
-            public static LocalizedString scalingamount = @"Scaling Amount (%):";
-
-            public static LocalizedString scalingstat = @"Scaling Stat:";
-
-            public static LocalizedString searchplaceholder = @"Search...";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
-
-            public static LocalizedString speed = @"Speed:";
-
-            public static LocalizedString spells = @"Spells";
-
-            public static LocalizedString stats = @"Stat Modifiers";
-
-            public static LocalizedString targetting = @"Targetting Info";
-
-            public static LocalizedString targettype = @"Target Type:";
-
-            public static Dictionary<int, LocalizedString> targettypes = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Self"},
-                {1, @"Single Target (includes self)"},
-                {2, @"AOE"},
-                {3, @"Linear (projectile)"},
-                {4, @"On Hit"},
-                {5, @"Trap"}
-            };
-
-            public static LocalizedString title = @"Spell Editor";
-
-            public static LocalizedString transformsprite = @"Sprite:";
-
-            public static LocalizedString type = @"Type:";
-
-            public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Combat Spell"},
-                {1, @"Warp to Map"},
-                {2, @"Warp to Target"},
-                {3, @"Dash"},
-                {4, @"Event"},
-            };
-
-            public static LocalizedString undo = @"Undo Changes";
-
-            public static LocalizedString undoprompt =
-                @"Are you sure you want to undo changes made to this spell? This action cannot be reverted!";
-
-            public static LocalizedString undotitle = @"Undo Changes";
-
-            public static LocalizedString warptomap = @"Warp Caster:";
-
-        }
-
-        public partial struct VariableEditor
+        public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
         {
+            {0, @"Combat Spell"},
+            {1, @"Warp to Map"},
+            {2, @"Warp to Target"},
+            {3, @"Dash"},
+            {4, @"Event"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString delete = @"Delete";
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this spell? This action cannot be reverted!";
 
-            public static LocalizedString deletecaption = @"Delete?";
+        public static LocalizedString undotitle = @"Undo Changes";
 
-            public static LocalizedString deleteprompt =
-                @"Are you sure you want to delete this variable? This action cannot be reverted!";
+        public static LocalizedString warptomap = @"Warp Caster:";
 
-            public static LocalizedString editor = @"Variable Editor";
+    }
 
-            public static LocalizedString False = @"False";
+    public partial struct VariableEditor
+    {
 
-            public static LocalizedString folderlabel = @"Folder:";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString foldertitle = @"Add Folder";
+        public static LocalizedString delete = @"Delete";
 
-            public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+        public static LocalizedString deletecaption = @"Delete?";
 
-            public static LocalizedString globalvariable = @"Server Variable";
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this variable? This action cannot be reverted!";
 
-            public static LocalizedString globalvariables = @"Global Variables";
+        public static LocalizedString editor = @"Variable Editor";
 
-            public static LocalizedString list = @"Variable List";
+        public static LocalizedString False = @"False";
 
-            public static LocalizedString name = @"Name:";
+        public static LocalizedString folderlabel = @"Folder:";
 
-            public static LocalizedString New = @"New";
+        public static LocalizedString foldertitle = @"Add Folder";
 
-            public static LocalizedString playervariable = @"Player Variable";
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
 
-            public static LocalizedString playervariables = @"Player Variables";
+        public static LocalizedString globalvariable = @"Server Variable";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString globalvariables = @"Global Variables";
 
-            public static LocalizedString searchplaceholder = @"Search...";
+        public static LocalizedString list = @"Variable List";
 
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString sortalphabetically = @"Order Alphabetically";
+        public static LocalizedString name = @"Name:";
 
-            public static LocalizedString textidgv = @"Text Id: \gv ";
+        public static LocalizedString New = @"New";
 
-            public static LocalizedString textidpv = @"Text Id: \pv ";
+        public static LocalizedString playervariable = @"Player Variable";
 
-            public static LocalizedString title = @"Variable Editor";
+        public static LocalizedString playervariables = @"Player Variables";
 
-            public static LocalizedString True = @"True";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString type = @"Variable Type";
+        public static LocalizedString searchplaceholder = @"Search...";
 
-            public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
-            {
-                {1, @"Boolean"},
-                {2, @"Integer"},
-                {3, @"String"},
-            };
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
 
-            public static LocalizedString undo = @"Undo Changes";
+        public static LocalizedString textidgv = @"Text Id: \gv ";
 
-            public static LocalizedString value = @"Value:";
+        public static LocalizedString textidpv = @"Text Id: \pv ";
 
-            public static LocalizedString guildvariable = @"Guild Variable";
+        public static LocalizedString title = @"Variable Editor";
 
-            public static LocalizedString guildvariables = @"Guild Variables";
+        public static LocalizedString True = @"True";
 
-            public static LocalizedString textidguildvar = @"Text Id: \guildvar ";
+        public static LocalizedString type = @"Variable Type";
 
-            public static LocalizedString UserVariableId = @"Text Id: \uservar ";
-
-        }
-
-        public partial struct TaskEditor
+        public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
         {
+            {1, @"Boolean"},
+            {2, @"Integer"},
+            {3, @"String"},
+        };
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString undo = @"Undo Changes";
 
-            public static LocalizedString completionevent = @"Quest: {00} - Task Completion Event";
+        public static LocalizedString value = @"Value:";
 
-            public static LocalizedString desc = @"Desc:";
+        public static LocalizedString guildvariable = @"Guild Variable";
 
-            public static LocalizedString editcompletionevent = @"Edit Task Completion Event";
+        public static LocalizedString guildvariables = @"Guild Variables";
 
-            public static LocalizedString editor = @"Task Editor";
+        public static LocalizedString textidguildvar = @"Text Id: \guildvar ";
 
-            public static LocalizedString eventdriven =
-                @"Event Driven: The description should lead the player to an event. The event will then complete the task using the complete quest task command.";
+        public static LocalizedString UserVariableId = @"Text Id: \uservar ";
 
-            public static LocalizedString gatheramount = @"Amount:";
+    }
 
-            public static LocalizedString gatheritems = @"Gather Item(s)";
+    public partial struct TaskEditor
+    {
 
-            public static LocalizedString item = @"Item:";
+        public static LocalizedString cancel = @"Cancel";
 
-            public static LocalizedString killnpcs = @"Kill NPC(s)";
+        public static LocalizedString completionevent = @"Quest: {00} - Task Completion Event";
 
-            public static LocalizedString npc = @"NPC:";
+        public static LocalizedString desc = @"Desc:";
 
-            public static LocalizedString npcamount = @"Amount:";
+        public static LocalizedString editcompletionevent = @"Edit Task Completion Event";
 
-            public static LocalizedString ok = @"Ok";
+        public static LocalizedString editor = @"Task Editor";
 
-            public static LocalizedString title = @"Add/Edit Quest Task";
+        public static LocalizedString eventdriven =
+            @"Event Driven: The description should lead the player to an event. The event will then complete the task using the complete quest task command.";
 
-            public static LocalizedString type = @"Task Type:";
+        public static LocalizedString gatheramount = @"Amount:";
 
-            public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Event Driven"},
-                {1, @"Gather Item(s)"},
-                {2, @"Kill NPC(s)"},
-            };
+        public static LocalizedString gatheritems = @"Gather Item(s)";
 
-            public static Dictionary<int, LocalizedString> descriptions = new Dictionary<int, LocalizedString>
-            {
-                {0, @"Event Driven - {00}"},
-                {1, @"Gather Items [{00} x{01}] - {02}"},
-                {2, @"Kill Npc(s) [{00} x{01}] - {02}"},
-            };
+        public static LocalizedString item = @"Item:";
 
-        }
+        public static LocalizedString killnpcs = @"Kill NPC(s)";
 
-        public partial struct AssetPacking
+        public static LocalizedString npc = @"NPC:";
+
+        public static LocalizedString npcamount = @"Amount:";
+
+        public static LocalizedString ok = @"Ok";
+
+        public static LocalizedString title = @"Add/Edit Quest Task";
+
+        public static LocalizedString type = @"Task Type:";
+
+        public static Dictionary<int, LocalizedString> types = new Dictionary<int, LocalizedString>
         {
+            {0, @"Event Driven"},
+            {1, @"Gather Item(s)"},
+            {2, @"Kill NPC(s)"},
+        };
 
-            public static LocalizedString title = "Packing assets, please wait!";
-
-            public static LocalizedString deleting = "Deleting old packs...";
-
-            public static LocalizedString collecting = "Creating texture packing list...";
-
-            public static LocalizedString calculating = "Calculating texture rects...";
-
-            public static LocalizedString exporting = "Exporting textures...";
-
-            public static LocalizedString sounds = "Packing up sounds...";
-
-            public static LocalizedString music = "Packing up music...";
-
-            public static LocalizedString done = "Done!";
-
-        }
-
-        public partial struct Tiles
+        public static Dictionary<int, LocalizedString> descriptions = new Dictionary<int, LocalizedString>
         {
+            {0, @"Event Driven - {00}"},
+            {1, @"Gather Items [{00} x{01}] - {02}"},
+            {2, @"Kill Npc(s) [{00} x{01}] - {02}"},
+        };
 
-            public static LocalizedString animated = @"Animated  [VX Format]";
+    }
 
-            public static LocalizedString animatedxp = @"Animated  [XP Format]";
+    public partial struct AssetPacking
+    {
 
-            public static LocalizedString autotile = @"Autotile     [VX Format]";
+        public static LocalizedString title = "Packing assets, please wait!";
 
-            public static LocalizedString autotilexp = @"Autotile     [XP Format]";
+        public static LocalizedString deleting = "Deleting old packs...";
 
-            public static LocalizedString cliff = @"Cliff           [VX Format]";
+        public static LocalizedString collecting = "Creating texture packing list...";
 
-            public static LocalizedString fake = @"Fake         [VX Format]";
+        public static LocalizedString calculating = "Calculating texture rects...";
 
-            public static LocalizedString layer = @"Layer:";
+        public static LocalizedString exporting = "Exporting textures...";
 
-            public static Dictionary<string, LocalizedString> maplayers = new Dictionary<string, LocalizedString>
-            {
-                { @"ground", @"Ground" },
-                { @"mask 1", @"Mask 1" },
-                { @"mask 2", @"Mask 2" },
-                { @"fringe 1", @"Fringe 1" },
-                { @"fringe 2", @"Fringe 2" }
-            };
+        public static LocalizedString sounds = "Packing up sounds...";
 
-            public static LocalizedString normal = @"Normal";
+        public static LocalizedString music = "Packing up music...";
 
-            public static LocalizedString tileset = @"Tileset:";
+        public static LocalizedString done = "Done!";
 
-            public static LocalizedString tiletype = @"Tile Type:";
+    }
 
-            public static LocalizedString waterfall = @"Waterfall   [VX Format]";
+    public partial struct Tiles
+    {
 
-        }
+        public static LocalizedString animated = @"Animated  [VX Format]";
 
-        public partial struct TimeEditor
+        public static LocalizedString animatedxp = @"Animated  [XP Format]";
+
+        public static LocalizedString autotile = @"Autotile     [VX Format]";
+
+        public static LocalizedString autotilexp = @"Autotile     [XP Format]";
+
+        public static LocalizedString cliff = @"Cliff           [VX Format]";
+
+        public static LocalizedString fake = @"Fake         [VX Format]";
+
+        public static LocalizedString layer = @"Layer:";
+
+        public static Dictionary<string, LocalizedString> maplayers = new Dictionary<string, LocalizedString>
         {
+            { @"ground", @"Ground" },
+            { @"mask 1", @"Mask 1" },
+            { @"mask 2", @"Mask 2" },
+            { @"fringe 1", @"Fringe 1" },
+            { @"fringe 2", @"Fringe 2" }
+        };
 
-            public static LocalizedString brightness = @"Brightness: {00}%";
+        public static LocalizedString normal = @"Normal";
 
-            public static LocalizedString cancel = @"Cancel";
+        public static LocalizedString tileset = @"Tileset:";
 
-            public static LocalizedString colorpaneldesc = @"Double click the panel above to change the overlay color.";
+        public static LocalizedString tiletype = @"Tile Type:";
 
-            public static LocalizedString interval = @"Invervals:";
+        public static LocalizedString waterfall = @"Waterfall   [VX Format]";
 
-            public static Dictionary<int, LocalizedString> intervals = new Dictionary<int, LocalizedString>
-            {
-                {0, @"24 hours"},
-                {1, @"12 hours"},
-                {2, @"8 hours"},
-                {3, @"6 hours"},
-                {4, @"4 hours"},
-                {5, @"3 hours"},
-                {6, @"2 hours"},
-                {7, @"1 hour"},
-                {8, @"45 minutes"},
-                {9, @"30 minutes"},
-                {10, @"15 minutes"},
-                {11, @"10 minutes"},
-            };
+    }
 
-            public static LocalizedString overlay = @"Range Overlay";
+    public partial struct TimeEditor
+    {
 
-            public static LocalizedString rate = @"Time Rate:";
+        public static LocalizedString brightness = @"Brightness: {00}%";
 
-            public static LocalizedString ratedesc = @"Enter 1 for normal rate of time.
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString colorpaneldesc = @"Double click the panel above to change the overlay color.";
+
+        public static LocalizedString interval = @"Invervals:";
+
+        public static Dictionary<int, LocalizedString> intervals = new Dictionary<int, LocalizedString>
+        {
+            {0, @"24 hours"},
+            {1, @"12 hours"},
+            {2, @"8 hours"},
+            {3, @"6 hours"},
+            {4, @"4 hours"},
+            {5, @"3 hours"},
+            {6, @"2 hours"},
+            {7, @"1 hour"},
+            {8, @"45 minutes"},
+            {9, @"30 minutes"},
+            {10, @"15 minutes"},
+            {11, @"10 minutes"},
+        };
+
+        public static LocalizedString overlay = @"Range Overlay";
+
+        public static LocalizedString rate = @"Time Rate:";
+
+        public static LocalizedString ratedesc = @"Enter 1 for normal rate of time.
 Values larger than one for faster days.
 Values between 0 and 1 for longer days.
 Negative values for time to flow backwards.";
 
-            public static LocalizedString ratesuffix = @"x Normal";
+        public static LocalizedString ratesuffix = @"x Normal";
 
-            public static LocalizedString save = @"Save";
+        public static LocalizedString save = @"Save";
 
-            public static LocalizedString settings = @"Time Settings";
+        public static LocalizedString settings = @"Time Settings";
 
-            public static LocalizedString sync = @"Sync With Server";
+        public static LocalizedString sync = @"Sync With Server";
 
-            public static LocalizedString times = @"Time of Day";
+        public static LocalizedString times = @"Time of Day";
 
-            public static LocalizedString title = @"Time Editor (Day/Night Settings)";
+        public static LocalizedString title = @"Time Editor (Day/Night Settings)";
 
-            public static LocalizedString to = @"to";
+        public static LocalizedString to = @"to";
 
-        }
+    }
 
-        public partial struct Update
+    public partial struct Update
+    {
+
+        public static LocalizedString Title = @"Intersect Editor - Updating";
+
+        public static LocalizedString Checking = @"Checking for updates, please wait!";
+
+        public static LocalizedString Updating = @"Downloading updates, {00}% done!";
+
+        public static LocalizedString Restart = @"Update complete! Relaunching!";
+
+        public static LocalizedString Done = @"Update complete! Launching game!";
+
+        public static LocalizedString Error = @"Error: {00}";
+
+        public static LocalizedString Files = @"{00} Files Remaining";
+
+        public static LocalizedString Size = @"{00} Left";
+
+        public static LocalizedString Percent = @"{00}%";
+
+    }
+
+    public partial struct UpdatePacking
+    {
+        public static LocalizedString SourceDirectoryPromptDescription = @"Pick the directory from which to generate the update";
+
+        public static LocalizedString TargetDirectoryPromptDescription = @"Pick the directory in which to save the packaged update";
+
+        public static LocalizedString Title = @"Packaging Updater Files, Please Wait!";
+
+        public static LocalizedString Deleting = @"Deleting existing or unchanged files..";
+
+        public static LocalizedString Differential = @"An update already exists in this folder, would you like to generate a differential update (only files that have changed)?";
+
+        public static LocalizedString DifferentialTitle = @"Create differential update?";
+
+        public static LocalizedString Empty = @"You must select an empty folder, or a folder already containing an Intersect update!";
+
+        public static LocalizedString InvalidBase = @"You cannot create the update within the editor folder, the update would include itself!";
+
+        public static LocalizedString Error = @"Error!";
+
+        public static LocalizedString Calculating = @"Calculating checksums, and creating update list...";
+
+        public static LocalizedString Done = @"Done!";
+
+    }
+
+    public partial struct Warping
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ChangeInstance = @"Change instance?";
+
+        public static LocalizedString direction = @"Dir: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString InstanceType = @"Instance Type";
+
+        public static LocalizedString map = @"Map: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MapInstancingGroup = @"Instance Settings";
+
+        public static LocalizedString visual = @"Open Visual Interface";
+
+        public static LocalizedString x = @"X: {00}";
+
+        public static LocalizedString y = @"Y: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WarpSound = @"Sound:";
+    }
+
+    public partial struct WarpSelection
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString alphabetical = @"Alphabetical";
+
+        public static LocalizedString maplist = @"Map List";
+
+        public static LocalizedString mappreview = @"Map Preview";
+
+        public static LocalizedString mapselectiontitle = @"Map Selection";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Warp Tile Selection";
+
+    }
+
+    public partial struct VariableSelector
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Button = @"Select a Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelCurrentSelection = @"Current Selection:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelGroup = @"Select a Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelVariableType = @"Variable Type";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LabelVariableValue = @"Variable";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Variable Selector";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ValueCurrentSelection = @"{00} ({01})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ValueNoneSelected = @"None Selected!";
+
+        public static Dictionary<int, LocalizedString> VariableTypes = new Dictionary<int, LocalizedString>
         {
-
-            public static LocalizedString Title = @"Intersect Editor - Updating";
-
-            public static LocalizedString Checking = @"Checking for updates, please wait!";
-
-            public static LocalizedString Updating = @"Downloading updates, {00}% done!";
-
-            public static LocalizedString Restart = @"Update complete! Relaunching!";
-
-            public static LocalizedString Done = @"Update complete! Launching game!";
-
-            public static LocalizedString Error = @"Error: {00}";
-
-            public static LocalizedString Files = @"{00} Files Remaining";
-
-            public static LocalizedString Size = @"{00} Left";
-
-            public static LocalizedString Percent = @"{00}%";
-
-        }
-
-        public partial struct UpdatePacking
-        {
-            public static LocalizedString SourceDirectoryPromptDescription = @"Pick the directory from which to generate the update";
-
-            public static LocalizedString TargetDirectoryPromptDescription = @"Pick the directory in which to save the packaged update";
-
-            public static LocalizedString Title = @"Packaging Updater Files, Please Wait!";
-
-            public static LocalizedString Deleting = @"Deleting existing or unchanged files..";
-
-            public static LocalizedString Differential = @"An update already exists in this folder, would you like to generate a differential update (only files that have changed)?";
-
-            public static LocalizedString DifferentialTitle = @"Create differential update?";
-
-            public static LocalizedString Empty = @"You must select an empty folder, or a folder already containing an Intersect update!";
-
-            public static LocalizedString InvalidBase = @"You cannot create the update within the editor folder, the update would include itself!";
-
-            public static LocalizedString Error = @"Error!";
-
-            public static LocalizedString Calculating = @"Calculating checksums, and creating update list...";
-
-            public static LocalizedString Done = @"Done!";
-
-        }
-
-        public partial struct Warping
-        {
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ChangeInstance = @"Change instance?";
-
-            public static LocalizedString direction = @"Dir: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString InstanceType = @"Instance Type";
-
-            public static LocalizedString map = @"Map: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString MapInstancingGroup = @"Instance Settings";
-
-            public static LocalizedString visual = @"Open Visual Interface";
-
-            public static LocalizedString x = @"X: {00}";
-
-            public static LocalizedString y = @"Y: {00}";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString WarpSound = @"Sound:";
-        }
-
-        public partial struct WarpSelection
-        {
-
-            public static LocalizedString cancel = @"Cancel";
-
-            public static LocalizedString alphabetical = @"Alphabetical";
-
-            public static LocalizedString maplist = @"Map List";
-
-            public static LocalizedString mappreview = @"Map Preview";
-
-            public static LocalizedString mapselectiontitle = @"Map Selection";
-
-            public static LocalizedString okay = @"Ok";
-
-            public static LocalizedString title = @"Warp Tile Selection";
-
-        }
-
-        public partial struct VariableSelector
-        {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Button = @"Select a Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelCurrentSelection = @"Current Selection:";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelGroup = @"Select a Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelVariableType = @"Variable Type";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString LabelVariableValue = @"Variable";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString Title = @"Variable Selector";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ValueCurrentSelection = @"{00} ({01})";
-
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-            public static LocalizedString ValueNoneSelected = @"None Selected!";
-
-            public static Dictionary<int, LocalizedString> VariableTypes = new Dictionary<int, LocalizedString>
-            {
-                {(int) VariableType.PlayerVariable, @"Player Variable" },
-                {(int) VariableType.ServerVariable, @"Server Variable" },
-                {(int) VariableType.GuildVariable, @"Guild Variable" },
-                {(int) VariableType.UserVariable, @"User Variable" },
-            };
-
-        }
+            {(int) VariableType.PlayerVariable, @"Player Variable" },
+            {(int) VariableType.ServerVariable, @"Server Variable" },
+            {(int) VariableType.GuildVariable, @"Guild Variable" },
+            {(int) VariableType.UserVariable, @"User Variable" },
+        };
 
     }
 

--- a/Intersect.Editor/Maps/MapGrid.cs
+++ b/Intersect.Editor/Maps/MapGrid.cs
@@ -12,769 +12,723 @@ using Microsoft.Xna.Framework.Graphics;
 
 using Newtonsoft.Json.Linq;
 
-namespace Intersect.Editor.Maps
+namespace Intersect.Editor.Maps;
+
+
+public partial class MapGrid
 {
 
-    public partial class MapGrid
+    public Rectangle ContentRect;
+
+    public MapGridItem[,] Grid;
+
+    public int GridHeight = 50;
+
+    public int GridWidth = 50;
+
+    public bool Loaded;
+
+    private MapGridItem mContextMap;
+
+    private ContextMenuStrip mContextMenu;
+
+    private bool mCreateTextures;
+
+    private int mCurrentCellX = -1;
+
+    private int mCurrentCellY = -1;
+
+    private ToolStripMenuItem mDropDownLinkItem;
+
+    private ToolStripMenuItem mDropDownUnlinkItem;
+
+    private List<Texture2D> mFreeTextures = new List<Texture2D>();
+
+    private List<Guid> mGridMaps = null;
+
+    private List<Guid> mLinkMaps = new List<Guid>();
+
+    private float mMaxZoom = 1f;
+
+    private float mMinZoom;
+
+    private ToolStripMenuItem mRecacheMapItem;
+
+    private bool mSizeChanged = true;
+
+    private object mTexLock = new object();
+
+    private List<Texture2D> mTextures = new List<Texture2D>();
+
+    private List<MapGridItem> mToLoad = new List<MapGridItem>();
+
+    private Thread mWorkerThread;
+
+    public bool ShowLines = true;
+
+    public int TileHeight;
+
+    public int TileWidth;
+
+    public Rectangle ViewRect;
+
+    public float Zoom = 1;
+
+    public MapGrid(
+        ToolStripMenuItem dropDownItem,
+        ToolStripMenuItem dropDownUnlink,
+        ToolStripMenuItem recacheItem,
+        ContextMenuStrip contextMenu,
+        Icon? icon
+    )
     {
+        mWorkerThread = new Thread(AsyncLoadingThread);
+        mWorkerThread.Start();
+        mDropDownLinkItem = dropDownItem;
+        mDropDownLinkItem.Click += LinkMapItem_Click;
+        mContextMenu = contextMenu;
+        mDropDownUnlinkItem = dropDownUnlink;
+        mDropDownUnlinkItem.Click += UnlinkMapItem_Click;
+        mRecacheMapItem = recacheItem;
+        mRecacheMapItem.Click += _recacheMapItem_Click;
 
-        public Rectangle ContentRect;
+        Icon = icon;
+    }
 
-        public MapGridItem[,] Grid;
+    public Icon? Icon { get; set; }
 
-        public int GridHeight = 50;
-
-        public int GridWidth = 50;
-
-        public bool Loaded;
-
-        private MapGridItem mContextMap;
-
-        private ContextMenuStrip mContextMenu;
-
-        private bool mCreateTextures;
-
-        private int mCurrentCellX = -1;
-
-        private int mCurrentCellY = -1;
-
-        private ToolStripMenuItem mDropDownLinkItem;
-
-        private ToolStripMenuItem mDropDownUnlinkItem;
-
-        private List<Texture2D> mFreeTextures = new List<Texture2D>();
-
-        private List<Guid> mGridMaps = null;
-
-        private List<Guid> mLinkMaps = new List<Guid>();
-
-        private float mMaxZoom = 1f;
-
-        private float mMinZoom;
-
-        private ToolStripMenuItem mRecacheMapItem;
-
-        private bool mSizeChanged = true;
-
-        private object mTexLock = new object();
-
-        private List<Texture2D> mTextures = new List<Texture2D>();
-
-        private List<MapGridItem> mToLoad = new List<MapGridItem>();
-
-        private Thread mWorkerThread;
-
-        public bool ShowLines = true;
-
-        public int TileHeight;
-
-        public int TileWidth;
-
-        public Rectangle ViewRect;
-
-        public float Zoom = 1;
-
-        public MapGrid(
-            ToolStripMenuItem dropDownItem,
-            ToolStripMenuItem dropDownUnlink,
-            ToolStripMenuItem recacheItem,
-            ContextMenuStrip contextMenu,
-            Icon? icon
-        )
+    private void AsyncLoadingThread()
+    {
+        while (!Globals.ClosingEditor)
         {
-            mWorkerThread = new Thread(AsyncLoadingThread);
-            mWorkerThread.Start();
-            mDropDownLinkItem = dropDownItem;
-            mDropDownLinkItem.Click += LinkMapItem_Click;
-            mContextMenu = contextMenu;
-            mDropDownUnlinkItem = dropDownUnlink;
-            mDropDownUnlinkItem.Click += UnlinkMapItem_Click;
-            mRecacheMapItem = recacheItem;
-            mRecacheMapItem.Click += _recacheMapItem_Click;
-
-            Icon = icon;
-        }
-
-        public Icon? Icon { get; set; }
-
-        private void AsyncLoadingThread()
-        {
-            while (!Globals.ClosingEditor)
+            lock (mTexLock)
             {
-                lock (mTexLock)
+                if (mToLoad.Count > 0 && mFreeTextures.Count > 0)
                 {
-                    if (mToLoad.Count > 0 && mFreeTextures.Count > 0)
+                    var itm = mToLoad[0];
+                    mToLoad.RemoveAt(0);
+                    var tex = mFreeTextures[0];
+                    mFreeTextures.RemoveAt(0);
+
+                    var texData = Database.LoadMapCache(itm.MapId, itm.Revision, TileWidth, TileHeight);
+                    try
                     {
-                        var itm = mToLoad[0];
-                        mToLoad.RemoveAt(0);
-                        var tex = mFreeTextures[0];
-                        mFreeTextures.RemoveAt(0);
-
-                        var texData = Database.LoadMapCache(itm.MapId, itm.Revision, TileWidth, TileHeight);
-                        try
+                        if (texData != null)
                         {
-                            if (texData != null)
-                            {
-                                tex.SetData(texData);
-                                itm.Tex = tex;
-                            }
-                            else
-                            {
-                                mFreeTextures.Add(tex);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            //Ignore errors that are likely caused by timing issues.
-                            mFreeTextures.Add(tex);
-                            mToLoad.Add(itm);
-                        }
-                    }
-                }
-            }
-        }
-
-        public Object GetMapGridLock()
-        {
-            return mTexLock;
-        }
-
-        public void Load(string[,] mapGrid)
-        {
-            lock (GetMapGridLock())
-            {
-                Loaded = false;
-                var gridMaps = new List<Guid>();
-                GridWidth = mapGrid.GetLength(0);
-                GridHeight = mapGrid.GetLength(1);
-                UnloadTextures();
-                Grid = new MapGridItem[GridWidth, GridHeight];
-                for (var x = -1; x <= GridWidth; x++)
-                {
-                    for (var y = -1; y <= GridHeight; y++)
-                    {
-                        if (y == -1 || y == GridHeight || x == -1 || x == GridWidth)
-                        {
+                            tex.SetData(texData);
+                            itm.Tex = tex;
                         }
                         else
                         {
-                            if (mapGrid[x, y] == null)
-                            {
-                                Grid[x, y] = new MapGridItem(Guid.Empty);
-                            }
-                            else
-                            {
-                                var obj = JObject.Parse(mapGrid[x, y]);
-                                Grid[x, y] = new MapGridItem(
-                                    Guid.Parse(obj["Guid"].ToString()), obj["Name"].ToString(),
-                                    int.Parse(obj["Revision"].ToString())
-                                );
-
-                                gridMaps.Add(Grid[x, y].MapId);
-                            }
+                            mFreeTextures.Add(tex);
                         }
                     }
-                }
-
-                //Get a list of maps -- if they are not in this grid.
-                mLinkMaps.Clear();
-                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
-                {
-                    if (!gridMaps.Contains(MapList.OrderedMaps[i].MapId))
+                    catch (Exception ex)
                     {
-                        mLinkMaps.Add(MapList.OrderedMaps[i].MapId);
+                        //Ignore errors that are likely caused by timing issues.
+                        mFreeTextures.Add(tex);
+                        mToLoad.Add(itm);
                     }
                 }
-
-                mMaxZoom = 1f; //Real Size
-                Zoom = mMinZoom;
-                TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
-                TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
-                ContentRect = new Rectangle(
-                    ViewRect.Width / 2 - TileWidth * (GridWidth + 2) / 2,
-                    ViewRect.Height / 2 - TileHeight * (GridHeight + 2) / 2, TileWidth * (GridWidth + 2),
-                    TileHeight * (GridHeight + 2)
-                );
-
-                mCreateTextures = true;
-                Loaded = true;
-                mGridMaps = gridMaps;
             }
         }
+    }
 
-        public void DoubleClick(int x, int y)
+    public Object GetMapGridLock()
+    {
+        return mTexLock;
+    }
+
+    public void Load(string[,] mapGrid)
+    {
+        lock (GetMapGridLock())
         {
-            for (var x1 = 1; x1 < GridWidth + 1; x1++)
+            Loaded = false;
+            var gridMaps = new List<Guid>();
+            GridWidth = mapGrid.GetLength(0);
+            GridHeight = mapGrid.GetLength(1);
+            UnloadTextures();
+            Grid = new MapGridItem[GridWidth, GridHeight];
+            for (var x = -1; x <= GridWidth; x++)
             {
-                for (var y1 = 1; y1 < GridHeight + 1; y1++)
+                for (var y = -1; y <= GridHeight; y++)
                 {
-                    if (new Rectangle(
-                        ContentRect.X + x1 * TileWidth, ContentRect.Y + y1 * TileHeight, TileWidth, TileHeight
-                    ).Contains(new System.Drawing.Point(x, y)))
+                    if (y == -1 || y == GridHeight || x == -1 || x == GridWidth)
                     {
-                        if (Grid[x1 - 1, y1 - 1].MapId != Guid.Empty)
+                    }
+                    else
+                    {
+                        if (mapGrid[x, y] == null)
                         {
-                            if (Globals.CurrentMap != null &&
-                                Globals.CurrentMap.Changed() &&
-                                DarkMessageBox.ShowInformation(
-                                    Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
-                                    Icon
-                                ) ==
-                                DialogResult.Yes)
-                            {
-                                SaveMap();
-                            }
+                            Grid[x, y] = new MapGridItem(Guid.Empty);
+                        }
+                        else
+                        {
+                            var obj = JObject.Parse(mapGrid[x, y]);
+                            Grid[x, y] = new MapGridItem(
+                                Guid.Parse(obj["Guid"].ToString()), obj["Name"].ToString(),
+                                int.Parse(obj["Revision"].ToString())
+                            );
 
-                            Globals.MainForm.EnterMap(Grid[x1 - 1, y1 - 1].MapId, true);
-                            Globals.MapEditorWindow.Select();
+                            gridMaps.Add(Grid[x, y].MapId);
                         }
                     }
                 }
             }
-        }
 
-        private void SaveMap()
-        {
-            if (Globals.CurrentTool == EditingTool.Selection)
+            //Get a list of maps -- if they are not in this grid.
+            mLinkMaps.Clear();
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
             {
-                if (Globals.Dragging == true)
+                if (!gridMaps.Contains(MapList.OrderedMaps[i].MapId))
                 {
-                    //Place the change, we done!
-                    Globals.MapEditorWindow.ProcessSelectionMovement(Globals.CurrentMap, true);
-                    Globals.MapEditorWindow.PlaceSelection();
+                    mLinkMaps.Add(MapList.OrderedMaps[i].MapId);
                 }
             }
 
-            PacketSender.SendMap(Globals.CurrentMap);
-        }
-
-        public void ScreenshotWorld()
-        {
-            var fileDialog = new SaveFileDialog()
-            {
-                Filter = "Png Image|*.png|JPeg Image|*.jpg|Bitmap Image|*.bmp|Gif Image|*.gif",
-                Title = Strings.MapGrid.savescreenshotdialogue
-            };
-
-            fileDialog.ShowDialog();
-            if (fileDialog.FileName != "")
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.MapGrid.savescreenshotconfirm, Strings.MapGrid.savescreenshottitle,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    FetchMissingPreviews(false);
-                    Globals.PreviewProgressForm = new FrmProgress();
-                    Globals.PreviewProgressForm.SetTitle(Strings.MapGrid.savingscreenshot);
-                    var screenShotThread = new Thread(() => ScreenshotWorld(fileDialog.FileName));
-                    screenShotThread.Start();
-                    Globals.PreviewProgressForm.ShowDialog();
-                }
-            }
-        }
-
-        void ScreenshotWorld(string filename)
-        {
-            var rowSize = Options.TileHeight * Options.MapHeight;
-            var colSize = Options.MapWidth * Options.TileWidth;
-            var cols = colSize * GridWidth;
-            var rows = rowSize * GridHeight;
-            var tmpBitmap = new Bitmap(colSize, rowSize);
-            var g = System.Drawing.Graphics.FromImage(tmpBitmap);
-            var png = new PngWriter(
-                new FileStream(filename, FileMode.OpenOrCreate), new ImageInfo(cols, rows, 16, true)
+            mMaxZoom = 1f; //Real Size
+            Zoom = mMinZoom;
+            TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
+            TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
+            ContentRect = new Rectangle(
+                ViewRect.Width / 2 - TileWidth * (GridWidth + 2) / 2,
+                ViewRect.Height / 2 - TileHeight * (GridHeight + 2) / 2, TileWidth * (GridWidth + 2),
+                TileHeight * (GridHeight + 2)
             );
 
-            var pngReaderDict = new Dictionary<Guid, Bitmap>();
-            var cacheRow = 0;
+            mCreateTextures = true;
+            Loaded = true;
+            mGridMaps = gridMaps;
+        }
+    }
 
-            //Generate one row at a time.
-            for (var y = 0; y < rows; y++)
+    public void DoubleClick(int x, int y)
+    {
+        for (var x1 = 1; x1 < GridWidth + 1; x1++)
+        {
+            for (var y1 = 1; y1 < GridHeight + 1; y1++)
             {
-                var gridRow = (int) Math.Floor(y / (double) rowSize);
-                if (gridRow != cacheRow)
+                if (new Rectangle(
+                    ContentRect.X + x1 * TileWidth, ContentRect.Y + y1 * TileHeight, TileWidth, TileHeight
+                ).Contains(new System.Drawing.Point(x, y)))
                 {
-                    foreach (var cache in pngReaderDict)
+                    if (Grid[x1 - 1, y1 - 1].MapId != Guid.Empty)
                     {
-                        cache.Value.Dispose();
-                    }
+                        if (Globals.CurrentMap != null &&
+                            Globals.CurrentMap.Changed() &&
+                            DarkMessageBox.ShowInformation(
+                                Strings.Mapping.savemapdialogue, Strings.Mapping.savemap, DarkDialogButton.YesNo,
+                                Icon
+                            ) ==
+                            DialogResult.Yes)
+                        {
+                            SaveMap();
+                        }
 
-                    pngReaderDict.Clear();
-                    cacheRow = gridRow;
+                        Globals.MainForm.EnterMap(Grid[x1 - 1, y1 - 1].MapId, true);
+                        Globals.MapEditorWindow.Select();
+                    }
+                }
+            }
+        }
+    }
+
+    private void SaveMap()
+    {
+        if (Globals.CurrentTool == EditingTool.Selection)
+        {
+            if (Globals.Dragging == true)
+            {
+                //Place the change, we done!
+                Globals.MapEditorWindow.ProcessSelectionMovement(Globals.CurrentMap, true);
+                Globals.MapEditorWindow.PlaceSelection();
+            }
+        }
+
+        PacketSender.SendMap(Globals.CurrentMap);
+    }
+
+    public void ScreenshotWorld()
+    {
+        var fileDialog = new SaveFileDialog()
+        {
+            Filter = "Png Image|*.png|JPeg Image|*.jpg|Bitmap Image|*.bmp|Gif Image|*.gif",
+            Title = Strings.MapGrid.savescreenshotdialogue
+        };
+
+        fileDialog.ShowDialog();
+        if (fileDialog.FileName != "")
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.MapGrid.savescreenshotconfirm, Strings.MapGrid.savescreenshottitle,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                FetchMissingPreviews(false);
+                Globals.PreviewProgressForm = new FrmProgress();
+                Globals.PreviewProgressForm.SetTitle(Strings.MapGrid.savingscreenshot);
+                var screenShotThread = new Thread(() => ScreenshotWorld(fileDialog.FileName));
+                screenShotThread.Start();
+                Globals.PreviewProgressForm.ShowDialog();
+            }
+        }
+    }
+
+    void ScreenshotWorld(string filename)
+    {
+        var rowSize = Options.TileHeight * Options.MapHeight;
+        var colSize = Options.MapWidth * Options.TileWidth;
+        var cols = colSize * GridWidth;
+        var rows = rowSize * GridHeight;
+        var tmpBitmap = new Bitmap(colSize, rowSize);
+        var g = System.Drawing.Graphics.FromImage(tmpBitmap);
+        var png = new PngWriter(
+            new FileStream(filename, FileMode.OpenOrCreate), new ImageInfo(cols, rows, 16, true)
+        );
+
+        var pngReaderDict = new Dictionary<Guid, Bitmap>();
+        var cacheRow = 0;
+
+        //Generate one row at a time.
+        for (var y = 0; y < rows; y++)
+        {
+            var gridRow = (int) Math.Floor(y / (double) rowSize);
+            if (gridRow != cacheRow)
+            {
+                foreach (var cache in pngReaderDict)
+                {
+                    cache.Value.Dispose();
                 }
 
-                var row = new byte[png.ImgInfo.Cols * 4];
-                for (var x = 0; x < GridWidth; x++)
+                pngReaderDict.Clear();
+                cacheRow = gridRow;
+            }
+
+            var row = new byte[png.ImgInfo.Cols * 4];
+            for (var x = 0; x < GridWidth; x++)
+            {
+                var gridCol = x;
+
+                var item = Grid[gridCol, gridRow];
+                if (item.MapId != Guid.Empty)
                 {
-                    var gridCol = x;
-
-                    var item = Grid[gridCol, gridRow];
-                    if (item.MapId != Guid.Empty)
+                    Bitmap reader = null;
+                    if (pngReaderDict.ContainsKey(item.MapId))
                     {
-                        Bitmap reader = null;
-                        if (pngReaderDict.ContainsKey(item.MapId))
+                        reader = pngReaderDict[item.MapId];
+                    }
+                    else
+                    {
+                        var data = Database.LoadMapCacheRaw(item.MapId, item.Revision);
+                        if (data != null)
                         {
-                            reader = pngReaderDict[item.MapId];
+                            reader = new Bitmap(new MemoryStream(data));
+                            pngReaderDict.Add(item.MapId, reader);
                         }
-                        else
-                        {
-                            var data = Database.LoadMapCacheRaw(item.MapId, item.Revision);
-                            if (data != null)
-                            {
-                                reader = new Bitmap(new MemoryStream(data));
-                                pngReaderDict.Add(item.MapId, reader);
-                            }
-                        }
+                    }
 
-                        if (reader != null)
-                        {
-                            var rowNum = y - gridRow * rowSize;
+                    if (reader != null)
+                    {
+                        var rowNum = y - gridRow * rowSize;
 
-                            //Get the pixel color we need
-                            for (var x1 = x * colSize; x1 < x * colSize + colSize; x1++)
-                            {
-                                var clr = reader.GetPixel(x1 - x * colSize, rowNum);
-
-                                // Color.FromArgb(ImageLineHelper.GetPixelToARGB8(line, x1 - (x) * colSize));
-                                row[x1 * 4] = clr.R;
-                                row[x1 * 4 + 1] = clr.G;
-                                row[x1 * 4 + 2] = clr.B;
-                                row[x1 * 4 + 3] = clr.A;
-                            }
-                        }
-                        else
+                        //Get the pixel color we need
+                        for (var x1 = x * colSize; x1 < x * colSize + colSize; x1++)
                         {
-                            for (var x1 = x * colSize; x1 < x * colSize + colSize; x1++)
-                            {
-                                row[x1 * 4] = 0;
-                                row[x1 * 4 + 1] = 255;
-                                row[x1 * 4 + 2] = 0;
-                                row[x1 * 4 + 3] = 255;
-                            }
+                            var clr = reader.GetPixel(x1 - x * colSize, rowNum);
+
+                            // Color.FromArgb(ImageLineHelper.GetPixelToARGB8(line, x1 - (x) * colSize));
+                            row[x1 * 4] = clr.R;
+                            row[x1 * 4 + 1] = clr.G;
+                            row[x1 * 4 + 2] = clr.B;
+                            row[x1 * 4 + 3] = clr.A;
                         }
                     }
                     else
                     {
                         for (var x1 = x * colSize; x1 < x * colSize + colSize; x1++)
                         {
-                            row[x1 * 4] = System.Drawing.Color.Gray.R;
-                            row[x1 * 4 + 1] = System.Drawing.Color.Gray.G;
-                            row[x1 * 4 + 2] = System.Drawing.Color.Gray.B;
-                            row[x1 * 4 + 3] = System.Drawing.Color.Gray.A;
+                            row[x1 * 4] = 0;
+                            row[x1 * 4 + 1] = 255;
+                            row[x1 * 4 + 2] = 0;
+                            row[x1 * 4 + 3] = 255;
                         }
-                    }
-                }
-
-                png.WriteRowByte(row, y);
-                Globals.PreviewProgressForm.SetProgress(
-                    Strings.MapGrid.savingrow.ToString(y, rows), (int) (y / (float) rows * 100), false
-                );
-
-                Application.DoEvents();
-            }
-
-            png.End();
-            Globals.PreviewProgressForm.NotifyClose();
-        }
-
-        public bool Contains(Guid mapId)
-        {
-            if (Grid != null && Loaded)
-            {
-                return mGridMaps.Contains(mapId);
-            }
-
-            return false;
-        }
-
-        public void ResetForm()
-        {
-            lock (mTexLock)
-            {
-                UnloadTextures();
-                mCreateTextures = true;
-            }
-        }
-
-        public void FetchMissingPreviews(bool clearAllFirst)
-        {
-            var maps = new List<Guid>();
-            if (clearAllFirst)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.MapGrid.clearandfetch, Strings.MapGrid.fetchcaption, DarkDialogButton.YesNo,
-                        Icon
-                    ) !=
-                    DialogResult.Yes)
-                {
-                    return;
-                }
-
-                if (DarkMessageBox.ShowInformation(
-                        Strings.MapGrid.keepmapcache, Strings.MapGrid.mapcachecaption, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    Database.GridHideOverlay = Core.Graphics.HideOverlay;
-                    Database.GridHideDarkness = Core.Graphics.HideDarkness;
-                    Database.GridHideFog = Core.Graphics.HideFog;
-                    Database.GridHideResources = Core.Graphics.HideResources;
-                    if (Core.Graphics.LightColor != null)
-                    {
-                        Database.GridLightColor = System.Drawing.Color.FromArgb(
-                                Core.Graphics.LightColor.A, Core.Graphics.LightColor.R, Core.Graphics.LightColor.G,
-                                Core.Graphics.LightColor.B
-                            )
-                            .ToArgb();
-                    }
-                    else
-                    {
-                        Database.GridLightColor = System.Drawing.Color.FromArgb(255, 255, 255, 255).ToArgb();
                     }
                 }
                 else
                 {
-                    Database.GridHideOverlay = true;
-                    Database.GridHideDarkness = true;
-                    Database.GridHideFog = true;
-                    Database.GridHideResources = false;
-                    Database.GridLightColor = System.Drawing.Color.White.ToArgb();
-                }
-
-                Database.SaveGridOptions();
-                Database.ClearAllMapCache();
-            }
-
-            //Get a list of maps without images.
-            for (var x = 0; x < GridWidth; x++)
-            {
-                for (var y = 0; y < GridHeight; y++)
-                {
-                    if (Grid[x, y].MapId != Guid.Empty)
+                    for (var x1 = x * colSize; x1 < x * colSize + colSize; x1++)
                     {
-                        var img = Database.LoadMapCacheLegacy(Grid[x, y].MapId, Grid[x, y].Revision);
-                        if (img == null)
-                        {
-                            maps.Add(Grid[x, y].MapId);
-                        }
-                        else
-                        {
-                            img.Dispose();
-                        }
+                        row[x1 * 4] = System.Drawing.Color.Gray.R;
+                        row[x1 * 4 + 1] = System.Drawing.Color.Gray.G;
+                        row[x1 * 4 + 2] = System.Drawing.Color.Gray.B;
+                        row[x1 * 4 + 3] = System.Drawing.Color.Gray.A;
                     }
                 }
             }
 
-            if (maps.Count > 0)
+            png.WriteRowByte(row, y);
+            Globals.PreviewProgressForm.SetProgress(
+                Strings.MapGrid.savingrow.ToString(y, rows), (int) (y / (float) rows * 100), false
+            );
+
+            Application.DoEvents();
+        }
+
+        png.End();
+        Globals.PreviewProgressForm.NotifyClose();
+    }
+
+    public bool Contains(Guid mapId)
+    {
+        if (Grid != null && Loaded)
+        {
+            return mGridMaps.Contains(mapId);
+        }
+
+        return false;
+    }
+
+    public void ResetForm()
+    {
+        lock (mTexLock)
+        {
+            UnloadTextures();
+            mCreateTextures = true;
+        }
+    }
+
+    public void FetchMissingPreviews(bool clearAllFirst)
+    {
+        var maps = new List<Guid>();
+        if (clearAllFirst)
+        {
+            if (DarkMessageBox.ShowWarning(
+                    Strings.MapGrid.clearandfetch, Strings.MapGrid.fetchcaption, DarkDialogButton.YesNo,
+                    Icon
+                ) !=
+                DialogResult.Yes)
             {
-                if (clearAllFirst ||
-                    DarkMessageBox.ShowWarning(
-                        Strings.MapGrid.justfetch, Strings.MapGrid.fetchcaption, DarkDialogButton.YesNo,
-                        Icon
-                    ) ==
-                    DialogResult.Yes)
+                return;
+            }
+
+            if (DarkMessageBox.ShowInformation(
+                    Strings.MapGrid.keepmapcache, Strings.MapGrid.mapcachecaption, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                Database.GridHideOverlay = Core.Graphics.HideOverlay;
+                Database.GridHideDarkness = Core.Graphics.HideDarkness;
+                Database.GridHideFog = Core.Graphics.HideFog;
+                Database.GridHideResources = Core.Graphics.HideResources;
+                if (Core.Graphics.LightColor != null)
                 {
-                    Globals.FetchingMapPreviews = true;
-                    Globals.PreviewProgressForm = new FrmProgress();
-                    Globals.PreviewProgressForm.SetTitle(Strings.MapGrid.fetchingmaps);
-                    Globals.PreviewProgressForm.SetProgress(
-                        Strings.MapGrid.fetchingprogress.ToString(0, maps.Count), 0, false
-                    );
+                    Database.GridLightColor = System.Drawing.Color.FromArgb(
+                            Core.Graphics.LightColor.A, Core.Graphics.LightColor.R, Core.Graphics.LightColor.G,
+                            Core.Graphics.LightColor.B
+                        )
+                        .ToArgb();
+                }
+                else
+                {
+                    Database.GridLightColor = System.Drawing.Color.FromArgb(255, 255, 255, 255).ToArgb();
+                }
+            }
+            else
+            {
+                Database.GridHideOverlay = true;
+                Database.GridHideDarkness = true;
+                Database.GridHideFog = true;
+                Database.GridHideResources = false;
+                Database.GridLightColor = System.Drawing.Color.White.ToArgb();
+            }
 
-                    Globals.FetchCount = maps.Count;
-                    Globals.MapsToFetch = maps;
-                    for (var i = 0; i < maps.Count; i++)
+            Database.SaveGridOptions();
+            Database.ClearAllMapCache();
+        }
+
+        //Get a list of maps without images.
+        for (var x = 0; x < GridWidth; x++)
+        {
+            for (var y = 0; y < GridHeight; y++)
+            {
+                if (Grid[x, y].MapId != Guid.Empty)
+                {
+                    var img = Database.LoadMapCacheLegacy(Grid[x, y].MapId, Grid[x, y].Revision);
+                    if (img == null)
                     {
-                        PacketSender.SendNeedMap(maps[i]);
+                        maps.Add(Grid[x, y].MapId);
                     }
-
-                    Globals.PreviewProgressForm.ShowDialog();
+                    else
+                    {
+                        img.Dispose();
+                    }
                 }
             }
         }
 
-        public void RightClickGrid(int x, int y, Panel mapGridView)
+        if (maps.Count > 0)
         {
-            for (var x1 = 0; x1 < GridWidth + 2; x1++)
+            if (clearAllFirst ||
+                DarkMessageBox.ShowWarning(
+                    Strings.MapGrid.justfetch, Strings.MapGrid.fetchcaption, DarkDialogButton.YesNo,
+                    Icon
+                ) ==
+                DialogResult.Yes)
             {
-                for (var y1 = 0; y1 < GridHeight + 2; y1++)
+                Globals.FetchingMapPreviews = true;
+                Globals.PreviewProgressForm = new FrmProgress();
+                Globals.PreviewProgressForm.SetTitle(Strings.MapGrid.fetchingmaps);
+                Globals.PreviewProgressForm.SetProgress(
+                    Strings.MapGrid.fetchingprogress.ToString(0, maps.Count), 0, false
+                );
+
+                Globals.FetchCount = maps.Count;
+                Globals.MapsToFetch = maps;
+                for (var i = 0; i < maps.Count; i++)
                 {
-                    if (new Rectangle(
-                        ContentRect.X + x1 * TileWidth, ContentRect.Y + y1 * TileHeight, TileWidth, TileHeight
-                    ).Contains(new System.Drawing.Point(x, y)))
+                    PacketSender.SendNeedMap(maps[i]);
+                }
+
+                Globals.PreviewProgressForm.ShowDialog();
+            }
+        }
+    }
+
+    public void RightClickGrid(int x, int y, Panel mapGridView)
+    {
+        for (var x1 = 0; x1 < GridWidth + 2; x1++)
+        {
+            for (var y1 = 0; y1 < GridHeight + 2; y1++)
+            {
+                if (new Rectangle(
+                    ContentRect.X + x1 * TileWidth, ContentRect.Y + y1 * TileHeight, TileWidth, TileHeight
+                ).Contains(new System.Drawing.Point(x, y)))
+                {
+                    mCurrentCellX = x1;
+                    mCurrentCellY = y1;
+                    if (mCurrentCellX >= 0 && mCurrentCellY >= 0)
                     {
-                        mCurrentCellX = x1;
-                        mCurrentCellY = y1;
-                        if (mCurrentCellX >= 0 && mCurrentCellY >= 0)
+                        if (mCurrentCellX >= 0 &&
+                            mCurrentCellY >= 0 &&
+                            mCurrentCellX - 1 <= GridWidth &&
+                            mCurrentCellY - 1 <= GridHeight)
                         {
-                            if (mCurrentCellX >= 0 &&
-                                mCurrentCellY >= 0 &&
-                                mCurrentCellX - 1 <= GridWidth &&
-                                mCurrentCellY - 1 <= GridHeight)
+                            if (mCurrentCellX == 0 ||
+                                mCurrentCellY == 0 ||
+                                mCurrentCellX - 1 == GridWidth ||
+                                mCurrentCellY - 1 == GridHeight ||
+                                Grid[mCurrentCellX - 1, mCurrentCellY - 1].MapId == Guid.Empty)
                             {
-                                if (mCurrentCellX == 0 ||
-                                    mCurrentCellY == 0 ||
-                                    mCurrentCellX - 1 == GridWidth ||
-                                    mCurrentCellY - 1 == GridHeight ||
-                                    Grid[mCurrentCellX - 1, mCurrentCellY - 1].MapId == Guid.Empty)
+                                var adjacentMap = Guid.Empty;
+
+                                //Check Left
+                                if (mCurrentCellX > 1 && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
                                 {
-                                    var adjacentMap = Guid.Empty;
-
-                                    //Check Left
-                                    if (mCurrentCellX > 1 && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
+                                    if (Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId != Guid.Empty)
                                     {
-                                        if (Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId != Guid.Empty)
-                                        {
-                                            adjacentMap = Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId;
-                                        }
-                                    }
-
-                                    //Check Right
-                                    if (mCurrentCellX < GridWidth &&
-                                        mCurrentCellY != 0 &&
-                                        mCurrentCellY - 1 < GridHeight)
-                                    {
-                                        if (Grid[mCurrentCellX, mCurrentCellY - 1].MapId != Guid.Empty)
-                                        {
-                                            adjacentMap = Grid[mCurrentCellX, mCurrentCellY - 1].MapId;
-                                        }
-                                    }
-
-                                    //Check Up
-                                    if (mCurrentCellX != 0 && mCurrentCellY > 1 && mCurrentCellX - 1 < GridWidth)
-                                    {
-                                        if (Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId != Guid.Empty)
-                                        {
-                                            adjacentMap = Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId;
-                                        }
-                                    }
-
-                                    //Check Down
-                                    if (mCurrentCellX != 0 &&
-                                        mCurrentCellY < GridHeight &&
-                                        mCurrentCellX - 1 < GridWidth)
-                                    {
-                                        if (Grid[mCurrentCellX - 1, mCurrentCellY].MapId != Guid.Empty)
-                                        {
-                                            adjacentMap = Grid[mCurrentCellX - 1, mCurrentCellY].MapId;
-                                        }
-                                    }
-
-                                    if (adjacentMap != Guid.Empty)
-                                    {
-                                        mContextMenu.Show(mapGridView, new System.Drawing.Point(x, y));
-                                        mDropDownUnlinkItem.Visible = false;
-                                        mDropDownLinkItem.Visible = true;
-                                        mRecacheMapItem.Visible = false;
+                                        adjacentMap = Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId;
                                     }
                                 }
-                                else
+
+                                //Check Right
+                                if (mCurrentCellX < GridWidth &&
+                                    mCurrentCellY != 0 &&
+                                    mCurrentCellY - 1 < GridHeight)
                                 {
-                                    mContextMap = Grid[mCurrentCellX - 1, mCurrentCellY - 1];
+                                    if (Grid[mCurrentCellX, mCurrentCellY - 1].MapId != Guid.Empty)
+                                    {
+                                        adjacentMap = Grid[mCurrentCellX, mCurrentCellY - 1].MapId;
+                                    }
+                                }
+
+                                //Check Up
+                                if (mCurrentCellX != 0 && mCurrentCellY > 1 && mCurrentCellX - 1 < GridWidth)
+                                {
+                                    if (Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId != Guid.Empty)
+                                    {
+                                        adjacentMap = Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId;
+                                    }
+                                }
+
+                                //Check Down
+                                if (mCurrentCellX != 0 &&
+                                    mCurrentCellY < GridHeight &&
+                                    mCurrentCellX - 1 < GridWidth)
+                                {
+                                    if (Grid[mCurrentCellX - 1, mCurrentCellY].MapId != Guid.Empty)
+                                    {
+                                        adjacentMap = Grid[mCurrentCellX - 1, mCurrentCellY].MapId;
+                                    }
+                                }
+
+                                if (adjacentMap != Guid.Empty)
+                                {
                                     mContextMenu.Show(mapGridView, new System.Drawing.Point(x, y));
-                                    mDropDownUnlinkItem.Visible = true;
-                                    mRecacheMapItem.Visible = true;
-                                    mDropDownLinkItem.Visible = false;
+                                    mDropDownUnlinkItem.Visible = false;
+                                    mDropDownLinkItem.Visible = true;
+                                    mRecacheMapItem.Visible = false;
                                 }
                             }
-                        }
-
-                        return;
-                    }
-                }
-            }
-
-            mCurrentCellX = -1;
-            mCurrentCellY = -1;
-        }
-
-        private void UnlinkMapItem_Click(object sender, EventArgs e)
-        {
-            if (mContextMap != null && mContextMap.MapId != Guid.Empty)
-            {
-                if (DarkMessageBox.ShowWarning(
-                        Strings.MapGrid.unlinkprompt.ToString(mContextMap.Name), Strings.MapGrid.unlinkcaption,
-                        DarkDialogButton.YesNo, Icon
-                    ) ==
-                    DialogResult.Yes)
-                {
-                    PacketSender.SendUnlinkMap(mContextMap.MapId);
-                }
-            }
-        }
-
-        private void _recacheMapItem_Click(object sender, EventArgs e)
-        {
-            if (mContextMap != null && mContextMap.MapId != Guid.Empty)
-            {
-                //Fetch and screenshot this singular map
-                Database.SaveMapCache(mContextMap.MapId, mContextMap.Revision, null);
-                if (MapInstance.Get(mContextMap.MapId) != null)
-                {
-                    MapInstance.Get(mContextMap.MapId).Delete();
-                }
-
-                Globals.MapsToFetch = new List<Guid>() {mContextMap.MapId};
-                PacketSender.SendNeedMap(mContextMap.MapId);
-            }
-        }
-
-        private void LinkMapItem_Click(object sender, EventArgs e)
-        {
-            var frmWarpSelection = new FrmWarpSelection();
-            frmWarpSelection.InitForm(false, mLinkMaps);
-            frmWarpSelection.ShowDialog();
-            if (frmWarpSelection.GetResult())
-            {
-                //Make sure the selected tile is adjacent to a map
-                var linkMapId = frmWarpSelection.GetMap();
-                var adjacentMapId = Guid.Empty;
-
-                //Check Left
-                if (mCurrentCellX > 1 && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
-                {
-                    if (Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId != Guid.Empty)
-                    {
-                        adjacentMapId = Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId;
-                    }
-                }
-
-                //Check Right
-                if (mCurrentCellX < GridWidth && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
-                {
-                    if (Grid[mCurrentCellX, mCurrentCellY - 1].MapId != Guid.Empty)
-                    {
-                        adjacentMapId = Grid[mCurrentCellX, mCurrentCellY - 1].MapId;
-                    }
-                }
-
-                //Check Up
-                if (mCurrentCellX != 0 && mCurrentCellY > 1 && mCurrentCellX - 1 < GridWidth)
-                {
-                    if (Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId != Guid.Empty)
-                    {
-                        adjacentMapId = Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId;
-                    }
-                }
-
-                //Check Down
-                if (mCurrentCellX != 0 && mCurrentCellY < GridHeight && mCurrentCellX - 1 < GridWidth)
-                {
-                    if (Grid[mCurrentCellX - 1, mCurrentCellY].MapId != Guid.Empty)
-                    {
-                        adjacentMapId = Grid[mCurrentCellX - 1, mCurrentCellY].MapId;
-                    }
-                }
-
-                if (adjacentMapId != Guid.Empty)
-                {
-                    PacketSender.SendLinkMap(adjacentMapId, linkMapId, mCurrentCellX - 1, mCurrentCellY - 1);
-                }
-            }
-        }
-
-        public void Update(Microsoft.Xna.Framework.Rectangle panelBounds)
-        {
-            mMinZoom = Math.Min(
-                           panelBounds.Width / (float) (Options.TileWidth * Options.MapWidth * (GridWidth + 2)),
-                           panelBounds.Height / (float) (Options.TileHeight * Options.MapHeight * (GridHeight + 2))
-                       ) /
-                       2f;
-
-            //Gotta calculate
-            if (Zoom < mMinZoom)
-            {
-                Zoom = mMinZoom * 2;
-                TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
-                TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
-                ContentRect = new Rectangle(0, 0, TileWidth * (GridWidth + 2), TileHeight * (GridHeight + 2));
-                lock (mTexLock)
-                {
-                    UnloadTextures();
-                }
-
-                mCreateTextures = true;
-            }
-
-            ViewRect = new Rectangle(panelBounds.Left, panelBounds.Top, panelBounds.Width, panelBounds.Height);
-            if (ContentRect.X + TileWidth > ViewRect.Width)
-            {
-                ContentRect.X = ViewRect.Width - TileWidth;
-            }
-
-            if (ContentRect.X + ContentRect.Width < TileWidth)
-            {
-                ContentRect.X = -ContentRect.Width + TileWidth;
-            }
-
-            if (ContentRect.Y + TileHeight > ViewRect.Height)
-            {
-                ContentRect.Y = ViewRect.Height - TileHeight;
-            }
-
-            if (ContentRect.Y + ContentRect.Height < TileHeight)
-            {
-                ContentRect.Y = -ContentRect.Height + TileHeight;
-            }
-
-            if (mCreateTextures)
-            {
-                CreateTextures(panelBounds);
-                mCreateTextures = false;
-            }
-
-            lock (GetMapGridLock())
-            {
-                if (Grid != null)
-                {
-                    lock (mTexLock)
-                    {
-                        for (var x = 0; x < GridWidth; x++)
-                        {
-                            for (var y = 0; y < GridHeight; y++)
+                            else
                             {
-                                //Figure out if this texture should be loaded
-                                if (new Rectangle(
-                                        ContentRect.X + (x + 1) * TileWidth, ContentRect.Y + (y + 1) * TileHeight,
-                                        TileWidth, TileHeight
-                                    ).IntersectsWith(ViewRect) &&
-                                    Grid[x, y] != null)
-                                {
-                                    //if not loaded, add it to the queue
-                                    if ((Grid[x, y].Tex == null || Grid[x, y].Tex.IsDisposed) &&
-                                        Grid[x, y].MapId != Guid.Empty &&
-                                        !mToLoad.Contains(Grid[x, y]))
-                                    {
-                                        mToLoad.Add(Grid[x, y]);
-                                    }
-                                }
-                                else
-                                {
-                                    //If loaded, kick it to the curb
-                                    if (mToLoad.Contains(Grid[x, y]))
-                                    {
-                                        mToLoad.Remove(Grid[x, y]);
-                                    }
-
-                                    if (Grid[x, y] != null && Grid[x, y].Tex != null)
-                                    {
-                                        mFreeTextures.Add(Grid[x, y].Tex);
-                                        Grid[x, y].Tex = null;
-                                    }
-                                }
+                                mContextMap = Grid[mCurrentCellX - 1, mCurrentCellY - 1];
+                                mContextMenu.Show(mapGridView, new System.Drawing.Point(x, y));
+                                mDropDownUnlinkItem.Visible = true;
+                                mRecacheMapItem.Visible = true;
+                                mDropDownLinkItem.Visible = false;
                             }
                         }
                     }
+
+                    return;
                 }
             }
         }
 
-        public MapGridItem GetItemAt(int mouseX, int mouseY)
+        mCurrentCellX = -1;
+        mCurrentCellY = -1;
+    }
+
+    private void UnlinkMapItem_Click(object sender, EventArgs e)
+    {
+        if (mContextMap != null && mContextMap.MapId != Guid.Empty)
         {
-            if (Loaded)
+            if (DarkMessageBox.ShowWarning(
+                    Strings.MapGrid.unlinkprompt.ToString(mContextMap.Name), Strings.MapGrid.unlinkcaption,
+                    DarkDialogButton.YesNo, Icon
+                ) ==
+                DialogResult.Yes)
+            {
+                PacketSender.SendUnlinkMap(mContextMap.MapId);
+            }
+        }
+    }
+
+    private void _recacheMapItem_Click(object sender, EventArgs e)
+    {
+        if (mContextMap != null && mContextMap.MapId != Guid.Empty)
+        {
+            //Fetch and screenshot this singular map
+            Database.SaveMapCache(mContextMap.MapId, mContextMap.Revision, null);
+            if (MapInstance.Get(mContextMap.MapId) != null)
+            {
+                MapInstance.Get(mContextMap.MapId).Delete();
+            }
+
+            Globals.MapsToFetch = new List<Guid>() {mContextMap.MapId};
+            PacketSender.SendNeedMap(mContextMap.MapId);
+        }
+    }
+
+    private void LinkMapItem_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.InitForm(false, mLinkMaps);
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            //Make sure the selected tile is adjacent to a map
+            var linkMapId = frmWarpSelection.GetMap();
+            var adjacentMapId = Guid.Empty;
+
+            //Check Left
+            if (mCurrentCellX > 1 && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
+            {
+                if (Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId != Guid.Empty)
+                {
+                    adjacentMapId = Grid[mCurrentCellX - 2, mCurrentCellY - 1].MapId;
+                }
+            }
+
+            //Check Right
+            if (mCurrentCellX < GridWidth && mCurrentCellY != 0 && mCurrentCellY - 1 < GridHeight)
+            {
+                if (Grid[mCurrentCellX, mCurrentCellY - 1].MapId != Guid.Empty)
+                {
+                    adjacentMapId = Grid[mCurrentCellX, mCurrentCellY - 1].MapId;
+                }
+            }
+
+            //Check Up
+            if (mCurrentCellX != 0 && mCurrentCellY > 1 && mCurrentCellX - 1 < GridWidth)
+            {
+                if (Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId != Guid.Empty)
+                {
+                    adjacentMapId = Grid[mCurrentCellX - 1, mCurrentCellY - 2].MapId;
+                }
+            }
+
+            //Check Down
+            if (mCurrentCellX != 0 && mCurrentCellY < GridHeight && mCurrentCellX - 1 < GridWidth)
+            {
+                if (Grid[mCurrentCellX - 1, mCurrentCellY].MapId != Guid.Empty)
+                {
+                    adjacentMapId = Grid[mCurrentCellX - 1, mCurrentCellY].MapId;
+                }
+            }
+
+            if (adjacentMapId != Guid.Empty)
+            {
+                PacketSender.SendLinkMap(adjacentMapId, linkMapId, mCurrentCellX - 1, mCurrentCellY - 1);
+            }
+        }
+    }
+
+    public void Update(Microsoft.Xna.Framework.Rectangle panelBounds)
+    {
+        mMinZoom = Math.Min(
+                       panelBounds.Width / (float) (Options.TileWidth * Options.MapWidth * (GridWidth + 2)),
+                       panelBounds.Height / (float) (Options.TileHeight * Options.MapHeight * (GridHeight + 2))
+                   ) /
+                   2f;
+
+        //Gotta calculate
+        if (Zoom < mMinZoom)
+        {
+            Zoom = mMinZoom * 2;
+            TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
+            TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
+            ContentRect = new Rectangle(0, 0, TileWidth * (GridWidth + 2), TileHeight * (GridHeight + 2));
+            lock (mTexLock)
+            {
+                UnloadTextures();
+            }
+
+            mCreateTextures = true;
+        }
+
+        ViewRect = new Rectangle(panelBounds.Left, panelBounds.Top, panelBounds.Width, panelBounds.Height);
+        if (ContentRect.X + TileWidth > ViewRect.Width)
+        {
+            ContentRect.X = ViewRect.Width - TileWidth;
+        }
+
+        if (ContentRect.X + ContentRect.Width < TileWidth)
+        {
+            ContentRect.X = -ContentRect.Width + TileWidth;
+        }
+
+        if (ContentRect.Y + TileHeight > ViewRect.Height)
+        {
+            ContentRect.Y = ViewRect.Height - TileHeight;
+        }
+
+        if (ContentRect.Y + ContentRect.Height < TileHeight)
+        {
+            ContentRect.Y = -ContentRect.Height + TileHeight;
+        }
+
+        if (mCreateTextures)
+        {
+            CreateTextures(panelBounds);
+            mCreateTextures = false;
+        }
+
+        lock (GetMapGridLock())
+        {
+            if (Grid != null)
             {
                 lock (mTexLock)
                 {
@@ -786,128 +740,172 @@ namespace Intersect.Editor.Maps
                             if (new Rectangle(
                                     ContentRect.X + (x + 1) * TileWidth, ContentRect.Y + (y + 1) * TileHeight,
                                     TileWidth, TileHeight
-                                ).Contains(new System.Drawing.Point(mouseX, mouseY)) &&
+                                ).IntersectsWith(ViewRect) &&
                                 Grid[x, y] != null)
                             {
-                                return Grid[x, y];
+                                //if not loaded, add it to the queue
+                                if ((Grid[x, y].Tex == null || Grid[x, y].Tex.IsDisposed) &&
+                                    Grid[x, y].MapId != Guid.Empty &&
+                                    !mToLoad.Contains(Grid[x, y]))
+                                {
+                                    mToLoad.Add(Grid[x, y]);
+                                }
+                            }
+                            else
+                            {
+                                //If loaded, kick it to the curb
+                                if (mToLoad.Contains(Grid[x, y]))
+                                {
+                                    mToLoad.Remove(Grid[x, y]);
+                                }
+
+                                if (Grid[x, y] != null && Grid[x, y].Tex != null)
+                                {
+                                    mFreeTextures.Add(Grid[x, y].Tex);
+                                    Grid[x, y].Tex = null;
+                                }
                             }
                         }
                     }
                 }
             }
-
-            return null;
         }
+    }
 
-        private void CreateTextures(Microsoft.Xna.Framework.Rectangle panelBounds)
+    public MapGridItem GetItemAt(int mouseX, int mouseY)
+    {
+        if (Loaded)
         {
             lock (mTexLock)
             {
-                var hCount = (int) Math.Ceiling((float) panelBounds.Width / TileWidth) + 2;
-                var wCount = (int) Math.Ceiling((float) panelBounds.Height / TileHeight) + 2;
-                for (var i = 0; i < hCount * wCount && i < GridWidth * GridHeight; i++)
+                for (var x = 0; x < GridWidth; x++)
                 {
-                    mTextures.Add(new Texture2D(Core.Graphics.GetGraphicsDevice(), TileWidth, TileHeight));
-                }
-
-                mFreeTextures.AddRange(mTextures.ToArray());
-            }
-        }
-
-        private void UnloadTextures()
-        {
-            lock (mTexLock)
-            {
-                for (var i = 0; i < mTextures.Count; i++)
-                {
-                    mTextures[i].Dispose();
-                }
-
-                mTextures.Clear();
-                mFreeTextures.Clear();
-                if (Grid != null && Loaded)
-                {
-                    for (var x = 0; x < GridWidth; x++)
+                    for (var y = 0; y < GridHeight; y++)
                     {
-                        for (var y = 0; y < GridHeight; y++)
+                        //Figure out if this texture should be loaded
+                        if (new Rectangle(
+                                ContentRect.X + (x + 1) * TileWidth, ContentRect.Y + (y + 1) * TileHeight,
+                                TileWidth, TileHeight
+                            ).Contains(new System.Drawing.Point(mouseX, mouseY)) &&
+                            Grid[x, y] != null)
                         {
-                            Grid[x, y].Tex = null;
+                            return Grid[x, y];
                         }
                     }
                 }
             }
         }
 
-        public void Move(int x, int y)
+        return null;
+    }
+
+    private void CreateTextures(Microsoft.Xna.Framework.Rectangle panelBounds)
+    {
+        lock (mTexLock)
         {
-            ContentRect.X -= x;
-            ContentRect.Y -= y;
-            if (ContentRect.X + TileWidth > ViewRect.Width)
+            var hCount = (int) Math.Ceiling((float) panelBounds.Width / TileWidth) + 2;
+            var wCount = (int) Math.Ceiling((float) panelBounds.Height / TileHeight) + 2;
+            for (var i = 0; i < hCount * wCount && i < GridWidth * GridHeight; i++)
             {
-                ContentRect.X = ViewRect.Width - TileWidth;
+                mTextures.Add(new Texture2D(Core.Graphics.GetGraphicsDevice(), TileWidth, TileHeight));
             }
 
-            if (ContentRect.X + ContentRect.Width < TileWidth)
-            {
-                ContentRect.X = -ContentRect.Width + TileWidth;
-            }
-
-            if (ContentRect.Y + TileHeight > ViewRect.Height)
-            {
-                ContentRect.Y = ViewRect.Height - TileHeight;
-            }
-
-            if (ContentRect.Y + ContentRect.Height < TileHeight)
-            {
-                ContentRect.Y = -ContentRect.Height + TileHeight;
-            }
+            mFreeTextures.AddRange(mTextures.ToArray());
         }
+    }
 
-        public void ZoomIn(int val, int mouseX, int mouseY)
+    private void UnloadTextures()
+    {
+        lock (mTexLock)
         {
-            var amt = val / 120;
-
-            //Find the original tile we are hovering over
-            var x1 = (double) Math.Min(ContentRect.Width, Math.Max(0, mouseX - ContentRect.X)) / (float) TileWidth;
-            var y1 = (double) Math.Min(ContentRect.Height, Math.Max(0, mouseY - ContentRect.Y)) / (float) TileHeight;
-            var prevZoom = Zoom;
-            Zoom += .05f * amt;
-            if (prevZoom != Zoom)
+            for (var i = 0; i < mTextures.Count; i++)
             {
-                lock (mTexLock)
+                mTextures[i].Dispose();
+            }
+
+            mTextures.Clear();
+            mFreeTextures.Clear();
+            if (Grid != null && Loaded)
+            {
+                for (var x = 0; x < GridWidth; x++)
                 {
-                    UnloadTextures();
+                    for (var y = 0; y < GridHeight; y++)
+                    {
+                        Grid[x, y].Tex = null;
+                    }
                 }
-
-                mCreateTextures = true;
             }
+        }
+    }
 
-            if (Zoom < mMinZoom)
-            {
-                Zoom = mMinZoom;
-            }
-
-            if (Zoom > mMaxZoom)
-            {
-                Zoom = mMaxZoom;
-            }
-
-            TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
-            TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
-
-            //were gonna get the X/Y of where the content rect would need so that the grid location that the mouse is hovering over would be center of the viewing rect
-            //Get the current location of the mouse over the current content rectangle
-
-            var x2 = (int) (x1 * TileWidth);
-            var y2 = (int) (y1 * TileHeight);
-
-            ContentRect = new Rectangle(
-                -x2 + mouseX, -y2 + mouseY, TileWidth * (GridWidth + 2), TileHeight * (GridHeight + 2)
-            );
-
-            //Lets go the extra mile to make sure our selected map is
+    public void Move(int x, int y)
+    {
+        ContentRect.X -= x;
+        ContentRect.Y -= y;
+        if (ContentRect.X + TileWidth > ViewRect.Width)
+        {
+            ContentRect.X = ViewRect.Width - TileWidth;
         }
 
+        if (ContentRect.X + ContentRect.Width < TileWidth)
+        {
+            ContentRect.X = -ContentRect.Width + TileWidth;
+        }
+
+        if (ContentRect.Y + TileHeight > ViewRect.Height)
+        {
+            ContentRect.Y = ViewRect.Height - TileHeight;
+        }
+
+        if (ContentRect.Y + ContentRect.Height < TileHeight)
+        {
+            ContentRect.Y = -ContentRect.Height + TileHeight;
+        }
+    }
+
+    public void ZoomIn(int val, int mouseX, int mouseY)
+    {
+        var amt = val / 120;
+
+        //Find the original tile we are hovering over
+        var x1 = (double) Math.Min(ContentRect.Width, Math.Max(0, mouseX - ContentRect.X)) / (float) TileWidth;
+        var y1 = (double) Math.Min(ContentRect.Height, Math.Max(0, mouseY - ContentRect.Y)) / (float) TileHeight;
+        var prevZoom = Zoom;
+        Zoom += .05f * amt;
+        if (prevZoom != Zoom)
+        {
+            lock (mTexLock)
+            {
+                UnloadTextures();
+            }
+
+            mCreateTextures = true;
+        }
+
+        if (Zoom < mMinZoom)
+        {
+            Zoom = mMinZoom;
+        }
+
+        if (Zoom > mMaxZoom)
+        {
+            Zoom = mMaxZoom;
+        }
+
+        TileWidth = (int) (Options.TileWidth * Options.MapWidth * Zoom);
+        TileHeight = (int) (Options.TileHeight * Options.MapHeight * Zoom);
+
+        //were gonna get the X/Y of where the content rect would need so that the grid location that the mouse is hovering over would be center of the viewing rect
+        //Get the current location of the mouse over the current content rectangle
+
+        var x2 = (int) (x1 * TileWidth);
+        var y2 = (int) (y1 * TileHeight);
+
+        ContentRect = new Rectangle(
+            -x2 + mouseX, -y2 + mouseY, TileWidth * (GridWidth + 2), TileHeight * (GridHeight + 2)
+        );
+
+        //Lets go the extra mile to make sure our selected map is
     }
 
 }

--- a/Intersect.Editor/Maps/MapGridItem.cs
+++ b/Intersect.Editor/Maps/MapGridItem.cs
@@ -1,26 +1,24 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 
-namespace Intersect.Editor.Maps
+namespace Intersect.Editor.Maps;
+
+
+public partial class MapGridItem
 {
 
-    public partial class MapGridItem
+    public MapGridItem(Guid id, string name = "", int revision = 0)
     {
-
-        public MapGridItem(Guid id, string name = "", int revision = 0)
-        {
-            MapId = id;
-            this.Name = name;
-            this.Revision = revision;
-        }
-
-        public string Name { get; set; }
-
-        public int Revision { get; set; }
-
-        public Guid MapId { get; set; }
-
-        public Texture2D Tex { get; set; }
-
+        MapId = id;
+        this.Name = name;
+        this.Revision = revision;
     }
+
+    public string Name { get; set; }
+
+    public int Revision { get; set; }
+
+    public Guid MapId { get; set; }
+
+    public Texture2D Tex { get; set; }
 
 }

--- a/Intersect.Editor/Maps/MapProperties.cs
+++ b/Intersect.Editor/Maps/MapProperties.cs
@@ -10,645 +10,325 @@ using Intersect.Utilities;
 
 using Graphics = Intersect.Editor.Core.Graphics;
 
-namespace Intersect.Editor.Maps
+namespace Intersect.Editor.Maps;
+
+
+partial class CustomCategory : CategoryAttribute
 {
 
-    partial class CustomCategory : CategoryAttribute
+    public CustomCategory(string category) : base(category)
     {
-
-        public CustomCategory(string category) : base(category)
-        {
-        }
-
-        protected override string GetLocalizedString(string value)
-        {
-            return Strings.MapProperties.categories[value];
-        }
-
     }
 
-    partial class CustomDisplayName : DisplayNameAttribute
+    protected override string GetLocalizedString(string value)
     {
-
-        public CustomDisplayName(string name) : base(name)
-        {
-        }
-
-        public override string DisplayName => Strings.MapProperties.displaynames[DisplayNameValue];
-
+        return Strings.MapProperties.categories[value];
     }
 
-    partial class CustomDescription : DescriptionAttribute
+}
+
+partial class CustomDisplayName : DisplayNameAttribute
+{
+
+    public CustomDisplayName(string name) : base(name)
     {
-
-        public CustomDescription(string desc) : base(desc)
-        {
-        }
-
-        public override string Description => Strings.MapProperties.descriptions[DescriptionValue];
-
     }
 
-    partial class MapProperties
+    public override string DisplayName => Strings.MapProperties.displaynames[DisplayNameValue];
+
+}
+
+partial class CustomDescription : DescriptionAttribute
+{
+
+    public CustomDescription(string desc) : base(desc)
     {
+    }
 
-        private MapBase mMyMap;
+    public override string Description => Strings.MapProperties.descriptions[DescriptionValue];
 
-        public MapProperties(MapBase map)
+}
+
+partial class MapProperties
+{
+
+    private MapBase mMyMap;
+
+    public MapProperties(MapBase map)
+    {
+        mMyMap = map;
+    }
+
+    [Browsable(false)]
+    public Guid MapId => mMyMap.Id;
+
+    [CustomCategory("general"), CustomDescription("namedesc"), CustomDisplayName("name"), DefaultValue("New Map")]
+    public string Name
+    {
+        get => mMyMap.Name;
+        set
         {
-            mMyMap = map;
-        }
-
-        [Browsable(false)]
-        public Guid MapId => mMyMap.Id;
-
-        [CustomCategory("general"), CustomDescription("namedesc"), CustomDisplayName("name"), DefaultValue("New Map")]
-        public string Name
-        {
-            get => mMyMap.Name;
-            set
-            {
-                if (mMyMap.Name != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Name = value;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("general"), CustomDescription("zonedesc"), CustomDisplayName("zonetype"),
-         DefaultValue("Normal"), TypeConverter(typeof(MapZoneProperty)), Browsable(true)]
-        public string ZoneType
-        {
-            get => Strings.MapProperties.zones[(int)mMyMap.ZoneType];
-            set
+            if (mMyMap.Name != value)
             {
                 Globals.MapEditorWindow.PrepUndoState();
-                for (byte i = 0; i < Enum.GetNames(typeof(MapZone)).Length; i++)
-                {
-                    if (Strings.MapProperties.zones[i] == value)
-                    {
-                        mMyMap.ZoneType = (MapZone)i;
-                    }
-                }
-
+                mMyMap.Name = value;
                 Globals.MapEditorWindow.AddUndoState();
             }
         }
-
-        [CustomCategory("audio"), CustomDescription("musicdesc"), CustomDisplayName("music"), DefaultValue("None"),
-         TypeConverter(typeof(MapMusicProperty)), Browsable(true)]
-        public string Music
-        {
-            get
-            {
-                var musicList = new List<string> { Strings.General.None };
-                musicList.AddRange(GameContentManager.SmartSortedMusicNames);
-                mMyMap.Music = musicList.Find(
-                    item => string.Equals(item, mMyMap.Music, StringComparison.InvariantCultureIgnoreCase)
-                );
-
-                return TextUtils.NullToNone(mMyMap.Music);
-            }
-            set
-            {
-                if (mMyMap.Music != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Music = TextUtils.SanitizeNone(value);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("audio"), CustomDescription("sounddesc"), CustomDisplayName("sound"), DefaultValue("None"),
-         TypeConverter(typeof(MapSoundProperty)), Browsable(true)]
-        public string Sound
-        {
-            get
-            {
-                var soundList = new List<string> { Strings.General.None };
-                soundList.AddRange(GameContentManager.SmartSortedSoundNames);
-                mMyMap.Sound = soundList.Find(
-                    item => string.Equals(item, mMyMap.Sound, StringComparison.InvariantCultureIgnoreCase)
-                );
-
-                return TextUtils.NullToNone(mMyMap.Sound);
-            }
-            set
-            {
-                if (mMyMap.Sound != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Sound = TextUtils.SanitizeNone(value);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("isindoorsdesc"), CustomDisplayName("isindoors"),
-         DefaultValue(false)]
-        public bool IsIndoors
-        {
-            get => mMyMap.IsIndoors;
-            set
-            {
-                if (mMyMap.IsIndoors != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.IsIndoors = value;
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("brightnessdesc"), CustomDisplayName("brightness"),
-         DefaultValue(100)]
-        public int Brightness
-        {
-            get => mMyMap.Brightness;
-            set
-            {
-                if (mMyMap.Brightness != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Brightness = Math.Max(value, 0);
-                    mMyMap.Brightness = Math.Min(mMyMap.Brightness, 100);
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("playerlightsizedesc"), CustomDisplayName("playerlightsize"),
-         DefaultValue(300)]
-        public int PlayerLightSize
-        {
-            get => mMyMap.PlayerLightSize;
-            set
-            {
-                if (mMyMap.PlayerLightSize != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.PlayerLightSize = Math.Max(value, 0);
-                    mMyMap.PlayerLightSize = Math.Min(mMyMap.PlayerLightSize, 1000);
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("playerlightexpanddesc"), CustomDisplayName("playerlightexpand"),
-         DefaultValue(0)]
-        public float PlayerLightExpand
-        {
-            get => mMyMap.PlayerLightExpand;
-            set
-            {
-                if (mMyMap.PlayerLightExpand != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.PlayerLightExpand = Math.Max(value, 0f);
-                    mMyMap.PlayerLightExpand = Math.Min(mMyMap.PlayerLightExpand, 1f);
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("playerlightintensitydesc"),
-         CustomDisplayName("playerlightintensity"), DefaultValue(255)]
-        public float PlayerLightIntensity
-        {
-            get => mMyMap.PlayerLightIntensity;
-            set
-            {
-                if (mMyMap.PlayerLightIntensity != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    var val = Math.Max(value, (byte)0);
-                    mMyMap.PlayerLightIntensity = (byte)Math.Min(val, (byte)255);
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("lighting"), CustomDescription("playerlightcolordesc"), CustomDisplayName("playerlightcolor"),
-         DefaultValue(0)]
-        public System.Drawing.Color PlayerLightColor
-        {
-            get =>
-                System.Drawing.Color.FromArgb(
-                    mMyMap.PlayerLightColor.A, mMyMap.PlayerLightColor.R, mMyMap.PlayerLightColor.G,
-                    mMyMap.PlayerLightColor.B
-                );
-            set
-            {
-                if (mMyMap.PlayerLightColor.A != value.A ||
-                    mMyMap.PlayerLightColor.R != value.R ||
-                    mMyMap.PlayerLightColor.G != value.G ||
-                    mMyMap.PlayerLightColor.B != value.B)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.PlayerLightColor = Color.FromArgb(value.A, value.R, value.G, value.B);
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("overlay"), CustomDescription("rhuedesc"), CustomDisplayName("rhue"), DefaultValue(0)]
-        public int RHue
-        {
-            get => mMyMap.RHue;
-            set
-            {
-                if (mMyMap.RHue != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.RHue = Math.Max(value, 0);
-                    mMyMap.RHue = Math.Min(mMyMap.RHue, 255);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("overlay"), CustomDescription("ghuedesc"), CustomDisplayName("ghue"), DefaultValue(0)]
-        public int GHue
-        {
-            get => mMyMap.GHue;
-            set
-            {
-                if (mMyMap.GHue != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.GHue = Math.Max(value, 0);
-                    mMyMap.GHue = Math.Min(mMyMap.GHue, 255);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("overlay"), CustomDescription("bhuedesc"), CustomDisplayName("bhue"), DefaultValue(0)]
-        public int BHue
-        {
-            get => mMyMap.BHue;
-            set
-            {
-                if (mMyMap.BHue != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.BHue = Math.Max(value, 0);
-                    mMyMap.BHue = Math.Min(mMyMap.BHue, 255);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("overlay"), CustomDescription("ahuedesc"), CustomDisplayName("ahue"), DefaultValue(0)]
-        public int AHue
-        {
-            get => mMyMap.AHue;
-            set
-            {
-                if (mMyMap.AHue != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.AHue = Math.Max(value, 0);
-                    mMyMap.AHue = Math.Min(mMyMap.AHue, 255);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("fog"), CustomDescription("fogdesc"), CustomDisplayName("fog"), DefaultValue("None"),
-         TypeConverter(typeof(MapFogProperty)), Browsable(true)]
-        public string Fog
-        {
-            get
-            {
-                var fogList = new List<string>
-                {
-                    Strings.General.None
-                };
-
-                fogList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Fog));
-                if (fogList.IndexOf(mMyMap.Fog) <= -1)
-                {
-                    mMyMap.Fog = null;
-                }
-
-                return TextUtils.NullToNone(mMyMap.Fog);
-            }
-            set
-            {
-                if (mMyMap.Fog != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Fog = TextUtils.SanitizeNone(value);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("fog"), CustomDescription("fogxspeeddesc"), CustomDisplayName("fogxspeed"), DefaultValue(0)]
-        public int FogXSpeed
-        {
-            get => mMyMap.FogXSpeed;
-            set
-            {
-                if (mMyMap.FogXSpeed != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.FogXSpeed = Math.Max(value, -5);
-                    mMyMap.FogXSpeed = Math.Min(mMyMap.FogXSpeed, 5);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("fog"), CustomDescription("fogyspeeddesc"), CustomDisplayName("fogyspeed"), DefaultValue(0)]
-        public int FogYSpeed
-        {
-            get => mMyMap.FogYSpeed;
-            set
-            {
-                if (mMyMap.FogYSpeed != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.FogYSpeed = Math.Max(value, -5);
-                    mMyMap.FogYSpeed = Math.Min(mMyMap.FogYSpeed, 5);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("fog"), CustomDescription("fogalphadesc"), CustomDisplayName("fogalpha"), DefaultValue(0)]
-        public int FogAlpha
-        {
-            get => mMyMap.FogTransparency;
-            set
-            {
-                if (mMyMap.FogTransparency != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.FogTransparency = Math.Max(value, 0);
-                    mMyMap.FogTransparency = Math.Min(mMyMap.FogTransparency, 255);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        //Weather
-        [CustomCategory("weather"), CustomDescription("weatherdesc"), CustomDisplayName("weather"),
-         DefaultValue("None"), TypeConverter(typeof(MapWeatherProperty)), Browsable(true)]
-        public string Weather
-        {
-            get
-            {
-                var WeatherList = new List<string>
-                {
-                    Strings.General.None
-                };
-
-                WeatherList.AddRange(AnimationBase.Names);
-                var name = AnimationBase.GetName(mMyMap.WeatherAnimationId);
-                if (AnimationBase.Get(mMyMap.WeatherAnimationId) == null)
-                {
-                    name = null;
-                }
-
-                return TextUtils.NullToNone(name);
-            }
-            set
-            {
-                var idVal = Guid.Empty;
-                if (!TextUtils.IsNone(value))
-                {
-                    var animationNames = new List<string>(AnimationBase.Names);
-                    var index = animationNames.IndexOf(value);
-                    idVal = AnimationBase.IdFromList(index);
-                }
-
-                if (mMyMap.WeatherAnimationId != idVal)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.WeatherAnimation = AnimationBase.Get(idVal);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("weather"), CustomDescription("weatherxspeeddesc"), CustomDisplayName("weatherxspeed"),
-         DefaultValue(0)]
-        public int WeatherXSpeed
-        {
-            get => mMyMap.WeatherXSpeed;
-            set
-            {
-                if (mMyMap.WeatherXSpeed != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.WeatherXSpeed = Math.Max(value, -5);
-                    mMyMap.WeatherXSpeed = Math.Min(mMyMap.WeatherXSpeed, 5);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("weather"), CustomDescription("weatheryspeeddesc"), CustomDisplayName("weatheryspeed"),
-         DefaultValue(0)]
-        public int WeatherYSpeed
-        {
-            get => mMyMap.WeatherYSpeed;
-            set
-            {
-                if (mMyMap.WeatherYSpeed != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.WeatherYSpeed = Math.Max(value, -5);
-                    mMyMap.WeatherYSpeed = Math.Min(mMyMap.WeatherYSpeed, 5);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("weather"), CustomDescription("weatherintensitydesc"), CustomDisplayName("weatherintensity"),
-         DefaultValue(0)]
-        public int WeatherAlpha
-        {
-            get => mMyMap.WeatherIntensity;
-            set
-            {
-                if (mMyMap.WeatherIntensity != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.WeatherIntensity = Math.Max(value, 0);
-                    mMyMap.WeatherIntensity = Math.Min(mMyMap.WeatherIntensity, 100);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("misc"), CustomDescription("panoramadesc"), CustomDisplayName("panorama"), DefaultValue("None"),
-         TypeConverter(typeof(MapImageProperty)), Browsable(true)]
-        public string Panorama
-        {
-            get
-            {
-                var imageList = new List<string>
-                {
-                    Strings.General.None
-                };
-
-                imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
-                if (imageList.IndexOf(mMyMap.Panorama) <= -1)
-                {
-                    mMyMap.Panorama = null;
-                }
-
-                return TextUtils.NullToNone(mMyMap.Panorama);
-            }
-            set
-            {
-                if (mMyMap.Panorama != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.Panorama = TextUtils.SanitizeNone(value);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("misc"), CustomDescription("overlaygraphicdesc"), CustomDisplayName("overlaygraphic"),
-         DefaultValue("None"), TypeConverter(typeof(MapImageProperty)), Browsable(true)]
-        public string OverlayGraphic
-        {
-            get
-            {
-                var imageList = new List<string>
-                {
-                    Strings.General.None
-                };
-
-                imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
-                if (imageList.IndexOf(mMyMap.OverlayGraphic) <= -1)
-                {
-                    mMyMap.OverlayGraphic = null;
-                }
-
-                return TextUtils.NullToNone(mMyMap.OverlayGraphic);
-            }
-            set
-            {
-                if (mMyMap.OverlayGraphic != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.OverlayGraphic = TextUtils.SanitizeNone(value);
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
-        [CustomCategory("player"), CustomDescription("hideequipmentdesc"), CustomDisplayName("hideequipment"),
-         DefaultValue(false)]
-        public bool HideEquipment
-        {
-            get => mMyMap.HideEquipment;
-            set
-            {
-                if (mMyMap.HideEquipment != value)
-                {
-                    Globals.MapEditorWindow.PrepUndoState();
-                    mMyMap.HideEquipment = value;
-                    Graphics.TilePreviewUpdated = true;
-                    Globals.MapEditorWindow.AddUndoState();
-                }
-            }
-        }
-
     }
 
-    public partial class MapMusicProperty : StringConverter
+    [CustomCategory("general"), CustomDescription("zonedesc"), CustomDisplayName("zonetype"),
+     DefaultValue("Normal"), TypeConverter(typeof(MapZoneProperty)), Browsable(true)]
+    public string ZoneType
     {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        get => Strings.MapProperties.zones[(int)mMyMap.ZoneType];
+        set
         {
-            //true means show a combobox
-            return true;
-        }
-
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
-        {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
-        }
-
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-        {
-            var musicList = new List<string>
+            Globals.MapEditorWindow.PrepUndoState();
+            for (byte i = 0; i < Enum.GetNames(typeof(MapZone)).Length; i++)
             {
-                Strings.General.None
-            };
+                if (Strings.MapProperties.zones[i] == value)
+                {
+                    mMyMap.ZoneType = (MapZone)i;
+                }
+            }
 
+            Globals.MapEditorWindow.AddUndoState();
+        }
+    }
+
+    [CustomCategory("audio"), CustomDescription("musicdesc"), CustomDisplayName("music"), DefaultValue("None"),
+     TypeConverter(typeof(MapMusicProperty)), Browsable(true)]
+    public string Music
+    {
+        get
+        {
+            var musicList = new List<string> { Strings.General.None };
             musicList.AddRange(GameContentManager.SmartSortedMusicNames);
+            mMyMap.Music = musicList.Find(
+                item => string.Equals(item, mMyMap.Music, StringComparison.InvariantCultureIgnoreCase)
+            );
 
-            return new StandardValuesCollection(musicList.ToArray());
+            return TextUtils.NullToNone(mMyMap.Music);
         }
-
-    }
-
-    public partial class MapSoundProperty : StringConverter
-    {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        set
         {
-            //true means show a combobox
-            return true;
-        }
-
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
-        {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
-        }
-
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-        {
-            var soundList = new List<string>
+            if (mMyMap.Music != value)
             {
-                Strings.General.None
-            };
-
-            soundList.AddRange(GameContentManager.SmartSortedSoundNames);
-
-            return new StandardValuesCollection(soundList.ToArray());
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.Music = TextUtils.SanitizeNone(value);
+                Globals.MapEditorWindow.AddUndoState();
+            }
         }
-
     }
 
-    public partial class MapFogProperty : StringConverter
+    [CustomCategory("audio"), CustomDescription("sounddesc"), CustomDisplayName("sound"), DefaultValue("None"),
+     TypeConverter(typeof(MapSoundProperty)), Browsable(true)]
+    public string Sound
     {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        get
         {
-            //true means show a combobox
-            return true;
-        }
+            var soundList = new List<string> { Strings.General.None };
+            soundList.AddRange(GameContentManager.SmartSortedSoundNames);
+            mMyMap.Sound = soundList.Find(
+                item => string.Equals(item, mMyMap.Sound, StringComparison.InvariantCultureIgnoreCase)
+            );
 
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+            return TextUtils.NullToNone(mMyMap.Sound);
+        }
+        set
         {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
+            if (mMyMap.Sound != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.Sound = TextUtils.SanitizeNone(value);
+                Globals.MapEditorWindow.AddUndoState();
+            }
         }
+    }
 
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    [CustomCategory("lighting"), CustomDescription("isindoorsdesc"), CustomDisplayName("isindoors"),
+     DefaultValue(false)]
+    public bool IsIndoors
+    {
+        get => mMyMap.IsIndoors;
+        set
+        {
+            if (mMyMap.IsIndoors != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.IsIndoors = value;
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("lighting"), CustomDescription("brightnessdesc"), CustomDisplayName("brightness"),
+     DefaultValue(100)]
+    public int Brightness
+    {
+        get => mMyMap.Brightness;
+        set
+        {
+            if (mMyMap.Brightness != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.Brightness = Math.Max(value, 0);
+                mMyMap.Brightness = Math.Min(mMyMap.Brightness, 100);
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("lighting"), CustomDescription("playerlightsizedesc"), CustomDisplayName("playerlightsize"),
+     DefaultValue(300)]
+    public int PlayerLightSize
+    {
+        get => mMyMap.PlayerLightSize;
+        set
+        {
+            if (mMyMap.PlayerLightSize != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.PlayerLightSize = Math.Max(value, 0);
+                mMyMap.PlayerLightSize = Math.Min(mMyMap.PlayerLightSize, 1000);
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("lighting"), CustomDescription("playerlightexpanddesc"), CustomDisplayName("playerlightexpand"),
+     DefaultValue(0)]
+    public float PlayerLightExpand
+    {
+        get => mMyMap.PlayerLightExpand;
+        set
+        {
+            if (mMyMap.PlayerLightExpand != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.PlayerLightExpand = Math.Max(value, 0f);
+                mMyMap.PlayerLightExpand = Math.Min(mMyMap.PlayerLightExpand, 1f);
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("lighting"), CustomDescription("playerlightintensitydesc"),
+     CustomDisplayName("playerlightintensity"), DefaultValue(255)]
+    public float PlayerLightIntensity
+    {
+        get => mMyMap.PlayerLightIntensity;
+        set
+        {
+            if (mMyMap.PlayerLightIntensity != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                var val = Math.Max(value, (byte)0);
+                mMyMap.PlayerLightIntensity = (byte)Math.Min(val, (byte)255);
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("lighting"), CustomDescription("playerlightcolordesc"), CustomDisplayName("playerlightcolor"),
+     DefaultValue(0)]
+    public System.Drawing.Color PlayerLightColor
+    {
+        get =>
+            System.Drawing.Color.FromArgb(
+                mMyMap.PlayerLightColor.A, mMyMap.PlayerLightColor.R, mMyMap.PlayerLightColor.G,
+                mMyMap.PlayerLightColor.B
+            );
+        set
+        {
+            if (mMyMap.PlayerLightColor.A != value.A ||
+                mMyMap.PlayerLightColor.R != value.R ||
+                mMyMap.PlayerLightColor.G != value.G ||
+                mMyMap.PlayerLightColor.B != value.B)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.PlayerLightColor = Color.FromArgb(value.A, value.R, value.G, value.B);
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("overlay"), CustomDescription("rhuedesc"), CustomDisplayName("rhue"), DefaultValue(0)]
+    public int RHue
+    {
+        get => mMyMap.RHue;
+        set
+        {
+            if (mMyMap.RHue != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.RHue = Math.Max(value, 0);
+                mMyMap.RHue = Math.Min(mMyMap.RHue, 255);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("overlay"), CustomDescription("ghuedesc"), CustomDisplayName("ghue"), DefaultValue(0)]
+    public int GHue
+    {
+        get => mMyMap.GHue;
+        set
+        {
+            if (mMyMap.GHue != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.GHue = Math.Max(value, 0);
+                mMyMap.GHue = Math.Min(mMyMap.GHue, 255);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("overlay"), CustomDescription("bhuedesc"), CustomDisplayName("bhue"), DefaultValue(0)]
+    public int BHue
+    {
+        get => mMyMap.BHue;
+        set
+        {
+            if (mMyMap.BHue != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.BHue = Math.Max(value, 0);
+                mMyMap.BHue = Math.Min(mMyMap.BHue, 255);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("overlay"), CustomDescription("ahuedesc"), CustomDisplayName("ahue"), DefaultValue(0)]
+    public int AHue
+    {
+        get => mMyMap.AHue;
+        set
+        {
+            if (mMyMap.AHue != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.AHue = Math.Max(value, 0);
+                mMyMap.AHue = Math.Min(mMyMap.AHue, 255);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("fog"), CustomDescription("fogdesc"), CustomDisplayName("fog"), DefaultValue("None"),
+     TypeConverter(typeof(MapFogProperty)), Browsable(true)]
+    public string Fog
+    {
+        get
         {
             var fogList = new List<string>
             {
@@ -656,88 +336,78 @@ namespace Intersect.Editor.Maps
             };
 
             fogList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Fog));
-
-            return new StandardValuesCollection(fogList.ToArray());
-        }
-
-    }
-
-    public partial class MapImageProperty : StringConverter
-    {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
-        {
-            //true means show a combobox
-            return true;
-        }
-
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
-        {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
-        }
-
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-        {
-            var imageList = new List<string>
+            if (fogList.IndexOf(mMyMap.Fog) <= -1)
             {
-                Strings.General.None
-            };
-
-            imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
-
-            return new StandardValuesCollection(imageList.ToArray());
-        }
-
-    }
-
-    public partial class MapZoneProperty : StringConverter
-    {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
-        {
-            //true means show a combobox
-            return true;
-        }
-
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
-        {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
-        }
-
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-        {
-            var values = new List<string>();
-            for (byte i = 0; i < Enum.GetNames(typeof(MapZone)).Length; i++)
-            {
-                values.Add(Strings.MapProperties.zones[i]);
+                mMyMap.Fog = null;
             }
 
-            return new StandardValuesCollection(values);
+            return TextUtils.NullToNone(mMyMap.Fog);
         }
-
+        set
+        {
+            if (mMyMap.Fog != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.Fog = TextUtils.SanitizeNone(value);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
     }
 
-    public partial class MapWeatherProperty : StringConverter
+    [CustomCategory("fog"), CustomDescription("fogxspeeddesc"), CustomDisplayName("fogxspeed"), DefaultValue(0)]
+    public int FogXSpeed
     {
-
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        get => mMyMap.FogXSpeed;
+        set
         {
-            //true means show a combobox
-            return true;
+            if (mMyMap.FogXSpeed != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.FogXSpeed = Math.Max(value, -5);
+                mMyMap.FogXSpeed = Math.Min(mMyMap.FogXSpeed, 5);
+                Globals.MapEditorWindow.AddUndoState();
+            }
         }
+    }
 
-        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    [CustomCategory("fog"), CustomDescription("fogyspeeddesc"), CustomDisplayName("fogyspeed"), DefaultValue(0)]
+    public int FogYSpeed
+    {
+        get => mMyMap.FogYSpeed;
+        set
         {
-            //true will limit to list. false will show the list,
-            //but allow free-form entry
-            return false;
+            if (mMyMap.FogYSpeed != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.FogYSpeed = Math.Max(value, -5);
+                mMyMap.FogYSpeed = Math.Min(mMyMap.FogYSpeed, 5);
+                Globals.MapEditorWindow.AddUndoState();
+            }
         }
+    }
 
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    [CustomCategory("fog"), CustomDescription("fogalphadesc"), CustomDisplayName("fogalpha"), DefaultValue(0)]
+    public int FogAlpha
+    {
+        get => mMyMap.FogTransparency;
+        set
+        {
+            if (mMyMap.FogTransparency != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.FogTransparency = Math.Max(value, 0);
+                mMyMap.FogTransparency = Math.Min(mMyMap.FogTransparency, 255);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    //Weather
+    [CustomCategory("weather"), CustomDescription("weatherdesc"), CustomDisplayName("weather"),
+     DefaultValue("None"), TypeConverter(typeof(MapWeatherProperty)), Browsable(true)]
+    public string Weather
+    {
+        get
         {
             var WeatherList = new List<string>
             {
@@ -745,10 +415,338 @@ namespace Intersect.Editor.Maps
             };
 
             WeatherList.AddRange(AnimationBase.Names);
+            var name = AnimationBase.GetName(mMyMap.WeatherAnimationId);
+            if (AnimationBase.Get(mMyMap.WeatherAnimationId) == null)
+            {
+                name = null;
+            }
 
-            return new StandardValuesCollection(WeatherList.ToArray());
+            return TextUtils.NullToNone(name);
+        }
+        set
+        {
+            var idVal = Guid.Empty;
+            if (!TextUtils.IsNone(value))
+            {
+                var animationNames = new List<string>(AnimationBase.Names);
+                var index = animationNames.IndexOf(value);
+                idVal = AnimationBase.IdFromList(index);
+            }
+
+            if (mMyMap.WeatherAnimationId != idVal)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.WeatherAnimation = AnimationBase.Get(idVal);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("weather"), CustomDescription("weatherxspeeddesc"), CustomDisplayName("weatherxspeed"),
+     DefaultValue(0)]
+    public int WeatherXSpeed
+    {
+        get => mMyMap.WeatherXSpeed;
+        set
+        {
+            if (mMyMap.WeatherXSpeed != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.WeatherXSpeed = Math.Max(value, -5);
+                mMyMap.WeatherXSpeed = Math.Min(mMyMap.WeatherXSpeed, 5);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("weather"), CustomDescription("weatheryspeeddesc"), CustomDisplayName("weatheryspeed"),
+     DefaultValue(0)]
+    public int WeatherYSpeed
+    {
+        get => mMyMap.WeatherYSpeed;
+        set
+        {
+            if (mMyMap.WeatherYSpeed != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.WeatherYSpeed = Math.Max(value, -5);
+                mMyMap.WeatherYSpeed = Math.Min(mMyMap.WeatherYSpeed, 5);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("weather"), CustomDescription("weatherintensitydesc"), CustomDisplayName("weatherintensity"),
+     DefaultValue(0)]
+    public int WeatherAlpha
+    {
+        get => mMyMap.WeatherIntensity;
+        set
+        {
+            if (mMyMap.WeatherIntensity != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.WeatherIntensity = Math.Max(value, 0);
+                mMyMap.WeatherIntensity = Math.Min(mMyMap.WeatherIntensity, 100);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("misc"), CustomDescription("panoramadesc"), CustomDisplayName("panorama"), DefaultValue("None"),
+     TypeConverter(typeof(MapImageProperty)), Browsable(true)]
+    public string Panorama
+    {
+        get
+        {
+            var imageList = new List<string>
+            {
+                Strings.General.None
+            };
+
+            imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
+            if (imageList.IndexOf(mMyMap.Panorama) <= -1)
+            {
+                mMyMap.Panorama = null;
+            }
+
+            return TextUtils.NullToNone(mMyMap.Panorama);
+        }
+        set
+        {
+            if (mMyMap.Panorama != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.Panorama = TextUtils.SanitizeNone(value);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("misc"), CustomDescription("overlaygraphicdesc"), CustomDisplayName("overlaygraphic"),
+     DefaultValue("None"), TypeConverter(typeof(MapImageProperty)), Browsable(true)]
+    public string OverlayGraphic
+    {
+        get
+        {
+            var imageList = new List<string>
+            {
+                Strings.General.None
+            };
+
+            imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
+            if (imageList.IndexOf(mMyMap.OverlayGraphic) <= -1)
+            {
+                mMyMap.OverlayGraphic = null;
+            }
+
+            return TextUtils.NullToNone(mMyMap.OverlayGraphic);
+        }
+        set
+        {
+            if (mMyMap.OverlayGraphic != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.OverlayGraphic = TextUtils.SanitizeNone(value);
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [CustomCategory("player"), CustomDescription("hideequipmentdesc"), CustomDisplayName("hideequipment"),
+     DefaultValue(false)]
+    public bool HideEquipment
+    {
+        get => mMyMap.HideEquipment;
+        set
+        {
+            if (mMyMap.HideEquipment != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.HideEquipment = value;
+                Graphics.TilePreviewUpdated = true;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+}
+
+public partial class MapMusicProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var musicList = new List<string>
+        {
+            Strings.General.None
+        };
+
+        musicList.AddRange(GameContentManager.SmartSortedMusicNames);
+
+        return new StandardValuesCollection(musicList.ToArray());
+    }
+
+}
+
+public partial class MapSoundProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var soundList = new List<string>
+        {
+            Strings.General.None
+        };
+
+        soundList.AddRange(GameContentManager.SmartSortedSoundNames);
+
+        return new StandardValuesCollection(soundList.ToArray());
+    }
+
+}
+
+public partial class MapFogProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var fogList = new List<string>
+        {
+            Strings.General.None
+        };
+
+        fogList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Fog));
+
+        return new StandardValuesCollection(fogList.ToArray());
+    }
+
+}
+
+public partial class MapImageProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var imageList = new List<string>
+        {
+            Strings.General.None
+        };
+
+        imageList.AddRange(GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Image));
+
+        return new StandardValuesCollection(imageList.ToArray());
+    }
+
+}
+
+public partial class MapZoneProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var values = new List<string>();
+        for (byte i = 0; i < Enum.GetNames(typeof(MapZone)).Length; i++)
+        {
+            values.Add(Strings.MapProperties.zones[i]);
         }
 
+        return new StandardValuesCollection(values);
+    }
+
+}
+
+public partial class MapWeatherProperty : StringConverter
+{
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+    {
+        //true means show a combobox
+        return true;
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+    {
+        //true will limit to list. false will show the list,
+        //but allow free-form entry
+        return false;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+        var WeatherList = new List<string>
+        {
+            Strings.General.None
+        };
+
+        WeatherList.AddRange(AnimationBase.Names);
+
+        return new StandardValuesCollection(WeatherList.ToArray());
     }
 
 }

--- a/Intersect.Editor/Maps/MapSaveState.cs
+++ b/Intersect.Editor/Maps/MapSaveState.cs
@@ -1,33 +1,31 @@
-﻿namespace Intersect.Editor.Classes.Maps
+﻿namespace Intersect.Editor.Classes.Maps;
+
+
+public partial class MapSaveState
 {
 
-    public partial class MapSaveState
+    public MapSaveState(string metadata, byte[] tiles, byte[] attributes, string eventData)
     {
+        Metadata = metadata;
+        Tiles = tiles;
+        Attributes = attributes;
+        EventData = eventData;
+    }
 
-        public MapSaveState(string metadata, byte[] tiles, byte[] attributes, string eventData)
-        {
-            Metadata = metadata;
-            Tiles = tiles;
-            Attributes = attributes;
-            EventData = eventData;
-        }
+    public string Metadata { get; set; }
 
-        public string Metadata { get; set; }
+    public byte[] Tiles { get; set; }
 
-        public byte[] Tiles { get; set; }
+    public byte[] Attributes { get; set; }
 
-        public byte[] Attributes { get; set; }
+    public string EventData { get; set; }
 
-        public string EventData { get; set; }
-
-        public bool Matches(MapSaveState otherState)
-        {
-            return Metadata == otherState.Metadata &&
-                   Tiles.SequenceEqual(otherState.Tiles) &&
-                   Attributes.SequenceEqual(otherState.Attributes) &&
-                   EventData.SequenceEqual(otherState.EventData);
-        }
-
+    public bool Matches(MapSaveState otherState)
+    {
+        return Metadata == otherState.Metadata &&
+               Tiles.SequenceEqual(otherState.Tiles) &&
+               Attributes.SequenceEqual(otherState.Attributes) &&
+               EventData.SequenceEqual(otherState.EventData);
     }
 
 }

--- a/Intersect.Editor/Networking/Network.cs
+++ b/Intersect.Editor/Networking/Network.cs
@@ -16,296 +16,295 @@ using System.Net;
 using Intersect.Utilities;
 using Intersect.Network.Packets.Unconnected.Client;
 
-namespace Intersect.Editor.Networking
+namespace Intersect.Editor.Networking;
+
+
+internal sealed class VirtualApplicationContext : IApplicationContext
+{
+    public VirtualApplicationContext(IPacketHelper packetHelper)
+    {
+        PacketHelper = packetHelper;
+    }
+
+    public bool HasErrors => throw new NotImplementedException();
+
+    public bool IsDisposed => throw new NotImplementedException();
+
+    public bool IsStarted => throw new NotImplementedException();
+
+    public bool IsRunning => throw new NotImplementedException();
+
+    public ICommandLineOptions StartupOptions => throw new NotImplementedException();
+
+    public Logger Logger => throw new NotImplementedException();
+
+    public IPacketHelper PacketHelper { get; }
+
+    public List<IApplicationService> Services => throw new NotImplementedException();
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public TApplicationService GetService<TApplicationService>() where TApplicationService : IApplicationService
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Start(bool lockUntilShutdown = true)
+    {
+        throw new NotImplementedException();
+    }
+
+    public LockingActionQueue StartWithActionQueue()
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal static partial class Network
 {
 
-    internal sealed class VirtualApplicationContext : IApplicationContext
+    public static bool Connecting;
+
+    public static bool ConnectionDenied;
+
+    public static ClientNetwork EditorLidgrenNetwork { get; set; }
+
+    internal static PacketHandler PacketHandler { get; private set; }
+
+    public static bool Connected => EditorLidgrenNetwork?.IsConnected ?? false;
+
+    public static void Connect()
     {
-        public VirtualApplicationContext(IPacketHelper packetHelper)
+        if (EditorLidgrenNetwork?.Connect() ?? true)
         {
-            PacketHelper = packetHelper;
+            return;
         }
 
-        public bool HasErrors => throw new NotImplementedException();
+        Log.Warn("Failed to connect to server.");
+    }
 
-        public bool IsDisposed => throw new NotImplementedException();
-
-        public bool IsStarted => throw new NotImplementedException();
-
-        public bool IsRunning => throw new NotImplementedException();
-
-        public ICommandLineOptions StartupOptions => throw new NotImplementedException();
-
-        public Logger Logger => throw new NotImplementedException();
-
-        public IPacketHelper PacketHelper { get; }
-
-        public List<IApplicationService> Services => throw new NotImplementedException();
-
-        public void Dispose()
+    public static void InitNetwork()
+    {
+        if (EditorLidgrenNetwork == null)
         {
-            throw new NotImplementedException();
+            var logger = Log.Default;
+            var packetTypeRegistry = new PacketTypeRegistry(logger);
+            if (!packetTypeRegistry.TryRegisterBuiltIn())
+            {
+                throw new Exception("Failed to register built-in packets.");
+            }
+
+            var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
+            packetHandlerRegistry.TryRegisterAvailableTypeHandlers(typeof(Network).Assembly, requireAttribute: true);
+            var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
+            PackedIntersectPacket.AddKnownTypes(packetHelper.AvailablePacketTypes);
+            var virtualEditorContext = new VirtualEditorContext(packetHelper, logger);
+            PacketHandler = new PacketHandler(virtualEditorContext, packetHandlerRegistry);
+
+            var config = new NetworkConfiguration(
+                ClientConfiguration.Instance.Host, ClientConfiguration.Instance.Port
+            );
+
+            var virtualApplicationContext = new VirtualApplicationContext(packetHelper);
+            var assembly = Assembly.GetExecutingAssembly();
+            using (var stream = assembly.GetManifestResourceStream("Intersect.Editor.network.handshake.bkey.pub"))
+            {
+                var rsaKey = new RsaKey(stream);
+                Debug.Assert(rsaKey != null, "rsaKey != null");
+                EditorLidgrenNetwork = new ClientNetwork(virtualApplicationContext, config, rsaKey.Parameters);
+            }
+
+            EditorLidgrenNetwork.Handler = PacketHandler.HandlePacket;
+            EditorLidgrenNetwork.OnDisconnected += HandleDc;
+            EditorLidgrenNetwork.OnConnectionDenied += delegate
+            {
+                Connecting = false;
+                ConnectionDenied = true;
+            };
         }
 
-        public TApplicationService GetService<TApplicationService>() where TApplicationService : IApplicationService
+        if (!Connected)
         {
-            throw new NotImplementedException();
-        }
-
-        public void Start(bool lockUntilShutdown = true)
-        {
-            throw new NotImplementedException();
-        }
-
-        public LockingActionQueue StartWithActionQueue()
-        {
-            throw new NotImplementedException();
+            Connecting = true;
         }
     }
 
-    internal static partial class Network
-    {
-
-        public static bool Connecting;
-
-        public static bool ConnectionDenied;
-
-        public static ClientNetwork EditorLidgrenNetwork { get; set; }
-
-        internal static PacketHandler PacketHandler { get; private set; }
-
-        public static bool Connected => EditorLidgrenNetwork?.IsConnected ?? false;
-
-        public static void Connect()
-        {
-            if (EditorLidgrenNetwork?.Connect() ?? true)
-            {
-                return;
-            }
-
-            Log.Warn("Failed to connect to server.");
-        }
-
-        public static void InitNetwork()
-        {
-            if (EditorLidgrenNetwork == null)
-            {
-                var logger = Log.Default;
-                var packetTypeRegistry = new PacketTypeRegistry(logger);
-                if (!packetTypeRegistry.TryRegisterBuiltIn())
-                {
-                    throw new Exception("Failed to register built-in packets.");
-                }
-
-                var packetHandlerRegistry = new PacketHandlerRegistry(packetTypeRegistry, logger);
-                packetHandlerRegistry.TryRegisterAvailableTypeHandlers(typeof(Network).Assembly, requireAttribute: true);
-                var packetHelper = new PacketHelper(packetTypeRegistry, packetHandlerRegistry);
-                PackedIntersectPacket.AddKnownTypes(packetHelper.AvailablePacketTypes);
-                var virtualEditorContext = new VirtualEditorContext(packetHelper, logger);
-                PacketHandler = new PacketHandler(virtualEditorContext, packetHandlerRegistry);
-
-                var config = new NetworkConfiguration(
-                    ClientConfiguration.Instance.Host, ClientConfiguration.Instance.Port
-                );
-
-                var virtualApplicationContext = new VirtualApplicationContext(packetHelper);
-                var assembly = Assembly.GetExecutingAssembly();
-                using (var stream = assembly.GetManifestResourceStream("Intersect.Editor.network.handshake.bkey.pub"))
-                {
-                    var rsaKey = new RsaKey(stream);
-                    Debug.Assert(rsaKey != null, "rsaKey != null");
-                    EditorLidgrenNetwork = new ClientNetwork(virtualApplicationContext, config, rsaKey.Parameters);
-                }
-
-                EditorLidgrenNetwork.Handler = PacketHandler.HandlePacket;
-                EditorLidgrenNetwork.OnDisconnected += HandleDc;
-                EditorLidgrenNetwork.OnConnectionDenied += delegate
-                {
-                    Connecting = false;
-                    ConnectionDenied = true;
-                };
-            }
-
-            if (!Connected)
-            {
-                Connecting = true;
-            }
-        }
-
-        /// <summary>
-        /// Interval between status pings in ms (e.g. full, bad version, etc.)
-        /// </summary>
+    /// <summary>
+    /// Interval between status pings in ms (e.g. full, bad version, etc.)
+    /// </summary>
 #if DEBUG
-        private const long ServerStatusPingInterval = 15_000;
+    private const long ServerStatusPingInterval = 15_000;
 #else
-        private const long ServerStatusPingInterval = 15_000;
+    private const long ServerStatusPingInterval = 15_000;
 #endif
 
-        private static string? _lastHost;
-        private static int? _lastPort;
-        private static IPEndPoint? _lastEndpoint;
+    private static string? _lastHost;
+    private static int? _lastPort;
+    private static IPEndPoint? _lastEndpoint;
 
-        private static bool TryResolveEndPoint([NotNullWhen(true)] out IPEndPoint? endPoint)
+    private static bool TryResolveEndPoint([NotNullWhen(true)] out IPEndPoint? endPoint)
+    {
+        var currentHost = ClientConfiguration.Instance.Host;
+        if (!string.Equals(_lastHost, currentHost))
         {
-            var currentHost = ClientConfiguration.Instance.Host;
-            if (!string.Equals(_lastHost, currentHost))
-            {
-                _lastHost = currentHost;
-                _lastEndpoint = default;
-            }
+            _lastHost = currentHost;
+            _lastEndpoint = default;
+        }
 
-            var currentPort = ClientConfiguration.Instance.Port;
-            if (_lastPort != currentPort)
-            {
-                _lastPort = currentPort;
-                _lastEndpoint = default;
-            }
+        var currentPort = ClientConfiguration.Instance.Port;
+        if (_lastPort != currentPort)
+        {
+            _lastPort = currentPort;
+            _lastEndpoint = default;
+        }
 
-            if (string.IsNullOrWhiteSpace(_lastHost))
-            {
-                endPoint = default;
-                return false;
-            }
+        if (string.IsNullOrWhiteSpace(_lastHost))
+        {
+            endPoint = default;
+            return false;
+        }
 
-            if (_lastEndpoint != default)
-            {
-                endPoint = _lastEndpoint;
-                return true;
-            }
-
-            var address = Dns.GetHostAddresses(_lastHost).FirstOrDefault();
-            var port = _lastPort;
-            if (address == default || !port.HasValue)
-            {
-                endPoint = default;
-                return false;
-            }
-
-            endPoint = new IPEndPoint(address, port.Value);
-            _lastEndpoint = endPoint;
+        if (_lastEndpoint != default)
+        {
+            endPoint = _lastEndpoint;
             return true;
         }
 
-        public static void Update()
+        var address = Dns.GetHostAddresses(_lastHost).FirstOrDefault();
+        var port = _lastPort;
+        if (address == default || !port.HasValue)
         {
-            if (Globals.LoginForm?.Visible ?? false)
+            endPoint = default;
+            return false;
+        }
+
+        endPoint = new IPEndPoint(address, port.Value);
+        _lastEndpoint = endPoint;
+        return true;
+    }
+
+    public static void Update()
+    {
+        if (Globals.LoginForm?.Visible ?? false)
+        {
+            var now = Timing.Global.MillisecondsUtc;
+            // ReSharper disable once InvertIf
+            if (Globals.NextServerStatusPing <= now)
             {
-                var now = Timing.Global.MillisecondsUtc;
-                // ReSharper disable once InvertIf
-                if (Globals.NextServerStatusPing <= now)
+                if (TryResolveEndPoint(out var serverEndpoint))
                 {
-                    if (TryResolveEndPoint(out var serverEndpoint))
+                    var network = EditorLidgrenNetwork;
+                    if (network == default)
                     {
-                        var network = EditorLidgrenNetwork;
-                        if (network == default)
-                        {
-                            Log.Info("No network created to poll for server status.");
-                        }
-                        else
-                        {
-                            network.SendUnconnected(serverEndpoint, new ServerStatusRequestPacket());
-                            Globals.NextServerStatusPing = now + ServerStatusPingInterval;
-                        }
+                        Log.Info("No network created to poll for server status.");
                     }
                     else
                     {
-                        Log.Info($"Unable to resolve '{_lastHost}:{_lastPort}'");
-                    }
-
-                    if (Globals.LoginForm.LastNetworkStatusChangeTime + ServerStatusPingInterval + ServerStatusPingInterval / 2 < now)
-                    {
-                        Globals.LoginForm.SetNetworkStatus(NetworkStatus.Offline);
+                        network.SendUnconnected(serverEndpoint, new ServerStatusRequestPacket());
+                        Globals.NextServerStatusPing = now + ServerStatusPingInterval;
                     }
                 }
-            }
-
-            if (!Connected && !Connecting && !ConnectionDenied)
-            {
-                InitNetwork();
-            }
-        }
-
-        public static void DestroyNetwork()
-        {
-            try
-            {
-                EditorLidgrenNetwork?.Close();
-                EditorLidgrenNetwork = null;
-                PacketHandler?.Registry?.Dispose();
-                PacketHandler = null;
-            }
-            catch (Exception)
-            {
-                // ignored
-            }
-        }
-
-        public static void HandleDc(INetworkLayerInterface sender, ConnectionEventArgs connectionEventArgs)
-        {
-            DestroyNetwork();
-            if (Globals.MainForm != null && Globals.MainForm.Visible)
-            {
-                if (Globals.MainForm.DisconnectDelegate != null)
+                else
                 {
-                    Globals.MainForm.BeginInvoke(Globals.MainForm.DisconnectDelegate);
-                    Globals.MainForm.DisconnectDelegate = null;
+                    Log.Info($"Unable to resolve '{_lastHost}:{_lastPort}'");
                 }
-            }
-            else if (Globals.LoginForm.Visible)
-            {
-                Connecting = false;
-                InitNetwork();
-            }
-            else
-            {
-                MessageBox.Show(@"Disconnected!");
-                Application.Exit();
-            }
-        }
 
-        public static void SendPacket(IntersectPacket packet)
-        {
-            if (EditorLidgrenNetwork != null)
-            {
-                if (!EditorLidgrenNetwork.Send(packet))
+                if (Globals.LoginForm.LastNetworkStatusChangeTime + ServerStatusPingInterval + ServerStatusPingInterval / 2 < now)
                 {
-                    throw new Exception("Beta 4 network send failed.");
+                    Globals.LoginForm.SetNetworkStatus(NetworkStatus.Offline);
                 }
             }
         }
 
+        if (!Connected && !Connecting && !ConnectionDenied)
+        {
+            InitNetwork();
+        }
     }
 
-    internal sealed partial class VirtualEditorContext : IApplicationContext
+    public static void DestroyNetwork()
     {
-        internal VirtualEditorContext(PacketHelper packetHelper, Logger logger)
+        try
         {
-            PacketHelper = packetHelper;
-            Logger = logger;
+            EditorLidgrenNetwork?.Close();
+            EditorLidgrenNetwork = null;
+            PacketHandler?.Registry?.Dispose();
+            PacketHandler = null;
         }
-
-        public bool HasErrors => Network.ConnectionDenied;
-
-        public bool IsDisposed { get; private set; }
-
-        public bool IsStarted => IsRunning || Network.Connecting;
-
-        public bool IsRunning => Network.Connected;
-
-        public ICommandLineOptions StartupOptions => default;
-
-        public Logger Logger { get; }
-
-        public List<IApplicationService> Services { get; } = new List<IApplicationService>();
-
-        public IPacketHelper PacketHelper { get; }
-
-        public void Dispose() => IsDisposed = true;
-
-        public TApplicationService GetService<TApplicationService>() where TApplicationService : IApplicationService => default;
-
-        public void Start(bool lockUntilShutdown = true) { }
-
-        public LockingActionQueue StartWithActionQueue() => default;
+        catch (Exception)
+        {
+            // ignored
+        }
     }
+
+    public static void HandleDc(INetworkLayerInterface sender, ConnectionEventArgs connectionEventArgs)
+    {
+        DestroyNetwork();
+        if (Globals.MainForm != null && Globals.MainForm.Visible)
+        {
+            if (Globals.MainForm.DisconnectDelegate != null)
+            {
+                Globals.MainForm.BeginInvoke(Globals.MainForm.DisconnectDelegate);
+                Globals.MainForm.DisconnectDelegate = null;
+            }
+        }
+        else if (Globals.LoginForm.Visible)
+        {
+            Connecting = false;
+            InitNetwork();
+        }
+        else
+        {
+            MessageBox.Show(@"Disconnected!");
+            Application.Exit();
+        }
+    }
+
+    public static void SendPacket(IntersectPacket packet)
+    {
+        if (EditorLidgrenNetwork != null)
+        {
+            if (!EditorLidgrenNetwork.Send(packet))
+            {
+                throw new Exception("Beta 4 network send failed.");
+            }
+        }
+    }
+
+}
+
+internal sealed partial class VirtualEditorContext : IApplicationContext
+{
+    internal VirtualEditorContext(PacketHelper packetHelper, Logger logger)
+    {
+        PacketHelper = packetHelper;
+        Logger = logger;
+    }
+
+    public bool HasErrors => Network.ConnectionDenied;
+
+    public bool IsDisposed { get; private set; }
+
+    public bool IsStarted => IsRunning || Network.Connecting;
+
+    public bool IsRunning => Network.Connected;
+
+    public ICommandLineOptions StartupOptions => default;
+
+    public Logger Logger { get; }
+
+    public List<IApplicationService> Services { get; } = new List<IApplicationService>();
+
+    public IPacketHelper PacketHelper { get; }
+
+    public void Dispose() => IsDisposed = true;
+
+    public TApplicationService GetService<TApplicationService>() where TApplicationService : IApplicationService => default;
+
+    public void Start(bool lockUntilShutdown = true) { }
+
+    public LockingActionQueue StartWithActionQueue() => default;
 }

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -13,688 +13,687 @@ using Intersect.Logging;
 using Intersect.Network;
 using Intersect.Network.Packets.Server;
 
-namespace Intersect.Editor.Networking
+namespace Intersect.Editor.Networking;
+
+internal sealed partial class PacketHandler
 {
-    internal sealed partial class PacketHandler
+    private sealed partial class VirtualPacketSender : IPacketSender
     {
-        private sealed partial class VirtualPacketSender : IPacketSender
+        public IApplicationContext ApplicationContext { get; }
+
+        public INetwork Network => Networking.Network.EditorLidgrenNetwork;
+
+        public VirtualPacketSender(IApplicationContext applicationContext) =>
+            ApplicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
+
+        #region Implementation of IPacketSender
+
+        /// <inheritdoc />
+        public bool Send(IPacket packet)
         {
-            public IApplicationContext ApplicationContext { get; }
-
-            public INetwork Network => Networking.Network.EditorLidgrenNetwork;
-
-            public VirtualPacketSender(IApplicationContext applicationContext) =>
-                ApplicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
-
-            #region Implementation of IPacketSender
-
-            /// <inheritdoc />
-            public bool Send(IPacket packet)
+            if (packet is IntersectPacket intersectPacket)
             {
-                if (packet is IntersectPacket intersectPacket)
-                {
-                    Networking.Network.SendPacket(intersectPacket);
+                Networking.Network.SendPacket(intersectPacket);
 
-                    return true;
-                }
+                return true;
+            }
 
+            return false;
+        }
+
+        #endregion
+    }
+
+    public delegate void GameObjectUpdated(GameObjectType type);
+
+    public delegate void MapUpdated();
+
+    public static GameObjectUpdated GameObjectUpdatedDelegate;
+
+    public static MapUpdated MapUpdatedDelegate;
+
+    public IApplicationContext Context { get; }
+
+    public Logger Logger { get; }
+
+    public PacketHandlerRegistry Registry { get; }
+
+    public IPacketSender VirtualSender { get; }
+
+    public PacketHandler(IApplicationContext context, PacketHandlerRegistry packetHandlerRegistry)
+    {
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
+
+        if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
+        {
+            throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
+        }
+
+        VirtualSender = new VirtualPacketSender(context);
+    }
+
+    public bool HandlePacket(IConnection connection, IPacket packet)
+    {
+        if (!(packet is IntersectPacket))
+        {
+            return false;
+        }
+
+        if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+        {
+            Logger.Error($"No registered handler for {packet.GetType().FullName}!");
+
+            return false;
+        }
+
+        if (Registry.TryGetPreprocessors(packet, out var preprocessors))
+        {
+            if (!preprocessors.All(preprocessor => preprocessor.Handle(VirtualSender, packet)))
+            {
+                // Preprocessors are intended to be silent filter functions
                 return false;
             }
-
-            #endregion
         }
 
-        public delegate void GameObjectUpdated(GameObjectType type);
-
-        public delegate void MapUpdated();
-
-        public static GameObjectUpdated GameObjectUpdatedDelegate;
-
-        public static MapUpdated MapUpdatedDelegate;
-
-        public IApplicationContext Context { get; }
-
-        public Logger Logger { get; }
-
-        public PacketHandlerRegistry Registry { get; }
-
-        public IPacketSender VirtualSender { get; }
-
-        public PacketHandler(IApplicationContext context, PacketHandlerRegistry packetHandlerRegistry)
+        if (Registry.TryGetPreHooks(packet, out var preHooks))
         {
-            Context = context ?? throw new ArgumentNullException(nameof(context));
-            Registry = packetHandlerRegistry ?? throw new ArgumentNullException(nameof(packetHandlerRegistry));
-
-            if (!Registry.TryRegisterAvailableMethodHandlers(GetType(), this, false) || Registry.IsEmpty)
+            if (!preHooks.All(hook => hook.Handle(VirtualSender, packet)))
             {
-                throw new InvalidOperationException("Failed to register method handlers, see logs for more details.");
-            }
-
-            VirtualSender = new VirtualPacketSender(context);
-        }
-
-        public bool HandlePacket(IConnection connection, IPacket packet)
-        {
-            if (!(packet is IntersectPacket))
-            {
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
                 return false;
             }
+        }
 
-            if (!Registry.TryGetHandler(packet, out HandlePacketGeneric handler))
+        if (!handler(VirtualSender, packet))
+        {
+            return false;
+        }
+
+        if (Registry.TryGetPostHooks(packet, out var postHooks))
+        {
+            if (!postHooks.All(hook => hook.Handle(VirtualSender, packet)))
             {
-                Logger.Error($"No registered handler for {packet.GetType().FullName}!");
-
+                // Hooks should not fail, if they do that's an error
+                Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
                 return false;
             }
+        }
 
-            if (Registry.TryGetPreprocessors(packet, out var preprocessors))
+        return true;
+    }
+
+    //PingPacket
+    public void HandlePacket(IPacketSender packetSender, PingPacket packet)
+    {
+        if (packet.RequestingReply)
+        {
+            PacketSender.SendPing();
+        }
+    }
+
+    //ConfigPacket
+    public void HandlePacket(IPacketSender packetSender, ConfigPacket packet)
+    {
+        Options.LoadFromServer(packet.Config);
+        try
+        {
+            Strings.Load();
+        } catch (Exception exception)
+        {
+            Log.Error(exception);
+            throw;
+        }
+    }
+
+    //JoinGamePacket
+    public void HandlePacket(IPacketSender packetSender, JoinGamePacket packet)
+    {
+        Globals.LoginForm.TryRemembering();
+        Globals.LoginForm.HideSafe();
+    }
+
+    //MapPacket
+    public void HandlePacket(IPacketSender packetSender, MapPacket packet)
+    {
+        if (packet.Deleted)
+        {
+            if (MapInstance.Get(packet.MapId) != null)
             {
-                if (!preprocessors.All(preprocessor => preprocessor.Handle(VirtualSender, packet)))
+                if (Globals.CurrentMap == MapInstance.Get(packet.MapId))
                 {
-                    // Preprocessors are intended to be silent filter functions
-                    return false;
+                    Globals.MainForm.EnterMap(MapList.List.FindFirstMap());
                 }
-            }
 
-            if (Registry.TryGetPreHooks(packet, out var preHooks))
-            {
-                if (!preHooks.All(hook => hook.Handle(VirtualSender, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PreHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            if (!handler(VirtualSender, packet))
-            {
-                return false;
-            }
-
-            if (Registry.TryGetPostHooks(packet, out var postHooks))
-            {
-                if (!postHooks.All(hook => hook.Handle(VirtualSender, packet)))
-                {
-                    // Hooks should not fail, if they do that's an error
-                    Logger.Error($"PostHook handler failed for {packet.GetType().FullName}.");
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        //PingPacket
-        public void HandlePacket(IPacketSender packetSender, PingPacket packet)
-        {
-            if (packet.RequestingReply)
-            {
-                PacketSender.SendPing();
+                MapInstance.Get(packet.MapId).Delete();
             }
         }
-
-        //ConfigPacket
-        public void HandlePacket(IPacketSender packetSender, ConfigPacket packet)
+        else
         {
-            Options.LoadFromServer(packet.Config);
-            try
+            var map = new MapInstance(packet.MapId);
+            map.Load(packet.Data);
+            map.LoadTileData(packet.TileData);
+            map.AttributeData = packet.AttributeData;
+            map.MapGridX = packet.GridX;
+            map.MapGridY = packet.GridY;
+            map.SaveStateAsUnchanged();
+            map.InitAutotiles();
+            map.UpdateAdjacentAutotiles();
+            if (MapInstance.Get(packet.MapId) != null)
             {
-                Strings.Load();
-            } catch (Exception exception)
-            {
-                Log.Error(exception);
-                throw;
-            }
-        }
-
-        //JoinGamePacket
-        public void HandlePacket(IPacketSender packetSender, JoinGamePacket packet)
-        {
-            Globals.LoginForm.TryRemembering();
-            Globals.LoginForm.HideSafe();
-        }
-
-        //MapPacket
-        public void HandlePacket(IPacketSender packetSender, MapPacket packet)
-        {
-            if (packet.Deleted)
-            {
-                if (MapInstance.Get(packet.MapId) != null)
+                lock (MapInstance.Get(packet.MapId).MapLock)
                 {
                     if (Globals.CurrentMap == MapInstance.Get(packet.MapId))
                     {
-                        Globals.MainForm.EnterMap(MapList.List.FindFirstMap());
+                        Globals.CurrentMap = map;
                     }
 
                     MapInstance.Get(packet.MapId).Delete();
                 }
             }
-            else
+
+            MapInstance.Lookup.Set(packet.MapId, map);
+            if (!Globals.InEditor && Globals.HasGameData)
             {
-                var map = new MapInstance(packet.MapId);
-                map.Load(packet.Data);
-                map.LoadTileData(packet.TileData);
-                map.AttributeData = packet.AttributeData;
-                map.MapGridX = packet.GridX;
-                map.MapGridY = packet.GridY;
-                map.SaveStateAsUnchanged();
-                map.InitAutotiles();
-                map.UpdateAdjacentAutotiles();
-                if (MapInstance.Get(packet.MapId) != null)
-                {
-                    lock (MapInstance.Get(packet.MapId).MapLock)
-                    {
-                        if (Globals.CurrentMap == MapInstance.Get(packet.MapId))
-                        {
-                            Globals.CurrentMap = map;
-                        }
-
-                        MapInstance.Get(packet.MapId).Delete();
-                    }
-                }
-
-                MapInstance.Lookup.Set(packet.MapId, map);
-                if (!Globals.InEditor && Globals.HasGameData)
-                {
-                    Globals.CurrentMap = map;
-                    Globals.LoginForm.BeginInvoke(Globals.LoginForm.EditorLoopDelegate);
-                }
-                else if (Globals.InEditor)
-                {
-                    if (Globals.FetchingMapPreviews || Globals.CurrentMap == map)
-                    {
-                        var currentMapId = Globals.CurrentMap.Id;
-                        var img = Database.LoadMapCacheLegacy(packet.MapId, map.Revision);
-                        if (img == null && !Globals.MapsToScreenshot.Contains(packet.MapId))
-                        {
-                            Globals.MapsToScreenshot.Add(packet.MapId);
-                        }
-
-                        img?.Dispose();
-                        if (Globals.FetchingMapPreviews)
-                        {
-                            if (Globals.MapsToFetch.Contains(packet.MapId))
-                            {
-                                Globals.MapsToFetch.Remove(packet.MapId);
-                                if (Globals.MapsToFetch.Count == 0)
-                                {
-                                    Globals.FetchingMapPreviews = false;
-                                    Globals.PreviewProgressForm.BeginInvoke(
-                                        (MethodInvoker) delegate { Globals.PreviewProgressForm.Dispose(); }
-                                    );
-                                }
-                                else
-                                {
-                                    //TODO Localize
-                                    Globals.PreviewProgressForm.SetProgress(
-                                        "Fetching Maps: " +
-                                        (Globals.FetchCount - Globals.MapsToFetch.Count) +
-                                        "/" +
-                                        Globals.FetchCount,
-                                        (int) ((float) (Globals.FetchCount - Globals.MapsToFetch.Count) /
-                                               (float) Globals.FetchCount *
-                                               100f), false
-                                    );
-                                }
-                            }
-                        }
-
-                        Globals.CurrentMap = MapInstance.Get(currentMapId);
-                    }
-
-                    if (packet.MapId != Globals.LoadingMap)
-                    {
-                        return;
-                    }
-
-                    Globals.CurrentMap = MapInstance.Get(Globals.LoadingMap);
-                    MapUpdatedDelegate();
-                    if (map.Up != Guid.Empty)
-                    {
-                        PacketSender.SendNeedMap(map.Up);
-                    }
-
-                    if (map.Down != Guid.Empty)
-                    {
-                        PacketSender.SendNeedMap(map.Down);
-                    }
-
-                    if (map.Left != Guid.Empty)
-                    {
-                        PacketSender.SendNeedMap(map.Left);
-                    }
-
-                    if (map.Right != Guid.Empty)
-                    {
-                        PacketSender.SendNeedMap(map.Right);
-                    }
-                }
-
-                if (Globals.CurrentMap.Id == packet.MapId && Globals.MapGrid != null && Globals.MapGrid.Loaded)
-                {
-                    for (var y = Globals.CurrentMap.MapGridY + 1; y >= Globals.CurrentMap.MapGridY - 1; y--)
-                    {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
-                        {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
-                            {
-                                var needMap = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                if (needMap == null && Globals.MapGrid.Grid[x, y].MapId != Guid.Empty)
-                                {
-                                    PacketSender.SendNeedMap(Globals.MapGrid.Grid[x, y].MapId);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        //GameDataPacket
-        public void HandlePacket(IPacketSender packetSender, GameDataPacket packet)
-        {
-            foreach (var obj in packet.GameObjects)
-            {
-                HandlePacket(packetSender, obj);
-            }
-
-            Globals.HasGameData = true;
-            if (!Globals.InEditor && Globals.HasGameData && Globals.CurrentMap != null)
-            {
+                Globals.CurrentMap = map;
                 Globals.LoginForm.BeginInvoke(Globals.LoginForm.EditorLoopDelegate);
             }
-
-            GameContentManager.LoadTilesets();
-        }
-
-        //EnterMapPacket
-        public void HandlePacket(IPacketSender packetSender, EnterMapPacket packet)
-        {
-            Globals.MainForm.BeginInvoke((Action) (() => Globals.MainForm.EnterMap(packet.MapId)));
-        }
-
-        //MapListPacket
-        public void HandlePacket(IPacketSender packetSender, MapListPacket packet)
-        {
-            MapList.List.JsonData = packet.MapListData;
-            MapList.List.PostLoad(MapBase.Lookup, false, true);
-
-            // If our current map is null, load our previous map as per our stored Id or the first available map.
-            if (Globals.CurrentMap == null)
+            else if (Globals.InEditor)
             {
-                // Check if we have a map we left off at before proceeding.
-                var firstMap = MapList.List.FindFirstMap();
-                var storedPreference = Preferences.LoadPreference("LastMapOpened");
-                if (!string.IsNullOrWhiteSpace(storedPreference))
+                if (Globals.FetchingMapPreviews || Globals.CurrentMap == map)
                 {
-                    // Check if the map Id isn't empty and if this map still exists.
-                    var storedMapId = Guid.Parse(storedPreference);
-                    if (storedMapId != Guid.Empty && MapList.List.FindMap(storedMapId) != null)
+                    var currentMapId = Globals.CurrentMap.Id;
+                    var img = Database.LoadMapCacheLegacy(packet.MapId, map.Revision);
+                    if (img == null && !Globals.MapsToScreenshot.Contains(packet.MapId))
                     {
-                        Globals.MainForm.EnterMap(storedMapId);
+                        Globals.MapsToScreenshot.Add(packet.MapId);
                     }
-                    // No longer exists, so just load the first.
-                    else
+
+                    img?.Dispose();
+                    if (Globals.FetchingMapPreviews)
                     {
-                        Globals.MainForm.EnterMap(firstMap);
+                        if (Globals.MapsToFetch.Contains(packet.MapId))
+                        {
+                            Globals.MapsToFetch.Remove(packet.MapId);
+                            if (Globals.MapsToFetch.Count == 0)
+                            {
+                                Globals.FetchingMapPreviews = false;
+                                Globals.PreviewProgressForm.BeginInvoke(
+                                    (MethodInvoker) delegate { Globals.PreviewProgressForm.Dispose(); }
+                                );
+                            }
+                            else
+                            {
+                                //TODO Localize
+                                Globals.PreviewProgressForm.SetProgress(
+                                    "Fetching Maps: " +
+                                    (Globals.FetchCount - Globals.MapsToFetch.Count) +
+                                    "/" +
+                                    Globals.FetchCount,
+                                    (int) ((float) (Globals.FetchCount - Globals.MapsToFetch.Count) /
+                                           (float) Globals.FetchCount *
+                                           100f), false
+                                );
+                            }
+                        }
+                    }
+
+                    Globals.CurrentMap = MapInstance.Get(currentMapId);
+                }
+
+                if (packet.MapId != Globals.LoadingMap)
+                {
+                    return;
+                }
+
+                Globals.CurrentMap = MapInstance.Get(Globals.LoadingMap);
+                MapUpdatedDelegate();
+                if (map.Up != Guid.Empty)
+                {
+                    PacketSender.SendNeedMap(map.Up);
+                }
+
+                if (map.Down != Guid.Empty)
+                {
+                    PacketSender.SendNeedMap(map.Down);
+                }
+
+                if (map.Left != Guid.Empty)
+                {
+                    PacketSender.SendNeedMap(map.Left);
+                }
+
+                if (map.Right != Guid.Empty)
+                {
+                    PacketSender.SendNeedMap(map.Right);
+                }
+            }
+
+            if (Globals.CurrentMap.Id == packet.MapId && Globals.MapGrid != null && Globals.MapGrid.Loaded)
+            {
+                for (var y = Globals.CurrentMap.MapGridY + 1; y >= Globals.CurrentMap.MapGridY - 1; y--)
+                {
+                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                    {
+                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                        {
+                            var needMap = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                            if (needMap == null && Globals.MapGrid.Grid[x, y].MapId != Guid.Empty)
+                            {
+                                PacketSender.SendNeedMap(Globals.MapGrid.Grid[x, y].MapId);
+                            }
+                        }
                     }
                 }
-                // Invalid Id, so load the first map.
+            }
+        }
+    }
+
+    //GameDataPacket
+    public void HandlePacket(IPacketSender packetSender, GameDataPacket packet)
+    {
+        foreach (var obj in packet.GameObjects)
+        {
+            HandlePacket(packetSender, obj);
+        }
+
+        Globals.HasGameData = true;
+        if (!Globals.InEditor && Globals.HasGameData && Globals.CurrentMap != null)
+        {
+            Globals.LoginForm.BeginInvoke(Globals.LoginForm.EditorLoopDelegate);
+        }
+
+        GameContentManager.LoadTilesets();
+    }
+
+    //EnterMapPacket
+    public void HandlePacket(IPacketSender packetSender, EnterMapPacket packet)
+    {
+        Globals.MainForm.BeginInvoke((Action) (() => Globals.MainForm.EnterMap(packet.MapId)));
+    }
+
+    //MapListPacket
+    public void HandlePacket(IPacketSender packetSender, MapListPacket packet)
+    {
+        MapList.List.JsonData = packet.MapListData;
+        MapList.List.PostLoad(MapBase.Lookup, false, true);
+
+        // If our current map is null, load our previous map as per our stored Id or the first available map.
+        if (Globals.CurrentMap == null)
+        {
+            // Check if we have a map we left off at before proceeding.
+            var firstMap = MapList.List.FindFirstMap();
+            var storedPreference = Preferences.LoadPreference("LastMapOpened");
+            if (!string.IsNullOrWhiteSpace(storedPreference))
+            {
+                // Check if the map Id isn't empty and if this map still exists.
+                var storedMapId = Guid.Parse(storedPreference);
+                if (storedMapId != Guid.Empty && MapList.List.FindMap(storedMapId) != null)
+                {
+                    Globals.MainForm.EnterMap(storedMapId);
+                }
+                // No longer exists, so just load the first.
                 else
                 {
                     Globals.MainForm.EnterMap(firstMap);
                 }
-                
             }
-
-            Globals.MapListWindow.BeginInvoke(Globals.MapListWindow.mapTreeList.MapListDelegate, Guid.Empty, null);
-            Globals.MapPropertiesWindow?.BeginInvoke(Globals.MapPropertiesWindow.UpdatePropertiesDelegate);
-        }
-
-        //ErrorMessagePacket
-        public void HandlePacket(IPacketSender packetSender, ErrorMessagePacket packet)
-        {
-            MessageBox.Show(packet.Error, packet.Header, MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
-
-        //MapGridPacket
-        public void HandlePacket(IPacketSender packetSender, MapGridPacket packet)
-        {
-            if (Globals.MapGrid != null)
+            // Invalid Id, so load the first map.
+            else
             {
-                Globals.MapGrid.Load(packet.EditorGrid);
-                if (Globals.CurrentMap != null && Globals.MapGrid != null && Globals.MapGrid.Loaded)
+                Globals.MainForm.EnterMap(firstMap);
+            }
+            
+        }
+
+        Globals.MapListWindow.BeginInvoke(Globals.MapListWindow.mapTreeList.MapListDelegate, Guid.Empty, null);
+        Globals.MapPropertiesWindow?.BeginInvoke(Globals.MapPropertiesWindow.UpdatePropertiesDelegate);
+    }
+
+    //ErrorMessagePacket
+    public void HandlePacket(IPacketSender packetSender, ErrorMessagePacket packet)
+    {
+        MessageBox.Show(packet.Error, packet.Header, MessageBoxButtons.OK, MessageBoxIcon.Error);
+    }
+
+    //MapGridPacket
+    public void HandlePacket(IPacketSender packetSender, MapGridPacket packet)
+    {
+        if (Globals.MapGrid != null)
+        {
+            Globals.MapGrid.Load(packet.EditorGrid);
+            if (Globals.CurrentMap != null && Globals.MapGrid != null && Globals.MapGrid.Loaded)
+            {
+                for (var y = Globals.CurrentMap.MapGridY + 1; y >= Globals.CurrentMap.MapGridY - 1; y--)
                 {
-                    for (var y = Globals.CurrentMap.MapGridY + 1; y >= Globals.CurrentMap.MapGridY - 1; y--)
+                    for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
                     {
-                        for (var x = Globals.CurrentMap.MapGridX - 1; x <= Globals.CurrentMap.MapGridX + 1; x++)
+                        if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
                         {
-                            if (x >= 0 && x < Globals.MapGrid.GridWidth && y >= 0 && y < Globals.MapGrid.GridHeight)
+                            var needMap = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
+                            if (needMap == null && Globals.MapGrid.Grid[x, y].MapId != Guid.Empty)
                             {
-                                var needMap = MapInstance.Get(Globals.MapGrid.Grid[x, y].MapId);
-                                if (needMap == null && Globals.MapGrid.Grid[x, y].MapId != Guid.Empty)
-                                {
-                                    PacketSender.SendNeedMap(Globals.MapGrid.Grid[x, y].MapId);
-                                }
+                                PacketSender.SendNeedMap(Globals.MapGrid.Grid[x, y].MapId);
                             }
                         }
                     }
                 }
             }
         }
+    }
 
-        //GameObjectPacket
-        public void HandlePacket(IPacketSender packetSender, GameObjectPacket packet)
+    //GameObjectPacket
+    public void HandlePacket(IPacketSender packetSender, GameObjectPacket packet)
+    {
+        var id = packet.Id;
+        var deleted = packet.Deleted;
+        var json = "";
+        if (!packet.Deleted)
         {
-            var id = packet.Id;
-            var deleted = packet.Deleted;
-            var json = "";
-            if (!packet.Deleted)
-            {
-                json = packet.Data;
-            }
-
-            switch (packet.Type)
-            {
-                case GameObjectType.Animation:
-                    if (deleted)
-                    {
-                        var anim = AnimationBase.Get(id);
-                        anim.Delete();
-                    }
-                    else
-                    {
-                        var anim = new AnimationBase(id);
-                        anim.Load(json);
-                        try
-                        {
-                            AnimationBase.Lookup.Set(id, anim);
-                        }
-                        catch (Exception exception)
-                        {
-                            Log.Error($"Another mystery NPE. [Lookup={AnimationBase.Lookup}]");
-                            if (exception.InnerException != null)
-                            {
-                                Log.Error(exception.InnerException);
-                            }
-
-                            Log.Error(exception);
-                            Log.Error($"{nameof(id)}={id},{nameof(anim)}={anim}");
-
-                            throw;
-                        }
-                    }
-
-                    break;
-
-                case GameObjectType.Class:
-                    if (deleted)
-                    {
-                        var cls = ClassBase.Get(id);
-                        cls.Delete();
-                    }
-                    else
-                    {
-                        var cls = new ClassBase(id);
-                        cls.Load(json);
-                        ClassBase.Lookup.Set(id, cls);
-                    }
-
-                    break;
-
-                case GameObjectType.Item:
-                    if (deleted)
-                    {
-                        var itm = ItemBase.Get(id);
-                        itm.Delete();
-                    }
-                    else
-                    {
-                        var itm = new ItemBase(id);
-                        itm.Load(json);
-                        ItemBase.Lookup.Set(id, itm);
-                    }
-
-                    break;
-                case GameObjectType.Npc:
-                    if (deleted)
-                    {
-                        var npc = NpcBase.Get(id);
-                        npc.Delete();
-                    }
-                    else
-                    {
-                        var npc = new NpcBase(id);
-                        npc.Load(json);
-                        NpcBase.Lookup.Set(id, npc);
-                    }
-
-                    break;
-
-                case GameObjectType.Projectile:
-                    if (deleted)
-                    {
-                        var proj = ProjectileBase.Get(id);
-                        proj.Delete();
-                    }
-                    else
-                    {
-                        var proj = new ProjectileBase(id);
-                        proj.Load(json);
-                        ProjectileBase.Lookup.Set(id, proj);
-                    }
-
-                    break;
-
-                case GameObjectType.Quest:
-                    if (deleted)
-                    {
-                        var qst = QuestBase.Get(id);
-                        qst.Delete();
-                    }
-                    else
-                    {
-                        var qst = new QuestBase(id);
-                        qst.Load(json);
-                        foreach (var tsk in qst.Tasks)
-                        {
-                            qst.OriginalTaskEventIds.Add(tsk.Id, tsk.CompletionEventId);
-                        }
-
-                        QuestBase.Lookup.Set(id, qst);
-                    }
-
-                    break;
-
-                case GameObjectType.Resource:
-                    if (deleted)
-                    {
-                        var res = ResourceBase.Get(id);
-                        res.Delete();
-                    }
-                    else
-                    {
-                        var res = new ResourceBase(id);
-                        res.Load(json);
-                        ResourceBase.Lookup.Set(id, res);
-                    }
-
-                    break;
-
-                case GameObjectType.Shop:
-                    if (deleted)
-                    {
-                        var shp = ShopBase.Get(id);
-                        shp.Delete();
-                    }
-                    else
-                    {
-                        var shp = new ShopBase(id);
-                        shp.Load(json);
-                        ShopBase.Lookup.Set(id, shp);
-                    }
-
-                    break;
-
-                case GameObjectType.Spell:
-                    if (deleted)
-                    {
-                        var spl = SpellBase.Get(id);
-                        spl.Delete();
-                    }
-                    else
-                    {
-                        var spl = new SpellBase(id);
-                        spl.Load(json);
-                        SpellBase.Lookup.Set(id, spl);
-                    }
-
-                    break;
-
-                case GameObjectType.CraftTables:
-                    if (deleted)
-                    {
-                        var cft = CraftingTableBase.Get(id);
-                        cft.Delete();
-                    }
-                    else
-                    {
-                        var cft = new CraftingTableBase(id);
-                        cft.Load(json);
-                        CraftingTableBase.Lookup.Set(id, cft);
-                    }
-
-                    break;
-
-                case GameObjectType.Crafts:
-                    if (deleted)
-                    {
-                        var cft = CraftBase.Get(id);
-                        cft.Delete();
-                    }
-                    else
-                    {
-                        var cft = new CraftBase(id);
-                        cft.Load(json);
-                        CraftBase.Lookup.Set(id, cft);
-                    }
-
-                    break;
-
-                case GameObjectType.Map:
-                    //Handled in a different packet
-                    break;
-
-                case GameObjectType.Event:
-                    var wasCommon = false;
-                    if (deleted)
-                    {
-                        var evt = EventBase.Get(id);
-                        wasCommon = evt.CommonEvent;
-                        evt.Delete();
-                    }
-                    else
-                    {
-                        var evt = new EventBase(id);
-                        evt.Load(json);
-                        wasCommon = evt.CommonEvent;
-                        EventBase.Lookup.Set(id, evt);
-                    }
-
-                    if (!wasCommon)
-                    {
-                        return;
-                    }
-
-                    break;
-
-                case GameObjectType.PlayerVariable:
-                    if (deleted)
-                    {
-                        var pvar = PlayerVariableBase.Get(id);
-                        pvar.Delete();
-                    }
-                    else
-                    {
-                        var pvar = new PlayerVariableBase(id);
-                        pvar.Load(json);
-                        PlayerVariableBase.Lookup.Set(id, pvar);
-                    }
-
-                    break;
-
-                case GameObjectType.ServerVariable:
-                    if (deleted)
-                    {
-                        var svar = ServerVariableBase.Get(id);
-                        svar.Delete();
-                    }
-                    else
-                    {
-                        var svar = new ServerVariableBase(id);
-                        svar.Load(json);
-                        ServerVariableBase.Lookup.Set(id, svar);
-                    }
-
-                    break;
-
-                case GameObjectType.Tileset:
-                    var obj = new TilesetBase(id);
-                    obj.Load(json);
-                    TilesetBase.Lookup.Set(id, obj);
-                    if (Globals.HasGameData && !packet.AnotherFollowing)
-                    {
-                        GameContentManager.LoadTilesets();
-                    }
-
-                    break;
-
-                case GameObjectType.GuildVariable:
-                    if (deleted)
-                    {
-                        var pvar = GuildVariableBase.Get(id);
-                        pvar.Delete();
-                    }
-                    else
-                    {
-                        var pvar = new GuildVariableBase(id);
-                        pvar.Load(json);
-                        GuildVariableBase.Lookup.Set(id, pvar);
-                    }
-
-                    break;
-
-                case GameObjectType.UserVariable:
-                    if (deleted)
-                    {
-                        var pvar = UserVariableBase.Get(id);
-                        pvar.Delete();
-                    }
-                    else
-                    {
-                        var pvar = new UserVariableBase(id);
-                        pvar.Load(json);
-                        UserVariableBase.Lookup.Set(id, pvar);
-                    }
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            GameObjectUpdatedDelegate?.Invoke(packet.Type);
+            json = packet.Data;
         }
 
-        //OpenEditorPacket
-        public void HandlePacket(IPacketSender packetSender, OpenEditorPacket packet)
+        switch (packet.Type)
         {
-            Globals.MainForm.BeginInvoke(Globals.MainForm.EditorDelegate, packet.Type);
+            case GameObjectType.Animation:
+                if (deleted)
+                {
+                    var anim = AnimationBase.Get(id);
+                    anim.Delete();
+                }
+                else
+                {
+                    var anim = new AnimationBase(id);
+                    anim.Load(json);
+                    try
+                    {
+                        AnimationBase.Lookup.Set(id, anim);
+                    }
+                    catch (Exception exception)
+                    {
+                        Log.Error($"Another mystery NPE. [Lookup={AnimationBase.Lookup}]");
+                        if (exception.InnerException != null)
+                        {
+                            Log.Error(exception.InnerException);
+                        }
+
+                        Log.Error(exception);
+                        Log.Error($"{nameof(id)}={id},{nameof(anim)}={anim}");
+
+                        throw;
+                    }
+                }
+
+                break;
+
+            case GameObjectType.Class:
+                if (deleted)
+                {
+                    var cls = ClassBase.Get(id);
+                    cls.Delete();
+                }
+                else
+                {
+                    var cls = new ClassBase(id);
+                    cls.Load(json);
+                    ClassBase.Lookup.Set(id, cls);
+                }
+
+                break;
+
+            case GameObjectType.Item:
+                if (deleted)
+                {
+                    var itm = ItemBase.Get(id);
+                    itm.Delete();
+                }
+                else
+                {
+                    var itm = new ItemBase(id);
+                    itm.Load(json);
+                    ItemBase.Lookup.Set(id, itm);
+                }
+
+                break;
+            case GameObjectType.Npc:
+                if (deleted)
+                {
+                    var npc = NpcBase.Get(id);
+                    npc.Delete();
+                }
+                else
+                {
+                    var npc = new NpcBase(id);
+                    npc.Load(json);
+                    NpcBase.Lookup.Set(id, npc);
+                }
+
+                break;
+
+            case GameObjectType.Projectile:
+                if (deleted)
+                {
+                    var proj = ProjectileBase.Get(id);
+                    proj.Delete();
+                }
+                else
+                {
+                    var proj = new ProjectileBase(id);
+                    proj.Load(json);
+                    ProjectileBase.Lookup.Set(id, proj);
+                }
+
+                break;
+
+            case GameObjectType.Quest:
+                if (deleted)
+                {
+                    var qst = QuestBase.Get(id);
+                    qst.Delete();
+                }
+                else
+                {
+                    var qst = new QuestBase(id);
+                    qst.Load(json);
+                    foreach (var tsk in qst.Tasks)
+                    {
+                        qst.OriginalTaskEventIds.Add(tsk.Id, tsk.CompletionEventId);
+                    }
+
+                    QuestBase.Lookup.Set(id, qst);
+                }
+
+                break;
+
+            case GameObjectType.Resource:
+                if (deleted)
+                {
+                    var res = ResourceBase.Get(id);
+                    res.Delete();
+                }
+                else
+                {
+                    var res = new ResourceBase(id);
+                    res.Load(json);
+                    ResourceBase.Lookup.Set(id, res);
+                }
+
+                break;
+
+            case GameObjectType.Shop:
+                if (deleted)
+                {
+                    var shp = ShopBase.Get(id);
+                    shp.Delete();
+                }
+                else
+                {
+                    var shp = new ShopBase(id);
+                    shp.Load(json);
+                    ShopBase.Lookup.Set(id, shp);
+                }
+
+                break;
+
+            case GameObjectType.Spell:
+                if (deleted)
+                {
+                    var spl = SpellBase.Get(id);
+                    spl.Delete();
+                }
+                else
+                {
+                    var spl = new SpellBase(id);
+                    spl.Load(json);
+                    SpellBase.Lookup.Set(id, spl);
+                }
+
+                break;
+
+            case GameObjectType.CraftTables:
+                if (deleted)
+                {
+                    var cft = CraftingTableBase.Get(id);
+                    cft.Delete();
+                }
+                else
+                {
+                    var cft = new CraftingTableBase(id);
+                    cft.Load(json);
+                    CraftingTableBase.Lookup.Set(id, cft);
+                }
+
+                break;
+
+            case GameObjectType.Crafts:
+                if (deleted)
+                {
+                    var cft = CraftBase.Get(id);
+                    cft.Delete();
+                }
+                else
+                {
+                    var cft = new CraftBase(id);
+                    cft.Load(json);
+                    CraftBase.Lookup.Set(id, cft);
+                }
+
+                break;
+
+            case GameObjectType.Map:
+                //Handled in a different packet
+                break;
+
+            case GameObjectType.Event:
+                var wasCommon = false;
+                if (deleted)
+                {
+                    var evt = EventBase.Get(id);
+                    wasCommon = evt.CommonEvent;
+                    evt.Delete();
+                }
+                else
+                {
+                    var evt = new EventBase(id);
+                    evt.Load(json);
+                    wasCommon = evt.CommonEvent;
+                    EventBase.Lookup.Set(id, evt);
+                }
+
+                if (!wasCommon)
+                {
+                    return;
+                }
+
+                break;
+
+            case GameObjectType.PlayerVariable:
+                if (deleted)
+                {
+                    var pvar = PlayerVariableBase.Get(id);
+                    pvar.Delete();
+                }
+                else
+                {
+                    var pvar = new PlayerVariableBase(id);
+                    pvar.Load(json);
+                    PlayerVariableBase.Lookup.Set(id, pvar);
+                }
+
+                break;
+
+            case GameObjectType.ServerVariable:
+                if (deleted)
+                {
+                    var svar = ServerVariableBase.Get(id);
+                    svar.Delete();
+                }
+                else
+                {
+                    var svar = new ServerVariableBase(id);
+                    svar.Load(json);
+                    ServerVariableBase.Lookup.Set(id, svar);
+                }
+
+                break;
+
+            case GameObjectType.Tileset:
+                var obj = new TilesetBase(id);
+                obj.Load(json);
+                TilesetBase.Lookup.Set(id, obj);
+                if (Globals.HasGameData && !packet.AnotherFollowing)
+                {
+                    GameContentManager.LoadTilesets();
+                }
+
+                break;
+
+            case GameObjectType.GuildVariable:
+                if (deleted)
+                {
+                    var pvar = GuildVariableBase.Get(id);
+                    pvar.Delete();
+                }
+                else
+                {
+                    var pvar = new GuildVariableBase(id);
+                    pvar.Load(json);
+                    GuildVariableBase.Lookup.Set(id, pvar);
+                }
+
+                break;
+
+            case GameObjectType.UserVariable:
+                if (deleted)
+                {
+                    var pvar = UserVariableBase.Get(id);
+                    pvar.Delete();
+                }
+                else
+                {
+                    var pvar = new UserVariableBase(id);
+                    pvar.Load(json);
+                    UserVariableBase.Lookup.Set(id, pvar);
+                }
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
         }
 
-        //TimeDataPacket
-        public void HandlePacket(IPacketSender packetSender, TimeDataPacket packet)
-        {
-            TimeBase.GetTimeBase().LoadFromJson(packet.TimeJson);
-        }
+        GameObjectUpdatedDelegate?.Invoke(packet.Type);
+    }
+
+    //OpenEditorPacket
+    public void HandlePacket(IPacketSender packetSender, OpenEditorPacket packet)
+    {
+        Globals.MainForm.BeginInvoke(Globals.MainForm.EditorDelegate, packet.Type);
+    }
+
+    //TimeDataPacket
+    public void HandlePacket(IPacketSender packetSender, TimeDataPacket packet)
+    {
+        TimeBase.GetTimeBase().LoadFromJson(packet.TimeJson);
     }
 }

--- a/Intersect.Editor/Networking/PacketSender.cs
+++ b/Intersect.Editor/Networking/PacketSender.cs
@@ -5,182 +5,180 @@ using Intersect.GameObjects.Maps.MapList;
 using Intersect.Models;
 using Intersect.Network.Packets.Editor;
 
-namespace Intersect.Editor.Networking
+namespace Intersect.Editor.Networking;
+
+
+public static partial class PacketSender
 {
 
-    public static partial class PacketSender
+    public static void SendPing()
     {
+        Network.SendPacket(new PingPacket());
+    }
 
-        public static void SendPing()
+    public static void SendLogin(string username, string password)
+    {
+        Network.SendPacket(new LoginPacket(username, password));
+    }
+
+    public static void SendNeedMap(Guid mapId)
+    {
+        Network.SendPacket(new NeedMapPacket(mapId));
+    }
+
+    public static void SendMap(MapInstance map)
+    {
+        Network.SendPacket(new MapUpdatePacket(map.Id, map.JsonData, map.GenerateTileData(), map.AttributeData));
+    }
+
+    public static void SendCreateMap(int location, Guid currentMapId, MapListItem parent)
+    {
+        if (location > -1)
         {
-            Network.SendPacket(new PingPacket());
+            Network.SendPacket(new CreateMapPacket(currentMapId, (byte) location));
+            return;
         }
 
-        public static void SendLogin(string username, string password)
+        switch (parent)
         {
-            Network.SendPacket(new LoginPacket(username, password));
+            case null:
+                Network.SendPacket(new CreateMapPacket(0, Guid.Empty));
+                break;
+
+            case MapListMap map:
+                Network.SendPacket(new CreateMapPacket(1, map.MapId));
+                break;
+
+            case MapListFolder folder:
+                Network.SendPacket(new CreateMapPacket(0, folder.FolderId));
+                break;
+        }
+    }
+
+    public static void SendMapListMove(int srcType, Guid srcId, int destType, Guid destId)
+    {
+        Network.SendPacket(new MapListUpdatePacket(MapListUpdate.MoveItem, srcType, srcId, destType, destId, ""));
+    }
+
+    public static void SendAddFolder(MapListItem parent)
+    {
+        switch (parent)
+        {
+            case null:
+                Network.SendPacket(new MapListUpdatePacket(MapListUpdate.AddFolder, 0, Guid.Empty, 0, Guid.Empty, string.Empty));
+                break;
+
+            case MapListMap map:
+                Network.SendPacket(
+                    new MapListUpdatePacket(
+                        MapListUpdate.AddFolder, 0, Guid.Empty, 1, map.MapId, string.Empty
+                    )
+                );
+                break;
+
+            case MapListFolder folder:
+                Network.SendPacket(
+                    new MapListUpdatePacket(
+                        MapListUpdate.AddFolder, 0, Guid.Empty, 0, folder.FolderId, string.Empty
+                    )
+                );
+                break;
+        }
+    }
+
+    public static void SendRename(MapListItem parent, string name)
+    {
+        switch (parent)
+        {
+            case MapListMap map:
+                Network.SendPacket(
+                    new MapListUpdatePacket(MapListUpdate.Rename, 1, map.MapId, 0, Guid.Empty, name)
+                );
+                break;
+
+            case MapListFolder folder:
+                Network.SendPacket(
+                    new MapListUpdatePacket(
+                        MapListUpdate.Rename, 0, folder.FolderId, 0, Guid.Empty, name
+                    )
+                );
+                break;
+        }
+    }
+
+    public static void SendDelete(MapListItem target)
+    {
+        switch (target)
+        {
+            case MapListMap map:
+                Network.SendPacket(
+                    new MapListUpdatePacket(MapListUpdate.Delete, 1, map.MapId, 0, Guid.Empty, string.Empty)
+                );
+                break;
+
+            case MapListFolder folder:
+                Network.SendPacket(
+                    new MapListUpdatePacket(
+                        MapListUpdate.Delete, 0, folder.FolderId, 0, Guid.Empty, string.Empty
+                    )
+                );
+                break;
+        }
+    }
+
+    public static void SendNeedGrid(Guid mapId)
+    {
+        Network.SendPacket(new RequestGridPacket(mapId));
+    }
+
+    public static void SendUnlinkMap(Guid mapId)
+    {
+        Network.SendPacket(new UnlinkMapPacket(mapId, Globals.CurrentMap.Id));
+    }
+
+    public static void SendLinkMap(Guid adjacentMapId, Guid linkMapId, int gridX, int gridY)
+    {
+        Network.SendPacket(new LinkMapPacket(linkMapId, adjacentMapId, gridX, gridY));
+    }
+
+    public static void SendCreateObject(GameObjectType type)
+    {
+        Network.SendPacket(new CreateGameObjectPacket(type));
+    }
+
+    public static void SendOpenEditor(GameObjectType type)
+    {
+        if (Globals.CurrentEditor != -1)
+        {
+            return;
         }
 
-        public static void SendNeedMap(Guid mapId)
-        {
-            Network.SendPacket(new NeedMapPacket(mapId));
-        }
+        Network.SendPacket(new RequestOpenEditorPacket(type));
+    }
 
-        public static void SendMap(MapInstance map)
-        {
-            Network.SendPacket(new MapUpdatePacket(map.Id, map.JsonData, map.GenerateTileData(), map.AttributeData));
-        }
+    public static void SendDeleteObject(IDatabaseObject obj)
+    {
+        Network.SendPacket(new DeleteGameObjectPacket(obj.Type, obj.Id));
+    }
 
-        public static void SendCreateMap(int location, Guid currentMapId, MapListItem parent)
-        {
-            if (location > -1)
-            {
-                Network.SendPacket(new CreateMapPacket(currentMapId, (byte) location));
-                return;
-            }
+    public static void SendSaveObject(IDatabaseObject obj)
+    {
+        Network.SendPacket(new SaveGameObjectPacket(obj.Type, obj.Id, obj.JsonData));
+    }
 
-            switch (parent)
-            {
-                case null:
-                    Network.SendPacket(new CreateMapPacket(0, Guid.Empty));
-                    break;
+    public static void SendSaveTime(string timeJson)
+    {
+        Network.SendPacket(new SaveTimeDataPacket(timeJson));
+    }
 
-                case MapListMap map:
-                    Network.SendPacket(new CreateMapPacket(1, map.MapId));
-                    break;
+    public static void SendNewTilesets(string[] tilesets)
+    {
+        Network.SendPacket(new AddTilesetsPacket(tilesets));
+    }
 
-                case MapListFolder folder:
-                    Network.SendPacket(new CreateMapPacket(0, folder.FolderId));
-                    break;
-            }
-        }
-
-        public static void SendMapListMove(int srcType, Guid srcId, int destType, Guid destId)
-        {
-            Network.SendPacket(new MapListUpdatePacket(MapListUpdate.MoveItem, srcType, srcId, destType, destId, ""));
-        }
-
-        public static void SendAddFolder(MapListItem parent)
-        {
-            switch (parent)
-            {
-                case null:
-                    Network.SendPacket(new MapListUpdatePacket(MapListUpdate.AddFolder, 0, Guid.Empty, 0, Guid.Empty, string.Empty));
-                    break;
-
-                case MapListMap map:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(
-                            MapListUpdate.AddFolder, 0, Guid.Empty, 1, map.MapId, string.Empty
-                        )
-                    );
-                    break;
-
-                case MapListFolder folder:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(
-                            MapListUpdate.AddFolder, 0, Guid.Empty, 0, folder.FolderId, string.Empty
-                        )
-                    );
-                    break;
-            }
-        }
-
-        public static void SendRename(MapListItem parent, string name)
-        {
-            switch (parent)
-            {
-                case MapListMap map:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(MapListUpdate.Rename, 1, map.MapId, 0, Guid.Empty, name)
-                    );
-                    break;
-
-                case MapListFolder folder:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(
-                            MapListUpdate.Rename, 0, folder.FolderId, 0, Guid.Empty, name
-                        )
-                    );
-                    break;
-            }
-        }
-
-        public static void SendDelete(MapListItem target)
-        {
-            switch (target)
-            {
-                case MapListMap map:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(MapListUpdate.Delete, 1, map.MapId, 0, Guid.Empty, string.Empty)
-                    );
-                    break;
-
-                case MapListFolder folder:
-                    Network.SendPacket(
-                        new MapListUpdatePacket(
-                            MapListUpdate.Delete, 0, folder.FolderId, 0, Guid.Empty, string.Empty
-                        )
-                    );
-                    break;
-            }
-        }
-
-        public static void SendNeedGrid(Guid mapId)
-        {
-            Network.SendPacket(new RequestGridPacket(mapId));
-        }
-
-        public static void SendUnlinkMap(Guid mapId)
-        {
-            Network.SendPacket(new UnlinkMapPacket(mapId, Globals.CurrentMap.Id));
-        }
-
-        public static void SendLinkMap(Guid adjacentMapId, Guid linkMapId, int gridX, int gridY)
-        {
-            Network.SendPacket(new LinkMapPacket(linkMapId, adjacentMapId, gridX, gridY));
-        }
-
-        public static void SendCreateObject(GameObjectType type)
-        {
-            Network.SendPacket(new CreateGameObjectPacket(type));
-        }
-
-        public static void SendOpenEditor(GameObjectType type)
-        {
-            if (Globals.CurrentEditor != -1)
-            {
-                return;
-            }
-
-            Network.SendPacket(new RequestOpenEditorPacket(type));
-        }
-
-        public static void SendDeleteObject(IDatabaseObject obj)
-        {
-            Network.SendPacket(new DeleteGameObjectPacket(obj.Type, obj.Id));
-        }
-
-        public static void SendSaveObject(IDatabaseObject obj)
-        {
-            Network.SendPacket(new SaveGameObjectPacket(obj.Type, obj.Id, obj.JsonData));
-        }
-
-        public static void SendSaveTime(string timeJson)
-        {
-            Network.SendPacket(new SaveTimeDataPacket(timeJson));
-        }
-
-        public static void SendNewTilesets(string[] tilesets)
-        {
-            Network.SendPacket(new AddTilesetsPacket(tilesets));
-        }
-
-        public static void SendEnterMap(Guid mapId)
-        {
-            Network.SendPacket(new EnterMapPacket(mapId));
-        }
-
+    public static void SendEnterMap(Guid mapId)
+    {
+        Network.SendPacket(new EnterMapPacket(mapId));
     }
 
 }


### PR DESCRIPTION
**Context:** File-scoped namespaces _were introduced in C# 10.0, which was released as part of .NET 6_. This feature allows developers to declare namespaces at the top of a file without enclosing them in a curly brace block, effectively making the namespace applicable to the entire file. Converting namespaces to file-scoped namespaces in C# promotes cleaner, more organized code that is easier to read, maintain, and scale as the project grows. It aligns with modern coding practices and helps prevent potential namespace conflicts, contributing to overall code quality and developer productivity.