### PR TITLE
chore: converts network namespaces to file-scoped namespaces

### DIFF
--- a/Intersect.Network/IServer.cs
+++ b/Intersect.Network/IServer.cs
@@ -1,11 +1,9 @@
-﻿namespace Intersect.Network
+﻿namespace Intersect.Network;
+
+
+public interface IServer
 {
 
-    public interface IServer
-    {
-
-        bool Listen();
-
-    }
+    bool Listen();
 
 }

--- a/Intersect.Network/Lidgren/LidgrenBuffer.cs
+++ b/Intersect.Network/Lidgren/LidgrenBuffer.cs
@@ -4,787 +4,785 @@ using Intersect.Memory;
 
 using Lidgren.Network;
 
-namespace Intersect.Network.Lidgren
+namespace Intersect.Network.Lidgren;
+
+
+public partial class LidgrenBuffer : IBuffer
 {
 
-    public partial class LidgrenBuffer : IBuffer
+    public LidgrenBuffer(NetBuffer buffer)
     {
+        Buffer = buffer;
+    }
 
-        public LidgrenBuffer(NetBuffer buffer)
+    public NetBuffer Buffer { get; }
+
+    public void Dispose()
+    {
+    }
+
+    public long Length => Buffer?.LengthBytes ?? -1;
+
+    public long Position => Buffer?.PositionInBytes ?? -1;
+
+    public long Remaining => Length - Position;
+
+    public byte[] ToBytes()
+    {
+        return Buffer?.ReadBytes((int)Length);
+    }
+
+    public bool Has(long bytes)
+    {
+        return bytes <= Remaining;
+    }
+
+    public bool Read(out bool value)
+    {
+        try
         {
-            Buffer = buffer;
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadBoolean();
+
+            return true;
         }
-
-        public NetBuffer Buffer { get; }
-
-        public void Dispose()
+        catch (Exception)
         {
-        }
-
-        public long Length => Buffer?.LengthBytes ?? -1;
-
-        public long Position => Buffer?.PositionInBytes ?? -1;
-
-        public long Remaining => Length - Position;
-
-        public byte[] ToBytes()
-        {
-            return Buffer?.ReadBytes((int)Length);
-        }
-
-        public bool Has(long bytes)
-        {
-            return bytes <= Remaining;
-        }
-
-        public bool Read(out bool value)
-        {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadBoolean();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(bool);
-
-                return false;
-            }
-        }
-
-        public bool Read(out byte value)
-        {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadByte();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(byte);
-
-                return false;
-            }
-        }
-
-        public bool Read(out byte[] value)
-        {
-            if (Read(out int count))
-            {
-                return Read(out value, count);
-            }
-
-            value = default(byte[]);
+            value = default(bool);
 
             return false;
         }
+    }
 
-        public bool Read(out byte[] value, long count)
+    public bool Read(out byte value)
+    {
+        try
         {
-            value = new byte[count];
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadByte();
 
-            return count < 1 || Read(ref value, 0, count);
+            return true;
         }
-
-        public bool Read(ref byte[] value, long offset, long count)
+        catch (Exception)
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                Buffer.ReadBytes(value, (int) offset, (int) count);
-
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        public bool Read(out char value)
-        {
-            if (Has(sizeof(char)) && Read(out var bytes, sizeof(char)))
-            {
-                value = BitConverter.ToChar(bytes, 0);
-
-                return true;
-            }
-
-            value = default(char);
+            value = default(byte);
 
             return false;
         }
+    }
 
-        public bool Read(out decimal value)
+    public bool Read(out byte[] value)
+    {
+        if (Read(out int count))
         {
-            value = default(decimal);
+            return Read(out value, count);
+        }
 
-            var bits = new int[4];
-            if (!Read(out bits[0]))
-            {
-                return false;
-            }
+        value = default(byte[]);
 
-            if (!Read(out bits[1]))
-            {
-                return false;
-            }
+        return false;
+    }
 
-            if (!Read(out bits[2]))
-            {
-                return false;
-            }
+    public bool Read(out byte[] value, long count)
+    {
+        value = new byte[count];
 
-            if (!Read(out bits[3]))
-            {
-                return false;
-            }
+        return count < 1 || Read(ref value, 0, count);
+    }
 
-            value = new decimal(bits);
+    public bool Read(ref byte[] value, long offset, long count)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            Buffer.ReadBytes(value, (int) offset, (int) count);
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public bool Read(out char value)
+    {
+        if (Has(sizeof(char)) && Read(out var bytes, sizeof(char)))
+        {
+            value = BitConverter.ToChar(bytes, 0);
 
             return true;
         }
 
-        public bool Read(out double value)
+        value = default(char);
+
+        return false;
+    }
+
+    public bool Read(out decimal value)
+    {
+        value = default(decimal);
+
+        var bits = new int[4];
+        if (!Read(out bits[0]))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadDouble();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(double);
-
-                return false;
-            }
+            return false;
         }
 
-        public bool Read(out float value)
+        if (!Read(out bits[1]))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadFloat();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(float);
-
-                return false;
-            }
+            return false;
         }
 
-        public bool Read(out int value)
+        if (!Read(out bits[2]))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadInt32();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(int);
-
-                return false;
-            }
+            return false;
         }
 
-        public bool Read(out long value)
+        if (!Read(out bits[3]))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadInt64();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(long);
-
-                return false;
-            }
+            return false;
         }
 
-        public bool Read(out sbyte value)
+        value = new decimal(bits);
+
+        return true;
+    }
+
+    public bool Read(out double value)
+    {
+        try
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadSByte();
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadDouble();
 
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(sbyte);
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(double);
 
-                return false;
-            }
+            return false;
+        }
+    }
+
+    public bool Read(out float value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadFloat();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(float);
+
+            return false;
+        }
+    }
+
+    public bool Read(out int value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadInt32();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(int);
+
+            return false;
+        }
+    }
+
+    public bool Read(out long value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadInt64();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(long);
+
+            return false;
+        }
+    }
+
+    public bool Read(out sbyte value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadSByte();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(sbyte);
+
+            return false;
+        }
+    }
+
+    public bool Read(out short value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadInt16();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(short);
+
+            return false;
+        }
+    }
+
+    public bool Read(out string value)
+    {
+        return Read(out value, Encoding.UTF8);
+    }
+
+    public bool Read(out string value, Encoding encoding, bool nullTerminated = false)
+    {
+        if (encoding == null)
+        {
+            throw new ArgumentNullException();
         }
 
-        public bool Read(out short value)
+        int length;
+        if (nullTerminated)
         {
-            try
+            var position = Buffer?.PositionInBytes ?? int.MaxValue;
+            var buffer = Buffer?.PeekDataBuffer() ?? Array.Empty<byte>();
+            while (Buffer?.LengthBytes - position > 0)
             {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadInt16();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(short);
-
-                return false;
-            }
-        }
-
-        public bool Read(out string value)
-        {
-            return Read(out value, Encoding.UTF8);
-        }
-
-        public bool Read(out string value, Encoding encoding, bool nullTerminated = false)
-        {
-            if (encoding == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            int length;
-            if (nullTerminated)
-            {
-                var position = Buffer?.PositionInBytes ?? int.MaxValue;
-                var buffer = Buffer?.PeekDataBuffer() ?? Array.Empty<byte>();
-                while (Buffer?.LengthBytes - position > 0)
+                if (buffer[position] == 0)
                 {
-                    if (buffer[position] == 0)
-                    {
-                        break;
-                    }
-
-                    position++;
+                    break;
                 }
 
-                length = Buffer?.LengthBytes - Buffer?.PositionInBytes ?? -1;
-            }
-            else if (!Read(out length))
-            {
-                value = default(string);
-
-                return false;
+                position++;
             }
 
-            switch (length)
-            {
-                case 0:
-                    value = "";
+            length = Buffer?.LengthBytes - Buffer?.PositionInBytes ?? -1;
+        }
+        else if (!Read(out length))
+        {
+            value = default(string);
 
-                    break;
+            return false;
+        }
 
-                case -1:
-                    value = null;
+        switch (length)
+        {
+            case 0:
+                value = "";
 
-                    break;
+                break;
 
-                default:
-                    value = Read(out var bytes, length) ? encoding.GetString(bytes, 0, length) : null;
+            case -1:
+                value = null;
 
-                    break;
-            }
+                break;
+
+            default:
+                value = Read(out var bytes, length) ? encoding.GetString(bytes, 0, length) : null;
+
+                break;
+        }
+
+        return true;
+    }
+
+    public bool Read(out uint value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadUInt32();
 
             return true;
         }
-
-        public bool Read(out uint value)
+        catch (Exception)
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadUInt32();
+            value = default(uint);
 
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(uint);
+            return false;
+        }
+    }
 
-                return false;
-            }
+    public bool Read(out ulong value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadUInt64();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(ulong);
+
+            return false;
+        }
+    }
+
+    public bool Read(out ushort value)
+    {
+        try
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            value = Buffer.ReadUInt16();
+
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default(ushort);
+
+            return false;
+        }
+    }
+
+    public bool ReadBool()
+    {
+        if (Read(out bool value))
+        {
+            return value;
         }
 
-        public bool Read(out ulong value)
+        throw new OutOfMemoryException();
+    }
+
+    public bool ReadBoolean()
+    {
+        if (Read(out bool value))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadUInt64();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(ulong);
-
-                return false;
-            }
+            return value;
         }
 
-        public bool Read(out ushort value)
+        throw new OutOfMemoryException();
+    }
+
+    public byte ReadByte()
+    {
+        if (Read(out byte value))
         {
-            try
-            {
-                // ReSharper disable once PossibleNullReferenceException
-                value = Buffer.ReadUInt16();
-
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(ushort);
-
-                return false;
-            }
+            return value;
         }
 
-        public bool ReadBool()
-        {
-            if (Read(out bool value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public byte ReadUInt8()
+    {
+        if (Read(out byte value))
+        {
+            return value;
         }
 
-        public bool ReadBoolean()
-        {
-            if (Read(out bool value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public byte[] ReadBytes()
+    {
+        if (Read(out byte[] value))
+        {
+            return value;
         }
 
-        public byte ReadByte()
-        {
-            if (Read(out byte value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public byte[] ReadBytes(long count)
+    {
+        if (Read(out var value, count))
+        {
+            return value;
         }
 
-        public byte ReadUInt8()
-        {
-            if (Read(out byte value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public byte[] ReadBytes(ref byte[] bytes, long offset, long count)
+    {
+        if (Read(ref bytes, offset, count))
+        {
+            return bytes;
         }
 
-        public byte[] ReadBytes()
-        {
-            if (Read(out byte[] value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public char ReadChar()
+    {
+        if (Read(out char value))
+        {
+            return value;
         }
 
-        public byte[] ReadBytes(long count)
-        {
-            if (Read(out var value, count))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public char ReadCharacter()
+    {
+        if (Read(out char value))
+        {
+            return value;
         }
 
-        public byte[] ReadBytes(ref byte[] bytes, long offset, long count)
-        {
-            if (Read(ref bytes, offset, count))
-            {
-                return bytes;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public decimal ReadDecimal()
+    {
+        if (Read(out decimal value))
+        {
+            return value;
         }
 
-        public char ReadChar()
-        {
-            if (Read(out char value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public double ReadDouble()
+    {
+        if (Read(out double value))
+        {
+            return value;
         }
 
-        public char ReadCharacter()
-        {
-            if (Read(out char value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public float ReadFloat()
+    {
+        if (Read(out float value))
+        {
+            return value;
         }
 
-        public decimal ReadDecimal()
-        {
-            if (Read(out decimal value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public float ReadSingle()
+    {
+        if (Read(out float value))
+        {
+            return value;
         }
 
-        public double ReadDouble()
-        {
-            if (Read(out double value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public int ReadInt()
+    {
+        if (Read(out int value))
+        {
+            return value;
         }
 
-        public float ReadFloat()
-        {
-            if (Read(out float value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public int ReadInt32()
+    {
+        if (Read(out int value))
+        {
+            return value;
         }
 
-        public float ReadSingle()
-        {
-            if (Read(out float value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public int ReadInteger()
+    {
+        if (Read(out int value))
+        {
+            return value;
         }
 
-        public int ReadInt()
-        {
-            if (Read(out int value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public long ReadInt64()
+    {
+        if (Read(out long value))
+        {
+            return value;
         }
 
-        public int ReadInt32()
-        {
-            if (Read(out int value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public long ReadLong()
+    {
+        if (Read(out long value))
+        {
+            return value;
         }
 
-        public int ReadInteger()
-        {
-            if (Read(out int value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public sbyte ReadInt8()
+    {
+        if (Read(out sbyte value))
+        {
+            return value;
         }
 
-        public long ReadInt64()
-        {
-            if (Read(out long value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public sbyte ReadSByte()
+    {
+        if (Read(out sbyte value))
+        {
+            return value;
         }
 
-        public long ReadLong()
-        {
-            if (Read(out long value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public short ReadInt16()
+    {
+        if (Read(out short value))
+        {
+            return value;
         }
 
-        public sbyte ReadInt8()
-        {
-            if (Read(out sbyte value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public short ReadShort()
+    {
+        if (Read(out short value))
+        {
+            return value;
         }
 
-        public sbyte ReadSByte()
-        {
-            if (Read(out sbyte value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public string ReadString()
+    {
+        if (Read(out string value))
+        {
+            return value;
         }
 
-        public short ReadInt16()
-        {
-            if (Read(out short value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public string ReadString(Encoding encoding, bool nullTerminated = false)
+    {
+        if (Read(out var value, encoding, nullTerminated))
+        {
+            return value;
         }
 
-        public short ReadShort()
-        {
-            if (Read(out short value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public uint ReadUInt()
+    {
+        if (Read(out uint value))
+        {
+            return value;
         }
 
-        public string ReadString()
-        {
-            if (Read(out string value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public uint ReadUInt32()
+    {
+        if (Read(out uint value))
+        {
+            return value;
         }
 
-        public string ReadString(Encoding encoding, bool nullTerminated = false)
-        {
-            if (Read(out var value, encoding, nullTerminated))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public uint ReadUnsignedInteger()
+    {
+        if (Read(out uint value))
+        {
+            return value;
         }
 
-        public uint ReadUInt()
-        {
-            if (Read(out uint value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public ulong ReadULong()
+    {
+        if (Read(out ulong value))
+        {
+            return value;
         }
 
-        public uint ReadUInt32()
-        {
-            if (Read(out uint value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public ulong ReadUInt64()
+    {
+        if (Read(out ulong value))
+        {
+            return value;
         }
 
-        public uint ReadUnsignedInteger()
-        {
-            if (Read(out uint value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public ushort ReadUInt16()
+    {
+        if (Read(out ushort value))
+        {
+            return value;
         }
 
-        public ulong ReadULong()
-        {
-            if (Read(out ulong value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public ushort ReadUShort()
+    {
+        if (Read(out ushort value))
+        {
+            return value;
         }
 
-        public ulong ReadUInt64()
-        {
-            if (Read(out ulong value))
-            {
-                return value;
-            }
+        throw new OutOfMemoryException();
+    }
 
-            throw new OutOfMemoryException();
+    public void Write(bool value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(byte value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(byte[] value)
+    {
+        Write(value?.Length ?? 0);
+        Write(value, value?.Length ?? 0);
+    }
+
+    public void Write(byte[] value, long count)
+    {
+        Write(value, 0, count);
+    }
+
+    public void Write(byte[] value, long offset, long count)
+    {
+        Buffer?.Write(value, (int) offset, (int) count);
+    }
+
+    public void Write(char value)
+    {
+        Buffer?.Write(BitConverter.GetBytes(value));
+    }
+
+    public void Write(decimal value)
+    {
+        var bits = decimal.GetBits(value);
+        Write(bits[0]);
+        Write(bits[1]);
+        Write(bits[2]);
+        Write(bits[3]);
+    }
+
+    public void Write(double value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(float value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(int value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(long value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(sbyte value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(short value)
+    {
+        Buffer?.Write(value);
+    }
+
+    public void Write(string value)
+    {
+        Write(value, Encoding.UTF8);
+    }
+
+    public void Write(string value, Encoding encoding, bool nullTerminated = false)
+    {
+        if (encoding == null)
+        {
+            throw new ArgumentNullException();
         }
 
-        public ushort ReadUInt16()
+        if (!nullTerminated)
         {
-            if (Read(out ushort value))
-            {
-                return value;
-            }
-
-            throw new OutOfMemoryException();
+            Write(value?.Length ?? -1);
         }
 
-        public ushort ReadUShort()
+        if (value == null)
         {
-            if (Read(out ushort value))
-            {
-                return value;
-            }
-
-            throw new OutOfMemoryException();
+            return;
         }
 
-        public void Write(bool value)
+        if (value.Length < 1)
         {
-            Buffer?.Write(value);
+            return;
         }
 
-        public void Write(byte value)
-        {
-            Buffer?.Write(value);
-        }
+        var bytes = encoding.GetBytes(value);
+        Write(bytes, bytes.Length);
+    }
 
-        public void Write(byte[] value)
-        {
-            Write(value?.Length ?? 0);
-            Write(value, value?.Length ?? 0);
-        }
+    public void Write(uint value)
+    {
+        Buffer?.Write(value);
+    }
 
-        public void Write(byte[] value, long count)
-        {
-            Write(value, 0, count);
-        }
+    public void Write(ulong value)
+    {
+        Buffer?.Write(value);
+    }
 
-        public void Write(byte[] value, long offset, long count)
-        {
-            Buffer?.Write(value, (int) offset, (int) count);
-        }
-
-        public void Write(char value)
-        {
-            Buffer?.Write(BitConverter.GetBytes(value));
-        }
-
-        public void Write(decimal value)
-        {
-            var bits = decimal.GetBits(value);
-            Write(bits[0]);
-            Write(bits[1]);
-            Write(bits[2]);
-            Write(bits[3]);
-        }
-
-        public void Write(double value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(float value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(int value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(long value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(sbyte value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(short value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(string value)
-        {
-            Write(value, Encoding.UTF8);
-        }
-
-        public void Write(string value, Encoding encoding, bool nullTerminated = false)
-        {
-            if (encoding == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (!nullTerminated)
-            {
-                Write(value?.Length ?? -1);
-            }
-
-            if (value == null)
-            {
-                return;
-            }
-
-            if (value.Length < 1)
-            {
-                return;
-            }
-
-            var bytes = encoding.GetBytes(value);
-            Write(bytes, bytes.Length);
-        }
-
-        public void Write(uint value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(ulong value)
-        {
-            Buffer?.Write(value);
-        }
-
-        public void Write(ushort value)
-        {
-            Buffer?.Write(value);
-        }
-
+    public void Write(ushort value)
+    {
+        Buffer?.Write(value);
     }
 
 }

--- a/Intersect.Network/Lidgren/LidgrenConnection.cs
+++ b/Intersect.Network/Lidgren/LidgrenConnection.cs
@@ -7,137 +7,135 @@ using Intersect.Utilities;
 using Lidgren.Network;
 using Lidgren.Network.Encryption;
 
-namespace Intersect.Network.Lidgren
+namespace Intersect.Network.Lidgren;
+
+
+public sealed partial class LidgrenConnection : AbstractConnection
 {
 
-    public sealed partial class LidgrenConnection : AbstractConnection
+    private byte[] mAesKey;
+
+    private byte[] mHandshakeSecret;
+
+    private byte[] mRsaSecret;
+
+    public LidgrenConnection(INetwork network, NetConnection connection, byte[] aesKey, RSAParameters rsaParameters)
+        : this(network, Guid.NewGuid(), connection, aesKey)
     {
-
-        private byte[] mAesKey;
-
-        private byte[] mHandshakeSecret;
-
-        private byte[] mRsaSecret;
-
-        public LidgrenConnection(INetwork network, NetConnection connection, byte[] aesKey, RSAParameters rsaParameters)
-            : this(network, Guid.NewGuid(), connection, aesKey)
-        {
-            CreateRsa(rsaParameters);
-        }
-
-        public LidgrenConnection(INetwork network, Guid guid, NetConnection netConnection, byte[] aesKey) : base(guid)
-        {
-            Network = network;
-            NetConnection = netConnection ?? throw new ArgumentNullException();
-            mAesKey = aesKey ?? throw new ArgumentNullException();
-
-            CreateAes();
-        }
-
-        public LidgrenConnection(
-            INetwork network,
-            Guid guid,
-            NetConnection netConnection,
-            byte[] handshakeSecret,
-            RSAParameters rsaParameters
-        ) : base(guid)
-        {
-            Network = network;
-            NetConnection = netConnection;
-            mHandshakeSecret = handshakeSecret;
-            CreateRsa(rsaParameters);
-        }
-
-        public INetwork Network { get; }
-
-        public NetConnection NetConnection { get; }
-
-        public RSACryptoServiceProvider Rsa { get; private set; }
-
-        public NetEncryption Aes { get; private set; }
-
-        public override string Ip => NetConnection?.RemoteEndPoint?.Address?.ToString();
-
-        public override int Port => NetConnection?.RemoteEndPoint?.Port ?? -1;
-
-        private void CreateRsa(RSAParameters rsaParameters)
-        {
-            Rsa = new RSACryptoServiceProvider();
-            Rsa.ImportParameters(rsaParameters);
-        }
-
-        private void CreateAes()
-        {
-            if (NetConnection == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (mAesKey == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            Aes = new NetAesGcmEncryption(NetConnection.Peer, mAesKey);
-        }
-
-        public bool HandleApproval(ApprovalPacket approval)
-        {
-            if (approval == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (approval.HandshakeSecret == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (approval.AesKey == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (mHandshakeSecret == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            if (!mHandshakeSecret.SequenceEqual(approval.HandshakeSecret))
-            {
-                Log.Error("Bad handshake secret received from server.");
-
-                return false;
-            }
-
-            mAesKey = approval.AesKey;
-
-            CreateAes();
-
-            Timing.Global.Synchronize(approval.UTC, approval.Offset);
-            Log.Debug($"approval Time={approval.Adjusted / TimeSpan.TicksPerMillisecond} Offset={approval.Offset / TimeSpan.TicksPerMillisecond} Real={approval.UTC / TimeSpan.TicksPerMillisecond}");
-            Log.Debug($"local Time={Timing.Global.Milliseconds} Offset={Timing.Global.MillisecondsOffset} Real={Timing.Global.MillisecondsUtc}");
-            Log.Debug($"real delta={(Timing.Global.TicksUtc - approval.UTC) / TimeSpan.TicksPerMillisecond}");
-            Log.Debug($"this.Statistics.Ping={this.Statistics.Ping} NCPing={(long)Math.Ceiling(NetConnection.AverageRoundtripTime * 1000)}");
-
-            return true;
-        }
-
-        public override void Dispose()
-        {
-            base.Dispose();
-            NetConnection?.Disconnect(NetworkStatus.Quitting.ToString());
-        }
-
-        public override bool Send(IPacket packet, TransmissionMode mode = TransmissionMode.All)
-        {
-            return Network?.Send(this, packet, mode) ?? false;
-        }
-
-        public override void Disconnect(string message = default)
-        {
-            NetConnection?.Disconnect(message);
-        }
+        CreateRsa(rsaParameters);
     }
 
+    public LidgrenConnection(INetwork network, Guid guid, NetConnection netConnection, byte[] aesKey) : base(guid)
+    {
+        Network = network;
+        NetConnection = netConnection ?? throw new ArgumentNullException();
+        mAesKey = aesKey ?? throw new ArgumentNullException();
+
+        CreateAes();
+    }
+
+    public LidgrenConnection(
+        INetwork network,
+        Guid guid,
+        NetConnection netConnection,
+        byte[] handshakeSecret,
+        RSAParameters rsaParameters
+    ) : base(guid)
+    {
+        Network = network;
+        NetConnection = netConnection;
+        mHandshakeSecret = handshakeSecret;
+        CreateRsa(rsaParameters);
+    }
+
+    public INetwork Network { get; }
+
+    public NetConnection NetConnection { get; }
+
+    public RSACryptoServiceProvider Rsa { get; private set; }
+
+    public NetEncryption Aes { get; private set; }
+
+    public override string Ip => NetConnection?.RemoteEndPoint?.Address?.ToString();
+
+    public override int Port => NetConnection?.RemoteEndPoint?.Port ?? -1;
+
+    private void CreateRsa(RSAParameters rsaParameters)
+    {
+        Rsa = new RSACryptoServiceProvider();
+        Rsa.ImportParameters(rsaParameters);
+    }
+
+    private void CreateAes()
+    {
+        if (NetConnection == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        if (mAesKey == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        Aes = new NetAesGcmEncryption(NetConnection.Peer, mAesKey);
+    }
+
+    public bool HandleApproval(ApprovalPacket approval)
+    {
+        if (approval == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        if (approval.HandshakeSecret == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        if (approval.AesKey == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        if (mHandshakeSecret == null)
+        {
+            throw new ArgumentNullException();
+        }
+
+        if (!mHandshakeSecret.SequenceEqual(approval.HandshakeSecret))
+        {
+            Log.Error("Bad handshake secret received from server.");
+
+            return false;
+        }
+
+        mAesKey = approval.AesKey;
+
+        CreateAes();
+
+        Timing.Global.Synchronize(approval.UTC, approval.Offset);
+        Log.Debug($"approval Time={approval.Adjusted / TimeSpan.TicksPerMillisecond} Offset={approval.Offset / TimeSpan.TicksPerMillisecond} Real={approval.UTC / TimeSpan.TicksPerMillisecond}");
+        Log.Debug($"local Time={Timing.Global.Milliseconds} Offset={Timing.Global.MillisecondsOffset} Real={Timing.Global.MillisecondsUtc}");
+        Log.Debug($"real delta={(Timing.Global.TicksUtc - approval.UTC) / TimeSpan.TicksPerMillisecond}");
+        Log.Debug($"this.Statistics.Ping={this.Statistics.Ping} NCPing={(long)Math.Ceiling(NetConnection.AverageRoundtripTime * 1000)}");
+
+        return true;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        NetConnection?.Disconnect(NetworkStatus.Quitting.ToString());
+    }
+
+    public override bool Send(IPacket packet, TransmissionMode mode = TransmissionMode.All)
+    {
+        return Network?.Send(this, packet, mode) ?? false;
+    }
+
+    public override void Disconnect(string message = default)
+    {
+        NetConnection?.Disconnect(message);
+    }
 }

--- a/Intersect.Network/Lidgren/LidgrenInterface.cs
+++ b/Intersect.Network/Lidgren/LidgrenInterface.cs
@@ -10,939 +10,937 @@ using Intersect.Utilities;
 
 using Lidgren.Network;
 
-namespace Intersect.Network.Lidgren
+namespace Intersect.Network.Lidgren;
+
+
+public sealed partial class LidgrenInterface : INetworkLayerInterface
 {
 
-    public sealed partial class LidgrenInterface : INetworkLayerInterface
+    private static readonly IConnection[] EmptyConnections = { };
+
+    private readonly IDictionary<long, Guid> mGuidLookup;
+
+    private readonly INetwork mNetwork;
+
+    private readonly NetPeer mPeer;
+
+    private readonly NetPeerConfiguration mPeerConfiguration;
+
+    private readonly RandomNumberGenerator mRng;
+
+    private readonly RSACryptoServiceProvider mRsa;
+
+    public LidgrenInterface(INetwork network, Type peerType, RSAParameters rsaParameters)
     {
-
-        private static readonly IConnection[] EmptyConnections = { };
-
-        private readonly IDictionary<long, Guid> mGuidLookup;
-
-        private readonly INetwork mNetwork;
-
-        private readonly NetPeer mPeer;
-
-        private readonly NetPeerConfiguration mPeerConfiguration;
-
-        private readonly RandomNumberGenerator mRng;
-
-        private readonly RSACryptoServiceProvider mRsa;
-
-        public LidgrenInterface(INetwork network, Type peerType, RSAParameters rsaParameters)
+        if (peerType == null)
         {
-            if (peerType == null)
+            throw new ArgumentNullException(nameof(peerType));
+        }
+
+        mNetwork = network ?? throw new ArgumentNullException(nameof(network));
+
+        var configuration = mNetwork.Configuration;
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(mNetwork.Configuration));
+        }
+
+        mRng = new RNGCryptoServiceProvider();
+
+        mRsa = new RSACryptoServiceProvider();
+        mRsa.ImportParameters(rsaParameters);
+        mPeerConfiguration = new NetPeerConfiguration(
+            $"{VersionHelper.ExecutableVersion} {VersionHelper.LibraryVersion} {SharedConstants.VersionName}"
+        )
+        {
+            AcceptIncomingConnections = configuration.IsServer
+        };
+
+        mPeerConfiguration.DisableMessageType(NetIncomingMessageType.Receipt);
+        mPeerConfiguration.EnableMessageType(NetIncomingMessageType.UnconnectedData);
+        mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ConnectionLatencyUpdated);
+
+        if (configuration.IsServer)
+        {
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.DiscoveryRequest);
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ConnectionApproval);
+            mPeerConfiguration.AcceptIncomingConnections = true;
+            mPeerConfiguration.MaximumConnections = configuration.MaximumConnections;
+
+            //mPeerConfiguration.LocalAddress = DnsUtils.Resolve(config.Host);
+            //mPeerConfiguration.EnableUPnP = true;
+            mPeerConfiguration.Port = configuration.Port;
+        }
+
+        if (Debugger.IsAttached)
+        {
+            mPeerConfiguration.ConnectionTimeout = 60;
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.VerboseDebugMessage);
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.DebugMessage);
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ErrorMessage);
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.WarningMessage);
+            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.Error);
+        }
+        else
+        {
+            mPeerConfiguration.ConnectionTimeout = 15;
+            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.VerboseDebugMessage);
+            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.DebugMessage);
+            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.ErrorMessage);
+            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.WarningMessage);
+            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.Error);
+        }
+
+        mPeerConfiguration.PingInterval = 2.5f;
+        mPeerConfiguration.UseMessageRecycling = true;
+        mPeerConfiguration.AutoExpandMTU = true;
+
+        var constructorInfo = peerType.GetConstructor(new[] {typeof(NetPeerConfiguration)});
+        if (constructorInfo == null)
+        {
+            throw new ArgumentNullException(nameof(constructorInfo));
+        }
+
+        var constructedPeer = constructorInfo.Invoke(new object[] {mPeerConfiguration}) as NetPeer;
+        mPeer = constructedPeer ?? throw new ArgumentNullException(nameof(constructedPeer));
+
+        mGuidLookup = new Dictionary<long, Guid>();
+
+        SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+        
+        mPeer?.RegisterReceivedCallback(
+            peer =>
             {
-                throw new ArgumentNullException(nameof(peerType));
-            }
-
-            mNetwork = network ?? throw new ArgumentNullException(nameof(network));
-
-            var configuration = mNetwork.Configuration;
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(mNetwork.Configuration));
-            }
-
-            mRng = new RNGCryptoServiceProvider();
-
-            mRsa = new RSACryptoServiceProvider();
-            mRsa.ImportParameters(rsaParameters);
-            mPeerConfiguration = new NetPeerConfiguration(
-                $"{VersionHelper.ExecutableVersion} {VersionHelper.LibraryVersion} {SharedConstants.VersionName}"
-            )
-            {
-                AcceptIncomingConnections = configuration.IsServer
-            };
-
-            mPeerConfiguration.DisableMessageType(NetIncomingMessageType.Receipt);
-            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.UnconnectedData);
-            mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ConnectionLatencyUpdated);
-
-            if (configuration.IsServer)
-            {
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.DiscoveryRequest);
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ConnectionApproval);
-                mPeerConfiguration.AcceptIncomingConnections = true;
-                mPeerConfiguration.MaximumConnections = configuration.MaximumConnections;
-
-                //mPeerConfiguration.LocalAddress = DnsUtils.Resolve(config.Host);
-                //mPeerConfiguration.EnableUPnP = true;
-                mPeerConfiguration.Port = configuration.Port;
-            }
-
-            if (Debugger.IsAttached)
-            {
-                mPeerConfiguration.ConnectionTimeout = 60;
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.VerboseDebugMessage);
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.DebugMessage);
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.ErrorMessage);
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.WarningMessage);
-                mPeerConfiguration.EnableMessageType(NetIncomingMessageType.Error);
-            }
-            else
-            {
-                mPeerConfiguration.ConnectionTimeout = 15;
-                mPeerConfiguration.DisableMessageType(NetIncomingMessageType.VerboseDebugMessage);
-                mPeerConfiguration.DisableMessageType(NetIncomingMessageType.DebugMessage);
-                mPeerConfiguration.DisableMessageType(NetIncomingMessageType.ErrorMessage);
-                mPeerConfiguration.DisableMessageType(NetIncomingMessageType.WarningMessage);
-                mPeerConfiguration.DisableMessageType(NetIncomingMessageType.Error);
-            }
-
-            mPeerConfiguration.PingInterval = 2.5f;
-            mPeerConfiguration.UseMessageRecycling = true;
-            mPeerConfiguration.AutoExpandMTU = true;
-
-            var constructorInfo = peerType.GetConstructor(new[] {typeof(NetPeerConfiguration)});
-            if (constructorInfo == null)
-            {
-                throw new ArgumentNullException(nameof(constructorInfo));
-            }
-
-            var constructedPeer = constructorInfo.Invoke(new object[] {mPeerConfiguration}) as NetPeer;
-            mPeer = constructedPeer ?? throw new ArgumentNullException(nameof(constructedPeer));
-
-            mGuidLookup = new Dictionary<long, Guid>();
-
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
-            
-            mPeer?.RegisterReceivedCallback(
-                peer =>
+                lock (mPeer)
                 {
-                    lock (mPeer)
+                    if (OnPacketAvailable == null)
                     {
-                        if (OnPacketAvailable == null)
-                        {
-                            Log.Debug("Unhandled inbound Lidgren message.");
-                            Log.Diagnostic($"Unhandled message: {TryHandleInboundMessage()}");
+                        Log.Debug("Unhandled inbound Lidgren message.");
+                        Log.Diagnostic($"Unhandled message: {TryHandleInboundMessage()}");
 
-                            return;
-                        }
-
-                        OnPacketAvailable(this);
+                        return;
                     }
+
+                    OnPacketAvailable(this);
                 }
-            );
+            }
+        );
+    }
+
+    public HandleConnectionEvent OnConnected { get; set; }
+
+    public HandleConnectionEvent OnConnectionApproved { get; set; }
+
+    public HandleConnectionEvent OnConnectionDenied { get; set; }
+
+    public HandleConnectionRequest OnConnectionRequested { get; set; }
+
+    public HandleConnectionEvent OnDisconnected { get; set; }
+
+    public HandlePacketAvailable OnPacketAvailable { get; set; }
+
+    public HandleUnconnectedMessage OnUnconnectedMessage { get; set; }
+
+    private bool IsDisposing { get; set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public bool SendUnconnectedPacket(IPEndPoint target, ReadOnlySpan<byte> data)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool SendUnconnectedPacket(IPEndPoint target, UnconnectedPacket packet)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Start()
+    {
+        if (mNetwork.Configuration.IsServer)
+        {
+            Log.Pretty.Info($"Listening on {mPeerConfiguration.LocalAddress}:{mPeerConfiguration.Port}.");
+            mPeer.Start();
+
+            return;
         }
 
-        public HandleConnectionEvent OnConnected { get; set; }
-
-        public HandleConnectionEvent OnConnectionApproved { get; set; }
-
-        public HandleConnectionEvent OnConnectionDenied { get; set; }
-
-        public HandleConnectionRequest OnConnectionRequested { get; set; }
-
-        public HandleConnectionEvent OnDisconnected { get; set; }
-
-        public HandlePacketAvailable OnPacketAvailable { get; set; }
-
-        public HandleUnconnectedMessage OnUnconnectedMessage { get; set; }
-
-        private bool IsDisposing { get; set; }
-
-        public bool IsDisposed { get; private set; }
-
-        public bool SendUnconnectedPacket(IPEndPoint target, ReadOnlySpan<byte> data)
+        if (!Connect())
         {
-            throw new NotImplementedException();
+            Log.Error("Failed to make the initial connection attempt.");
+        }
+    }
+
+    public bool Connect()
+    {
+        if (mNetwork.Configuration.IsServer)
+        {
+            throw new InvalidOperationException("Server interfaces cannot use Connect().");
         }
 
-        public bool SendUnconnectedPacket(IPEndPoint target, UnconnectedPacket packet)
+        Log.Info($"Connecting to {mNetwork.Configuration.Host}:{mNetwork.Configuration.Port}...");
+
+        var handshakeSecret = new byte[32];
+        mRng.GetNonZeroBytes(handshakeSecret);
+
+        var connectionRsa = new RSACryptoServiceProvider(2048);
+        var hailParameters = connectionRsa.ExportParameters(false);
+        var hail = new HailPacket(mRsa, handshakeSecret, SharedConstants.VersionData, hailParameters);
+        hail.Encrypt();
+
+        var hailMessage = mPeer.CreateMessage(hail.Data.Length);
+        if (hailMessage == null)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
-        public void Start()
+        hailMessage.Data = hail.Data;
+        hailMessage.LengthBytes = hail.Data.Length;
+
+        if (mPeer.Status == NetPeerStatus.NotRunning)
         {
-            if (mNetwork.Configuration.IsServer)
-            {
-                Log.Pretty.Info($"Listening on {mPeerConfiguration.LocalAddress}:{mPeerConfiguration.Port}.");
-                mPeer.Start();
-
-                return;
-            }
-
-            if (!Connect())
-            {
-                Log.Error("Failed to make the initial connection attempt.");
-            }
+            mPeer.Start();
         }
 
-        public bool Connect()
+        var connection = mPeer.Connect(mNetwork.Configuration.Host, mNetwork.Configuration.Port, hailMessage);
+        var server = new LidgrenConnection(
+            mNetwork, Guid.Empty, connection, handshakeSecret, connectionRsa.ExportParameters(true)
+        );
+
+        if (mNetwork.AddConnection(server))
         {
-            if (mNetwork.Configuration.IsServer)
-            {
-                throw new InvalidOperationException("Server interfaces cannot use Connect().");
-            }
+            return true;
+        }
 
-            Log.Info($"Connecting to {mNetwork.Configuration.Host}:{mNetwork.Configuration.Port}...");
+        Log.Error("Failed to add connection to list.");
+        connection?.Disconnect("client_error");
 
-            var handshakeSecret = new byte[32];
-            mRng.GetNonZeroBytes(handshakeSecret);
+        return false;
+    }
 
-            var connectionRsa = new RSACryptoServiceProvider(2048);
-            var hailParameters = connectionRsa.ExportParameters(false);
-            var hail = new HailPacket(mRsa, handshakeSecret, SharedConstants.VersionData, hailParameters);
-            hail.Encrypt();
+    protected IConnection FindConnection(NetConnection netConnection)
+    {
+        var lidgrenId = netConnection?.RemoteUniqueIdentifier ?? -1;
+        Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
+        if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
+        {
+            return default;
+        }
 
-            var hailMessage = mPeer.CreateMessage(hail.Data.Length);
-            if (hailMessage == null)
-            {
-                throw new InvalidOperationException();
-            }
+        return mNetwork.FindConnection(guid);
+    }
 
-            hailMessage.Data = hail.Data;
-            hailMessage.LengthBytes = hail.Data.Length;
+    event HandleConnectionEvent? INetworkLayerInterface.OnConnected
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
 
-            if (mPeer.Status == NetPeerStatus.NotRunning)
-            {
-                mPeer.Start();
-            }
+    event HandleConnectionEvent? INetworkLayerInterface.OnConnectionApproved
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
 
-            var connection = mPeer.Connect(mNetwork.Configuration.Host, mNetwork.Configuration.Port, hailMessage);
-            var server = new LidgrenConnection(
-                mNetwork, Guid.Empty, connection, handshakeSecret, connectionRsa.ExportParameters(true)
-            );
+    event HandleConnectionEvent? INetworkLayerInterface.OnConnectionDenied
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
 
-            if (mNetwork.AddConnection(server))
-            {
-                return true;
-            }
+    event HandleConnectionRequest? INetworkLayerInterface.OnConnectionRequested
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
 
-            Log.Error("Failed to add connection to list.");
-            connection?.Disconnect("client_error");
+    event HandleConnectionEvent? INetworkLayerInterface.OnDisconnected
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
+
+    event HandlePacketAvailable? INetworkLayerInterface.OnPacketAvailable
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
+
+    event HandleUnconnectedMessage? INetworkLayerInterface.OnUnconnectedMessage
+    {
+        add => throw new NotImplementedException();
+        remove => throw new NotImplementedException();
+    }
+
+    public bool TryGetInboundBuffer(out IBuffer buffer, out IConnection connection)
+    {
+        buffer = default;
+        connection = default;
+
+        var message = TryHandleInboundMessage();
+        if (message == null)
+        {
+            return true;
+        }
+
+        connection = FindConnection(message.SenderConnection);
+        if (connection == null)
+        {
+            //Log.Error($"Received message from an unregistered endpoint.");
+            mPeer.Recycle(message);
 
             return false;
         }
 
-        protected IConnection FindConnection(NetConnection netConnection)
+        if (connection != null)
         {
-            var lidgrenId = netConnection?.RemoteUniqueIdentifier ?? -1;
-            Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
-            if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
+            var lidgrenConnection = connection as LidgrenConnection;
+            if (lidgrenConnection?.Aes == null)
             {
-                return default;
-            }
-
-            return mNetwork.FindConnection(guid);
-        }
-
-        event HandleConnectionEvent? INetworkLayerInterface.OnConnected
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandleConnectionEvent? INetworkLayerInterface.OnConnectionApproved
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandleConnectionEvent? INetworkLayerInterface.OnConnectionDenied
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandleConnectionRequest? INetworkLayerInterface.OnConnectionRequested
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandleConnectionEvent? INetworkLayerInterface.OnDisconnected
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandlePacketAvailable? INetworkLayerInterface.OnPacketAvailable
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        event HandleUnconnectedMessage? INetworkLayerInterface.OnUnconnectedMessage
-        {
-            add => throw new NotImplementedException();
-            remove => throw new NotImplementedException();
-        }
-
-        public bool TryGetInboundBuffer(out IBuffer buffer, out IConnection connection)
-        {
-            buffer = default;
-            connection = default;
-
-            var message = TryHandleInboundMessage();
-            if (message == null)
-            {
-                return true;
-            }
-
-            connection = FindConnection(message.SenderConnection);
-            if (connection == null)
-            {
-                //Log.Error($"Received message from an unregistered endpoint.");
-                mPeer.Recycle(message);
+                Log.Error("No provider to decrypt data with.");
 
                 return false;
             }
 
-            if (connection != null)
+            if (!lidgrenConnection.Aes.Decrypt(message))
             {
-                var lidgrenConnection = connection as LidgrenConnection;
-                if (lidgrenConnection?.Aes == null)
+                Log.Error($"Error decrypting inbound Lidgren message [Connection:{connection.Guid}].");
+
+                return false;
+            }
+        }
+        else
+        {
+            //Log.Warn($"Received message from an unregistered endpoint.");
+        }
+
+        buffer = new LidgrenBuffer(message);
+
+        return true;
+    }
+
+    public void ReleaseInboundBuffer(IBuffer buffer)
+    {
+        var message = (buffer as LidgrenBuffer)?.Buffer as NetIncomingMessage;
+        mPeer?.Recycle(message);
+    }
+
+    public bool SendPacket(
+        IPacket packet,
+        IConnection connection = null,
+        TransmissionMode transmissionMode = TransmissionMode.All
+    )
+    {
+        if (connection == null)
+        {
+            return SendPacket(packet, EmptyConnections, transmissionMode);
+        }
+
+        if (!(connection is LidgrenConnection lidgrenConnection))
+        {
+            Log.Diagnostic("Tried to send to a non-Lidgren connection.");
+
+            return false;
+        }
+
+        var deliveryMethod = TranslateTransmissionMode(transmissionMode);
+        if (mPeer == null)
+        {
+            throw new ArgumentNullException(nameof(mPeer));
+        }
+
+        if (packet == null)
+        {
+            Log.Diagnostic("Tried to send a null packet.");
+
+            return false;
+        }
+
+        var message = mPeer.CreateMessage();
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        message.Data = packet.Data;
+        message.LengthBytes = message.Data.Length;
+
+        SendMessage(message, lidgrenConnection, NetDeliveryMethod.ReliableOrdered);
+
+        return true;
+    }
+
+    public bool SendPacket(
+        IPacket packet,
+        ICollection<IConnection> connections,
+        TransmissionMode transmissionMode = TransmissionMode.All
+    )
+    {
+        var deliveryMethod = TranslateTransmissionMode(transmissionMode);
+        if (mPeer == null)
+        {
+            throw new ArgumentNullException(nameof(mPeer));
+        }
+
+        if (packet == null)
+        {
+            Log.Diagnostic("Tried to send a null packet.");
+
+            return false;
+        }
+
+        var message = mPeer.CreateMessage();
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        message.Data = packet.Data;
+        message.LengthBytes = message.Data.Length;
+
+        if (connections == null || connections.Count(connection => connection != null) < 1)
+        {
+            connections = mNetwork?.FindConnections<IConnection>();
+        }
+
+        var lidgrenConnections = connections?.OfType<LidgrenConnection>().ToList();
+        if (lidgrenConnections?.Count > 0)
+        {
+            var firstConnection = lidgrenConnections.First();
+
+            lidgrenConnections.ForEach(
+                lidgrenConnection =>
                 {
-                    Log.Error("No provider to decrypt data with.");
-
-                    return false;
-                }
-
-                if (!lidgrenConnection.Aes.Decrypt(message))
-                {
-                    Log.Error($"Error decrypting inbound Lidgren message [Connection:{connection.Guid}].");
-
-                    return false;
-                }
-            }
-            else
-            {
-                //Log.Warn($"Received message from an unregistered endpoint.");
-            }
-
-            buffer = new LidgrenBuffer(message);
-
-            return true;
-        }
-
-        public void ReleaseInboundBuffer(IBuffer buffer)
-        {
-            var message = (buffer as LidgrenBuffer)?.Buffer as NetIncomingMessage;
-            mPeer?.Recycle(message);
-        }
-
-        public bool SendPacket(
-            IPacket packet,
-            IConnection connection = null,
-            TransmissionMode transmissionMode = TransmissionMode.All
-        )
-        {
-            if (connection == null)
-            {
-                return SendPacket(packet, EmptyConnections, transmissionMode);
-            }
-
-            if (!(connection is LidgrenConnection lidgrenConnection))
-            {
-                Log.Diagnostic("Tried to send to a non-Lidgren connection.");
-
-                return false;
-            }
-
-            var deliveryMethod = TranslateTransmissionMode(transmissionMode);
-            if (mPeer == null)
-            {
-                throw new ArgumentNullException(nameof(mPeer));
-            }
-
-            if (packet == null)
-            {
-                Log.Diagnostic("Tried to send a null packet.");
-
-                return false;
-            }
-
-            var message = mPeer.CreateMessage();
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            message.Data = packet.Data;
-            message.LengthBytes = message.Data.Length;
-
-            SendMessage(message, lidgrenConnection, NetDeliveryMethod.ReliableOrdered);
-
-            return true;
-        }
-
-        public bool SendPacket(
-            IPacket packet,
-            ICollection<IConnection> connections,
-            TransmissionMode transmissionMode = TransmissionMode.All
-        )
-        {
-            var deliveryMethod = TranslateTransmissionMode(transmissionMode);
-            if (mPeer == null)
-            {
-                throw new ArgumentNullException(nameof(mPeer));
-            }
-
-            if (packet == null)
-            {
-                Log.Diagnostic("Tried to send a null packet.");
-
-                return false;
-            }
-
-            var message = mPeer.CreateMessage();
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            message.Data = packet.Data;
-            message.LengthBytes = message.Data.Length;
-
-            if (connections == null || connections.Count(connection => connection != null) < 1)
-            {
-                connections = mNetwork?.FindConnections<IConnection>();
-            }
-
-            var lidgrenConnections = connections?.OfType<LidgrenConnection>().ToList();
-            if (lidgrenConnections?.Count > 0)
-            {
-                var firstConnection = lidgrenConnections.First();
-
-                lidgrenConnections.ForEach(
-                    lidgrenConnection =>
+                    if (lidgrenConnection == null)
                     {
-                        if (lidgrenConnection == null)
-                        {
-                            return;
-                        }
-
-                        if (firstConnection == lidgrenConnection)
-                        {
-                            return;
-                        }
-
-                        if (message.Data == null)
-                        {
-                            throw new ArgumentNullException(nameof(message.Data));
-                        }
-
-                        //var messageClone = mPeer.CreateMessage(message.Data.Length);
-                        //if (messageClone == null)
-                        //{
-                        //    throw new ArgumentNullException(nameof(messageClone));
-                        //}
-
-                        //Buffer.BlockCopy(message.Data, 0, messageClone.Data, 0, message.Data.Length);
-                        //messageClone.LengthBytes = message.LengthBytes;
-                        SendMessage(message, lidgrenConnection, deliveryMethod);
+                        return;
                     }
-                );
 
-                SendMessage(message, lidgrenConnections.First(), deliveryMethod);
-            }
-            else
-            {
-                Log.Diagnostic("No lidgren connections, skipping...");
-            }
-
-            return true;
-        }
-
-        public void Stop(string reason = "stopping")
-        {
-            Disconnect(reason);
-        }
-
-        public void Disconnect(IConnection connection, string message)
-        {
-            Disconnect(new[] {connection}, message);
-        }
-
-        public void Disconnect(ICollection<IConnection> connections, string message)
-        {
-            if (connections == null)
-            {
-                return;
-            }
-
-            foreach (var connection in connections)
-            {
-                (connection as LidgrenConnection)?.NetConnection?.Disconnect(message);
-                (connection as LidgrenConnection)?.NetConnection?.Peer.FlushSendQueue();
-                (connection as LidgrenConnection)?.Dispose();
-            }
-        }
-
-        public void Dispose()
-        {
-            if (IsDisposed)
-            {
-                throw new ObjectDisposedException(nameof(LidgrenInterface));
-            }
-
-            if (IsDisposing)
-            {
-                return;
-            }
-
-            IsDisposing = true;
-
-            switch (mPeer.Status)
-            {
-                case NetPeerStatus.NotRunning:
-                case NetPeerStatus.ShutdownRequested:
-                    break;
-
-                case NetPeerStatus.Running:
-                case NetPeerStatus.Starting:
-                    mPeer.Shutdown(@"Terminating.");
-
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mPeer.Status));
-            }
-
-            IsDisposed = true;
-            IsDisposing = false;
-        }
-
-        private NetIncomingMessage TryHandleInboundMessage()
-        {
-            Debug.Assert(mPeer != null, "mPeer != null");
-
-            if (!mPeer.ReadMessage(out var message))
-            {
-                return null;
-            }
-
-            var senderConnection = message.SenderConnection;
-            var lidgrenId = senderConnection?.RemoteUniqueIdentifier ?? -1;
-            var lidgrenIdHex = BitConverter.ToString(BitConverter.GetBytes(lidgrenId));
-
-            switch (message.MessageType)
-            {
-                case NetIncomingMessageType.Data:
-
-                    //Log.Diagnostic($"{message.MessageType}: {message}");
-                    return message;
-
-                case NetIncomingMessageType.StatusChanged:
-                    Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
-                    Debug.Assert(mNetwork != null, "mNetwork != null");
-
-                    switch (senderConnection?.Status ?? NetConnectionStatus.None)
+                    if (firstConnection == lidgrenConnection)
                     {
-                        case NetConnectionStatus.None:
-                        case NetConnectionStatus.InitiatedConnect:
-                        case NetConnectionStatus.ReceivedInitiation:
-                        case NetConnectionStatus.RespondedAwaitingApproval:
-                        case NetConnectionStatus.RespondedConnect:
-                            Log.Diagnostic($"{message.MessageType}: {message} [{senderConnection?.Status}]");
+                        return;
+                    }
 
-                            break;
+                    if (message.Data == null)
+                    {
+                        throw new ArgumentNullException(nameof(message.Data));
+                    }
 
-                        case NetConnectionStatus.Disconnecting:
-                            Log.Debug($"{message.MessageType}: {message} [{senderConnection?.Status}]");
+                    //var messageClone = mPeer.CreateMessage(message.Data.Length);
+                    //if (messageClone == null)
+                    //{
+                    //    throw new ArgumentNullException(nameof(messageClone));
+                    //}
 
-                            break;
+                    //Buffer.BlockCopy(message.Data, 0, messageClone.Data, 0, message.Data.Length);
+                    //messageClone.LengthBytes = message.LengthBytes;
+                    SendMessage(message, lidgrenConnection, deliveryMethod);
+                }
+            );
 
-                        case NetConnectionStatus.Connected:
+            SendMessage(message, lidgrenConnections.First(), deliveryMethod);
+        }
+        else
+        {
+            Log.Diagnostic("No lidgren connections, skipping...");
+        }
+
+        return true;
+    }
+
+    public void Stop(string reason = "stopping")
+    {
+        Disconnect(reason);
+    }
+
+    public void Disconnect(IConnection connection, string message)
+    {
+        Disconnect(new[] {connection}, message);
+    }
+
+    public void Disconnect(ICollection<IConnection> connections, string message)
+    {
+        if (connections == null)
+        {
+            return;
+        }
+
+        foreach (var connection in connections)
+        {
+            (connection as LidgrenConnection)?.NetConnection?.Disconnect(message);
+            (connection as LidgrenConnection)?.NetConnection?.Peer.FlushSendQueue();
+            (connection as LidgrenConnection)?.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (IsDisposed)
+        {
+            throw new ObjectDisposedException(nameof(LidgrenInterface));
+        }
+
+        if (IsDisposing)
+        {
+            return;
+        }
+
+        IsDisposing = true;
+
+        switch (mPeer.Status)
+        {
+            case NetPeerStatus.NotRunning:
+            case NetPeerStatus.ShutdownRequested:
+                break;
+
+            case NetPeerStatus.Running:
+            case NetPeerStatus.Starting:
+                mPeer.Shutdown(@"Terminating.");
+
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mPeer.Status));
+        }
+
+        IsDisposed = true;
+        IsDisposing = false;
+    }
+
+    private NetIncomingMessage TryHandleInboundMessage()
+    {
+        Debug.Assert(mPeer != null, "mPeer != null");
+
+        if (!mPeer.ReadMessage(out var message))
+        {
+            return null;
+        }
+
+        var senderConnection = message.SenderConnection;
+        var lidgrenId = senderConnection?.RemoteUniqueIdentifier ?? -1;
+        var lidgrenIdHex = BitConverter.ToString(BitConverter.GetBytes(lidgrenId));
+
+        switch (message.MessageType)
+        {
+            case NetIncomingMessageType.Data:
+
+                //Log.Diagnostic($"{message.MessageType}: {message}");
+                return message;
+
+            case NetIncomingMessageType.StatusChanged:
+                Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
+                Debug.Assert(mNetwork != null, "mNetwork != null");
+
+                switch (senderConnection?.Status ?? NetConnectionStatus.None)
+                {
+                    case NetConnectionStatus.None:
+                    case NetConnectionStatus.InitiatedConnect:
+                    case NetConnectionStatus.ReceivedInitiation:
+                    case NetConnectionStatus.RespondedAwaitingApproval:
+                    case NetConnectionStatus.RespondedConnect:
+                        Log.Diagnostic($"{message.MessageType}: {message} [{senderConnection?.Status}]");
+
+                        break;
+
+                    case NetConnectionStatus.Disconnecting:
+                        Log.Debug($"{message.MessageType}: {message} [{senderConnection?.Status}]");
+
+                        break;
+
+                    case NetConnectionStatus.Connected:
+                    {
+                        LidgrenConnection intersectConnection;
+                        if (!mNetwork.Configuration.IsServer)
                         {
-                            LidgrenConnection intersectConnection;
-                            if (!mNetwork.Configuration.IsServer)
+                            intersectConnection = mNetwork.FindConnection<LidgrenConnection>(Guid.Empty);
+                            if (intersectConnection == null)
                             {
-                                intersectConnection = mNetwork.FindConnection<LidgrenConnection>(Guid.Empty);
-                                if (intersectConnection == null)
-                                {
-                                    Log.Error("Bad state, no connection found.");
-                                    mNetwork.Disconnect("client_connection_missing");
-                                    senderConnection?.Disconnect("client_connection_missing");
-
-                                    break;
-                                }
-
-                                FireHandler(
-                                    OnConnectionApproved, nameof(OnConnectionApproved), this, new ConnectionEventArgs
-                                    {
-                                        NetworkStatus = NetworkStatus.Connecting,
-                                        Connection = intersectConnection
-                                    }
-                                );
-
-                                Debug.Assert(senderConnection != null, "connection != null");
-                                var approvalPacketData = senderConnection.RemoteHailMessage.Data;
-                                var approval = MessagePacker.Instance.Deserialize(approvalPacketData) as ApprovalPacket;
-
-                                if (!(approval?.Decrypt(intersectConnection.Rsa) ?? false))
-                                {
-                                    Log.Error("Unable to read approval message, disconnecting.");
-                                    mNetwork.Disconnect("client_error");
-                                    senderConnection.Disconnect("client_error");
-
-                                    break;
-                                }
-
-                                if (!intersectConnection.HandleApproval(approval))
-                                {
-                                    mNetwork.Disconnect(NetworkStatus.HandshakeFailure.ToString());
-                                    senderConnection.Disconnect(NetworkStatus.HandshakeFailure.ToString());
-
-                                    break;
-                                }
-
-                                if (!(mNetwork is ClientNetwork clientNetwork))
-                                {
-                                    throw new InvalidOperationException();
-                                }
-
-                                clientNetwork.AssignId(approval.Guid);
-
-                                Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
-                                mGuidLookup.Add(senderConnection.RemoteUniqueIdentifier, Guid.Empty);
-                            }
-                            else
-                            {
-                                Log.Diagnostic($"{message.MessageType}: {message} [{senderConnection?.Status}]");
-                                if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
-                                {
-                                    Log.Error($"Unknown client connected ({lidgrenIdHex}).");
-                                    senderConnection?.Disconnect("server_unknown_client");
-
-                                    break;
-                                }
-
-                                intersectConnection = mNetwork.FindConnection<LidgrenConnection>(guid);
-                            }
-
-                            if (OnConnected != null)
-                            {
-                                intersectConnection?.HandleConnected();
-                            }
-
-                            FireHandler(
-                                OnConnected, nameof(OnConnected), this, new ConnectionEventArgs
-                                {
-                                    NetworkStatus = NetworkStatus.Online,
-                                    Connection = intersectConnection
-                                }
-                            );
-                        }
-
-                            break;
-
-                        case NetConnectionStatus.Disconnected:
-                        {
-                            Debug.Assert(senderConnection != null, "connection != null");
-                            Log.Debug($"{message.MessageType}: {message} [{senderConnection.Status}]");
-                            var result = (NetConnectionStatus) message.ReadByte();
-                            var reason = message.ReadString();
-
-                            NetworkStatus networkStatus;
-                            try
-                            {
-                                networkStatus = reason switch
-                                {
-                                    //Lidgren won't accept a connection with a bad version and sends this message back so we need to manually handle it
-                                    "Wrong application identifier!" => NetworkStatus.VersionMismatch,
-                                    "Connection timed out" => NetworkStatus.Quitting,
-                                    "Failed to establish connection - no response from remote host" => NetworkStatus.Offline,
-                                    "closing" => NetworkStatus.Offline,
-                                    _ => (NetworkStatus)Enum.Parse(typeof(NetworkStatus), reason ?? "<null>", true)
-                                };
-                            }
-                            catch (Exception exception)
-                            {
-                                Log.Diagnostic(exception);
-                                networkStatus = NetworkStatus.Unknown;
-                            }
-
-                            HandleConnectionEvent disconnectHandler;
-                            string disconnectHandlerName;
-                            switch (networkStatus)
-                            {
-                                case NetworkStatus.HandshakeFailure:
-                                case NetworkStatus.ServerFull:
-                                case NetworkStatus.VersionMismatch:
-                                case NetworkStatus.Failed:
-                                    disconnectHandler = OnConnectionDenied;
-                                    disconnectHandlerName = nameof(OnConnectionDenied);
-                                    Log.Diagnostic($"Disconnecting because of {networkStatus} ({reason})");
-                                    break;
-
-                                case NetworkStatus.Connecting:
-                                case NetworkStatus.Online:
-                                case NetworkStatus.Offline:
-                                case NetworkStatus.Quitting:
-                                case NetworkStatus.Unknown:
-                                    disconnectHandler = OnDisconnected;
-                                    disconnectHandlerName = nameof(OnDisconnected);
-
-                                    break;
-
-                                default:
-                                    throw new ArgumentOutOfRangeException();
-                            }
-
-                            if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
-                            {
-                                Log.Debug($"Unknown client disconnected ({lidgrenIdHex}).");
-                                FireHandler(
-                                    disconnectHandler, disconnectHandlerName, this,
-                                    new ConnectionEventArgs {NetworkStatus = networkStatus}
-                                );
+                                Log.Error("Bad state, no connection found.");
+                                mNetwork.Disconnect("client_connection_missing");
+                                senderConnection?.Disconnect("client_connection_missing");
 
                                 break;
                             }
 
-                            var client = mNetwork.FindConnection(guid);
-                            if (client != null)
+                            FireHandler(
+                                OnConnectionApproved, nameof(OnConnectionApproved), this, new ConnectionEventArgs
+                                {
+                                    NetworkStatus = NetworkStatus.Connecting,
+                                    Connection = intersectConnection
+                                }
+                            );
+
+                            Debug.Assert(senderConnection != null, "connection != null");
+                            var approvalPacketData = senderConnection.RemoteHailMessage.Data;
+                            var approval = MessagePacker.Instance.Deserialize(approvalPacketData) as ApprovalPacket;
+
+                            if (!(approval?.Decrypt(intersectConnection.Rsa) ?? false))
                             {
-                                client.HandleDisconnected();
+                                Log.Error("Unable to read approval message, disconnecting.");
+                                mNetwork.Disconnect("client_error");
+                                senderConnection.Disconnect("client_error");
 
-                                FireHandler(
-                                    disconnectHandler, disconnectHandlerName, this,
-                                    new ConnectionEventArgs {Connection = client, NetworkStatus = NetworkStatus.Offline}
-                                );
-
-                                mNetwork.RemoveConnection(client);
+                                break;
                             }
 
-                            mGuidLookup.Remove(senderConnection.RemoteUniqueIdentifier);
+                            if (!intersectConnection.HandleApproval(approval))
+                            {
+                                mNetwork.Disconnect(NetworkStatus.HandshakeFailure.ToString());
+                                senderConnection.Disconnect(NetworkStatus.HandshakeFailure.ToString());
+
+                                break;
+                            }
+
+                            if (!(mNetwork is ClientNetwork clientNetwork))
+                            {
+                                throw new InvalidOperationException();
+                            }
+
+                            clientNetwork.AssignId(approval.Guid);
+
+                            Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
+                            mGuidLookup.Add(senderConnection.RemoteUniqueIdentifier, Guid.Empty);
                         }
-
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-
-                    break;
-
-                case NetIncomingMessageType.UnconnectedData:
-                    UnconnectedMessageSender sender = new(this, message.SenderEndPoint, mPeer);
-                    OnUnconnectedMessage?.Invoke(sender, new LidgrenBuffer(message));
-                    Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
-
-                    break;
-
-                case NetIncomingMessageType.ConnectionApproval:
-                {
-                    try
-                    {
-                        var hail = MessagePacker.Instance.Deserialize(message.Data) as HailPacket;
-                        if (!(hail?.Decrypt(mRsa) ?? false))
+                        else
                         {
-                            Log.Warn($"Failed to read hail, denying connection [{lidgrenIdHex}].");
-                            senderConnection?.Deny(NetworkStatus.HandshakeFailure.ToString());
+                            Log.Diagnostic($"{message.MessageType}: {message} [{senderConnection?.Status}]");
+                            if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
+                            {
+                                Log.Error($"Unknown client connected ({lidgrenIdHex}).");
+                                senderConnection?.Disconnect("server_unknown_client");
 
-                            break;
+                                break;
+                            }
+
+                            intersectConnection = mNetwork.FindConnection<LidgrenConnection>(guid);
                         }
 
-                        Debug.Assert(SharedConstants.VersionData != null, "SharedConstants.VERSION_DATA != null");
-                        Debug.Assert(hail.VersionData != null, "hail.VersionData != null");
-                        if (!SharedConstants.VersionData.SequenceEqual(hail.VersionData))
+                        if (OnConnected != null)
                         {
-                            Log.Error($"Bad version detected, denying connection [{lidgrenIdHex}].");
-                            senderConnection?.Deny(NetworkStatus.VersionMismatch.ToString());
-
-                            break;
-                        }
-                        
-                        Log.Debug($"hail Time={hail.Adjusted / TimeSpan.TicksPerMillisecond} Offset={hail.Offset / TimeSpan.TicksPerMillisecond} Real={hail.UTC / TimeSpan.TicksPerMillisecond}");
-                        Log.Debug($"local Time={Timing.Global.Milliseconds} Offset={(long)Timing.Global.MillisecondsOffset} Real={Timing.Global.MillisecondsUtc}");
-                        Log.Debug($"real delta={(Timing.Global.TicksUtc - hail.UTC) / TimeSpan.TicksPerMillisecond}");
-                        Log.Debug($"NCPing={(long)Math.Ceiling(senderConnection.AverageRoundtripTime * 1000)}");
-
-                        // Check if we've got more connections than we're allowed to handle!
-                        if (mNetwork.ConnectionCount >= Options.Instance.MaxClientConnections)
-                        {
-                            Log.Info($"Connection limit reached, denying connection [{lidgrenIdHex}].");
-                                senderConnection?.Deny(NetworkStatus.ServerFull.ToString());
-                            break;
+                            intersectConnection?.HandleConnected();
                         }
 
-                        if (OnConnectionApproved == null)
-                        {
-                            Log.Error($"No handlers for OnConnectionApproved, denying connection [{lidgrenIdHex}].");
-                            senderConnection?.Deny(NetworkStatus.Failed.ToString());
-
-                            break;
-                        }
-
-                        /* Approving connection from here-on. */
-                        var aesKey = new byte[32];
-                        mRng?.GetNonZeroBytes(aesKey);
-                        var client = new LidgrenConnection(mNetwork, senderConnection, aesKey, hail.RsaParameters);
-
-                        if (!OnConnectionRequested(this, client))
-                        {
-                            Log.Warn($"Connection blocked due to ban or ip filter!");
-                            senderConnection?.Deny(NetworkStatus.Failed.ToString());
-
-                            break;
-                        }
-
-                        Debug.Assert(mNetwork != null, "mNetwork != null");
-                        if (!mNetwork.AddConnection(client))
-                        {
-                            Log.Error($"Failed to add the connection.");
-                            senderConnection?.Deny(NetworkStatus.Failed.ToString());
-
-                            break;
-                        }
-
-                        Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
-                        Debug.Assert(senderConnection != null, "connection != null");
-                        mGuidLookup.Add(senderConnection.RemoteUniqueIdentifier, client.Guid);
-
-                        Debug.Assert(mPeer != null, "mPeer != null");
-                        var approval = new ApprovalPacket(client.Rsa, hail.HandshakeSecret, aesKey, client.Guid);
-                        approval.Encrypt();
-
-                        var approvalMessage = mPeer.CreateMessage(approval.Data.Length);
-                        if (approvalMessage == null)
-                        {
-                            throw new InvalidOperationException();
-                        }
-
-                        approvalMessage.Data = approval.Data;
-                        approvalMessage.LengthBytes = approvalMessage.Data.Length;
-                        senderConnection.Approve(approvalMessage);
-
-                        OnConnectionApproved(
-                            this, new ConnectionEventArgs {Connection = client, NetworkStatus = NetworkStatus.Online}
+                        FireHandler(
+                            OnConnected, nameof(OnConnected), this, new ConnectionEventArgs
+                            {
+                                NetworkStatus = NetworkStatus.Online,
+                                Connection = intersectConnection
+                            }
                         );
                     }
-                    catch
+
+                        break;
+
+                    case NetConnectionStatus.Disconnected:
                     {
-                        senderConnection?.Deny(NetworkStatus.Failed.ToString());
+                        Debug.Assert(senderConnection != null, "connection != null");
+                        Log.Debug($"{message.MessageType}: {message} [{senderConnection.Status}]");
+                        var result = (NetConnectionStatus) message.ReadByte();
+                        var reason = message.ReadString();
+
+                        NetworkStatus networkStatus;
+                        try
+                        {
+                            networkStatus = reason switch
+                            {
+                                //Lidgren won't accept a connection with a bad version and sends this message back so we need to manually handle it
+                                "Wrong application identifier!" => NetworkStatus.VersionMismatch,
+                                "Connection timed out" => NetworkStatus.Quitting,
+                                "Failed to establish connection - no response from remote host" => NetworkStatus.Offline,
+                                "closing" => NetworkStatus.Offline,
+                                _ => (NetworkStatus)Enum.Parse(typeof(NetworkStatus), reason ?? "<null>", true)
+                            };
+                        }
+                        catch (Exception exception)
+                        {
+                            Log.Diagnostic(exception);
+                            networkStatus = NetworkStatus.Unknown;
+                        }
+
+                        HandleConnectionEvent disconnectHandler;
+                        string disconnectHandlerName;
+                        switch (networkStatus)
+                        {
+                            case NetworkStatus.HandshakeFailure:
+                            case NetworkStatus.ServerFull:
+                            case NetworkStatus.VersionMismatch:
+                            case NetworkStatus.Failed:
+                                disconnectHandler = OnConnectionDenied;
+                                disconnectHandlerName = nameof(OnConnectionDenied);
+                                Log.Diagnostic($"Disconnecting because of {networkStatus} ({reason})");
+                                break;
+
+                            case NetworkStatus.Connecting:
+                            case NetworkStatus.Online:
+                            case NetworkStatus.Offline:
+                            case NetworkStatus.Quitting:
+                            case NetworkStatus.Unknown:
+                                disconnectHandler = OnDisconnected;
+                                disconnectHandlerName = nameof(OnDisconnected);
+
+                                break;
+
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+
+                        if (!mGuidLookup.TryGetValue(lidgrenId, out var guid))
+                        {
+                            Log.Debug($"Unknown client disconnected ({lidgrenIdHex}).");
+                            FireHandler(
+                                disconnectHandler, disconnectHandlerName, this,
+                                new ConnectionEventArgs {NetworkStatus = networkStatus}
+                            );
+
+                            break;
+                        }
+
+                        var client = mNetwork.FindConnection(guid);
+                        if (client != null)
+                        {
+                            client.HandleDisconnected();
+
+                            FireHandler(
+                                disconnectHandler, disconnectHandlerName, this,
+                                new ConnectionEventArgs {Connection = client, NetworkStatus = NetworkStatus.Offline}
+                            );
+
+                            mNetwork.RemoveConnection(client);
+                        }
+
+                        mGuidLookup.Remove(senderConnection.RemoteUniqueIdentifier);
                     }
 
-                    break;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
                 }
 
-                case NetIncomingMessageType.VerboseDebugMessage:
-                    Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+                break;
 
-                    break;
+            case NetIncomingMessageType.UnconnectedData:
+                UnconnectedMessageSender sender = new(this, message.SenderEndPoint, mPeer);
+                OnUnconnectedMessage?.Invoke(sender, new LidgrenBuffer(message));
+                Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
 
-                case NetIncomingMessageType.DebugMessage:
-                    Log.Debug($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+                break;
 
-                    break;
-
-                case NetIncomingMessageType.WarningMessage:
-                    Log.Warn($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
-
-                    break;
-
-                case NetIncomingMessageType.ErrorMessage:
-                case NetIncomingMessageType.Error:
-                    Log.Error($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
-
-                    break;
-
-                case NetIncomingMessageType.Receipt:
-                    Log.Info($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
-
-                    break;
-
-                case NetIncomingMessageType.DiscoveryRequest:
-                case NetIncomingMessageType.DiscoveryResponse:
-                case NetIncomingMessageType.NatIntroductionSuccess:
-                    Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
-                    break;
-
-                case NetIncomingMessageType.ConnectionLatencyUpdated:
+            case NetIncomingMessageType.ConnectionApproval:
+            {
+                try
                 {
-                    Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
-                    var rtt = message.ReadFloat();
-                    var connection = FindConnection(senderConnection);
-                    if (connection != null)
+                    var hail = MessagePacker.Instance.Deserialize(message.Data) as HailPacket;
+                    if (!(hail?.Decrypt(mRsa) ?? false))
                     {
-                        connection.Statistics.Ping = (long)Math.Ceiling(senderConnection.AverageRoundtripTime * 1000);
+                        Log.Warn($"Failed to read hail, denying connection [{lidgrenIdHex}].");
+                        senderConnection?.Deny(NetworkStatus.HandshakeFailure.ToString());
+
+                        break;
                     }
-                    break;
+
+                    Debug.Assert(SharedConstants.VersionData != null, "SharedConstants.VERSION_DATA != null");
+                    Debug.Assert(hail.VersionData != null, "hail.VersionData != null");
+                    if (!SharedConstants.VersionData.SequenceEqual(hail.VersionData))
+                    {
+                        Log.Error($"Bad version detected, denying connection [{lidgrenIdHex}].");
+                        senderConnection?.Deny(NetworkStatus.VersionMismatch.ToString());
+
+                        break;
+                    }
+                    
+                    Log.Debug($"hail Time={hail.Adjusted / TimeSpan.TicksPerMillisecond} Offset={hail.Offset / TimeSpan.TicksPerMillisecond} Real={hail.UTC / TimeSpan.TicksPerMillisecond}");
+                    Log.Debug($"local Time={Timing.Global.Milliseconds} Offset={(long)Timing.Global.MillisecondsOffset} Real={Timing.Global.MillisecondsUtc}");
+                    Log.Debug($"real delta={(Timing.Global.TicksUtc - hail.UTC) / TimeSpan.TicksPerMillisecond}");
+                    Log.Debug($"NCPing={(long)Math.Ceiling(senderConnection.AverageRoundtripTime * 1000)}");
+
+                    // Check if we've got more connections than we're allowed to handle!
+                    if (mNetwork.ConnectionCount >= Options.Instance.MaxClientConnections)
+                    {
+                        Log.Info($"Connection limit reached, denying connection [{lidgrenIdHex}].");
+                            senderConnection?.Deny(NetworkStatus.ServerFull.ToString());
+                        break;
+                    }
+
+                    if (OnConnectionApproved == null)
+                    {
+                        Log.Error($"No handlers for OnConnectionApproved, denying connection [{lidgrenIdHex}].");
+                        senderConnection?.Deny(NetworkStatus.Failed.ToString());
+
+                        break;
+                    }
+
+                    /* Approving connection from here-on. */
+                    var aesKey = new byte[32];
+                    mRng?.GetNonZeroBytes(aesKey);
+                    var client = new LidgrenConnection(mNetwork, senderConnection, aesKey, hail.RsaParameters);
+
+                    if (!OnConnectionRequested(this, client))
+                    {
+                        Log.Warn($"Connection blocked due to ban or ip filter!");
+                        senderConnection?.Deny(NetworkStatus.Failed.ToString());
+
+                        break;
+                    }
+
+                    Debug.Assert(mNetwork != null, "mNetwork != null");
+                    if (!mNetwork.AddConnection(client))
+                    {
+                        Log.Error($"Failed to add the connection.");
+                        senderConnection?.Deny(NetworkStatus.Failed.ToString());
+
+                        break;
+                    }
+
+                    Debug.Assert(mGuidLookup != null, "mGuidLookup != null");
+                    Debug.Assert(senderConnection != null, "connection != null");
+                    mGuidLookup.Add(senderConnection.RemoteUniqueIdentifier, client.Guid);
+
+                    Debug.Assert(mPeer != null, "mPeer != null");
+                    var approval = new ApprovalPacket(client.Rsa, hail.HandshakeSecret, aesKey, client.Guid);
+                    approval.Encrypt();
+
+                    var approvalMessage = mPeer.CreateMessage(approval.Data.Length);
+                    if (approvalMessage == null)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    approvalMessage.Data = approval.Data;
+                    approvalMessage.LengthBytes = approvalMessage.Data.Length;
+                    senderConnection.Approve(approvalMessage);
+
+                    OnConnectionApproved(
+                        this, new ConnectionEventArgs {Connection = client, NetworkStatus = NetworkStatus.Online}
+                    );
+                }
+                catch
+                {
+                    senderConnection?.Deny(NetworkStatus.Failed.ToString());
                 }
 
-                default:
-                    throw new ArgumentOutOfRangeException();
+                break;
             }
 
-            return null;
+            case NetIncomingMessageType.VerboseDebugMessage:
+                Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+
+                break;
+
+            case NetIncomingMessageType.DebugMessage:
+                Log.Debug($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+
+                break;
+
+            case NetIncomingMessageType.WarningMessage:
+                Log.Warn($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+
+                break;
+
+            case NetIncomingMessageType.ErrorMessage:
+            case NetIncomingMessageType.Error:
+                Log.Error($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+
+                break;
+
+            case NetIncomingMessageType.Receipt:
+                Log.Info($"Net Incoming Message: {message.MessageType}: {message.ReadString()}");
+
+                break;
+
+            case NetIncomingMessageType.DiscoveryRequest:
+            case NetIncomingMessageType.DiscoveryResponse:
+            case NetIncomingMessageType.NatIntroductionSuccess:
+                Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
+                break;
+
+            case NetIncomingMessageType.ConnectionLatencyUpdated:
+            {
+                Log.Diagnostic($"Net Incoming Message: {message.MessageType}: {message}");
+                var rtt = message.ReadFloat();
+                var connection = FindConnection(senderConnection);
+                if (connection != null)
+                {
+                    connection.Statistics.Ping = (long)Math.Ceiling(senderConnection.AverageRoundtripTime * 1000);
+                }
+                break;
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
         }
 
-        private bool FireHandler(
-            HandleConnectionEvent handler,
-            string name,
-            INetworkLayerInterface sender,
-            ConnectionEventArgs connectionEventArgs
-        )
+        return null;
+    }
+
+    private bool FireHandler(
+        HandleConnectionEvent handler,
+        string name,
+        INetworkLayerInterface sender,
+        ConnectionEventArgs connectionEventArgs
+    )
+    {
+        handler?.Invoke(sender, connectionEventArgs);
+
+        if (handler == null)
         {
-            handler?.Invoke(sender, connectionEventArgs);
-
-            if (handler == null)
-            {
-                Log.Error($"No handlers for '{name}'.");
-            }
-
-            return handler != null;
+            Log.Error($"No handlers for '{name}'.");
         }
 
-        private void SendMessage(
-            NetOutgoingMessage message,
-            LidgrenConnection connection,
-            NetDeliveryMethod deliveryMethod,
-            int sequenceChannel = 0
-        )
+        return handler != null;
+    }
+
+    private void SendMessage(
+        NetOutgoingMessage message,
+        LidgrenConnection connection,
+        NetDeliveryMethod deliveryMethod,
+        int sequenceChannel = 0
+    )
+    {
+        if (message == null)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            if (connection == null)
-            {
-                throw new ArgumentNullException(nameof(connection));
-            }
-
-            if (connection.NetConnection == null)
-            {
-                throw new ArgumentNullException(nameof(connection.NetConnection));
-            }
-
-            lock (connection.Aes)
-            {
-                message.Encrypt(connection.Aes);
-            }
-            connection.NetConnection.SendMessage(message, deliveryMethod, sequenceChannel);
+            throw new ArgumentNullException(nameof(message));
         }
 
-        private static NetDeliveryMethod TranslateTransmissionMode(TransmissionMode transmissionMode)
+        if (connection == null)
         {
-            switch (transmissionMode)
-            {
-                case TransmissionMode.Any:
-                    return NetDeliveryMethod.Unreliable;
-
-                case TransmissionMode.Latest:
-                    return NetDeliveryMethod.ReliableSequenced;
-
-                // ReSharper disable once RedundantCaseLabel
-                case TransmissionMode.All:
-                default:
-                    return NetDeliveryMethod.ReliableOrdered;
-            }
+            throw new ArgumentNullException(nameof(connection));
         }
 
-        internal bool Disconnect(string message)
+        if (connection.NetConnection == null)
         {
-            mPeer.Connections?.ForEach(connection => connection?.Disconnect(message));
-
-            return true;
+            throw new ArgumentNullException(nameof(connection.NetConnection));
         }
 
+        lock (connection.Aes)
+        {
+            message.Encrypt(connection.Aes);
+        }
+        connection.NetConnection.SendMessage(message, deliveryMethod, sequenceChannel);
+    }
+
+    private static NetDeliveryMethod TranslateTransmissionMode(TransmissionMode transmissionMode)
+    {
+        switch (transmissionMode)
+        {
+            case TransmissionMode.Any:
+                return NetDeliveryMethod.Unreliable;
+
+            case TransmissionMode.Latest:
+                return NetDeliveryMethod.ReliableSequenced;
+
+            // ReSharper disable once RedundantCaseLabel
+            case TransmissionMode.All:
+            default:
+                return NetDeliveryMethod.ReliableOrdered;
+        }
+    }
+
+    internal bool Disconnect(string message)
+    {
+        mPeer.Connections?.ForEach(connection => connection?.Disconnect(message));
+
+        return true;
     }
 
 }

--- a/Intersect.Network/NetworkMetaStatus.cs
+++ b/Intersect.Network/NetworkMetaStatus.cs
@@ -1,21 +1,19 @@
-﻿namespace Intersect.Network
+﻿namespace Intersect.Network;
+
+
+public enum NetworkMetaStatus
 {
 
-    public enum NetworkMetaStatus
-    {
+    Unknown = 0,
 
-        Unknown = 0,
+    ConnectionEstablished = 1,
 
-        ConnectionEstablished = 1,
+    HandshakeRequested = 2,
 
-        HandshakeRequested = 2,
+    HandshakeReceived = 4,
 
-        HandshakeReceived = 4,
+    HandshakeCompleted = 8,
 
-        HandshakeCompleted = 8,
-
-        Connected = 16
-
-    }
+    Connected = 16
 
 }


### PR DESCRIPTION
**Context:** File-scoped namespaces _were introduced in C# 10.0, which was released as part of .NET 6_. This feature allows developers to declare namespaces at the top of a file without enclosing them in a curly brace block, effectively making the namespace applicable to the entire file. Converting namespaces to file-scoped namespaces in C# promotes cleaner, more organized code that is easier to read, maintain, and scale as the project grows. It aligns with modern coding practices and helps prevent potential namespace conflicts, contributing to overall code quality and developer productivity.